### PR TITLE
Remove 1-second debounce guard from VS Code extension panel opening

### DIFF
--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -12,15 +12,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const panelManager = new PanelManager();
   panelManager.setExtensionPath(context.extensionPath);
 
-  let lastOpenTime = 0;
-
   const openInPanel = async (url: string) => {
-    const now = Date.now();
-    if (now - lastOpenTime < 1000) {
-      log.info(`[open] skipped duplicate (${now - lastOpenTime}ms since last): ${url}`);
-      return;
-    }
-    lastOpenTime = now;
     log.info(`[open] received url: ${url}`);
 
     // Each panel gets its own cookie proxy so multiple agents


### PR DESCRIPTION
Removes the 1-second debounce guard from openInPanel() — it was added under the mistaken belief that the extension was launching duplicate tabs
	∙	Test: trigger plan reviews in quick succession, confirm each opens its own panel