### PR TITLE
fix: handle string-form permission.edit in opencode config hook 

### DIFF
--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -41,6 +41,7 @@ import {
 } from "./commands";
 import { planDenyFeedback } from "@plannotator/shared/feedback-templates";
 import {
+  normalizeEditPermission,
   stripConflictingPlanModeRules,
 } from "./plan-mode";
 
@@ -188,7 +189,7 @@ export const PlannotatorPlugin: Plugin = async (ctx) => {
       opencodeConfig.agent.plan ??= {};
       opencodeConfig.agent.plan.permission ??= {};
       opencodeConfig.agent.plan.permission.edit = {
-        ...opencodeConfig.agent.plan.permission.edit,
+        ...normalizeEditPermission(opencodeConfig.agent.plan.permission.edit),
         "*.md": "allow",
       };
     },

--- a/apps/opencode-plugin/plan-mode.test.ts
+++ b/apps/opencode-plugin/plan-mode.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "os";
 import path from "path";
 import {
   getPlanDirectory,
+  normalizeEditPermission,
   validatePlanPath,
   stripConflictingPlanModeRules,
 } from "./plan-mode";
@@ -141,6 +142,41 @@ describe("validatePlanPath", () => {
     const result2 = validatePlanPath(planPath, planDir);
     expect(result2.ok).toBe(true);
     if (result2.ok) expect(result2.content).toBe("# Plan v2 — addressed feedback");
+  });
+});
+
+describe("normalizeEditPermission", () => {
+  test("returns empty object for undefined", () => {
+    expect(normalizeEditPermission(undefined)).toEqual({});
+  });
+
+  test("converts 'deny' string to wildcard object", () => {
+    // Triggered by `tools: { edit: false }` or `permission: { edit: "deny" }`
+    expect(normalizeEditPermission("deny")).toEqual({ "*": "deny" });
+  });
+
+  test("converts 'allow' string to wildcard object", () => {
+    expect(normalizeEditPermission("allow")).toEqual({ "*": "allow" });
+  });
+
+  test("converts 'ask' string to wildcard object", () => {
+    expect(normalizeEditPermission("ask")).toEqual({ "*": "ask" });
+  });
+
+  test("passes through an existing object unchanged", () => {
+    const obj = { "*.ts": "deny", "src/**": "allow" };
+    expect(normalizeEditPermission(obj)).toEqual(obj);
+  });
+
+  test("merging with '*.md': 'allow' preserves deny-all + md-allow", () => {
+    // This is the main scenario fixed by this function:
+    // user has tools: { edit: false } which produces permission.edit = "deny",
+    // and we need to merge in "*.md": "allow" without string-spreading.
+    const base = normalizeEditPermission("deny");
+    const merged = { ...base, "*.md": "allow" };
+    expect(merged).toEqual({ "*": "deny", "*.md": "allow" });
+    // Crucially, no char-index keys like "0", "1", "2", "3"
+    expect(Object.keys(merged)).not.toContain("0");
   });
 });
 

--- a/apps/opencode-plugin/plan-mode.ts
+++ b/apps/opencode-plugin/plan-mode.ts
@@ -84,6 +84,29 @@ export function validatePlanPath(
   return { ok: true, content };
 }
 
+// ── Permission helpers ────────────────────────────────────────────────────
+
+/**
+ * Normalize an `edit` permission value before merging additional rules.
+ *
+ * OpenCode's zod transform converts legacy `tools: { edit: false }` to
+ * `permission.edit = "deny"` (a plain string) before any plugin sees the
+ * config.  Spreading a string in JS produces char-index keys:
+ *   `{ ..."deny" }` → `{ "0": "d", "1": "e", "2": "n", "3": "y" }`
+ * which corrupt the permission ruleset and cause zod validation failures.
+ *
+ * This function converts a string action to `{ "*": action }` (equivalent
+ * wildcard object) so the caller can safely spread it and add overrides.
+ */
+export function normalizeEditPermission(
+  edit: string | Record<string, string> | undefined,
+): Record<string, string> {
+  if (typeof edit === "string") {
+    return { "*": edit };
+  }
+  return edit ?? {};
+}
+
 // ── Prompt stripping ──────────────────────────────────────────────────────
 
 function shouldStripPlanModeLine(line: string): boolean {


### PR DESCRIPTION
When users configure the deprecated `tools` field on the plan agent (e.g.`"tools": { "write": false, "edit": false }`), OpenCode's config resolver converts it to `permission.edit = "deny"` before any plugin sees the config.

Plannotator's config hook then spread that string value:

```
    opencodeConfig.agent.plan.permission.edit = {
      ...opencodeConfig.agent.plan.permission.edit, // spread "deny"
      "*.md": "allow",
    };
```

`{ ..."deny" }` in JavaScript produces `{ "0": "d", "1": "e", "2": "n", "3": "y" }`, which corrupts the permission ruleset and triggers 4 zod validation errors at startup (`Invalid option: expected one of "allow"|"deny"|"ask"`).

The same bug also triggers when the user writes `permission: { edit: "deny" }` directly, since the Permissions docs confirm both string and object forms are valid.

## Changes

- Extract `normalizeEditPermission()` into `plan-mode.ts` — converts a string action to `{ "*": action }` (preserving user intent as a wildcard rule) and passes objects through unchanged.
- Use `normalizeEditPermission` in the config hook instead of the bare spread.
- Add 6 test cases covering `undefined`, each string action, existing object
  input, and the merged result asserting no char-index keys are produced.

Fixes #338