### PR TITLE
fix: annotate-last resolves wrong session after cd

### DIFF
--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -51,7 +51,7 @@ import { registerSession, unregisterSession, listSessions } from "@plannotator/s
 import { openBrowser } from "@plannotator/server/browser";
 import { detectProjectName } from "@plannotator/server/project";
 import { planDenyFeedback } from "@plannotator/shared/feedback-templates";
-import { findSessionLogsForCwd, getLastRenderedMessage, type RenderedMessage } from "./session-log";
+import { findSessionLogsForCwd, resolveSessionLogByPpid, findSessionLogsByAncestorWalk, getLastRenderedMessage, type RenderedMessage } from "./session-log";
 import { findCodexRolloutByThreadId, getLastCodexMessage } from "./codex-session";
 import path from "path";
 
@@ -351,21 +351,43 @@ if (args[0] === "sessions") {
       }
     }
   } else {
-    // Claude Code path: find session logs by CWD
-    const candidates = findSessionLogsForCwd(projectRoot);
+    // Claude Code path: resolve session log
+    //
+    // Strategy (most precise → least precise):
+    // 1. PPID session metadata: ~/.claude/sessions/<ppid>.json gives us the
+    //    exact sessionId and original cwd. Deterministic, O(1), no scanning.
+    // 2. CWD slug match: existing behavior — works when the shell CWD hasn't
+    //    changed from the session's project directory.
+    // 3. Ancestor walk: walk up the directory tree trying parent slugs. Handles
+    //    the common case where the user `cd`'d deeper into a subdirectory.
 
     if (process.env.PLANNOTATOR_DEBUG) {
       console.error(`[DEBUG] Project root: ${projectRoot}`);
-      console.error(`[DEBUG] Candidates: ${candidates.join(", ")}`);
+      console.error(`[DEBUG] PPID: ${process.ppid}`);
     }
 
-    for (const logPath of candidates) {
+    /** Try each log path, return the first that yields a message. */
+    function tryLogCandidates(label: string, getPaths: () => string[]): void {
+      if (lastMessage) return;
+      const paths = getPaths();
       if (process.env.PLANNOTATOR_DEBUG) {
-        console.error(`[DEBUG] Trying: ${logPath}`);
+        console.error(`[DEBUG] ${label}: ${paths.length ? paths.join(", ") : "(none)"}`);
       }
-      lastMessage = getLastRenderedMessage(logPath);
-      if (lastMessage) break;
+      for (const logPath of paths) {
+        lastMessage = getLastRenderedMessage(logPath);
+        if (lastMessage) return;
+      }
     }
+
+    // 1. Try PPID-based session metadata (most reliable)
+    const ppidLog = resolveSessionLogByPpid();
+    tryLogCandidates("PPID session metadata", () => ppidLog ? [ppidLog] : []);
+
+    // 2. Fall back to CWD slug match
+    tryLogCandidates("CWD slug match", () => findSessionLogsForCwd(projectRoot));
+
+    // 3. Fall back to ancestor directory walk
+    tryLogCandidates("Ancestor walk", () => findSessionLogsByAncestorWalk(projectRoot));
   }
 
   if (!lastMessage) {

--- a/apps/hook/server/session-log.test.ts
+++ b/apps/hook/server/session-log.test.ts
@@ -14,8 +14,14 @@ import {
   findAnchorIndex,
   extractLastRenderedMessage,
   projectSlugFromCwd,
+  findSessionLogsByAncestorWalk,
+  findSessionLogsForCwd,
   type SessionLogEntry,
 } from "./session-log";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { tmpdir } from "node:os";
 
 // --- Fixture Helpers ---
 
@@ -544,5 +550,70 @@ describe("parseSessionLog", () => {
 
   test("handles empty input", () => {
     expect(parseSessionLog("")).toHaveLength(0);
+  });
+});
+
+describe("findSessionLogsByAncestorWalk", () => {
+  // These tests use the real ~/.claude/projects/ directory structure.
+  // They verify the ancestor walk logic without needing mocks.
+
+  test("returns empty array for root directory (no parents to walk)", () => {
+    const result = findSessionLogsByAncestorWalk("/");
+    expect(result).toEqual([]);
+  });
+
+  test("walks up to find parent directory session logs", () => {
+    // Create a temporary project slug structure
+    const testId = `plannotator-test-${Date.now()}`;
+    const testDir = join(tmpdir(), testId, "sub", "deep");
+    const slugDir = join(
+      homedir(),
+      ".claude",
+      "projects",
+      // Slug for the parent (tmpdir/testId)
+      `${join(tmpdir(), testId)}`.replace(/[^a-zA-Z0-9-]/g, "-")
+    );
+
+    try {
+      // Set up: create a fake session log at the parent slug
+      mkdirSync(slugDir, { recursive: true });
+      const fakeLog = join(slugDir, "fake-session.jsonl");
+      writeFileSync(fakeLog, '{"type":"assistant","message":{"id":"m1","content":[{"type":"text","text":"hello"}]}}\n');
+
+      // Walk from the deep subdirectory — should find the parent's logs
+      const result = findSessionLogsByAncestorWalk(testDir);
+      expect(result.length).toBeGreaterThan(0);
+      expect(result[0]).toBe(fakeLog);
+    } finally {
+      // Cleanup
+      rmSync(slugDir, { recursive: true, force: true });
+    }
+  });
+
+  test("does not return results for the exact CWD (caller already tried it)", () => {
+    // Create a temp slug for the exact CWD
+    const testId = `plannotator-test-exact-${Date.now()}`;
+    const testDir = join(tmpdir(), testId);
+    const slugDir = join(
+      homedir(),
+      ".claude",
+      "projects",
+      testDir.replace(/[^a-zA-Z0-9-]/g, "-")
+    );
+
+    try {
+      mkdirSync(slugDir, { recursive: true });
+      writeFileSync(
+        join(slugDir, "fake.jsonl"),
+        '{"type":"assistant","message":{"id":"m1","content":[{"type":"text","text":"hi"}]}}\n'
+      );
+
+      // Ancestor walk skips the exact CWD — the caller already tried it
+      const result = findSessionLogsByAncestorWalk(testDir);
+      // Should not find the CWD's own slug; only parents
+      expect(result.every((p) => !p.includes(slugDir))).toBe(true);
+    } finally {
+      rmSync(slugDir, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/hook/server/session-log.ts
+++ b/apps/hook/server/session-log.ts
@@ -160,9 +160,9 @@ function readSessionMetadata(pid: number): SessionMetadata | null {
  *
  * Strategy:
  * 1. Read ~/.claude/sessions/<ppid>.json to get the exact sessionId and cwd.
- * 2. Build the project slug from the session's original cwd (not the current
- *    shell cwd, which may have diverged after `cd`).
- * 3. Return the exact JSONL path: ~/.claude/projects/<slug>/<sessionId>.jsonl
+ * 2. Use findSessionLogsForCwd() with the session's original cwd (not the
+ *    current shell cwd), which handles case-insensitive slug matching on Windows.
+ * 3. Return the log matching the sessionId, or null.
  *
  * Returns null if session metadata is unavailable or the log file doesn't exist.
  */
@@ -173,9 +173,8 @@ export function resolveSessionLogByPpid(): string | null {
   const meta = readSessionMetadata(ppid);
   if (!meta?.sessionId || !meta?.cwd) return null;
 
-  const slug = projectSlugFromCwd(meta.cwd);
-  const projectsDir = join(homedir(), ".claude", "projects");
-  return join(projectsDir, slug, `${meta.sessionId}.jsonl`);
+  const candidates = findSessionLogsForCwd(meta.cwd);
+  return candidates.find((p) => p.includes(meta.sessionId)) ?? null;
 }
 
 /**

--- a/apps/hook/server/session-log.ts
+++ b/apps/hook/server/session-log.ts
@@ -15,7 +15,7 @@
  */
 
 import { readdirSync, statSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 
 // --- Types ---
@@ -116,6 +116,86 @@ export function findSessionLogsForCwd(cwd: string): string[] {
     }
   } catch {
     // projectsDir doesn't exist
+  }
+
+  return [];
+}
+
+// --- Session Metadata Resolution ---
+
+/**
+ * Claude Code writes per-process session metadata to:
+ *   ~/.claude/sessions/<pid>.json
+ *
+ * Each file contains:
+ *   { pid, sessionId, cwd, startedAt }
+ *
+ * This lets us deterministically resolve the correct session log
+ * when the shell CWD has diverged from the session's project directory
+ * (e.g. after the user runs `cd` during a session).
+ */
+
+interface SessionMetadata {
+  pid: number;
+  sessionId: string;
+  cwd: string;
+  startedAt: number;
+}
+
+/**
+ * Read a Claude Code session metadata file for a given PID.
+ * Returns null if the file doesn't exist or can't be parsed.
+ */
+function readSessionMetadata(pid: number): SessionMetadata | null {
+  const metaPath = join(homedir(), ".claude", "sessions", `${pid}.json`);
+  try {
+    return JSON.parse(readFileSync(metaPath, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the session log path using Claude Code's session metadata.
+ *
+ * Strategy:
+ * 1. Read ~/.claude/sessions/<ppid>.json to get the exact sessionId and cwd.
+ * 2. Build the project slug from the session's original cwd (not the current
+ *    shell cwd, which may have diverged after `cd`).
+ * 3. Return the exact JSONL path: ~/.claude/projects/<slug>/<sessionId>.jsonl
+ *
+ * Returns null if session metadata is unavailable or the log file doesn't exist.
+ */
+export function resolveSessionLogByPpid(): string | null {
+  const ppid = process.ppid;
+  if (!ppid) return null;
+
+  const meta = readSessionMetadata(ppid);
+  if (!meta?.sessionId || !meta?.cwd) return null;
+
+  const slug = projectSlugFromCwd(meta.cwd);
+  const projectsDir = join(homedir(), ".claude", "projects");
+  return join(projectsDir, slug, `${meta.sessionId}.jsonl`);
+}
+
+/**
+ * Walk up the directory tree from `cwd` trying each ancestor as a project slug.
+ * Returns session logs from the first ancestor that has any, sorted by mtime.
+ *
+ * Used as a fallback when session metadata resolution (PPID) is unavailable.
+ * Stops at the filesystem root to avoid infinite loops.
+ */
+export function findSessionLogsByAncestorWalk(cwd: string): string[] {
+  let dir = dirname(cwd);
+  if (dir === cwd) return [];
+
+  while (true) {
+    const logs = findSessionLogsForCwd(dir);
+    if (logs.length > 0) return logs;
+
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
   }
 
   return [];
@@ -289,7 +369,11 @@ export function extractLastRenderedMessage(
 export function getLastRenderedMessage(
   logPath: string,
 ): RenderedMessage | null {
-  const content = readFileSync(logPath, "utf-8");
-  const entries = parseSessionLog(content);
-  return extractLastRenderedMessage(entries, entries.length);
+  try {
+    const content = readFileSync(logPath, "utf-8");
+    const entries = parseSessionLog(content);
+    return extractLastRenderedMessage(entries, entries.length);
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
## Problem

`/plannotator-last` annotates the wrong message when the user `cd`'s during a Claude Code session. No error, no warning — just the wrong content in the annotation UI.

### What happens

`findSessionLogsForCwd()` builds a project slug from `process.cwd()`. Claude Code's session log lives under the slug for the *original* session directory, not the current shell CWD.

1. Session starts in `/Users/me` → log stored at `~/.claude/projects/-Users-me/<id>.jsonl`
2. User runs `cd ~/projects/my-app`
3. `/plannotator-last` uses CWD → looks in `~/.claude/projects/-Users-me-projects-my-app/`
4. Finds a stale session from a previous day that happened to use that directory
5. Opens the annotation UI with that old session's last message

The user has no way to tell something went wrong until they read the text and realize it's not what they expected. By then they may have already written annotations against the wrong content.

### Who this affects

Anyone who `cd`'s during a session. That's a common workflow — `cd` into a repo, run commands, then annotate the assistant's response.

This is a Claude Code-only bug. Codex uses `CODEX_THREAD_ID`, OpenCode and Pi use their SDK APIs — none of them resolve sessions via CWD. The fix is scoped to the Claude Code `else` branch; no other harness is touched.

## Fix

Three-tier session resolution (most precise first):

**1. PPID session metadata** (new, primary path)

Claude Code writes `~/.claude/sessions/<pid>.json`:

```json
{"pid": 17326, "sessionId": "112c3961-...", "cwd": "/Users/me", "startedAt": ...}
```

When `/plannotator-last` runs, its parent process is the Claude Code instance. `process.ppid` → read the metadata → get the exact session ID and original CWD → open the exact JSONL. O(1), no scanning, no mtime heuristics.

**2. CWD slug match** (existing behavior, unchanged)

Works when the shell CWD hasn't diverged from the session's project directory.

**3. Ancestor walk** (new fallback)

Walk up the directory tree trying parent slugs. Handles the case where PPID metadata is unavailable and the user `cd`'d deeper into a subdirectory.

### Other changes

- `getLastRenderedMessage()` now catches read errors instead of throwing on missing/corrupt files, so the fallback cascade doesn't crash mid-resolution.
- Extracted `tryLogCandidates()` to deduplicate the candidate iteration loop (was copy-pasted between CWD and ancestor fallbacks).

## Test plan

- [x] 44 tests pass (`bun test apps/hook/server/`)
- [x] 3 new tests for `findSessionLogsByAncestorWalk` (root returns empty, walks up to parent, skips exact CWD)
- [x] This is a Claude Code-only bug. Codex uses `CODEX_THREAD_ID`, OpenCode and Pi use their SDK APIs — none of them resolve sessions via CWD. The fix is scoped to the Claude Code `else` branch; no other harness is touched.