### PR TITLE
fix(opencode-plugin): move bundled workspace dep to devDependencies

### DIFF
--- a/apps/opencode-plugin/package.json
+++ b/apps/opencode-plugin/package.json
@@ -35,7 +35,9 @@
     "prepublishOnly": "bun run build"
   },
   "dependencies": {
-    "@opencode-ai/plugin": "^1.1.10",
+    "@opencode-ai/plugin": "^1.1.10"
+  },
+  "devDependencies": {
     "@plannotator/server": "workspace:*"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Problem

`@plannotator/opencode@0.8.3` is broken for all consumers. Installing it via npm/bun fails with `BunInstallFailedError` because the published package.json contains a `workspace:*` dependency on `@plannotator/server`, which is unresolvable outside the monorepo.

The regression was introduced in #162 (commit 3a9a38e), which added `"@plannotator/server": "workspace:*"` to `dependencies`. Prior versions (0.8.2 and earlier) did not have this dependency and installed correctly.

## Fix

Move `@plannotator/server` from `dependencies` to `devDependencies`. This is safe because the build script already bundles it into `dist/index.js` (only `@opencode-ai/plugin` is externalized via `--external`), so consumers never need to resolve it at install time.

Verified the full build (`bun run build`) still succeeds with this change.