### PR TITLE
feat(pi-extension): add remote session support for SSH/devcontainer

### DIFF
--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -36,6 +36,15 @@ import {
   openBrowser,
 } from "./server.js";
 
+// ── Types ──────────────────────────────────────────────────────────────
+
+/** Common interface for servers that can wait for a user decision in a browser. */
+interface DecisionServer<T> {
+  url: string;
+  stop: () => void;
+  waitForDecision: () => Promise<T>;
+}
+
 // Load HTML at runtime (jiti doesn't support import attributes)
 const __dirname = dirname(fileURLToPath(import.meta.url));
 let planHtmlContent = "";
@@ -65,6 +74,25 @@ function getTextContent(message: AssistantMessage): string {
     .filter((block): block is TextContent => block.type === "text")
     .map((block) => block.text)
     .join("\n");
+}
+
+/**
+ * Open browser for user review, wait for decision, then stop server.
+ * Handles remote session notification automatically.
+ */
+async function runBrowserReview<T>(
+  server: DecisionServer<T>,
+  ctx: ExtensionContext,
+): Promise<T> {
+  const browserResult = openBrowser(server.url);
+  if (browserResult.isRemote) {
+    ctx.ui.notify(`Remote session. Open manually: ${browserResult.url}`, "info");
+  }
+
+  const result = await server.waitForDecision();
+  await new Promise((r) => setTimeout(r, 1500));
+  server.stop();
+  return result;
 }
 
 export default function plannotator(pi: ExtensionAPI): void {
@@ -248,11 +276,7 @@ export default function plannotator(pi: ExtensionAPI): void {
         htmlContent: reviewHtmlContent,
       });
 
-      openBrowser(server.url);
-
-      const result = await server.waitForDecision();
-      await new Promise((r) => setTimeout(r, 1500));
-      server.stop();
+      const result = await runBrowserReview(server, ctx);
 
       if (result.feedback) {
         if (result.approved) {
@@ -295,11 +319,7 @@ export default function plannotator(pi: ExtensionAPI): void {
         htmlContent: planHtmlContent,
       });
 
-      openBrowser(server.url);
-
-      const result = await server.waitForDecision();
-      await new Promise((r) => setTimeout(r, 1500));
-      server.stop();
+      const result = await runBrowserReview(server, ctx);
 
       if (result.feedback) {
         pi.sendUserMessage(
@@ -396,12 +416,7 @@ export default function plannotator(pi: ExtensionAPI): void {
         origin: "pi",
       });
 
-      openBrowser(server.url);
-
-      // Wait for user decision in the browser
-      const result = await server.waitForDecision();
-      await new Promise((r) => setTimeout(r, 1500));
-      server.stop();
+      const result = await runBrowserReview(server, ctx);
 
       if (result.approved) {
         phase = "executing";

--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -267,7 +267,7 @@ export default function plannotator(pi: ExtensionAPI): void {
       const gitCtx = getGitContext();
       const { patch: rawPatch, label: gitRef } = runGitDiff("uncommitted", gitCtx.defaultBranch);
 
-      const server = startReviewServer({
+      const server = await startReviewServer({
         rawPatch,
         gitRef,
         origin: "pi",
@@ -312,7 +312,7 @@ export default function plannotator(pi: ExtensionAPI): void {
       ctx.ui.notify(`Opening annotation UI for ${filePath}...`, "info");
 
       const markdown = readFileSync(absolutePath, "utf-8");
-      const server = startAnnotateServer({
+      const server = await startAnnotateServer({
         markdown,
         filePath: absolutePath,
         origin: "pi",
@@ -410,7 +410,7 @@ export default function plannotator(pi: ExtensionAPI): void {
       }
 
       // Start browser-based plan review server
-      const server = startPlanReviewServer({
+      const server = await startPlanReviewServer({
         plan: planContent,
         htmlContent: planHtmlContent,
         origin: "pi",

--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -28,8 +28,11 @@ import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-age
 import { Key } from "@mariozechner/pi-tui";
 import { markCompletedSteps, parseChecklist, type ChecklistItem } from "./utils.js";
 import {
+  type AnnotateServerResult,
   startPlanReviewServer,
+  type PlanServerResult,
   startReviewServer,
+  type ReviewServerResult,
   startAnnotateServer,
   getGitContext,
   runGitDiff,
@@ -93,6 +96,10 @@ async function runBrowserReview<T>(
   await new Promise((r) => setTimeout(r, 1500));
   server.stop();
   return result;
+}
+
+function getStartupErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : "Unknown error";
 }
 
 export default function plannotator(pi: ExtensionAPI): void {
@@ -267,14 +274,20 @@ export default function plannotator(pi: ExtensionAPI): void {
       const gitCtx = getGitContext();
       const { patch: rawPatch, label: gitRef } = runGitDiff("uncommitted", gitCtx.defaultBranch);
 
-      const server = await startReviewServer({
-        rawPatch,
-        gitRef,
-        origin: "pi",
-        diffType: "uncommitted",
-        gitContext: gitCtx,
-        htmlContent: reviewHtmlContent,
-      });
+      let server: ReviewServerResult;
+      try {
+        server = await startReviewServer({
+          rawPatch,
+          gitRef,
+          origin: "pi",
+          diffType: "uncommitted",
+          gitContext: gitCtx,
+          htmlContent: reviewHtmlContent,
+        });
+      } catch (err) {
+        ctx.ui.notify(`Failed to start code review UI: ${getStartupErrorMessage(err)}`, "error");
+        return;
+      }
 
       const result = await runBrowserReview(server, ctx);
 
@@ -312,12 +325,18 @@ export default function plannotator(pi: ExtensionAPI): void {
       ctx.ui.notify(`Opening annotation UI for ${filePath}...`, "info");
 
       const markdown = readFileSync(absolutePath, "utf-8");
-      const server = await startAnnotateServer({
-        markdown,
-        filePath: absolutePath,
-        origin: "pi",
-        htmlContent: planHtmlContent,
-      });
+      let server: AnnotateServerResult;
+      try {
+        server = await startAnnotateServer({
+          markdown,
+          filePath: absolutePath,
+          origin: "pi",
+          htmlContent: planHtmlContent,
+        });
+      } catch (err) {
+        ctx.ui.notify(`Failed to start annotation UI: ${getStartupErrorMessage(err)}`, "error");
+        return;
+      }
 
       const result = await runBrowserReview(server, ctx);
 
@@ -410,11 +429,21 @@ export default function plannotator(pi: ExtensionAPI): void {
       }
 
       // Start browser-based plan review server
-      const server = await startPlanReviewServer({
-        plan: planContent,
-        htmlContent: planHtmlContent,
-        origin: "pi",
-      });
+      let server: PlanServerResult;
+      try {
+        server = await startPlanReviewServer({
+          plan: planContent,
+          htmlContent: planHtmlContent,
+          origin: "pi",
+        });
+      } catch (err) {
+        const message = `Failed to start plan review UI: ${getStartupErrorMessage(err)}`;
+        ctx.ui.notify(message, "error");
+        return {
+          content: [{ type: "text", text: message }],
+          details: { approved: false },
+        };
+      }
 
       const result = await runBrowserReview(server, ctx);
 

--- a/apps/pi-extension/server.ts
+++ b/apps/pi-extension/server.ts
@@ -78,11 +78,36 @@ function getServerPort(): { port: number; portSource: "env" | "remote-default" |
   return { port: 0, portSource: "random" };
 }
 
-function listenOnPort(server: Server): { port: number; portSource: "env" | "remote-default" | "random" } {
+const MAX_RETRIES = 5;
+const RETRY_DELAY_MS = 500;
+
+async function listenOnPort(server: Server): Promise<{ port: number; portSource: "env" | "remote-default" | "random" }> {
   const result = getServerPort();
-  server.listen(result.port);
-  const addr = server.address() as { port: number };
-  return { port: addr.port, portSource: result.portSource };
+
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(result.port, () => {
+          server.removeListener("error", reject);
+          resolve();
+        });
+      });
+      const addr = server.address() as { port: number };
+      return { port: addr.port, portSource: result.portSource };
+    } catch (err: unknown) {
+      const isAddressInUse = err instanceof Error && err.message.includes("EADDRINUSE");
+      if (isAddressInUse && attempt < MAX_RETRIES) {
+        await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
+        continue;
+      }
+      const hint = isRemoteSession() ? " (set PLANNOTATOR_PORT to use a different port)" : "";
+      throw new Error(`Port ${result.port} in use after ${MAX_RETRIES} retries${hint}`);
+    }
+  }
+
+  // Unreachable, but satisfies TypeScript
+  throw new Error("Failed to bind port");
 }
 
 /**
@@ -91,12 +116,12 @@ function listenOnPort(server: Server): { port: number; portSource: "env" | "remo
  * Returns { opened: true } if browser was opened, { opened: false, isRemote: true, url } if remote session.
  */
 export function openBrowser(url: string): { opened: boolean; isRemote?: boolean; url?: string } {
-  if (isRemoteSession()) {
+  const browser = process.env.PLANNOTATOR_BROWSER || process.env.BROWSER;
+  if (isRemoteSession() && !browser) {
     return { opened: false, isRemote: true, url };
   }
 
   try {
-    const browser = process.env.PLANNOTATOR_BROWSER || process.env.BROWSER;
     const platform = process.platform;
     const wsl = platform === "linux" && os.release().toLowerCase().includes("microsoft");
 
@@ -323,7 +348,7 @@ export function startPlanReviewServer(options: {
   plan: string;
   htmlContent: string;
   origin?: string;
-}): PlanServerResult {
+}): Promise<PlanServerResult> {
   // Version history
   const slug = generateSlug(options.plan);
   const project = detectProjectName();
@@ -382,7 +407,7 @@ export function startPlanReviewServer(options: {
     }
   });
 
-  const { port, portSource } = listenOnPort(server);
+  const { port, portSource } = await listenOnPort(server);
 
   return {
     port,
@@ -471,7 +496,7 @@ export function startReviewServer(options: {
   origin?: string;
   diffType?: DiffType;
   gitContext?: GitContext;
-}): ReviewServerResult {
+}): Promise<ReviewServerResult> {
   let currentPatch = options.rawPatch;
   let currentGitRef = options.gitRef;
   let currentDiffType: DiffType = options.diffType || "uncommitted";
@@ -517,7 +542,7 @@ export function startReviewServer(options: {
     }
   });
 
-  const { port, portSource } = listenOnPort(server);
+  const { port, portSource } = await listenOnPort(server);
 
   return {
     port,
@@ -543,7 +568,7 @@ export function startAnnotateServer(options: {
   filePath: string;
   htmlContent: string;
   origin?: string;
-}): AnnotateServerResult {
+}): Promise<AnnotateServerResult> {
   let resolveDecision!: (result: { feedback: string }) => void;
   const decisionPromise = new Promise<{ feedback: string }>((r) => {
     resolveDecision = r;
@@ -568,7 +593,7 @@ export function startAnnotateServer(options: {
     }
   });
 
-  const { port, portSource } = listenOnPort(server);
+  const { port, portSource } = await listenOnPort(server);
 
   return {
     port,

--- a/apps/pi-extension/server.ts
+++ b/apps/pi-extension/server.ts
@@ -101,8 +101,11 @@ async function listenOnPort(server: Server): Promise<{ port: number; portSource:
         await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
         continue;
       }
-      const hint = isRemoteSession() ? " (set PLANNOTATOR_PORT to use a different port)" : "";
-      throw new Error(`Port ${result.port} in use after ${MAX_RETRIES} retries${hint}`);
+      if (isAddressInUse) {
+        const hint = isRemoteSession() ? " (set PLANNOTATOR_PORT to use a different port)" : "";
+        throw new Error(`Port ${result.port} in use after ${MAX_RETRIES} retries${hint}`);
+      }
+      throw err;
     }
   }
 
@@ -344,7 +347,7 @@ export interface PlanServerResult {
   stop: () => void;
 }
 
-export function startPlanReviewServer(options: {
+export async function startPlanReviewServer(options: {
   plan: string;
   htmlContent: string;
   origin?: string;
@@ -489,7 +492,7 @@ export function runGitDiff(diffType: DiffType, defaultBranch = "main"): { patch:
   }
 }
 
-export function startReviewServer(options: {
+export async function startReviewServer(options: {
   rawPatch: string;
   gitRef: string;
   htmlContent: string;
@@ -563,7 +566,7 @@ export interface AnnotateServerResult {
   stop: () => void;
 }
 
-export function startAnnotateServer(options: {
+export async function startAnnotateServer(options: {
   markdown: string;
   filePath: string;
   htmlContent: string;

--- a/apps/pi-extension/server.ts
+++ b/apps/pi-extension/server.ts
@@ -38,17 +38,63 @@ function html(res: import("node:http").ServerResponse, content: string): void {
   res.end(content);
 }
 
-function listenOnRandomPort(server: Server): number {
-  server.listen(0);
+const DEFAULT_REMOTE_PORT = 19432;
+
+/**
+ * Check if running in a remote session (SSH, devcontainer, etc.)
+ * Honors PLANNOTATOR_REMOTE env var, or detects SSH_TTY/SSH_CONNECTION.
+ */
+function isRemoteSession(): boolean {
+  const remote = process.env.PLANNOTATOR_REMOTE;
+  if (remote === "1" || remote?.toLowerCase() === "true") {
+    return true;
+  }
+  // Legacy SSH detection
+  if (process.env.SSH_TTY || process.env.SSH_CONNECTION) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Get the server port to use.
+ * - PLANNOTATOR_PORT env var takes precedence
+ * - Remote sessions default to 19432 (for port forwarding)
+ * - Local sessions use random port
+ * Returns { port, portSource } so caller can notify user if needed.
+ */
+function getServerPort(): { port: number; portSource: "env" | "remote-default" | "random" } {
+  const envPort = process.env.PLANNOTATOR_PORT;
+  if (envPort) {
+    const parsed = parseInt(envPort, 10);
+    if (!isNaN(parsed) && parsed > 0 && parsed < 65536) {
+      return { port: parsed, portSource: "env" };
+    }
+    // Invalid port - fall back silently, caller can check env var themselves
+  }
+  if (isRemoteSession()) {
+    return { port: DEFAULT_REMOTE_PORT, portSource: "remote-default" };
+  }
+  return { port: 0, portSource: "random" };
+}
+
+function listenOnPort(server: Server): { port: number; portSource: "env" | "remote-default" | "random" } {
+  const result = getServerPort();
+  server.listen(result.port);
   const addr = server.address() as { port: number };
-  return addr.port;
+  return { port: addr.port, portSource: result.portSource };
 }
 
 /**
  * Open URL in system browser (Node-compatible, no Bun $ dependency).
  * Honors PLANNOTATOR_BROWSER and BROWSER env vars, matching packages/server/browser.ts.
+ * Returns { opened: true } if browser was opened, { opened: false, isRemote: true, url } if remote session.
  */
-export function openBrowser(url: string): void {
+export function openBrowser(url: string): { opened: boolean; isRemote?: boolean; url?: string } {
+  if (isRemoteSession()) {
+    return { opened: false, isRemote: true, url };
+  }
+
   try {
     const browser = process.env.PLANNOTATOR_BROWSER || process.env.BROWSER;
     const platform = process.platform;
@@ -82,8 +128,9 @@ export function openBrowser(url: string): void {
     const child = spawn(cmd, args, { detached: true, stdio: "ignore" });
     child.once("error", () => {});
     child.unref();
+    return { opened: true };
   } catch {
-    // Silently fail
+    return { opened: false };
   }
 }
 
@@ -266,6 +313,7 @@ function listProjectPlans(
 
 export interface PlanServerResult {
   port: number;
+  portSource: "env" | "remote-default" | "random";
   url: string;
   waitForDecision: () => Promise<{ approved: boolean; feedback?: string }>;
   stop: () => void;
@@ -334,17 +382,16 @@ export function startPlanReviewServer(options: {
     }
   });
 
-  const port = listenOnRandomPort(server);
+  const { port, portSource } = listenOnPort(server);
 
   return {
     port,
+    portSource,
     url: `http://localhost:${port}`,
     waitForDecision: () => decisionPromise,
     stop: () => server.close(),
   };
 }
-
-// ── Code Review Server ──────────────────────────────────────────────────
 
 export type DiffType = "uncommitted" | "staged" | "unstaged" | "last-commit" | "branch";
 
@@ -361,6 +408,7 @@ export interface GitContext {
 
 export interface ReviewServerResult {
   port: number;
+  portSource: "env" | "remote-default" | "random";
   url: string;
   waitForDecision: () => Promise<{ approved: boolean; feedback: string }>;
   stop: () => void;
@@ -469,10 +517,11 @@ export function startReviewServer(options: {
     }
   });
 
-  const port = listenOnRandomPort(server);
+  const { port, portSource } = listenOnPort(server);
 
   return {
     port,
+    portSource,
     url: `http://localhost:${port}`,
     waitForDecision: () => decisionPromise,
     stop: () => server.close(),
@@ -483,6 +532,7 @@ export function startReviewServer(options: {
 
 export interface AnnotateServerResult {
   port: number;
+  portSource: "env" | "remote-default" | "random";
   url: string;
   waitForDecision: () => Promise<{ feedback: string }>;
   stop: () => void;
@@ -518,10 +568,11 @@ export function startAnnotateServer(options: {
     }
   });
 
-  const port = listenOnRandomPort(server);
+  const { port, portSource } = listenOnPort(server);
 
   return {
     port,
+    portSource,
     url: `http://localhost:${port}`,
     waitForDecision: () => decisionPromise,
     stop: () => server.close(),


### PR DESCRIPTION
## Changes

- Detect remote sessions via `PLANNOTATOR_REMOTE` env var or `SSH_TTY`/`SSH_CONNECTION`
- Support `PLANNOTATOR_PORT` for fixed port (default 19432) in remote sessions
- `openBrowser()` returns `{ isRemote, url }` to notify users to open manually
- Extract `runBrowserReview` helper to consolidate browser-open-wait-stop pattern

## Usage

For devcontainer/SSH sessions, set:
```bash
export PLANNOTATOR_REMOTE=1
export PLANNOTATOR_PORT=9999  # optional, defaults to 19432
```

Then configure port forwarding and open the URL manually when prompted.