### PR TITLE
fix: include untracked new files in uncommitted/unstaged code review diffs

### DIFF
--- a/packages/server/git.ts
+++ b/packages/server/git.ts
@@ -97,6 +97,41 @@ export async function getGitContext(): Promise<GitContext> {
 }
 
 /**
+ * Get diffs for untracked (new) files not yet added to git.
+ *
+ * `git diff HEAD` and `git diff` only show tracked files. Newly created files
+ * that haven't been staged with `git add` are invisible to those commands.
+ * This helper discovers them via `git ls-files --others --exclude-standard` and
+ * generates a proper unified diff for each using `git diff --no-index`.
+ *
+ * Note: `git diff --no-index` exits with code 1 when files differ (standard git
+ * behaviour), so we use `.nothrow()` to avoid treating that as an error.
+ */
+async function getUntrackedFileDiffs(srcPrefix = 'a/', dstPrefix = 'b/'): Promise<string> {
+  try {
+    const output = (await $`git ls-files --others --exclude-standard`.quiet()).text();
+    const files = output.trim().split('\n').filter((f) => f.length > 0);
+    if (files.length === 0) return '';
+
+    const diffs = await Promise.all(
+      files.map(async (file) => {
+        try {
+          const result = await $`git diff --no-index --src-prefix=${srcPrefix} --dst-prefix=${dstPrefix} /dev/null ${file}`
+            .quiet()
+            .nothrow();
+          return result.text();
+        } catch {
+          return '';
+        }
+      }),
+    );
+    return diffs.join('');
+  } catch {
+    return '';
+  }
+}
+
+/**
  * Run git diff with the specified type
  */
 export async function runGitDiff(
@@ -108,20 +143,28 @@ export async function runGitDiff(
 
   try {
     switch (diffType) {
-      case "uncommitted":
-        patch = (await $`git diff HEAD --src-prefix=a/ --dst-prefix=b/`.quiet()).text();
+      case "uncommitted": {
+        // Include tracked changes (staged + unstaged vs HEAD) and untracked new files
+        const trackedDiff = (await $`git diff HEAD --src-prefix=a/ --dst-prefix=b/`.quiet()).text();
+        const untrackedDiff = await getUntrackedFileDiffs();
+        patch = trackedDiff + untrackedDiff;
         label = "Uncommitted changes";
         break;
+      }
 
       case "staged":
         patch = (await $`git diff --staged --src-prefix=a/ --dst-prefix=b/`.quiet()).text();
         label = "Staged changes";
         break;
 
-      case "unstaged":
-        patch = (await $`git diff --src-prefix=a/ --dst-prefix=b/`.quiet()).text();
+      case "unstaged": {
+        // Include unstaged changes to tracked files and untracked new files
+        const trackedDiff = (await $`git diff --src-prefix=a/ --dst-prefix=b/`.quiet()).text();
+        const untrackedDiff = await getUntrackedFileDiffs();
+        patch = trackedDiff + untrackedDiff;
         label = "Unstaged changes";
         break;
+      }
 
       case "last-commit":
         patch = (await $`git diff HEAD~1..HEAD --src-prefix=a/ --dst-prefix=b/`.quiet()).text();


### PR DESCRIPTION
## Summary

Fixes #189

Newly created files (untracked by git) were missing from the `plannotator-review` UI because `git diff HEAD` and `git diff` only output changes for files that are already tracked. Any file created by the agent but not yet staged with `git add` was invisible to the code review interface.

## Root Cause

In `packages/server/git.ts`, the `runGitDiff()` function uses:

- `git diff HEAD` for the **uncommitted** view
- `git diff` for the **unstaged** view

Both commands silently omit untracked files.

## Fix

Add a `getUntrackedFileDiffs()` helper that:

1. Discovers untracked files via `git ls-files --others --exclude-standard`
   (respects `.gitignore`, so `node_modules`, `dist`, etc. are excluded automatically)
2. Generates a standard unified diff for each file via `git diff --no-index --src-prefix=a/ --dst-prefix=b/ /dev/null <file>`

The resulting diffs are appended to the tracked-file diff in both the **uncommitted** and **unstaged** modes. The **staged** / **last-commit** / **branch** modes are not affected (they work correctly as-is).

## Changes

- `packages/server/git.ts` — add `getUntrackedFileDiffs()` helper; update `uncommitted` and `unstaged` cases in `runGitDiff()` to include its output (+47/-4 lines)

---
🤖 Generated with Claude Code