### PR TITLE
feat: save to notes without approving

### DIFF
--- a/packages/ui/components/ExportModal.tsx
+++ b/packages/ui/components/ExportModal.tsx
@@ -1,11 +1,14 @@
 /**
- * Export Modal with tabs for Share and Raw Diff
+ * Export Modal with tabs for Share, Raw Diff, and Notes
  *
  * Share tab (default): Shows shareable URL with copy button
  * Raw Diff tab: Shows human-readable diff output with copy/download
+ * Notes tab: Save plan to Obsidian/Bear without approving
  */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { getObsidianSettings, getEffectiveVaultPath } from '../utils/obsidian';
+import { getBearSettings } from '../utils/bear';
 
 interface ExportModalProps {
   isOpen: boolean;
@@ -16,9 +19,15 @@ interface ExportModalProps {
   annotationCount: number;
   taterSprite?: React.ReactNode;
   sharingEnabled?: boolean;
+  markdown?: string;
+  isApiMode?: boolean;
+  initialTab?: Tab;
 }
 
-type Tab = 'share' | 'diff';
+type Tab = 'share' | 'diff' | 'notes';
+
+type SaveTarget = 'obsidian' | 'bear';
+type SaveStatus = 'idle' | 'saving' | 'success' | 'error';
 
 export const ExportModal: React.FC<ExportModalProps> = ({
   isOpen,
@@ -29,11 +38,39 @@ export const ExportModal: React.FC<ExportModalProps> = ({
   annotationCount,
   taterSprite,
   sharingEnabled = true,
+  markdown,
+  isApiMode = false,
+  initialTab,
 }) => {
-  const [activeTab, setActiveTab] = useState<Tab>(sharingEnabled ? 'share' : 'diff');
+  const defaultTab = initialTab || (sharingEnabled ? 'share' : 'diff');
+  const [activeTab, setActiveTab] = useState<Tab>(defaultTab);
   const [copied, setCopied] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<Record<SaveTarget, SaveStatus>>({ obsidian: 'idle', bear: 'idle' });
+  const [saveErrors, setSaveErrors] = useState<Record<string, string>>({});
+
+  // Reset tab when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      setActiveTab(initialTab || (sharingEnabled ? 'share' : 'diff'));
+    }
+  }, [isOpen, initialTab, sharingEnabled]);
+
+  // Reset save status when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      setSaveStatus({ obsidian: 'idle', bear: 'idle' });
+      setSaveErrors({});
+    }
+  }, [isOpen]);
 
   if (!isOpen) return null;
+
+  const showNotesTab = isApiMode && !!markdown;
+  const obsidianSettings = getObsidianSettings();
+  const bearSettings = getBearSettings();
+  const effectiveVaultPath = getEffectiveVaultPath(obsidianSettings);
+  const isObsidianReady = obsidianSettings.enabled && effectiveVaultPath.trim().length > 0;
+  const isBearReady = bearSettings.enabled;
 
   const handleCopyUrl = async () => {
     try {
@@ -65,6 +102,56 @@ export const ExportModal: React.FC<ExportModalProps> = ({
     URL.revokeObjectURL(url);
   };
 
+  const handleSaveToNotes = async (target: SaveTarget) => {
+    if (!markdown) return;
+
+    setSaveStatus(prev => ({ ...prev, [target]: 'saving' }));
+    setSaveErrors(prev => { const next = { ...prev }; delete next[target]; return next; });
+
+    const body: { obsidian?: object; bear?: object } = {};
+
+    if (target === 'obsidian') {
+      body.obsidian = {
+        vaultPath: effectiveVaultPath,
+        folder: obsidianSettings.folder || 'plannotator',
+        plan: markdown,
+      };
+    }
+    if (target === 'bear') {
+      body.bear = { plan: markdown };
+    }
+
+    try {
+      const res = await fetch('/api/save-notes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const data = await res.json();
+      const result = data.results?.[target];
+
+      if (result?.success) {
+        setSaveStatus(prev => ({ ...prev, [target]: 'success' }));
+      } else {
+        setSaveStatus(prev => ({ ...prev, [target]: 'error' }));
+        setSaveErrors(prev => ({ ...prev, [target]: result?.error || 'Save failed' }));
+      }
+    } catch {
+      setSaveStatus(prev => ({ ...prev, [target]: 'error' }));
+      setSaveErrors(prev => ({ ...prev, [target]: 'Save failed' }));
+    }
+  };
+
+  const handleSaveAll = async () => {
+    const targets: SaveTarget[] = [];
+    if (isObsidianReady) targets.push('obsidian');
+    if (isBearReady) targets.push('bear');
+    await Promise.all(targets.map(t => handleSaveToNotes(t)));
+  };
+
+  // Determine which tabs to show
+  const showTabs = sharingEnabled || showNotesTab;
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm p-4">
       <div
@@ -95,19 +182,21 @@ export const ExportModal: React.FC<ExportModalProps> = ({
 
         {/* Body */}
         <div className="flex-1 overflow-auto p-4">
-          {/* Tabs - only show if sharing is enabled */}
-          {sharingEnabled && (
+          {/* Tabs */}
+          {showTabs && (
             <div className="flex gap-1 bg-muted rounded-lg p-1 mb-4">
-              <button
-                onClick={() => setActiveTab('share')}
-                className={`flex-1 px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
-                  activeTab === 'share'
-                    ? 'bg-background text-foreground shadow-sm'
-                    : 'text-muted-foreground hover:text-foreground'
-                }`}
-              >
-                Share
-              </button>
+              {sharingEnabled && (
+                <button
+                  onClick={() => setActiveTab('share')}
+                  className={`flex-1 px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
+                    activeTab === 'share'
+                      ? 'bg-background text-foreground shadow-sm'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  Share
+                </button>
+              )}
               <button
                 onClick={() => setActiveTab('diff')}
                 className={`flex-1 px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
@@ -118,11 +207,23 @@ export const ExportModal: React.FC<ExportModalProps> = ({
               >
                 Raw Diff
               </button>
+              {showNotesTab && (
+                <button
+                  onClick={() => setActiveTab('notes')}
+                  className={`flex-1 px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
+                    activeTab === 'notes'
+                      ? 'bg-background text-foreground shadow-sm'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  Notes
+                </button>
+              )}
             </div>
           )}
 
           {/* Tab content */}
-          {sharingEnabled && activeTab === 'share' ? (
+          {activeTab === 'share' && sharingEnabled ? (
             <div className="space-y-4">
               <div>
                 <label className="block text-xs font-medium text-muted-foreground mb-2">
@@ -164,6 +265,110 @@ export const ExportModal: React.FC<ExportModalProps> = ({
               <p className="text-xs text-muted-foreground">
                 This URL contains the full plan and all annotations. Anyone with this link can view and add to your annotations.
               </p>
+            </div>
+          ) : activeTab === 'notes' && showNotesTab ? (
+            <div className="space-y-4">
+              <p className="text-xs text-muted-foreground">
+                Save this plan to your notes app without approving or denying.
+              </p>
+
+              {/* Obsidian */}
+              <div className="border border-border rounded-lg p-3 space-y-2">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className={`w-2 h-2 rounded-full ${isObsidianReady ? 'bg-success' : 'bg-muted-foreground/30'}`} />
+                    <span className="text-sm font-medium">Obsidian</span>
+                  </div>
+                  {isObsidianReady ? (
+                    <button
+                      onClick={() => handleSaveToNotes('obsidian')}
+                      disabled={saveStatus.obsidian === 'saving'}
+                      className={`px-3 py-1 rounded-md text-xs font-medium transition-all ${
+                        saveStatus.obsidian === 'success'
+                          ? 'bg-success/15 text-success'
+                          : saveStatus.obsidian === 'error'
+                            ? 'bg-destructive/15 text-destructive'
+                            : saveStatus.obsidian === 'saving'
+                              ? 'bg-muted text-muted-foreground opacity-50'
+                              : 'bg-primary text-primary-foreground hover:opacity-90'
+                      }`}
+                    >
+                      {saveStatus.obsidian === 'saving' ? 'Saving...'
+                        : saveStatus.obsidian === 'success' ? 'Saved'
+                        : saveStatus.obsidian === 'error' ? 'Failed'
+                        : 'Save'}
+                    </button>
+                  ) : (
+                    <span className="text-xs text-muted-foreground">Not configured</span>
+                  )}
+                </div>
+                {isObsidianReady && (
+                  <div className="text-[10px] text-muted-foreground/70">
+                    {effectiveVaultPath}/{obsidianSettings.folder || 'plannotator'}/
+                  </div>
+                )}
+                {!isObsidianReady && (
+                  <div className="text-[10px] text-muted-foreground/70">
+                    Enable in Settings &gt; Saving &gt; Obsidian
+                  </div>
+                )}
+                {saveErrors.obsidian && (
+                  <div className="text-[10px] text-destructive">{saveErrors.obsidian}</div>
+                )}
+              </div>
+
+              {/* Bear */}
+              <div className="border border-border rounded-lg p-3 space-y-2">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className={`w-2 h-2 rounded-full ${isBearReady ? 'bg-success' : 'bg-muted-foreground/30'}`} />
+                    <span className="text-sm font-medium">Bear</span>
+                  </div>
+                  {isBearReady ? (
+                    <button
+                      onClick={() => handleSaveToNotes('bear')}
+                      disabled={saveStatus.bear === 'saving'}
+                      className={`px-3 py-1 rounded-md text-xs font-medium transition-all ${
+                        saveStatus.bear === 'success'
+                          ? 'bg-success/15 text-success'
+                          : saveStatus.bear === 'error'
+                            ? 'bg-destructive/15 text-destructive'
+                            : saveStatus.bear === 'saving'
+                              ? 'bg-muted text-muted-foreground opacity-50'
+                              : 'bg-primary text-primary-foreground hover:opacity-90'
+                      }`}
+                    >
+                      {saveStatus.bear === 'saving' ? 'Saving...'
+                        : saveStatus.bear === 'success' ? 'Saved'
+                        : saveStatus.bear === 'error' ? 'Failed'
+                        : 'Save'}
+                    </button>
+                  ) : (
+                    <span className="text-xs text-muted-foreground">Not configured</span>
+                  )}
+                </div>
+                {!isBearReady && (
+                  <div className="text-[10px] text-muted-foreground/70">
+                    Enable in Settings &gt; Saving &gt; Bear
+                  </div>
+                )}
+                {saveErrors.bear && (
+                  <div className="text-[10px] text-destructive">{saveErrors.bear}</div>
+                )}
+              </div>
+
+              {/* Save All button */}
+              {isObsidianReady && isBearReady && (
+                <div className="flex justify-end">
+                  <button
+                    onClick={handleSaveAll}
+                    disabled={saveStatus.obsidian === 'saving' || saveStatus.bear === 'saving'}
+                    className="px-3 py-1.5 rounded-md text-xs font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity disabled:opacity-50"
+                  >
+                    Save All
+                  </button>
+                </div>
+              )}
             </div>
           ) : (
             <pre className="bg-muted rounded-lg p-4 text-xs font-mono leading-relaxed overflow-x-auto whitespace-pre-wrap">

--- a/packages/ui/components/Settings.tsx
+++ b/packages/ui/components/Settings.tsx
@@ -35,6 +35,11 @@ import {
   PERMISSION_MODE_OPTIONS,
   type PermissionMode,
 } from '../utils/permissionMode';
+import {
+  getDefaultNotesApp,
+  saveDefaultNotesApp,
+  type DefaultNotesApp,
+} from '../utils/defaultNotesApp';
 import { useAgents } from '../hooks/useAgents';
 
 type SettingsTab = 'general' | 'display' | 'saving';
@@ -66,6 +71,7 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
   const [uiPrefs, setUiPrefs] = useState<UIPreferences>({ tocEnabled: true, stickyActionsEnabled: true });
   const [permissionMode, setPermissionMode] = useState<PermissionMode>('bypassPermissions');
   const [agentWarning, setAgentWarning] = useState<string | null>(null);
+  const [defaultNotesApp, setDefaultNotesApp] = useState<DefaultNotesApp>('ask');
 
   // Fetch available agents for OpenCode
   const { agents: availableAgents, validateAgent, getAgentWarning } = useAgents(origin ?? null);
@@ -88,6 +94,7 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
       setPlanSave(getPlanSaveSettings());
       setUiPrefs(getUIPreferences());
       setPermissionMode(getPermissionModeSettings().mode);
+      setDefaultNotesApp(getDefaultNotesApp());
 
       // Validate agent setting when dialog opens
       if (origin === 'opencode') {
@@ -148,6 +155,11 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
   const handlePermissionModeChange = (mode: PermissionMode) => {
     setPermissionMode(mode);
     savePermissionModeSettings(mode);
+  };
+
+  const handleDefaultNotesAppChange = (app: DefaultNotesApp) => {
+    setDefaultNotesApp(app);
+    saveDefaultNotesApp(app);
   };
 
   const handleRegenerateIdentity = () => {
@@ -476,6 +488,35 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
                           </div>
                         </div>
                       )}
+                    </div>
+
+                    <div className="border-t border-border" />
+
+                    {/* Default Notes App */}
+                    <div className="space-y-2">
+                      <div>
+                        <div className="text-sm font-medium">Default Save Action</div>
+                        <div className="text-xs text-muted-foreground">
+                          Used for keyboard shortcut ({navigator.platform?.includes('Mac') ? 'Cmd' : 'Ctrl'}+S)
+                        </div>
+                      </div>
+                      <select
+                        value={defaultNotesApp}
+                        onChange={(e) => handleDefaultNotesAppChange(e.target.value as DefaultNotesApp)}
+                        className="w-full px-3 py-2 bg-muted rounded-lg text-sm focus:outline-none focus:ring-1 focus:ring-primary/50 cursor-pointer"
+                      >
+                        <option value="ask">Ask each time</option>
+                        <option value="download">Download Diff</option>
+                        {obsidian.enabled && <option value="obsidian">Obsidian</option>}
+                        {bear.enabled && <option value="bear">Bear</option>}
+                      </select>
+                      <div className="text-[10px] text-muted-foreground/70">
+                        {defaultNotesApp === 'ask'
+                          ? 'Opens Export dialog with Notes tab'
+                          : defaultNotesApp === 'download'
+                            ? `${navigator.platform?.includes('Mac') ? 'Cmd' : 'Ctrl'}+S downloads the diff file`
+                            : `${navigator.platform?.includes('Mac') ? 'Cmd' : 'Ctrl'}+S saves directly to ${defaultNotesApp === 'obsidian' ? 'Obsidian' : 'Bear'}`}
+                      </div>
                     </div>
 
                     <div className="border-t border-border" />

--- a/packages/ui/utils/defaultNotesApp.ts
+++ b/packages/ui/utils/defaultNotesApp.ts
@@ -1,0 +1,20 @@
+/**
+ * Default Notes App Preference
+ *
+ * Stores the user's preferred notes app for the Cmd/Ctrl+S shortcut.
+ * Uses cookies (not localStorage) because each hook invocation runs on a random port.
+ */
+
+import { storage } from './storage';
+
+const STORAGE_KEY = 'plannotator-default-notes-app';
+
+export type DefaultNotesApp = 'obsidian' | 'bear' | 'download' | 'ask';
+
+export function getDefaultNotesApp(): DefaultNotesApp {
+  return (storage.getItem(STORAGE_KEY) as DefaultNotesApp) || 'ask';
+}
+
+export function saveDefaultNotesApp(app: DefaultNotesApp): void {
+  storage.setItem(STORAGE_KEY, app);
+}


### PR DESCRIPTION
## Summary

Related to #127. Decouples Obsidian/Bear saves from the approve/deny flow so users can save plans to their notes app independently — useful for manually approving in Claude Code with shift+tab (context clearing).

- **`POST /api/save-notes` endpoint** — reuses existing `saveToObsidian()`/`saveToBear()` without resolving the hook decision
- **"Notes" tab in Export dialog** — per-integration save buttons with status feedback (configured/not configured, saving/success/error)
- **Split Export button** — dropdown with quick actions: Copy Share Link, Download Diff, Save to Obsidian, Save to Bear
- **`Cmd/Ctrl+S` keyboard shortcut** — saves to configured default or opens Notes tab
- **"Default Save Action" setting** — in Settings > Saving, choose between Ask / Download Diff / Obsidian / Bear

## Test plan

- [ ] `bun run dev:hook` — open plan review UI
- [ ] Click Export → verify 3 tabs (Share, Diff, Notes); default tab is Share
- [ ] Notes tab: save buttons show for configured integrations, "not configured" hint for others
- [ ] Export dropdown chevron: Copy Share Link, Download Diff, and configured notes apps appear
- [ ] Quick save from dropdown → toast appears confirming save
- [ ] Set default to Obsidian in Settings > Saving → `Cmd+S` saves directly, toast confirms
- [ ] Set default to "Ask" → `Cmd+S` opens Export dialog on Notes tab
- [ ] Approve flow still triggers Obsidian/Bear as before (no regression)
- [ ] `bun run build:hook && bun run build:opencode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)