### PR TITLE
fix: guard Obsidian mkdir against Bun EEXIST regression

### DIFF
--- a/packages/server/integrations.ts
+++ b/packages/server/integrations.ts
@@ -258,8 +258,10 @@ export async function saveToObsidian(config: ObsidianConfig): Promise<Integratio
     const folderName = folder.trim() || "plannotator";
     const targetFolder = join(normalizedVault, folderName);
 
-    // Create folder if it doesn't exist
-    mkdirSync(targetFolder, { recursive: true });
+    // Create folder if it doesn't exist (guard for Bun mkdirSync regression)
+    if (!existsSync(targetFolder)) {
+      mkdirSync(targetFolder, { recursive: true });
+    }
 
     // Generate filename and full path
     const filename = generateFilename(plan, config.filenameFormat, config.filenameSeparator);


### PR DESCRIPTION
## Summary
- Adds `existsSync` guard before `mkdirSync` in Obsidian save to work around Bun regression (v1.1.43–1.1.45) that throws EEXIST on `mkdirSync({ recursive: true })` when the directory already exists
- No-op on fixed Bun versions, prevents save failure on affected ones

Fixes #315

## Test plan
- [ ] Save to Obsidian with a folder that doesn't exist yet (creates it)
- [ ] Save to Obsidian again to the same folder (no EEXIST error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)