### PR TITLE
fix: mermaid diagrams clipped due to fixed SVG dimensions

### DIFF
--- a/packages/ui/components/MermaidBlock.tsx
+++ b/packages/ui/components/MermaidBlock.tsx
@@ -96,8 +96,9 @@ export const MermaidBlock: React.FC<{ block: Block }> = ({ block }) => {
         const id = `mermaid-${block.id}`;
         const { svg: renderedSvg } = await mermaid.render(id, block.content);
         const cleaned = renderedSvg
-          .replace(/ width="[^"]*"/, '')
-          .replace(/ height="[^"]*"/, '');
+          .replace(/ width="[^"]*"/, ' width="100%"')
+          .replace(/ height="[^"]*"/, ' height="100%"')
+          .replace(/ style="[^"]*"/, '');
         setSvg(cleaned);
         setError(null);
       } catch (err) {


### PR DESCRIPTION
## Summary

- Replace stripped SVG `width`/`height` with `100%` so diagrams fill the container
- Remove Mermaid's inline `style` attribute to clear `max-width` constraint
- `viewBox` continues to handle content scaling and zoom/pan as before

Fixes #155

## Test plan

- [x] Verify flowchart, sequence, gantt, and other diagram types render at full container width
- [x] Verify zoom in/out and pan controls still work correctly
- [x] Verify fit-to-screen button resets view properly
- [x] Verify diagrams with different aspect ratios scale correctly