### PR TITLE
fix: respect XDG_CONFIG_HOME in postinstall script

### DIFF
--- a/apps/opencode-plugin/package.json
+++ b/apps/opencode-plugin/package.json
@@ -29,7 +29,7 @@
   ],
   "scripts": {
     "build": "cp ../hook/dist/index.html ./plannotator.html && cp ../review/dist/index.html ./review-editor.html && bun build index.ts --outfile dist/index.js --target bun --external @opencode-ai/plugin",
-    "postinstall": "mkdir -p ~/.config/opencode/command && cp ./commands/*.md ~/.config/opencode/command/ 2>/dev/null || true",
+    "postinstall": "mkdir -p ${XDG_CONFIG_HOME:-$HOME/.config}/opencode/command && cp ./commands/*.md ${XDG_CONFIG_HOME:-$HOME/.config}/opencode/command/ 2>/dev/null || true",
     "prepublishOnly": "bun run build"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

The `postinstall` script in `apps/opencode-plugin/package.json` previously hardcoded `~/.config/opencode/command` as the destination for slash command files. This causes data leakage for users running OpenCode in portable or XDG-compliant environments where `XDG_CONFIG_HOME` is set to a custom location.

## Changes

Updated the postinstall script to use `${XDG_CONFIG_HOME:-$HOME/.config}` instead of `~/.config`:

```diff
- "postinstall": "mkdir -p ~/.config/opencode/command && ..."
+ "postinstall": "mkdir -p ${XDG_CONFIG_HOME:-$HOME/.config}/opencode/command && ..."
```

## Behavior

- **When `XDG_CONFIG_HOME` is set**: Uses the custom config directory (for portable/containerized installations)
- **When `XDG_CONFIG_HOME` is unset**: Falls back to `~/.config` (no behavior change for standard installations)

This follows the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/) and ensures the plugin works correctly in:
- Portable OpenCode installations
- Containerized environments (Docker, devcontainers)
- Multi-user systems with custom home directories
- Any setup where XDG environment variables are configured

## Testing

Verified that after this change:
- Command files are correctly placed in `$XDG_CONFIG_HOME/opencode/command/` when the variable is set
- Standard installations continue to work with `~/.config/opencode/command/`