### PR TITLE
feat: remote session notifications via Tailscale and ntfy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,9 @@ claude --plugin-dir ./apps/hook
 | `PLANNOTATOR_SHARE` | Set to `disabled` to turn off URL sharing entirely. Default: enabled. Can also be set via `~/.plannotator/config.json` (`{ "share": "disabled" }`); the env var takes precedence. |
 | `PLANNOTATOR_SHARE_URL` | Custom base URL for share links (self-hosted portal). Default: `https://share.plannotator.ai`. |
 | `PLANNOTATOR_PASTE_URL` | Base URL of the paste service API for short URL sharing. Default: `https://plannotator-paste.plannotator.workers.dev`. |
+| `PLANNOTATOR_HOSTNAME` | Explicit hostname for remote URLs (e.g. `mybox.ts.net`). Auto-detected from Tailscale if not set. |
+| `CLAUDE_HOOKS_NTFY_URL` | Full ntfy URL (e.g. `https://ntfy.sh/mytopic`). When set, remote review URLs are sent as push notifications. |
+| `CLAUDE_HOOKS_NTFY_TOKEN` | Optional ntfy auth token (Bearer). |
 | `PLANNOTATOR_ORIGIN` | Explicit agent-origin override at the top of the detection chain. Valid values: `claude-code`, `amp`, `droid`, `opencode`, `codex`, `copilot-cli`, `gemini-cli`, `kiro-cli`, `pi`. Invalid values silently fall through to env-based detection. Unset by default. |
 | `PLANNOTATOR_JINA` | Set to `0` / `false` to disable Jina Reader for URL annotation, or `1` / `true` to enable. Default: enabled. Can also be set via `~/.plannotator/config.json` (`{ "jina": false }`) or per-invocation via `--no-jina`. |
 | `JINA_API_KEY` | Optional Jina Reader API key for higher rate limits (500 RPM vs 20 RPM unauthenticated). Free keys include 10M tokens. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,9 +126,9 @@ claude --plugin-dir ./apps/hook
 
 | Variable | Description |
 |----------|-------------|
-| `PLANNOTATOR_REMOTE` | Set to `1` / `true` for remote mode, `0` / `false` for local mode, or leave unset for SSH auto-detection. Uses a fixed port in remote mode; browser-opening behavior depends on the environment. |
+| `PLANNOTATOR_REMOTE` | Set to `1` / `true` for remote mode, `0` / `false` for local mode, or leave unset for SSH auto-detection. Uses a random port and binds beyond localhost in remote mode; browser-opening behavior depends on the environment. |
 | `PLANNOTATOR_AGENT_TERMINAL_REMOTE` | Set to `1` / `true` to enable the annotate-mode agent terminal while `PLANNOTATOR_REMOTE` is active. Off by default because remote mode binds beyond localhost. |
-| `PLANNOTATOR_PORT` | Fixed port to use. Default: random locally, `19432` for remote sessions. |
+| `PLANNOTATOR_PORT` | Fixed port to use. Default: random. Remote sessions are reached via a resolved hostname (Tailscale / `PLANNOTATOR_HOSTNAME`), not a fixed forwarded port. |
 | `PLANNOTATOR_BROWSER` | Custom browser to open plans in. macOS: app name or path. Linux/Windows: executable path. |
 | `PLANNOTATOR_SHARE` | Set to `disabled` to turn off URL sharing entirely. Default: enabled. Can also be set via `~/.plannotator/config.json` (`{ "share": "disabled" }`); the env var takes precedence. |
 | `PLANNOTATOR_SHARE_URL` | Custom base URL for share links (self-hosted portal). Default: `https://share.plannotator.ai`. |
@@ -357,7 +357,7 @@ During normal plan review, an Archive sidebar tab provides the same browsing via
 | `/api/external-annotations` | PATCH | Update fields on a single annotation (`?id=`) |
 | `/api/external-annotations` | DELETE | Remove by `?id=`, `?source=`, or clear all |
 
-All servers use random ports locally or fixed port (`19432`) in remote mode.
+All servers use random ports. Remote sessions are reached via a resolved hostname (Tailscale / `PLANNOTATOR_HOSTNAME`) or the read-only share link, not a fixed forwarded port.
 
 ### Paste Service (`apps/paste-service/`)
 

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Settings are saved in cookies (not localStorage) because each hook invocation ru
 | Variable | Description |
 |---|---|
 | `PLANNOTATOR_REMOTE` | `1`/`true` for remote mode, `0`/`false` for local, unset for SSH auto-detection |
-| `PLANNOTATOR_PORT` | Fixed port (default: random locally, `19432` remote) |
+| `PLANNOTATOR_PORT` | Fixed port (default: random; remote sessions are reached via a resolved hostname, not a fixed port) |
 | `PLANNOTATOR_BROWSER` | Custom browser to open plans in |
 | `PLANNOTATOR_SHARE` | `disabled` to turn off URL sharing |
 | `PLANNOTATOR_SHARE_URL` | Custom base URL for share links (self-hosted portal) |

--- a/apps/codex/README.md
+++ b/apps/codex/README.md
@@ -115,8 +115,8 @@ The message opens in the annotation UI where you can highlight text, add comment
 
 | Variable | Description |
 |----------|-------------|
-| `PLANNOTATOR_REMOTE` | Set to `1` / `true` for remote mode, `0` / `false` for local mode, or leave unset for SSH auto-detection. Uses a fixed port in remote mode; browser-opening behavior depends on the environment. |
-| `PLANNOTATOR_PORT` | Fixed port to use. Default: random locally, `19432` for remote sessions. |
+| `PLANNOTATOR_REMOTE` | Set to `1` / `true` for remote mode, `0` / `false` for local mode, or leave unset for SSH auto-detection. Uses a random port and binds beyond localhost in remote mode; browser-opening behavior depends on the environment. |
+| `PLANNOTATOR_PORT` | Fixed port to use. Default: random. Remote sessions are reached via a resolved hostname (Tailscale / `PLANNOTATOR_HOSTNAME`), not a fixed forwarded port. |
 | `PLANNOTATOR_BROWSER` | Custom browser to open. macOS: app name or path. Linux/Windows: executable path. |
 
 ## Links

--- a/apps/copilot/README.md
+++ b/apps/copilot/README.md
@@ -52,8 +52,8 @@ When you use plan mode in Copilot CLI:
 
 | Variable | Description |
 |----------|-------------|
-| `PLANNOTATOR_REMOTE` | Set to `1` / `true` for remote mode, `0` / `false` for local mode, or leave unset for SSH auto-detection. Uses a fixed port in remote mode; browser-opening behavior depends on the environment. |
-| `PLANNOTATOR_PORT` | Fixed port to use. Default: random locally, `19432` for remote sessions. |
+| `PLANNOTATOR_REMOTE` | Set to `1` / `true` for remote mode, `0` / `false` for local mode, or leave unset for SSH auto-detection. Uses a random port and binds beyond localhost in remote mode; browser-opening behavior depends on the environment. |
+| `PLANNOTATOR_PORT` | Fixed port to use. Default: random. Remote sessions are reached via a resolved hostname (Tailscale / `PLANNOTATOR_HOSTNAME`), not a fixed forwarded port. |
 | `PLANNOTATOR_BROWSER` | Custom browser to open. macOS: app name or path. Linux/Windows: executable path. |
 | `PLANNOTATOR_SHARE` | Set to `disabled` to turn off URL sharing. |
 

--- a/apps/gemini/README.md
+++ b/apps/gemini/README.md
@@ -72,8 +72,8 @@ If the installer didn't auto-configure your settings (e.g. `~/.gemini/settings.j
 
 | Variable | Description |
 |----------|-------------|
-| `PLANNOTATOR_REMOTE` | Set to `1` for remote mode (devcontainer, SSH). Uses fixed port and skips browser open. |
-| `PLANNOTATOR_PORT` | Fixed port to use. Default: random locally, `19432` for remote sessions. |
+| `PLANNOTATOR_REMOTE` | Set to `1` for remote mode (devcontainer, SSH). Uses a random port, binds beyond localhost, and skips opening a browser on the remote host. |
+| `PLANNOTATOR_PORT` | Fixed port to use. Default: random. Remote sessions are reached via a resolved hostname (Tailscale / `PLANNOTATOR_HOSTNAME`), not a fixed forwarded port. |
 | `PLANNOTATOR_BROWSER` | Custom browser to open. macOS: app name or path. Linux/Windows: executable path. |
 | `PLANNOTATOR_SHARE` | Set to `disabled` to turn off URL sharing. |
 

--- a/apps/hook/README.md
+++ b/apps/hook/README.md
@@ -77,8 +77,8 @@ When Claude Code calls `ExitPlanMode`, this hook intercepts and:
 
 | Variable | Description |
 |----------|-------------|
-| `PLANNOTATOR_REMOTE` | Set to `1` / `true` for remote mode, `0` / `false` for local mode, or leave unset for SSH auto-detection. Uses a fixed port in remote mode; browser-opening behavior depends on the environment. |
-| `PLANNOTATOR_PORT` | Fixed port to use. Default: random locally, `19432` for remote sessions. |
+| `PLANNOTATOR_REMOTE` | Set to `1` / `true` for remote mode, `0` / `false` for local mode, or leave unset for SSH auto-detection. Uses a random port and binds beyond localhost in remote mode; browser-opening behavior depends on the environment. |
+| `PLANNOTATOR_PORT` | Fixed port to use. Default: random. Remote sessions are reached via a resolved hostname (Tailscale / `PLANNOTATOR_HOSTNAME`), not a fixed forwarded port. |
 | `PLANNOTATOR_BROWSER` | Custom browser to open plans in. macOS: app name or path. Linux/Windows: executable path. |
 | `PLANNOTATOR_SHARE_URL` | Custom share portal URL for self-hosting. Default: `https://share.plannotator.ai`. |
 

--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -834,7 +834,7 @@ if (args[0] === "sessions") {
       handleReviewServerReady(url, isRemote, port);
 
       if (isRemote && sharingEnabled && rawPatch) {
-        await writeRemoteShareLink(rawPatch, shareBaseUrl, "review changes", "diff only").catch(() => {});
+        await writeRemoteShareLink(rawPatch, shareBaseUrl, "review changes", "diff only", { serverUrl: url, pasteApiUrl }).catch(() => {});
       }
     },
   });
@@ -1035,9 +1035,13 @@ if (args[0] === "sessions") {
           await writeRemoteShareLink("", shareBaseUrl, "annotate", "HTML document only", {
             rawHtml: inlineHtmlLocalAssets(rawHtml, absolutePath),
             pasteApiUrl,
+            serverUrl: url,
           }).catch(() => {});
         } else if (markdown) {
-          await writeRemoteShareLink(markdown, shareBaseUrl, "annotate", "document only").catch(() => {});
+          await writeRemoteShareLink(markdown, shareBaseUrl, "annotate", "document only", {
+            pasteApiUrl,
+            serverUrl: url,
+          }).catch(() => {});
         }
       }
     },
@@ -1910,7 +1914,7 @@ if (args[0] === "sessions") {
       handleServerReady(url, isRemote, port);
 
       if (isRemote && sharingEnabled) {
-        await writeRemoteShareLink(planContent, shareBaseUrl, "review the plan", "plan only").catch(() => {});
+        await writeRemoteShareLink(planContent, shareBaseUrl, "review the plan", "plan only", { serverUrl: url, pasteApiUrl }).catch(() => {});
       }
     },
   });

--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -64,7 +64,7 @@
  *
  * Environment variables:
  *   PLANNOTATOR_REMOTE - Set to "1"/"true" for remote, "0"/"false" for local
- *   PLANNOTATOR_PORT   - Fixed port to use (default: random locally, 19432 for remote)
+ *   PLANNOTATOR_PORT   - Fixed port to use (default: random)
  */
 
 import {

--- a/apps/marketing/src/content/docs/getting-started/configuration.md
+++ b/apps/marketing/src/content/docs/getting-started/configuration.md
@@ -12,8 +12,8 @@ Plannotator is configured through environment variables, hook/plugin configurati
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `PLANNOTATOR_REMOTE` | auto-detect | Set to `1` or `true` to force remote mode, `0` or `false` to force local mode, or leave unset to auto-detect via `SSH_TTY` / `SSH_CONNECTION`. Uses a fixed port in remote mode; browser-opening behavior depends on the environment. |
-| `PLANNOTATOR_PORT` | random (local) / `19432` (remote) | Fixed server port. Useful for port forwarding in remote environments. |
+| `PLANNOTATOR_REMOTE` | auto-detect | Set to `1` or `true` to force remote mode, `0` or `false` to force local mode, or leave unset to auto-detect via `SSH_TTY` / `SSH_CONNECTION`. Uses a random port and binds beyond localhost in remote mode; browser-opening behavior depends on the environment. |
+| `PLANNOTATOR_PORT` | random | Fixed server port. When unset, every session uses a random port; remote sessions are reached via a resolved hostname (Tailscale / `PLANNOTATOR_HOSTNAME`), not a fixed forwarded port. |
 | `PLANNOTATOR_BROWSER` | system default | Custom browser or script to open the UI. |
 | `PLANNOTATOR_SHARE` | enabled | Set to `disabled` to turn off URL sharing entirely. Can also be set via `~/.plannotator/config.json` (`{ "share": "disabled" }`). |
 | `PLANNOTATOR_SHARE_URL` | `https://share.plannotator.ai` | Point share links at a self-hosted portal. |

--- a/apps/marketing/src/content/docs/guides/remote-and-devcontainers.md
+++ b/apps/marketing/src/content/docs/guides/remote-and-devcontainers.md
@@ -6,7 +6,7 @@ sidebar:
 section: "Guides"
 ---
 
-Plannotator works in remote environments — SSH sessions, VS Code Remote, devcontainers, and Docker. The key difference is that remote sessions benefit from a fixed port for forwarding, and browser-opening behavior depends on your environment.
+Plannotator works in remote environments — SSH sessions, VS Code Remote, devcontainers, and Docker. In remote mode the server binds beyond localhost and never opens a browser on the remote host; instead it surfaces a URL you open on your local machine.
 
 ## Remote mode
 
@@ -14,13 +14,32 @@ Set `PLANNOTATOR_REMOTE=1` (or `true`) to force remote mode:
 
 ```bash
 export PLANNOTATOR_REMOTE=1
-export PLANNOTATOR_PORT=9999  # Choose a port you'll forward
 ```
 
-Remote mode changes two behaviors:
+Remote mode changes these behaviors:
 
-1. **Fixed port** — Uses `PLANNOTATOR_PORT` (default: `19432`) instead of a random port, so you can set up port forwarding once
-2. **Browser handling changes** — In headless setups you may need to open the forwarded URL manually instead of relying on browser auto-open
+1. **Binds beyond localhost** — The server listens on `0.0.0.0` on a random port (so parallel sessions never collide), instead of loopback only
+2. **Reachable via a resolved hostname** — Plannotator surfaces a URL built from `PLANNOTATOR_HOSTNAME` if set, otherwise an auto-detected [Tailscale](#tailscale-recommended) hostname. No fixed port forwarding required. If no reachable hostname is found, it generates a read-only share link instead
+3. **No browser on the remote host** — The reachable URL is printed to stderr and, if `CLAUDE_HOOKS_NTFY_URL` is set, sent as an ntfy push. Open it on your local machine
+
+## Tailscale (recommended)
+
+If both your remote host and local machine are on the same [Tailscale](https://tailscale.com/) tailnet, Plannotator auto-detects the host's Tailscale DNS name via `tailscale status` and builds a directly-reachable URL (full review with approve/deny) — no port forwarding or share link needed. Nothing to configure beyond having Tailscale running on the remote host.
+
+To override auto-detection (or to use a non-Tailscale reachable hostname), set it explicitly:
+
+```bash
+export PLANNOTATOR_HOSTNAME=mybox.ts.net
+```
+
+## Fixed port + forwarding (fallback)
+
+If you can't use a reachable hostname, pin a port and forward it yourself. Setting `PLANNOTATOR_PORT` opts back into a stable port for forwarding:
+
+```bash
+export PLANNOTATOR_REMOTE=1
+export PLANNOTATOR_PORT=9999  # Choose a port you'll forward
+```
 
 ### Legacy detection
 

--- a/apps/marketing/src/content/docs/reference/api-endpoints.md
+++ b/apps/marketing/src/content/docs/reference/api-endpoints.md
@@ -8,7 +8,7 @@ section: "Reference"
 
 Plannotator runs a local Bun HTTP server for each session. The server serves the UI and exposes a REST API for communication between the browser and the CLI.
 
-All servers use random ports locally or a fixed port (`19432` by default) in remote mode.
+All servers use random ports. Remote sessions are reached via a resolved hostname (Tailscale / `PLANNOTATOR_HOSTNAME`) or a read-only share link, not a fixed forwarded port.
 
 ## Plan server
 

--- a/apps/marketing/src/content/docs/reference/environment-variables.md
+++ b/apps/marketing/src/content/docs/reference/environment-variables.md
@@ -12,8 +12,9 @@ All Plannotator environment variables and their defaults.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `PLANNOTATOR_REMOTE` | auto-detect | Set to `1` or `true` to force remote mode, `0` or `false` to force local mode, or leave unset to auto-detect via `SSH_TTY` / `SSH_CONNECTION`. Uses a fixed port in remote mode; browser-opening behavior depends on the environment. |
-| `PLANNOTATOR_PORT` | random (local) / `19432` (remote) | Fixed server port. When not set, local sessions use a random port; remote sessions default to `19432`. |
+| `PLANNOTATOR_REMOTE` | auto-detect | Set to `1` or `true` to force remote mode, `0` or `false` to force local mode, or leave unset to auto-detect via `SSH_TTY` / `SSH_CONNECTION`. Uses a random port and binds beyond localhost in remote mode; browser-opening behavior depends on the environment. |
+| `PLANNOTATOR_PORT` | random | Fixed server port. When not set, every session uses a random port. Remote sessions are reached via a resolved hostname (Tailscale / `PLANNOTATOR_HOSTNAME`), not a fixed forwarded port. |
+| `PLANNOTATOR_HOSTNAME` | auto-detect | Explicit hostname for remote URLs (e.g. `mybox.ts.net`). Auto-detected from Tailscale when unset; falls back to a read-only share link if no reachable hostname is available. |
 | `PLANNOTATOR_BROWSER` | system default | Custom browser to open the UI in. macOS: app name or path. Linux/Windows: executable path. Can also be a script. Takes priority over `BROWSER`. Also settable per-invocation with `--browser`. |
 | `BROWSER` | (none) | Standard env var for specifying a browser. VS Code sets this automatically in devcontainers. Used as fallback when `PLANNOTATOR_BROWSER` is not set. |
 | `PLANNOTATOR_ORIGIN` | auto-detect | Explicit agent-origin override. Valid values: `claude-code`, `amp`, `droid`, `opencode`, `codex`, `copilot-cli`, `pi`, `gemini-cli`, `kiro-cli`. Invalid values silently fall through to env-based detection. |
@@ -70,9 +71,10 @@ When running your own paste service binary, these variables configure it:
 
 When remote mode is forced with `PLANNOTATOR_REMOTE=1` / `true`, or SSH is detected while `PLANNOTATOR_REMOTE` is unset:
 
-- Server binds to `PLANNOTATOR_PORT` (default `19432`) instead of a random port
-- Browser-opening behavior depends on the environment and configured browser handler
-- In headless setups, you may need to open the forwarded URL manually
+- Server binds beyond localhost (`0.0.0.0`) on a random port (or `PLANNOTATOR_PORT` if set)
+- The reachable URL uses a resolved hostname — `PLANNOTATOR_HOSTNAME` if set, otherwise an auto-detected Tailscale hostname — so no fixed port forwarding is needed
+- When no reachable hostname is available, a read-only share link is generated instead
+- A browser is never opened on the remote host; the reachable URL is surfaced via stderr and an optional ntfy push
 
 ### Legacy SSH detection
 
@@ -88,8 +90,15 @@ If either is present, Plannotator enables remote mode automatically when `PLANNO
 ## Port resolution order
 
 1. `PLANNOTATOR_PORT` environment variable (if valid integer 0-65535; `0` means random)
-2. `19432` if in remote mode
-3. `0` (random) if in local mode
+2. `0` (random) otherwise — both local and remote sessions use a random port
+
+## Hostname resolution order
+
+For the user-facing URL of a remote session:
+
+1. `PLANNOTATOR_HOSTNAME` environment variable (explicit override)
+2. Tailscale hostname (auto-detected via `tailscale status`)
+3. `localhost` fallback — surfaced as a read-only share link instead of a direct URL
 
 ## Custom browser examples
 

--- a/apps/opencode-plugin/README.md
+++ b/apps/opencode-plugin/README.md
@@ -151,8 +151,8 @@ Register the tool but manage prompts and permissions yourself:
 
 | Variable | Description |
 |----------|-------------|
-| `PLANNOTATOR_REMOTE` | Set to `1` / `true` for remote mode, `0` / `false` for local mode, or leave unset for SSH auto-detection. Uses a fixed port in remote mode; browser-opening behavior depends on the environment. |
-| `PLANNOTATOR_PORT` | Fixed port to use. Default: random locally, `19432` for remote sessions. |
+| `PLANNOTATOR_REMOTE` | Set to `1` / `true` for remote mode, `0` / `false` for local mode, or leave unset for SSH auto-detection. Uses a random port and binds beyond localhost in remote mode; browser-opening behavior depends on the environment. |
+| `PLANNOTATOR_PORT` | Fixed port to use. Default: random. Remote sessions are reached via a resolved hostname (Tailscale / `PLANNOTATOR_HOSTNAME`), not a fixed forwarded port. |
 | `PLANNOTATOR_BROWSER` | Custom browser to open plans in. macOS: app name or path. Linux/Windows: executable path. |
 | `PLANNOTATOR_SHARE_URL` | Custom share portal URL for self-hosting. Default: `https://share.plannotator.ai`. |
 | `PLANNOTATOR_PASTE_URL` | Custom paste service URL for self-hosting. Default: `https://plannotator-paste.plannotator.workers.dev`. |

--- a/apps/opencode-plugin/embedded.ts
+++ b/apps/opencode-plugin/embedded.ts
@@ -43,6 +43,16 @@ export async function runEmbeddedPlanReview(
     onReady: async (url, isRemote, port) => {
       await handleServerReady(url, isRemote, port);
       input.logReady(url, isRemote, port);
+      if (isRemote && input.sharingEnabled) {
+        const { writeRemoteShareLink } = await import("@plannotator/server/share-url");
+        await writeRemoteShareLink(
+          input.planContent,
+          input.shareBaseUrl,
+          "review the plan",
+          "plan only",
+          { serverUrl: url, pasteApiUrl: input.pasteApiUrl },
+        ).catch(() => {});
+      }
     },
   });
 

--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -8,7 +8,7 @@
  *
  * Environment variables:
  *   PLANNOTATOR_REMOTE - Set to "1"/"true" for remote, "0"/"false" for local
- *   PLANNOTATOR_PORT   - Fixed port to use (default: random locally, 19432 for remote)
+ *   PLANNOTATOR_PORT   - Fixed port to use (default: random)
  *   PLANNOTATOR_PLAN_TIMEOUT_SECONDS - Max wait for approval (default: 345600, set 0 to disable)
  *   PLANNOTATOR_ALLOW_SUBAGENTS - Set to "1" to allow subagents to see submit_plan
  *

--- a/apps/pi-extension/plannotator-browser.ts
+++ b/apps/pi-extension/plannotator-browser.ts
@@ -23,6 +23,7 @@ import {
 	unstageFile,
 } from "./server.js";
 import { openBrowser, isRemoteSession } from "./server/network.js";
+import { prepareRemoteShareLink } from "./generated/share-url.js";
 import { parsePRUrl, checkPRAuth, fetchPR } from "./server/pr.js";
 import {
 	getMRLabel,
@@ -92,10 +93,61 @@ export function getStartupErrorMessage(err: unknown): string {
 	return err instanceof Error ? err.message : "Unknown error";
 }
 
-async function openBrowserForServer(serverUrl: string, ctx: ExtensionContext): Promise<void> {
+/**
+ * Describes the content to share if the remote server isn't directly reachable.
+ * When omitted, only the raw server URL is surfaced (e.g. archive browsing).
+ */
+interface RemoteShareSpec {
+	content: string;
+	verb: string;
+	noun: string;
+	rawHtml?: string;
+}
+
+/**
+ * On remote sessions, surface a directly-reachable URL (Tailscale/explicit
+ * hostname → full approve/deny) or a read-only share link as fallback, and
+ * fire an ntfy push if configured. Falls back to the raw server URL on error.
+ */
+async function notifyRemoteShareLink(
+	serverUrl: string,
+	ctx: ExtensionContext,
+	share: RemoteShareSpec,
+): Promise<void> {
+	try {
+		const link = await prepareRemoteShareLink(
+			share.content,
+			process.env.PLANNOTATOR_SHARE_URL || undefined,
+			share.verb,
+			share.noun,
+			{
+				serverUrl,
+				pasteApiUrl: process.env.PLANNOTATOR_PASTE_URL || undefined,
+				rawHtml: share.rawHtml,
+			},
+		);
+		const suffix = link.ntfyOk ? " [notified via ntfy]" : "";
+		ctx.ui.notify(
+			`[Plannotator] Open on your local machine to ${share.verb}: ${link.url} (${link.descriptor})${suffix}`,
+			"info",
+		);
+	} catch {
+		ctx.ui.notify(`[Plannotator] ${serverUrl}`, "info");
+	}
+}
+
+async function openBrowserForServer(
+	serverUrl: string,
+	ctx: ExtensionContext,
+	remoteShare?: RemoteShareSpec,
+): Promise<void> {
 	const browserResult = await openBrowser(serverUrl);
 	if (isRemoteSession()) {
-		ctx.ui.notify(`[Plannotator] ${serverUrl}`, "info");
+		if (remoteShare) {
+			await notifyRemoteShareLink(serverUrl, ctx, remoteShare);
+		} else {
+			ctx.ui.notify(`[Plannotator] ${serverUrl}`, "info");
+		}
 	} else if (!browserResult.opened) {
 		ctx.ui.notify(`Open this URL to review: ${serverUrl}`, "info");
 	}
@@ -142,8 +194,9 @@ function startBrowserDecisionSession<T>(
 	server: { url: string; stop: () => void },
 	ctx: ExtensionContext,
 	waitForResult: () => Promise<T>,
+	remoteShare?: RemoteShareSpec,
 ): BrowserDecisionSession<T> {
-	openBrowserForServer(server.url, ctx);
+	openBrowserForServer(server.url, ctx, remoteShare);
 	let stopped = false;
 	let stopReject: ((err: Error) => void) | undefined;
 	let decisionPromise: Promise<T> | undefined;
@@ -197,7 +250,11 @@ export async function startPlanReviewBrowserSession(
 		pasteApiUrl: process.env.PLANNOTATOR_PASTE_URL || undefined,
 	});
 
-	const session = startBrowserDecisionSession(server, ctx, server.waitForDecision);
+	const session = startBrowserDecisionSession(server, ctx, server.waitForDecision, {
+		content: planContent,
+		verb: "review the plan",
+		noun: "plan only",
+	});
 	server.onDecision(() => {
 		setTimeout(() => session.stop(), 1500);
 	});
@@ -486,7 +543,11 @@ export async function startCodeReviewBrowserSession(
 		onCleanup: worktreeCleanup,
 	});
 
-	return startBrowserDecisionSession(server, ctx, server.waitForDecision);
+	return startBrowserDecisionSession(server, ctx, server.waitForDecision, {
+		content: rawPatch,
+		verb: "review changes",
+		noun: "diff only",
+	});
 }
 
 export async function openMarkdownAnnotation(
@@ -562,7 +623,14 @@ export async function startMarkdownAnnotationSession(
 		agentCwd: ctx.cwd,
 	});
 
-	return startBrowserDecisionSession(server, ctx, server.waitForDecision);
+	return startBrowserDecisionSession(
+		server,
+		ctx,
+		server.waitForDecision,
+		rawHtml
+			? { content: "", verb: "annotate", noun: "HTML document only", rawHtml }
+			: { content: resolvedMarkdown, verb: "annotate", noun: "document only" },
+	);
 }
 
 export async function openLastMessageAnnotation(

--- a/apps/pi-extension/plannotator-browser.ts
+++ b/apps/pi-extension/plannotator-browser.ts
@@ -107,7 +107,8 @@ interface RemoteShareSpec {
 /**
  * On remote sessions, surface a directly-reachable URL (Tailscale/explicit
  * hostname → full approve/deny) or a read-only share link as fallback, and
- * fire an ntfy push if configured. Falls back to the raw server URL on error.
+ * fire an ntfy push if configured. On error, surface the failure reason rather
+ * than the (locally-unreachable) raw server URL.
  */
 async function notifyRemoteShareLink(
 	serverUrl: string,
@@ -131,8 +132,19 @@ async function notifyRemoteShareLink(
 			`[Plannotator] Open on your local machine to ${share.verb}: ${link.url} (${link.descriptor})${suffix}`,
 			"info",
 		);
-	} catch {
-		ctx.ui.notify(`[Plannotator] ${serverUrl}`, "info");
+	} catch (error) {
+		// prepareRemoteShareLink only throws when the read-only fallback share
+		// link can't be generated (the server URL isn't directly reachable here,
+		// so echoing it would be useless to the remote user). Surface the reason
+		// and a hint instead. Mirrors the Bun CLI's writeRemoteShareLink warning.
+		const reason = error instanceof Error ? error.message : String(error);
+		const pasteHint = share.rawHtml
+			? " HTML sharing uses the paste service; check PLANNOTATOR_PASTE_URL or try a smaller/self-contained HTML file."
+			: "";
+		ctx.ui.notify(
+			`[Plannotator] Could not create a remote share link for ${share.noun}: ${reason}.${pasteHint}`,
+			"error",
+		);
 	}
 }
 

--- a/apps/pi-extension/server/network.test.ts
+++ b/apps/pi-extension/server/network.test.ts
@@ -2,15 +2,18 @@ import { afterEach, describe, expect, test } from "bun:test";
 import {
 	getServerHostname,
 	getServerPort,
+	getServerUrlHostname,
 	isNoOpBrowserSentinel,
 	isRemoteSession,
 	openBrowser,
+	resetServerUrlHostnameCache,
 } from "./network";
 
 const savedEnv: Record<string, string | undefined> = {};
 const envKeys = [
 	"PLANNOTATOR_REMOTE",
 	"PLANNOTATOR_PORT",
+	"PLANNOTATOR_HOSTNAME",
 	"SSH_TTY",
 	"SSH_CONNECTION",
 	"PLANNOTATOR_BROWSER",
@@ -93,10 +96,10 @@ describe("pi port selection", () => {
 		expect(getServerPort()).toEqual({ port: 0, portSource: "random" });
 	});
 
-	test("uses default remote port when SSH is detected", () => {
+	test("uses a random port for remote sessions (hostname is resolved separately)", () => {
 		clearEnv();
 		process.env.SSH_CONNECTION = "192.168.1.1 12345 192.168.1.2 22";
-		expect(getServerPort()).toEqual({ port: 19432, portSource: "remote-default" });
+		expect(getServerPort()).toEqual({ port: 0, portSource: "random" });
 	});
 
 	test("PLANNOTATOR_PORT still takes precedence", () => {
@@ -118,6 +121,33 @@ describe("pi server hostname", () => {
 		clearEnv();
 		process.env.PLANNOTATOR_REMOTE = "1";
 		expect(getServerHostname()).toBe("0.0.0.0");
+	});
+});
+
+describe("pi server url hostname", () => {
+	test("PLANNOTATOR_HOSTNAME overrides everything", async () => {
+		clearEnv();
+		resetServerUrlHostnameCache();
+		process.env.PLANNOTATOR_HOSTNAME = "mybox.ts.net";
+		expect(await getServerUrlHostname()).toBe("mybox.ts.net");
+	});
+
+	test("falls back to localhost for non-remote sessions without an explicit hostname", async () => {
+		clearEnv();
+		resetServerUrlHostnameCache();
+		expect(await getServerUrlHostname()).toBe("localhost");
+	});
+
+	test("memoizes the resolved hostname until reset", async () => {
+		clearEnv();
+		resetServerUrlHostnameCache();
+		process.env.PLANNOTATOR_HOSTNAME = "first.ts.net";
+		expect(await getServerUrlHostname()).toBe("first.ts.net");
+		// Cached: a later env change is ignored until the cache is reset.
+		process.env.PLANNOTATOR_HOSTNAME = "second.ts.net";
+		expect(await getServerUrlHostname()).toBe("first.ts.net");
+		resetServerUrlHostnameCache();
+		expect(await getServerUrlHostname()).toBe("second.ts.net");
 	});
 });
 

--- a/apps/pi-extension/server/network.test.ts
+++ b/apps/pi-extension/server/network.test.ts
@@ -185,4 +185,18 @@ describe("pi browser no-op sentinels", () => {
 			url: "http://127.0.0.1:19432",
 		});
 	});
+
+	test("remote session never launches a browser on the remote host, even with a real browser handler set", async () => {
+		clearEnv();
+		process.env.PLANNOTATOR_REMOTE = "1";
+		process.env.PLANNOTATOR_BROWSER = "/usr/bin/firefox";
+
+		// Must bail (no spawn on the remote host); the reachable URL is surfaced
+		// to the user's local machine via the notification path instead.
+		expect(await openBrowser("http://127.0.0.1:45231")).toEqual({
+			opened: false,
+			isRemote: true,
+			url: "http://127.0.0.1:45231",
+		});
+	});
 });

--- a/apps/pi-extension/server/network.ts
+++ b/apps/pi-extension/server/network.ts
@@ -10,7 +10,6 @@ import { release } from "node:os";
 import { delimiter, join } from "node:path";
 import { loadConfig, resolveUseGlimpse } from "../generated/config.js";
 
-const DEFAULT_REMOTE_PORT = 19432;
 const LOOPBACK_HOST = "127.0.0.1";
 const NOOP_BROWSER_VALUES = new Set(["true", "false", "none", ":", "0", "1"]);
 
@@ -55,8 +54,9 @@ export function isRemoteSession(): boolean {
 /**
  * Get the server port to use.
  * - PLANNOTATOR_PORT env var takes precedence
- * - Remote sessions default to 19432 (for port forwarding)
- * - Local sessions use random port
+ * - Everything else uses a random port. Remote sessions are reached via a
+ *   resolved hostname (Tailscale/PLANNOTATOR_HOSTNAME) instead of a fixed
+ *   forwarded port, so a random port is fine and lets parallel sessions coexist.
  * Returns { port, portSource } so caller can notify user if needed.
  */
 export function getServerPort(): {
@@ -71,14 +71,108 @@ export function getServerPort(): {
 		}
 		// Invalid port - fall back silently, caller can check env var themselves
 	}
-	if (isRemoteSession()) {
-		return { port: DEFAULT_REMOTE_PORT, portSource: "remote-default" };
-	}
 	return { port: 0, portSource: "random" };
 }
 
 export function getServerHostname(): string {
 	return isRemoteSession() ? "0.0.0.0" : LOOPBACK_HOST;
+}
+
+let cachedHostname: string | null | undefined;
+
+/**
+ * Reset the memoized hostname. Test-only — production resolves once per process.
+ */
+export function resetServerUrlHostnameCache(): void {
+	cachedHostname = undefined;
+}
+
+/**
+ * Get the hostname to use in user-facing server URLs.
+ *
+ * Priority:
+ *   1. PLANNOTATOR_HOSTNAME env var (explicit override)
+ *   2. Tailscale hostname (auto-detected via `tailscale status`)
+ *   3. "localhost" (fallback)
+ */
+export async function getServerUrlHostname(): Promise<string> {
+	if (cachedHostname !== undefined) {
+		return cachedHostname ?? "localhost";
+	}
+
+	const envHostname = process.env.PLANNOTATOR_HOSTNAME;
+	if (envHostname) {
+		cachedHostname = envHostname;
+		return envHostname;
+	}
+
+	if (isRemoteSession()) {
+		const tsHostname = await detectTailscaleHostname();
+		if (tsHostname) {
+			cachedHostname = tsHostname;
+			return tsHostname;
+		}
+	}
+
+	cachedHostname = null;
+	return "localhost";
+}
+
+/**
+ * Detect the Tailscale DNS name by running `tailscale status --self --json`.
+ * Returns null if Tailscale is not available, not running, or hangs.
+ */
+function detectTailscaleHostname(): Promise<string | null> {
+	return new Promise((resolvePromise) => {
+		let settled = false;
+		let stdout = "";
+		let child: ReturnType<typeof spawn>;
+		const finish = (value: string | null) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			resolvePromise(value);
+		};
+
+		try {
+			child = spawn("tailscale", ["status", "--self", "--json"], {
+				stdio: ["ignore", "pipe", "ignore"],
+			});
+		} catch {
+			resolvePromise(null);
+			return;
+		}
+
+		// Guard against a wedged tailscaled: kill the probe if it neither prints
+		// nor exits within the timeout so callers never hang.
+		const timer = setTimeout(() => {
+			try {
+				child.kill();
+			} catch {
+				/* ignore */
+			}
+			finish(null);
+		}, 3_000);
+
+		child.stdout?.on("data", (chunk) => {
+			stdout += chunk.toString();
+		});
+		child.once("error", () => finish(null));
+		child.once("close", (code) => {
+			if (code !== 0) return finish(null);
+			try {
+				const data = JSON.parse(stdout);
+				// DNSName has a trailing dot, e.g. "a4000.chaco-dory.ts.net."
+				const dnsName = data?.Self?.DNSName;
+				if (typeof dnsName === "string" && dnsName.length > 1) {
+					return finish(dnsName.replace(/\.$/, ""));
+				}
+			} catch {
+				/* fall through to null */
+			}
+			finish(null);
+		});
+	});
 }
 
 const MAX_RETRIES = 5;

--- a/apps/pi-extension/server/network.ts
+++ b/apps/pi-extension/server/network.ts
@@ -9,6 +9,10 @@ import type { Server } from "node:http";
 import { release } from "node:os";
 import { delimiter, join } from "node:path";
 import { loadConfig, resolveUseGlimpse } from "../generated/config.js";
+import {
+	createHostnameResolver,
+	parseTailscaleDnsName,
+} from "../generated/hostname.js";
 
 const LOOPBACK_HOST = "127.0.0.1";
 const NOOP_BROWSER_VALUES = new Set(["true", "false", "none", ":", "0", "1"]);
@@ -61,7 +65,7 @@ export function isRemoteSession(): boolean {
  */
 export function getServerPort(): {
 	port: number;
-	portSource: "env" | "remote-default" | "random";
+	portSource: "env" | "random";
 } {
 	const envPort = process.env.PLANNOTATOR_PORT;
 	if (envPort) {
@@ -78,13 +82,16 @@ export function getServerHostname(): string {
 	return isRemoteSession() ? "0.0.0.0" : LOOPBACK_HOST;
 }
 
-let cachedHostname: string | null | undefined;
+const hostnameResolver = createHostnameResolver({
+	isRemoteSession,
+	detectTailscaleHostname,
+});
 
 /**
  * Reset the memoized hostname. Test-only — production resolves once per process.
  */
 export function resetServerUrlHostnameCache(): void {
-	cachedHostname = undefined;
+	hostnameResolver.reset();
 }
 
 /**
@@ -95,27 +102,8 @@ export function resetServerUrlHostnameCache(): void {
  *   2. Tailscale hostname (auto-detected via `tailscale status`)
  *   3. "localhost" (fallback)
  */
-export async function getServerUrlHostname(): Promise<string> {
-	if (cachedHostname !== undefined) {
-		return cachedHostname ?? "localhost";
-	}
-
-	const envHostname = process.env.PLANNOTATOR_HOSTNAME;
-	if (envHostname) {
-		cachedHostname = envHostname;
-		return envHostname;
-	}
-
-	if (isRemoteSession()) {
-		const tsHostname = await detectTailscaleHostname();
-		if (tsHostname) {
-			cachedHostname = tsHostname;
-			return tsHostname;
-		}
-	}
-
-	cachedHostname = null;
-	return "localhost";
+export function getServerUrlHostname(): Promise<string> {
+	return hostnameResolver.resolve();
 }
 
 /**
@@ -159,18 +147,7 @@ function detectTailscaleHostname(): Promise<string | null> {
 		});
 		child.once("error", () => finish(null));
 		child.once("close", (code) => {
-			if (code !== 0) return finish(null);
-			try {
-				const data = JSON.parse(stdout);
-				// DNSName has a trailing dot, e.g. "a4000.chaco-dory.ts.net."
-				const dnsName = data?.Self?.DNSName;
-				if (typeof dnsName === "string" && dnsName.length > 1) {
-					return finish(dnsName.replace(/\.$/, ""));
-				}
-			} catch {
-				/* fall through to null */
-			}
-			finish(null);
+			finish(code === 0 ? parseTailscaleDnsName(stdout) : null);
 		});
 	});
 }
@@ -180,7 +157,7 @@ const RETRY_DELAY_MS = 500;
 
 export async function listenOnPort(
 	server: Server,
-): Promise<{ port: number; portSource: "env" | "remote-default" | "random" }> {
+): Promise<{ port: number; portSource: "env" | "random" }> {
 	const result = getServerPort();
 
 	for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
@@ -311,7 +288,12 @@ export async function openBrowser(url: string): Promise<{
 		: rawPlannotatorBrowser;
 	const envBrowser = isNoOpBrowserSentinel(rawBrowser) ? undefined : rawBrowser;
 	const browser = plannotatorBrowser || envBrowser;
-	if (isRemoteSession() && !browser) {
+	// In a remote session, never launch a browser on the remote host — even when
+	// PLANNOTATOR_BROWSER/BROWSER is set, that would open (e.g. an X-forwarded
+	// window over SSH) on the wrong machine. The reachable URL is surfaced to the
+	// user's local machine via the notification path instead. Mirrors the Bun
+	// server's remote bail in packages/server/browser.ts.
+	if (isRemoteSession()) {
 		return { opened: false, isRemote: true, url };
 	}
 

--- a/apps/pi-extension/server/serverAnnotate.ts
+++ b/apps/pi-extension/server/serverAnnotate.ts
@@ -59,7 +59,7 @@ import {
 
 export interface AnnotateServerResult {
 	port: number;
-	portSource: "env" | "remote-default" | "random";
+	portSource: "env" | "random";
 	url: string;
 	waitForDecision: () => Promise<{ feedback: string; annotations: unknown[]; exit?: boolean; approved?: boolean; selectedMessageId?: string; feedbackScope?: "message" | "messages" }>;
 	stop: () => void;

--- a/apps/pi-extension/server/serverPlan.ts
+++ b/apps/pi-extension/server/serverPlan.ts
@@ -65,7 +65,7 @@ export interface PlanReviewDecision {
 export interface PlanServerResult {
 	reviewId: string;
 	port: number;
-	portSource: "env" | "remote-default" | "random";
+	portSource: "env" | "random";
 	url: string;
 	waitForDecision: () => Promise<PlanReviewDecision>;
 	onDecision: (listener: (result: PlanReviewDecision) => void | Promise<void>) => () => void;

--- a/apps/pi-extension/server/serverReview.ts
+++ b/apps/pi-extension/server/serverReview.ts
@@ -170,7 +170,7 @@ function detectWSL(): boolean {
 
 export interface ReviewServerResult {
 	port: number;
-	portSource: "env" | "remote-default" | "random";
+	portSource: "env" | "random";
 	url: string;
 	isRemote: boolean;
 	waitForDecision: () => Promise<{

--- a/apps/pi-extension/vendor.sh
+++ b/apps/pi-extension/vendor.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")"
 rm -rf generated
 mkdir -p generated generated/ai/providers
 
-for f in feedback-templates prompts review-core diff-paths cli-pagination jj-core vcs-core review-args storage draft project pr-types pr-provider pr-stack pr-github pr-gitlab checklist integrations-common repo reference-common favicon code-file resolve-file annotate-reference-roots-node config external-annotation agent-jobs agent-terminal worktree worktree-pool html-to-markdown html-assets html-assets-node url-to-markdown tour annotate-args at-reference review-workspace-node review-workspace pfm-reminder improvement-hooks code-nav data-dir semantic-diff-types semantic-diff source-save source-save-node workspace-status open-in-apps compress crypto; do
+for f in feedback-templates prompts review-core diff-paths cli-pagination jj-core vcs-core review-args storage draft project pr-types pr-provider pr-stack pr-github pr-gitlab checklist integrations-common repo reference-common favicon code-file resolve-file annotate-reference-roots-node config external-annotation agent-jobs agent-terminal worktree worktree-pool html-to-markdown html-assets html-assets-node url-to-markdown tour annotate-args at-reference review-workspace-node review-workspace pfm-reminder improvement-hooks code-nav data-dir semantic-diff-types semantic-diff source-save source-save-node workspace-status open-in-apps compress crypto hostname; do
   src="../../packages/shared/$f.ts"
   printf '// @generated — DO NOT EDIT. Source: packages/shared/%s.ts\n' "$f" | cat - "$src" > "generated/$f.ts"
 done

--- a/apps/pi-extension/vendor.sh
+++ b/apps/pi-extension/vendor.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")"
 rm -rf generated
 mkdir -p generated generated/ai/providers
 
-for f in feedback-templates prompts review-core diff-paths cli-pagination jj-core vcs-core review-args storage draft project pr-types pr-provider pr-stack pr-github pr-gitlab checklist integrations-common repo reference-common favicon code-file resolve-file annotate-reference-roots-node config external-annotation agent-jobs agent-terminal worktree worktree-pool html-to-markdown html-assets html-assets-node url-to-markdown tour annotate-args at-reference review-workspace-node review-workspace pfm-reminder improvement-hooks code-nav data-dir semantic-diff-types semantic-diff source-save source-save-node workspace-status open-in-apps; do
+for f in feedback-templates prompts review-core diff-paths cli-pagination jj-core vcs-core review-args storage draft project pr-types pr-provider pr-stack pr-github pr-gitlab checklist integrations-common repo reference-common favicon code-file resolve-file annotate-reference-roots-node config external-annotation agent-jobs agent-terminal worktree worktree-pool html-to-markdown html-assets html-assets-node url-to-markdown tour annotate-args at-reference review-workspace-node review-workspace pfm-reminder improvement-hooks code-nav data-dir semantic-diff-types semantic-diff source-save source-save-node workspace-status open-in-apps compress crypto; do
   src="../../packages/shared/$f.ts"
   printf '// @generated — DO NOT EDIT. Source: packages/shared/%s.ts\n' "$f" | cat - "$src" > "generated/$f.ts"
 done
@@ -21,6 +21,19 @@ for f in agent-review-message codex-review claude-review path-utils; do
     | sed 's|from "./path-utils"|from "./path-utils.js"|' \
     | sed 's|from "@plannotator/shared/review-workspace"|from "./review-workspace.js"|' \
     | sed 's|from "@plannotator/shared/data-dir"|from "./data-dir"|' \
+    > "generated/$f.ts"
+done
+
+# share-url lives in packages/server/ — its only runtime-specific dependency is
+# the hostname resolver, rewritten from the Bun ./remote module to Pi's hand-
+# written server/network.ts (Node child_process). Shared compress/crypto map to
+# the flat generated/ layout.
+for f in share-url; do
+  src="../../packages/server/$f.ts"
+  printf '// @generated — DO NOT EDIT. Source: packages/server/%s.ts\n' "$f" | cat - "$src" \
+    | sed 's|from "@plannotator/shared/compress"|from "./compress.js"|' \
+    | sed 's|from "@plannotator/shared/crypto"|from "./crypto.js"|' \
+    | sed 's|from "./remote"|from "../server/network.js"|' \
     > "generated/$f.ts"
 done
 

--- a/apps/portal/ANNOTATE.md
+++ b/apps/portal/ANNOTATE.md
@@ -175,6 +175,6 @@ The annotate server respects the same environment variables as plan review:
 
 | Variable | Description |
 |----------|-------------|
-| `PLANNOTATOR_REMOTE` | Set to `1` / `true` for remote mode, `0` / `false` for local mode, or leave unset for SSH auto-detection (fixed port in remote mode; browser behavior depends on the environment) |
-| `PLANNOTATOR_PORT` | Fixed port (default: random locally, `19432` for remote) |
+| `PLANNOTATOR_REMOTE` | Set to `1` / `true` for remote mode, `0` / `false` for local mode, or leave unset for SSH auto-detection (random port and binds beyond localhost in remote mode; browser behavior depends on the environment) |
+| `PLANNOTATOR_PORT` | Fixed port (default: random; remote sessions are reached via a resolved hostname, not a fixed port) |
 | `PLANNOTATOR_BROWSER` | Custom browser to open the UI in |

--- a/apps/review/server/index.ts
+++ b/apps/review/server/index.ts
@@ -12,7 +12,7 @@
  *
  * Environment variables:
  *   PLANNOTATOR_REMOTE - Set to "1"/"true" for remote, "0"/"false" for local
- *   PLANNOTATOR_PORT   - Fixed port to use (default: random locally, 19432 for remote)
+ *   PLANNOTATOR_PORT   - Fixed port to use (default: random)
  */
 
 import { $ } from "bun";

--- a/packages/server/annotate.ts
+++ b/packages/server/annotate.ts
@@ -8,7 +8,7 @@
  *
  * Environment variables:
  *   PLANNOTATOR_REMOTE - Set to "1"/"true" for remote, "0"/"false" for local
- *   PLANNOTATOR_PORT   - Fixed port to use (default: random locally, 19432 for remote)
+ *   PLANNOTATOR_PORT   - Fixed port to use (default: random)
  */
 
 import { isRemoteSession, getServerHostname, getServerPort } from "./remote";

--- a/packages/server/browser.ts
+++ b/packages/server/browser.ts
@@ -205,6 +205,16 @@ export async function openBrowser(
       }
     }
 
+    // In a remote session the only legitimate way to reach a browser is the
+    // VS Code IPC bridge above (which opens on the user's local machine). The
+    // local fallbacks below (glimpse, xdg-open/open/start) would launch a
+    // browser on the remote host itself — e.g. an ugly X-forwarded window over
+    // SSH — which is never what a remote user wants. The reachable URL is
+    // already surfaced via stderr + ntfy, so bail out here instead.
+    if (isRemote) {
+      return false;
+    }
+
     if (options?.useGlimpse && !browser && !isRemote && resolveUseGlimpse(loadConfig())) {
       const openedViaGlimpse = await openGlimpse(url);
       if (openedViaGlimpse) {

--- a/packages/server/browser.ts
+++ b/packages/server/browser.ts
@@ -215,7 +215,7 @@ export async function openBrowser(
       return false;
     }
 
-    if (options?.useGlimpse && !browser && !isRemote && resolveUseGlimpse(loadConfig())) {
+    if (options?.useGlimpse && !browser && resolveUseGlimpse(loadConfig())) {
       const openedViaGlimpse = await openGlimpse(url);
       if (openedViaGlimpse) {
         return true;

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -5,7 +5,7 @@
  *
  * Environment variables:
  *   PLANNOTATOR_REMOTE - Set to "1"/"true" for remote, "0"/"false" for local
- *   PLANNOTATOR_PORT   - Fixed port to use (default: random locally, 19432 for remote)
+ *   PLANNOTATOR_PORT   - Fixed port to use (default: random)
  *   PLANNOTATOR_ORIGIN - Explicit origin override; validated against AGENT_CONFIG
  *                        in packages/shared/agents.ts. Supported values:
  *                        "claude-code", "opencode", "codex", "copilot-cli",

--- a/packages/server/remote.test.ts
+++ b/packages/server/remote.test.ts
@@ -91,10 +91,14 @@ describe("getServerPort", () => {
     expect(getServerPort()).toBe(0);
   });
 
-  test("returns 19432 for remote session", () => {
+  test("returns 0 (random port) for remote session", () => {
+    // Remote sessions also use a random port now: the reachable URL hostname
+    // (Tailscale/explicit) is resolved separately, so port forwarding — and
+    // the old fixed 19432 default — is no longer needed. Random ports also let
+    // parallel sessions coexist without colliding.
     clearEnv();
     process.env.PLANNOTATOR_REMOTE = "1";
-    expect(getServerPort()).toBe(19432);
+    expect(getServerPort()).toBe(0);
   });
 
   test("returns 0 when PLANNOTATOR_REMOTE=false overrides SSH", () => {

--- a/packages/server/remote.ts
+++ b/packages/server/remote.ts
@@ -13,6 +13,11 @@
  * allows random ports, so parallel sessions work.
  */
 
+import {
+  createHostnameResolver,
+  parseTailscaleDnsName,
+} from "@plannotator/shared/hostname";
+
 const LOOPBACK_HOST = "127.0.0.1";
 
 function getRemoteOverride(): boolean | null {
@@ -80,13 +85,16 @@ export function getServerHostname(): string {
   return isRemoteSession() ? "0.0.0.0" : LOOPBACK_HOST;
 }
 
-let cachedHostname: string | null | undefined;
+const hostnameResolver = createHostnameResolver({
+  isRemoteSession,
+  detectTailscaleHostname,
+});
 
 /**
  * Reset the memoized hostname. Test-only — production resolves once per process.
  */
 export function resetServerUrlHostnameCache(): void {
-  cachedHostname = undefined;
+  hostnameResolver.reset();
 }
 
 /**
@@ -97,30 +105,8 @@ export function resetServerUrlHostnameCache(): void {
  *   2. Tailscale hostname (auto-detected via `tailscale status`)
  *   3. "localhost" (fallback)
  */
-export async function getServerUrlHostname(): Promise<string> {
-  if (cachedHostname !== undefined) {
-    return cachedHostname ?? "localhost";
-  }
-
-  // 1. Explicit env var
-  const envHostname = process.env.PLANNOTATOR_HOSTNAME;
-  if (envHostname) {
-    cachedHostname = envHostname;
-    return envHostname;
-  }
-
-  // 2. Auto-detect Tailscale
-  if (isRemoteSession()) {
-    const tsHostname = await detectTailscaleHostname();
-    if (tsHostname) {
-      cachedHostname = tsHostname;
-      return tsHostname;
-    }
-  }
-
-  // 3. Fallback
-  cachedHostname = null;
-  return "localhost";
+export function getServerUrlHostname(): Promise<string> {
+  return hostnameResolver.resolve();
 }
 
 /**
@@ -148,14 +134,7 @@ async function detectTailscaleHostname(): Promise<string | null> {
     }
     if (exitCode !== 0) return null;
 
-    const data = JSON.parse(text);
-    // DNSName has a trailing dot, e.g. "a4000.chaco-dory.ts.net."
-    const dnsName = data?.Self?.DNSName;
-    if (typeof dnsName === "string" && dnsName.length > 1) {
-      return dnsName.replace(/\.$/, "");
-    }
-
-    return null;
+    return parseTailscaleDnsName(text);
   } catch {
     return null;
   }

--- a/packages/server/remote.ts
+++ b/packages/server/remote.ts
@@ -1,14 +1,18 @@
 /**
- * Remote session detection and port configuration
+ * Remote session detection, port configuration, and hostname resolution
  *
  * Environment variables:
- *   PLANNOTATOR_REMOTE - Set to "1"/"true" to force remote, "0"/"false" to force local
- *   PLANNOTATOR_PORT   - Fixed port to use (default: random locally, 19432 for remote)
+ *   PLANNOTATOR_REMOTE   - Set to "1"/"true" to force remote, "0"/"false" to force local
+ *   PLANNOTATOR_PORT     - Fixed port to use (default: random)
+ *   PLANNOTATOR_HOSTNAME - Explicit hostname for remote URLs (e.g. "mybox.ts.net")
  *
  * Legacy (still supported): SSH_TTY, SSH_CONNECTION
+ *
+ * When Tailscale is available, the server URL uses the Tailscale hostname
+ * so remote users can connect directly without port forwarding. This also
+ * allows random ports, so parallel sessions work.
  */
 
-const DEFAULT_REMOTE_PORT = 19432;
 const LOOPBACK_HOST = "127.0.0.1";
 
 function getRemoteOverride(): boolean | null {
@@ -46,7 +50,11 @@ export function isRemoteSession(): boolean {
 }
 
 /**
- * Get the server port to use
+ * Get the server port to use.
+ *
+ * Always uses a random port (0) unless PLANNOTATOR_PORT is explicitly set.
+ * The old default of 19432 for remote is no longer needed since we resolve
+ * the actual hostname (Tailscale/explicit) instead of relying on port forwarding.
  */
 export function getServerPort(): number {
   // Explicit port from environment takes precedence
@@ -61,14 +69,77 @@ export function getServerPort(): number {
     );
   }
 
-  // Remote sessions use fixed port for port forwarding; local uses random
-  return isRemoteSession() ? DEFAULT_REMOTE_PORT : 0;
+  return 0;
 }
 
 /**
  * Bind local sessions to loopback, but keep remote sessions reachable via the
- * container or host network interface for SSH/devcontainer/Docker forwarding.
+ * container or host network interface (Tailscale/SSH/devcontainer/Docker).
  */
 export function getServerHostname(): string {
   return isRemoteSession() ? "0.0.0.0" : LOOPBACK_HOST;
+}
+
+let cachedHostname: string | null | undefined;
+
+/**
+ * Get the hostname to use in user-facing server URLs.
+ *
+ * Priority:
+ *   1. PLANNOTATOR_HOSTNAME env var (explicit override)
+ *   2. Tailscale hostname (auto-detected via `tailscale status`)
+ *   3. "localhost" (fallback)
+ */
+export async function getServerUrlHostname(): Promise<string> {
+  if (cachedHostname !== undefined) {
+    return cachedHostname ?? "localhost";
+  }
+
+  // 1. Explicit env var
+  const envHostname = process.env.PLANNOTATOR_HOSTNAME;
+  if (envHostname) {
+    cachedHostname = envHostname;
+    return envHostname;
+  }
+
+  // 2. Auto-detect Tailscale
+  if (isRemoteSession()) {
+    const tsHostname = await detectTailscaleHostname();
+    if (tsHostname) {
+      cachedHostname = tsHostname;
+      return tsHostname;
+    }
+  }
+
+  // 3. Fallback
+  cachedHostname = null;
+  return "localhost";
+}
+
+/**
+ * Detect the Tailscale DNS name by running `tailscale status --self --json`.
+ * Returns null if Tailscale is not available or not running.
+ */
+async function detectTailscaleHostname(): Promise<string | null> {
+  try {
+    const proc = Bun.spawn(["tailscale", "status", "--self", "--json"], {
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+
+    const text = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) return null;
+
+    const data = JSON.parse(text);
+    // DNSName has a trailing dot, e.g. "a4000.chaco-dory.ts.net."
+    const dnsName = data?.Self?.DNSName;
+    if (typeof dnsName === "string" && dnsName.length > 1) {
+      return dnsName.replace(/\.$/, "");
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
 }

--- a/packages/server/remote.ts
+++ b/packages/server/remote.ts
@@ -83,6 +83,13 @@ export function getServerHostname(): string {
 let cachedHostname: string | null | undefined;
 
 /**
+ * Reset the memoized hostname. Test-only — production resolves once per process.
+ */
+export function resetServerUrlHostnameCache(): void {
+  cachedHostname = undefined;
+}
+
+/**
  * Get the hostname to use in user-facing server URLs.
  *
  * Priority:
@@ -127,8 +134,18 @@ async function detectTailscaleHostname(): Promise<string | null> {
       stderr: "ignore",
     });
 
-    const text = await new Response(proc.stdout).text();
-    const exitCode = await proc.exited;
+    // Guard against a wedged tailscaled: kill the probe if it neither prints
+    // nor exits within the timeout so callers (writeRemoteShareLink) never hang.
+    const timer = setTimeout(() => proc.kill(), 3_000);
+
+    let text: string;
+    let exitCode: number;
+    try {
+      text = await new Response(proc.stdout).text();
+      exitCode = await proc.exited;
+    } finally {
+      clearTimeout(timer);
+    }
     if (exitCode !== 0) return null;
 
     const data = JSON.parse(text);

--- a/packages/server/review.ts
+++ b/packages/server/review.ts
@@ -6,7 +6,7 @@
  *
  * Environment variables:
  *   PLANNOTATOR_REMOTE - Set to "1"/"true" for remote, "0"/"false" for local
- *   PLANNOTATOR_PORT   - Fixed port to use (default: random locally, 19432 for remote)
+ *   PLANNOTATOR_PORT   - Fixed port to use (default: random)
  */
 
 import { isRemoteSession, getServerHostname, getServerPort } from "./remote";

--- a/packages/server/share-url.test.ts
+++ b/packages/server/share-url.test.ts
@@ -1,6 +1,82 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { decompress } from "@plannotator/shared/compress";
-import { generateRemoteShareUrl, writeRemoteShareLink } from "./share-url";
+import { generateRemoteShareUrl, prepareRemoteShareLink, writeRemoteShareLink } from "./share-url";
+import { resetServerUrlHostnameCache } from "./remote";
+
+const shareEnvKeys = ["PLANNOTATOR_HOSTNAME", "PLANNOTATOR_REMOTE", "CLAUDE_HOOKS_NTFY_URL", "CLAUDE_HOOKS_NTFY_TOKEN"];
+const savedShareEnv: Record<string, string | undefined> = {};
+
+function clearShareEnv() {
+  for (const key of shareEnvKeys) {
+    savedShareEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  resetServerUrlHostnameCache();
+}
+
+afterEach(() => {
+  for (const key of shareEnvKeys) {
+    if (savedShareEnv[key] !== undefined) process.env[key] = savedShareEnv[key];
+    else delete process.env[key];
+  }
+  resetServerUrlHostnameCache();
+});
+
+describe("prepareRemoteShareLink", () => {
+  test("rewrites the local host to the resolved hostname for a directly-reachable link", async () => {
+    clearShareEnv();
+    process.env.PLANNOTATOR_HOSTNAME = "mybox.ts.net";
+
+    const link = await prepareRemoteShareLink("# Plan", "https://share.example.test", "review the plan", "plan only", {
+      serverUrl: "http://localhost:45231",
+    });
+
+    expect(link.kind).toBe("reachable");
+    expect(link.url).toBe("http://mybox.ts.net:45231");
+    expect(link.descriptor).toContain("full review with approve/deny");
+    expect(link.ntfyOk).toBe(false);
+  });
+
+  test("falls back to a read-only share link when no reachable hostname is available", async () => {
+    clearShareEnv();
+    // Force non-remote so Tailscale detection is skipped and the host resolves
+    // to "localhost" (the box running the suite may itself be on a tailnet).
+    process.env.PLANNOTATOR_REMOTE = "0";
+    resetServerUrlHostnameCache();
+
+    const link = await prepareRemoteShareLink("# Plan", "https://share.example.test", "review the plan", "plan only", {
+      serverUrl: "http://localhost:45231",
+    });
+
+    expect(link.kind).toBe("share");
+    expect(link.url.startsWith("https://share.example.test/#")).toBe(true);
+    expect(link.descriptor).toContain("read-only");
+  });
+
+  test("sends an ntfy push for the reachable link via the injected fetch", async () => {
+    clearShareEnv();
+    process.env.PLANNOTATOR_HOSTNAME = "mybox.ts.net";
+    process.env.CLAUDE_HOOKS_NTFY_URL = "https://ntfy.example.test/mytopic";
+
+    const fetchImpl = mock(async (url: string | URL | Request, init?: RequestInit) => {
+      expect(String(url)).toBe("https://ntfy.example.test/mytopic");
+      expect(init?.method).toBe("POST");
+      const headers = init?.headers as Record<string, string>;
+      expect(headers.Title).toBe("Plannotator: review the plan");
+      expect(headers.Click).toBe("http://mybox.ts.net:45231");
+      expect(String(init?.body)).toBe("http://mybox.ts.net:45231");
+      return new Response(null, { status: 200 });
+    }) as typeof fetch;
+
+    const link = await prepareRemoteShareLink("# Plan", "https://share.example.test", "review the plan", "plan only", {
+      serverUrl: "http://localhost:45231",
+      fetchImpl,
+    });
+
+    expect(link.ntfyOk).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe("generateRemoteShareUrl", () => {
   test("keeps markdown remote shares hash-based", async () => {

--- a/packages/server/share-url.ts
+++ b/packages/server/share-url.ts
@@ -1,12 +1,21 @@
 /**
- * Server-side share URL generation for remote sessions
+ * Server-side share URL generation and notification for remote sessions.
  *
- * Generates a share.plannotator.ai URL from plan content so remote users
- * can open the review in their local browser without port forwarding.
+ * When Tailscale (or PLANNOTATOR_HOSTNAME) is available, the server URL is
+ * directly reachable from the user's local browser — no port forwarding
+ * needed. That URL is shown as the primary link (full approve/deny).
+ *
+ * As a fallback, a read-only share.plannotator.ai URL is generated so remote
+ * users can still open the review in their local browser (plan-only).
+ *
+ * Notification priority:
+ *   1. ntfy push notification (if CLAUDE_HOOKS_NTFY_URL is set)
+ *   2. stderr (fallback — works for OpenCode, logging, etc.)
  */
 
 import { compress } from "@plannotator/shared/compress";
 import { encrypt } from "@plannotator/shared/crypto";
+import { getServerUrlHostname } from "./remote";
 
 const DEFAULT_SHARE_BASE = "https://share.plannotator.ai";
 const DEFAULT_PASTE_API = "https://plannotator-paste.plannotator.workers.dev";
@@ -15,6 +24,25 @@ export interface RemoteShareOptions {
   rawHtml?: string;
   pasteApiUrl?: string;
   fetchImpl?: typeof fetch;
+  /**
+   * Local server URL (e.g. `http://localhost:45231`). When a reachable
+   * hostname (Tailscale/explicit) is detected, its `localhost` host is
+   * rewritten to that hostname and shown as the primary link with full
+   * approve/deny. Left untouched otherwise (read-only share link is used).
+   */
+  serverUrl?: string;
+}
+
+/**
+ * Resolve the directly-reachable server URL by swapping the local host for the
+ * detected Tailscale/explicit hostname. Returns null when no reachable
+ * hostname is available (so the read-only share link should be used instead).
+ */
+async function resolveReachableServerUrl(serverUrl?: string): Promise<string | null> {
+  if (!serverUrl) return null;
+  const host = await getServerUrlHostname();
+  if (host === "localhost") return null;
+  return serverUrl.replace("localhost", host).replace("127.0.0.1", host);
 }
 
 /**
@@ -98,9 +126,51 @@ export function formatSize(bytes: number): string {
 }
 
 /**
- * Generate a remote share URL and write it to stderr for the user.
- * Keeps the local server running, but warns when the fallback share link
- * cannot be created for remote sessions.
+ * Send URL via ntfy push notification.
+ *
+ * Reads config from env vars (compatible with claude-code ntfy hooks):
+ *   CLAUDE_HOOKS_NTFY_URL   - Full ntfy URL (e.g. https://ntfy.sh/mytopic)
+ *   CLAUDE_HOOKS_NTFY_TOKEN - Optional auth token
+ *
+ * Returns true if the notification was sent successfully.
+ */
+async function notifyNtfy(url: string, verb: string): Promise<boolean> {
+  const ntfyUrl = process.env.CLAUDE_HOOKS_NTFY_URL;
+  if (!ntfyUrl) return false;
+
+  const headers: Record<string, string> = {
+    Title: `Plannotator: ${verb}`,
+    Click: url,
+    Tags: "clipboard",
+  };
+
+  const token = process.env.CLAUDE_HOOKS_NTFY_TOKEN;
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+
+  try {
+    const response = await fetch(ntfyUrl, {
+      method: "POST",
+      headers,
+      body: url,
+      signal: AbortSignal.timeout(5_000),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Notify the remote user about the review server URL.
+ *
+ * When a directly-reachable server URL is provided (Tailscale/explicit
+ * hostname), it is shown as the primary link with full approve/deny.
+ * Otherwise a read-only share URL is generated as the fallback.
+ *
+ * Notifies via ntfy push (if configured) and stderr. Silently does nothing
+ * on failure.
  */
 export async function writeRemoteShareLink(
   content: string,
@@ -109,14 +179,28 @@ export async function writeRemoteShareLink(
   noun: string,
   options: RemoteShareOptions = {},
 ): Promise<void> {
+  // Primary path: the server is directly reachable (full review w/ approve/deny).
+  const reachableUrl = await resolveReachableServerUrl(options.serverUrl);
+  if (reachableUrl) {
+    const ntfyOk = await notifyNtfy(reachableUrl, verb);
+    const lines = [`\n  Open this link on your local machine to ${verb}:\n  ${reachableUrl}\n`];
+    lines.push(`  (${noun} — full review with approve/deny)`);
+    if (ntfyOk) lines.push(`  [notified via ntfy]`);
+    lines.push("\n");
+    process.stderr.write(lines.join("\n"));
+    return;
+  }
+
+  // Fallback path: read-only share URL (works without port forwarding).
   try {
     const shareUrl = await generateRemoteShareUrl(content, shareBaseUrl, options);
+    const ntfyOk = await notifyNtfy(shareUrl, verb);
     const size = formatSize(new TextEncoder().encode(shareUrl).length);
-    process.stderr.write(
-      `\n  Open this link on your local machine to ${verb}:\n` +
-      `  ${shareUrl}\n\n` +
-      `  (${size} — ${noun}, annotations added in browser)\n\n`
-    );
+    const lines = [`\n  Open this link on your local machine to ${verb}:\n  ${shareUrl}\n`];
+    lines.push(`  (${size} — ${noun}, read-only, annotations added in browser)`);
+    if (ntfyOk) lines.push(`  [notified via ntfy]`);
+    lines.push("\n");
+    process.stderr.write(lines.join("\n"));
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
     const pasteHint = options.rawHtml

--- a/packages/server/share-url.ts
+++ b/packages/server/share-url.ts
@@ -134,7 +134,11 @@ export function formatSize(bytes: number): string {
  *
  * Returns true if the notification was sent successfully.
  */
-async function notifyNtfy(url: string, verb: string): Promise<boolean> {
+async function notifyNtfy(
+  url: string,
+  verb: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<boolean> {
   const ntfyUrl = process.env.CLAUDE_HOOKS_NTFY_URL;
   if (!ntfyUrl) return false;
 
@@ -150,7 +154,7 @@ async function notifyNtfy(url: string, verb: string): Promise<boolean> {
   }
 
   try {
-    const response = await fetch(ntfyUrl, {
+    const response = await fetchImpl(ntfyUrl, {
       method: "POST",
       headers,
       body: url,
@@ -163,14 +167,87 @@ async function notifyNtfy(url: string, verb: string): Promise<boolean> {
 }
 
 /**
- * Notify the remote user about the review server URL.
+ * Write a "open this link" block to stderr for the remote user.
+ * `descriptor` is the parenthetical that distinguishes the reachable
+ * (full review) link from the read-only share link.
+ */
+function emitShareLink(
+  url: string,
+  verb: string,
+  descriptor: string,
+  ntfyOk: boolean,
+): void {
+  const lines = [
+    `\n  Open this link on your local machine to ${verb}:\n  ${url}\n`,
+    `  (${descriptor})`,
+  ];
+  if (ntfyOk) lines.push(`  [notified via ntfy]`);
+  lines.push("\n");
+  process.stderr.write(lines.join("\n"));
+}
+
+/**
+ * A resolved remote share link, ready to surface to the user.
+ */
+export interface RemoteShareLink {
+  /** The URL to open locally. */
+  url: string;
+  /** Parenthetical describing the link (size/read-only vs full review). */
+  descriptor: string;
+  /** Whether the directly-reachable server URL or the read-only fallback. */
+  kind: "reachable" | "share";
+  /** True if an ntfy push notification was sent. */
+  ntfyOk: boolean;
+}
+
+/**
+ * Resolve the remote share link and fire the ntfy push (if configured).
  *
  * When a directly-reachable server URL is provided (Tailscale/explicit
- * hostname), it is shown as the primary link with full approve/deny.
+ * hostname), it is returned as the primary link with full approve/deny.
  * Otherwise a read-only share URL is generated as the fallback.
  *
- * Notifies via ntfy push (if configured) and stderr. Silently does nothing
- * on failure.
+ * Runtime-agnostic: returns the link so callers can surface it however suits
+ * them (stderr for the Bun CLI, the host UI for Pi). Throws only when the
+ * fallback share URL cannot be generated.
+ */
+export async function prepareRemoteShareLink(
+  content: string,
+  shareBaseUrl: string | undefined,
+  verb: string,
+  noun: string,
+  options: RemoteShareOptions = {},
+): Promise<RemoteShareLink> {
+  // Primary path: the server is directly reachable (full review w/ approve/deny).
+  const reachableUrl = await resolveReachableServerUrl(options.serverUrl);
+  if (reachableUrl) {
+    const ntfyOk = await notifyNtfy(reachableUrl, verb, options.fetchImpl);
+    return {
+      url: reachableUrl,
+      descriptor: `${noun} — full review with approve/deny`,
+      kind: "reachable",
+      ntfyOk,
+    };
+  }
+
+  // Fallback path: read-only share URL (works without port forwarding).
+  const shareUrl = await generateRemoteShareUrl(content, shareBaseUrl, options);
+  const ntfyOk = await notifyNtfy(shareUrl, verb, options.fetchImpl);
+  const size = formatSize(new TextEncoder().encode(shareUrl).length);
+  return {
+    url: shareUrl,
+    descriptor: `${size} — ${noun}, read-only, annotations added in browser`,
+    kind: "share",
+    ntfyOk,
+  };
+}
+
+/**
+ * Notify the remote user about the review server URL via stderr (Bun CLI).
+ *
+ * Resolves the link via {@link prepareRemoteShareLink}, then writes it to
+ * stderr. Notifies via ntfy push too (if configured). Silently warns on
+ * failure to generate the fallback share link.
  */
 export async function writeRemoteShareLink(
   content: string,
@@ -179,28 +256,9 @@ export async function writeRemoteShareLink(
   noun: string,
   options: RemoteShareOptions = {},
 ): Promise<void> {
-  // Primary path: the server is directly reachable (full review w/ approve/deny).
-  const reachableUrl = await resolveReachableServerUrl(options.serverUrl);
-  if (reachableUrl) {
-    const ntfyOk = await notifyNtfy(reachableUrl, verb);
-    const lines = [`\n  Open this link on your local machine to ${verb}:\n  ${reachableUrl}\n`];
-    lines.push(`  (${noun} — full review with approve/deny)`);
-    if (ntfyOk) lines.push(`  [notified via ntfy]`);
-    lines.push("\n");
-    process.stderr.write(lines.join("\n"));
-    return;
-  }
-
-  // Fallback path: read-only share URL (works without port forwarding).
   try {
-    const shareUrl = await generateRemoteShareUrl(content, shareBaseUrl, options);
-    const ntfyOk = await notifyNtfy(shareUrl, verb);
-    const size = formatSize(new TextEncoder().encode(shareUrl).length);
-    const lines = [`\n  Open this link on your local machine to ${verb}:\n  ${shareUrl}\n`];
-    lines.push(`  (${size} — ${noun}, read-only, annotations added in browser)`);
-    if (ntfyOk) lines.push(`  [notified via ntfy]`);
-    lines.push("\n");
-    process.stderr.write(lines.join("\n"));
+    const link = await prepareRemoteShareLink(content, shareBaseUrl, verb, noun, options);
+    emitShareLink(link.url, verb, link.descriptor, link.ntfyOk);
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
     const pasteHint = options.rawHtml

--- a/packages/shared/hostname.ts
+++ b/packages/shared/hostname.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared hostname-resolution logic for user-facing server URLs.
+ *
+ * The only runtime-specific dependency is spawning `tailscale status`, which
+ * each runtime injects (Bun.spawn for the Bun server, node:child_process for
+ * the Pi extension). Everything else — env-var priority, memoization, and
+ * DNSName parsing — lives here so the two runtimes can't drift.
+ */
+
+/**
+ * Parse the Tailscale DNS name out of `tailscale status --self --json` output.
+ * Returns null if the JSON is malformed or carries no usable DNSName.
+ */
+export function parseTailscaleDnsName(json: string): string | null {
+  try {
+    const data = JSON.parse(json);
+    // DNSName has a trailing dot, e.g. "a4000.chaco-dory.ts.net."
+    const dnsName = data?.Self?.DNSName;
+    if (typeof dnsName === "string" && dnsName.length > 1) {
+      return dnsName.replace(/\.$/, "");
+    }
+  } catch {
+    /* fall through to null */
+  }
+  return null;
+}
+
+export interface HostnameResolverDeps {
+  /** True when running in a remote session (gates the Tailscale probe). */
+  isRemoteSession: () => boolean;
+  /** Spawn `tailscale status` and resolve its hostname, or null. */
+  detectTailscaleHostname: () => Promise<string | null>;
+  /** Read the explicit hostname override. Defaults to PLANNOTATOR_HOSTNAME. */
+  getEnvHostname?: () => string | undefined;
+}
+
+export interface HostnameResolver {
+  /**
+   * Resolve the hostname for user-facing URLs.
+   * Priority: PLANNOTATOR_HOSTNAME → Tailscale → "localhost".
+   */
+  resolve: () => Promise<string>;
+  /** Reset the memoized hostname. Test-only — production resolves once. */
+  reset: () => void;
+}
+
+/**
+ * Build a memoizing hostname resolver.
+ *
+ * A successfully resolved hostname (explicit or Tailscale) is cached for the
+ * process lifetime. The "localhost" fallback is intentionally NOT cached so a
+ * probe that ran before tailscaled was ready can still succeed on a later
+ * call — this matters for the long-lived Pi extension process, which would
+ * otherwise be stuck on read-only share links for its whole lifetime. The
+ * one-shot Bun CLI resolves once regardless, so the behavior is unchanged
+ * there.
+ */
+export function createHostnameResolver(
+  deps: HostnameResolverDeps,
+): HostnameResolver {
+  const getEnvHostname =
+    deps.getEnvHostname ?? (() => process.env.PLANNOTATOR_HOSTNAME);
+  let cached: string | undefined;
+
+  return {
+    reset() {
+      cached = undefined;
+    },
+    async resolve(): Promise<string> {
+      if (cached !== undefined) return cached;
+
+      // 1. Explicit env var
+      const envHostname = getEnvHostname();
+      if (envHostname) {
+        cached = envHostname;
+        return envHostname;
+      }
+
+      // 2. Auto-detect Tailscale (remote sessions only)
+      if (deps.isRemoteSession()) {
+        const tsHostname = await deps.detectTailscaleHostname();
+        if (tsHostname) {
+          cached = tsHostname;
+          return tsHostname;
+        }
+      }
+
+      // 3. Fallback — not cached, so a later probe can still resolve.
+      return "localhost";
+    },
+  };
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -6,6 +6,7 @@
     "./agents": "./agents.ts",
     "./compress": "./compress.ts",
     "./crypto": "./crypto.ts",
+    "./hostname": "./hostname.ts",
     "./diff-paths": "./diff-paths.ts",
     "./feedback-templates": "./feedback-templates.ts",
     "./jj-core": "./jj-core.ts",

--- a/packages/ui/utils/planAgentInstructions.ts
+++ b/packages/ui/utils/planAgentInstructions.ts
@@ -13,8 +13,8 @@
  * the single source of truth for the agent-facing contract surface.
  *
  * The only dynamic value is `origin`, which is interpolated at click time from
- * `window.location.origin` so the agent gets the correct base URL whether the
- * server is running on a random local port or the fixed remote port (19432).
+ * `window.location.origin` so the agent gets the correct base URL whatever
+ * (random) port the server bound to, local or remote.
  */
 export function buildPlanAgentInstructions(origin: string): string {
   return `# Plannotator — External Annotations

--- a/tests/manual/ssh/DOCKER_SSH_TEST.md
+++ b/tests/manual/ssh/DOCKER_SSH_TEST.md
@@ -34,18 +34,21 @@ chmod +x test-ssh.sh
 
 You should see:
 - `[SSH Remote Session Detected]` message
-- Instructions for SSH port forwarding
-- Server running on port 19432
+- A reachable URL (Tailscale/`PLANNOTATOR_HOSTNAME`) or a read-only share link
+- Server running on a random port (set `PLANNOTATOR_PORT` to pin it for forwarding)
 
 ### Option 2: Test via SSH with port forwarding
+
+Remote sessions use a random port by default, so pin one with `PLANNOTATOR_PORT`
+to forward it:
 
 ```bash
 # In one terminal, SSH with port forwarding
 ssh -p 2222 -L 19432:localhost:19432 root@localhost
 
-# Inside the SSH session, run:
+# Inside the SSH session, run (pin the port so forwarding lines up):
 cd /app
-echo '{"tool_input":{"plan":"# Test Plan\n\nTest content"}}' | bun run apps/hook/server/index.ts
+echo '{"tool_input":{"plan":"# Test Plan\n\nTest content"}}' | PLANNOTATOR_PORT=19432 bun run apps/hook/server/index.ts
 
 # In another terminal on your local machine, open browser
 open http://localhost:19432
@@ -89,4 +92,4 @@ cd /app
 PLANNOTATOR_PORT=9999 ./test-ssh.sh
 ```
 
-Server should use port 9999 instead of 19432.
+Server should use port 9999 instead of a random port.


### PR DESCRIPTION
## Summary

Fixes #192 — remote Claude Code sessions can now open the plan review UI without port forwarding.

**Note:** This is not a general-purpose solution — it relies on Tailscale, tmux, and/or ntfy, which are not common dependencies. It's shared as a working proof-of-concept and inspiration for how remote access can work. A more general solution (e.g., a session router on a fixed port, or first-class support for Claude Code surfacing hook messages) is still needed for broad adoption. See #192 for discussion.

### What's here

- **Tailscale auto-detection**: Detects Tailscale hostname via `tailscale status --self --json`, so the server URL is directly reachable (e.g. `http://mybox.ts.net:PORT`). Also supports explicit `PLANNOTATOR_HOSTNAME` env var.
- **Random ports in remote mode**: Removed the fixed port 19432 default, so parallel Claude sessions work without port conflicts.
- **`0.0.0.0` binding**: Server binds to all interfaces when a non-localhost hostname is detected.
- **tmux popup**: When `$TMUX` is set, shows a `tmux display-popup` with the server URL — works inside Claude Code's TUI since it's a tmux-layer overlay that bypasses Claude's stdio capture.
- **ntfy push notification**: When `CLAUDE_HOOKS_NTFY_URL` is set (compatible with existing claude-code ntfy hooks), sends a push notification with a clickable link.
- **Short URLs via paste service**: Uses the existing paste service (zero-knowledge encrypted) for compact share links when the server isn't directly reachable.

### Why this isn't the general solution

The core problem is that **Claude Code doesn't surface hook stderr to the user** — it captures it to a socket. This means there's no built-in way for a hook to communicate a URL (or anything else) to the user while it's running.

The workarounds here are all external channels:
- **Tailscale** — requires the user to have a mesh VPN set up
- **tmux popup** — requires the user to be running inside tmux
- **ntfy** — requires a push notification service

For users without any of these, the only option remains manual SSH port forwarding (`ssh -L PORT:localhost:PORT`), which is fragile since ports are now random.

### Ideas for a general solution

1. **Claude Code feature request**: A hook progress/message channel that surfaces stderr (or a dedicated stream) to the user's terminal. This would solve the problem at the root.
2. **Session router**: A long-lived server on a fixed port that multiplexes multiple plan sessions on subpaths (`/session/<id>`). Users forward one port, all sessions are accessible. More complex but works without external dependencies.
3. **VS Code Remote auto-forwarding**: VS Code Remote already auto-forwards ports. If the server prints a `localhost:PORT` URL to stderr, VS Code picks it up. This works today for VS Code Remote users — the missing piece is just surfacing the URL.

## Test plan

- [x] Tested on remote SSH session with Tailscale — tmux popup shows `http://hostname:port`, opens in local browser, full approve/deny works
- [x] Tested ntfy push notification — clickable link arrives on phone
- [ ] Verify local (non-remote) mode is unchanged — should still open browser directly
- [x] Verify parallel Claude sessions get different random ports
- [ ] Verify fallback when Tailscale is not installed (falls back to localhost + share URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)