### PR TITLE
fix(opencode): notify URL in remote mode and add 10-min decision timeout

### DIFF
--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -26,7 +26,7 @@ import {
   handleAnnotateServerReady,
 } from "@plannotator/server/annotate";
 import { getGitContext, runGitDiff } from "@plannotator/server/git";
-import os from "node:os";
+import { writeRemoteShareLink } from "@plannotator/server/share-url";
 
 // @ts-ignore - Bun import attribute for text
 import indexHtml from "./plannotator.html" with { type: "text" };
@@ -312,27 +312,24 @@ Do NOT proceed with implementation until your plan is approved.
             shareBaseUrl: getShareBaseUrl(),
             htmlContent,
             opencodeClient: ctx.client,
-            onReady: (url, isRemote, port) => {
+            onReady: async (url, isRemote, port) => {
               handleServerReady(url, isRemote, port);
-              if (isRemote) {
-                const hostname = os.hostname();
-                ctx.client.app.log({
-                  level: "info",
-                  message: `[Plannotator] UI ready — open in browser: http://localhost:${port} (or http://${hostname}:${port} if remote)`,
-                }).catch(() => {});
+              if (isRemote && await getSharingEnabled()) {
+                await writeRemoteShareLink(args.plan, getShareBaseUrl(), "review the plan", "plan only").catch(() => {});
               }
             },
           });
 
           const PLANNOTATOR_TIMEOUT_MS = 10 * 60 * 1000; // 10min timeout
+          let timeoutId: ReturnType<typeof setTimeout>;
           const result = await Promise.race([
-            server.waitForDecision(),
-            new Promise<{ approved: boolean; feedback?: string }>((resolve) =>
-              setTimeout(
+            server.waitForDecision().then((r) => { clearTimeout(timeoutId); return r; }),
+            new Promise<{ approved: boolean; feedback?: string }>((resolve) => {
+              timeoutId = setTimeout(
                 () => resolve({ approved: false, feedback: "[Plannotator] No response within 10 minutes. Port released automatically. Please call submit_plan again." }),
                 PLANNOTATOR_TIMEOUT_MS
-              )
-            ),
+              );
+            }),
           ]);
           await Bun.sleep(1500);
           server.stop();


### PR DESCRIPTION
## Problem

In `PLANNOTATOR_REMOTE=1` environments (SSH, devcontainer, OpenCode web UI accessed via Tailscale or a reverse proxy), two compounding bugs make `submit_plan` effectively unusable:

### Bug 1 — No URL notification (closes #192)

When `isRemote=true`, `handleServerReady()` correctly skips opening a browser — but does nothing else. The user has **no way to know** where to navigate to reach the Plannotator UI. The server silently waits forever.

For OpenCode users accessing the web UI remotely, `ctx.client.app.log()` provides the right channel to surface this information directly in the chat UI.

### Bug 2 — No timeout on `waitForDecision()`

If the user never visits the URL (because they don't know it), `waitForDecision()` blocks indefinitely and **holds the port permanently**. Any subsequent `submit_plan` call fails immediately with `EADDRINUSE` (after 5 retries × 500ms). From the user's perspective, `submit_plan` appears to silently not execute.

## Fix

**`apps/opencode-plugin/index.ts`**

1. **URL notification**: When `isRemote=true`, emit a log message via `ctx.client.app.log()` showing the Plannotator URL (both `localhost:<port>` and `hostname:<port>` for remote access).

2. **10-minute timeout**: Wrap `waitForDecision()` in `Promise.race()` with a 10-minute timeout that auto-denies and releases the port, breaking the permanent-occupation cycle.

```diff
+import os from "node:os";

  onReady: (url, isRemote, port) => {
    handleServerReady(url, isRemote, port);
+   if (isRemote) {
+     const hostname = os.hostname();
+     ctx.client.app.log({
+       level: "info",
+       message: `[Plannotator] UI ready — open in browser: http://localhost:${port} (or http://${hostname}:${port} if remote)`,
+     }).catch(() => {});
+   }
  },

- const result = await server.waitForDecision();
+ const PLANNOTATOR_TIMEOUT_MS = 10 * 60 * 1000; // 10min timeout
+ const result = await Promise.race([
+   server.waitForDecision(),
+   new Promise<{ approved: boolean; feedback?: string }>((resolve) =>
+     setTimeout(
+       () => resolve({ approved: false, feedback: "[Plannotator] No response within 10 minutes. Port released automatically. Please call submit_plan again." }),
+       PLANNOTATOR_TIMEOUT_MS
+     )
+   ),
+ ]);
```

## Notes

- The timeout auto-deny returns a clear message so the agent knows to call `submit_plan` again, rather than treating it as a real rejection.
- `os.hostname()` uses the Node.js built-in — no new dependencies.
- Only the `submit_plan` execute path is changed. The `/plannotator-review` and `/plannotator-annotate` command handlers are not affected.

---

> **AI authorship disclosure**: This fix was authored by Claude (Anthropic) and reviewed by [@codeg-dev](https://github.com/codeg-dev) before submission.