### PR TITLE
fix: honor CLAUDE_CONFIG_DIR in install scripts

### DIFF
--- a/scripts/install.cmd
+++ b/scripts/install.cmd
@@ -128,7 +128,11 @@ if !ERRORLEVEL! neq 0 (
 )
 
 REM Install /review slash command
-set "CLAUDE_COMMANDS_DIR=%USERPROFILE%\.claude\commands"
+if defined CLAUDE_CONFIG_DIR (
+    set "CLAUDE_COMMANDS_DIR=%CLAUDE_CONFIG_DIR%\commands"
+) else (
+    set "CLAUDE_COMMANDS_DIR=%USERPROFILE%\.claude\commands"
+)
 if not exist "!CLAUDE_COMMANDS_DIR!" mkdir "!CLAUDE_COMMANDS_DIR!"
 
 (

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -87,7 +87,7 @@ Remove-Item -Recurse -Force "$env:USERPROFILE\.cache\opencode\node_modules\@plan
 Remove-Item -Recurse -Force "$env:USERPROFILE\.bun\install\cache\@plannotator" -ErrorAction SilentlyContinue
 
 # Install Claude Code slash command
-$claudeCommandsDir = "$env:USERPROFILE\.claude\commands"
+$claudeCommandsDir = if ($env:CLAUDE_CONFIG_DIR) { "$env:CLAUDE_CONFIG_DIR\commands" } else { "$env:USERPROFILE\.claude\commands" }
 New-Item -ItemType Directory -Force -Path $claudeCommandsDir | Out-Null
 
 @"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -87,7 +87,7 @@ fi
 rm -rf "$HOME/.cache/opencode/node_modules/@plannotator" "$HOME/.bun/install/cache/@plannotator" 2>/dev/null || true
 
 # Install /review slash command
-CLAUDE_COMMANDS_DIR="$HOME/.claude/commands"
+CLAUDE_COMMANDS_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/commands"
 mkdir -p "$CLAUDE_COMMANDS_DIR"
 
 cat > "$CLAUDE_COMMANDS_DIR/plannotator-review.md" << 'COMMAND_EOF'


### PR DESCRIPTION
## Summary
- All three install scripts (`install.sh`, `install.ps1`, `install.cmd`) now respect the `CLAUDE_CONFIG_DIR` environment variable when installing the `/plannotator-review` slash command
- Falls back to the default `~/.claude/` when the variable is unset
- Only the slash command path is affected — the binary install location and plugin registration are independent of this

Closes #136

## Test plan
- [ ] Run `CLAUDE_CONFIG_DIR=/tmp/test-claude ./scripts/install.sh` and verify the command file lands in `/tmp/test-claude/commands/`
- [ ] Run without `CLAUDE_CONFIG_DIR` set and verify it falls back to `~/.claude/commands/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)