### PR TITLE
fix: preserve slashes in Bear nested tags

### DIFF
--- a/packages/server/integrations.test.ts
+++ b/packages/server/integrations.test.ts
@@ -83,6 +83,14 @@ describe("buildHashtags", () => {
   test("handles whitespace-only custom tags as empty", () => {
     expect(buildHashtags("   ", ["auto"])).toBe("#auto");
   });
+
+  test("preserves slashes in nested Bear tags", () => {
+    expect(buildHashtags("plannotator/plans, work/code", [])).toBe("#plannotator/plans #work/code");
+  });
+
+  test("preserves slashes in auto tags with nested paths", () => {
+    expect(buildHashtags(undefined, ["plannotator/plans", "work"])).toBe("#plannotator/plans #work");
+  });
 });
 
 describe("buildBearContent", () => {

--- a/packages/ui/utils/bear.test.ts
+++ b/packages/ui/utils/bear.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeTags } from "./bear";
+
+describe("normalizeTags", () => {
+  test("basic comma-separated tags", () => {
+    expect(normalizeTags("plan, work")).toBe("plan, work");
+  });
+
+  test("strips # prefix", () => {
+    expect(normalizeTags("#plan, ##work")).toBe("plan, work");
+  });
+
+  test("lowercases", () => {
+    expect(normalizeTags("Plan, WORK")).toBe("plan, work");
+  });
+
+  test("replaces spaces with hyphens", () => {
+    expect(normalizeTags("my plan, some work")).toBe("my-plan, some-work");
+  });
+
+  test("preserves slashes for Bear nested tags", () => {
+    expect(normalizeTags("plannotator/plans")).toBe("plannotator/plans");
+  });
+
+  test("preserves deep nested tags", () => {
+    expect(normalizeTags("work/projects/frontend")).toBe("work/projects/frontend");
+  });
+
+  test("mixed nested and flat tags", () => {
+    expect(normalizeTags("plannotator/plans, work, code/review")).toBe("plannotator/plans, work, code/review");
+  });
+
+  test("collapses consecutive slashes", () => {
+    expect(normalizeTags("work//plans")).toBe("work/plans");
+  });
+
+  test("strips leading/trailing slashes", () => {
+    expect(normalizeTags("/work/plans/")).toBe("work/plans");
+  });
+
+  test("filters empty segments", () => {
+    expect(normalizeTags(",, plan")).toBe("plan");
+  });
+});

--- a/packages/ui/utils/bear.ts
+++ b/packages/ui/utils/bear.ts
@@ -53,7 +53,7 @@ export function saveBearSettings(settings: BearSettings): void {
 export function normalizeTags(raw: string): string {
   return raw
     .split(',')
-    .map(t => t.trim().replace(/^#+/, '').toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, ''))
+    .map(t => t.trim().replace(/^#+/, '').toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9\-\/]/g, '').replace(/\/+/g, '/').replace(/^\/|\/$/g, ''))
     .filter(Boolean)
     .join(', ');
 }


### PR DESCRIPTION
## Summary
- `normalizeTags()` in `packages/ui/utils/bear.ts` stripped `/` from custom tags, breaking Bear's nested tag feature (e.g. `plannotator/plans` → `plannotatorplans`)
- Allow `/` in the character class, collapse consecutive slashes, strip leading/trailing slashes

## Test plan
- [x] New `bear.test.ts` with regression tests for nested tags
- [x] Added slash-tag tests to `integrations.test.ts` for `buildHashtags`
- [x] All 39 tests pass