### PR TITLE
fix(pinpoint): restore click handler after exiting plan diff

### DIFF
--- a/packages/ui/hooks/usePinpoint.ts
+++ b/packages/ui/hooks/usePinpoint.ts
@@ -84,10 +84,16 @@ export function usePinpoint({
   // Click — create Range and trigger web-highlighter
   useEffect(() => {
     const container = containerRef.current;
-    const highlighter = highlighterRef.current;
-    if (!isActive || !container || !highlighter) return;
+    if (!isActive || !container) return;
 
     const handleClick = (e: MouseEvent) => {
+      // Read highlighter at click time, not effect setup time.
+      // On remount (e.g. after exiting plan diff), the highlighter init effect
+      // may not have run yet when this effect sets up, but it will be ready by
+      // the time the user clicks.
+      const highlighter = highlighterRef.current;
+      if (!highlighter) return;
+
       const target = e.target as HTMLElement;
       const resolved = resolvePinpointTarget(target, container, { clientX: e.clientX, clientY: e.clientY });
       if (!resolved) return;


### PR DESCRIPTION
## Summary

- **Bug**: Pinpoint mode stops working (clicks do nothing) after entering and exiting Plan Diff view. Drag selection continues to work fine.
- **Root cause**: The `usePinpoint` click effect read `highlighterRef.current` at effect setup time and exited early if null. After exiting plan diff, the `Viewer` component fully remounts — `usePinpoint`'s click effect ran *before* the highlighter init effect (line 500), so the ref was still `null`. The effect bailed without installing the click handler, and nothing triggered a re-run since all dependencies (stable refs, unchanged `isActive`) remained the same.
- **Why drag selection still worked**: Drag selection uses `web-highlighter`'s own internal mouseup listener (set up during `highlighter.run()`), which is independent of the `usePinpoint` hook.
- **Why hover overlay still worked**: The mousemove effect in `usePinpoint` doesn't depend on `highlighterRef`, so it continued functioning normally.

## Fix

Moved `highlighterRef.current` from effect setup time into the click handler body, so it's resolved lazily at click time when the highlighter is guaranteed to be initialized.

## Test plan

- [ ] Open a plan with version history (so diff badge appears)
- [ ] Switch to Pinpoint input method
- [ ] Click the diff badge to enter Plan Diff view
- [ ] Exit Plan Diff view (click "Exit Diff" or press Escape)
- [ ] Verify pinpoint hover overlay still appears on elements
- [ ] Verify clicking an element in pinpoint mode creates an annotation
- [ ] Verify drag selection still works after toggling diff on/off
- [ ] Verify pinpoint works on initial load (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)