### PR TITLE
fix(server): prevent arbitrary file read via /api/image

### DIFF
--- a/packages/server/annotate.ts
+++ b/packages/server/annotate.ts
@@ -15,6 +15,7 @@ import { mkdirSync } from "fs";
 import { isRemoteSession, getServerPort } from "./remote";
 import { openBrowser } from "./browser";
 import { getRepoInfo } from "./repo";
+import { validateImagePath, validateUploadExtension, UPLOAD_DIR } from "./image";
 
 // Re-export utilities
 export { isRemoteSession, getServerPort } from "./remote";
@@ -129,8 +130,12 @@ export async function startAnnotateServer(
             if (!imagePath) {
               return new Response("Missing path parameter", { status: 400 });
             }
+            const validation = validateImagePath(imagePath);
+            if (!validation.valid) {
+              return new Response(validation.error!, { status: 403 });
+            }
             try {
-              const file = Bun.file(imagePath);
+              const file = Bun.file(validation.resolved);
               if (!(await file.exists())) {
                 return new Response("File not found", { status: 404 });
               }
@@ -149,10 +154,12 @@ export async function startAnnotateServer(
                 return new Response("No file provided", { status: 400 });
               }
 
-              const ext = file.name.split(".").pop() || "png";
-              const tempDir = "/tmp/plannotator";
-              mkdirSync(tempDir, { recursive: true });
-              const tempPath = `${tempDir}/${crypto.randomUUID()}.${ext}`;
+              const extResult = validateUploadExtension(file.name);
+              if (!extResult.valid) {
+                return Response.json({ error: extResult.error }, { status: 400 });
+              }
+              mkdirSync(UPLOAD_DIR, { recursive: true });
+              const tempPath = `${UPLOAD_DIR}/${crypto.randomUUID()}.${extResult.ext}`;
 
               await Bun.write(tempPath, file);
               return Response.json({ path: tempPath, originalName: file.name });

--- a/packages/server/image.ts
+++ b/packages/server/image.ts
@@ -1,0 +1,65 @@
+import { resolve } from "path";
+
+const ALLOWED_IMAGE_EXTENSIONS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+  "svg",
+  "bmp",
+  "ico",
+  "tiff",
+  "tif",
+  "avif",
+]);
+
+const UPLOAD_DIR = "/tmp/plannotator";
+
+function getExtension(filePath: string): string {
+  const lastDot = filePath.lastIndexOf(".");
+  if (lastDot === -1) return "";
+  return filePath.slice(lastDot + 1).toLowerCase();
+}
+
+function hasImageExtension(filePath: string): boolean {
+  return ALLOWED_IMAGE_EXTENSIONS.has(getExtension(filePath));
+}
+
+export function validateImagePath(rawPath: string): {
+  valid: boolean;
+  resolved: string;
+  error?: string;
+} {
+  const resolved = resolve(rawPath);
+
+  if (!hasImageExtension(resolved)) {
+    return {
+      valid: false,
+      resolved,
+      error: "Path does not point to a supported image file",
+    };
+  }
+
+  return { valid: true, resolved };
+}
+
+export function validateUploadExtension(fileName: string): {
+  valid: boolean;
+  ext: string;
+  error?: string;
+} {
+  const ext = getExtension(fileName) || "png";
+
+  if (!ALLOWED_IMAGE_EXTENSIONS.has(ext)) {
+    return {
+      valid: false,
+      ext,
+      error: `File extension ".${ext}" is not a supported image type`,
+    };
+  }
+
+  return { valid: true, ext };
+}
+
+export { UPLOAD_DIR };


### PR DESCRIPTION
## Summary

The `/api/image` endpoint in all three server files (`index.ts`, `review.ts`, `annotate.ts`) serves files from the local filesystem based on a user-provided `path` query parameter **with no validation**. Since the local HTTP server has no authentication, any process or browser tab on localhost can read arbitrary files as the current user.

**Example exploit:**
```
GET http://localhost:<port>/api/image?path=/etc/passwd
GET http://localhost:<port>/api/image?path=/Users/<user>/.ssh/id_rsa
GET http://localhost:<port>/api/image?path=/Users/<user>/.aws/credentials
```

This is particularly concerning because:
- The server binds to localhost with **no authentication** and **no CORS restrictions**
- The hook timeout is 345,600 seconds (4 days), keeping the server exposed for extended periods
- A malicious webpage could probe common ports to discover the running plannotator server

## Fix

This PR adds a shared `image.ts` validation module used by all three servers:

- **Image extension allowlist** — `/api/image` now only serves files with known image extensions (`png`, `jpg`, `jpeg`, `gif`, `webp`, `svg`, `bmp`, `ico`, `tiff`, `tif`, `avif`)
- **Path normalization** — Uses `path.resolve()` to eliminate `../` traversal sequences before validation
- **Upload extension validation** — The `/api/upload` endpoint now validates uploaded file extensions against the same allowlist instead of accepting any extension

### Files changed
- `packages/server/image.ts` — New shared validation module
- `packages/server/index.ts` — Plan server: uses validated paths
- `packages/server/review.ts` — Review server: uses validated paths
- `packages/server/annotate.ts` — Annotate server: uses validated paths

## Test plan

- [ ] Verify `/api/image?path=/tmp/plannotator/<uuid>.png` still serves uploaded images
- [ ] Verify `/api/image?path=/etc/passwd` returns 403
- [ ] Verify `/api/image?path=../../etc/passwd` returns 403
- [ ] Verify `/api/image?path=/some/file.txt` returns 403
- [ ] Verify uploading a `.png` file succeeds
- [ ] Verify uploading a `.sh` file returns 400
- [ ] Verify manual image path references with valid extensions still work