### PR TITLE
feat: Close annotation toolbar on ESC key press

### DIFF
--- a/packages/ui/components/AnnotationToolbar.tsx
+++ b/packages/ui/components/AnnotationToolbar.tsx
@@ -129,10 +129,12 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
     if (step !== "menu") return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
+      // Escape closes the toolbar
+      if (e.key === "Escape") { onClose(); return; }
       // Ignore if modifier keys are held (except shift for capitals)
       if (e.ctrlKey || e.metaKey || e.altKey) return;
       // Ignore special keys
-      if (e.key === "Escape" || e.key === "Tab" || e.key === "Enter") return;
+      if (e.key === "Tab" || e.key === "Enter") return;
       // Only trigger on printable characters (single char keys)
       if (e.key.length !== 1) return;
 


### PR DESCRIPTION
 ## Summary

  - Allow users to dismiss the annotation toolbar by pressing ESC
  - Moves ESC from the ignored keys list to an active `onClose()` handler