### PR TITLE
ci(release): add automated npm publishing with OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,18 +4,31 @@ on:
   push:
     tags:
       - 'v*'
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Validate build and npm publish without uploading
+        type: boolean
+        default: true
 
 permissions:
   contents: write
+  id-token: write
+
+env:
+  DRY_RUN: ${{ !(startsWith(github.ref, 'refs/tags/') || inputs.dry-run == 'false') }}
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
         with:
           bun-version: latest
 
@@ -50,7 +63,7 @@ jobs:
           sha256sum plannotator-win32-x64.exe > plannotator-win32-x64.exe.sha256
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: binaries
           path: |
@@ -59,15 +72,16 @@ jobs:
 
   release:
     needs: build
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: binaries
           path: artifacts
@@ -76,9 +90,53 @@ jobs:
         run: ls -la artifacts/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           files: artifacts/*
           generate_release_notes: true
           draft: false
           prerelease: ${{ contains(github.ref, '-') }}
+
+  npm-publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
+        with:
+          bun-version: latest
+
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build packages
+        run: |
+          bun run build:review
+          bun run build:hook
+          bun run build:opencode
+          bun run build:pi
+
+      - name: Publish @plannotator/opencode
+        working-directory: apps/opencode-plugin
+        run: |
+          bun pm pack
+          if [[ "$DRY_RUN" == "false" ]]; then
+            npm publish *.tgz --provenance --access public
+          fi
+
+      - name: Publish @plannotator/pi-extension
+        working-directory: apps/pi-extension
+        run: |
+          bun pm pack
+          if [[ "$DRY_RUN" == "false" ]]; then
+            npm publish *.tgz --provenance --access public
+          fi


### PR DESCRIPTION
## Summary

Adds automated npm publishing to the release workflow for `@plannotator/opencode` and `@plannotator/pi-extension`, using npm's OIDC trusted publishing (no long-lived secrets required). Also adds CI smoke testing on pull requests and a manual dry-run trigger.

## What changed

The `release.yml` workflow now has three trigger events and a new `npm-publish` job:

### Triggers

- **Tag push (`v*`)**: Full release. Builds binaries, creates GitHub Release, and publishes both packages to npm with provenance attestations. This is the existing behavior plus npm publishing.
- **Pull request (to `main`)**: Smoke test. Runs the full build pipeline and packs the npm packages without publishing. Catches build breakage before merge. The `release` job is skipped (no tag).
- **Manual dispatch (`workflow_dispatch`)**: On-demand validation. Has a "dry run" checkbox (default: checked) that controls whether npm publish actually uploads. Useful for verifying the pipeline end-to-end.

### Dry-run logic

A workflow-level `DRY_RUN` env var is derived once and used everywhere:

| Trigger | `DRY_RUN` | npm behavior | GitHub Release |
|---|---|---|---|
| Tag push | `false` | Real publish | Created |
| Pull request | `true` | `bun pm pack` only | Skipped |
| Manual, default | `true` | `bun pm pack` only | Skipped |
| Manual, unchecked | `false` | Real publish | Skipped (no tag) |

### npm publishing approach

`bun publish` does not yet support OIDC or provenance ([oven-sh/bun#15601](https://github.com/oven-sh/bun/issues/15601)), so the job uses a two-step approach:

1. **`bun pm pack`** builds the tarball and resolves `workspace:*` references
2. **`npm publish *.tgz --provenance --access public`** publishes via OIDC with provenance attestation

This keeps the build on bun while using npm CLI for the publish step, which supports [trusted publishing](https://docs.npmjs.com/trusted-publishers/) natively.

### Other changes

- Action versions pinned to full SHA (supply chain hardening)
- `id-token: write` permission added at workflow level for OIDC
- `release` job gated at job level with `if: startsWith(github.ref, 'refs/tags/')` instead of always running

## Setup required before first publish

### Configure trusted publishers on npmjs.com

For each package (`@plannotator/opencode` and `@plannotator/pi-extension`):

1. Go to **npmjs.com** > your package > **Settings** > **Trusted Publisher**
2. Select **GitHub Actions**
3. Fill in:
   - **Organization or user**: `backnotprop`
   - **Repository**: `plannotator`
   - **Workflow filename**: `release.yml`
   - **Environment name**: (leave blank)

Full instructions: [npm trusted publishing docs](https://docs.npmjs.com/trusted-publishers/)

### That's it

No `NPM_TOKEN` secret or any other repository configuration is needed. OIDC trusted publishing uses short-lived tokens generated per workflow run, authenticated by GitHub's OIDC provider. Provenance attestations are generated automatically, giving consumers a verified link from the published package back to the source commit and workflow that built it ([npm provenance docs](https://docs.npmjs.com/generating-provenance-statements)).

## Testing

Validated on my fork ([rcdailey/plannotator](https://github.com/rcdailey/plannotator/actions/runs/22264343163)) using dry-run mode. Both packages pack successfully with correct contents and resolved workspace dependencies.