### PR TITLE
feat: add Cmd+Enter keyboard shortcut to submit

### DIFF
--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -544,6 +544,44 @@ const App: React.FC = () => {
     }
   };
 
+  // Global keyboard shortcuts (Cmd/Ctrl+Enter to submit)
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Only handle Cmd/Ctrl+Enter
+      if (e.key !== 'Enter' || !(e.metaKey || e.ctrlKey)) return;
+
+      // Don't intercept if typing in an input/textarea
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+
+      // Don't intercept if any modal is open
+      if (showExport || showFeedbackPrompt || showClaudeCodeWarning ||
+          showPermissionModeSetup || pendingPasteImage) return;
+
+      // Don't intercept if already submitted or submitting
+      if (submitted || isSubmitting) return;
+
+      // Don't intercept in demo/share mode (no API)
+      if (!isApiMode) return;
+
+      e.preventDefault();
+
+      // No annotations → Approve, otherwise → Send Feedback
+      if (annotations.length === 0) {
+        handleApprove();
+      } else {
+        handleDeny();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [
+    showExport, showFeedbackPrompt, showClaudeCodeWarning,
+    showPermissionModeSetup, pendingPasteImage,
+    submitted, isSubmitting, isApiMode, annotations.length,
+  ]);
+
   const handleAddAnnotation = (ann: Annotation) => {
     setAnnotations(prev => [...prev, ann]);
     setSelectedAnnotationId(ann.id);

--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -444,6 +444,35 @@ const ReviewApp: React.FC = () => {
     }
   }, []);
 
+  // Cmd/Ctrl+Enter keyboard shortcut to approve or send feedback
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Enter' || !(e.metaKey || e.ctrlKey)) return;
+
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+      if (showExportModal || showNoAnnotationsDialog || showApproveWarning) return;
+      if (submitted || isSendingFeedback || isApproving) return;
+      if (!origin) return; // Demo mode
+
+      e.preventDefault();
+
+      // No annotations → Approve, otherwise → Send Feedback
+      if (annotations.length === 0) {
+        handleApprove();
+      } else {
+        handleSendFeedback();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [
+    showExportModal, showNoAnnotationsDialog, showApproveWarning,
+    submitted, isSendingFeedback, isApproving, origin, annotations.length,
+    handleApprove, handleSendFeedback
+  ]);
+
   const activeFile = files[activeFileIndex];
   const feedbackMarkdown = useMemo(() =>
     exportReviewFeedback(annotations, files),


### PR DESCRIPTION
## Summary

- Adds **Cmd+Enter** (Ctrl+Enter on Windows/Linux) keyboard shortcut for quick submission
- No annotations → Approve (proceed with implementation)
- With annotations → Send Feedback (request revision)

Closes #80

## Implementation

- **Plan Review** (`packages/editor/App.tsx`): Calls `handleApprove()` or `handleDeny()` based on annotation state
- **Code Review** (`packages/review-editor/App.tsx`): Calls `handleApprove()` or `handleSendFeedback()` based on annotation state

Both implementations skip when:
- Input/textarea is focused (preserves Cmd+Enter to save annotation edits)
- Modal is open
- Already submitting
- In demo/share mode

## Test plan

- [ ] Plan review: Cmd+Enter with no annotations → approves
- [ ] Plan review: Cmd+Enter with annotations → sends feedback
- [ ] Code review: Cmd+Enter with no annotations → approves (LGTM)
- [ ] Code review: Cmd+Enter with annotations → sends feedback
- [ ] Editing annotation in panel: Cmd+Enter saves edit (not global submit)
- [ ] Typing in input: Cmd+Enter does nothing globally

🤖 Generated with [Claude Code](https://claude.com/claude-code)