### PR TITLE
feat: add file-scoped comments to /plannotator-review

### DIFF
--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -97,10 +97,34 @@ function exportReviewFeedback(annotations: CodeAnnotation[], files: DiffFile[]):
   for (const [filePath, fileAnnotations] of grouped) {
     output += `## ${filePath}\n\n`;
 
-    const sorted = [...fileAnnotations].sort((a, b) => a.lineStart - b.lineStart);
+    const sorted = [...fileAnnotations].sort((a, b) => {
+      const aScope = a.scope ?? 'line';
+      const bScope = b.scope ?? 'line';
+      if (aScope !== bScope) {
+        return aScope === 'file' ? -1 : 1;
+      }
+      return a.lineStart - b.lineStart;
+    });
 
     for (let i = 0; i < sorted.length; i++) {
       const ann = sorted[i];
+      const scope = ann.scope ?? 'line';
+
+      if (scope === 'file') {
+        output += `### File Comment\n`;
+
+        if (ann.text) {
+          output += `${ann.text}\n`;
+        }
+
+        if (ann.suggestedCode) {
+          output += `\n**Suggested code:**\n\`\`\`\n${ann.suggestedCode}\n\`\`\`\n`;
+        }
+
+        output += '\n';
+        continue;
+      }
+
       const lineRange = ann.lineStart === ann.lineEnd
         ? `Line ${ann.lineStart}`
         : `Lines ${ann.lineStart}-${ann.lineEnd}`;
@@ -279,6 +303,7 @@ const ReviewApp: React.FC = () => {
     const newAnnotation: CodeAnnotation = {
       id: generateId(),
       type,
+      scope: 'line',
       filePath: files[activeFileIndex].path,
       lineStart,
       lineEnd,
@@ -293,6 +318,27 @@ const ReviewApp: React.FC = () => {
     setAnnotations(prev => [...prev, newAnnotation]);
     setPendingSelection(null);
   }, [pendingSelection, files, activeFileIndex, identity]);
+
+  const handleAddFileComment = useCallback((text: string) => {
+    const activeFile = files[activeFileIndex];
+    const trimmed = text.trim();
+    if (!activeFile || !trimmed) return;
+
+    const newAnnotation: CodeAnnotation = {
+      id: generateId(),
+      type: 'comment',
+      scope: 'file',
+      filePath: activeFile.path,
+      lineStart: 1,
+      lineEnd: 1,
+      side: 'new',
+      text: trimmed,
+      createdAt: Date.now(),
+      author: identity,
+    };
+
+    setAnnotations(prev => [...prev, newAnnotation]);
+  }, [files, activeFileIndex, identity]);
 
   // Edit annotation
   const handleEditAnnotation = useCallback((
@@ -854,6 +900,7 @@ const ReviewApp: React.FC = () => {
                 pendingSelection={pendingSelection}
                 onLineSelection={handleLineSelection}
                 onAddAnnotation={handleAddAnnotation}
+                onAddFileComment={handleAddFileComment}
                 onEditAnnotation={handleEditAnnotation}
                 onSelectAnnotation={handleSelectAnnotation}
                 onDeleteAnnotation={handleDeleteAnnotation}

--- a/packages/review-editor/components/DiffViewer.tsx
+++ b/packages/review-editor/components/DiffViewer.tsx
@@ -20,6 +20,7 @@ interface DiffViewerProps {
   pendingSelection: SelectedLineRange | null;
   onLineSelection: (range: SelectedLineRange | null) => void;
   onAddAnnotation: (type: CodeAnnotationType, text?: string, suggestedCode?: string, originalCode?: string) => void;
+  onAddFileComment: (text: string) => void;
   onEditAnnotation: (id: string, text?: string, suggestedCode?: string, originalCode?: string) => void;
   onSelectAnnotation: (id: string | null) => void;
   onDeleteAnnotation: (id: string) => void;
@@ -42,6 +43,7 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
   pendingSelection,
   onLineSelection,
   onAddAnnotation,
+  onAddFileComment,
   onEditAnnotation,
   onSelectAnnotation,
   onDeleteAnnotation,
@@ -118,18 +120,20 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
 
   // Map annotations to @pierre/diffs format
   const lineAnnotations = useMemo(() => {
-    return annotations.map(ann => ({
-      side: ann.side === 'new' ? 'additions' as const : 'deletions' as const,
-      lineNumber: ann.lineEnd,
-      metadata: {
-        annotationId: ann.id,
-        type: ann.type,
-        text: ann.text,
-        suggestedCode: ann.suggestedCode,
-        originalCode: ann.originalCode,
-        author: ann.author,
-      } as DiffAnnotationMetadata,
-    }));
+    return annotations
+      .filter(ann => (ann.scope ?? 'line') === 'line')
+      .map(ann => ({
+        side: ann.side === 'new' ? 'additions' as const : 'deletions' as const,
+        lineNumber: ann.lineEnd,
+        metadata: {
+          annotationId: ann.id,
+          type: ann.type,
+          text: ann.text,
+          suggestedCode: ann.suggestedCode,
+          originalCode: ann.originalCode,
+          author: ann.author,
+        } as DiffAnnotationMetadata,
+      }));
   }, [annotations]);
 
   // Handle edit: find annotation and start editing in toolbar
@@ -218,6 +222,7 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
         onStage={onStage}
         canStage={canStage}
         stageError={stageError}
+        onAddFileComment={onAddFileComment}
       />
 
       <div className="p-4">

--- a/packages/review-editor/components/DiffViewer.tsx
+++ b/packages/review-editor/components/DiffViewer.tsx
@@ -3,6 +3,7 @@ import { FileDiff } from '@pierre/diffs/react';
 import { getSingularPatch, processFile } from '@pierre/diffs';
 import { CodeAnnotation, CodeAnnotationType, SelectedLineRange, DiffAnnotationMetadata } from '@plannotator/ui/types';
 import { useTheme } from '@plannotator/ui/components/ThemeProvider';
+import { CommentPopover } from '@plannotator/ui/components/CommentPopover';
 import { detectLanguage } from '../utils/detectLanguage';
 import { useAnnotationToolbar } from '../hooks/useAnnotationToolbar';
 import { FileHeader } from './FileHeader';
@@ -57,6 +58,7 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
 }) => {
   const { theme, colorTheme, resolvedMode } = useTheme();
   const containerRef = useRef<HTMLDivElement>(null);
+  const [fileCommentAnchor, setFileCommentAnchor] = useState<HTMLElement | null>(null);
 
   const toolbar = useAnnotationToolbar({ patch, filePath, onLineSelection, onAddAnnotation, onEditAnnotation });
 
@@ -222,7 +224,7 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
         onStage={onStage}
         canStage={canStage}
         stageError={stageError}
-        onAddFileComment={onAddFileComment}
+        onFileComment={setFileCommentAnchor}
       />
 
       <div className="p-4">
@@ -274,6 +276,19 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
           modalLayout={toolbar.modalLayout}
           setModalLayout={toolbar.setModalLayout}
           onClose={() => toolbar.setShowCodeModal(false)}
+        />
+      )}
+
+      {fileCommentAnchor && (
+        <CommentPopover
+          anchorEl={fileCommentAnchor}
+          contextText={filePath.split('/').pop() || filePath}
+          isGlobal={false}
+          onSubmit={(text) => {
+            onAddFileComment(text);
+            setFileCommentAnchor(null);
+          }}
+          onClose={() => setFileCommentAnchor(null)}
         />
       )}
     </div>

--- a/packages/review-editor/components/FileHeader.tsx
+++ b/packages/review-editor/components/FileHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 interface FileHeaderProps {
   filePath: string;
@@ -10,7 +10,7 @@ interface FileHeaderProps {
   onStage?: () => void;
   canStage?: boolean;
   stageError?: string | null;
-  onAddFileComment?: (text: string) => void;
+  onFileComment?: (anchorEl: HTMLElement) => void;
 }
 
 /** Sticky file header with file path, Viewed toggle, Git Add, and Copy Diff button */
@@ -24,45 +24,10 @@ export const FileHeader: React.FC<FileHeaderProps> = ({
   onStage,
   canStage = false,
   stageError,
-  onAddFileComment,
+  onFileComment,
 }) => {
   const [copied, setCopied] = useState(false);
-  const [showFileComment, setShowFileComment] = useState(false);
-  const [fileCommentText, setFileCommentText] = useState('');
-  const composerRef = useRef<HTMLDivElement>(null);
-
-  const handleSubmitFileComment = () => {
-    if (!onAddFileComment) return;
-    const trimmed = fileCommentText.trim();
-    if (!trimmed) return;
-    onAddFileComment(trimmed);
-    setFileCommentText('');
-    setShowFileComment(false);
-  };
-
-  useEffect(() => {
-    if (!showFileComment) return;
-
-    const handlePointerDown = (e: PointerEvent) => {
-      const target = e.target as Node | null;
-      if (!target) return;
-      if (composerRef.current?.contains(target)) return;
-      setShowFileComment(false);
-    };
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        setShowFileComment(false);
-      }
-    };
-
-    document.addEventListener('pointerdown', handlePointerDown, true);
-    document.addEventListener('keydown', handleKeyDown);
-    return () => {
-      document.removeEventListener('pointerdown', handlePointerDown, true);
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [showFileComment]);
+  const fileCommentRef = useRef<HTMLButtonElement>(null);
 
   return (
     <div className="sticky top-0 z-10 px-4 py-2 bg-card/95 backdrop-blur border-b border-border flex items-center justify-between">
@@ -123,60 +88,18 @@ export const FileHeader: React.FC<FileHeaderProps> = ({
         {stageError && (
           <span className="text-xs text-destructive">{stageError}</span>
         )}
-        {onAddFileComment && (
-          <div className="relative" ref={composerRef}>
-            <button
-              onClick={() => setShowFileComment(prev => !prev)}
-              className={`text-xs px-2 py-1 rounded transition-colors flex items-center gap-1 ${
-                showFileComment
-                  ? 'bg-primary/15 text-primary'
-                  : 'text-muted-foreground hover:text-foreground hover:bg-muted'
-              }`}
-              title="Add file-scoped comment"
-            >
-              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-4l-4 4v-4z" />
-              </svg>
-              File Comment
-            </button>
-
-            {showFileComment && (
-              <div className="absolute right-0 top-full mt-2 w-80 bg-popover border border-border rounded-lg shadow-xl p-2 z-20">
-                <textarea
-                  value={fileCommentText}
-                  onChange={(e) => setFileCommentText(e.target.value)}
-                  placeholder="Add feedback for this file..."
-                  className="w-full px-2.5 py-2 bg-muted rounded-md text-xs resize-none focus:outline-none focus:ring-1 focus:ring-primary/50"
-                  rows={4}
-                  autoFocus
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !e.nativeEvent.isComposing) {
-                      e.preventDefault();
-                      handleSubmitFileComment();
-                    }
-                  }}
-                />
-                <div className="mt-2 flex items-center justify-between">
-                  <span className="text-[10px] text-muted-foreground">Cmd/Ctrl+Enter</span>
-                  <div className="flex items-center gap-1.5">
-                    <button
-                      onClick={() => setShowFileComment(false)}
-                      className="px-2 py-1 text-xs rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      onClick={handleSubmitFileComment}
-                      disabled={!fileCommentText.trim()}
-                      className="px-2 py-1 text-xs rounded-md bg-primary text-primary-foreground disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                      Add
-                    </button>
-                  </div>
-                </div>
-              </div>
-            )}
-          </div>
+        {onFileComment && (
+          <button
+            ref={fileCommentRef}
+            onClick={() => fileCommentRef.current && onFileComment(fileCommentRef.current)}
+            className="text-xs px-2 py-1 rounded transition-colors flex items-center gap-1 text-muted-foreground hover:text-foreground hover:bg-muted"
+            title="Add file-scoped comment"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-4l-4 4v-4z" />
+            </svg>
+            File Comment
+          </button>
         )}
         <button
           onClick={async () => {

--- a/packages/review-editor/components/FileHeader.tsx
+++ b/packages/review-editor/components/FileHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 interface FileHeaderProps {
   filePath: string;
@@ -10,6 +10,7 @@ interface FileHeaderProps {
   onStage?: () => void;
   canStage?: boolean;
   stageError?: string | null;
+  onAddFileComment?: (text: string) => void;
 }
 
 /** Sticky file header with file path, Viewed toggle, Git Add, and Copy Diff button */
@@ -23,8 +24,45 @@ export const FileHeader: React.FC<FileHeaderProps> = ({
   onStage,
   canStage = false,
   stageError,
+  onAddFileComment,
 }) => {
   const [copied, setCopied] = useState(false);
+  const [showFileComment, setShowFileComment] = useState(false);
+  const [fileCommentText, setFileCommentText] = useState('');
+  const composerRef = useRef<HTMLDivElement>(null);
+
+  const handleSubmitFileComment = () => {
+    if (!onAddFileComment) return;
+    const trimmed = fileCommentText.trim();
+    if (!trimmed) return;
+    onAddFileComment(trimmed);
+    setFileCommentText('');
+    setShowFileComment(false);
+  };
+
+  useEffect(() => {
+    if (!showFileComment) return;
+
+    const handlePointerDown = (e: PointerEvent) => {
+      const target = e.target as Node | null;
+      if (!target) return;
+      if (composerRef.current?.contains(target)) return;
+      setShowFileComment(false);
+    };
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setShowFileComment(false);
+      }
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown, true);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown, true);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [showFileComment]);
 
   return (
     <div className="sticky top-0 z-10 px-4 py-2 bg-card/95 backdrop-blur border-b border-border flex items-center justify-between">
@@ -84,6 +122,61 @@ export const FileHeader: React.FC<FileHeaderProps> = ({
         )}
         {stageError && (
           <span className="text-xs text-destructive">{stageError}</span>
+        )}
+        {onAddFileComment && (
+          <div className="relative" ref={composerRef}>
+            <button
+              onClick={() => setShowFileComment(prev => !prev)}
+              className={`text-xs px-2 py-1 rounded transition-colors flex items-center gap-1 ${
+                showFileComment
+                  ? 'bg-primary/15 text-primary'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+              }`}
+              title="Add file-scoped comment"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-4l-4 4v-4z" />
+              </svg>
+              File Comment
+            </button>
+
+            {showFileComment && (
+              <div className="absolute right-0 top-full mt-2 w-80 bg-popover border border-border rounded-lg shadow-xl p-2 z-20">
+                <textarea
+                  value={fileCommentText}
+                  onChange={(e) => setFileCommentText(e.target.value)}
+                  placeholder="Add feedback for this file..."
+                  className="w-full px-2.5 py-2 bg-muted rounded-md text-xs resize-none focus:outline-none focus:ring-1 focus:ring-primary/50"
+                  rows={4}
+                  autoFocus
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !e.nativeEvent.isComposing) {
+                      e.preventDefault();
+                      handleSubmitFileComment();
+                    }
+                  }}
+                />
+                <div className="mt-2 flex items-center justify-between">
+                  <span className="text-[10px] text-muted-foreground">Cmd/Ctrl+Enter</span>
+                  <div className="flex items-center gap-1.5">
+                    <button
+                      onClick={() => setShowFileComment(false)}
+                      className="px-2 py-1 text-xs rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={handleSubmitFileComment}
+                      disabled={!fileCommentText.trim()}
+                      className="px-2 py-1 text-xs rounded-md bg-primary text-primary-foreground disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      Add
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
         )}
         <button
           onClick={async () => {

--- a/packages/review-editor/components/ReviewPanel.tsx
+++ b/packages/review-editor/components/ReviewPanel.tsx
@@ -68,6 +68,25 @@ function formatTimestamp(ts: number): string {
   return new Date(ts).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 }
 
+const FILE_SCOPE_FIRST = { file: 0, line: 1 } as const;
+
+function getAnnotationScope(annotation: CodeAnnotation): 'line' | 'file' {
+  return annotation.scope ?? 'line';
+}
+
+function compareCodeAnnotations(a: CodeAnnotation, b: CodeAnnotation): number {
+  const aScope = getAnnotationScope(a);
+  const bScope = getAnnotationScope(b);
+
+  if (aScope !== bScope) {
+    return FILE_SCOPE_FIRST[aScope] - FILE_SCOPE_FIRST[bScope];
+  }
+
+  return aScope === 'file'
+    ? b.createdAt - a.createdAt
+    : a.lineStart - b.lineStart;
+}
+
 export const ReviewPanel: React.FC<ReviewPanelProps> = ({
   isOpen,
   onToggle,
@@ -102,9 +121,9 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({
       existing.push(ann);
       grouped.set(ann.filePath, existing);
     }
-    // Sort each group by line number
+    // Sort file comments first, then line comments
     for (const [, anns] of grouped) {
-      anns.sort((a, b) => a.lineStart - b.lineStart);
+      anns.sort(compareCodeAnnotations);
     }
     return grouped;
   }, [annotations]);
@@ -151,6 +170,7 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({
                   <div className="space-y-1">
                     {fileAnnotations.map((annotation) => {
                       const isSelected = selectedAnnotationId === annotation.id;
+                      const isFileScope = getAnnotationScope(annotation) === 'file';
                       return (
                         <div
                           key={annotation.id}
@@ -164,11 +184,17 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({
                           {/* Header: Line + Timestamp */}
                           <div className="flex items-center justify-between mb-1.5">
                             <div className="flex items-center gap-2">
-                              <span className="text-[10px] font-mono text-muted-foreground">
-                                {annotation.lineStart === annotation.lineEnd
-                                  ? `L${annotation.lineStart}`
-                                  : `L${annotation.lineStart}-${annotation.lineEnd}`}
-                              </span>
+                              {isFileScope ? (
+                                <span className="text-[9px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded bg-primary/10 text-primary">
+                                  file
+                                </span>
+                              ) : (
+                                <span className="text-[10px] font-mono text-muted-foreground">
+                                  {annotation.lineStart === annotation.lineEnd
+                                    ? `L${annotation.lineStart}`
+                                    : `L${annotation.lineStart}-${annotation.lineEnd}`}
+                                </span>
+                              )}
                               {annotation.author && (
                                 <span className={`text-[10px] truncate max-w-[100px] ${isCurrentUser(annotation.author) ? 'text-muted-foreground/50' : 'text-muted-foreground/70'}`}>
                                   {annotation.author}{isCurrentUser(annotation.author) && ' (me)'}

--- a/packages/ui/types.ts
+++ b/packages/ui/types.ts
@@ -60,10 +60,12 @@ export interface DiffResult {
 
 // Code Review Types
 export type CodeAnnotationType = 'comment' | 'suggestion' | 'concern';
+export type CodeAnnotationScope = 'line' | 'file';
 
 export interface CodeAnnotation {
   id: string;
   type: CodeAnnotationType;
+  scope?: CodeAnnotationScope; // Defaults to 'line' for backward compatibility
   filePath: string;
   lineStart: number;
   lineEnd: number;


### PR DESCRIPTION
## Summary
- Add a file-scoped comment flow to `/plannotator-review` via a `File Comment` composer in each file header.
- Keep line-scoped comments unchanged and include file-scoped comments in Review Panel and exported feedback (`### File Comment`).
- Small cleanup: extract Review Panel sort helpers for readability while preserving behavior.

Closes #302

## Test plan
- [x] `bun run build:review`
- [x] Manual end-to-end smoke test through `/plannotator-review` (feedback payload included `### File Comment`).