### PR TITLE
feat: show repo identifier in tab title (#342)

### DIFF
--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -95,6 +95,13 @@ const App: React.FC = () => {
   const [shareBaseUrl, setShareBaseUrl] = useState<string | undefined>(undefined);
   const [pasteApiUrl, setPasteApiUrl] = useState<string | undefined>(undefined);
   const [repoInfo, setRepoInfo] = useState<{ display: string; branch?: string } | null>(null);
+
+  useEffect(() => {
+    if (repoInfo) {
+      document.title = `${repoInfo.display} · Plannotator`;
+    }
+  }, [repoInfo]);
+
   const [showExportDropdown, setShowExportDropdown] = useState(false);
   const [initialExportTab, setInitialExportTab] = useState<'share' | 'annotations' | 'notes'>();
   const [noteSaveToast, setNoteSaveToast] = useState<{ type: 'success' | 'error'; message: string } | null>(null);

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -97,9 +97,7 @@ const App: React.FC = () => {
   const [repoInfo, setRepoInfo] = useState<{ display: string; branch?: string } | null>(null);
 
   useEffect(() => {
-    if (repoInfo) {
-      document.title = `${repoInfo.display} · Plannotator`;
-    }
+    document.title = repoInfo ? `${repoInfo.display} · Plannotator` : "Plannotator";
   }, [repoInfo]);
 
   const [showExportDropdown, setShowExportDropdown] = useState(false);

--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -112,9 +112,7 @@ const ReviewApp: React.FC = () => {
   const [repoInfo, setRepoInfo] = useState<{ display: string; branch?: string } | null>(null);
 
   useEffect(() => {
-    if (repoInfo) {
-      document.title = `${repoInfo.display} · Code Review`;
-    }
+    document.title = repoInfo ? `${repoInfo.display} · Code Review` : "Code Review";
   }, [repoInfo]);
 
   const [prMetadata, setPrMetadata] = useState<PRMetadata | null>(null);

--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -110,6 +110,13 @@ const ReviewApp: React.FC = () => {
   const [showApproveWarning, setShowApproveWarning] = useState(false);
   const [sharingEnabled, setSharingEnabled] = useState(true);
   const [repoInfo, setRepoInfo] = useState<{ display: string; branch?: string } | null>(null);
+
+  useEffect(() => {
+    if (repoInfo) {
+      document.title = `${repoInfo.display} · Code Review`;
+    }
+  }, [repoInfo]);
+
   const [prMetadata, setPrMetadata] = useState<PRMetadata | null>(null);
 
   const identity = useMemo(() => getIdentity(), []);


### PR DESCRIPTION
## Summary
- Adds dynamic page title with repo/directory name for both plan review and code review tabs
- Format: `{repoName} · Plannotator` or `{repoName} · Code Review`
- Makes it easy to distinguish multiple Plannotator tabs from different repos

Closes #342