### PR TITLE
fix(server): prevent permission mode override from unauthenticated request

### DIFF
--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -244,7 +244,6 @@ export async function startPlannotatorServer(
             // Check for note integrations and optional feedback
             let feedback: string | undefined;
             let agentSwitch: string | undefined;
-            let requestedPermissionMode: string | undefined;
             let planSaveEnabled = true; // default to enabled for backwards compat
             let planSaveCustomPath: string | undefined;
             try {
@@ -254,7 +253,6 @@ export async function startPlannotatorServer(
                 feedback?: string;
                 agentSwitch?: string;
                 planSave?: { enabled: boolean; customPath?: string };
-                permissionMode?: string;
               };
 
               // Capture feedback if provided (for "approve with notes")
@@ -265,11 +263,6 @@ export async function startPlannotatorServer(
               // Capture agent switch setting for OpenCode
               if (body.agentSwitch) {
                 agentSwitch = body.agentSwitch;
-              }
-
-              // Capture permission mode from client request (Claude Code)
-              if (body.permissionMode) {
-                requestedPermissionMode = body.permissionMode;
               }
 
               // Capture plan save settings
@@ -312,9 +305,8 @@ export async function startPlannotatorServer(
               savedPath = saveFinalSnapshot(slug, "approved", plan, diff, planSaveCustomPath);
             }
 
-            // Use permission mode from client request if provided, otherwise fall back to hook input
-            const effectivePermissionMode = requestedPermissionMode || permissionMode;
-            resolveDecision({ approved: true, feedback, savedPath, agentSwitch, permissionMode: effectivePermissionMode });
+            // Always use the permission mode from the hook event (stdin), never from the browser
+            resolveDecision({ approved: true, feedback, savedPath, agentSwitch, permissionMode });
             return Response.json({ ok: true, savedPath });
           }
 


### PR DESCRIPTION
## Summary

The `/api/approve` endpoint in the plan server accepts a `permissionMode` field from the browser POST body. This value **takes priority** over the trusted `permissionMode` received from the Claude Code hook event via stdin:

```typescript
// Before: browser value overrides trusted hook event value
const effectivePermissionMode = requestedPermissionMode || permissionMode;
```

The resulting value flows directly into Claude Code's `updatedPermissions` with `setMode`, which changes the session's permission level:

```json
{
  "hookSpecificOutput": {
    "decision": {
      "behavior": "allow",
      "updatedPermissions": [{ "type": "setMode", "mode": "<attacker-controlled>", "destination": "session" }]
    }
  }
}
```

Since the local HTTP server has **no authentication**, any process on localhost can POST to `/api/approve` with an arbitrary `permissionMode` value to escalate the Claude Code session's permission level.

## Fix

Remove the `permissionMode` field from the `/api/approve` request body type. The server now exclusively uses the `permissionMode` from the original hook event (stdin), which is the trusted source provided by Claude Code itself.

```typescript
// After: only use the trusted value from the hook event
resolveDecision({ approved: true, feedback, savedPath, agentSwitch, permissionMode });
```

### Files changed
- `packages/server/index.ts` — Remove browser `permissionMode` override in `/api/approve` handler

## Test plan

- [ ] Verify plan approval still works correctly
- [ ] Verify the session permission mode is preserved as-is after plan approval
- [ ] Verify `/api/approve` POST body no longer accepts `permissionMode`