### PR TITLE
feat: persist editor mode selection between plan reviews

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "plannotator",
@@ -47,7 +48,7 @@
     },
     "apps/opencode-plugin": {
       "name": "@plannotator/opencode",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "dependencies": {
         "@opencode-ai/plugin": "^1.1.10",
       },
@@ -117,7 +118,7 @@
     },
     "packages/server": {
       "name": "@plannotator/server",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "peerDependencies": {
         "bun": ">=1.0.0",
       },

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -19,6 +19,7 @@ import { getObsidianSettings, getEffectiveVaultPath, CUSTOM_PATH_SENTINEL } from
 import { getBearSettings } from '@plannotator/ui/utils/bear';
 import { getAgentSwitchSettings, getEffectiveAgentName } from '@plannotator/ui/utils/agentSwitch';
 import { getPlanSaveSettings } from '@plannotator/ui/utils/planSave';
+import { getEditorMode, saveEditorMode } from '@plannotator/ui/utils/editorMode';
 import {
   getPermissionModeSettings,
   needsPermissionModeSetup,
@@ -332,7 +333,7 @@ const App: React.FC = () => {
   const [showAgentWarning, setShowAgentWarning] = useState(false);
   const [agentWarningMessage, setAgentWarningMessage] = useState('');
   const [isPanelOpen, setIsPanelOpen] = useState(true);
-  const [editorMode, setEditorMode] = useState<EditorMode>('selection');
+  const [editorMode, setEditorMode] = useState<EditorMode>(getEditorMode);
   const [taterMode, setTaterMode] = useState(() => {
     const stored = storage.getItem('plannotator-tater-mode');
     return stored === 'true';
@@ -392,6 +393,11 @@ const App: React.FC = () => {
   const handleTaterModeChange = (enabled: boolean) => {
     setTaterMode(enabled);
     storage.setItem('plannotator-tater-mode', String(enabled));
+  };
+
+  const handleEditorModeChange = (mode: EditorMode) => {
+    setEditorMode(mode);
+    saveEditorMode(mode);
   };
 
   // Check if we're in API mode (served from Bun hook server)
@@ -801,7 +807,7 @@ const App: React.FC = () => {
             <div className="min-h-full flex flex-col items-center px-4 py-3 md:px-10 md:py-8 xl:px-16">
               {/* Mode Switcher */}
               <div className="w-full max-w-[832px] 2xl:max-w-5xl mb-3 md:mb-4 flex justify-start">
-                <ModeSwitcher mode={editorMode} onChange={setEditorMode} taterMode={taterMode} />
+                <ModeSwitcher mode={editorMode} onChange={handleEditorModeChange} taterMode={taterMode} />
               </div>
 
               <Viewer

--- a/packages/ui/utils/editorMode.ts
+++ b/packages/ui/utils/editorMode.ts
@@ -1,0 +1,31 @@
+/**
+ * Editor Mode Settings Utility
+ *
+ * Persists the last-used editor mode (selection, comment, redline) so it
+ * carries over between plan reviews.
+ */
+
+import { storage } from './storage';
+import type { EditorMode } from '../types';
+
+const STORAGE_KEY = 'plannotator-editor-mode';
+
+const DEFAULT_MODE: EditorMode = 'selection';
+
+/**
+ * Get the last-used editor mode from storage
+ */
+export function getEditorMode(): EditorMode {
+  const stored = storage.getItem(STORAGE_KEY);
+  if (stored === 'selection' || stored === 'comment' || stored === 'redline') {
+    return stored;
+  }
+  return DEFAULT_MODE;
+}
+
+/**
+ * Save editor mode to storage
+ */
+export function saveEditorMode(mode: EditorMode): void {
+  storage.setItem(STORAGE_KEY, mode);
+}


### PR DESCRIPTION
## Summary

- Adds persistent state for the editor mode (Selection, Comment, Redline) buttons
- The last selected mode is now remembered between plan reviews using cookie-based storage
- Follows the existing pattern used for taterMode, agentSwitch, and other settings

## Changes

- New `packages/ui/utils/editorMode.ts` utility with `getEditorMode()` and `saveEditorMode()` functions
- Updated `packages/editor/App.tsx` to initialize state from storage and save on mode change