### PR TITLE
fix(browser): use open -a only for PLANNOTATOR_BROWSER on macOS

### DIFF
--- a/packages/server/browser.ts
+++ b/packages/server/browser.ts
@@ -52,8 +52,8 @@ export async function openBrowser(url: string): Promise<boolean> {
       const plannotatorBrowser = process.env.PLANNOTATOR_BROWSER;
       if (plannotatorBrowser && platform === "darwin") {
         await $`open -a ${plannotatorBrowser} ${url}`.quiet();
-      } else if (platform === "win32" || wsl) {
-        await $`cmd.exe /c start "" ${browser} ${url}`.quiet();
+      } else if ((platform === "win32" || wsl) && plannotatorBrowser) {
+        await $`cmd.exe /c start "" ${plannotatorBrowser} ${url}`.quiet();
       } else {
         await $`${browser} ${url}`.quiet();
       }

--- a/packages/server/browser.ts
+++ b/packages/server/browser.ts
@@ -49,9 +49,9 @@ export async function openBrowser(url: string): Promise<boolean> {
     const wsl = await isWSL();
 
     if (browser) {
-      // Custom browser specified (PLANNOTATOR_BROWSER takes priority over BROWSER)
-      if (platform === "darwin") {
-        await $`open -a ${browser} ${url}`.quiet();
+      const plannotatorBrowser = process.env.PLANNOTATOR_BROWSER;
+      if (plannotatorBrowser && platform === "darwin") {
+        await $`open -a ${plannotatorBrowser} ${url}`.quiet();
       } else if (platform === "win32" || wsl) {
         await $`cmd.exe /c start "" ${browser} ${url}`.quiet();
       } else {


### PR DESCRIPTION
  open -a expects a macOS application name (e.g. "Google Chrome"), not a shell command. When BROWSER=open, the previous code invoked open -a open <url>, which exits with Unable to find application named 'open'.

  This also breaks VS Code devcontainers, which set BROWSER to a script path (/path/to/helpers/browser.sh) — as seen in VS Code's source. This was the primary motivation behind PR #153, but the implementation incorrectly routed BROWSER through open -a on macOS.

https://github.com/microsoft/vscode/blob/790026d0e1c167f9b09a977ddedcbb0d193e3658/src/vs/server/node/extensionHostConnection.ts#L63

  PLANNOTATOR_BROWSER retains its macOS-specific behavior (open -a <app-name>). BROWSER is now executed directly as $BROWSER <url> on all platforms.