### PR TITLE
fix(opencode-plugin): exclude sub-agents and build agent from prompt injection

### DIFF
--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -63,10 +63,52 @@ export const PlannotatorPlugin: Plugin = async (ctx) => {
     },
 
     // Inject planning instructions into system prompt
-    "experimental.chat.system.transform": async (_input, output) => {
+    "experimental.chat.system.transform": async (input, output) => {
       // Skip for title generation requests
       const existingSystem = output.system.join("\n").toLowerCase();
       if (existingSystem.includes("title generator") || existingSystem.includes("generate a title")) {
+        return;
+      }
+
+      try {
+        // Fetch session messages to determine current agent
+        const messagesResponse = await ctx.client.session.messages({
+          path: { id: input.sessionID }
+        });
+        const messages = messagesResponse.data;
+
+        // Find last user message (reverse iteration)
+        let lastUserAgent: string | undefined;
+        if (messages) {
+          for (let i = messages.length - 1; i >= 0; i--) {
+            const msg = messages[i];
+            if (msg.info.role === "user") {
+              // @ts-ignore - UserMessage has agent field
+              lastUserAgent = msg.info.agent;
+              break;
+            }
+          }
+        }
+
+        // Skip if agent detection fails (safer)
+        if (!lastUserAgent) return;
+
+        // Hardcoded exclusion: build agent
+        if (lastUserAgent === "build") return;
+
+        // Dynamic exclusion: check agent mode via API
+        const agentsResponse = await ctx.client.app.agents({
+          query: { directory: ctx.directory }
+        });
+        const agents = agentsResponse.data;
+        const agent = agents?.find((a: { name: string }) => a.name === lastUserAgent);
+
+        // Skip if agent is a sub-agent
+        // @ts-ignore - Agent has mode field
+        if (agent?.mode === "subagent") return;
+
+      } catch {
+        // Skip injection on any error (safer)
         return;
       }
 


### PR DESCRIPTION
## Summary

- Fixing: #86
- Relevant PRs: #90 #95
- Excluding-focused approach

- Add agent filtering to `experimental.chat.system.transform` hook in the OpenCode plugin
- Exclude "build" agent via hardcoded check
- Exclude sub-agents (mode: "subagent") via dynamic API check
- Skip prompt injection on detection failure (safer behavior)