### PR TITLE
fix(pi-extension): wire PLANNOTATOR_PASTE_URL through all servers

### DIFF
--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -291,6 +291,7 @@ export default function plannotator(pi: ExtensionAPI): void {
           htmlContent: reviewHtmlContent,
           sharingEnabled: process.env.PLANNOTATOR_SHARE !== "disabled",
           shareBaseUrl: process.env.PLANNOTATOR_SHARE_URL || undefined,
+          pasteApiUrl: process.env.PLANNOTATOR_PASTE_URL || undefined,
         });
       } catch (err) {
         ctx.ui.notify(`Failed to start code review UI: ${getStartupErrorMessage(err)}`, "error");
@@ -340,6 +341,9 @@ export default function plannotator(pi: ExtensionAPI): void {
           filePath: absolutePath,
           origin: "pi",
           htmlContent: planHtmlContent,
+          sharingEnabled: process.env.PLANNOTATOR_SHARE !== "disabled",
+          shareBaseUrl: process.env.PLANNOTATOR_SHARE_URL || undefined,
+          pasteApiUrl: process.env.PLANNOTATOR_PASTE_URL || undefined,
         });
       } catch (err) {
         ctx.ui.notify(`Failed to start annotation UI: ${getStartupErrorMessage(err)}`, "error");
@@ -394,6 +398,9 @@ export default function plannotator(pi: ExtensionAPI): void {
           origin: "pi",
           mode: "annotate-last",
           htmlContent: planHtmlContent,
+          sharingEnabled: process.env.PLANNOTATOR_SHARE !== "disabled",
+          shareBaseUrl: process.env.PLANNOTATOR_SHARE_URL || undefined,
+          pasteApiUrl: process.env.PLANNOTATOR_PASTE_URL || undefined,
         });
       } catch (err) {
         ctx.ui.notify(`Failed to start annotation UI: ${getStartupErrorMessage(err)}`, "error");
@@ -497,6 +504,9 @@ export default function plannotator(pi: ExtensionAPI): void {
           plan: planContent,
           htmlContent: planHtmlContent,
           origin: "pi",
+          sharingEnabled: process.env.PLANNOTATOR_SHARE !== "disabled",
+          shareBaseUrl: process.env.PLANNOTATOR_SHARE_URL || undefined,
+          pasteApiUrl: process.env.PLANNOTATOR_PASTE_URL || undefined,
         });
       } catch (err) {
         const message = `Failed to start plan review UI: ${getStartupErrorMessage(err)}`;

--- a/apps/pi-extension/server.ts
+++ b/apps/pi-extension/server.ts
@@ -614,7 +614,17 @@ export async function startPlanReviewServer(options: {
   plan: string;
   htmlContent: string;
   origin?: string;
+  sharingEnabled?: boolean;
+  shareBaseUrl?: string;
+  pasteApiUrl?: string;
 }): Promise<PlanServerResult> {
+  const sharingEnabled =
+    options.sharingEnabled ?? process.env.PLANNOTATOR_SHARE !== "disabled";
+  const shareBaseUrl =
+    (options.shareBaseUrl ?? process.env.PLANNOTATOR_SHARE_URL) || undefined;
+  const pasteApiUrl =
+    (options.pasteApiUrl ?? process.env.PLANNOTATOR_PASTE_URL) || undefined;
+
   // Version history
   const slug = generateSlug(options.plan);
   const project = detectProjectName();
@@ -659,7 +669,7 @@ export async function startPlanReviewServer(options: {
     } else if (url.pathname === "/api/plan/history") {
       json(res, { project, plans: listProjectPlans(project) });
     } else if (url.pathname === "/api/plan") {
-      json(res, { plan: options.plan, origin: options.origin ?? "pi", previousPlan, versionInfo });
+      json(res, { plan: options.plan, origin: options.origin ?? "pi", previousPlan, versionInfo, sharingEnabled, shareBaseUrl, pasteApiUrl });
     } else if (url.pathname === "/api/approve" && req.method === "POST") {
       const body = await parseBody(req);
       resolveDecision({ approved: true, feedback: body.feedback as string | undefined });
@@ -751,6 +761,7 @@ export async function startReviewServer(options: {
   error?: string;
   sharingEnabled?: boolean;
   shareBaseUrl?: string;
+  pasteApiUrl?: string;
 }): Promise<ReviewServerResult> {
   const draftKey = contentHash(options.rawPatch);
   const repoInfo = getRepoInfo();
@@ -763,6 +774,8 @@ export async function startReviewServer(options: {
     options.sharingEnabled ?? process.env.PLANNOTATOR_SHARE !== "disabled";
   const shareBaseUrl =
     (options.shareBaseUrl ?? process.env.PLANNOTATOR_SHARE_URL) || undefined;
+  const pasteApiUrl =
+    (options.pasteApiUrl ?? process.env.PLANNOTATOR_PASTE_URL) || undefined;
 
   let resolveDecision!: (result: {
     approved: boolean;
@@ -791,6 +804,7 @@ export async function startReviewServer(options: {
         gitContext: options.gitContext,
         sharingEnabled,
         shareBaseUrl,
+        pasteApiUrl,
         repoInfo,
         ...(currentError ? { error: currentError } : {}),
       });
@@ -991,7 +1005,18 @@ export async function startAnnotateServer(options: {
   filePath: string;
   htmlContent: string;
   origin?: string;
+  mode?: string;
+  sharingEnabled?: boolean;
+  shareBaseUrl?: string;
+  pasteApiUrl?: string;
 }): Promise<AnnotateServerResult> {
+  const sharingEnabled =
+    options.sharingEnabled ?? process.env.PLANNOTATOR_SHARE !== "disabled";
+  const shareBaseUrl =
+    (options.shareBaseUrl ?? process.env.PLANNOTATOR_SHARE_URL) || undefined;
+  const pasteApiUrl =
+    (options.pasteApiUrl ?? process.env.PLANNOTATOR_PASTE_URL) || undefined;
+
   let resolveDecision!: (result: { feedback: string }) => void;
   const decisionPromise = new Promise<{ feedback: string }>((r) => {
     resolveDecision = r;
@@ -1004,8 +1029,11 @@ export async function startAnnotateServer(options: {
       json(res, {
         plan: options.markdown,
         origin: options.origin ?? "pi",
-        mode: "annotate",
+        mode: options.mode || "annotate",
         filePath: options.filePath,
+        sharingEnabled,
+        shareBaseUrl,
+        pasteApiUrl,
       });
     } else if (url.pathname === "/api/feedback" && req.method === "POST") {
       const body = await parseBody(req);


### PR DESCRIPTION
## Problem

The pi extension reads `PLANNOTATOR_SHARE_URL` but never reads or passes `PLANNOTATOR_PASTE_URL` to the browser UI. This means self-hosted paste service configurations are ignored — the browser always falls back to the hardcoded default.

The Claude Code hook (`apps/hook/server/index.ts:87`) correctly wires this through, but the pi extension doesn't.

## Fix

Wires `PLANNOTATOR_PASTE_URL` through all three server types in the pi extension:

- **`startPlanReviewServer`** — adds `sharingEnabled`, `shareBaseUrl`, `pasteApiUrl` to options and includes them in the `/api/plan` response
- **`startReviewServer`** — adds `pasteApiUrl` to options and includes it in the `/api/diff` response  
- **`startAnnotateServer`** — adds `sharingEnabled`, `shareBaseUrl`, `pasteApiUrl` to options and includes them in the `/api/plan` response

Also passes the `mode` option through `startAnnotateServer` so `annotate-last` is correctly forwarded to the browser UI.

## Testing

Set env vars and verify the share UI uses the custom URLs:
```bash
export PLANNOTATOR_SHARE_URL=https://my-portal.example.com
export PLANNOTATOR_PASTE_URL=https://my-paste.example.com
```