### PR TITLE
fix: VS Code extension doesn't work in SSH remote sessions

### DIFF
--- a/packages/server/shared-handlers.ts
+++ b/packages/server/shared-handlers.ts
@@ -112,13 +112,13 @@ export function handleDraftDelete(contentKey: string): Response {
   return Response.json({ ok: true });
 }
 
-/** Open browser for local sessions. Used by all 3 servers. */
+/** Open browser for local sessions or when a custom handler (e.g. VS Code extension) is configured. */
 export async function handleServerReady(
   url: string,
   isRemote: boolean,
   _port: number,
 ): Promise<void> {
-  if (!isRemote) {
+  if (!isRemote || process.env.PLANNOTATOR_BROWSER) {
     await openBrowser(url);
   }
 }


### PR DESCRIPTION
## Links

Closes #259

## Summary

In VS Code Remote SSH sessions, the Plannotator extension never opens a panel because `handleServerReady()` skips `openBrowser()` when it detects a remote session. However, the VS Code extension sets `PLANNOTATOR_BROWSER` to its own `open-in-vscode` handler, which should be respected regardless of session type.

**Fix:** When `PLANNOTATOR_BROWSER` is set, always call `openBrowser()` — even in remote sessions. This env var is the explicit signal that a custom handler (the VS Code extension) exists.

This is a one-line condition change in the shared handler used by all three modes (plan review, code review, annotate).

## Validation

- In a VS Code Remote SSH session, open an integrated terminal and run Claude Code with the plannotator plugin
- Trigger a plan review — the panel should now open in VS Code
- Verify code review (`/plannotator-review`) and annotate (`/plannotator-annotate`) also work in remote sessions
- Verify local (non-SSH) sessions are unaffected