### PR TITLE
feat(opencode): require question tool before plan submission

### DIFF
--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -124,7 +124,7 @@ export const PlannotatorPlugin: Plugin = async (ctx) => {
       output.system.push(`
 ## Plan Submission
 
-When you have completed your plan, you MUST call the \`submit_plan\` tool to submit it for user review.
+When you have completed your plan and have asked the user about any key decisions or trade-offs using the \`question\` tool, you MUST call the \`submit_plan\` tool to submit it for user review.
 The user will be able to:
 - Review your plan visually in a dedicated UI
 - Annotate specific sections with feedback
@@ -293,7 +293,7 @@ Do NOT proceed with implementation until your plan is approved.
     tool: {
       submit_plan: tool({
         description:
-          "Submit your completed plan for interactive user review. The user can annotate, approve, or request changes. Call this when you have finished creating your implementation plan.",
+          "Submit your completed plan for interactive user review. The user can annotate, approve, or request changes. Before calling this tool, ensure you have asked the user about key decisions and trade-offs using the question tool. Call this when your plan is ready for review.",
         args: {
           plan: tool.schema
             .string()


### PR DESCRIPTION
**Current behavior:**
When using OpenCode with Plannotator the agent never asks clarifying questions before submitting the plan.

**Targetted behavior:**
The agent asks clarifying question when appropriate, before submitting the plan.

"MUST call the \`submit_plan\` tool to submit it for user review" seems to override parts of opencode plan mode prompt - more specifically, the part that instructs to ask clarifying questions. https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/session/prompt/plan.txt

**What's changed**
Update system prompt and submit_plan tool description to instruct agents to use the question tool to ask about key decisions and trade-offs before calling submit_plan.