### PR TITLE
fix: increase hook timeout to 4 days

### DIFF
--- a/apps/hook/hooks/hooks.json
+++ b/apps/hook/hooks/hooks.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "command": "plannotator",
-            "timeout": 1800
+            "timeout": 345600
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Increases the plannotator hook timeout from 30 minutes to 4 days (345600 seconds)
- Prevents the server from being killed during extended plan review sessions

Fixes #84

## Test plan

- [ ] Open a plan in the browser
- [ ] Leave it idle for extended period (> 30 min)
- [ ] Verify browser UI remains functional

🤖 Generated with [Claude Code](https://claude.ai/code)