### PR TITLE
fix: Guard Enter key handlers with isComposing for CJK IME support

### DIFF
--- a/packages/ui/components/AnnotationPanel.tsx
+++ b/packages/ui/components/AnnotationPanel.tsx
@@ -174,7 +174,7 @@ const AnnotationCard: React.FC<{
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !e.nativeEvent.isComposing) {
       e.preventDefault();
       handleSaveEdit();
     } else if (e.key === 'Escape') {

--- a/packages/ui/components/AnnotationToolbar.tsx
+++ b/packages/ui/components/AnnotationToolbar.tsx
@@ -257,7 +257,7 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
             onChange={(e) => setInputValue(e.target.value)}
             onKeyDown={(e) => {
               if (e.key === "Escape") setStep("menu");
-              if (e.key === "Enter" && !e.shiftKey) {
+              if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
                 e.preventDefault();
                 if (inputValue.trim() || images.length > 0) {
                   onAnnotate(activeType!, inputValue || undefined, images.length > 0 ? images : undefined);

--- a/packages/ui/components/AttachmentsButton.tsx
+++ b/packages/ui/components/AttachmentsButton.tsx
@@ -310,7 +310,7 @@ export const AttachmentsButton: React.FC<AttachmentsButtonProps> = ({
                   type="text"
                   value={manualPath}
                   onChange={(e) => setManualPath(e.target.value)}
-                  onKeyDown={(e) => e.key === 'Enter' && handleManualAdd()}
+                  onKeyDown={(e) => e.key === 'Enter' && !e.nativeEvent.isComposing && handleManualAdd()}
                   placeholder="Paste path or URL..."
                   className="flex-1 px-2 py-1.5 text-xs bg-background border border-border rounded-md focus:outline-none focus:ring-1 focus:ring-primary"
                 />

--- a/packages/ui/components/ImageAnnotator/index.tsx
+++ b/packages/ui/components/ImageAnnotator/index.tsx
@@ -241,7 +241,7 @@ export const ImageAnnotator: React.FC<ImageAnnotatorProps> = ({
               value={name}
               onChange={(e) => setName(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === 'Enter') {
+                if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
                   e.preventDefault();
                   handleAccept();
                 }

--- a/packages/ui/components/Viewer.tsx
+++ b/packages/ui/components/Viewer.tsx
@@ -737,7 +737,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
                     setGlobalCommentValue('');
                   }
                   // Enter to submit, Shift+Enter for newline
-                  if (e.key === 'Enter' && !e.shiftKey) {
+                  if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
                     e.preventDefault();
                     if (globalCommentValue.trim()) {
                       handleAddGlobalComment();


### PR DESCRIPTION
## Summary

- Add `!e.nativeEvent.isComposing` guard to all Enter-to-submit handlers in the plan editor UI
- CJK users press Enter to confirm IME character selection — without this guard, Enter triggers form submission instead of confirming the character
- Zero behavior change for non-IME (English/Latin) users

## Changes

5 files, 1 line each:

| File | Handler | Priority |
|---|---|---|
| `packages/ui/components/AnnotationToolbar.tsx` | Inline comment submit (Enter) | High — reported bug |
| `packages/ui/components/Viewer.tsx` | Global comment submit (Enter) | High |
| `packages/ui/components/AnnotationPanel.tsx` | Annotation edit save (Cmd+Enter) | Medium |
| `packages/ui/components/ImageAnnotator/index.tsx` | Image name accept (Enter) | Medium |
| `packages/ui/components/AttachmentsButton.tsx` | Manual path add (Enter) | Low |

The review-editor `AnnotationToolbar` (added in #198) already has this guard — this brings parity to the plan editor side.

## Test plan

- [ ] Open plan editor, create annotation comment, type text, press Enter → submits (no regression)
- [ ] Shift+Enter still inserts newline in comment and global comment textareas
- [ ] CJK IME: Enter to confirm character selection does not submit the form

Fixes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)