### PR TITLE
docs: add Codex support

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,9 @@ irm https://plannotator.ai/install.ps1 | iex
 
 **Then in Codex, run directly:**
 
-```bash
-plannotator review           # Code review for current changes
-plannotator annotate file.md # Annotate a markdown file
+```
+!plannotator review           # Code review for current changes
+!plannotator annotate file.md # Annotate a markdown file
 ```
 
 Plan mode is not yet supported.

--- a/apps/codex/README.md
+++ b/apps/codex/README.md
@@ -20,20 +20,20 @@ irm https://plannotator.ai/install.ps1 | iex
 
 ### Code Review
 
-Run `plannotator review` to open the code review UI for your current changes:
+Run `!plannotator review` to open the code review UI for your current changes:
 
-```bash
-plannotator review
+```
+!plannotator review
 ```
 
 This captures your git diff, opens a browser with the review UI, and waits for your feedback. When you submit annotations, the feedback is printed to stdout.
 
 ### Annotate Markdown
 
-Run `plannotator annotate` to annotate any markdown file:
+Run `!plannotator annotate` to annotate any markdown file:
 
-```bash
-plannotator annotate path/to/file.md
+```
+!plannotator annotate path/to/file.md
 ```
 
 ## Environment Variables

--- a/apps/marketing/src/content/docs/getting-started/installation.md
+++ b/apps/marketing/src/content/docs/getting-started/installation.md
@@ -105,7 +105,7 @@ Plan mode is not yet supported.
 
 Install the binary, then use it directly:
 
-```bash
-plannotator review           # Code review for current changes
-plannotator annotate file.md # Annotate a markdown file
+```
+!plannotator review           # Code review for current changes
+!plannotator annotate file.md # Annotate a markdown file
 ```


### PR DESCRIPTION
## Summary
- Add `apps/codex/README.md` stub with install and usage docs
- Add "Install for Codex" section to root README
- Replace "Coming soon" in marketing installation docs with actual instructions

Codex runs `plannotator review` and `plannotator annotate` as normal shell commands — no plugin or skill needed.

## Test plan
- [ ] Verify links in README render correctly
- [ ] Verify marketing docs build (`bun run build:marketing`)
- [ ] Test `plannotator review` from a Codex session

🤖 Generated with [Claude Code](https://claude.com/claude-code)