### PR TITLE
fix: remove duplicate 'Code Review' header in pi extension review feedback

### DIFF
--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -304,7 +304,7 @@ export default function plannotator(pi: ExtensionAPI): void {
         if (result.approved) {
           pi.sendUserMessage(`# Code Review\n\nCode review completed — no changes requested.`);
         } else {
-          pi.sendUserMessage(`# Code Review Feedback\n\n${result.feedback}\n\nPlease address this feedback.`);
+          pi.sendUserMessage(`${result.feedback}\n\nPlease address this feedback.`);
         }
       } else {
         ctx.ui.notify("Code review closed (no feedback).", "info");

--- a/packages/review-editor/utils/exportFeedback.test.ts
+++ b/packages/review-editor/utils/exportFeedback.test.ts
@@ -135,4 +135,16 @@ describe("exportReviewFeedback", () => {
     ]);
     expect(result).toContain("### Line 3 (old)");
   });
+
+  it("contains exactly one top-level heading so integrations can use the output directly", () => {
+    const result = exportReviewFeedback([ann()]);
+    const headingMatches = result.match(/^# /gm) || [];
+    expect(headingMatches).toHaveLength(1);
+  });
+
+  it("contains exactly one top-level heading in PR mode", () => {
+    const result = exportReviewFeedback([ann()], prMeta);
+    const headingMatches = result.match(/^# /gm) || [];
+    expect(headingMatches).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## Problem

When the plannotator review UI submits feedback back to pi, the "Code Review" heading appears twice:

```markdown
# Code Review Feedback

# Code Review Feedback

[actual annotations]

Please address this feedback.
```

## Cause

`exportReviewFeedback()` in `packages/review-editor/utils/exportFeedback.ts` already generates its output with a `# Code Review Feedback` header. The pi extension's `plannotator-review` command handler then wraps this output in another `# Code Review Feedback\n\n${result.feedback}`, duplicating the heading.

## Fix

- **`apps/pi-extension/index.ts`**: Send `result.feedback` directly (it already has its own header) instead of wrapping it with a redundant `# Code Review Feedback` prefix.
- **`packages/review-editor/utils/exportFeedback.test.ts`**: Added two tests verifying that `exportReviewFeedback` output contains exactly one top-level heading (local mode and PR mode), preventing future regressions.

## Testing

All 272 tests pass (`bun test`).