### PR TITLE
feat: import teammate review from share link

### DIFF
--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -3,6 +3,7 @@ import { parseMarkdownToBlocks, exportDiff, extractFrontmatter, Frontmatter } fr
 import { Viewer, ViewerHandle } from '@plannotator/ui/components/Viewer';
 import { AnnotationPanel } from '@plannotator/ui/components/AnnotationPanel';
 import { ExportModal } from '@plannotator/ui/components/ExportModal';
+import { ImportModal } from '@plannotator/ui/components/ImportModal';
 import { ConfirmDialog } from '@plannotator/ui/components/ConfirmDialog';
 import { Annotation, Block, EditorMode } from '@plannotator/ui/types';
 import { ThemeProvider } from '@plannotator/ui/components/ThemeProvider';
@@ -333,6 +334,7 @@ const App: React.FC = () => {
   const [blocks, setBlocks] = useState<Block[]>([]);
   const [frontmatter, setFrontmatter] = useState<Frontmatter | null>(null);
   const [showExport, setShowExport] = useState(false);
+  const [showImport, setShowImport] = useState(false);
   const [showFeedbackPrompt, setShowFeedbackPrompt] = useState(false);
   const [showClaudeCodeWarning, setShowClaudeCodeWarning] = useState(false);
   const [showAgentWarning, setShowAgentWarning] = useState(false);
@@ -375,6 +377,7 @@ const App: React.FC = () => {
     pendingSharedAnnotations,
     sharedGlobalAttachments,
     clearPendingSharedAnnotations,
+    importFromShareUrl,
   } = useSharing(
     markdown,
     annotations,
@@ -605,7 +608,7 @@ const App: React.FC = () => {
       if (tag === 'INPUT' || tag === 'TEXTAREA') return;
 
       // Don't intercept if any modal is open
-      if (showExport || showFeedbackPrompt || showClaudeCodeWarning ||
+      if (showExport || showImport || showFeedbackPrompt || showClaudeCodeWarning ||
           showAgentWarning || showPermissionModeSetup || showUIFeaturesSetup || pendingPasteImage) return;
 
       // Don't intercept if already submitted or submitting
@@ -636,7 +639,7 @@ const App: React.FC = () => {
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [
-    showExport, showFeedbackPrompt, showClaudeCodeWarning, showAgentWarning,
+    showExport, showImport, showFeedbackPrompt, showClaudeCodeWarning, showAgentWarning,
     showPermissionModeSetup, showUIFeaturesSetup, pendingPasteImage,
     submitted, isSubmitting, isApiMode, annotations.length,
     origin, getAgentWarning,
@@ -909,6 +912,19 @@ const App: React.FC = () => {
               </svg>
             </button>
 
+            {sharingEnabled && (
+              <button
+                onClick={() => setShowImport(true)}
+                className="p-1.5 md:px-2.5 md:py-1 rounded-md text-xs font-medium bg-muted hover:bg-muted/80 transition-colors"
+                title="Import teammate review"
+              >
+                <svg className="w-4 h-4 md:hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m4-4l-4 4m0 0l-4-4m4 4V4" />
+                </svg>
+                <span className="hidden md:inline">Import</span>
+              </button>
+            )}
+
             <div className="relative flex" data-export-dropdown>
               <button
                 onClick={() => { setInitialExportTab(undefined); setShowExport(true); }}
@@ -1062,6 +1078,13 @@ const App: React.FC = () => {
           markdown={markdown}
           isApiMode={isApiMode}
           initialTab={initialExportTab}
+        />
+
+        {/* Import Modal */}
+        <ImportModal
+          isOpen={showImport}
+          onClose={() => setShowImport(false)}
+          onImport={importFromShareUrl}
         />
 
         {/* Feedback prompt dialog */}

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -912,19 +912,6 @@ const App: React.FC = () => {
               </svg>
             </button>
 
-            {sharingEnabled && (
-              <button
-                onClick={() => setShowImport(true)}
-                className="p-1.5 md:px-2.5 md:py-1 rounded-md text-xs font-medium bg-muted hover:bg-muted/80 transition-colors"
-                title="Import teammate review"
-              >
-                <svg className="w-4 h-4 md:hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m4-4l-4 4m0 0l-4-4m4 4V4" />
-                </svg>
-                <span className="hidden md:inline">Import</span>
-              </button>
-            )}
-
             <div className="relative flex" data-export-dropdown>
               <button
                 onClick={() => { setInitialExportTab(undefined); setShowExport(true); }}
@@ -1003,6 +990,23 @@ const App: React.FC = () => {
                     <div className="px-3 py-2 text-[10px] text-muted-foreground">
                       No notes apps configured.
                     </div>
+                  )}
+                  {sharingEnabled && (
+                    <>
+                      <div className="my-1 border-t border-border" />
+                      <button
+                        onClick={() => {
+                          setShowExportDropdown(false);
+                          setShowImport(true);
+                        }}
+                        className="w-full text-left px-3 py-1.5 text-xs hover:bg-muted transition-colors flex items-center gap-2"
+                      >
+                        <svg className="w-3.5 h-3.5 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m4-4l-4 4m0 0l-4-4m4 4V4" />
+                        </svg>
+                        Import Review
+                      </button>
+                    </>
                   )}
                 </div>
               )}

--- a/packages/ui/components/ImportModal.tsx
+++ b/packages/ui/components/ImportModal.tsx
@@ -1,0 +1,138 @@
+/**
+ * Import Modal for loading teammate annotations from a share URL
+ */
+
+import React, { useState } from 'react';
+import type { ImportResult } from '../hooks/useSharing';
+
+interface ImportModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onImport: (url: string) => Promise<ImportResult>;
+}
+
+export const ImportModal: React.FC<ImportModalProps> = ({
+  isOpen,
+  onClose,
+  onImport,
+}) => {
+  const [url, setUrl] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<ImportResult | null>(null);
+
+  if (!isOpen) return null;
+
+  const handleImport = async () => {
+    if (!url.trim()) return;
+    setLoading(true);
+    setResult(null);
+    const res = await onImport(url.trim());
+    setResult(res);
+    setLoading(false);
+    if (res.success && res.count > 0) {
+      // Auto-close after successful import
+      setTimeout(() => {
+        setUrl('');
+        setResult(null);
+        onClose();
+      }, 1500);
+    }
+  };
+
+  const handleClose = () => {
+    setUrl('');
+    setResult(null);
+    onClose();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !loading) {
+      handleImport();
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm p-4">
+      <div
+        className="bg-card border border-border rounded-xl w-full max-w-lg flex flex-col shadow-2xl"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="p-4 border-b border-border">
+          <div className="flex justify-between items-center">
+            <h3 className="font-semibold text-sm">Import Teammate Review</h3>
+            <button
+              onClick={handleClose}
+              className="p-1.5 rounded-md hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        {/* Body */}
+        <div className="p-4 space-y-4">
+          <div>
+            <label className="block text-xs font-medium text-muted-foreground mb-2">
+              Plannotator Share Link
+            </label>
+            <input
+              type="text"
+              value={url}
+              onChange={e => setUrl(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="https://share.plannotator.ai/#..."
+              className="w-full bg-muted rounded-lg px-3 py-2 text-xs font-mono focus:outline-none focus:ring-2 focus:ring-accent/50"
+              disabled={loading}
+              autoFocus
+            />
+          </div>
+
+          <p className="text-xs text-muted-foreground">
+            Paste a share link from a teammate to import their annotations into the current plan review.
+          </p>
+
+          {/* Result feedback */}
+          {result && (
+            <div className={`rounded-lg px-3 py-2 text-xs ${
+              result.success && result.count > 0
+                ? 'bg-green-500/10 text-green-600 dark:text-green-400'
+                : result.success && result.count === 0
+                ? 'bg-yellow-500/10 text-yellow-600 dark:text-yellow-400'
+                : 'bg-destructive/10 text-destructive'
+            }`}>
+              {result.success && result.count > 0 && (
+                <span>Imported {result.count} annotation{result.count !== 1 ? 's' : ''} from "{result.planTitle}"</span>
+              )}
+              {result.success && result.count === 0 && (
+                <span>{result.error || 'No new annotations to import (all already exist)'}</span>
+              )}
+              {!result.success && (
+                <span>{result.error || 'Failed to import'}</span>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="p-4 border-t border-border flex justify-end gap-2">
+          <button
+            onClick={handleClose}
+            className="px-3 py-1.5 rounded-md text-xs font-medium bg-muted hover:bg-muted/80 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleImport}
+            disabled={!url.trim() || loading}
+            className="px-3 py-1.5 rounded-md text-xs font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {loading ? 'Importing...' : 'Import'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/ui/components/ImportModal.tsx
+++ b/packages/ui/components/ImportModal.tsx
@@ -2,7 +2,7 @@
  * Import Modal for loading teammate annotations from a share URL
  */
 
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import type { ImportResult } from '../hooks/useSharing';
 
 interface ImportModalProps {
@@ -19,6 +19,7 @@ export const ImportModal: React.FC<ImportModalProps> = ({
   const [url, setUrl] = useState('');
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<ImportResult | null>(null);
+  const autoCloseTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   if (!isOpen) return null;
 
@@ -31,7 +32,8 @@ export const ImportModal: React.FC<ImportModalProps> = ({
     setLoading(false);
     if (res.success && res.count > 0) {
       // Auto-close after successful import
-      setTimeout(() => {
+      autoCloseTimer.current = setTimeout(() => {
+        autoCloseTimer.current = null;
         setUrl('');
         setResult(null);
         onClose();
@@ -40,6 +42,10 @@ export const ImportModal: React.FC<ImportModalProps> = ({
   };
 
   const handleClose = () => {
+    if (autoCloseTimer.current) {
+      clearTimeout(autoCloseTimer.current);
+      autoCloseTimer.current = null;
+    }
     setUrl('');
     setResult(null);
     onClose();

--- a/packages/ui/hooks/useSharing.ts
+++ b/packages/ui/hooks/useSharing.ts
@@ -12,9 +12,17 @@ import { Annotation } from '../types';
 import {
   parseShareHash,
   generateShareUrl,
+  decompress,
   fromShareable,
   formatUrlSize,
 } from '../utils/sharing';
+
+export interface ImportResult {
+  success: boolean;
+  count: number;
+  planTitle: string;
+  error?: string;
+}
 
 interface UseSharingResult {
   /** Whether the current session was loaded from a shared URL */
@@ -40,6 +48,9 @@ interface UseSharingResult {
 
   /** Manually trigger share URL generation */
   refreshShareUrl: () => Promise<void>;
+
+  /** Import annotations from a teammate's share URL */
+  importFromShareUrl: (url: string) => Promise<ImportResult>;
 }
 
 export function useSharing(
@@ -142,6 +153,64 @@ export function useSharing(
     refreshShareUrl();
   }, [refreshShareUrl]);
 
+  // Import annotations from a teammate's share URL
+  const importFromShareUrl = useCallback(async (url: string): Promise<ImportResult> => {
+    try {
+      // Extract hash from URL
+      const hashIndex = url.indexOf('#');
+      if (hashIndex === -1) {
+        return { success: false, count: 0, planTitle: '', error: 'Invalid share URL: no hash fragment found' };
+      }
+      const hash = url.slice(hashIndex + 1);
+      if (!hash) {
+        return { success: false, count: 0, planTitle: '', error: 'Invalid share URL: empty hash' };
+      }
+
+      // Decompress payload
+      const payload = await decompress(hash);
+
+      // Extract plan title from embedded plan text
+      const lines = (payload.p || '').trim().split('\n');
+      const titleLine = lines.find(l => l.startsWith('#'));
+      const planTitle = titleLine ? titleLine.replace(/^#+\s*/, '').trim() : 'Unknown Plan';
+
+      // Convert to full annotations
+      const importedAnnotations = fromShareable(payload.a);
+
+      if (importedAnnotations.length === 0) {
+        return { success: true, count: 0, planTitle, error: 'No annotations found in share link' };
+      }
+
+      // Deduplicate: skip annotations that already exist (by originalText + type + text)
+      const newAnnotations = importedAnnotations.filter(imp =>
+        !annotations.some(existing =>
+          existing.originalText === imp.originalText &&
+          existing.type === imp.type &&
+          existing.text === imp.text
+        )
+      );
+
+      if (newAnnotations.length > 0) {
+        // Merge: append new annotations to existing ones
+        setAnnotations([...annotations, ...newAnnotations]);
+
+        // Set as pending so they get applied to DOM highlights
+        setPendingSharedAnnotations(newAnnotations);
+
+        // Handle global attachments
+        if (payload.g?.length) {
+          setGlobalAttachments([...globalAttachments, ...payload.g]);
+          setSharedGlobalAttachments(payload.g);
+        }
+      }
+
+      return { success: true, count: newAnnotations.length, planTitle };
+    } catch (e) {
+      const errorMessage = e instanceof Error ? e.message : 'Failed to decompress share URL';
+      return { success: false, count: 0, planTitle: '', error: errorMessage };
+    }
+  }, [annotations, globalAttachments, setAnnotations, setGlobalAttachments]);
+
   return {
     isSharedSession,
     isLoadingShared,
@@ -151,5 +220,6 @@ export function useSharing(
     sharedGlobalAttachments,
     clearPendingSharedAnnotations,
     refreshShareUrl,
+    importFromShareUrl,
   };
 }

--- a/packages/ui/hooks/useSharing.ts
+++ b/packages/ui/hooks/useSharing.ts
@@ -197,9 +197,12 @@ export function useSharing(
         // Set as pending so they get applied to DOM highlights
         setPendingSharedAnnotations(newAnnotations);
 
-        // Handle global attachments
+        // Handle global attachments (deduplicate by path)
         if (payload.g?.length) {
-          setGlobalAttachments([...globalAttachments, ...payload.g]);
+          const newPaths = payload.g.filter(p => !globalAttachments.includes(p));
+          if (newPaths.length > 0) {
+            setGlobalAttachments([...globalAttachments, ...newPaths]);
+          }
           setSharedGlobalAttachments(payload.g);
         }
       }


### PR DESCRIPTION
## Summary
- Adds an **Import** button to the header toolbar that lets users import annotations from a teammate's plannotator share URL
- New `ImportModal` component with URL input, loading state, and success/error feedback (shows plan title + annotation count)
- `importFromShareUrl()` function in `useSharing` hook that decodes the share link, deserializes annotations, deduplicates against existing ones, and merges into the current session

## Motivation
Currently sharing is one-directional: you can export a share link for a teammate to view, but there's no way to bring their annotations back into your session. This closes that loop.

## Workflow
1. User exports share link → sends to teammate
2. Teammate opens link, adds their own annotations, copies their new share link
3. User clicks **Import** → pastes teammate's link → annotations are merged into the current session

## Test plan
- [ ] Open plannotator in plan review mode
- [ ] Verify Import button appears in header (next to Export) when sharing is enabled
- [ ] Add annotations, copy share URL via Export
- [ ] Open a new session, click Import, paste the share URL
- [ ] Verify annotations appear with highlights and in the annotation panel
- [ ] Verify duplicate annotations are skipped on re-import
- [ ] Verify Import button is hidden when `PLANNOTATOR_SHARE=disabled`

🤖 Generated with [Claude Code](https://claude.com/claude-code)