### PR TITLE
feat: bidirectional scroll navigation between annotations and highlights

### DIFF
--- a/packages/editor/index.css
+++ b/packages/editor/index.css
@@ -249,6 +249,18 @@ pre code.hljs .hljs-code {
   background: oklch(0.70 0.20 60 / 0.15);
 }
 
+.annotation-highlight.focused {
+  background: oklch(0.70 0.20 200 / 0.45) !important;
+  box-shadow: 0 0 8px oklch(0.70 0.20 200 / 0.4);
+  border-bottom: 2px solid oklch(0.70 0.20 200);
+  filter: none;
+}
+
+.light .annotation-highlight.focused {
+  background: oklch(0.70 0.22 200 / 0.3) !important;
+  box-shadow: 0 0 6px oklch(0.60 0.20 200 / 0.3);
+}
+
 .annotation-highlight:hover {
   filter: brightness(1.2);
   cursor: pointer;

--- a/packages/ui/components/AnnotationPanel.tsx
+++ b/packages/ui/components/AnnotationPanel.tsx
@@ -43,7 +43,7 @@ export const AnnotationPanel: React.FC<PanelProps> = ({
     if (!selectedId || !listRef.current) return;
     const card = listRef.current.querySelector(`[data-annotation-id="${selectedId}"]`);
     if (card) {
-      card.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
     }
   }, [selectedId]);
 

--- a/packages/ui/components/AnnotationPanel.tsx
+++ b/packages/ui/components/AnnotationPanel.tsx
@@ -34,8 +34,18 @@ export const AnnotationPanel: React.FC<PanelProps> = ({
   onDeleteEditorAnnotation,
 }) => {
   const [copied, setCopied] = useState(false);
+  const listRef = useRef<HTMLDivElement>(null);
   const sortedAnnotations = [...annotations].sort((a, b) => a.createdA - b.createdA);
   const totalCount = annotations.length + (editorAnnotations?.length ?? 0);
+
+  // Scroll selected annotation card into view
+  useEffect(() => {
+    if (!selectedId || !listRef.current) return;
+    const card = listRef.current.querySelector(`[data-annotation-id="${selectedId}"]`);
+    if (card) {
+      card.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+  }, [selectedId]);
 
   const handleQuickShare = async () => {
     if (!shareUrl) return;
@@ -65,7 +75,7 @@ export const AnnotationPanel: React.FC<PanelProps> = ({
       </div>
 
       {/* List */}
-      <div className="flex-1 overflow-y-auto p-2 space-y-1.5">
+      <div ref={listRef} className="flex-1 overflow-y-auto p-2 space-y-1.5">
         {totalCount === 0 ? (
           <div className="flex flex-col items-center justify-center h-40 text-center px-4">
             <div className="w-10 h-10 rounded-full bg-muted/50 flex items-center justify-center mb-3">
@@ -276,6 +286,7 @@ const AnnotationCard: React.FC<{
 
   return (
     <div
+      data-annotation-id={annotation.id}
       onClick={onSelect}
       className={`
         group relative p-2.5 rounded-lg border cursor-pointer transition-all

--- a/packages/ui/components/Viewer.tsx
+++ b/packages/ui/components/Viewer.tsx
@@ -572,6 +572,46 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
     });
   }, [annotations]);
 
+  // Scroll to and focus the selected annotation's highlight in the content
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    // Clear all previously focused highlights
+    containerRef.current.querySelectorAll('.annotation-highlight.focused').forEach(el => {
+      el.classList.remove('focused');
+    });
+
+    if (!selectedAnnotationId) return;
+
+    // Find highlight elements: try web-highlighter first, then manual marks
+    const highlighter = highlighterRef.current;
+    let targetElements: Element[] = [];
+
+    if (highlighter) {
+      try {
+        const doms = highlighter.getDoms(selectedAnnotationId);
+        if (doms && doms.length > 0) {
+          targetElements = Array.from(doms);
+        }
+      } catch (e) {}
+    }
+
+    if (targetElements.length === 0) {
+      const manualMarks = containerRef.current.querySelectorAll(
+        `[data-bind-id="${selectedAnnotationId}"]`
+      );
+      if (manualMarks.length > 0) {
+        targetElements = Array.from(manualMarks);
+      }
+    }
+
+    if (targetElements.length === 0) return;
+
+    // Apply focused class to all elements and scroll the first one into view
+    targetElements.forEach(el => el.classList.add('focused'));
+    targetElements[0].scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }, [selectedAnnotationId]);
+
   const handleAnnotate = (type: AnnotationType) => {
     const highlighter = highlighterRef.current;
     if (!toolbarState || !highlighter) return;

--- a/packages/ui/components/Viewer.tsx
+++ b/packages/ui/components/Viewer.tsx
@@ -121,6 +121,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
   const modeRef = useRef<EditorMode>(mode);
   const onAddAnnotationRef = useRef(onAddAnnotation);
   const pendingSourceRef = useRef<any>(null);
+  const justCreatedIdRef = useRef<string | null>(null);
   const [toolbarState, setToolbarState] = useState<{
     element: HTMLElement;
     source: any;
@@ -260,6 +261,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
       highlighter.addClass('comment', source.id);
     }
 
+    justCreatedIdRef.current = newAnnotation.id;
     onAddAnnotationRef.current(newAnnotation);
   };
 
@@ -583,6 +585,12 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
 
     if (!selectedAnnotationId) return;
 
+    // Skip scroll+focus when annotation was just created (user is already looking at it)
+    if (justCreatedIdRef.current === selectedAnnotationId) {
+      justCreatedIdRef.current = null;
+      return;
+    }
+
     // Find highlight elements: try web-highlighter first, then manual marks
     const highlighter = highlighterRef.current;
     let targetElements: Element[] = [];
@@ -609,7 +617,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
 
     // Apply focused class to all elements and scroll the first one into view
     targetElements.forEach(el => el.classList.add('focused'));
-    targetElements[0].scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    targetElements[0].scrollIntoView({ behavior: 'smooth', block: 'center' });
   }, [selectedAnnotationId]);
 
   const handleAnnotate = (type: AnnotationType) => {
@@ -662,6 +670,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
       images,
     };
 
+    justCreatedIdRef.current = newAnnotation.id;
     onAddAnnotationRef.current(newAnnotation);
     window.getSelection()?.removeAllRanges();
   };


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                        
  - Clicking an annotation card in the right panel scrolls the plan content to the corresponding highlighted text and applies a distinctive "focused" highlight color (cyan glow)                                                 
  - Clicking highlighted text in the plan scrolls the annotation panel to bring the corresponding card into view                                                                                                                    
  - New `.annotation-highlight.focused` CSS class with dark and light mode support                                                                                                                                                
  - Scroll targets are centered in the viewport for easy visibility
  - Creating a new annotation does not trigger scroll/focus (user is already looking at it)

  ## Motivation
  When reviewing a long, detailed plan with many annotations — especially after importing a teammate's review — it's easy to lose track of which annotation card corresponds to which highlighted line in the content. The existing behavior only applies a subtle selected border to the card when a highlight is clicked, but doesn't scroll either panel, forcing the user to manually hunt for the matching element.

  ## How it works
  1. **Card → Highlight:** `Viewer.tsx` watches `selectedAnnotationId` and uses `highlighter.getDoms()` (for web-highlighter annotations) or `querySelector('[data-bind-id]')` (for shared/imported annotations) to find the
  corresponding `<mark>` elements. It applies a `.focused` class (bright cyan glow) and calls `scrollIntoView({ behavior: 'smooth', block: 'center' })`.
  2. **Highlight → Card:** `AnnotationPanel.tsx` watches `selectedId` and scrolls the matching `[data-annotation-id]` card into view within the panel's scroll container using `block: 'center'`.
  3. **Skip on creation:** A `justCreatedIdRef` tracks newly created annotation IDs so the scroll+focus effect is skipped when the user just added an annotation (they're already looking at it).
  4. **Edge cases:** Global comments (no highlight in content) gracefully no-op. Multi-node selections focus all marks and scroll to the first. Already-visible elements scroll smoothly to the center.

  ## Test plan
  - [ ] Add several annotations spread across a long plan
  - [ ] Click an annotation card → content scrolls to highlight with cyan glow, centered in viewport
  - [ ] Click highlighted text → panel scrolls to show the corresponding card with selected border, centered
  - [ ] Add a new annotation → no cyan focus or scroll triggered (user stays in place)
  - [ ] Click a global comment card → no scroll in content (expected)
  - [ ] Import a teammate's shared review → verify bidirectional navigation works with imported annotations
  - [ ] Verify focused highlight color in both dark and light mode
  - [ ] Test across Chrome, Firefox, Safari, and Edge

  🤖 Generated with [Claude Code](https://claude.com/claude-code)