### PR TITLE
fix: suppress native mobile context menu on text selection

### DIFF
--- a/packages/ui/components/Viewer.tsx
+++ b/packages/ui/components/Viewer.tsx
@@ -209,6 +209,21 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
     onCodeBlockClick: handlePinpointCodeBlockClick,
   });
 
+  // Suppress native context menu on touch devices (prevents cut/copy/paste overlay on mobile)
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const isTouchPrimary = window.matchMedia('(pointer: coarse)').matches;
+    if (!isTouchPrimary) return;
+
+    const handleContextMenu = (e: Event) => {
+      e.preventDefault();
+    };
+
+    container.addEventListener('contextmenu', handleContextMenu);
+    return () => container.removeEventListener('contextmenu', handleContextMenu);
+  }, []);
+
   // Detect when sticky action bar is "stuck" to show card background
   useEffect(() => {
     if (!stickyActions || !stickySentinelRef.current) return;
@@ -923,6 +938,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
         className={`w-full bg-card rounded-xl shadow-xl p-5 md:p-8 lg:p-10 xl:p-12 relative ${
           linkedDocInfo ? 'border-2 border-primary' : 'border border-border/50'
         } ${inputMethod === 'pinpoint' ? 'cursor-crosshair' : ''}`}
+        style={{ WebkitTouchCallout: 'none' } as React.CSSProperties}
       >
         {/* Repo info + plan diff badge + demo badge + linked doc badge - top left */}
         {(repoInfo || hasPreviousVersion || showDemoBadge || linkedDocInfo) && (


### PR DESCRIPTION
  ## Description

  On mobile (iOS Safari, Android Chrome), long-pressing to select text triggers the native context menu (cut/copy/paste) which overlays the annotation toolbar/picker.

  ---

  ## Fix

  Two complementary techniques scoped to the annotation `<article>` container only:

  - **CSS**: `-webkit-touch-callout: none` — suppresses iOS Safari callout
  - **JS**: `contextmenu` event listener with `preventDefault()` in a dedicated `useEffect`, gated by `(pointer: coarse)` media query — suppresses Android Chrome and other mobile browsers

  Desktop right-click remains unaffected.

  ---

  ## File changed

  | File | Change |
  |------|--------|
  | `packages/ui/components/Viewer.tsx` | Add `useEffect` for contextmenu suppression + `-webkit-touch-callout: none` inline style |

  ---

  ## Test Plan

  ### Mobile — iOS Safari
  - [ ] Long-press to select text — native callout (cut/copy/paste) should NOT appear
  - [ ] Annotation toolbar/picker appears without obstruction
  - [ ] Text selection handles still work normally
  - [ ] All annotation modes work (Markup, Comment, Redline, Label)
  - [ ] Pinpoint mode tap works without context menu

  ### Mobile — Android Chrome
  - [ ] Long-press to select text — native context menu should NOT appear
  - [ ] Annotation toolbar/picker appears without obstruction
  - [ ] Text selection handles still work normally
  - [ ] All annotation modes work (Markup, Comment, Redline, Label)

  ### Mobile — Other browsers
  - [ ] Firefox Mobile — same behavior as above
  - [ ] Samsung Internet — same behavior as above

  ### Desktop — No regressions
  - [ ] Right-click on content still works normally (context menu appears)
  - [ ] Text selection + annotation toolbar works as before
  - [ ] All modes (Markup, Comment, Redline, Label) unaffected