### PR TITLE
fix(opencode): skip Plan Submission prompt for title generation

### DIFF
--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -34,6 +34,14 @@ const reviewHtmlContent = reviewHtml as unknown as string;
 export const PlannotatorPlugin: Plugin = async (ctx) => {
   return {
     "experimental.chat.system.transform": async (_input, output) => {
+      // Skip adding Plan Submission prompt for title generation requests
+      // Title generation has a specific system prompt containing "title generator"
+      // and typically has no tools
+      const existingSystem = output.system.join("\n").toLowerCase();
+      if (existingSystem.includes("title generator") || existingSystem.includes("generate a title")) {
+        return; // Skip - this is a title generation request
+      }
+
       output.system.push(`
 ## Plan Submission
 


### PR DESCRIPTION
## Summary

- Fixes title generation showing prompt fragments instead of generated titles
- The `experimental.chat.system.transform` hook was injecting "Plan Submission" system prompt into ALL requests, including title generation
- This caused OpenCode's title generator to see the wrong system prompt and attempt to call `submit_plan` instead of generating a title

## Changes

Added a check in the OpenCode plugin's system transform to detect title generation requests by looking for "title generator" or "generate a title" in the existing system prompt, and skip injecting the Plan Submission instructions for those requests.

## Test plan

- [ ] Start OpenCode with the plannotator plugin
- [ ] Send a message that triggers title generation
- [ ] Verify the title is generated correctly (not showing prompt fragments or trying to call submit_plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)