### PR TITLE
feat: add PLANNOTATOR_BROWSER env var for custom browser selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ claude --plugin-dir ./apps/hook
 |----------|-------------|
 | `PLANNOTATOR_REMOTE` | Set to `1` or `true` for remote mode (devcontainer, SSH). Uses fixed port and skips browser open. |
 | `PLANNOTATOR_PORT` | Fixed port to use. Default: random locally, `19432` for remote sessions. |
+| `PLANNOTATOR_BROWSER` | Custom browser to open plans in. macOS: app name or path. Linux/Windows: executable path. |
 
 **Legacy:** `SSH_TTY` and `SSH_CONNECTION` are still detected. Prefer `PLANNOTATOR_REMOTE=1` for explicit control.
 

--- a/apps/hook/README.md
+++ b/apps/hook/README.md
@@ -70,6 +70,14 @@ When Claude Code calls `ExitPlanMode`, this hook intercepts and:
 3. Approve → Claude proceeds with implementation
 4. Request changes → Your annotations are sent back to Claude
 
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `PLANNOTATOR_REMOTE` | Set to `1` for remote mode (devcontainer, SSH). Uses fixed port and skips browser open. |
+| `PLANNOTATOR_PORT` | Fixed port to use. Default: random locally, `19432` for remote sessions. |
+| `PLANNOTATOR_BROWSER` | Custom browser to open plans in. macOS: app name or path. Linux/Windows: executable path. |
+
 ## Remote / Devcontainer Usage
 
 When running Claude Code in a remote environment (SSH, devcontainer, WSL), set these environment variables:

--- a/apps/opencode-plugin/README.md
+++ b/apps/opencode-plugin/README.md
@@ -49,9 +49,17 @@ Restart OpenCode. The `submit_plan` tool is now available.
 - **Private sharing**: Plans and annotations compress into the URL itself—share a link, no accounts or backend required
 - **Obsidian integration**: Auto-save approved plans to your vault with frontmatter and tags
 
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `PLANNOTATOR_REMOTE` | Set to `1` for remote mode (devcontainer, SSH). Uses fixed port and skips browser open. |
+| `PLANNOTATOR_PORT` | Fixed port to use. Default: random locally, `19432` for remote sessions. |
+| `PLANNOTATOR_BROWSER` | Custom browser to open plans in. macOS: app name or path. Linux/Windows: executable path. |
+
 ## Devcontainer / Docker
 
-Works in containerized environments. Set two env vars and forward the port:
+Works in containerized environments. Set the env vars and forward the port:
 
 ```json
 {

--- a/packages/server/browser.ts
+++ b/packages/server/browser.ts
@@ -5,18 +5,35 @@
 import { $ } from "bun";
 
 /**
- * Open a URL in the default browser
+ * Open a URL in the browser
+ *
+ * Uses PLANNOTATOR_BROWSER env var if set, otherwise uses system default.
+ * - macOS: Set to app name ("Google Chrome") or path ("/Applications/Firefox.app")
+ * - Linux/Windows: Set to executable path ("/usr/bin/firefox")
+ *
  * Fails silently if browser can't be opened
  */
 export async function openBrowser(url: string): Promise<boolean> {
   try {
+    const browser = process.env.PLANNOTATOR_BROWSER;
     const platform = process.platform;
-    if (platform === "win32") {
-      await $`cmd /c start ${url}`.quiet();
-    } else if (platform === "darwin") {
-      await $`open ${url}`.quiet();
+
+    if (browser) {
+      // Custom browser specified
+      if (platform === "darwin") {
+        await $`open -a ${browser} ${url}`.quiet();
+      } else {
+        await $`${browser} ${url}`.quiet();
+      }
     } else {
-      await $`xdg-open ${url}`.quiet();
+      // Default system browser
+      if (platform === "win32") {
+        await $`cmd /c start ${url}`.quiet();
+      } else if (platform === "darwin") {
+        await $`open ${url}`.quiet();
+      } else {
+        await $`xdg-open ${url}`.quiet();
+      }
     }
     return true;
   } catch {


### PR DESCRIPTION
## Summary

- Add `PLANNOTATOR_BROWSER` environment variable to specify which browser opens plan files
- Default behavior unchanged - only activates when env var is set
- Document in CLAUDE.md and both plugin READMEs

## Usage

```bash
# macOS - app name or path
export PLANNOTATOR_BROWSER="Google Chrome"
export PLANNOTATOR_BROWSER="/Applications/Firefox.app"

# Linux/Windows - executable path
export PLANNOTATOR_BROWSER="/usr/bin/firefox"
```

## Test plan

- [ ] Without env var: Opens in default browser (unchanged)
- [ ] With env var on macOS: Opens in specified app
- [ ] With env var on Linux: Opens with specified executable

Closes #42

🤖 Generated with [Claude Code](https://claude.ai/code)