### PR TITLE
Add plan saving to ~/.plannotator/plans/

### DIFF
--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -101,6 +101,7 @@ Do NOT proceed with implementation until your plan is approved.
               return `Plan approved with notes!
 
 Plan Summary: ${args.summary}
+${result.savedPath ? `Saved to: ${result.savedPath}` : ""}
 
 ## Implementation Notes
 
@@ -113,9 +114,11 @@ Proceed with implementation, incorporating these notes where applicable.`;
 
             return `Plan approved!
 
-Plan Summary: ${args.summary}`;
+Plan Summary: ${args.summary}
+${result.savedPath ? `Saved to: ${result.savedPath}` : ""}`;
           } else {
             return `Plan needs revision.
+${result.savedPath ? `\nSaved to: ${result.savedPath}` : ""}
 
 The user has requested changes to your plan. Please review their feedback below and revise your plan accordingly.
 

--- a/packages/server/storage.ts
+++ b/packages/server/storage.ts
@@ -1,0 +1,90 @@
+/**
+ * Plan Storage Utility
+ *
+ * Saves plans and annotations to ~/.plannotator/plans/
+ * Cross-platform: works on Windows, macOS, and Linux.
+ */
+
+import { homedir } from "os";
+import { join } from "path";
+import { mkdirSync, writeFileSync } from "fs";
+import { sanitizeTag } from "./project";
+
+/**
+ * Get the plan storage directory, creating it if needed.
+ * Cross-platform: uses os.homedir() for Windows/macOS/Linux compatibility.
+ */
+export function getPlanDir(): string {
+  const home = homedir();
+  const planDir = join(home, ".plannotator", "plans");
+  mkdirSync(planDir, { recursive: true });
+  return planDir;
+}
+
+/**
+ * Extract the first heading from markdown content.
+ */
+function extractFirstHeading(markdown: string): string | null {
+  const match = markdown.match(/^#\s+(.+)$/m);
+  if (!match) return null;
+  return match[1].trim();
+}
+
+/**
+ * Generate a slug from plan content.
+ * Format: YYYY-MM-DD-{sanitized-heading}
+ */
+export function generateSlug(plan: string): string {
+  const date = new Date().toISOString().split("T")[0]; // YYYY-MM-DD
+
+  const heading = extractFirstHeading(plan);
+  const slug = heading ? sanitizeTag(heading) : null;
+
+  return slug ? `${date}-${slug}` : `${date}-plan`;
+}
+
+/**
+ * Save the plan markdown to disk.
+ * Returns the full path to the saved file.
+ */
+export function savePlan(slug: string, content: string): string {
+  const planDir = getPlanDir();
+  const filePath = join(planDir, `${slug}.md`);
+  writeFileSync(filePath, content, "utf-8");
+  return filePath;
+}
+
+/**
+ * Save annotations (diff) to disk.
+ * Returns the full path to the saved file.
+ */
+export function saveAnnotations(slug: string, diffContent: string): string {
+  const planDir = getPlanDir();
+  const filePath = join(planDir, `${slug}.diff.md`);
+  writeFileSync(filePath, diffContent, "utf-8");
+  return filePath;
+}
+
+/**
+ * Save the final snapshot on approve/deny.
+ * Combines plan and diff into a single file with status suffix.
+ * Returns the full path to the saved file.
+ */
+export function saveFinalSnapshot(
+  slug: string,
+  status: "approved" | "denied",
+  plan: string,
+  diff: string
+): string {
+  const planDir = getPlanDir();
+  const filePath = join(planDir, `${slug}-${status}.md`);
+
+  // Combine plan with diff appended
+  let content = plan;
+  if (diff && diff !== "No changes detected.") {
+    content += "\n\n---\n\n" + diff;
+  }
+
+  writeFileSync(filePath, content, "utf-8");
+  return filePath;
+}


### PR DESCRIPTION
## Summary

- Saves all plans and annotations to `~/.plannotator/plans/` for both Claude Code and OpenCode users
- Cross-platform support (Windows, macOS, Linux) using `os.homedir()`
- OpenCode agent is notified of saved path in tool result

## File Structure

```
~/.plannotator/plans/
  2026-01-07-my-plan.md           # Plan (saved on open)
  2026-01-07-my-plan.diff.md      # Annotations (saved on decision)
  2026-01-07-my-plan-approved.md  # Final snapshot with status
```

## Changes

- **New:** `packages/server/storage.ts` - Plan persistence module
- **Updated:** `packages/server/index.ts` - Save on start + decision
- **Updated:** `apps/opencode-plugin/index.ts` - Show saved path

## Test plan

- [x] Deny with annotations → saves `.md`, `.diff.md`, `-denied.md`
- [x] Approve without annotations → saves `.md`, `-approved.md`
- [x] OpenCode approve with annotations → saves all + agent sees path

🤖 Generated with [Claude Code](https://claude.com/claude-code)