### PR TITLE
fix: add missing /plannotator-annotate command to install scripts

### DIFF
--- a/scripts/install.cmd
+++ b/scripts/install.cmd
@@ -152,6 +152,23 @@ echo Address the code review feedback above. The user has reviewed your changes 
 
 echo Installed /plannotator-review command to !CLAUDE_COMMANDS_DIR!\plannotator-review.md
 
+(
+echo ---
+echo description: Open interactive annotation UI for a markdown file
+echo allowed-tools: Bash^(plannotator:*^)
+echo ---
+echo.
+echo ## Markdown Annotations
+echo.
+echo !`plannotator annotate $ARGUMENTS`
+echo.
+echo ## Your task
+echo.
+echo Address the annotation feedback above. The user has reviewed the markdown file and provided specific annotations and comments.
+) > "!CLAUDE_COMMANDS_DIR!\plannotator-annotate.md"
+
+echo Installed /plannotator-annotate command to !CLAUDE_COMMANDS_DIR!\plannotator-annotate.md
+
 echo.
 echo Test the install:
 echo   echo {"tool_input":{"plan":"# Test Plan\\n\\nHello world"}} ^| plannotator
@@ -160,6 +177,6 @@ echo Then install the Claude Code plugin:
 echo   /plugin marketplace add backnotprop/plannotator
 echo   /plugin install plannotator@plannotator
 echo.
-echo The /plannotator-review command is ready to use!
+echo The /plannotator-review and /plannotator-annotate commands are ready to use!
 echo.
 exit /b 0

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -107,6 +107,24 @@ Address the code review feedback above. The user has reviewed your changes in th
 
 Write-Host "Installed /plannotator-review command to $claudeCommandsDir\plannotator-review.md"
 
+# Install Claude Code /annotate slash command
+@'
+---
+description: Open interactive annotation UI for a markdown file
+allowed-tools: Bash(plannotator:*)
+---
+
+## Markdown Annotations
+
+!`plannotator annotate $ARGUMENTS`
+
+## Your task
+
+Address the annotation feedback above. The user has reviewed the markdown file and provided specific annotations and comments.
+'@ | Set-Content -Path "$claudeCommandsDir\plannotator-annotate.md"
+
+Write-Host "Installed /plannotator-annotate command to $claudeCommandsDir\plannotator-annotate.md"
+
 # Install OpenCode slash command
 $opencodeCommandsDir = "$env:USERPROFILE\.config\opencode\command"
 New-Item -ItemType Directory -Force -Path $opencodeCommandsDir | Out-Null
@@ -122,6 +140,18 @@ Acknowledge "Opening code review..." and wait for the user's feedback.
 
 Write-Host "Installed /plannotator-review command to $opencodeCommandsDir\plannotator-review.md"
 
+# Install OpenCode /annotate slash command
+@"
+---
+description: Open interactive annotation UI for a markdown file
+---
+
+The Plannotator Annotate has been triggered. Opening the annotation UI...
+Acknowledge "Opening annotation UI..." and wait for the user's feedback.
+"@ | Set-Content -Path "$opencodeCommandsDir\plannotator-annotate.md"
+
+Write-Host "Installed /plannotator-annotate command to $opencodeCommandsDir\plannotator-annotate.md"
+
 Write-Host ""
 Write-Host "=========================================="
 Write-Host "  OPENCODE USERS"
@@ -131,7 +161,7 @@ Write-Host "Add the plugin to your opencode.json:"
 Write-Host ""
 Write-Host '  "plugin": ["@plannotator/opencode@latest"]'
 Write-Host ""
-Write-Host "Then restart OpenCode. The /plannotator-review command is ready!"
+Write-Host "Then restart OpenCode. The /plannotator-review and /plannotator-annotate commands are ready!"
 Write-Host ""
 Write-Host "=========================================="
 Write-Host "  CLAUDE CODE USERS: YOU ARE ALL SET!"
@@ -141,4 +171,4 @@ Write-Host "Install the Claude Code plugin:"
 Write-Host "  /plugin marketplace add backnotprop/plannotator"
 Write-Host "  /plugin install plannotator@plannotator"
 Write-Host ""
-Write-Host "The /plannotator-review command is ready to use after you restart Claude Code!"
+Write-Host "The /plannotator-review and /plannotator-annotate commands are ready to use after you restart Claude Code!"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -107,6 +107,24 @@ COMMAND_EOF
 
 echo "Installed /plannotator-review command to ${CLAUDE_COMMANDS_DIR}/plannotator-review.md"
 
+# Install /annotate slash command for Claude Code
+cat > "$CLAUDE_COMMANDS_DIR/plannotator-annotate.md" << 'COMMAND_EOF'
+---
+description: Open interactive annotation UI for a markdown file
+allowed-tools: Bash(plannotator:*)
+---
+
+## Markdown Annotations
+
+!`plannotator annotate $ARGUMENTS`
+
+## Your task
+
+Address the annotation feedback above. The user has reviewed the markdown file and provided specific annotations and comments.
+COMMAND_EOF
+
+echo "Installed /plannotator-annotate command to ${CLAUDE_COMMANDS_DIR}/plannotator-annotate.md"
+
 # Install OpenCode slash command
 OPENCODE_COMMANDS_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/opencode/command"
 mkdir -p "$OPENCODE_COMMANDS_DIR"
@@ -122,6 +140,18 @@ COMMAND_EOF
 
 echo "Installed /plannotator-review command to ${OPENCODE_COMMANDS_DIR}/plannotator-review.md"
 
+# Install /annotate slash command for OpenCode
+cat > "$OPENCODE_COMMANDS_DIR/plannotator-annotate.md" << 'COMMAND_EOF'
+---
+description: Open interactive annotation UI for a markdown file
+---
+
+The Plannotator Annotate has been triggered. Opening the annotation UI...
+Acknowledge "Opening annotation UI..." and wait for the user's feedback.
+COMMAND_EOF
+
+echo "Installed /plannotator-annotate command to ${OPENCODE_COMMANDS_DIR}/plannotator-annotate.md"
+
 echo ""
 echo "=========================================="
 echo "  OPENCODE USERS"
@@ -131,7 +161,7 @@ echo "Add the plugin to your opencode.json:"
 echo ""
 echo '  "plugin": ["@plannotator/opencode@latest"]'
 echo ""
-echo "Then restart OpenCode. The /plannotator-review command is ready!"
+echo "Then restart OpenCode. The /plannotator-review and /plannotator-annotate commands are ready!"
 echo ""
 echo "=========================================="
 echo "  CLAUDE CODE USERS: YOU'RE ALL SET!"
@@ -141,4 +171,4 @@ echo "Install the Claude Code plugin:"
 echo "  /plugin marketplace add backnotprop/plannotator"
 echo "  /plugin install plannotator@plannotator"
 echo ""
-echo "The /plannotator-review command is ready to use after you restart Claude Code!"
+echo "The /plannotator-review and /plannotator-annotate commands are ready to use after you restart Claude Code!"


### PR DESCRIPTION
## Summary

- The annotate feature was added but all three install scripts (`install.sh`, `install.ps1`, `install.cmd`) were not updated to install the `/plannotator-annotate` slash command
- Add annotate command installation for both Claude Code and OpenCode in all platform scripts
- Update post-install messages to mention the annotate command

## Changes

| File | Change |
|------|--------|
| `scripts/install.sh` | +Claude Code annotate command, +OpenCode annotate command |
| `scripts/install.ps1` | +Claude Code annotate command (literal here-string to preserve `$ARGUMENTS`), +OpenCode annotate command |
| `scripts/install.cmd` | +Claude Code annotate command |

## Test plan

- [ ] Run `install.sh` on macOS/Linux, verify `~/.claude/commands/plannotator-annotate.md` is created with correct content
- [ ] Run `install.ps1` on Windows, verify `$ARGUMENTS` is written literally (not expanded as PowerShell variable)
- [ ] Run `install.cmd` on Windows, verify annotate command file is created
- [ ] Verify `/plannotator-annotate` command appears in Claude Code after restart