### PR TITLE
fix: annotate-last fails on Windows with non-ASCII paths

### DIFF
--- a/apps/hook/server/session-log.test.ts
+++ b/apps/hook/server/session-log.test.ts
@@ -160,7 +160,7 @@ function buildLog(...lines: string[]): string {
 // --- Tests ---
 
 describe("projectSlugFromCwd", () => {
-  test("converts absolute path to slug", () => {
+  test("converts Unix absolute path to slug", () => {
     expect(projectSlugFromCwd("/Users/ramos/cupcake/cupcake-rego/feat-annotate-last")).toBe(
       "-Users-ramos-cupcake-cupcake-rego-feat-annotate-last"
     );
@@ -168,6 +168,36 @@ describe("projectSlugFromCwd", () => {
 
   test("handles root path", () => {
     expect(projectSlugFromCwd("/")).toBe("-");
+  });
+
+  test("converts Windows backslashes to dashes", () => {
+    expect(projectSlugFromCwd("C:\\Users\\alexey\\Documents\\project")).toBe(
+      "C--Users-alexey-Documents-project"
+    );
+  });
+
+  test("converts non-ASCII characters (Cyrillic) to dashes", () => {
+    expect(projectSlugFromCwd("C:\\Users\\alexey\\Documents\\1С_конфигурации\\ERP_Medicine")).toBe(
+      "C--Users-alexey-Documents-1---------------ERP-Medicine"
+    );
+  });
+
+  test("converts underscores to dashes", () => {
+    expect(projectSlugFromCwd("/home/user/my_project")).toBe(
+      "-home-user-my-project"
+    );
+  });
+
+  test("preserves hyphens and alphanumeric characters", () => {
+    expect(projectSlugFromCwd("/home/user/my-project-123")).toBe(
+      "-home-user-my-project-123"
+    );
+  });
+
+  test("converts spaces and special characters to dashes", () => {
+    expect(projectSlugFromCwd("/home/user/my project (v2)")).toBe(
+      "-home-user-my-project--v2-"
+    );
   });
 });
 

--- a/apps/hook/server/session-log.ts
+++ b/apps/hook/server/session-log.ts
@@ -49,10 +49,11 @@ export interface RenderedMessage {
 
 /**
  * Derive the project slug from a working directory path.
- * Claude Code uses the absolute path with `/` replaced by `-` (leading `-` kept).
+ * Claude Code replaces every character outside [a-zA-Z0-9-] with `-`.
+ * On Windows it also lowercases drive letters (C: → c-).
  */
 export function projectSlugFromCwd(cwd: string): string {
-  return cwd.replace(/\//g, "-");
+  return cwd.replace(/[^a-zA-Z0-9-]/g, "-");
 }
 
 /**
@@ -88,11 +89,36 @@ export function findSessionLogs(projectDir: string): string[] {
 /**
  * Find session log candidates for a given working directory.
  * Returns all .jsonl paths sorted by mtime (most recent first).
+ *
+ * Tries the exact slug first, then a case-insensitive match. On Windows,
+ * Claude Code lowercases the entire slug (e.g. `C-Users-...` → `c-users-...`)
+ * while our cwd may have mixed case. The fallback scans the projects directory
+ * for a case-insensitive match.
  */
 export function findSessionLogsForCwd(cwd: string): string[] {
   const slug = projectSlugFromCwd(cwd);
-  const projectDir = join(homedir(), ".claude", "projects", slug);
-  return findSessionLogs(projectDir);
+  const projectsDir = join(homedir(), ".claude", "projects");
+  const projectDir = join(projectsDir, slug);
+
+  // Try exact match first
+  const logs = findSessionLogs(projectDir);
+  if (logs.length > 0) return logs;
+
+  // Fallback: case-insensitive directory scan (handles Windows drive letter casing)
+  const slugLower = slug.toLowerCase();
+  try {
+    const dirs = readdirSync(projectsDir);
+    for (const dir of dirs) {
+      if (dir.toLowerCase() === slugLower) {
+        const fallbackLogs = findSessionLogs(join(projectsDir, dir));
+        if (fallbackLogs.length > 0) return fallbackLogs;
+      }
+    }
+  } catch {
+    // projectsDir doesn't exist
+  }
+
+  return [];
 }
 
 // --- Log Parsing ---


### PR DESCRIPTION
## Summary
- Aligns `projectSlugFromCwd` regex with Claude Code's actual normalization: `[^a-zA-Z0-9-]` → `-` (was only replacing `/`)
- Adds case-insensitive fallback for directory lookup to handle Windows drive letter casing (`C:` vs `c:`)
- Adds tests for Windows backslashes, Cyrillic characters, underscores, spaces

Closes #339

## Test plan
- [ ] Pull on Windows machine with non-ASCII project path (e.g. Cyrillic) and run `/plannotator-last`
- [ ] Verify session logs are found and last message renders in annotation UI
- [ ] Test with underscore-containing paths
- [ ] `bun test apps/hook/server/session-log.test.ts` passes (32/32)