### PR TITLE
fix: clean up old Windows install locations

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -15,6 +15,19 @@ $arch = if ([Environment]::Is64BitOperatingSystem) {
 $platform = "win32-$arch"
 $binaryName = "plannotator-$platform.exe"
 
+# Clean up old install locations that may take precedence in PATH
+$oldLocations = @(
+    "$env:USERPROFILE\.local\bin\plannotator.exe",
+    "$env:USERPROFILE\.local\bin\plannotator"
+)
+
+foreach ($oldPath in $oldLocations) {
+    if (Test-Path $oldPath) {
+        Write-Host "Removing old installation at $oldPath..."
+        Remove-Item -Force $oldPath -ErrorAction SilentlyContinue
+    }
+}
+
 Write-Host "Fetching latest version..."
 $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$repo/releases/latest"
 $latestTag = $release.tag_name


### PR DESCRIPTION
## Summary

Users with older installations at `~/.local/bin` had PATH conflicts where the old binary took precedence over the new install location (`$env:LOCALAPPDATA\plannotator`).

Fixes #100

## Changes

The PowerShell install script now removes plannotator from old locations before installing:
- `$env:USERPROFILE\.local\bin\plannotator.exe`
- `$env:USERPROFILE\.local\bin\plannotator`

## Test plan

- [ ] Windows user with old `.local\bin` install runs the script
- [ ] Old binary is removed
- [ ] New binary is installed and takes precedence

---

Generated with [Claude Code](https://claude.ai/code)