### PR TITLE
feat: clipboard paste for per-annotation images & fix absolute path resolution

### DIFF
--- a/packages/server/resolve-file.ts
+++ b/packages/server/resolve-file.ts
@@ -42,12 +42,10 @@ export async function resolveMarkdownFile(
     return { kind: "not_found", input };
   }
 
-  // 1. Absolute path — use as-is
+  // 1. Absolute path — use as-is (no project root restriction;
+  //    the user explicitly typed the full path)
   if (input.startsWith("/")) {
     const normalized = resolve(input);
-    if (!normalized.startsWith(projectRoot + "/") && normalized !== projectRoot) {
-      return { kind: "not_found", input };
-    }
     if (await Bun.file(normalized).exists()) {
       return { kind: "found", path: normalized };
     }

--- a/packages/ui/components/AttachmentsButton.tsx
+++ b/packages/ui/components/AttachmentsButton.tsx
@@ -87,6 +87,28 @@ export const AttachmentsButton: React.FC<AttachmentsButtonProps> = ({
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [isOpen]);
 
+  // Paste image from clipboard when popover is open (per-annotation attachments).
+  // Uses capture phase + stopPropagation to prevent the global paste handler in
+  // App.tsx from also processing the same event.
+  useEffect(() => {
+    if (!isOpen || annotatorImage) return;
+    const handlePaste = (e: ClipboardEvent) => {
+      const items = e.clipboardData?.items;
+      if (!items) return;
+      for (const item of items) {
+        if (item.type.startsWith('image/')) {
+          e.preventDefault();
+          e.stopPropagation();
+          const file = item.getAsFile();
+          if (file) handleFileSelect(file);
+          return;
+        }
+      }
+    };
+    document.addEventListener('paste', handlePaste, true);
+    return () => document.removeEventListener('paste', handlePaste, true);
+  }, [isOpen, annotatorImage]);
+
   const handleFileSelect = (file: File) => {
     // Derive name before opening annotator so user sees it immediately
     const initialName = deriveImageName(file.name, images.map(i => i.name));
@@ -294,6 +316,9 @@ export const AttachmentsButton: React.FC<AttachmentsButtonProps> = ({
                     </svg>
                     <span className="text-xs text-muted-foreground">
                       Drop image or click to browse
+                    </span>
+                    <span className="text-[10px] text-muted-foreground/70">
+                      {navigator.platform?.includes('Mac') ? '⌘' : 'Ctrl'}+V to paste from clipboard
                     </span>
                   </>
                 )}


### PR DESCRIPTION
## Summary

- **Clipboard paste for per-annotation attachments**: When the `AttachmentsButton` popover is open, users can paste images from the clipboard (Cmd+V / Ctrl+V) directly into per-annotation attachments. Uses a capture-phase event listener with `stopPropagation` to prevent the existing global paste handler in `App.tsx` from double-processing the event.
- **Keyboard shortcut hint**: Adds a platform-aware hint ("⌘+V to paste from clipboard" on Mac, "Ctrl+V" elsewhere) in the drop zone UI.
- **Fix absolute path resolution regression**: `resolveMarkdownFile()` from #237 incorrectly rejected absolute paths outside the project root (e.g., `/Users/me/Downloads/notes.md`). The original `plannotator annotate` behavior allowed any user-provided absolute path; the project root boundary should only constrain relative/bare filename search.

## Files changed

| File | Change |
|------|--------|
| `packages/ui/components/AttachmentsButton.tsx` | Add capture-phase paste listener + hint text |
| `packages/server/resolve-file.ts` | Remove project root boundary check for absolute paths |

## How the paste listener works

The global paste handler in `App.tsx` (line 724) listens on `document` in the **bubble** phase and adds pasted images to global feedback attachments. The new `AttachmentsButton` listener registers on `document` in the **capture** phase, which fires first. When the popover is open, it intercepts the paste and routes the image to the per-annotation attachments, calling `stopPropagation()` so the global handler never sees the event. When the popover is closed, the listener is removed, so global paste works as before.

## Test plan

- [ ] Open annotation UI, paste an image with Cmd+V (no popover open) → image goes to global attachments (1 image, not 2)
- [ ] Open the per-annotation attachments popover, paste an image → image goes to that annotation's attachments
- [ ] Verify hint text shows "⌘+V" on Mac, "Ctrl+V" on other platforms
- [ ] Run `/plannotator-annotate /absolute/path/outside/project.md` → file opens correctly
- [ ] Run `/plannotator-annotate relative-file.md` → still resolves within project root

🤖 Generated with [Claude Code](https://claude.com/claude-code)