### PR TITLE
improve: clarify post-decision messaging

### DIFF
--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -791,9 +791,12 @@ const App: React.FC = () => {
                 </p>
               </div>
 
-              <div className="pt-4 border-t border-border">
+              <div className="pt-4 border-t border-border space-y-2">
                 <p className="text-sm text-muted-foreground">
-                  Return to your <span className="text-foreground font-medium">{agentName}</span> to continue.
+                  You can close this tab and return to <span className="text-foreground font-medium">{agentName}</span>.
+                </p>
+                <p className="text-xs text-muted-foreground/60">
+                  Your response has been sent.
                 </p>
               </div>
             </div>


### PR DESCRIPTION
## Summary

Improve the completion screen messaging to make it explicit that users can close the tab.

**Before:**
> Return to your Claude Code to continue.

**After:**
> You can close this tab and return to Claude Code.
> Your response has been sent.

## Context

Related to #41 - this is a quick win to improve UX while keeping the issue open for potential auto-close implementation in the future.

Note: True auto-close via `window.close()` is blocked by browser security for tabs not opened via `window.open()`.

## Test plan

- [ ] Approve a plan, verify new messaging shows
- [ ] Deny a plan, verify new messaging shows

🤖 Generated with [Claude Code](https://claude.ai/code)