### PR TITLE
fix(review): disable external diff in git commands

### DIFF
--- a/apps/pi-extension/review-core.ts
+++ b/apps/pi-extension/review-core.ts
@@ -188,6 +188,7 @@ async function getUntrackedFileDiffs(
       const diffResult = await runtime.runGit(
         [
           "diff",
+          "--no-ext-diff",
           "--no-index",
           `--src-prefix=${srcPrefix}`,
           `--dst-prefix=${dstPrefix}`,
@@ -271,6 +272,7 @@ export async function runGitDiff(
       case "uncommitted": {
         const trackedDiffArgs = [
           "diff",
+          "--no-ext-diff",
           "HEAD",
           "--src-prefix=a/",
           "--dst-prefix=b/",
@@ -298,6 +300,7 @@ export async function runGitDiff(
       case "staged": {
         const stagedDiffArgs = [
           "diff",
+          "--no-ext-diff",
           "--staged",
           "--src-prefix=a/",
           "--dst-prefix=b/",
@@ -312,7 +315,7 @@ export async function runGitDiff(
       }
 
       case "unstaged": {
-        const trackedDiffArgs = ["diff", "--src-prefix=a/", "--dst-prefix=b/"];
+        const trackedDiffArgs = ["diff", "--no-ext-diff", "--src-prefix=a/", "--dst-prefix=b/"];
         const trackedDiff = assertGitSuccess(
           await runtime.runGit(trackedDiffArgs, { cwd }),
           trackedDiffArgs,
@@ -335,8 +338,8 @@ export async function runGitDiff(
         );
         const args =
           hasParent.exitCode === 0
-            ? ["diff", "HEAD~1..HEAD", "--src-prefix=a/", "--dst-prefix=b/"]
-            : ["diff", "--root", "HEAD", "--src-prefix=a/", "--dst-prefix=b/"];
+            ? ["diff", "--no-ext-diff", "HEAD~1..HEAD", "--src-prefix=a/", "--dst-prefix=b/"]
+            : ["diff", "--no-ext-diff", "--root", "HEAD", "--src-prefix=a/", "--dst-prefix=b/"];
         const lastCommitDiff = assertGitSuccess(
           await runtime.runGit(args, { cwd }),
           args,
@@ -349,6 +352,7 @@ export async function runGitDiff(
       case "branch": {
         const branchDiffArgs = [
           "diff",
+          "--no-ext-diff",
           `${defaultBranch}..HEAD`,
           "--src-prefix=a/",
           "--dst-prefix=b/",

--- a/apps/review/server/index.ts
+++ b/apps/review/server/index.ts
@@ -34,11 +34,11 @@ const gitRef = args.filter((arg) => arg !== "--staged").join(" ").trim();
 // Build git diff command
 let diffCommand: string[];
 if (isStaged) {
-  diffCommand = ["git", "diff", "--staged"];
+  diffCommand = ["git", "diff", "--no-ext-diff", "--staged"];
 } else if (gitRef) {
-  diffCommand = ["git", "diff", gitRef];
+  diffCommand = ["git", "diff", "--no-ext-diff", gitRef];
 } else {
-  diffCommand = ["git", "diff"];
+  diffCommand = ["git", "diff", "--no-ext-diff"];
 }
 
 // Execute git diff

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "plannotator",
@@ -51,7 +52,7 @@
     },
     "apps/opencode-plugin": {
       "name": "@plannotator/opencode",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "dependencies": {
         "@opencode-ai/plugin": "^1.1.10",
       },
@@ -73,7 +74,7 @@
     },
     "apps/pi-extension": {
       "name": "@plannotator/pi-extension",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "peerDependencies": {
         "@mariozechner/pi-coding-agent": ">=0.53.0",
       },
@@ -153,7 +154,7 @@
     },
     "packages/server": {
       "name": "@plannotator/server",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "dependencies": {
         "@plannotator/shared": "workspace:*",
       },

--- a/packages/shared/review-core.test.ts
+++ b/packages/shared/review-core.test.ts
@@ -134,7 +134,7 @@ describe("review-core", () => {
 
     expect(result.patch).toBe("");
     expect(result.label).toBe("Error: branch");
-    expect(result.error).toContain("git diff master..HEAD");
+    expect(result.error).toContain("git diff --no-ext-diff master..HEAD");
   });
 
   test("git context lists worktrees and file content lookup returns old/new content", async () => {

--- a/packages/shared/review-core.ts
+++ b/packages/shared/review-core.ts
@@ -188,6 +188,7 @@ async function getUntrackedFileDiffs(
       const diffResult = await runtime.runGit(
         [
           "diff",
+          "--no-ext-diff",
           "--no-index",
           `--src-prefix=${srcPrefix}`,
           `--dst-prefix=${dstPrefix}`,
@@ -271,6 +272,7 @@ export async function runGitDiff(
       case "uncommitted": {
         const trackedDiffArgs = [
           "diff",
+          "--no-ext-diff",
           "HEAD",
           "--src-prefix=a/",
           "--dst-prefix=b/",
@@ -298,6 +300,7 @@ export async function runGitDiff(
       case "staged": {
         const stagedDiffArgs = [
           "diff",
+          "--no-ext-diff",
           "--staged",
           "--src-prefix=a/",
           "--dst-prefix=b/",
@@ -312,7 +315,7 @@ export async function runGitDiff(
       }
 
       case "unstaged": {
-        const trackedDiffArgs = ["diff", "--src-prefix=a/", "--dst-prefix=b/"];
+        const trackedDiffArgs = ["diff", "--no-ext-diff", "--src-prefix=a/", "--dst-prefix=b/"];
         const trackedDiff = assertGitSuccess(
           await runtime.runGit(trackedDiffArgs, { cwd }),
           trackedDiffArgs,
@@ -335,8 +338,8 @@ export async function runGitDiff(
         );
         const args =
           hasParent.exitCode === 0
-            ? ["diff", "HEAD~1..HEAD", "--src-prefix=a/", "--dst-prefix=b/"]
-            : ["diff", "--root", "HEAD", "--src-prefix=a/", "--dst-prefix=b/"];
+            ? ["diff", "--no-ext-diff", "HEAD~1..HEAD", "--src-prefix=a/", "--dst-prefix=b/"]
+            : ["diff", "--no-ext-diff", "--root", "HEAD", "--src-prefix=a/", "--dst-prefix=b/"];
         const lastCommitDiff = assertGitSuccess(
           await runtime.runGit(args, { cwd }),
           args,
@@ -349,6 +352,7 @@ export async function runGitDiff(
       case "branch": {
         const branchDiffArgs = [
           "diff",
+          "--no-ext-diff",
           `${defaultBranch}..HEAD`,
           "--src-prefix=a/",
           "--dst-prefix=b/",


### PR DESCRIPTION
 ## Summary
   - Standardize review-related `git diff` calls to include `--no-ext-diff` so external diff tools don't affect output
   - Update review-core test expectations accordingly

   ## Changes
   - apps/pi-extension/review-core.ts
   - packages/shared/review-core.ts
   - apps/review/server/index.ts
   - packages/shared/review-core.test.ts
   - bun.lock
