### PR TITLE
fix(annotate): resolve file paths correctly on Windows

### DIFF
--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -37,6 +37,7 @@ import {
 } from "@plannotator/server/annotate";
 import { getGitContext, runGitDiff } from "@plannotator/server/git";
 import { writeRemoteShareLink } from "@plannotator/server/share-url";
+import path from "path";
 
 // Embed the built HTML at compile time
 // @ts-ignore - Bun import attribute for text

--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -111,15 +111,33 @@ if (args[0] === "review") {
   // ANNOTATE MODE
   // ============================================
 
-  const filePath = args[1];
+  let filePath = args[1];
   if (!filePath) {
     console.error("Usage: plannotator annotate <file.md>");
     process.exit(1);
   }
 
-  // Resolve to absolute path
-  const path = await import("path");
-  const absolutePath = path.resolve(filePath);
+  // Strip @ prefix if present (Claude Code file reference syntax)
+  if (filePath.startsWith("@")) {
+    filePath = filePath.slice(1);
+  }
+
+  // Resolve path - use PLANNOTATOR_CWD if set (original working directory before script cd'd)
+  const originalCwd = process.env.PLANNOTATOR_CWD || process.cwd();
+
+  // Debug: log path resolution (visible in stderr, won't interfere with stdout JSON)
+  if (process.env.PLANNOTATOR_DEBUG) {
+    console.error(`[DEBUG] Original CWD: ${originalCwd}`);
+    console.error(`[DEBUG] File path arg: ${filePath}`);
+  }
+
+  const absolutePath = path.isAbsolute(filePath)
+    ? filePath
+    : path.join(originalCwd, filePath);
+
+  if (process.env.PLANNOTATOR_DEBUG) {
+    console.error(`[DEBUG] Resolved path: ${absolutePath}`);
+  }
 
   // Read the markdown file
   const file = Bun.file(absolutePath);


### PR DESCRIPTION
## Problem

The `plannotator annotate <file.md>` command fails to resolve file paths correctly on Windows when:

1. The file path uses `@` prefix (Claude Code file reference syntax)
2. The working directory changes between the caller and the Bun script (e.g., Pi extension sets `cwd` but the script runs from a different directory)
3. Relative paths are resolved against the wrong base directory

`path.resolve(filePath)` uses `process.cwd()` which may differ from the original caller's working directory.

## Fix

- Strip `@` prefix if present (common in Claude Code `@/path/to/file` references)
- Support `PLANNOTATOR_CWD` env var to pass the original working directory
- Use `path.isAbsolute()` + `path.join(originalCwd, filePath)` instead of bare `path.resolve()`
- Add optional debug logging via `PLANNOTATOR_DEBUG` env var

## Testing

Tested on Windows 11 with Pi coding agent. Both relative and absolute paths resolve correctly now.