### PR TITLE
fix: non-blocking browser launch in Pi extension (Linux)

### DIFF
--- a/apps/pi-extension/server.ts
+++ b/apps/pi-extension/server.ts
@@ -79,7 +79,9 @@ export function openBrowser(url: string): void {
       args = [url];
     }
 
-    spawn(cmd, args, { detached: true, stdio: "ignore" }).unref();
+    const child = spawn(cmd, args, { detached: true, stdio: "ignore" });
+    child.once("error", () => {});
+    child.unref();
   } catch {
     // Silently fail
   }


### PR DESCRIPTION
## Summary

- Replace `execSync(xdg-open ...)` with `spawn(..., { detached: true, stdio: "ignore" }).unref()` in the Pi extension's `openBrowser()`
- `execSync` blocks the Node.js event loop, so the HTTP server can't respond to the browser's initial page request on Linux desktops where `xdg-open` doesn't immediately exit — causing a deadlock

Closes #288

## Test plan

- [ ] Test on Linux (Wayland/Hyprland) with Chromium — verify page loads without hanging
- [ ] Test on macOS — verify `open` still works
- [ ] Test with `PLANNOTATOR_BROWSER` override

🤖 Generated with [Claude Code](https://claude.com/claude-code)