### PR TITLE
Harden pi-extension local server + planning guards + tool restoration

### DIFF
--- a/apps/pi-extension/README.md
+++ b/apps/pi-extension/README.md
@@ -61,7 +61,7 @@ When the agent calls `exit_plan_mode`, the Plannotator UI opens in your browser.
 - **Deny with annotations** to send structured feedback back to the agent
 - **Approve with notes** to proceed but include implementation guidance
 
-The agent iterates on the plan until you approve, then executes with full tool access. On resubmission, Plan Diff highlights what changed since the previous version.
+The agent iterates on the plan until you approve, then executes with the same tool set that was active before entering plan mode. On resubmission, Plan Diff highlights what changed since the previous version.
 
 ### Code review
 
@@ -102,15 +102,25 @@ During execution, the agent marks completed steps with `[DONE:n]` markers. Progr
 The extension manages a state machine: **idle** → **planning** → **executing** → **idle**.
 
 During **planning**:
-- Tools restricted to: `read`, `bash` (read-only commands only), `grep`, `find`, `ls`, `write` (plan file only), `exit_plan_mode`
-- `edit` is disabled, bash is gated to a read-only allowlist, writes only allowed to the plan file
+- Tools restricted to: `read`, `bash` (read-only commands only), `grep`, `find`, `ls`, `write` (plan file only), `edit` (plan file only), `exit_plan_mode`
+- Bash is gated to a strict read-only allowlist
+- Sensitive commands are blocked in planning mode (`curl`, `wget`, `env`, `printenv`)
 
 During **executing**:
-- Full tool access: `read`, `bash`, `edit`, `write`
+- Restores the exact tool set that was active before planning began
 - Progress tracked via `[DONE:n]` markers in agent responses
 - Plan re-read from disk each turn to stay current
 
+Local review servers bind to `127.0.0.1` only.
+
 State persists across session restarts via Pi's `appendEntry` API.
+
+## Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `PLANNOTATOR_DISABLE_HISTORY` | Set to `1` / `true` / `yes` to disable plan history writes under `~/.plannotator/history`. |
+| `PLANNOTATOR_HISTORY_MAX_VERSIONS` | Maximum versions retained per plan slug (default: `200`). |
 
 ## Requirements
 

--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -53,10 +53,15 @@ try {
 
 // Tool sets by phase
 const PLANNING_TOOLS = ["read", "bash", "grep", "find", "ls", "write", "edit", "exit_plan_mode"];
-const EXECUTION_TOOLS = ["read", "bash", "edit", "write"];
-const NORMAL_TOOLS = ["read", "bash", "edit", "write"];
+const FALLBACK_ACTIVE_TOOLS = ["read", "bash", "edit", "write"];
 
 type Phase = "idle" | "planning" | "executing";
+
+interface PersistedPlannotatorState {
+  phase: Phase;
+  planFilePath?: string;
+  previousActiveTools?: string[];
+}
 
 function isAssistantMessage(m: AgentMessage): m is AssistantMessage {
   return m.role === "assistant" && Array.isArray(m.content);
@@ -73,6 +78,7 @@ export default function plannotator(pi: ExtensionAPI): void {
   let phase: Phase = "idle";
   let planFilePath = "PLAN.md";
   let checklistItems: ChecklistItem[] = [];
+  let previousActiveTools: string[] = [];
 
   // ── Flags ────────────────────────────────────────────────────────────
 
@@ -92,6 +98,36 @@ export default function plannotator(pi: ExtensionAPI): void {
 
   function resolvePlanPath(cwd: string): string {
     return resolve(cwd, planFilePath);
+  }
+
+  function normalizeTools(tools: string[] | undefined): string[] {
+    return Array.from(new Set((tools ?? []).filter((t): t is string => typeof t === "string" && t.length > 0)));
+  }
+
+  function capturePrePlanTools(): void {
+    const active = normalizeTools(pi.getActiveTools()).filter((t) => t !== "exit_plan_mode");
+    previousActiveTools = active.length > 0 ? active : [...FALLBACK_ACTIVE_TOOLS];
+  }
+
+  function getRestoredTools(): string[] {
+    return previousActiveTools.length > 0 ? [...previousActiveTools] : [...FALLBACK_ACTIVE_TOOLS];
+  }
+
+  function applyRestoredTools(): string[] {
+    const tools = getRestoredTools();
+    pi.setActiveTools(tools);
+    return tools;
+  }
+
+  function enterExecuting(ctx?: ExtensionContext): string[] {
+    phase = "executing";
+    const restoredTools = applyRestoredTools();
+    if (ctx) {
+      updateStatus(ctx);
+      updateWidget(ctx);
+    }
+    persistState();
+    return restoredTools;
   }
 
   function updateStatus(ctx: ExtensionContext): void {
@@ -123,10 +159,11 @@ export default function plannotator(pi: ExtensionAPI): void {
   }
 
   function persistState(): void {
-    pi.appendEntry("plannotator", { phase, planFilePath });
+    pi.appendEntry("plannotator", { phase, planFilePath, previousActiveTools });
   }
 
   function enterPlanning(ctx: ExtensionContext): void {
+    capturePrePlanTools();
     phase = "planning";
     checklistItems = [];
     pi.setActiveTools(PLANNING_TOOLS);
@@ -137,13 +174,14 @@ export default function plannotator(pi: ExtensionAPI): void {
   }
 
   function exitToIdle(ctx: ExtensionContext): void {
+    const restoredTools = applyRestoredTools();
     phase = "idle";
     checklistItems = [];
-    pi.setActiveTools(NORMAL_TOOLS);
+    previousActiveTools = [];
     updateStatus(ctx);
     updateWidget(ctx);
     persistState();
-    ctx.ui.notify("Plannotator: disabled. Full access restored.");
+    ctx.ui.notify(`Plannotator: disabled. Restored tools: ${restoredTools.join(", ")}.`);
   }
 
   function togglePlanMode(ctx: ExtensionContext): void {
@@ -318,14 +356,12 @@ export default function plannotator(pi: ExtensionAPI): void {
 
       // Non-interactive or no HTML: auto-approve
       if (!ctx.hasUI || !planHtmlContent) {
-        phase = "executing";
-        pi.setActiveTools(EXECUTION_TOOLS);
-        persistState();
+        const restoredTools = enterExecuting(ctx);
         return {
           content: [
             {
               type: "text",
-              text: "Plan auto-approved (non-interactive mode). Execute the plan now.",
+              text: `Plan auto-approved (non-interactive mode). Execute the plan now. Restored tools: ${restoredTools.join(", ")}.`,
             },
           ],
           details: { approved: true },
@@ -347,11 +383,7 @@ export default function plannotator(pi: ExtensionAPI): void {
       server.stop();
 
       if (result.approved) {
-        phase = "executing";
-        pi.setActiveTools(EXECUTION_TOOLS);
-        updateStatus(ctx);
-        updateWidget(ctx);
-        persistState();
+        const restoredTools = enterExecuting(ctx);
 
         pi.appendEntry("plannotator-execute", { planFilePath });
 
@@ -364,7 +396,7 @@ export default function plannotator(pi: ExtensionAPI): void {
             content: [
               {
                 type: "text",
-                text: `Plan approved with notes! You now have full tool access (read, bash, edit, write). Execute the plan in ${planFilePath}. ${doneMsg}\n\n## Implementation Notes\n\nThe user approved your plan but added the following notes to consider during implementation:\n\n${result.feedback}\n\nProceed with implementation, incorporating these notes where applicable.`,
+                text: `Plan approved with notes! Restored pre-plan tools (${restoredTools.join(", ")}). Execute the plan in ${planFilePath}. ${doneMsg}\n\n## Implementation Notes\n\nThe user approved your plan but added the following notes to consider during implementation:\n\n${result.feedback}\n\nProceed with implementation, incorporating these notes where applicable.`,
               },
             ],
             details: { approved: true, feedback: result.feedback },
@@ -375,7 +407,7 @@ export default function plannotator(pi: ExtensionAPI): void {
           content: [
             {
               type: "text",
-              text: `Plan approved. You now have full tool access (read, bash, edit, write). Execute the plan in ${planFilePath}. ${doneMsg}`,
+              text: `Plan approved. Restored pre-plan tools (${restoredTools.join(", ")}). Execute the plan in ${planFilePath}. ${doneMsg}`,
             },
           ],
           details: { approved: true },
@@ -524,7 +556,7 @@ Do not end your turn without doing one of these two things.`,
           message: {
             customType: "plannotator-context",
             content: `[PLANNOTATOR - EXECUTING PLAN]
-Full tool access is enabled. Execute the plan from ${planFilePath}.
+Pre-plan tool access has been restored (${getRestoredTools().join(", ")}). Execute the plan from ${planFilePath}.
 
 Remaining steps:
 ${todoList}
@@ -588,12 +620,14 @@ Execute each step in order. After completing a step, include [DONE:n] in your re
         },
         { triggerTurn: false },
       );
+      const restoredTools = applyRestoredTools();
       phase = "idle";
       checklistItems = [];
-      pi.setActiveTools(NORMAL_TOOLS);
+      previousActiveTools = [];
       updateStatus(ctx);
       updateWidget(ctx);
       persistState();
+      ctx.ui.notify(`Plannotator: plan complete. Restored tools: ${restoredTools.join(", ")}.`, "success");
     }
   });
 
@@ -614,11 +648,16 @@ Execute each step in order. After completing a step, include [DONE:n] in your re
     const entries = ctx.sessionManager.getEntries();
     const stateEntry = entries
       .filter((e: { type: string; customType?: string }) => e.type === "custom" && e.customType === "plannotator")
-      .pop() as { data?: { phase: Phase; planFilePath?: string } } | undefined;
+      .pop() as { data?: PersistedPlannotatorState } | undefined;
 
     if (stateEntry?.data) {
       phase = stateEntry.data.phase ?? phase;
       planFilePath = stateEntry.data.planFilePath ?? planFilePath;
+      previousActiveTools = normalizeTools(stateEntry.data.previousActiveTools).filter((t) => t !== "exit_plan_mode");
+    }
+
+    if ((phase === "planning" || phase === "executing") && previousActiveTools.length === 0) {
+      capturePrePlanTools();
     }
 
     // Rebuild execution state from disk + session messages
@@ -659,7 +698,7 @@ Execute each step in order. After completing a step, include [DONE:n] in your re
     if (phase === "planning") {
       pi.setActiveTools(PLANNING_TOOLS);
     } else if (phase === "executing") {
-      pi.setActiveTools(EXECUTION_TOOLS);
+      applyRestoredTools();
     }
 
     updateStatus(ctx);

--- a/apps/pi-extension/server.ts
+++ b/apps/pi-extension/server.ts
@@ -9,7 +9,7 @@
 import { createServer, type IncomingMessage, type Server } from "node:http";
 import { execSync } from "node:child_process";
 import os from "node:os";
-import { mkdirSync, writeFileSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { mkdirSync, writeFileSync, readFileSync, readdirSync, statSync, unlinkSync } from "node:fs";
 import { join, basename } from "node:path";
 
 // ── Helpers ──────────────────────────────────────────────────────────────
@@ -38,9 +38,15 @@ function html(res: import("node:http").ServerResponse, content: string): void {
   res.end(content);
 }
 
+const LOOPBACK_HOST = "127.0.0.1";
+const DEFAULT_HISTORY_MAX_VERSIONS = 200;
+
 function listenOnRandomPort(server: Server): number {
-  server.listen(0);
-  const addr = server.address() as { port: number };
+  server.listen({ port: 0, host: LOOPBACK_HOST });
+  const addr = server.address();
+  if (!addr || typeof addr === "string") {
+    throw new Error("Failed to bind local server");
+  }
   return addr.port;
 }
 
@@ -121,6 +127,56 @@ function detectProjectName(): string {
   }
 }
 
+function isTruthyEnv(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
+function isHistoryDisabled(): boolean {
+  return isTruthyEnv(process.env.PLANNOTATOR_DISABLE_HISTORY);
+}
+
+function getHistoryMaxVersions(): number {
+  const raw = process.env.PLANNOTATOR_HISTORY_MAX_VERSIONS;
+  if (!raw) return DEFAULT_HISTORY_MAX_VERSIONS;
+
+  const parsed = parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_HISTORY_MAX_VERSIONS;
+  }
+  return parsed;
+}
+
+function pruneHistoryVersions(historyDir: string): void {
+  const maxVersions = getHistoryMaxVersions();
+  if (maxVersions <= 0) return;
+
+  try {
+    const versions = readdirSync(historyDir)
+      .map((entry) => {
+        const match = entry.match(/^(\d+)\.md$/);
+        if (!match) return null;
+        return { entry, version: parseInt(match[1], 10) };
+      })
+      .filter((v): v is { entry: string; version: number } => v !== null)
+      .sort((a, b) => a.version - b.version);
+
+    const removeCount = versions.length - maxVersions;
+    if (removeCount <= 0) return;
+
+    for (const stale of versions.slice(0, removeCount)) {
+      try {
+        unlinkSync(join(historyDir, stale.entry));
+      } catch {
+        // best effort cleanup
+      }
+    }
+  } catch {
+    // best effort cleanup
+  }
+}
+
 function getHistoryDir(project: string, slug: string): string {
   const historyDir = join(os.homedir(), ".plannotator", "history", project, slug);
   mkdirSync(historyDir, { recursive: true });
@@ -149,6 +205,10 @@ function saveToHistory(
   slug: string,
   plan: string,
 ): { version: number; path: string; isNew: boolean } {
+  if (isHistoryDisabled()) {
+    return { version: 0, path: "", isNew: false };
+  }
+
   const historyDir = getHistoryDir(project, slug);
   const nextVersion = getNextVersionNumber(historyDir);
   if (nextVersion > 1) {
@@ -156,13 +216,17 @@ function saveToHistory(
     try {
       const existing = readFileSync(latestPath, "utf-8");
       if (existing === plan) {
+        pruneHistoryVersions(historyDir);
         return { version: nextVersion - 1, path: latestPath, isNew: false };
       }
-    } catch { /* proceed with saving */ }
+    } catch {
+      // proceed with saving
+    }
   }
   const fileName = `${String(nextVersion).padStart(3, "0")}.md`;
   const filePath = join(historyDir, fileName);
   writeFileSync(filePath, plan, "utf-8");
+  pruneHistoryVersions(historyDir);
   return { version: nextVersion, path: filePath, isNew: true };
 }
 
@@ -266,16 +330,33 @@ export function startPlanReviewServer(options: {
   // Version history
   const slug = generateSlug(options.plan);
   const project = detectProjectName();
-  const historyResult = saveToHistory(project, slug, options.plan);
-  const previousPlan =
-    historyResult.version > 1
-      ? getPlanVersion(project, slug, historyResult.version - 1)
-      : null;
-  const versionInfo = {
-    version: historyResult.version,
-    totalVersions: getVersionCount(project, slug),
+  const historyEnabled = !isHistoryDisabled();
+
+  let previousPlan: string | null = null;
+  let versionInfo: {
+    version: number;
+    totalVersions: number;
+    project: string;
+    historyDisabled?: boolean;
+  } = {
+    version: 0,
+    totalVersions: 0,
     project,
+    historyDisabled: true,
   };
+
+  if (historyEnabled) {
+    const historyResult = saveToHistory(project, slug, options.plan);
+    previousPlan =
+      historyResult.version > 1
+        ? getPlanVersion(project, slug, historyResult.version - 1)
+        : null;
+    versionInfo = {
+      version: historyResult.version,
+      totalVersions: getVersionCount(project, slug),
+      project,
+    };
+  }
 
   let resolveDecision!: (result: { approved: boolean; feedback?: string }) => void;
   const decisionPromise = new Promise<{ approved: boolean; feedback?: string }>((r) => {
@@ -283,9 +364,14 @@ export function startPlanReviewServer(options: {
   });
 
   const server = createServer(async (req, res) => {
-    const url = new URL(req.url!, `http://localhost`);
+    const url = new URL(req.url!, `http://${LOOPBACK_HOST}`);
 
     if (url.pathname === "/api/plan/version") {
+      if (!historyEnabled) {
+        json(res, { error: "Plan history is disabled" }, 404);
+        return;
+      }
+
       const vParam = url.searchParams.get("v");
       if (!vParam) {
         json(res, { error: "Missing v parameter" }, 400);
@@ -303,8 +389,16 @@ export function startPlanReviewServer(options: {
       }
       json(res, { plan: content, version: v });
     } else if (url.pathname === "/api/plan/versions") {
+      if (!historyEnabled) {
+        json(res, { project, slug, versions: [], historyDisabled: true });
+        return;
+      }
       json(res, { project, slug, versions: listVersions(project, slug) });
     } else if (url.pathname === "/api/plan/history") {
+      if (!historyEnabled) {
+        json(res, { project, plans: [], historyDisabled: true });
+        return;
+      }
       json(res, { project, plans: listProjectPlans(project) });
     } else if (url.pathname === "/api/plan") {
       json(res, { plan: options.plan, origin: options.origin ?? "pi", previousPlan, versionInfo });
@@ -325,7 +419,7 @@ export function startPlanReviewServer(options: {
 
   return {
     port,
-    url: `http://localhost:${port}`,
+    url: `http://${LOOPBACK_HOST}:${port}`,
     waitForDecision: () => decisionPromise,
     stop: () => server.close(),
   };
@@ -421,7 +515,7 @@ export function startReviewServer(options: {
   });
 
   const server = createServer(async (req, res) => {
-    const url = new URL(req.url!, `http://localhost`);
+    const url = new URL(req.url!, `http://${LOOPBACK_HOST}`);
 
     if (url.pathname === "/api/diff" && req.method === "GET") {
       json(res, {
@@ -457,7 +551,7 @@ export function startReviewServer(options: {
 
   return {
     port,
-    url: `http://localhost:${port}`,
+    url: `http://${LOOPBACK_HOST}:${port}`,
     waitForDecision: () => decisionPromise,
     stop: () => server.close(),
   };
@@ -484,7 +578,7 @@ export function startAnnotateServer(options: {
   });
 
   const server = createServer(async (req, res) => {
-    const url = new URL(req.url!, `http://localhost`);
+    const url = new URL(req.url!, `http://${LOOPBACK_HOST}`);
 
     if (url.pathname === "/api/plan" && req.method === "GET") {
       json(res, {
@@ -506,7 +600,7 @@ export function startAnnotateServer(options: {
 
   return {
     port,
-    url: `http://localhost:${port}`,
+    url: `http://${LOOPBACK_HOST}:${port}`,
     waitForDecision: () => decisionPromise,
     stop: () => server.close(),
   };

--- a/apps/pi-extension/utils.ts
+++ b/apps/pi-extension/utils.ts
@@ -31,8 +31,8 @@ const SAFE_PATTERNS = [
   /^\s*grep\b/, /^\s*find\b/, /^\s*ls\b/, /^\s*pwd\b/, /^\s*echo\b/,
   /^\s*printf\b/, /^\s*wc\b/, /^\s*sort\b/, /^\s*uniq\b/, /^\s*diff\b/,
   /^\s*file\b/, /^\s*stat\b/, /^\s*du\b/, /^\s*df\b/, /^\s*tree\b/,
-  /^\s*which\b/, /^\s*whereis\b/, /^\s*type\b/, /^\s*env\b/,
-  /^\s*printenv\b/, /^\s*uname\b/, /^\s*whoami\b/, /^\s*id\b/,
+  /^\s*which\b/, /^\s*whereis\b/, /^\s*type\b/,
+  /^\s*uname\b/, /^\s*whoami\b/, /^\s*id\b/,
   /^\s*date\b/, /^\s*cal\b/, /^\s*uptime\b/, /^\s*ps\b/,
   /^\s*top\b/, /^\s*htop\b/, /^\s*free\b/,
   /^\s*git\s+(status|log|diff|show|branch|remote|config\s+--get)/i,
@@ -40,12 +40,22 @@ const SAFE_PATTERNS = [
   /^\s*npm\s+(list|ls|view|info|search|outdated|audit)/i,
   /^\s*yarn\s+(list|info|why|audit)/i,
   /^\s*node\s+--version/i, /^\s*python\s+--version/i,
-  /^\s*curl\s/i, /^\s*wget\s+-O\s*-/i,
   /^\s*jq\b/, /^\s*sed\s+-n/i, /^\s*awk\b/,
   /^\s*rg\b/, /^\s*fd\b/, /^\s*bat\b/, /^\s*exa\b/,
 ];
 
+const BLOCKED_SENSITIVE_PATTERNS = [
+  /(^|[\s|&;()])curl\b/i,
+  /(^|[\s|&;()])wget\b/i,
+  /(^|[\s|&;()])env\b/i,
+  /(^|[\s|&;()])printenv\b/i,
+];
+
 export function isSafeCommand(command: string): boolean {
+  if (BLOCKED_SENSITIVE_PATTERNS.some((p) => p.test(command))) {
+    return false;
+  }
+
   const isDestructive = DESTRUCTIVE_PATTERNS.some((p) => p.test(command));
   const isSafe = SAFE_PATTERNS.some((p) => p.test(command));
   return !isDestructive && isSafe;


### PR DESCRIPTION
## Summary
This PR hardens `apps/pi-extension` in four areas:

1. **Bind local review servers to loopback only**
   - `server.listen({ port: 0, host: "127.0.0.1" })`
   - All generated URLs now use `http://127.0.0.1:<port>`

2. **Tighten planning bash allowlist**
   - Removed `curl`, `wget`, `env`, `printenv` from safe allowlist
   - Added explicit blocked token checks so piped/compound commands are also denied

3. **Preserve/restore pre-plan active tools**
   - Snapshot active tools before entering planning
   - Restore that exact set when entering execution/idle
   - Persist and restore snapshot across session resume
   - Avoid hardcoding normal execution tools on exit

4. **Add plan history controls/retention**
   - `PLANNOTATOR_DISABLE_HISTORY=1|true|yes` disables writing `~/.plannotator/history`
   - `PLANNOTATOR_HISTORY_MAX_VERSIONS` caps versions per plan slug (default `200`)
   - Old versions are pruned on save

## Files changed
- `apps/pi-extension/server.ts`
- `apps/pi-extension/utils.ts`
- `apps/pi-extension/index.ts`
- `apps/pi-extension/README.md`

## Notes
- This is intentionally focused on hardening and runtime behavior.
- README updated with new behavior and env vars.
