### PR TITLE
fix: detect OS for update banner install command

### DIFF
--- a/packages/ui/components/UpdateBanner.tsx
+++ b/packages/ui/components/UpdateBanner.tsx
@@ -1,8 +1,14 @@
 import React, { useState } from 'react';
 import { useUpdateCheck } from '../hooks/useUpdateCheck';
 
-const DEFAULT_INSTALL_COMMAND = 'curl -fsSL https://plannotator.ai/install.sh | bash';
 const PI_INSTALL_COMMAND = 'pi install npm:@plannotator/pi-extension';
+
+function getInstallCommand(): string {
+  const isWindows = typeof navigator !== 'undefined' && /^Win/.test(navigator.platform);
+  return isWindows
+    ? 'powershell -c "irm https://plannotator.ai/install.ps1 | iex"'
+    : 'curl -fsSL https://plannotator.ai/install.sh | bash';
+}
 
 interface UpdateBannerProps {
   origin?: 'claude-code' | 'opencode' | 'pi' | null;
@@ -19,7 +25,7 @@ export const UpdateBanner: React.FC<UpdateBannerProps> = ({ origin }) => {
   const effectiveOrigin = previewOrigin || origin;
   const isPi = effectiveOrigin === 'pi';
   const isOpenCode = effectiveOrigin === 'opencode';
-  const installCommand = isPi ? PI_INSTALL_COMMAND : DEFAULT_INSTALL_COMMAND;
+  const installCommand = isPi ? PI_INSTALL_COMMAND : getInstallCommand();
 
   if (!updateInfo?.updateAvailable || dismissed) return null;
 


### PR DESCRIPTION
## Summary
- Fixes #265 — Windows users were always shown the bash/curl install command in the update banner
- Detects OS via `navigator.platform` and shows the PowerShell command (`irm install.ps1 | iex`) on Windows

## Test plan
- [ ] Open plan review UI with `?preview-update=99.0.0` to force update banner
- [ ] On macOS/Linux: verify copied command is `curl -fsSL https://plannotator.ai/install.sh | bash`
- [ ] On Windows (or override `navigator.platform` in devtools): verify copied command is `powershell -c "irm https://plannotator.ai/install.ps1 | iex"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)