### PR TITLE
feat: enable inline editing for annotations

### DIFF
--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -530,6 +530,12 @@ const App: React.FC = () => {
     if (selectedAnnotationId === id) setSelectedAnnotationId(null);
   };
 
+  const handleEditAnnotation = (id: string, updates: Partial<Annotation>) => {
+    setAnnotations(prev => prev.map(ann =>
+      ann.id === id ? { ...ann, ...updates } : ann
+    ));
+  };
+
   const handleIdentityChange = (oldIdentity: string, newIdentity: string) => {
     setAnnotations(prev => prev.map(ann =>
       ann.author === oldIdentity ? { ...ann, author: newIdentity } : ann
@@ -712,6 +718,7 @@ const App: React.FC = () => {
             selectedId={selectedAnnotationId}
             onSelect={setSelectedAnnotationId}
             onDelete={handleDeleteAnnotation}
+            onEdit={handleEditAnnotation}
             shareUrl={shareUrl}
           />
         </div>


### PR DESCRIPTION

## Summary
- Enable inline editing for annotations directly in the panel
- Wire AnnotationPanel/ReviewPanel to sync and validate edits
- Add supporting types/state to stay compatible with the viewer

<img width="1102" height="809" alt="image" src="https://github.com/user-attachments/assets/15b53b7c-3cb0-47f7-b3f9-4e415a7df986" />

## Why
- Sometimes I only need to tweak a specific annotation instead of deleting and recreating it, so inline edits reduce friction and preserve context.
