### PR TITLE
fix: enable linked doc navigation in annotate mode

### DIFF
--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -506,9 +506,19 @@ const App: React.FC = () => {
     if (vaultBrowser.activeFile && vaultPath) {
       linkedDocHook.open(docPath, buildVaultDocUrl(vaultPath));
     } else {
-      linkedDocHook.open(docPath);
+      // Pass the current file's directory as base for relative path resolution
+      const baseDir = linkedDocHook.filepath
+        ? linkedDocHook.filepath.replace(/\/[^/]+$/, '')
+        : imageBaseDir;
+      if (baseDir) {
+        linkedDocHook.open(docPath, (path) =>
+          `/api/doc?path=${encodeURIComponent(path)}&base=${encodeURIComponent(baseDir)}`
+        );
+      } else {
+        linkedDocHook.open(docPath);
+      }
     }
-  }, [vaultBrowser.activeFile, vaultPath, linkedDocHook, buildVaultDocUrl]);
+  }, [vaultBrowser.activeFile, vaultPath, linkedDocHook, buildVaultDocUrl, imageBaseDir]);
 
   // Wrap linked doc back to also clear vault active file
   const handleLinkedDocBack = React.useCallback(() => {

--- a/packages/server/annotate.ts
+++ b/packages/server/annotate.ts
@@ -14,7 +14,9 @@
 import { isRemoteSession, getServerPort } from "./remote";
 import { getRepoInfo } from "./repo";
 import { handleImage, handleUpload, handleServerReady, handleDraftSave, handleDraftLoad, handleDraftDelete } from "./shared-handlers";
+import { handleDoc } from "./reference-handlers";
 import { contentHash, deleteDraft } from "./draft";
+import { dirname } from "path";
 
 // Re-export utilities
 export { isRemoteSession, getServerPort } from "./remote";
@@ -128,6 +130,17 @@ export async function startAnnotateServer(
           // API: Serve images (local paths or temp uploads)
           if (url.pathname === "/api/image") {
             return handleImage(req);
+          }
+
+          // API: Serve a linked markdown document
+          // Inject source file's directory as base for relative path resolution
+          if (url.pathname === "/api/doc" && req.method === "GET") {
+            if (!url.searchParams.has("base")) {
+              const docUrl = new URL(req.url);
+              docUrl.searchParams.set("base", dirname(filePath));
+              return handleDoc(new Request(docUrl.toString()));
+            }
+            return handleDoc(req);
           }
 
           // API: Upload image -> save to temp -> return path

--- a/packages/server/reference-handlers.ts
+++ b/packages/server/reference-handlers.ts
@@ -73,6 +73,20 @@ export async function handleDoc(req: Request): Promise<Response> {
     return Response.json({ error: "Missing path parameter" }, { status: 400 });
   }
 
+  // If a base directory is provided, try resolving relative to it first
+  // (used by annotate mode to resolve paths relative to the source file)
+  const base = url.searchParams.get("base");
+  if (base && !requestedPath.startsWith("/") && /\.mdx?$/i.test(requestedPath)) {
+    const fromBase = resolve(base, requestedPath);
+    try {
+      const file = Bun.file(fromBase);
+      if (await file.exists()) {
+        const markdown = await file.text();
+        return Response.json({ markdown, filepath: fromBase });
+      }
+    } catch { /* fall through to standard resolution */ }
+  }
+
   const projectRoot = process.cwd();
   const result = await resolveMarkdownFile(requestedPath, projectRoot);
 


### PR DESCRIPTION
## Summary

- **Bug:** Clicking `.md` links in annotated files (e.g., `[37% IQM](comparison_iqm_37.md)`) showed "Failed to connect to server" because the annotate server had no `/api/doc` endpoint — requests fell through to the SPA catch-all, returning HTML instead of JSON.
- **Root cause:** The `/api/doc` handler (`handleDoc`) was only registered in the plan server (`packages/server/index.ts`), not the annotate server (`packages/server/annotate.ts`).
- **Fix:** Three targeted changes:
  1. **`annotate.ts`** — Add `/api/doc` route, auto-injecting the source file's parent directory as `?base=` so relative sibling links (e.g., `comparison_iqm_37.md` from `plots/gamma_segments/comparison_iqm_35.md`) resolve from the correct location
  2. **`reference-handlers.ts`** — `handleDoc()` now accepts an optional `?base=` query param and tries resolving relative to it before falling back to the project-root glob search
  3. **`App.tsx`** — `handleOpenLinkedDoc` passes the current file's directory as `?base=` when navigating linked-doc → linked-doc, so chained relative links also resolve correctly

## Test plan

- [ ] `plannotator annotate` a markdown file that contains relative `.md` links to sibling files
- [ ] Click a `.md` link — linked doc should load in-place with back button
- [ ] From the linked doc, click another `.md` link — should resolve relative to *that* doc's directory
- [ ] Click back — should return to the original annotated file
- [ ] Plan server linked doc navigation still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)