### PR TITLE
Add AI provider layer with Claude Agent SDK integration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
     },
     "apps/opencode-plugin": {
       "name": "@plannotator/opencode",
-      "version": "0.14.3",
+      "version": "0.14.4",
       "dependencies": {
         "@opencode-ai/plugin": "^1.1.10",
       },
@@ -78,7 +78,7 @@
     },
     "apps/pi-extension": {
       "name": "@plannotator/pi-extension",
-      "version": "0.14.3",
+      "version": "0.14.4",
       "peerDependencies": {
         "@mariozechner/pi-coding-agent": ">=0.53.0",
       },
@@ -134,6 +134,16 @@
         "typescript": "^5.0.0",
       },
     },
+    "packages/ai": {
+      "name": "@plannotator/ai",
+      "version": "0.0.1",
+      "peerDependencies": {
+        "@anthropic-ai/claude-agent-sdk": ">=0.1.0",
+      },
+      "optionalPeers": [
+        "@anthropic-ai/claude-agent-sdk",
+      ],
+    },
     "packages/editor": {
       "name": "@plannotator/editor",
       "version": "0.0.1",
@@ -159,7 +169,7 @@
     },
     "packages/server": {
       "name": "@plannotator/server",
-      "version": "0.14.3",
+      "version": "0.14.4",
       "dependencies": {
         "@plannotator/shared": "workspace:*",
       },
@@ -584,6 +594,8 @@
     "@pierre/theme": ["@pierre/theme@0.0.22", "", {}, "sha512-ePUIdQRNGjrveELTU7fY89Xa7YGHHEy5Po5jQy/18lm32eRn96+tnYJEtFooGdffrx55KBUtOXfvVy/7LDFFhA=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@plannotator/ai": ["@plannotator/ai@workspace:packages/ai"],
 
     "@plannotator/editor": ["@plannotator/editor@workspace:packages/editor"],
 

--- a/packages/ai/ai.test.ts
+++ b/packages/ai/ai.test.ts
@@ -1,0 +1,407 @@
+import { describe, test, expect } from "bun:test";
+import { SessionManager } from "./session-manager.ts";
+import { buildSystemPrompt, buildForkPreamble } from "./context.ts";
+import {
+  registerProvider,
+  getProvider,
+  getDefaultProvider,
+  listProviders,
+  unregisterProvider,
+  disposeAll,
+  registerProviderFactory,
+  createProvider,
+} from "./provider.ts";
+import { createAIEndpoints } from "./endpoints.ts";
+import type {
+  AIProvider,
+  AISession,
+  AIMessage,
+  AIContext,
+} from "./types.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers — mock provider/session for testing
+// ---------------------------------------------------------------------------
+
+function mockSession(
+  id: string,
+  parentSessionId: string | null = null
+): AISession {
+  let active = false;
+  return {
+    get id() {
+      return id;
+    },
+    parentSessionId,
+    get isActive() {
+      return active;
+    },
+    async *query(prompt: string): AsyncIterable<AIMessage> {
+      active = true;
+      yield { type: "text_delta", delta: `Echo: ${prompt}` };
+      yield {
+        type: "result",
+        sessionId: id,
+        success: true,
+        result: `Echo: ${prompt}`,
+      };
+      active = false;
+    },
+    abort() {
+      active = false;
+    },
+  };
+}
+
+let sessionCounter = 0;
+
+function mockProvider(name = "mock"): AIProvider {
+  return {
+    name,
+    capabilities: { fork: true, resume: true, streaming: true, tools: false },
+    async createSession(opts) {
+      return mockSession(`session-${++sessionCounter}`, null);
+    },
+    async forkSession(opts) {
+      const parent = opts.context.parent;
+      return mockSession(
+        `forked-${++sessionCounter}`,
+        parent?.sessionId ?? null
+      );
+    },
+    async resumeSession(sessionId) {
+      return mockSession(sessionId, null);
+    },
+    dispose() {},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SessionManager", () => {
+  test("tracks sessions and lists them newest-first", () => {
+    const sm = new SessionManager();
+    const s1 = mockSession("s1");
+    const s2 = mockSession("s2");
+
+    const e1 = sm.track(s1, "plan-review", "First");
+    const e2 = sm.track(s2, "code-review", "Second");
+    // Force different timestamps to avoid same-ms ambiguity
+    e1.lastActiveAt = 1000;
+    e2.lastActiveAt = 2000;
+
+    expect(sm.size).toBe(2);
+    const list = sm.list();
+    expect(list[0].session.id).toBe("s2"); // newest first
+    expect(list[1].session.id).toBe("s1");
+  });
+
+  test("get returns entry by ID", () => {
+    const sm = new SessionManager();
+    sm.track(mockSession("s1"), "plan-review");
+    expect(sm.get("s1")?.session.id).toBe("s1");
+    expect(sm.get("nonexistent")).toBeUndefined();
+  });
+
+  test("touch updates lastActiveAt", async () => {
+    const sm = new SessionManager();
+    sm.track(mockSession("s1"), "plan-review");
+    const before = sm.get("s1")!.lastActiveAt;
+
+    await new Promise((r) => setTimeout(r, 10));
+    sm.touch("s1");
+
+    expect(sm.get("s1")!.lastActiveAt).toBeGreaterThan(before);
+  });
+
+  test("remove removes entry", () => {
+    const sm = new SessionManager();
+    sm.track(mockSession("s1"), "plan-review");
+    sm.remove("s1");
+    expect(sm.size).toBe(0);
+  });
+
+  test("forksOf filters by parent", () => {
+    const sm = new SessionManager();
+    sm.track(mockSession("s1"), "plan-review");
+    sm.track(mockSession("fork1", "parent-123"), "plan-review");
+    sm.track(mockSession("fork2", "parent-123"), "plan-review");
+    sm.track(mockSession("fork3", "other-parent"), "code-review");
+
+    const forks = sm.forksOf("parent-123");
+    expect(forks.length).toBe(2);
+    expect(forks.map((f) => f.session.id).sort()).toEqual(["fork1", "fork2"]);
+  });
+
+  test("evicts oldest idle session when maxSessions reached", () => {
+    const sm = new SessionManager({ maxSessions: 2 });
+    sm.track(mockSession("s1"), "plan-review");
+    sm.track(mockSession("s2"), "plan-review");
+    sm.track(mockSession("s3"), "plan-review"); // should evict s1
+
+    expect(sm.size).toBe(2);
+    expect(sm.get("s1")).toBeUndefined();
+    expect(sm.get("s2")).toBeDefined();
+    expect(sm.get("s3")).toBeDefined();
+  });
+
+  test("disposeAll aborts active sessions and clears", () => {
+    const sm = new SessionManager();
+    const s1 = mockSession("s1");
+    sm.track(s1, "plan-review");
+    sm.disposeAll();
+    expect(sm.size).toBe(0);
+  });
+});
+
+describe("Context builders", () => {
+  test("buildSystemPrompt for plan-review", () => {
+    const ctx: AIContext = {
+      mode: "plan-review",
+      plan: { plan: "# My Plan\n\nStep 1: do things" },
+    };
+    const prompt = buildSystemPrompt(ctx);
+    expect(prompt).toContain("plan review tool");
+    expect(prompt).toContain("# My Plan");
+    expect(prompt).toContain("Step 1: do things");
+  });
+
+  test("buildSystemPrompt for code-review", () => {
+    const ctx: AIContext = {
+      mode: "code-review",
+      review: { patch: "diff --git a/foo.ts b/foo.ts\n+hello" },
+    };
+    const prompt = buildSystemPrompt(ctx);
+    expect(prompt).toContain("code review tool");
+    expect(prompt).toContain("diff --git");
+  });
+
+  test("buildSystemPrompt for annotate", () => {
+    const ctx: AIContext = {
+      mode: "annotate",
+      annotate: { content: "# Doc\nSome content", filePath: "/tmp/test.md" },
+    };
+    const prompt = buildSystemPrompt(ctx);
+    expect(prompt).toContain("annotation tool");
+    expect(prompt).toContain("/tmp/test.md");
+  });
+
+  test("buildForkPreamble includes context and instructions", () => {
+    const ctx: AIContext = {
+      mode: "plan-review",
+      plan: {
+        plan: "# Plan\nDetails here",
+        annotations: "- Remove section 3",
+      },
+      parent: { sessionId: "parent-123", cwd: "/project" },
+    };
+    const preamble = buildForkPreamble(ctx);
+    expect(preamble).toContain("reviewing your work in Plannotator");
+    expect(preamble).toContain("# Plan");
+    expect(preamble).toContain("Remove section 3");
+  });
+
+  test("buildForkPreamble for code-review with selected code", () => {
+    const ctx: AIContext = {
+      mode: "code-review",
+      review: {
+        patch: "+new line",
+        filePath: "src/auth.ts",
+        selectedCode: "function verify()",
+        lineRange: { start: 10, end: 15, side: "new" },
+      },
+      parent: { sessionId: "p", cwd: "/proj" },
+    };
+    const preamble = buildForkPreamble(ctx);
+    expect(preamble).toContain("src/auth.ts");
+    expect(preamble).toContain("function verify()");
+    expect(preamble).toContain("Lines 10-15");
+  });
+
+  test("truncates very long plans", () => {
+    const longPlan = "x".repeat(100_000);
+    const ctx: AIContext = {
+      mode: "plan-review",
+      plan: { plan: longPlan },
+    };
+    const prompt = buildSystemPrompt(ctx);
+    expect(prompt).toContain("[truncated for context window]");
+    expect(prompt.length).toBeLessThan(longPlan.length);
+  });
+});
+
+describe("Provider registry", () => {
+  test("register, get, list, unregister", () => {
+    disposeAll(); // clean state
+
+    const p = mockProvider("test-provider");
+    registerProvider(p);
+
+    expect(getProvider("test-provider")).toBe(p);
+    expect(getDefaultProvider()).toBe(p);
+    expect(listProviders()).toEqual(["test-provider"]);
+
+    unregisterProvider("test-provider");
+    expect(getProvider("test-provider")).toBeUndefined();
+    expect(listProviders()).toEqual([]);
+  });
+
+  test("createProvider via factory", async () => {
+    disposeAll();
+
+    registerProviderFactory("test-type", async (config) => {
+      return mockProvider(config.type);
+    });
+
+    const provider = await createProvider({ type: "test-type" });
+    expect(provider.name).toBe("test-type");
+    expect(getProvider("test-type")).toBe(provider);
+
+    disposeAll();
+  });
+
+  test("createProvider throws for unknown type", async () => {
+    disposeAll();
+    await expect(createProvider({ type: "unknown" })).rejects.toThrow(
+      "No AI provider factory"
+    );
+  });
+});
+
+describe("AI endpoints", () => {
+  test("capabilities returns available: false when no provider", async () => {
+    disposeAll();
+    const sm = new SessionManager();
+    const endpoints = createAIEndpoints({ sessionManager: sm });
+
+    const res = await endpoints["/api/ai/capabilities"](new Request("http://localhost/api/ai/capabilities"));
+    const data = await res.json();
+    expect(data.available).toBe(false);
+    expect(data.provider).toBeNull();
+  });
+
+  test("capabilities returns provider info when registered", async () => {
+    disposeAll();
+    registerProvider(mockProvider("mock"));
+    const sm = new SessionManager();
+    const endpoints = createAIEndpoints({ sessionManager: sm });
+
+    const res = await endpoints["/api/ai/capabilities"](new Request("http://localhost/api/ai/capabilities"));
+    const data = await res.json();
+    expect(data.available).toBe(true);
+    expect(data.provider).toBe("mock");
+    expect(data.capabilities.fork).toBe(true);
+
+    disposeAll();
+  });
+
+  test("session creation and query flow", async () => {
+    disposeAll();
+    registerProvider(mockProvider("mock"));
+    const sm = new SessionManager();
+    const endpoints = createAIEndpoints({ sessionManager: sm });
+
+    // Create session
+    const createRes = await endpoints["/api/ai/session"](
+      new Request("http://localhost/api/ai/session", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          context: { mode: "plan-review", plan: { plan: "# Test" } },
+        }),
+      })
+    );
+    const createData = (await createRes.json()) as { sessionId: string };
+    expect(createData.sessionId).toBeDefined();
+    expect(sm.size).toBe(1);
+
+    // Query
+    const queryRes = await endpoints["/api/ai/query"](
+      new Request("http://localhost/api/ai/query", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sessionId: createData.sessionId,
+          prompt: "What is this plan about?",
+        }),
+      })
+    );
+    expect(queryRes.headers.get("Content-Type")).toBe("text/event-stream");
+
+    // Read SSE stream
+    const text = await queryRes.text();
+    expect(text).toContain("Echo: What is this plan about?");
+    expect(text).toContain("[DONE]");
+
+    disposeAll();
+  });
+
+  test("abort endpoint", async () => {
+    disposeAll();
+    registerProvider(mockProvider("mock"));
+    const sm = new SessionManager();
+    const endpoints = createAIEndpoints({ sessionManager: sm });
+
+    // Create session
+    const createRes = await endpoints["/api/ai/session"](
+      new Request("http://localhost/api/ai/session", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          context: { mode: "plan-review", plan: { plan: "# Test" } },
+        }),
+      })
+    );
+    const { sessionId } = (await createRes.json()) as { sessionId: string };
+
+    // Abort
+    const abortRes = await endpoints["/api/ai/abort"](
+      new Request("http://localhost/api/ai/abort", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sessionId }),
+      })
+    );
+    const abortData = (await abortRes.json()) as { ok: boolean };
+    expect(abortData.ok).toBe(true);
+
+    disposeAll();
+  });
+
+  test("sessions list endpoint", async () => {
+    disposeAll();
+    registerProvider(mockProvider("mock"));
+    const sm = new SessionManager();
+    const endpoints = createAIEndpoints({ sessionManager: sm });
+
+    // Create two sessions
+    await endpoints["/api/ai/session"](
+      new Request("http://localhost/api/ai/session", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          context: { mode: "plan-review", plan: { plan: "# A" } },
+        }),
+      })
+    );
+    await endpoints["/api/ai/session"](
+      new Request("http://localhost/api/ai/session", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          context: { mode: "code-review", review: { patch: "+x" } },
+        }),
+      })
+    );
+
+    const listRes = await endpoints["/api/ai/sessions"](
+      new Request("http://localhost/api/ai/sessions")
+    );
+    const sessions = (await listRes.json()) as Array<{ mode: string }>;
+    expect(sessions.length).toBe(2);
+
+    disposeAll();
+  });
+});

--- a/packages/ai/context.ts
+++ b/packages/ai/context.ts
@@ -1,0 +1,221 @@
+/**
+ * Context builders — translate Plannotator review state into system prompts
+ * that give the AI session the right background for answering questions.
+ *
+ * These are provider-agnostic: any AIProvider implementation can use them
+ * to build the system prompt it needs.
+ */
+
+import type { AIContext } from "./types.ts";
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a system prompt from the given context.
+ *
+ * The prompt tells the AI:
+ * - What role it plays (plan reviewer, code reviewer, etc.)
+ * - The content it should reference (plan markdown, diff patch, file)
+ * - Any annotations the user has already made
+ * - That it's operating inside Plannotator (not a general coding session)
+ */
+export function buildSystemPrompt(ctx: AIContext): string {
+  switch (ctx.mode) {
+    case "plan-review":
+      return buildPlanReviewPrompt(ctx);
+    case "code-review":
+      return buildCodeReviewPrompt(ctx);
+    case "annotate":
+      return buildAnnotatePrompt(ctx);
+  }
+}
+
+/**
+ * Build a compact context summary suitable for injecting into a fork prompt.
+ *
+ * When forking from a parent session, we don't need a full system prompt
+ * (the parent's history already provides context). Instead, we inject a
+ * short "you are now in Plannotator" preamble with the relevant content.
+ */
+export function buildForkPreamble(ctx: AIContext): string {
+  const lines: string[] = [
+    "The user is now reviewing your work in Plannotator and has a question.",
+    "Answer concisely based on the conversation history and the context below.",
+    "",
+  ];
+
+  switch (ctx.mode) {
+    case "plan-review": {
+      lines.push("## Current Plan Under Review");
+      lines.push("");
+      lines.push(truncate(ctx.plan.plan, MAX_PLAN_CHARS));
+      if (ctx.plan.annotations) {
+        lines.push("");
+        lines.push("## User Annotations So Far");
+        lines.push(ctx.plan.annotations);
+      }
+      break;
+    }
+    case "code-review": {
+      if (ctx.review.filePath) {
+        lines.push(`## Reviewing: ${ctx.review.filePath}`);
+      }
+      if (ctx.review.selectedCode) {
+        lines.push("");
+        lines.push("### Selected Code");
+        lines.push("```");
+        lines.push(ctx.review.selectedCode);
+        lines.push("```");
+      }
+      if (ctx.review.lineRange) {
+        const { start, end, side } = ctx.review.lineRange;
+        lines.push(`Lines ${start}-${end} (${side} side)`);
+      }
+      lines.push("");
+      lines.push("## Diff Patch");
+      lines.push("```diff");
+      lines.push(truncate(ctx.review.patch, MAX_DIFF_CHARS));
+      lines.push("```");
+      if (ctx.review.annotations) {
+        lines.push("");
+        lines.push("## User Annotations So Far");
+        lines.push(ctx.review.annotations);
+      }
+      break;
+    }
+    case "annotate": {
+      lines.push(`## Annotating: ${ctx.annotate.filePath}`);
+      lines.push("");
+      lines.push(truncate(ctx.annotate.content, MAX_PLAN_CHARS));
+      if (ctx.annotate.annotations) {
+        lines.push("");
+        lines.push("## User Annotations So Far");
+        lines.push(ctx.annotate.annotations);
+      }
+      break;
+    }
+  }
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+const MAX_PLAN_CHARS = 60_000;
+const MAX_DIFF_CHARS = 40_000;
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max) + "\n\n... [truncated for context window]";
+}
+
+function buildPlanReviewPrompt(
+  ctx: Extract<AIContext, { mode: "plan-review" }>
+): string {
+  const sections: string[] = [
+    "You are an AI assistant embedded in Plannotator, a plan review tool.",
+    "The user is reviewing an implementation plan produced by a coding agent.",
+    "Your role is to help them understand the plan, answer questions about it,",
+    "and provide insights about the proposed approach.",
+    "",
+    "Guidelines:",
+    "- Be concise and direct.",
+    "- Reference specific sections of the plan when relevant.",
+    "- If the user asks about code or architecture, draw from the plan content.",
+    "- You can suggest improvements or flag concerns if asked.",
+    "- Do not make changes to files or execute code.",
+    "",
+    "## Plan Under Review",
+    "",
+    truncate(ctx.plan.plan, MAX_PLAN_CHARS),
+  ];
+
+  if (ctx.plan.previousPlan) {
+    sections.push("");
+    sections.push("## Previous Plan Version (for reference)");
+    sections.push(truncate(ctx.plan.previousPlan, MAX_PLAN_CHARS / 2));
+  }
+
+  if (ctx.plan.annotations) {
+    sections.push("");
+    sections.push("## User Annotations");
+    sections.push(ctx.plan.annotations);
+  }
+
+  return sections.join("\n");
+}
+
+function buildCodeReviewPrompt(
+  ctx: Extract<AIContext, { mode: "code-review" }>
+): string {
+  const sections: string[] = [
+    "You are an AI assistant embedded in Plannotator's code review tool.",
+    "The user is reviewing a code diff and may ask questions about specific",
+    "changes, request explanations, or want help writing review comments.",
+    "",
+    "Guidelines:",
+    "- Be concise and direct.",
+    "- Reference specific files, lines, and hunks when relevant.",
+    "- Explain what changed and why, based on the diff context.",
+    "- You can suggest alternative implementations if asked.",
+    "- Do not make changes to files or execute code.",
+  ];
+
+  if (ctx.review.filePath) {
+    sections.push("");
+    sections.push(`## Currently Viewing: ${ctx.review.filePath}`);
+  }
+
+  if (ctx.review.selectedCode) {
+    sections.push("");
+    sections.push("## Selected Code");
+    sections.push("```");
+    sections.push(ctx.review.selectedCode);
+    sections.push("```");
+  }
+
+  sections.push("");
+  sections.push("## Diff");
+  sections.push("```diff");
+  sections.push(truncate(ctx.review.patch, MAX_DIFF_CHARS));
+  sections.push("```");
+
+  if (ctx.review.annotations) {
+    sections.push("");
+    sections.push("## User Annotations");
+    sections.push(ctx.review.annotations);
+  }
+
+  return sections.join("\n");
+}
+
+function buildAnnotatePrompt(
+  ctx: Extract<AIContext, { mode: "annotate" }>
+): string {
+  const sections: string[] = [
+    "You are an AI assistant embedded in Plannotator's annotation tool.",
+    "The user is annotating a markdown document and may ask questions about",
+    "its content or request help crafting annotation comments.",
+    "",
+    "Guidelines:",
+    "- Be concise and direct.",
+    "- Reference specific sections of the document when relevant.",
+    "- Do not make changes to files or execute code.",
+    "",
+    `## Document: ${ctx.annotate.filePath}`,
+    "",
+    truncate(ctx.annotate.content, MAX_PLAN_CHARS),
+  ];
+
+  if (ctx.annotate.annotations) {
+    sections.push("");
+    sections.push("## User Annotations");
+    sections.push(ctx.annotate.annotations);
+  }
+
+  return sections.join("\n");
+}

--- a/packages/ai/endpoints.ts
+++ b/packages/ai/endpoints.ts
@@ -1,0 +1,234 @@
+/**
+ * HTTP endpoint handlers for AI features.
+ *
+ * These handlers are provider-agnostic — they work with whatever AIProvider
+ * is registered. They're designed to be mounted into any Plannotator server
+ * (plan review, code review, annotate) via the shared server infrastructure.
+ *
+ * Endpoints:
+ *   POST /api/ai/session       — Create or fork an AI session
+ *   POST /api/ai/query         — Send a message and stream the response
+ *   POST /api/ai/abort         — Abort the current query
+ *   GET  /api/ai/sessions      — List active sessions
+ *   GET  /api/ai/capabilities  — Check if AI features are available
+ */
+
+import type { AIContext, AIMessage, CreateSessionOptions } from "./types.ts";
+import { getDefaultProvider } from "./provider.ts";
+import { SessionManager } from "./session-manager.ts";
+
+// ---------------------------------------------------------------------------
+// Types for request/response
+// ---------------------------------------------------------------------------
+
+export interface CreateSessionRequest {
+  /** The context mode and content for the session. */
+  context: AIContext;
+  /** Optional model override. */
+  model?: string;
+  /** Max agentic turns. */
+  maxTurns?: number;
+  /** Max budget in USD. */
+  maxBudgetUsd?: number;
+}
+
+export interface QueryRequest {
+  /** The session ID to query. */
+  sessionId: string;
+  /** The user's prompt/question. */
+  prompt: string;
+}
+
+export interface AbortRequest {
+  /** The session ID to abort. */
+  sessionId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Handler factory
+// ---------------------------------------------------------------------------
+
+export interface AIEndpointDeps {
+  /** Session manager instance (one per server). */
+  sessionManager: SessionManager;
+}
+
+/**
+ * Create the route handler map for AI endpoints.
+ *
+ * Usage in a Bun server:
+ * ```ts
+ * const aiHandlers = createAIEndpoints({ sessionManager });
+ *
+ * // In your request handler:
+ * if (url.pathname.startsWith('/api/ai/')) {
+ *   const handler = aiHandlers[url.pathname];
+ *   if (handler) return handler(req);
+ * }
+ * ```
+ */
+export function createAIEndpoints(deps: AIEndpointDeps) {
+  const { sessionManager } = deps;
+
+  return {
+    "/api/ai/capabilities": async (_req: Request) => {
+      const provider = getDefaultProvider();
+      return Response.json({
+        available: !!provider,
+        provider: provider?.name ?? null,
+        capabilities: provider?.capabilities ?? null,
+      });
+    },
+
+    "/api/ai/session": async (req: Request) => {
+      if (req.method !== "POST") {
+        return new Response("Method not allowed", { status: 405 });
+      }
+
+      const provider = getDefaultProvider();
+      if (!provider) {
+        return Response.json(
+          { error: "No AI provider available" },
+          { status: 503 }
+        );
+      }
+
+      const body = (await req.json()) as CreateSessionRequest;
+      const { context, model, maxTurns, maxBudgetUsd } = body;
+
+      if (!context?.mode) {
+        return Response.json(
+          { error: "Missing context.mode" },
+          { status: 400 }
+        );
+      }
+
+      try {
+        const options: CreateSessionOptions = {
+          context,
+          model,
+          maxTurns,
+          maxBudgetUsd,
+        };
+
+        // Fork if parent session is provided, otherwise create fresh
+        const session = context.parent
+          ? await provider.forkSession(options)
+          : await provider.createSession(options);
+
+        const entry = sessionManager.track(session, context.mode);
+
+        return Response.json({
+          sessionId: session.id,
+          parentSessionId: session.parentSessionId,
+          mode: context.mode,
+          createdAt: entry.createdAt,
+        });
+      } catch (err) {
+        return Response.json(
+          {
+            error:
+              err instanceof Error ? err.message : "Failed to create session",
+          },
+          { status: 500 }
+        );
+      }
+    },
+
+    "/api/ai/query": async (req: Request) => {
+      if (req.method !== "POST") {
+        return new Response("Method not allowed", { status: 405 });
+      }
+
+      const body = (await req.json()) as QueryRequest;
+      const { sessionId, prompt } = body;
+
+      if (!sessionId || !prompt) {
+        return Response.json(
+          { error: "Missing sessionId or prompt" },
+          { status: 400 }
+        );
+      }
+
+      const entry = sessionManager.get(sessionId);
+      if (!entry) {
+        return Response.json(
+          { error: "Session not found" },
+          { status: 404 }
+        );
+      }
+
+      sessionManager.touch(sessionId);
+
+      // Stream the response using Server-Sent Events (SSE)
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        async start(controller) {
+          try {
+            for await (const message of entry.session.query(prompt)) {
+              const data = JSON.stringify(message);
+              controller.enqueue(
+                encoder.encode(`data: ${data}\n\n`)
+              );
+            }
+            controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+          } catch (err) {
+            const errorMsg: AIMessage = {
+              type: "error",
+              error: err instanceof Error ? err.message : String(err),
+              code: "stream_error",
+            };
+            controller.enqueue(
+              encoder.encode(`data: ${JSON.stringify(errorMsg)}\n\n`)
+            );
+          } finally {
+            controller.close();
+          }
+        },
+      });
+
+      return new Response(stream, {
+        headers: {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+        },
+      });
+    },
+
+    "/api/ai/abort": async (req: Request) => {
+      if (req.method !== "POST") {
+        return new Response("Method not allowed", { status: 405 });
+      }
+
+      const body = (await req.json()) as AbortRequest;
+      const entry = sessionManager.get(body.sessionId);
+      if (!entry) {
+        return Response.json(
+          { error: "Session not found" },
+          { status: 404 }
+        );
+      }
+
+      entry.session.abort();
+      return Response.json({ ok: true });
+    },
+
+    "/api/ai/sessions": async (_req: Request) => {
+      const entries = sessionManager.list();
+      return Response.json(
+        entries.map((e) => ({
+          sessionId: e.session.id,
+          mode: e.mode,
+          parentSessionId: e.parentSessionId,
+          createdAt: e.createdAt,
+          lastActiveAt: e.lastActiveAt,
+          isActive: e.session.isActive,
+          label: e.label,
+        }))
+      );
+    },
+  } as const;
+}
+
+export type AIEndpoints = ReturnType<typeof createAIEndpoints>;

--- a/packages/ai/index.ts
+++ b/packages/ai/index.ts
@@ -1,0 +1,101 @@
+/**
+ * @plannotator/ai — AI provider layer for Plannotator.
+ *
+ * This package provides the backbone for AI-powered features (inline chat,
+ * plan Q&A, code review assistance) across all Plannotator surfaces.
+ *
+ * Architecture:
+ *
+ *   ┌─────────────────┐     ┌──────────────┐
+ *   │  Plan Review UI  │────▶│              │
+ *   ├─────────────────┤     │  AI Endpoints │──▶ SSE stream
+ *   │  Code Review UI  │────▶│  (HTTP)      │
+ *   ├─────────────────┤     │              │
+ *   │  Annotate UI     │────▶└──────┬───────┘
+ *   └─────────────────┘            │
+ *                                  ▼
+ *                         ┌────────────────┐
+ *                         │ Session Manager │
+ *                         └────────┬───────┘
+ *                                  │
+ *                         ┌────────▼───────┐
+ *                         │  AIProvider     │ (abstract)
+ *                         └────────┬───────┘
+ *                                  │
+ *                    ┌─────────────┼──────────────┐
+ *                    ▼             ▼               ▼
+ *           ┌──────────────┐ ┌──────────┐  ┌───────────┐
+ *           │ Claude Agent │ │ OpenCode │  │  Future   │
+ *           │ SDK Provider │ │ Provider │  │ Providers │
+ *           └──────────────┘ └──────────┘  └───────────┘
+ *
+ * Quick start:
+ *
+ * ```ts
+ * // 1. Import and register the Claude Agent SDK provider
+ * import "@plannotator/ai/providers/claude-agent-sdk";
+ * import { createProvider, createAIEndpoints, SessionManager } from "@plannotator/ai";
+ *
+ * // 2. Create the provider from config
+ * await createProvider({ type: "claude-agent-sdk", cwd: process.cwd() });
+ *
+ * // 3. Create endpoints and session manager for your server
+ * const sessionManager = new SessionManager();
+ * const aiEndpoints = createAIEndpoints({ sessionManager });
+ *
+ * // 4. Mount endpoints in your Bun server
+ * // aiEndpoints["/api/ai/query"](request) → SSE Response
+ * ```
+ */
+
+// Types
+export type {
+  AIProvider,
+  AIProviderCapabilities,
+  AIProviderConfig,
+  AISession,
+  AIMessage,
+  AITextMessage,
+  AITextDeltaMessage,
+  AIToolUseMessage,
+  AIToolResultMessage,
+  AIErrorMessage,
+  AIResultMessage,
+  AIContext,
+  AIContextMode,
+  PlanContext,
+  CodeReviewContext,
+  AnnotateContext,
+  ParentSession,
+  CreateSessionOptions,
+  ClaudeAgentSDKConfig,
+} from "./types.ts";
+
+// Provider registry
+export {
+  registerProvider,
+  unregisterProvider,
+  getProvider,
+  getDefaultProvider,
+  listProviders,
+  disposeAll,
+  registerProviderFactory,
+  createProvider,
+} from "./provider.ts";
+
+// Context builders
+export { buildSystemPrompt, buildForkPreamble } from "./context.ts";
+
+// Session manager
+export { SessionManager } from "./session-manager.ts";
+export type { SessionEntry, SessionManagerOptions } from "./session-manager.ts";
+
+// HTTP endpoints
+export { createAIEndpoints } from "./endpoints.ts";
+export type {
+  AIEndpoints,
+  AIEndpointDeps,
+  CreateSessionRequest,
+  QueryRequest,
+  AbortRequest,
+} from "./endpoints.ts";

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@plannotator/ai",
+  "version": "0.0.1",
+  "private": true,
+  "description": "AI provider layer for Plannotator — pluggable agent runtime backbone",
+  "exports": {
+    ".": "./index.ts",
+    "./types": "./types.ts",
+    "./context": "./context.ts",
+    "./provider": "./provider.ts",
+    "./session-manager": "./session-manager.ts",
+    "./endpoints": "./endpoints.ts",
+    "./providers/claude-agent-sdk": "./providers/claude-agent-sdk.ts"
+  },
+  "peerDependencies": {
+    "@anthropic-ai/claude-agent-sdk": ">=0.1.0"
+  },
+  "peerDependenciesMeta": {
+    "@anthropic-ai/claude-agent-sdk": {
+      "optional": true
+    }
+  }
+}

--- a/packages/ai/provider.ts
+++ b/packages/ai/provider.ts
@@ -1,0 +1,90 @@
+/**
+ * Provider registry — manages available AI providers by name.
+ *
+ * The registry is a simple Map that consumers (servers, UI endpoints)
+ * use to look up the active provider. Only one provider is typically
+ * active at a time, but the registry supports multiple for testing
+ * and future multi-provider scenarios.
+ */
+
+import type { AIProvider, AIProviderConfig } from "./types.ts";
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+const providers = new Map<string, AIProvider>();
+
+/** Register a provider instance. Replaces any existing provider with the same name. */
+export function registerProvider(provider: AIProvider): void {
+  providers.set(provider.name, provider);
+}
+
+/** Unregister and dispose a provider by name. No-op if not found. */
+export function unregisterProvider(name: string): void {
+  const provider = providers.get(name);
+  if (provider) {
+    provider.dispose();
+    providers.delete(name);
+  }
+}
+
+/** Get a registered provider by name. Returns undefined if not found. */
+export function getProvider(name: string): AIProvider | undefined {
+  return providers.get(name);
+}
+
+/** Get the first (and typically only) registered provider. */
+export function getDefaultProvider(): AIProvider | undefined {
+  const first = providers.values().next();
+  return first.done ? undefined : first.value;
+}
+
+/** List all registered provider names. */
+export function listProviders(): string[] {
+  return [...providers.keys()];
+}
+
+/** Dispose all providers and clear the registry. */
+export function disposeAll(): void {
+  for (const provider of providers.values()) {
+    provider.dispose();
+  }
+  providers.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+type ProviderFactory = (config: AIProviderConfig) => Promise<AIProvider>;
+const factories = new Map<string, ProviderFactory>();
+
+/** Register a factory function for a provider type. */
+export function registerProviderFactory(
+  type: string,
+  factory: ProviderFactory
+): void {
+  factories.set(type, factory);
+}
+
+/**
+ * Create and register a provider from config.
+ *
+ * Uses the factory registered for `config.type` to instantiate the provider,
+ * then registers it in the global registry.
+ *
+ * @throws If no factory is registered for the given type.
+ */
+export async function createProvider(config: AIProviderConfig): Promise<AIProvider> {
+  const factory = factories.get(config.type);
+  if (!factory) {
+    throw new Error(
+      `No AI provider factory registered for type "${config.type}". ` +
+        `Available: ${[...factories.keys()].join(", ") || "(none)"}`
+    );
+  }
+  const provider = await factory(config);
+  registerProvider(provider);
+  return provider;
+}

--- a/packages/ai/providers/claude-agent-sdk.ts
+++ b/packages/ai/providers/claude-agent-sdk.ts
@@ -1,0 +1,353 @@
+/**
+ * Claude Agent SDK provider — the first concrete AIProvider implementation.
+ *
+ * Uses @anthropic-ai/claude-agent-sdk to create sessions that can:
+ * - Start fresh with Plannotator context as the system prompt
+ * - Fork from a parent Claude Code session (preserving full history)
+ * - Resume a previous Plannotator inline chat session
+ * - Stream text deltas back to the UI in real time
+ *
+ * Sessions are read-only by default (tools limited to Read, Glob, Grep)
+ * to keep inline chat safe and cost-bounded.
+ */
+
+import { buildSystemPrompt, buildForkPreamble } from "../context.ts";
+import type {
+  AIProvider,
+  AIProviderCapabilities,
+  AISession,
+  AIMessage,
+  AIContext,
+  CreateSessionOptions,
+  ClaudeAgentSDKConfig,
+} from "../types.ts";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PROVIDER_NAME = "claude-agent-sdk";
+
+/** Default read-only tools for inline chat. */
+const DEFAULT_ALLOWED_TOOLS = ["Read", "Glob", "Grep", "WebSearch"];
+
+/** Sensible defaults for inline chat — keep it fast and cheap. */
+const DEFAULT_MAX_TURNS = 3;
+const DEFAULT_MODEL = "claude-sonnet-4-6";
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export class ClaudeAgentSDKProvider implements AIProvider {
+  readonly name = PROVIDER_NAME;
+  readonly capabilities: AIProviderCapabilities = {
+    fork: true,
+    resume: true,
+    streaming: true,
+    tools: true,
+  };
+
+  private config: ClaudeAgentSDKConfig;
+
+  constructor(config: ClaudeAgentSDKConfig) {
+    this.config = config;
+  }
+
+  async createSession(options: CreateSessionOptions): Promise<AISession> {
+    const systemPrompt = buildSystemPrompt(options.context);
+    return new ClaudeAgentSDKSession({
+      systemPrompt,
+      context: options.context,
+      model: options.model ?? this.config.model ?? DEFAULT_MODEL,
+      maxTurns: options.maxTurns ?? DEFAULT_MAX_TURNS,
+      maxBudgetUsd: options.maxBudgetUsd,
+      allowedTools: this.config.allowedTools ?? DEFAULT_ALLOWED_TOOLS,
+      permissionMode: this.config.permissionMode ?? "plan",
+      cwd: this.config.cwd ?? process.cwd(),
+      abortController: options.abortController ?? new AbortController(),
+      parentSessionId: null,
+      forkFromSession: null,
+    });
+  }
+
+  async forkSession(options: CreateSessionOptions): Promise<AISession> {
+    const parent = options.context.parent;
+    if (!parent) {
+      throw new Error(
+        "Cannot fork: no parent session provided in context. " +
+          "Use createSession() for standalone sessions."
+      );
+    }
+
+    const preamble = buildForkPreamble(options.context);
+
+    return new ClaudeAgentSDKSession({
+      systemPrompt: null, // forked sessions inherit the parent's system prompt
+      forkPreamble: preamble,
+      context: options.context,
+      model: options.model ?? this.config.model ?? DEFAULT_MODEL,
+      maxTurns: options.maxTurns ?? DEFAULT_MAX_TURNS,
+      maxBudgetUsd: options.maxBudgetUsd,
+      allowedTools: this.config.allowedTools ?? DEFAULT_ALLOWED_TOOLS,
+      permissionMode: this.config.permissionMode ?? "plan",
+      cwd: parent.cwd,
+      abortController: options.abortController ?? new AbortController(),
+      parentSessionId: parent.sessionId,
+      forkFromSession: parent.sessionId,
+    });
+  }
+
+  async resumeSession(
+    sessionId: string,
+    abortController?: AbortController
+  ): Promise<AISession> {
+    return new ClaudeAgentSDKSession({
+      systemPrompt: null,
+      context: null,
+      model: this.config.model ?? DEFAULT_MODEL,
+      maxTurns: DEFAULT_MAX_TURNS,
+      maxBudgetUsd: undefined,
+      allowedTools: this.config.allowedTools ?? DEFAULT_ALLOWED_TOOLS,
+      permissionMode: this.config.permissionMode ?? "plan",
+      cwd: this.config.cwd ?? process.cwd(),
+      abortController: abortController ?? new AbortController(),
+      parentSessionId: null,
+      forkFromSession: null,
+      resumeSessionId: sessionId,
+    });
+  }
+
+  dispose(): void {
+    // No persistent resources to clean up
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Session
+// ---------------------------------------------------------------------------
+
+interface SessionConfig {
+  systemPrompt: string | null;
+  forkPreamble?: string;
+  context: AIContext | null;
+  model: string;
+  maxTurns: number;
+  maxBudgetUsd?: number;
+  allowedTools: string[];
+  permissionMode: string;
+  cwd: string;
+  abortController: AbortController;
+  parentSessionId: string | null;
+  forkFromSession: string | null;
+  resumeSessionId?: string;
+}
+
+class ClaudeAgentSDKSession implements AISession {
+  readonly id: string;
+  readonly parentSessionId: string | null;
+
+  private config: SessionConfig;
+  private _isActive = false;
+  private _sessionId: string | null = null;
+
+  constructor(config: SessionConfig) {
+    this.config = config;
+    this.parentSessionId = config.parentSessionId;
+    // Generate a temporary ID; will be replaced by the real session ID from the SDK
+    this.id = config.resumeSessionId ?? crypto.randomUUID();
+  }
+
+  get isActive(): boolean {
+    return this._isActive;
+  }
+
+  async *query(prompt: string): AsyncIterable<AIMessage> {
+    this._isActive = true;
+
+    try {
+      // Dynamic import — the SDK is an optional peer dependency.
+      // This allows the package to be imported in environments where
+      // the SDK isn't installed (e.g., OpenCode runtime) without failing.
+      const { query } = await import("@anthropic-ai/claude-agent-sdk");
+
+      const queryPrompt = this.buildQueryPrompt(prompt);
+      const options = this.buildQueryOptions();
+
+      const stream = query({ prompt: queryPrompt, options });
+
+      for await (const message of stream) {
+        // Map SDK messages to our AIMessage types
+        const mapped = mapSDKMessage(message);
+        if (mapped) {
+          // Capture the real session ID from the SDK
+          if (
+            "session_id" in message &&
+            message.session_id &&
+            !this._sessionId
+          ) {
+            this._sessionId = message.session_id as string;
+            // Update the public ID to match the real one
+            (this as { id: string }).id = this._sessionId;
+          }
+          yield mapped;
+        }
+      }
+    } catch (err) {
+      yield {
+        type: "error",
+        error: err instanceof Error ? err.message : String(err),
+        code: "provider_error",
+      };
+    } finally {
+      this._isActive = false;
+    }
+  }
+
+  abort(): void {
+    if (this._isActive) {
+      this.config.abortController.abort();
+      this._isActive = false;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal
+  // -------------------------------------------------------------------------
+
+  /**
+   * Build the prompt string, prepending the fork preamble if this is a forked session.
+   */
+  private buildQueryPrompt(userPrompt: string): string {
+    if (this.config.forkPreamble) {
+      return `${this.config.forkPreamble}\n\n---\n\nUser question: ${userPrompt}`;
+    }
+    return userPrompt;
+  }
+
+  /**
+   * Build the Options object for the SDK query() call.
+   */
+  private buildQueryOptions(): Record<string, unknown> {
+    const opts: Record<string, unknown> = {
+      model: this.config.model,
+      maxTurns: this.config.maxTurns,
+      allowedTools: this.config.allowedTools,
+      cwd: this.config.cwd,
+      abortController: this.config.abortController,
+      includePartialMessages: true,
+      persistSession: true,
+    };
+
+    if (this.config.maxBudgetUsd) {
+      opts.maxBudgetUsd = this.config.maxBudgetUsd;
+    }
+
+    // System prompt — only for fresh sessions (not forks/resumes)
+    if (this.config.systemPrompt) {
+      opts.systemPrompt = this.config.systemPrompt;
+    }
+
+    // Fork: resume the parent session with forkSession: true
+    if (this.config.forkFromSession) {
+      opts.resume = this.config.forkFromSession;
+      opts.forkSession = true;
+    }
+
+    // Resume: pick up an existing Plannotator session
+    if (this.config.resumeSessionId) {
+      opts.resume = this.config.resumeSessionId;
+    }
+
+    // Permission mode
+    if (this.config.permissionMode === "bypassPermissions") {
+      opts.permissionMode = "bypassPermissions";
+      opts.allowDangerouslySkipPermissions = true;
+    } else if (this.config.permissionMode === "plan") {
+      opts.permissionMode = "plan";
+    }
+
+    return opts;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Message mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Map an SDK message to an AIMessage, or null if it's not relevant.
+ */
+function mapSDKMessage(msg: Record<string, unknown>): AIMessage | null {
+  const type = msg.type as string;
+
+  switch (type) {
+    case "assistant": {
+      // Full assistant message — extract text content
+      const message = msg.message as Record<string, unknown> | undefined;
+      if (!message) return null;
+      const content = message.content as Array<Record<string, unknown>>;
+      if (!content) return null;
+
+      const textParts: string[] = [];
+      for (const block of content) {
+        if (block.type === "text" && typeof block.text === "string") {
+          textParts.push(block.text);
+        } else if (block.type === "tool_use") {
+          return {
+            type: "tool_use",
+            toolName: block.name as string,
+            toolInput: block.input as Record<string, unknown>,
+            toolUseId: block.id as string,
+          };
+        }
+      }
+      if (textParts.length > 0) {
+        return { type: "text", text: textParts.join("") };
+      }
+      return null;
+    }
+
+    case "stream_event": {
+      // Partial streaming — extract text deltas
+      const event = msg.event as Record<string, unknown> | undefined;
+      if (!event) return null;
+      const eventType = event.type as string;
+
+      if (eventType === "content_block_delta") {
+        const delta = event.delta as Record<string, unknown>;
+        if (delta?.type === "text_delta" && typeof delta.text === "string") {
+          return { type: "text_delta", delta: delta.text };
+        }
+      }
+      return null;
+    }
+
+    case "result": {
+      const sessionId = (msg.session_id as string) ?? "";
+      const subtype = msg.subtype as string;
+      return {
+        type: "result",
+        sessionId,
+        success: subtype === "success",
+        result: (msg.result as string) ?? undefined,
+        costUsd: msg.total_cost_usd as number | undefined,
+        turns: msg.num_turns as number | undefined,
+      };
+    }
+
+    default:
+      return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory registration
+// ---------------------------------------------------------------------------
+
+import { registerProviderFactory } from "../provider.ts";
+
+registerProviderFactory(
+  PROVIDER_NAME,
+  async (config) => new ClaudeAgentSDKProvider(config as ClaudeAgentSDKConfig)
+);

--- a/packages/ai/session-manager.ts
+++ b/packages/ai/session-manager.ts
@@ -1,0 +1,158 @@
+/**
+ * Session manager — tracks active and historical AI sessions.
+ *
+ * Each Plannotator server instance (plan review, code review, annotate)
+ * gets its own SessionManager. It tracks:
+ *
+ * - Active sessions (currently streaming or idle but resumable)
+ * - The lineage from forked sessions back to their parent
+ * - Metadata for UI display (timestamps, mode, status)
+ *
+ * This is an in-memory store scoped to the server's lifetime. Sessions
+ * are not persisted to disk by the manager (the underlying provider
+ * handles its own persistence via the agent SDK).
+ */
+
+import type { AISession, AIContext, AIContextMode } from "./types.ts";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SessionEntry {
+  /** The live session handle (if still active). */
+  session: AISession;
+  /** What mode this session was created for. */
+  mode: AIContextMode;
+  /** The parent session ID this was forked from (null if standalone). */
+  parentSessionId: string | null;
+  /** When this session was created. */
+  createdAt: number;
+  /** When the last query was sent. */
+  lastActiveAt: number;
+  /** Short description for UI display (e.g., the user's first question). */
+  label?: string;
+}
+
+export interface SessionManagerOptions {
+  /**
+   * Maximum number of sessions to keep in the manager.
+   * Oldest idle sessions are evicted when the limit is reached.
+   * Default: 20.
+   */
+  maxSessions?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+export class SessionManager {
+  private sessions = new Map<string, SessionEntry>();
+  private maxSessions: number;
+
+  constructor(options: SessionManagerOptions = {}) {
+    this.maxSessions = options.maxSessions ?? 20;
+  }
+
+  /**
+   * Track a newly created session.
+   */
+  track(session: AISession, mode: AIContextMode, label?: string): SessionEntry {
+    this.evictIfNeeded();
+
+    const entry: SessionEntry = {
+      session,
+      mode,
+      parentSessionId: session.parentSessionId,
+      createdAt: Date.now(),
+      lastActiveAt: Date.now(),
+      label,
+    };
+    this.sessions.set(session.id, entry);
+    return entry;
+  }
+
+  /**
+   * Get a tracked session by ID.
+   */
+  get(sessionId: string): SessionEntry | undefined {
+    return this.sessions.get(sessionId);
+  }
+
+  /**
+   * Mark a session as recently active (updates lastActiveAt).
+   */
+  touch(sessionId: string): void {
+    const entry = this.sessions.get(sessionId);
+    if (entry) {
+      entry.lastActiveAt = Date.now();
+    }
+  }
+
+  /**
+   * Remove a session from tracking.
+   * Does NOT abort the session — call session.abort() first if needed.
+   */
+  remove(sessionId: string): void {
+    this.sessions.delete(sessionId);
+  }
+
+  /**
+   * List all tracked sessions, newest first.
+   */
+  list(): SessionEntry[] {
+    return [...this.sessions.values()].sort(
+      (a, b) => b.lastActiveAt - a.lastActiveAt
+    );
+  }
+
+  /**
+   * List sessions forked from a specific parent.
+   */
+  forksOf(parentSessionId: string): SessionEntry[] {
+    return this.list().filter(
+      (e) => e.parentSessionId === parentSessionId
+    );
+  }
+
+  /**
+   * Get the number of tracked sessions.
+   */
+  get size(): number {
+    return this.sessions.size;
+  }
+
+  /**
+   * Abort all active sessions and clear tracking.
+   */
+  disposeAll(): void {
+    for (const entry of this.sessions.values()) {
+      if (entry.session.isActive) {
+        entry.session.abort();
+      }
+    }
+    this.sessions.clear();
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal
+  // -------------------------------------------------------------------------
+
+  private evictIfNeeded(): void {
+    if (this.sessions.size < this.maxSessions) return;
+
+    // Find the oldest idle session to evict
+    let oldest: { id: string; at: number } | null = null;
+    for (const [id, entry] of this.sessions) {
+      if (entry.session.isActive) continue; // don't evict active sessions
+      if (!oldest || entry.lastActiveAt < oldest.at) {
+        oldest = { id, at: entry.lastActiveAt };
+      }
+    }
+
+    if (oldest) {
+      this.sessions.delete(oldest.id);
+    }
+  }
+}

--- a/packages/ai/types.ts
+++ b/packages/ai/types.ts
@@ -1,0 +1,285 @@
+/**
+ * Core types for the Plannotator AI provider layer.
+ *
+ * This module defines the abstract interfaces that any agent runtime
+ * (Claude Agent SDK, OpenCode, future providers) must implement to
+ * power AI features inside Plannotator's plan review and code review UIs.
+ */
+
+// ---------------------------------------------------------------------------
+// Context — what the AI session knows about
+// ---------------------------------------------------------------------------
+
+/** The surface the user is interacting with when they invoke AI. */
+export type AIContextMode = "plan-review" | "code-review" | "annotate";
+
+/**
+ * Describes the parent agent session that originally produced the plan or diff.
+ * Used to fork conversations with full history.
+ */
+export interface ParentSession {
+  /** Session ID from the host agent (e.g. Claude Code session UUID). */
+  sessionId: string;
+  /** Working directory the parent session was running in. */
+  cwd: string;
+}
+
+/**
+ * Snapshot of plan-review-specific context.
+ * Passed when AIContextMode is "plan-review".
+ */
+export interface PlanContext {
+  /** The full plan markdown as submitted by the agent. */
+  plan: string;
+  /** Previous plan version (if this is a resubmission). */
+  previousPlan?: string;
+  /** The version number in the plan's history. */
+  version?: number;
+  /** Annotations the user has made so far (serialised for the prompt). */
+  annotations?: string;
+}
+
+/**
+ * Snapshot of code-review-specific context.
+ * Passed when AIContextMode is "code-review".
+ */
+export interface CodeReviewContext {
+  /** The unified diff patch. */
+  patch: string;
+  /** The specific file being discussed (if scoped). */
+  filePath?: string;
+  /** The line range being discussed (if scoped). */
+  lineRange?: { start: number; end: number; side: "old" | "new" };
+  /** The code snippet being discussed (if scoped). */
+  selectedCode?: string;
+  /** Summary of annotations the user has made. */
+  annotations?: string;
+}
+
+/**
+ * Snapshot of annotate-mode context.
+ * Passed when AIContextMode is "annotate".
+ */
+export interface AnnotateContext {
+  /** The markdown file content being annotated. */
+  content: string;
+  /** Path to the file on disk. */
+  filePath: string;
+  /** Summary of annotations the user has made. */
+  annotations?: string;
+}
+
+/**
+ * Union of mode-specific contexts, discriminated by `mode`.
+ */
+export type AIContext =
+  | { mode: "plan-review"; plan: PlanContext; parent?: ParentSession }
+  | { mode: "code-review"; review: CodeReviewContext; parent?: ParentSession }
+  | { mode: "annotate"; annotate: AnnotateContext; parent?: ParentSession };
+
+// ---------------------------------------------------------------------------
+// Messages — what streams back from the AI
+// ---------------------------------------------------------------------------
+
+export interface AITextMessage {
+  type: "text";
+  text: string;
+}
+
+export interface AITextDeltaMessage {
+  type: "text_delta";
+  delta: string;
+}
+
+export interface AIToolUseMessage {
+  type: "tool_use";
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  toolUseId: string;
+}
+
+export interface AIToolResultMessage {
+  type: "tool_result";
+  toolUseId: string;
+  result: string;
+}
+
+export interface AIErrorMessage {
+  type: "error";
+  error: string;
+  code?: string;
+}
+
+export interface AIResultMessage {
+  type: "result";
+  sessionId: string;
+  success: boolean;
+  /** The final text result (if success). */
+  result?: string;
+  /** Total cost in USD (if available). */
+  costUsd?: number;
+  /** Number of agentic turns used. */
+  turns?: number;
+}
+
+export type AIMessage =
+  | AITextMessage
+  | AITextDeltaMessage
+  | AIToolUseMessage
+  | AIToolResultMessage
+  | AIErrorMessage
+  | AIResultMessage;
+
+// ---------------------------------------------------------------------------
+// Session — a live conversation with the AI
+// ---------------------------------------------------------------------------
+
+export interface AISession {
+  /** Unique identifier for this session. */
+  readonly id: string;
+
+  /**
+   * The parent session this was forked from, if any.
+   * Null for fresh sessions.
+   */
+  readonly parentSessionId: string | null;
+
+  /**
+   * Send a prompt and stream back messages.
+   * The returned async iterable yields messages as they arrive.
+   */
+  query(prompt: string): AsyncIterable<AIMessage>;
+
+  /**
+   * Abort the current in-flight query.
+   * Safe to call if no query is running (no-op).
+   */
+  abort(): void;
+
+  /** Whether a query is currently in progress. */
+  readonly isActive: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Provider — the pluggable backend
+// ---------------------------------------------------------------------------
+
+export interface AIProviderCapabilities {
+  /** Whether the provider supports forking from a parent session. */
+  fork: boolean;
+  /** Whether the provider supports resuming a prior session by ID. */
+  resume: boolean;
+  /** Whether the provider streams partial text deltas. */
+  streaming: boolean;
+  /** Whether the provider can execute tools (read files, search, etc.). */
+  tools: boolean;
+}
+
+export interface CreateSessionOptions {
+  /** The context (plan, diff, file) to seed the session with. */
+  context: AIContext;
+  /**
+   * Model override. Provider-specific string.
+   * Falls back to provider default if omitted.
+   */
+  model?: string;
+  /**
+   * Maximum agentic turns for the session.
+   * Keeps inline chat cost-bounded.
+   */
+  maxTurns?: number;
+  /**
+   * Maximum budget in USD for this session.
+   */
+  maxBudgetUsd?: number;
+  /**
+   * AbortController for the caller to cancel the session externally.
+   */
+  abortController?: AbortController;
+}
+
+/**
+ * An AI provider implements the bridge between Plannotator and a specific
+ * agent runtime. The provider is responsible for:
+ *
+ * 1. Creating new AI sessions seeded with review context
+ * 2. Forking from parent agent sessions to maintain conversation history
+ * 3. Streaming responses back as AIMessage events
+ *
+ * Providers are registered by name and selected at runtime based on the
+ * host environment (Claude Code → "claude-agent-sdk", OpenCode → future).
+ */
+export interface AIProvider {
+  /** Unique name for this provider (e.g. "claude-agent-sdk"). */
+  readonly name: string;
+
+  /** What this provider can do. */
+  readonly capabilities: AIProviderCapabilities;
+
+  /**
+   * Create a fresh session (no parent history).
+   * Context is injected via the system prompt.
+   */
+  createSession(options: CreateSessionOptions): Promise<AISession>;
+
+  /**
+   * Fork from a parent agent session.
+   *
+   * The new session inherits the parent's full conversation history
+   * (files read, analysis performed, decisions made) and additionally
+   * receives the Plannotator review context. This enables the user to
+   * ask contextual questions like "why did you change this function?"
+   * without the AI losing insight.
+   *
+   * If the provider doesn't support forking, this should throw.
+   */
+  forkSession(options: CreateSessionOptions): Promise<AISession>;
+
+  /**
+   * Resume a previously created Plannotator AI session by its ID.
+   * Used when the user returns to a conversation they started earlier.
+   *
+   * If the provider doesn't support resuming, this should throw.
+   */
+  resumeSession(
+    sessionId: string,
+    abortController?: AbortController
+  ): Promise<AISession>;
+
+  /**
+   * Clean up any resources held by the provider.
+   * Called when the server shuts down.
+   */
+  dispose(): void;
+}
+
+// ---------------------------------------------------------------------------
+// Provider configuration
+// ---------------------------------------------------------------------------
+
+/**
+ * Configuration passed to a provider factory.
+ * Each provider type may extend this with its own fields.
+ */
+export interface AIProviderConfig {
+  /** Provider type identifier (matches AIProvider.name). */
+  type: string;
+  /** Working directory for the agent. */
+  cwd?: string;
+  /** Default model to use. */
+  model?: string;
+}
+
+export interface ClaudeAgentSDKConfig extends AIProviderConfig {
+  type: "claude-agent-sdk";
+  /**
+   * Tools the AI session is allowed to use.
+   * Defaults to read-only tools for safety in inline chat.
+   */
+  allowedTools?: string[];
+  /**
+   * Permission mode for the session.
+   * Defaults to "plan" (read-only, no execution).
+   */
+  permissionMode?: "default" | "plan" | "bypassPermissions";
+}


### PR DESCRIPTION
## Summary

This PR introduces a complete AI provider abstraction layer for Plannotator, enabling AI-powered features (inline chat, plan Q&A, code review assistance) across all review surfaces. It includes a pluggable provider architecture, the first concrete implementation (Claude Agent SDK), HTTP endpoints for streaming responses, and comprehensive test coverage.

## Key Changes

- **Core Types** (`types.ts`): Defined abstract interfaces for AI providers, sessions, messages, and context modes (plan-review, code-review, annotate). Supports forking from parent agent sessions to maintain conversation history.

- **Provider Registry** (`provider.ts`): Implemented a pluggable provider registry with factory pattern support. Allows runtime registration/unregistration of providers and dynamic provider creation from configuration.

- **Session Manager** (`session-manager.ts`): Built in-memory session tracking with LRU eviction, parent-child session lineage tracking, and metadata for UI display (timestamps, mode, labels).

- **Context Builders** (`context.ts`): Created system prompt and fork preamble generators that translate Plannotator review state into AI-friendly context. Includes content truncation to respect context windows.

- **HTTP Endpoints** (`endpoints.ts`): Implemented provider-agnostic REST endpoints:
  - `POST /api/ai/session` — Create or fork sessions
  - `POST /api/ai/query` — Stream responses via Server-Sent Events
  - `POST /api/ai/abort` — Cancel in-flight queries
  - `GET /api/ai/sessions` — List active sessions
  - `GET /api/ai/capabilities` — Check provider availability

- **Claude Agent SDK Provider** (`providers/claude-agent-sdk.ts`): First concrete provider implementation supporting:
  - Fresh session creation with Plannotator system prompts
  - Forking from parent Claude Code sessions with full history preservation
  - Session resumption by ID
  - Streaming text deltas and tool use messages
  - Read-only tool access (Read, Glob, Grep, WebSearch) for safe inline chat
  - Dynamic SDK import to avoid hard dependency in non-Claude environments

- **Comprehensive Tests** (`ai.test.ts`): 407 lines of test coverage including:
  - Session manager lifecycle and eviction
  - Context prompt building for all modes
  - Provider registry operations
  - Full HTTP endpoint flow (create → query → stream)
  - Error handling and edge cases

## Notable Implementation Details

- **Provider-agnostic design**: HTTP endpoints and context builders work with any AIProvider implementation, enabling future providers (OpenCode, etc.) without changes to core infrastructure.

- **Fork semantics**: Forked sessions inherit parent conversation history while receiving Plannotator review context, enabling contextual questions like "why did you change this function?"

- **Streaming architecture**: Uses Server-Sent Events (SSE) for real-time response streaming with proper error handling and completion signaling.

- **Optional peer dependency**: Claude Agent SDK is a peer dependency with dynamic import, allowing the package to be used in environments where the SDK isn't installed.

- **Session lineage tracking**: Maintains parent-child relationships for forked sessions, enabling UI features like "show related conversations."

- **Cost-bounded inline chat**: Default configuration limits agentic turns and provides budget controls to keep inline chat fast and cost-effective.

