### PR TITLE
Add cross-platform browser support (Windows/Linux)

### DIFF
--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -73,13 +73,22 @@ const server = Bun.serve({
 // Log to stderr so it doesn't interfere with hook stdout
 console.error(`Plannotator server running on http://localhost:${server.port}`);
 
-// Open browser
-try {
-  await $`open http://localhost:${server.port}`.quiet();
-} catch {
-  // Fallback for non-macOS
-  console.error(`Open browser manually: http://localhost:${server.port}`);
-}
+// Open browser - cross-platform support
+  const url = `http://localhost:${server.port}`;
+  console.error(`Plannotator server running on ${url}`);
+
+  try {
+    const platform = process.platform;
+    if (platform === "win32") {
+      await $`cmd /c start ${url}`.quiet();
+    } else if (platform === "darwin") {
+      await $`open ${url}`.quiet();
+    } else {
+      await $`xdg-open ${url}`.quiet();
+    }
+  } catch {
+    console.error(`Open browser manually: ${url}`);
+  }
 
 // Wait for user decision (blocks until approve/deny)
 const result = await decisionPromise;


### PR DESCRIPTION
## Summary
The current implementation only uses `open` command which only works on macOS.
This PR adds cross-platform support for opening the browser automatically.

## Changes
- Windows: `cmd /c start`
- Linux: `xdg-open`
- macOS: `open` (unchanged)

## Testing
Tested on Windows 10 - browser opens correctly when ExitPlanMode hook triggers.