### PR TITLE
feat: add resizable side panels

### DIFF
--- a/packages/review-editor/components/FileTree.tsx
+++ b/packages/review-editor/components/FileTree.tsx
@@ -28,6 +28,7 @@ interface FileTreeProps {
   activeDiffType?: string;
   onSelectDiff?: (diffType: string) => void;
   isLoadingDiff?: boolean;
+  width?: number;
 }
 
 export const FileTree: React.FC<FileTreeProps> = ({
@@ -44,6 +45,7 @@ export const FileTree: React.FC<FileTreeProps> = ({
   activeDiffType,
   onSelectDiff,
   isLoadingDiff,
+  width,
 }) => {
   // Keyboard navigation: j/k or arrow keys
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
@@ -82,7 +84,7 @@ export const FileTree: React.FC<FileTreeProps> = ({
   };
 
   return (
-    <aside className="w-64 border-r border-border bg-card/30 flex flex-col overflow-hidden">
+    <aside className="border-r border-border bg-card/30 flex flex-col flex-shrink-0 overflow-hidden" style={{ width: width ?? 256 }}>
       {/* Header */}
       <div className="p-3 border-b border-border/50">
         <div className="flex items-center justify-between">

--- a/packages/review-editor/components/ReviewPanel.tsx
+++ b/packages/review-editor/components/ReviewPanel.tsx
@@ -17,6 +17,7 @@ interface ReviewPanelProps {
   onSelectAnnotation: (id: string | null) => void;
   onDeleteAnnotation: (id: string) => void;
   feedbackMarkdown?: string;
+  width?: number;
 }
 
 function formatTimestamp(ts: number): string {
@@ -45,6 +46,7 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({
   onSelectAnnotation,
   onDeleteAnnotation,
   feedbackMarkdown,
+  width,
 }) => {
   const [copied, setCopied] = useState(false);
 
@@ -76,7 +78,7 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({
   if (!isOpen) return null;
 
   return (
-    <aside className="w-72 border-l border-border/50 bg-card/30 backdrop-blur-sm flex flex-col">
+    <aside className="border-l border-border/50 bg-card/30 backdrop-blur-sm flex flex-col flex-shrink-0" style={{ width: width ?? 288 }}>
         {/* Header */}
         <div className="p-3 border-b border-border/50">
           <div className="flex items-center justify-between">

--- a/packages/ui/components/AnnotationPanel.tsx
+++ b/packages/ui/components/AnnotationPanel.tsx
@@ -13,6 +13,7 @@ interface PanelProps {
   selectedId: string | null;
   shareUrl?: string;
   sharingEnabled?: boolean;
+  width?: number;
 }
 
 export const AnnotationPanel: React.FC<PanelProps> = ({
@@ -24,7 +25,8 @@ export const AnnotationPanel: React.FC<PanelProps> = ({
   onEdit,
   selectedId,
   shareUrl,
-  sharingEnabled = true
+  sharingEnabled = true,
+  width,
 }) => {
   const [copied, setCopied] = useState(false);
   const sortedAnnotations = [...annotations].sort((a, b) => a.createdA - b.createdA);
@@ -43,7 +45,7 @@ export const AnnotationPanel: React.FC<PanelProps> = ({
   if (!isOpen) return null;
 
   return (
-    <aside className="w-72 border-l border-border/50 bg-card/30 backdrop-blur-sm flex flex-col">
+    <aside className="border-l border-border/50 bg-card/30 backdrop-blur-sm flex flex-col flex-shrink-0" style={{ width: width ?? 288 }}>
       {/* Header */}
       <div className="p-3 border-b border-border/50">
         <div className="flex items-center justify-between">

--- a/packages/ui/components/ResizeHandle.tsx
+++ b/packages/ui/components/ResizeHandle.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import type { ResizeHandleProps as BaseProps } from '../hooks/useResizablePanel';
+
+interface Props extends BaseProps {
+  className?: string;
+}
+
+export const ResizeHandle: React.FC<Props> = ({
+  isDragging,
+  onMouseDown,
+  onDoubleClick,
+  className,
+}) => (
+  <div
+    onMouseDown={onMouseDown}
+    onDoubleClick={onDoubleClick}
+    className={`w-1 cursor-col-resize flex-shrink-0 transition-colors ${
+      isDragging ? 'bg-primary/50' : 'hover:bg-border'
+    }${className ? ` ${className}` : ''}`}
+  />
+);

--- a/packages/ui/components/TableOfContents.tsx
+++ b/packages/ui/components/TableOfContents.tsx
@@ -12,6 +12,7 @@ interface TableOfContentsProps {
   activeId: string | null;
   onNavigate: (blockId: string) => void;
   className?: string;
+  style?: React.CSSProperties;
 }
 
 interface TocItemProps {
@@ -142,6 +143,7 @@ export function TableOfContents({
   activeId,
   onNavigate,
   className = '',
+  style,
 }: TableOfContentsProps) {
   // Calculate annotation counts per section
   const annotationCounts = useMemo(
@@ -192,6 +194,7 @@ export function TableOfContents({
     <nav
       className={`bg-card/50 backdrop-blur-sm border-r border-border overflow-y-auto ${className}`}
       aria-label="Table of contents"
+      style={style}
     >
       <div className="p-4">
         <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">

--- a/packages/ui/hooks/useResizablePanel.ts
+++ b/packages/ui/hooks/useResizablePanel.ts
@@ -1,0 +1,84 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { storage } from '../utils/storage';
+
+interface UseResizablePanelOptions {
+  storageKey: string;
+  defaultWidth?: number;
+  minWidth?: number;
+  maxWidth?: number;
+  side?: 'left' | 'right';
+}
+
+export interface ResizeHandleProps {
+  isDragging: boolean;
+  onMouseDown: (e: React.MouseEvent) => void;
+  onDoubleClick: () => void;
+}
+
+export function useResizablePanel({
+  storageKey,
+  defaultWidth = 288,
+  minWidth = 200,
+  maxWidth = 600,
+  side = 'right',
+}: UseResizablePanelOptions) {
+  const [width, setWidth] = useState(() => {
+    const saved = storage.getItem(storageKey);
+    if (saved) {
+      const n = Number(saved);
+      if (!Number.isNaN(n) && n >= minWidth && n <= maxWidth) return n;
+    }
+    return defaultWidth;
+  });
+
+  const [isDragging, setIsDragging] = useState(false);
+  const startXRef = useRef(0);
+  const startWidthRef = useRef(0);
+  const widthRef = useRef(width);
+
+  const updateWidth = useCallback((value: number) => {
+    widthRef.current = value;
+    setWidth(value);
+  }, []);
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    startXRef.current = e.clientX;
+    startWidthRef.current = widthRef.current;
+    setIsDragging(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isDragging) return;
+
+    const onMove = (e: MouseEvent) => {
+      const delta = side === 'right'
+        ? startXRef.current - e.clientX
+        : e.clientX - startXRef.current;
+      updateWidth(Math.min(maxWidth, Math.max(minWidth, startWidthRef.current + delta)));
+    };
+
+    const onUp = () => {
+      setIsDragging(false);
+      storage.setItem(storageKey, String(widthRef.current));
+    };
+
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+    return () => {
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+    };
+  }, [isDragging, minWidth, maxWidth, storageKey, side, updateWidth]);
+
+  const resetWidth = useCallback(() => {
+    updateWidth(defaultWidth);
+    storage.setItem(storageKey, String(defaultWidth));
+  }, [defaultWidth, storageKey, updateWidth]);
+
+  return {
+    width,
+    isDragging,
+    handleProps: { isDragging, onMouseDown: handleMouseDown, onDoubleClick: resetWidth } as ResizeHandleProps,
+  };
+}


### PR DESCRIPTION
## Summary

- Drag-to-resize for annotation panel, table of contents, and file tree sidebar
- Panel widths persist in cookie storage across sessions and random-port hook invocations
- Double-click the drag handle to reset to default width

## Changes

### New files
- `packages/ui/hooks/useResizablePanel.ts` — Shared hook with `left`/`right` side support, cookie persistence, `handleProps` spread API
- `packages/ui/components/ResizeHandle.tsx` — Drag handle component (4px, `hover:bg-border`, `bg-primary/50` while dragging)

### Modified files
- `packages/ui/components/AnnotationPanel.tsx` — `width` prop, `flex-shrink-0`
- `packages/ui/components/TableOfContents.tsx` — `style` prop
- `packages/review-editor/components/ReviewPanel.tsx` — `width` prop, `flex-shrink-0`
- `packages/review-editor/components/FileTree.tsx` — `width` prop, `flex-shrink-0`
- `packages/editor/App.tsx` — Integrate TOC + annotation panel resize
- `packages/review-editor/App.tsx` — Integrate file tree + annotation panel resize

## Panel defaults

| Panel | Default | Min | Max | Storage key |
|-------|---------|-----|-----|-------------|
| Annotation (plan) | 288px | 200 | 600 | `plannotator-panel-width` |
| Annotation (review) | 288px | 200 | 600 | `plannotator-review-panel-width` |
| Table of Contents | 240px | 160 | 400 | `plannotator-toc-width` |
| File Tree | 256px | 160 | 400 | `plannotator-filetree-width` |