### PR TITLE
fix: replace plan mode prompt instead of stripping it

### DIFF
--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -193,15 +193,34 @@ export const PlannotatorPlugin: Plugin = async (ctx) => {
       };
     },
 
-    // Strip OpenCode's "STRICTLY FORBIDDEN" plan mode prompt from synthetic
-    // user messages. OpenCode injects these to prevent file edits in plan mode,
-    // but we need the agent to be able to write plan files.
+    // Replace OpenCode's "STRICTLY FORBIDDEN" plan mode prompt with a version
+    // that allows markdown file writing. OpenCode's original blocks ALL file edits,
+    // but we need the agent to write plans, specs, docs, etc.
     "experimental.chat.messages.transform": async (input, output) => {
       for (const message of output.messages) {
         if (message.info.role !== "user") continue;
-        message.parts = message.parts.filter(
-          (part: any) => !(part.type === "text" && part.text?.includes("STRICTLY FORBIDDEN"))
-        );
+        for (const part of message.parts as any[]) {
+          if (part.type !== "text" || !part.text?.includes("STRICTLY FORBIDDEN")) continue;
+          part.text = `<system-reminder>
+# Plan Mode - System Reminder
+
+CRITICAL: Plan mode ACTIVE. You are in a PLANNING phase. The ONLY file modifications
+allowed are writing or editing markdown files (.md) — plans, specs, documentation, etc.
+All other file edits, code modifications, and system changes are STRICTLY FORBIDDEN.
+Do NOT use bash commands to manipulate non-markdown files. Commands may ONLY read/inspect.
+
+## Responsibility
+
+Your responsibility is to think, read, search, and delegate explore agents to construct
+a well-formed plan. Ask the user clarifying questions and surface tradeoffs rather than
+making assumptions about intent. Use submit_plan to submit your plan for user review.
+
+## Important
+
+The user wants a plan, not execution. You MUST NOT edit source code, run non-readonly
+tools (except writing markdown files), or otherwise make changes to the system.
+</system-reminder>`;
+        }
       }
     },
 


### PR DESCRIPTION
## Summary

- **Before**: `messages.transform` hook nuked OpenCode's entire plan mode `STRICTLY FORBIDDEN` message, leaving the model with no prompt-level guardrails. Models went rogue — writing Python scripts via Bash to edit code (reported by @ilmpc in #328).
- **After**: Replaces the message with a tailored version that keeps the read-only constraint but allows markdown file writing (.md) for plans, specs, docs, etc.

The replacement message:
- Retains `STRICTLY FORBIDDEN` language for non-markdown edits and destructive bash commands
- Allows `.md` file writing explicitly
- Keeps the Responsibility section (explore, ask questions, surface tradeoffs)
- Keeps the Important section (no execution, no source code edits)

## Test plan

- [ ] OpenCode plan mode: agent should use `submit_plan` and write plan .md files without going rogue
- [ ] Agent should NOT attempt to edit source code, run destructive bash, or write Python workarounds
- [ ] Non-plan primary agents (Build) should still see `submit_plan` and work normally
- [ ] Weaker models (GPT-5-mini) should respect the STRICTLY FORBIDDEN constraint

Fixes #328