### PR TITLE
fix: respect XDG Base Directory Specification of ~/.local/bin

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,7 +2,7 @@
 set -e
 
 REPO="backnotprop/plannotator"
-INSTALL_DIR="${XDG_DATA_HOME:-$HOME/.local}/bin"
+INSTALL_DIR="$HOME/.local/bin"
 
 case "$(uname -s)" in
     Darwin) os="darwin" ;;


### PR DESCRIPTION
The installer is currently broken for people with a defined `XDG_DATA_HOME` because that env var isn't the place where user-specific executables are meant to go. They go (unconditionally, there is no env var to override it) in `~/.local/bin`

So hardcoding `~/.local/bin` is respecting the XDG spec.

Spec reference for that [here](https://specifications.freedesktop.org/basedir/latest/#variables)