### PR TITLE
fix: render inline links inside bold and italic markdown

### DIFF
--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -56,7 +56,7 @@ import type { PlanDiffMode } from '@plannotator/ui/components/plan-diff/PlanDiff
 const PLAN_CONTENT = `# Implementation Plan: Real-time Collaboration
 
 ## Overview
-Add real-time collaboration features to the editor using WebSocket connections and operational transforms.
+Add real-time collaboration features to the editor using **[WebSocket API](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API)** and *[operational transforms](https://en.wikipedia.org/wiki/Operational_transformation)*.
 
 ### Architecture
 

--- a/packages/ui/components/Viewer.tsx
+++ b/packages/ui/components/Viewer.tsx
@@ -955,7 +955,7 @@ const InlineMarkdown: React.FC<{ text: string; onOpenLinkedDoc?: (path: string) 
     // Bold: **text**
     let match = remaining.match(/^\*\*(.+?)\*\*/);
     if (match) {
-      parts.push(<strong key={key++} className="font-semibold">{match[1]}</strong>);
+      parts.push(<strong key={key++} className="font-semibold"><InlineMarkdown text={match[1]} onOpenLinkedDoc={onOpenLinkedDoc} /></strong>);
       remaining = remaining.slice(match[0].length);
       continue;
     }
@@ -963,7 +963,7 @@ const InlineMarkdown: React.FC<{ text: string; onOpenLinkedDoc?: (path: string) 
     // Italic: *text*
     match = remaining.match(/^\*(.+?)\*/);
     if (match) {
-      parts.push(<em key={key++}>{match[1]}</em>);
+      parts.push(<em key={key++}><InlineMarkdown text={match[1]} onOpenLinkedDoc={onOpenLinkedDoc} /></em>);
       remaining = remaining.slice(match[0].length);
       continue;
     }

--- a/packages/ui/components/plan-diff/PlanCleanDiffView.tsx
+++ b/packages/ui/components/plan-diff/PlanCleanDiffView.tsx
@@ -299,7 +299,7 @@ const InlineMarkdown: React.FC<{ text: string }> = ({ text }) => {
     if (match) {
       parts.push(
         <strong key={key++} className="font-semibold">
-          {match[1]}
+          <InlineMarkdown text={match[1]} />
         </strong>
       );
       remaining = remaining.slice(match[0].length);
@@ -308,7 +308,7 @@ const InlineMarkdown: React.FC<{ text: string }> = ({ text }) => {
 
     match = remaining.match(/^\*(.+?)\*/);
     if (match) {
-      parts.push(<em key={key++}>{match[1]}</em>);
+      parts.push(<em key={key++}><InlineMarkdown text={match[1]} /></em>);
       remaining = remaining.slice(match[0].length);
       continue;
     }


### PR DESCRIPTION
## Summary
- make inline markdown rendering recursive for bold and italic segments so nested links are parsed instead of rendered as plain text
- apply the same fix in both the main viewer and the clean diff viewer to keep plan rendering consistent
- update the editor sample plan content to cover linked text inside bold and italic formatting