### PR TITLE
feat: Render diagrams by default in plan review

### DIFF
--- a/packages/ui/components/GraphvizBlock.tsx
+++ b/packages/ui/components/GraphvizBlock.tsx
@@ -107,7 +107,7 @@ export const GraphvizBlock: React.FC<{ block: Block }> = ({ block }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [svg, setSvg] = useState('');
   const [error, setError] = useState<string | null>(null);
-  const [showSource, setShowSource] = useState(true);
+  const [showSource, setShowSource] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
 
   const zoomLevelRef = useRef(1);

--- a/packages/ui/components/MermaidBlock.tsx
+++ b/packages/ui/components/MermaidBlock.tsx
@@ -132,7 +132,7 @@ export const MermaidBlock: React.FC<{ block: Block }> = ({ block }) => {
   const expandedOverlayRef = useRef<HTMLDivElement>(null);
   const [svg, setSvg] = useState('');
   const [error, setError] = useState<string | null>(null);
-  const [showSource, setShowSource] = useState(true);
+  const [showSource, setShowSource] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
 
   // All zoom/pan state as refs to avoid re-renders


### PR DESCRIPTION
## Summary

- Show Mermaid and Graphviz diagrams in rendered mode by default in the plan review UI
- Keep the existing source toggle available so reviewers can still inspect the raw diagram definition

Fixed #275