### PR TITLE
fix: opencode review cwd context flow

### DIFF
--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -31,7 +31,7 @@ import {
   startAnnotateServer,
   handleAnnotateServerReady,
 } from "@plannotator/server/annotate";
-import { getGitContext, runGitDiff } from "@plannotator/server/git";
+import { getGitContext, runGitDiffWithContext } from "@plannotator/server/git";
 import { writeRemoteShareLink } from "@plannotator/server/share-url";
 import { resolveMarkdownFile } from "@plannotator/server/resolve-file";
 import { planDenyFeedback } from "@plannotator/shared/feedback-templates";
@@ -279,10 +279,11 @@ Do NOT proceed with implementation until your plan is approved.
           message: "Opening code review UI...",
         });
 
-        const gitContext = await getGitContext();
-        const { patch: rawPatch, label: gitRef, error: diffError } = await runGitDiff(
+        const cwd = ctx.directory;
+        const gitContext = await getGitContext(cwd);
+        const { patch: rawPatch, label: gitRef, error: diffError } = await runGitDiffWithContext(
           "uncommitted",
-          gitContext.defaultBranch
+          gitContext
         );
 
         const server = await startReviewServer({

--- a/apps/pi-extension/review-core.ts
+++ b/apps/pi-extension/review-core.ts
@@ -31,6 +31,7 @@ export interface GitContext {
   defaultBranch: string;
   diffOptions: DiffOption[];
   worktrees: WorktreeInfo[];
+  cwd?: string;
 }
 
 export interface DiffResult {
@@ -88,8 +89,9 @@ export async function getDefaultBranch(
 
 export async function getWorktrees(
   runtime: ReviewGitRuntime,
+  cwd?: string,
 ): Promise<WorktreeInfo[]> {
-  const result = await runtime.runGit(["worktree", "list", "--porcelain"]);
+  const result = await runtime.runGit(["worktree", "list", "--porcelain"], { cwd });
   if (result.exitCode !== 0) return [];
 
   const entries: WorktreeInfo[] = [];
@@ -129,10 +131,11 @@ export async function getWorktrees(
 
 export async function getGitContext(
   runtime: ReviewGitRuntime,
+  cwd?: string,
 ): Promise<GitContext> {
   const [currentBranch, defaultBranch] = await Promise.all([
-    getCurrentBranch(runtime),
-    getDefaultBranch(runtime),
+    getCurrentBranch(runtime, cwd),
+    getDefaultBranch(runtime, cwd),
   ]);
 
   const diffOptions: DiffOption[] = [
@@ -147,8 +150,8 @@ export async function getGitContext(
   }
 
   const [worktrees, currentTreePathResult] = await Promise.all([
-    getWorktrees(runtime),
-    runtime.runGit(["rev-parse", "--show-toplevel"]),
+    getWorktrees(runtime, cwd),
+    runtime.runGit(["rev-parse", "--show-toplevel"], { cwd }),
   ]);
 
   const currentTreePath =
@@ -161,6 +164,7 @@ export async function getGitContext(
     defaultBranch,
     diffOptions,
     worktrees: worktrees.filter((wt) => wt.path !== currentTreePath),
+    cwd,
   };
 }
 
@@ -248,10 +252,11 @@ export async function runGitDiff(
   runtime: ReviewGitRuntime,
   diffType: DiffType,
   defaultBranch: string = "main",
+  externalCwd?: string,
 ): Promise<DiffResult> {
   let patch = "";
   let label = "";
-  let cwd: string | undefined;
+  let cwd: string | undefined = externalCwd;
   let effectiveDiffType = diffType as string;
 
   if (diffType.startsWith("worktree:")) {
@@ -391,6 +396,14 @@ export async function runGitDiff(
   }
 
   return { patch, label };
+}
+
+export async function runGitDiffWithContext(
+  runtime: ReviewGitRuntime,
+  diffType: DiffType,
+  gitContext: GitContext,
+): Promise<DiffResult> {
+  return runGitDiff(runtime, diffType, gitContext.defaultBranch, gitContext.cwd);
 }
 
 export async function getFileContentsForDiff(

--- a/packages/server/git.ts
+++ b/packages/server/git.ts
@@ -22,6 +22,7 @@ import {
   gitResetFile as gitResetFileCore,
   parseWorktreeDiffType,
   runGitDiff as runGitDiffCore,
+  runGitDiffWithContext as runGitDiffWithContextCore,
   validateFilePath,
 } from "@plannotator/shared/review-core";
 
@@ -75,15 +76,23 @@ export function getWorktrees(): Promise<WorktreeInfo[]> {
   return getWorktreesCore(runtime);
 }
 
-export function getGitContext(): Promise<GitContext> {
-  return getGitContextCore(runtime);
+export function getGitContext(cwd?: string): Promise<GitContext> {
+  return getGitContextCore(runtime, cwd);
 }
 
 export function runGitDiff(
   diffType: DiffType,
   defaultBranch: string = "main",
+  cwd?: string,
 ): Promise<DiffResult> {
-  return runGitDiffCore(runtime, diffType, defaultBranch);
+  return runGitDiffCore(runtime, diffType, defaultBranch, cwd);
+}
+
+export function runGitDiffWithContext(
+  diffType: DiffType,
+  gitContext: GitContext,
+): Promise<DiffResult> {
+  return runGitDiffWithContextCore(runtime, diffType, gitContext);
 }
 
 export function getFileContentsForDiff(

--- a/packages/server/review.ts
+++ b/packages/server/review.ts
@@ -156,9 +156,10 @@ export async function startReviewServer(
               }
 
               const defaultBranch = gitContext?.defaultBranch || "main";
+              const defaultCwd = gitContext?.cwd;
 
               // Run the new diff
-              const result = await runGitDiff(newDiffType, defaultBranch);
+              const result = await runGitDiff(newDiffType, defaultBranch, defaultCwd);
 
               // Update state
               currentPatch = result.patch;
@@ -195,11 +196,13 @@ export async function startReviewServer(
               }
             }
             const defaultBranch = gitContext?.defaultBranch || "main";
+            const defaultCwd = gitContext?.cwd;
             const result = await getFileContentsForDiff(
               currentDiffType,
               defaultBranch,
               filePath,
               oldPath,
+              defaultCwd,
             );
             return Response.json(result);
           }
@@ -217,6 +220,9 @@ export async function startReviewServer(
               if (currentDiffType.startsWith("worktree:")) {
                 const parsed = parseWorktreeDiffType(currentDiffType);
                 if (parsed) cwd = parsed.path;
+              }
+              if (!cwd) {
+                cwd = gitContext?.cwd;
               }
 
               if (body.undo) {

--- a/packages/shared/review-core.ts
+++ b/packages/shared/review-core.ts
@@ -31,6 +31,7 @@ export interface GitContext {
   defaultBranch: string;
   diffOptions: DiffOption[];
   worktrees: WorktreeInfo[];
+  cwd?: string;
 }
 
 export interface DiffResult {
@@ -88,8 +89,9 @@ export async function getDefaultBranch(
 
 export async function getWorktrees(
   runtime: ReviewGitRuntime,
+  cwd?: string,
 ): Promise<WorktreeInfo[]> {
-  const result = await runtime.runGit(["worktree", "list", "--porcelain"]);
+  const result = await runtime.runGit(["worktree", "list", "--porcelain"], { cwd });
   if (result.exitCode !== 0) return [];
 
   const entries: WorktreeInfo[] = [];
@@ -129,10 +131,11 @@ export async function getWorktrees(
 
 export async function getGitContext(
   runtime: ReviewGitRuntime,
+  cwd?: string,
 ): Promise<GitContext> {
   const [currentBranch, defaultBranch] = await Promise.all([
-    getCurrentBranch(runtime),
-    getDefaultBranch(runtime),
+    getCurrentBranch(runtime, cwd),
+    getDefaultBranch(runtime, cwd),
   ]);
 
   const diffOptions: DiffOption[] = [
@@ -147,8 +150,8 @@ export async function getGitContext(
   }
 
   const [worktrees, currentTreePathResult] = await Promise.all([
-    getWorktrees(runtime),
-    runtime.runGit(["rev-parse", "--show-toplevel"]),
+    getWorktrees(runtime, cwd),
+    runtime.runGit(["rev-parse", "--show-toplevel"], { cwd }),
   ]);
 
   const currentTreePath =
@@ -161,6 +164,7 @@ export async function getGitContext(
     defaultBranch,
     diffOptions,
     worktrees: worktrees.filter((wt) => wt.path !== currentTreePath),
+    cwd,
   };
 }
 
@@ -248,10 +252,11 @@ export async function runGitDiff(
   runtime: ReviewGitRuntime,
   diffType: DiffType,
   defaultBranch: string = "main",
+  externalCwd?: string,
 ): Promise<DiffResult> {
   let patch = "";
   let label = "";
-  let cwd: string | undefined;
+  let cwd: string | undefined = externalCwd;
   let effectiveDiffType = diffType as string;
 
   if (diffType.startsWith("worktree:")) {
@@ -391,6 +396,14 @@ export async function runGitDiff(
   }
 
   return { patch, label };
+}
+
+export async function runGitDiffWithContext(
+  runtime: ReviewGitRuntime,
+  diffType: DiffType,
+  gitContext: GitContext,
+): Promise<DiffResult> {
+  return runGitDiff(runtime, diffType, gitContext.defaultBranch, gitContext.cwd);
 }
 
 export async function getFileContentsForDiff(


### PR DESCRIPTION
## What
- Fix OpenCode review to use the project directory from command context (`ctx.directory`) instead of relying on implicit process cwd.
- Add `cwd` to `GitContext` and add `runGitDiffWithContext()` so review calls use one consistent context object.
- Update follow-up review endpoints (`/api/diff/switch`, `/api/file-content`, `/api/git-add`) to reuse `gitContext.cwd`.
- Keep worktree behavior unchanged: explicit worktree paths still override default cwd.
## Why
- In some setups (tmux/server/attach flows), process cwd can differ from the repository being reviewed.
- That could produce empty or incorrect diffs after the initial review open.
- This change makes review behavior deterministic by carrying cwd as explicit session context.
## Validation
```bash
bun test packages/shared/review-core.test.ts
bun run build:review && bun run build:hook && bun run build:opencode
Passed locally.
```
## Notes
- Scope is review flow only.
- Annotate flow still uses process.cwd() and is intentionally unchanged in this PR.