### PR TITLE
feat: add Comment mode and type-to-comment shortcut

### DIFF
--- a/packages/ui/components/ModeSwitcher.tsx
+++ b/packages/ui/components/ModeSwitcher.tsx
@@ -29,6 +29,16 @@ export const ModeSwitcher: React.FC<ModeSwitcherProps> = ({ mode, onChange, tate
         label="Selection"
       />
       <ModeButton
+        active={mode === 'comment'}
+        onClick={() => onChange('comment')}
+        icon={
+          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
+          </svg>
+        }
+        label="Comment"
+      />
+      <ModeButton
         active={mode === 'redline'}
         onClick={() => onChange('redline')}
         icon={

--- a/packages/ui/types.ts
+++ b/packages/ui/types.ts
@@ -6,7 +6,7 @@ export enum AnnotationType {
   GLOBAL_COMMENT = 'GLOBAL_COMMENT',
 }
 
-export type EditorMode = 'selection' | 'redline';
+export type EditorMode = 'selection' | 'comment' | 'redline';
 
 export interface Annotation {
   id: string;


### PR DESCRIPTION
## Summary

Implements quick commenting feature requested in #93:

- **Type-to-comment in Selection mode**: Select text → toolbar shows → start typing → auto-transitions to comment input with your typed character (no click needed!)
- **New "Comment" mode**: Dedicated mode where selecting text shows comment input immediately

## Changes

| File | Change |
|------|--------|
| `packages/ui/types.ts` | Add `'comment'` to EditorMode |
| `packages/ui/components/ModeSwitcher.tsx` | Add Comment mode button (between Selection and Redline) |
| `packages/ui/components/AnnotationToolbar.tsx` | Add `initialStep`/`initialType` props, type-to-comment keydown handler, fix autofocus timing |
| `packages/ui/components/Viewer.tsx` | Handle comment mode in CREATE handler |

## Test plan

- [ ] **Selection mode + type**: Select text → toolbar shows → press any key → input appears with that character, cursor at end
- [ ] **Selection mode + click**: Select text → click Comment button → input appears (unchanged behavior)
- [ ] **Comment mode**: Switch to Comment → select text → input appears immediately with autofocus
- [ ] **Redline mode**: Select text → auto-deletion (unchanged)
- [ ] **Escape in comment input**: Goes back to menu (can then close or pick different action)

Closes #93

🤖 Generated with [Claude Code](https://claude.ai/code)