### PR TITLE
feat: add "Approve in CLI" button for native plan approval

### DIFF
--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -276,6 +276,23 @@ if (args[0] === "sessions") {
   // PLAN REVIEW MODE (default)
   // ============================================
 
+  // Passthrough flag path — used by "Approve in CLI" to skip UI on next invocation
+  const passthroughFlag = path.join(process.env.HOME || "~", ".plannotator", ".cli-passthrough");
+
+  // Check for CLI passthrough flag — if set, return no decision so CLI shows native prompt
+  try {
+    if (await Bun.file(passthroughFlag).exists()) {
+      const { unlink } = await import("node:fs/promises");
+      await unlink(passthroughFlag);
+      // Return empty response — no decision means CLI falls through to native prompt
+      // (the one with "Yes, clear context" / "Yes, auto-accept" options)
+      console.log("{}");
+      process.exit(0);
+    }
+  } catch {
+    // Flag doesn't exist or can't read — continue normally
+  }
+
   // Read hook event from stdin
   const eventJson = await Bun.stdin.text();
 
@@ -335,7 +352,22 @@ if (args[0] === "sessions") {
   server.stop();
 
   // Output JSON for PermissionRequest hook decision control
-  if (result.approved) {
+  if (result.deferToCli) {
+    // Write passthrough flag so next ExitPlanMode invocation skips the UI
+    await Bun.write(passthroughFlag, "1");
+    // Deny with instruction to re-call ExitPlanMode — the passthrough flag will auto-approve next time
+    console.log(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "PermissionRequest",
+          decision: {
+            behavior: "deny",
+            message: "The user chose to approve this plan via the CLI. Call ExitPlanMode again immediately with the exact same plan. Do NOT modify the plan.",
+          },
+        },
+      })
+    );
+  } else if (result.approved) {
     // Build updatedPermissions to preserve the current permission mode
     const updatedPermissions = [];
     if (result.permissionMode) {

--- a/bun.lock
+++ b/bun.lock
@@ -50,7 +50,7 @@
     },
     "apps/opencode-plugin": {
       "name": "@plannotator/opencode",
-      "version": "0.11.4",
+      "version": "0.12.0",
       "dependencies": {
         "@opencode-ai/plugin": "^1.1.10",
       },
@@ -71,7 +71,7 @@
     },
     "apps/pi-extension": {
       "name": "@plannotator/pi-extension",
-      "version": "0.11.4",
+      "version": "0.12.0",
       "peerDependencies": {
         "@mariozechner/pi-coding-agent": ">=0.53.0",
       },
@@ -151,7 +151,7 @@
     },
     "packages/server": {
       "name": "@plannotator/server",
-      "version": "0.11.4",
+      "version": "0.12.0",
       "dependencies": {
         "@plannotator/shared": "workspace:*",
       },

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -466,6 +466,16 @@ const App: React.FC = () => {
   };
 
   // API mode handlers
+  const handleDeferToCli = async () => {
+    setIsSubmitting(true);
+    try {
+      await fetch('/api/defer-to-cli', { method: 'POST' });
+      setSubmitted('approved');
+    } catch {
+      setIsSubmitting(false);
+    }
+  };
+
   const handleApprove = async () => {
     setIsSubmitting(true);
     try {
@@ -931,6 +941,28 @@ const App: React.FC = () => {
                     </div>
                   )}
                 </div>}
+
+                {!annotateMode && origin === 'claude-code' && (
+                  <div className="relative group/defer">
+                    <button
+                      onClick={handleDeferToCli}
+                      disabled={isSubmitting}
+                      className={`px-2 py-1 md:px-2.5 rounded-md text-xs font-medium transition-all ${
+                        isSubmitting
+                          ? 'opacity-50 cursor-not-allowed bg-muted text-muted-foreground'
+                          : 'bg-muted text-muted-foreground hover:bg-accent hover:text-accent-foreground'
+                      }`}
+                    >
+                      <span className="md:hidden">CLI</span>
+                      <span className="hidden md:inline">Approve in CLI</span>
+                    </button>
+                    <div className="absolute top-full right-0 mt-2 px-3 py-2 bg-popover border border-border rounded-lg shadow-xl text-xs text-foreground w-56 text-center opacity-0 invisible group-hover/defer:opacity-100 group-hover/defer:visible transition-all pointer-events-none z-50">
+                      <div className="absolute bottom-full right-4 border-4 border-transparent border-b-border" />
+                      <div className="absolute bottom-full right-4 mt-px border-4 border-transparent border-b-popover" />
+                      Approve via Claude Code's native flow. Use this if you want to /compact before implementing.
+                    </div>
+                  </div>
+                )}
 
                 <div className="w-px h-5 bg-border/50 mx-1 hidden md:block" />
               </>

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -76,13 +76,14 @@ export interface ServerResult {
   url: string;
   /** Whether running in remote mode */
   isRemote: boolean;
-  /** Wait for user decision (approve/deny) */
+  /** Wait for user decision (approve/deny/defer) */
   waitForDecision: () => Promise<{
     approved: boolean;
     feedback?: string;
     savedPath?: string;
     agentSwitch?: string;
     permissionMode?: string;
+    deferToCli?: boolean;
   }>;
   /** Stop the server */
   stop: () => void;
@@ -140,6 +141,7 @@ export async function startPlannotatorServer(
     savedPath?: string;
     agentSwitch?: string;
     permissionMode?: string;
+    deferToCli?: boolean;
   }) => void;
   const decisionPromise = new Promise<{
     approved: boolean;
@@ -147,6 +149,7 @@ export async function startPlannotatorServer(
     savedPath?: string;
     agentSwitch?: string;
     permissionMode?: string;
+    deferToCli?: boolean;
   }>((resolve) => {
     resolveDecision = resolve;
   });
@@ -387,6 +390,14 @@ export async function startPlannotatorServer(
             const effectivePermissionMode = requestedPermissionMode || permissionMode;
             resolveDecision({ approved: true, feedback, savedPath, agentSwitch, permissionMode: effectivePermissionMode });
             return Response.json({ ok: true, savedPath });
+          }
+
+          // API: Defer to CLI — let Claude Code's native approval handle it
+          if (url.pathname === "/api/defer-to-cli" && req.method === "POST") {
+            // Clean up draft on defer
+            deleteDraft(draftKey);
+            resolveDecision({ approved: false, deferToCli: true });
+            return Response.json({ ok: true });
           }
 
           // API: Deny with feedback


### PR DESCRIPTION
## Summary
- Adds an **Approve in CLI** button to the plan review toolbar (Claude Code only)
- Lets users defer to Claude Code's native ExitPlanMode prompt, which includes built-in options like "Yes, clear context" and permission mode selection that aren't accessible when plannotator intercepts the PermissionRequest hook
- Uses a file-based passthrough flag (`~/.plannotator/.cli-passthrough`):
  1. User clicks "Approve in CLI" in the web UI
  2. Hook writes passthrough flag, returns deny instructing model to re-call ExitPlanMode
  3. Next invocation sees flag, deletes it, returns `{}` (empty response)
  4. CLI falls through to its native approval prompt

## Motivation

When plannotator intercepts `ExitPlanMode` via the PermissionRequest hook, the CLI's native approval prompt is bypassed entirely. This means users lose access to options like "Yes, clear context and auto-accept edits" which is valuable for managing context window usage on long sessions. This PR provides an escape hatch back to the native flow when needed.

## Files changed
- `apps/hook/server/index.ts` — Passthrough flag check on startup + `deferToCli` decision handler
- `packages/server/index.ts` — New `/api/defer-to-cli` endpoint + `deferToCli` field in decision type
- `packages/editor/App.tsx` — "Approve in CLI" button + `handleDeferToCli` handler

## Test plan
- [ ] Open a plan in plannotator, click "Approve in CLI"
- [ ] Verify the native Claude Code approval prompt appears with clear context options
- [ ] Verify normal Approve/Deny buttons still work as before
- [ ] Verify the passthrough flag is cleaned up after use