### PR TITLE
fix: remove duplicate 'Code Review' header in opencode plugin

### DIFF
--- a/apps/opencode-plugin/commands.ts
+++ b/apps/opencode-plugin/commands.ts
@@ -110,7 +110,7 @@ export async function handleReviewCommand(
         ? "# Code Review\n\nCode review completed — no changes requested."
         : isPRMode
           ? result.feedback
-          : `# Code Review Feedback\n\n${result.feedback}\n\nPlease address this feedback.`;
+          : `${result.feedback}\n\nPlease address this feedback.`;
 
       try {
         await client.session.prompt({


### PR DESCRIPTION
## Summary
- Same issue as #370 — `exportReviewFeedback()` already includes a `# Code Review Feedback` header, but the OpenCode plugin was wrapping it with another one, causing the heading to appear twice.
- Removed the redundant header prefix from `sendUserMessage()` in `apps/opencode-plugin/commands.ts`.

Closes #374

## Test plan
- [ ] Run `/plannotator-review` in OpenCode, submit feedback, verify only one `# Code Review Feedback` heading appears