### PR TITLE
feat: support custom agents for agent switching

### DIFF
--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -16,7 +16,7 @@ import { storage } from '@plannotator/ui/utils/storage';
 import { UpdateBanner } from '@plannotator/ui/components/UpdateBanner';
 import { getObsidianSettings } from '@plannotator/ui/utils/obsidian';
 import { getBearSettings } from '@plannotator/ui/utils/bear';
-import { getAgentSwitchSettings } from '@plannotator/ui/utils/agentSwitch';
+import { getAgentSwitchSettings, getEffectiveAgentName } from '@plannotator/ui/utils/agentSwitch';
 import { getPlanSaveSettings } from '@plannotator/ui/utils/planSave';
 import { ImageAnnotator } from '@plannotator/ui/components/ImageAnnotator';
 
@@ -457,8 +457,11 @@ const App: React.FC = () => {
       // Build request body - include integrations if enabled
       const body: { obsidian?: object; bear?: object; feedback?: string; agentSwitch?: string; planSave?: { enabled: boolean; customPath?: string } } = {};
 
-      // Always include agent switch setting for OpenCode
-      body.agentSwitch = agentSwitchSettings.switchTo;
+      // Include agent switch setting for OpenCode (effective name handles custom agents)
+      const effectiveAgent = getEffectiveAgentName(agentSwitchSettings);
+      if (effectiveAgent) {
+        body.agentSwitch = effectiveAgent;
+      }
 
       // Include plan save settings
       body.planSave = {

--- a/packages/ui/components/Settings.tsx
+++ b/packages/ui/components/Settings.tsx
@@ -85,8 +85,8 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
     saveBearSettings(newSettings);
   };
 
-  const handleAgentChange = (switchTo: AgentSwitchSettings['switchTo']) => {
-    const newSettings = { switchTo };
+  const handleAgentChange = (switchTo: AgentSwitchSettings['switchTo'], customName?: string) => {
+    const newSettings = { switchTo, customName: customName ?? agent.customName };
     setAgent(newSettings);
     saveAgentSwitchSettings(newSettings);
   };
@@ -229,8 +229,19 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
                         </option>
                       ))}
                     </select>
+                    {agent.switchTo === 'custom' && (
+                      <input
+                        type="text"
+                        value={agent.customName || ''}
+                        onChange={(e) => handleAgentChange('custom', e.target.value)}
+                        placeholder="Enter agent name..."
+                        className="w-full px-3 py-2 bg-muted rounded-lg text-sm focus:outline-none focus:ring-1 focus:ring-primary/50 placeholder:text-muted-foreground/50"
+                      />
+                    )}
                     <div className="text-[10px] text-muted-foreground/70">
-                      {AGENT_OPTIONS.find(o => o.value === agent.switchTo)?.description}
+                      {agent.switchTo === 'custom' && agent.customName
+                        ? `Switch to "${agent.customName}" agent after approval`
+                        : AGENT_OPTIONS.find(o => o.value === agent.switchTo)?.description}
                     </div>
                   </div>
                 </>

--- a/packages/ui/utils/agentSwitch.ts
+++ b/packages/ui/utils/agentSwitch.ts
@@ -2,7 +2,7 @@
  * Agent Switch Settings Utility
  *
  * Manages settings for automatic agent switching after plan approval.
- * Used by OpenCode users who want to disable auto-switch (e.g., oh-my-opencode).
+ * Supports built-in agents (build), disabled, or custom agent names.
  *
  * Uses cookies (not localStorage) because each hook invocation runs on a
  * random port, and localStorage is scoped by origin including port.
@@ -11,15 +11,18 @@
 import { storage } from './storage';
 
 const STORAGE_KEY = 'plannotator-agent-switch';
+const CUSTOM_NAME_KEY = 'plannotator-agent-custom';
 
-export type AgentSwitchOption = 'build' | 'disabled';
+export type AgentSwitchOption = 'build' | 'disabled' | 'custom';
 
 export interface AgentSwitchSettings {
   switchTo: AgentSwitchOption;
+  customName?: string;
 }
 
 export const AGENT_OPTIONS: { value: AgentSwitchOption; label: string; description: string }[] = [
   { value: 'build', label: 'Build', description: 'Switch to build agent after approval' },
+  { value: 'custom', label: 'Custom', description: 'Switch to a custom agent after approval' },
   { value: 'disabled', label: 'Disabled', description: 'Stay on current agent after approval' },
 ];
 
@@ -32,8 +35,10 @@ const DEFAULT_SETTINGS: AgentSwitchSettings = {
  */
 export function getAgentSwitchSettings(): AgentSwitchSettings {
   const stored = storage.getItem(STORAGE_KEY);
-  if (stored === 'disabled' || stored === 'build') {
-    return { switchTo: stored };
+  const customName = storage.getItem(CUSTOM_NAME_KEY) || undefined;
+
+  if (stored === 'disabled' || stored === 'build' || stored === 'custom') {
+    return { switchTo: stored, customName };
   }
   return DEFAULT_SETTINGS;
 }
@@ -43,4 +48,21 @@ export function getAgentSwitchSettings(): AgentSwitchSettings {
  */
 export function saveAgentSwitchSettings(settings: AgentSwitchSettings): void {
   storage.setItem(STORAGE_KEY, settings.switchTo);
+  if (settings.customName) {
+    storage.setItem(CUSTOM_NAME_KEY, settings.customName);
+  }
+}
+
+/**
+ * Get the effective agent name for switching
+ * Returns undefined if disabled, otherwise returns the agent name
+ */
+export function getEffectiveAgentName(settings: AgentSwitchSettings): string | undefined {
+  if (settings.switchTo === 'disabled') {
+    return undefined;
+  }
+  if (settings.switchTo === 'custom' && settings.customName) {
+    return settings.customName;
+  }
+  return settings.switchTo; // 'build' or fallback
 }


### PR DESCRIPTION
## Summary

Add support for custom agent names in the agent switching setting (OpenCode only).

**Before:** Only "Build" and "Disabled" options
**After:** "Build", "Custom", and "Disabled" - with text input for custom agent name

## Changes

| File | Change |
|------|--------|
| `packages/ui/utils/agentSwitch.ts` | Add `custom` option, `customName` field, `getEffectiveAgentName()` |
| `packages/ui/components/Settings.tsx` | Show text input when Custom selected |
| `packages/editor/App.tsx` | Use effective agent name when sending to server |

## How it works

1. User selects "Custom" from dropdown
2. Text input appears for entering agent name
3. On approve, the custom agent name is sent to the server
4. OpenCode plugin switches to that agent

## Test plan

- [ ] Select "Build" - switches to build agent after approval
- [ ] Select "Custom", enter "my-agent" - switches to my-agent after approval  
- [ ] Select "Disabled" - stays on current agent after approval
- [ ] Custom name persists across sessions (stored in cookie)

Closes #47

🤖 Generated with [Claude Code](https://claude.ai/code)