### PR TITLE
fix: CommentPopover closes when adding image attachments

### DIFF
--- a/packages/ui/components/AttachmentsButton.tsx
+++ b/packages/ui/components/AttachmentsButton.tsx
@@ -242,12 +242,14 @@ export const AttachmentsButton: React.FC<AttachmentsButtonProps> = ({
           {/* Backdrop */}
           <div
             className="fixed inset-0 z-[90]"
+            data-popover-layer
             onClick={() => setIsOpen(false)}
           />
 
           {/* Popover content */}
           <div
             className="fixed z-[100] w-72 bg-card border border-border rounded-xl shadow-2xl p-3"
+            data-popover-layer
             style={{ top: position.top, left: position.left }}
             onClick={e => e.stopPropagation()}
           >

--- a/packages/ui/components/CommentPopover.tsx
+++ b/packages/ui/components/CommentPopover.tsx
@@ -87,9 +87,9 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
       const target = e.target as Node | null;
       if (!target) return;
       if (popoverRef.current?.contains(target)) return;
-      // Don't close if clicking inside an AttachmentsButton portal (z-index 90+)
+      // Don't close if clicking inside a child portal (AttachmentsButton, ImageAnnotator, etc.)
       const el = target as HTMLElement;
-      if (el.closest?.('[class*="z-[90]"], [class*="z-[100]"]')) return;
+      if (el.closest?.('[data-popover-layer]')) return;
       onClose();
     };
 

--- a/packages/ui/components/ImageAnnotator/index.tsx
+++ b/packages/ui/components/ImageAnnotator/index.tsx
@@ -201,6 +201,7 @@ export const ImageAnnotator: React.FC<ImageAnnotatorProps> = ({
   return (
     <div
       className="fixed inset-0 z-[200] flex items-center justify-center bg-background/90 backdrop-blur-sm"
+      data-popover-layer
       onClick={handleBackdropClick}
     >
       {/* Canvas with image and toolbar */}


### PR DESCRIPTION
## Summary

- CommentPopover's click-outside handler only excluded portals matching `z-[90]`/`z-[100]` class strings, but the ImageAnnotator renders at `z-[200]` — so interacting with it closed the popover
- Replaced fragile z-index class matching with a `data-popover-layer` attribute on all overlay portals (AttachmentsButton backdrop/content, ImageAnnotator)
- Global attachments were unaffected since that AttachmentsButton isn't inside a CommentPopover

## Test plan

- [ ] Open a text selection comment popover, click the image button, select a file — popover should stay open through the ImageAnnotator flow
- [ ] Verify global attachments still work
- [ ] Verify clicking outside the CommentPopover (on the document background) still closes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)