### PR TITLE
fix: improve deny message framing to prevent ignored feedback

### DIFF
--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -240,7 +240,7 @@ if (args[0] === "review") {
           hookEventName: "PermissionRequest",
           decision: {
             behavior: "deny",
-            message: result.feedback || "Plan changes requested",
+            message: `YOUR PLAN WAS NOT APPROVED. You MUST revise the plan to address ALL of the feedback below before calling ExitPlanMode again. Do not resubmit the same plan — use the Edit tool to make targeted changes to the plan file first.\n\n${result.feedback || "Plan changes requested"}`,
           },
         },
       })


### PR DESCRIPTION
## Summary

- Prepends a directive preamble to the deny `decision.message` so Claude Code treats feedback as mandatory, not informational
- The `exportAnnotations()` output is unchanged — this just wraps it with an imperative instruction

Closes #215

## Test plan

- [ ] Deny a plan with annotations → verify Claude edits the plan before resubmitting
- [ ] Deny with no annotations → verify fallback message still works
- [ ] Approve path unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)