### PR TITLE
feat: configurable Bear tags + fix double-title bug

### DIFF
--- a/apps/hook/dev-mock-api.ts
+++ b/apps/hook/dev-mock-api.ts
@@ -3,8 +3,6 @@
  * Provides plan data with version history so the Versions tab works in dev mode.
  */
 import type { Plugin } from 'vite';
-import { execSync } from 'child_process';
-import type { IncomingMessage, ServerResponse } from 'http';
 
 // Version 1: earlier draft (shorter, missing sections)
 const PLAN_V1 = `# Implementation Plan: Real-time Collaboration
@@ -252,61 +250,8 @@ export function devMockApi(): Plugin {
           return;
         }
 
-        // Handle approve/save-notes for Bear testing in dev mode
-        if ((req.url === '/api/approve' || req.url === '/api/save-notes') && req.method === 'POST') {
-          parseBody(req).then((body) => {
-            const results: Record<string, unknown> = {};
-            if (body.bear?.plan) {
-              try {
-                const plan = body.bear.plan as string;
-                const customTags = body.bear.customTags as string | undefined;
-                const tagPosition = (body.bear.tagPosition as string) || 'append';
-
-                // Extract title from H1
-                const h1Match = plan.match(/^#\s+(?:Implementation\s+Plan:|Plan:)?\s*(.+)$/im);
-                const title = h1Match?.[1]?.trim().replace(/[<>:"/\\|?*(){}\[\]#~`]/g, '').slice(0, 50) || 'Plan';
-
-                // Strip H1 from body
-                const strippedBody = plan.replace(/^#\s+(?:Implementation\s+Plan:|Plan:)?\s*.+\n?/im, '').trimStart();
-
-                // Build hashtags
-                let hashtags: string;
-                if (customTags?.trim()) {
-                  hashtags = customTags.split(',').map((t: string) => `#${t.trim()}`).filter((t: string) => t !== '#').join(' ');
-                } else {
-                  hashtags = '#plannotator #dev';
-                }
-
-                const content = tagPosition === 'prepend'
-                  ? `${hashtags}\n\n${strippedBody}`
-                  : `${strippedBody}\n\n${hashtags}`;
-
-                const url = `bear://x-callback-url/create?title=${encodeURIComponent(title)}&text=${encodeURIComponent(content)}&open_note=no`;
-                execSync(`open "${url}"`);
-                results.bear = { success: true };
-              } catch (err) {
-                results.bear = { success: false, error: String(err) };
-              }
-            }
-            res.setHeader('Content-Type', 'application/json');
-            res.end(JSON.stringify({ ok: true, ...results }));
-          });
-          return;
-        }
-
         next();
       });
     },
   };
-}
-
-function parseBody(req: IncomingMessage): Promise<Record<string, any>> {
-  return new Promise((resolve) => {
-    let data = '';
-    req.on('data', (chunk: Buffer) => { data += chunk; });
-    req.on('end', () => {
-      try { resolve(JSON.parse(data)); }
-      catch { resolve({}); }
-    });
-  });
 }

--- a/apps/hook/dev-mock-api.ts
+++ b/apps/hook/dev-mock-api.ts
@@ -3,6 +3,8 @@
  * Provides plan data with version history so the Versions tab works in dev mode.
  */
 import type { Plugin } from 'vite';
+import { execSync } from 'child_process';
+import type { IncomingMessage, ServerResponse } from 'http';
 
 // Version 1: earlier draft (shorter, missing sections)
 const PLAN_V1 = `# Implementation Plan: Real-time Collaboration
@@ -250,8 +252,61 @@ export function devMockApi(): Plugin {
           return;
         }
 
+        // Handle approve/save-notes for Bear testing in dev mode
+        if ((req.url === '/api/approve' || req.url === '/api/save-notes') && req.method === 'POST') {
+          parseBody(req).then((body) => {
+            const results: Record<string, unknown> = {};
+            if (body.bear?.plan) {
+              try {
+                const plan = body.bear.plan as string;
+                const customTags = body.bear.customTags as string | undefined;
+                const tagPosition = (body.bear.tagPosition as string) || 'append';
+
+                // Extract title from H1
+                const h1Match = plan.match(/^#\s+(?:Implementation\s+Plan:|Plan:)?\s*(.+)$/im);
+                const title = h1Match?.[1]?.trim().replace(/[<>:"/\\|?*(){}\[\]#~`]/g, '').slice(0, 50) || 'Plan';
+
+                // Strip H1 from body
+                const strippedBody = plan.replace(/^#\s+(?:Implementation\s+Plan:|Plan:)?\s*.+\n?/im, '').trimStart();
+
+                // Build hashtags
+                let hashtags: string;
+                if (customTags?.trim()) {
+                  hashtags = customTags.split(',').map((t: string) => `#${t.trim()}`).filter((t: string) => t !== '#').join(' ');
+                } else {
+                  hashtags = '#plannotator #dev';
+                }
+
+                const content = tagPosition === 'prepend'
+                  ? `${hashtags}\n\n${strippedBody}`
+                  : `${strippedBody}\n\n${hashtags}`;
+
+                const url = `bear://x-callback-url/create?title=${encodeURIComponent(title)}&text=${encodeURIComponent(content)}&open_note=no`;
+                execSync(`open "${url}"`);
+                results.bear = { success: true };
+              } catch (err) {
+                results.bear = { success: false, error: String(err) };
+              }
+            }
+            res.setHeader('Content-Type', 'application/json');
+            res.end(JSON.stringify({ ok: true, ...results }));
+          });
+          return;
+        }
+
         next();
       });
     },
   };
+}
+
+function parseBody(req: IncomingMessage): Promise<Record<string, any>> {
+  return new Promise((resolve) => {
+    let data = '';
+    req.on('data', (chunk: Buffer) => { data += chunk; });
+    req.on('end', () => {
+      try { resolve(JSON.parse(data)); }
+      catch { resolve({}); }
+    });
+  });
 }

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -506,7 +506,11 @@ const App: React.FC = () => {
       }
 
       if (bearSettings.enabled) {
-        body.bear = { plan: markdown };
+        body.bear = {
+          plan: markdown,
+          customTags: bearSettings.customTags,
+          tagPosition: bearSettings.tagPosition,
+        };
       }
 
       // Include annotations as feedback if any exist (for OpenCode "approve with notes")
@@ -731,7 +735,12 @@ const App: React.FC = () => {
       }
     }
     if (target === 'bear') {
-      body.bear = { plan: markdown };
+      const bs = getBearSettings();
+      body.bear = {
+        plan: markdown,
+        customTags: bs.customTags,
+        tagPosition: bs.tagPosition,
+      };
     }
 
     try {

--- a/packages/server/integrations.test.ts
+++ b/packages/server/integrations.test.ts
@@ -5,27 +5,13 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { extractTitle, extractTags } from "./integrations";
-
-// We can't test saveToBear() directly (calls `open` with bear:// URL),
-// but we can test the building blocks and inline the body-construction logic.
-
-function stripH1(plan: string): string {
-  return plan.replace(/^#\s+.+\n?/m, "").trimStart();
-}
-
-function buildHashtags(customTags: string | undefined, autoTags: string[]): string {
-  if (customTags?.trim()) {
-    return customTags.split(",").map(t => `#${t.trim()}`).filter(t => t !== "#").join(" ");
-  }
-  return autoTags.map(t => `#${t}`).join(" ");
-}
-
-function buildContent(body: string, hashtags: string, tagPosition: "prepend" | "append"): string {
-  return tagPosition === "prepend"
-    ? `${hashtags}\n\n${body}`
-    : `${body}\n\n${hashtags}`;
-}
+import {
+  extractTitle,
+  extractTags,
+  stripH1,
+  buildHashtags,
+  buildBearContent,
+} from "./integrations";
 
 describe("extractTitle", () => {
   test("extracts plain H1", () => {
@@ -99,14 +85,14 @@ describe("buildHashtags", () => {
   });
 });
 
-describe("buildContent", () => {
+describe("buildBearContent", () => {
   test("appends tags by default", () => {
-    const result = buildContent("Body text", "#plan #work", "append");
+    const result = buildBearContent("Body text", "#plan #work", "append");
     expect(result).toBe("Body text\n\n#plan #work");
   });
 
   test("prepends tags when configured", () => {
-    const result = buildContent("Body text", "#plan #work", "prepend");
+    const result = buildBearContent("Body text", "#plan #work", "prepend");
     expect(result).toBe("#plan #work\n\nBody text");
   });
 });
@@ -123,7 +109,7 @@ describe("full Bear content pipeline", () => {
   test("custom tags prepended after title removal", () => {
     const body = stripH1(plan);
     const hashtags = buildHashtags("plan, work", []);
-    const content = buildContent(body, hashtags, "prepend");
+    const content = buildBearContent(body, hashtags, "prepend");
     expect(content).toStartWith("#plan #work");
     expect(content).toContain("## Context");
     expect(content).not.toContain("# SPE-589");
@@ -132,7 +118,7 @@ describe("full Bear content pipeline", () => {
   test("auto tags appended when no custom tags", () => {
     const body = stripH1(plan);
     const hashtags = buildHashtags("", ["plannotator", "dev"]);
-    const content = buildContent(body, hashtags, "append");
+    const content = buildBearContent(body, hashtags, "append");
     expect(content).toEndWith("#plannotator #dev");
     expect(content).toStartWith("## Context");
   });

--- a/packages/server/integrations.test.ts
+++ b/packages/server/integrations.test.ts
@@ -98,11 +98,11 @@ describe("buildBearContent", () => {
 });
 
 describe("full Bear content pipeline", () => {
-  const plan = "# SPE-589: Fix cross-account expense\n\n## Context\nSome content here";
+  const plan = "# Add user authentication flow\n\n## Context\nSome content here";
 
   test("no double title — H1 stripped from body", () => {
     const body = stripH1(plan);
-    expect(body).not.toContain("# SPE-589");
+    expect(body).not.toContain("# Add user");
     expect(body).toStartWith("## Context");
   });
 
@@ -112,7 +112,7 @@ describe("full Bear content pipeline", () => {
     const content = buildBearContent(body, hashtags, "prepend");
     expect(content).toStartWith("#plan #work");
     expect(content).toContain("## Context");
-    expect(content).not.toContain("# SPE-589");
+    expect(content).not.toContain("# Add user");
   });
 
   test("auto tags appended when no custom tags", () => {

--- a/packages/server/integrations.test.ts
+++ b/packages/server/integrations.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Bear Integration Tests
+ *
+ * Run: bun test packages/server/integrations.test.ts
+ */
+
+import { describe, expect, test } from "bun:test";
+import { extractTitle, extractTags } from "./integrations";
+
+// We can't test saveToBear() directly (calls `open` with bear:// URL),
+// but we can test the building blocks and inline the body-construction logic.
+
+function stripH1(plan: string): string {
+  return plan.replace(/^#\s+.+\n?/m, "").trimStart();
+}
+
+function buildHashtags(customTags: string | undefined, autoTags: string[]): string {
+  if (customTags?.trim()) {
+    return customTags.split(",").map(t => `#${t.trim()}`).filter(t => t !== "#").join(" ");
+  }
+  return autoTags.map(t => `#${t}`).join(" ");
+}
+
+function buildContent(body: string, hashtags: string, tagPosition: "prepend" | "append"): string {
+  return tagPosition === "prepend"
+    ? `${hashtags}\n\n${body}`
+    : `${body}\n\n${hashtags}`;
+}
+
+describe("extractTitle", () => {
+  test("extracts plain H1", () => {
+    expect(extractTitle("# My Plan\n\nContent")).toBe("My Plan");
+  });
+
+  test("strips Implementation Plan: prefix", () => {
+    expect(extractTitle("# Implementation Plan: Auth Flow\n\nContent")).toBe("Auth Flow");
+  });
+
+  test("strips Plan: prefix", () => {
+    expect(extractTitle("# Plan: Database Migration\n\nContent")).toBe("Database Migration");
+  });
+
+  test("falls back to 'Plan' when no H1", () => {
+    expect(extractTitle("No heading here")).toBe("Plan");
+  });
+
+  test("truncates to 50 chars", () => {
+    const long = "A".repeat(60);
+    expect(extractTitle(`# ${long}`).length).toBe(50);
+  });
+
+  test("removes special characters", () => {
+    expect(extractTitle("# Fix [bug] #123")).toBe("Fix bug 123");
+  });
+});
+
+describe("stripH1", () => {
+  test("strips first H1 line", () => {
+    expect(stripH1("# My Plan\n\n## Section\nContent")).toBe("## Section\nContent");
+  });
+
+  test("strips H1 with any wording", () => {
+    expect(stripH1("# Whatever Title Here\nBody")).toBe("Body");
+  });
+
+  test("only strips first H1, not subsequent ones", () => {
+    const input = "# First\n\n# Second\nBody";
+    expect(stripH1(input)).toBe("# Second\nBody");
+  });
+
+  test("handles plan with no H1", () => {
+    expect(stripH1("Just text\nMore text")).toBe("Just text\nMore text");
+  });
+
+  test("does not strip ## H2 headings", () => {
+    expect(stripH1("## Not H1\nBody")).toBe("## Not H1\nBody");
+  });
+});
+
+describe("buildHashtags", () => {
+  test("uses custom tags when provided", () => {
+    expect(buildHashtags("plan, work", ["plannotator"])).toBe("#plan #work");
+  });
+
+  test("falls back to auto tags when custom is empty", () => {
+    expect(buildHashtags("", ["plannotator", "myproject"])).toBe("#plannotator #myproject");
+  });
+
+  test("falls back to auto tags when custom is undefined", () => {
+    expect(buildHashtags(undefined, ["plannotator"])).toBe("#plannotator");
+  });
+
+  test("filters empty tags from trailing comma", () => {
+    expect(buildHashtags("plan, work,", ["plannotator"])).toBe("#plan #work");
+  });
+
+  test("handles whitespace-only custom tags as empty", () => {
+    expect(buildHashtags("   ", ["auto"])).toBe("#auto");
+  });
+});
+
+describe("buildContent", () => {
+  test("appends tags by default", () => {
+    const result = buildContent("Body text", "#plan #work", "append");
+    expect(result).toBe("Body text\n\n#plan #work");
+  });
+
+  test("prepends tags when configured", () => {
+    const result = buildContent("Body text", "#plan #work", "prepend");
+    expect(result).toBe("#plan #work\n\nBody text");
+  });
+});
+
+describe("full Bear content pipeline", () => {
+  const plan = "# SPE-589: Fix cross-account expense\n\n## Context\nSome content here";
+
+  test("no double title — H1 stripped from body", () => {
+    const body = stripH1(plan);
+    expect(body).not.toContain("# SPE-589");
+    expect(body).toStartWith("## Context");
+  });
+
+  test("custom tags prepended after title removal", () => {
+    const body = stripH1(plan);
+    const hashtags = buildHashtags("plan, work", []);
+    const content = buildContent(body, hashtags, "prepend");
+    expect(content).toStartWith("#plan #work");
+    expect(content).toContain("## Context");
+    expect(content).not.toContain("# SPE-589");
+  });
+
+  test("auto tags appended when no custom tags", () => {
+    const body = stripH1(plan);
+    const hashtags = buildHashtags("", ["plannotator", "dev"]);
+    const content = buildContent(body, hashtags, "append");
+    expect(content).toEndWith("#plannotator #dev");
+    expect(content).toStartWith("## Context");
+  });
+});
+
+describe("extractTags", () => {
+  test("always includes plannotator tag", async () => {
+    const tags = await extractTags("# Simple Plan\n\nContent");
+    expect(tags).toContain("plannotator");
+  });
+
+  test("extracts words from title", async () => {
+    const tags = await extractTags("# Authentication Service Refactor\n\nContent");
+    expect(tags).toContain("authentication");
+    expect(tags).toContain("service");
+    expect(tags).toContain("refactor");
+  });
+
+  test("filters stop words from title", async () => {
+    const tags = await extractTags("# Implementation Plan for the System\n\nContent");
+    expect(tags).not.toContain("implementation");
+    expect(tags).not.toContain("plan");
+    expect(tags).not.toContain("the");
+    expect(tags).not.toContain("for");
+  });
+
+  test("extracts code fence languages", async () => {
+    const tags = await extractTags("# Plan\n\n```typescript\ncode\n```\n\n```rust\ncode\n```");
+    expect(tags).toContain("typescript");
+    expect(tags).toContain("rust");
+  });
+
+  test("skips generic languages", async () => {
+    const tags = await extractTags("# Plan\n\n```json\n{}\n```\n\n```yaml\nfoo\n```");
+    expect(tags).not.toContain("json");
+    expect(tags).not.toContain("yaml");
+  });
+
+  test("limits to 7 tags", async () => {
+    const tags = await extractTags("# One Two Three Four\n\n```go\n```\n```python\n```\n```ruby\n```\n```swift\n```");
+    expect(tags.length).toBeLessThanOrEqual(7);
+  });
+});

--- a/packages/server/integrations.ts
+++ b/packages/server/integrations.ts
@@ -286,7 +286,7 @@ export async function saveToBear(config: BearConfig): Promise<IntegrationResult>
     const title = extractTitle(plan);
 
     // Strip first H1 from body (Bear's title param already carries it)
-    const body = plan.replace(/^#\s+(?:Implementation\s+Plan:|Plan:)?\s*.+\n?/im, '').trimStart();
+    const body = plan.replace(/^#\s+.+\n?/m, '').trimStart();
 
     // Build hashtags: custom tags if provided, otherwise auto-generate
     let hashtags: string;

--- a/packages/server/integrations.ts
+++ b/packages/server/integrations.ts
@@ -276,6 +276,23 @@ export async function saveToObsidian(config: ObsidianConfig): Promise<Integratio
 
 // --- Bear Integration ---
 
+export function stripH1(plan: string): string {
+  return plan.replace(/^#\s+.+\n?/m, '').trimStart();
+}
+
+export function buildHashtags(customTags: string | undefined, autoTags: string[]): string {
+  if (customTags?.trim()) {
+    return customTags.split(',').map(t => `#${t.trim()}`).filter(t => t !== '#').join(' ');
+  }
+  return autoTags.map(t => `#${t}`).join(' ');
+}
+
+export function buildBearContent(body: string, hashtags: string, tagPosition: 'prepend' | 'append'): string {
+  return tagPosition === 'prepend'
+    ? `${hashtags}\n\n${body}`
+    : `${body}\n\n${hashtags}`;
+}
+
 /**
  * Save plan to Bear using x-callback-url
  */
@@ -284,23 +301,14 @@ export async function saveToBear(config: BearConfig): Promise<IntegrationResult>
     const { plan, customTags, tagPosition = 'append' } = config;
 
     const title = extractTitle(plan);
+    const body = stripH1(plan);
 
-    // Strip first H1 from body (Bear's title param already carries it)
-    const body = plan.replace(/^#\s+.+\n?/m, '').trimStart();
+    const tags = customTags?.trim()
+      ? undefined
+      : await extractTags(plan);
+    const hashtags = buildHashtags(customTags, tags ?? []);
 
-    // Build hashtags: custom tags if provided, otherwise auto-generate
-    let hashtags: string;
-    if (customTags?.trim()) {
-      hashtags = customTags.split(',').map(t => `#${t.trim()}`).filter(t => t !== '#').join(' ');
-    } else {
-      const tags = await extractTags(plan);
-      hashtags = tags.map(t => `#${t}`).join(' ');
-    }
-
-    // Position tags relative to content
-    const content = tagPosition === 'prepend'
-      ? `${hashtags}\n\n${body}`
-      : `${body}\n\n${hashtags}`;
+    const content = buildBearContent(body, hashtags, tagPosition);
 
     const url = `bear://x-callback-url/create?title=${encodeURIComponent(title)}&text=${encodeURIComponent(content)}&open_note=no`;
 

--- a/packages/server/integrations.ts
+++ b/packages/server/integrations.ts
@@ -19,6 +19,8 @@ export interface ObsidianConfig {
 
 export interface BearConfig {
   plan: string;
+  customTags?: string;
+  tagPosition?: 'prepend' | 'append';
 }
 
 export interface IntegrationResult {
@@ -279,20 +281,29 @@ export async function saveToObsidian(config: ObsidianConfig): Promise<Integratio
  */
 export async function saveToBear(config: BearConfig): Promise<IntegrationResult> {
   try {
-    const { plan } = config;
+    const { plan, customTags, tagPosition = 'append' } = config;
 
-    // Extract title and tags
     const title = extractTitle(plan);
-    const tags = await extractTags(plan);
-    const hashtags = tags.map(t => `#${t}`).join(' ');
 
-    // Append hashtags to content
-    const content = `${plan}\n\n${hashtags}`;
+    // Strip first H1 from body (Bear's title param already carries it)
+    const body = plan.replace(/^#\s+(?:Implementation\s+Plan:|Plan:)?\s*.+\n?/im, '').trimStart();
 
-    // Build Bear URL
+    // Build hashtags: custom tags if provided, otherwise auto-generate
+    let hashtags: string;
+    if (customTags?.trim()) {
+      hashtags = customTags.split(',').map(t => `#${t.trim()}`).filter(t => t !== '#').join(' ');
+    } else {
+      const tags = await extractTags(plan);
+      hashtags = tags.map(t => `#${t}`).join(' ');
+    }
+
+    // Position tags relative to content
+    const content = tagPosition === 'prepend'
+      ? `${hashtags}\n\n${body}`
+      : `${body}\n\n${hashtags}`;
+
     const url = `bear://x-callback-url/create?title=${encodeURIComponent(title)}&text=${encodeURIComponent(content)}&open_note=no`;
 
-    // Open Bear via URL scheme
     await $`open ${url}`.quiet();
 
     return { success: true };

--- a/packages/ui/components/Settings.tsx
+++ b/packages/ui/components/Settings.tsx
@@ -12,6 +12,7 @@ import {
 import {
   getBearSettings,
   saveBearSettings,
+  normalizeTags,
   type BearSettings,
 } from '../utils/bear';
 import {
@@ -75,7 +76,7 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
   });
   const [detectedVaults, setDetectedVaults] = useState<string[]>([]);
   const [vaultsLoading, setVaultsLoading] = useState(false);
-  const [bear, setBear] = useState<BearSettings>({ enabled: false });
+  const [bear, setBear] = useState<BearSettings>({ enabled: false, customTags: '', tagPosition: 'append' });
   const [agent, setAgent] = useState<AgentSwitchSettings>({ switchTo: 'build' });
   const [planSave, setPlanSave] = useState<PlanSaveSettings>({ enabled: true, customPath: null });
   const [uiPrefs, setUiPrefs] = useState<UIPreferences>({ tocEnabled: true, stickyActionsEnabled: true });
@@ -159,8 +160,8 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
     saveObsidianSettings(newSettings);
   };
 
-  const handleBearChange = (enabled: boolean) => {
-    const newSettings = { enabled };
+  const handleBearChange = (updates: Partial<BearSettings>) => {
+    const newSettings = { ...bear, ...updates };
     setBear(newSettings);
     saveBearSettings(newSettings);
   };
@@ -1163,28 +1164,59 @@ tags: [plan, ...]
 
                 {/* === BEAR TAB === */}
                 {activeTab === 'bear' && (
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <div className="text-sm font-medium">Bear Notes</div>
-                      <div className="text-xs text-muted-foreground">
-                        Auto-save approved plans to Bear
+                  <>
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <div className="text-sm font-medium">Bear Notes</div>
+                        <div className="text-xs text-muted-foreground">
+                          Auto-save approved plans to Bear
+                        </div>
                       </div>
-                    </div>
-                    <button
-                      role="switch"
-                      aria-checked={bear.enabled}
-                      onClick={() => handleBearChange(!bear.enabled)}
-                      className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                        bear.enabled ? 'bg-primary' : 'bg-muted'
-                      }`}
-                    >
-                      <span
-                        className={`inline-block h-4 w-4 transform rounded-full bg-white shadow-sm transition-transform ${
-                          bear.enabled ? 'translate-x-6' : 'translate-x-1'
+                      <button
+                        role="switch"
+                        aria-checked={bear.enabled}
+                        onClick={() => handleBearChange({ enabled: !bear.enabled })}
+                        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                          bear.enabled ? 'bg-primary' : 'bg-muted'
                         }`}
-                      />
-                    </button>
-                  </div>
+                      >
+                        <span
+                          className={`inline-block h-4 w-4 transform rounded-full bg-white shadow-sm transition-transform ${
+                            bear.enabled ? 'translate-x-6' : 'translate-x-1'
+                          }`}
+                        />
+                      </button>
+                    </div>
+                    {bear.enabled && (
+                      <div className="mt-3 space-y-3">
+                        <div className="space-y-1.5 pl-0.5">
+                          <label className="text-xs text-muted-foreground">Custom Tags</label>
+                          <input
+                            type="text"
+                            value={bear.customTags}
+                            onChange={(e) => handleBearChange({ customTags: e.target.value })}
+                            onBlur={(e) => handleBearChange({ customTags: normalizeTags(e.target.value) })}
+                            placeholder="plan, work"
+                            className="w-full px-3 py-2 bg-muted rounded-lg text-xs font-mono placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-primary/50"
+                          />
+                          <div className="text-[10px] text-muted-foreground">
+                            Comma-separated, kebab-case. Leave empty for auto-generated tags.
+                          </div>
+                        </div>
+                        <div className="space-y-1.5 pl-0.5">
+                          <label className="text-xs text-muted-foreground">Tag Position</label>
+                          <select
+                            value={bear.tagPosition}
+                            onChange={(e) => handleBearChange({ tagPosition: e.target.value as 'prepend' | 'append' })}
+                            className="w-full px-3 py-2 bg-muted rounded-lg text-xs focus:outline-none focus:ring-1 focus:ring-primary/50"
+                          >
+                            <option value="append">Append (end of note)</option>
+                            <option value="prepend">Prepend (after title)</option>
+                          </select>
+                        </div>
+                      </div>
+                    )}
+                  </>
                 )}
 
               </div>

--- a/packages/ui/utils/bear.ts
+++ b/packages/ui/utils/bear.ts
@@ -8,26 +8,39 @@
 import { storage } from './storage';
 
 const STORAGE_KEY_ENABLED = 'plannotator-bear-enabled';
+const STORAGE_KEY_CUSTOM_TAGS = 'plannotator-bear-custom-tags';
+const STORAGE_KEY_TAG_POSITION = 'plannotator-bear-tag-position';
 
-/**
- * Bear integration settings
- */
+export type TagPosition = 'prepend' | 'append';
+
 export interface BearSettings {
   enabled: boolean;
+  customTags: string;
+  tagPosition: TagPosition;
 }
 
-/**
- * Get current Bear settings from storage
- */
 export function getBearSettings(): BearSettings {
   return {
     enabled: storage.getItem(STORAGE_KEY_ENABLED) === 'true',
+    customTags: storage.getItem(STORAGE_KEY_CUSTOM_TAGS) ?? '',
+    tagPosition: (storage.getItem(STORAGE_KEY_TAG_POSITION) as TagPosition) || 'append',
   };
 }
 
-/**
- * Save Bear settings to storage
- */
 export function saveBearSettings(settings: BearSettings): void {
   storage.setItem(STORAGE_KEY_ENABLED, String(settings.enabled));
+  storage.setItem(STORAGE_KEY_CUSTOM_TAGS, settings.customTags);
+  storage.setItem(STORAGE_KEY_TAG_POSITION, settings.tagPosition);
+}
+
+/**
+ * Normalize raw tag input to clean kebab-case, comma-separated string.
+ * Strips # prefixes, lowercases, replaces spaces with hyphens, removes invalid chars.
+ */
+export function normalizeTags(raw: string): string {
+  return raw
+    .split(',')
+    .map(t => t.trim().replace(/^#+/, '').toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, ''))
+    .filter(Boolean)
+    .join(', ');
 }

--- a/packages/ui/utils/bear.ts
+++ b/packages/ui/utils/bear.ts
@@ -13,12 +13,18 @@ const STORAGE_KEY_TAG_POSITION = 'plannotator-bear-tag-position';
 
 export type TagPosition = 'prepend' | 'append';
 
+/**
+ * Bear integration settings
+ */
 export interface BearSettings {
   enabled: boolean;
   customTags: string;
   tagPosition: TagPosition;
 }
 
+/**
+ * Get current Bear settings from storage
+ */
 export function getBearSettings(): BearSettings {
   return {
     enabled: storage.getItem(STORAGE_KEY_ENABLED) === 'true',
@@ -27,6 +33,9 @@ export function getBearSettings(): BearSettings {
   };
 }
 
+/**
+ * Save Bear settings to storage
+ */
 export function saveBearSettings(settings: BearSettings): void {
   storage.setItem(STORAGE_KEY_ENABLED, String(settings.enabled));
   storage.setItem(STORAGE_KEY_CUSTOM_TAGS, settings.customTags);


### PR DESCRIPTION
## Summary

- **Fix double title bug** — Bear's `title` URL param + the `# H1` in markdown body both rendered as titles. Now strips H1 from body before sending to Bear.
- **Configurable tags** — New settings in Bear tab: custom tags (comma-separated, kebab-case) and tag position (prepend/append). Empty = auto-generated tags (existing behavior).
- **Dev mock** — Added `/api/approve` and `/api/save-notes` handlers to dev mock for Bear testing in dev mode.

## Demo

https://github.com/user-attachments/assets/af364227-f164-4fcf-84ca-d8fa4928020a


## Test plan

- [x] Enable Bear, leave tags empty → approve → auto-generated tags at bottom, title once
- [x] Set custom tags `plan, hello, this-is-an-example` → approve → `#plan #hello #this-is-an-example`
- [x] Set position to prepend → tags appear right after title
- [x] Input normalization: `#Plan, #Work` → `plan, work` on blur
- [x] Dev mock: `curl -X POST /api/approve` with custom tags works