### PR TITLE
Add SSH remote session support with fixed port

### DIFF
--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -2,7 +2,10 @@
  * Plannotator Ephemeral Server
  *
  * Spawned by ExitPlanMode hook to serve Plannotator UI and handle approve/deny decisions.
- * Uses random port to support multiple concurrent Claude Code sessions.
+ * Supports both local and SSH remote sessions.
+ *
+ * Environment variables:
+ *   PLANNOTATOR_PORT - Fixed port to use (default: random locally, 19432 over SSH)
  *
  * Reads hook event from stdin, extracts plan content, serves UI, returns decision.
  */
@@ -11,6 +14,34 @@ import { $ } from "bun";
 
 // Embed the built HTML at compile time
 import indexHtml from "../dist/index.html" with { type: "text" };
+
+// --- SSH Detection and Port Configuration ---
+
+const DEFAULT_SSH_PORT = 19432;
+
+function isSSHSession(): boolean {
+  // SSH_TTY is set when SSH allocates a pseudo-terminal
+  // SSH_CONNECTION contains "client_ip client_port server_ip server_port"
+  return !!(process.env.SSH_TTY || process.env.SSH_CONNECTION);
+}
+
+function getServerPort(): number {
+  // Explicit port from environment takes precedence
+  const envPort = process.env.PLANNOTATOR_PORT;
+  if (envPort) {
+    const parsed = parseInt(envPort, 10);
+    if (!isNaN(parsed) && parsed > 0 && parsed < 65536) {
+      return parsed;
+    }
+    console.error(`Warning: Invalid PLANNOTATOR_PORT "${envPort}", using default`);
+  }
+
+  // Over SSH, use fixed port for port forwarding; locally use random
+  return isSSHSession() ? DEFAULT_SSH_PORT : 0;
+}
+
+const isRemote = isSSHSession();
+const configuredPort = getServerPort();
 
 // Read hook event from stdin
 const eventJson = await Bun.stdin.text();
@@ -35,50 +66,91 @@ const decisionPromise = new Promise<{ approved: boolean; feedback?: string }>(
   (resolve) => { resolveDecision = resolve; }
 );
 
-const server = Bun.serve({
-  port: 0, // Random available port - critical for multi-instance support
+// --- Server with port conflict handling ---
 
-  async fetch(req) {
-    const url = new URL(req.url);
+const MAX_RETRIES = 5;
+const RETRY_DELAY_MS = 500;
 
-    // API: Get plan content
-    if (url.pathname === "/api/plan") {
-      return Response.json({ plan: planContent });
-    }
+async function startServer(): Promise<ReturnType<typeof Bun.serve>> {
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      return Bun.serve({
+        port: configuredPort,
 
-    // API: Approve plan
-    if (url.pathname === "/api/approve" && req.method === "POST") {
-      resolveDecision({ approved: true });
-      return Response.json({ ok: true });
-    }
+        async fetch(req) {
+          const url = new URL(req.url);
 
-    // API: Deny with feedback
-    if (url.pathname === "/api/deny" && req.method === "POST") {
-      try {
-        const body = await req.json() as { feedback?: string };
-        resolveDecision({ approved: false, feedback: body.feedback || "Plan rejected by user" });
-      } catch {
-        resolveDecision({ approved: false, feedback: "Plan rejected by user" });
+          // API: Get plan content
+          if (url.pathname === "/api/plan") {
+            return Response.json({ plan: planContent });
+          }
+
+          // API: Approve plan
+          if (url.pathname === "/api/approve" && req.method === "POST") {
+            resolveDecision({ approved: true });
+            return Response.json({ ok: true });
+          }
+
+          // API: Deny with feedback
+          if (url.pathname === "/api/deny" && req.method === "POST") {
+            try {
+              const body = await req.json() as { feedback?: string };
+              resolveDecision({ approved: false, feedback: body.feedback || "Plan rejected by user" });
+            } catch {
+              resolveDecision({ approved: false, feedback: "Plan rejected by user" });
+            }
+            return Response.json({ ok: true });
+          }
+
+          // Serve embedded HTML for all other routes (SPA)
+          return new Response(indexHtml, {
+            headers: { "Content-Type": "text/html" }
+          });
+        },
+      });
+    } catch (err: unknown) {
+      const isAddressInUse = err instanceof Error && err.message.includes("EADDRINUSE");
+      if (isAddressInUse && attempt < MAX_RETRIES) {
+        console.error(`Port ${configuredPort} in use, retrying in ${RETRY_DELAY_MS}ms... (${attempt}/${MAX_RETRIES})`);
+        await Bun.sleep(RETRY_DELAY_MS);
+        continue;
       }
-      return Response.json({ ok: true });
+      if (isAddressInUse) {
+        console.error(`\nError: Port ${configuredPort} is already in use after ${MAX_RETRIES} retries.`);
+        if (isRemote) {
+          console.error(`Another Plannotator session may be running.`);
+          console.error(`To use a different port, set PLANNOTATOR_PORT environment variable.\n`);
+        }
+        process.exit(1);
+      }
+      throw err;
     }
+  }
+  throw new Error("Unreachable");
+}
 
-    // Serve embedded HTML for all other routes (SPA)
-    return new Response(indexHtml, {
-      headers: { "Content-Type": "text/html" }
-    });
-  },
-});
+const server = await startServer();
 
-// Log to stderr so it doesn't interfere with hook stdout
-console.error(`Plannotator server running on http://localhost:${server.port}`);
+// --- Conditional browser opening and messaging ---
 
-// Open browser
-try {
-  await $`open http://localhost:${server.port}`.quiet();
-} catch {
-  // Fallback for non-macOS
-  console.error(`Open browser manually: http://localhost:${server.port}`);
+const serverUrl = `http://localhost:${server.port}`;
+console.error(`\nPlannotator server running on ${serverUrl}`);
+
+if (isRemote) {
+  // SSH session: print helpful setup instructions
+  console.error(`\n[SSH Remote Session Detected]`);
+  console.error(`Add this to your local ~/.ssh/config to access Plannotator:\n`);
+  console.error(`  Host your-server-alias`);
+  console.error(`    LocalForward ${server.port} localhost:${server.port}\n`);
+  console.error(`Then open ${serverUrl} in your local browser.\n`);
+} else {
+  // Local session: try to open browser
+  try {
+    await $`open ${serverUrl}`.quiet();
+  } catch {
+    // Fallback for non-macOS or if open fails
+    console.error(`Open browser manually: ${serverUrl}`);
+  }
 }
 
 // Wait for user decision (blocks until approve/deny)


### PR DESCRIPTION
- Auto-detect SSH sessions via SSH_TTY/SSH_CONNECTION env vars
- Use fixed port 19432 over SSH for predictable port forwarding
- Add PLANNOTATOR_PORT env var for custom port configuration
- Add retry loop (5 attempts) for port conflicts
- Print SSH config hint when running remotely
- Skip browser auto-open in SSH sessions