### PR TITLE
feat: shortcut-registry

### DIFF
--- a/apps/marketing/src/components/ShortcutReference.astro
+++ b/apps/marketing/src/components/ShortcutReference.astro
@@ -1,0 +1,37 @@
+---
+import { shortcutReferenceSurfaces } from '../lib/shortcutReference';
+import { formatShortcutBindingsText } from '../../../../packages/ui/shortcuts';
+---
+
+<p>Keyboard shortcuts available across the Plannotator review and annotation UIs.</p>
+
+{shortcutReferenceSurfaces.map((surface) => (
+  <Fragment>
+    <h2 id={surface.slug}>{surface.title}</h2>
+    <p>{surface.description}</p>
+
+    {surface.sections.map((section) => (
+      <Fragment>
+        <h3 id={section.slug}>{section.title}</h3>
+        <table>
+          <thead>
+            <tr>
+              <th>Shortcut</th>
+              <th>Action</th>
+              <th>Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            {section.shortcuts.map((shortcut) => (
+              <tr>
+                <td><code>{formatShortcutBindingsText(shortcut.bindings)}</code></td>
+                <td>{shortcut.description}</td>
+                <td>{shortcut.hint ?? '—'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </Fragment>
+    ))}
+  </Fragment>
+))}

--- a/apps/marketing/src/content/docs/reference/keyboard-shortcuts.md
+++ b/apps/marketing/src/content/docs/reference/keyboard-shortcuts.md
@@ -6,22 +6,4 @@ sidebar:
 section: "Reference"
 ---
 
-Keyboard shortcuts available in the Plannotator plan review, code review, and annotation UIs.
-
-## Global shortcuts
-
-| Shortcut | Context | Action |
-|----------|---------|--------|
-| `Cmd/Ctrl+Enter` | Plan review (no annotations) | Approve plan |
-| `Cmd/Ctrl+Enter` | Plan review (with annotations) | Send feedback |
-| `Cmd/Ctrl+Enter` | Code review | Send feedback / Approve |
-| `Cmd/Ctrl+Enter` | Annotate mode | Send annotations |
-| `Cmd/Ctrl+S` | Any mode (with API) | Quick save to default notes app |
-| `Escape` | Annotation toolbar | Close toolbar |
-
-## Notes
-
-- `Cmd/Ctrl+Enter` is blocked when a modal or dialog is open (export, import, confirm dialogs, image annotator)
-- `Cmd/Ctrl+Enter` is blocked when typing in an input or textarea
-- `Cmd/Ctrl+S` opens the Export modal if no default notes app is configured
-- `Escape` in the annotation toolbar closes it without creating an annotation
+This page is generated from the shared shortcut registry at build time.

--- a/apps/marketing/src/lib/shortcutReference.ts
+++ b/apps/marketing/src/lib/shortcutReference.ts
@@ -1,0 +1,21 @@
+import { planReviewSurface, annotateSurface } from '../../../../packages/editor/shortcuts';
+import { codeReviewSurface } from '../../../../packages/review-editor/shortcuts';
+import { listRegistryShortcutSections } from '../../../../packages/ui/shortcuts';
+import type { ShortcutSurface } from '../../../../packages/ui/shortcuts';
+
+const slugify = (value: string) => value.toLowerCase().replace(/\s+/g, '-');
+
+const allSurfaces: ShortcutSurface[] = [planReviewSurface, annotateSurface, codeReviewSurface];
+
+export const shortcutReferenceSurfaces = allSurfaces.map((surface) => ({
+  ...surface,
+  sections: listRegistryShortcutSections(surface.registry).map((section) => ({
+    ...section,
+    slug: `${surface.slug}-${slugify(section.title)}`,
+  })),
+}));
+
+export const shortcutReferenceHeadings = shortcutReferenceSurfaces.flatMap((surface) => [
+  { depth: 2 as const, slug: surface.slug, text: surface.title },
+  ...surface.sections.map((section) => ({ depth: 3 as const, slug: section.slug, text: section.title })),
+]);

--- a/apps/marketing/src/pages/docs/[...slug].astro
+++ b/apps/marketing/src/pages/docs/[...slug].astro
@@ -1,6 +1,8 @@
 ---
 import { getCollection, render } from 'astro:content';
 import Docs from '../../layouts/Docs.astro';
+import ShortcutReference from '../../components/ShortcutReference.astro';
+import { shortcutReferenceHeadings } from '../../lib/shortcutReference';
 
 export async function getStaticPaths() {
   const docs = await getCollection('docs');
@@ -11,7 +13,12 @@ export async function getStaticPaths() {
 }
 
 const { doc } = Astro.props;
-const { Content, headings } = await render(doc);
+const isShortcutReference = doc.id === 'reference/keyboard-shortcuts';
+const rendered = isShortcutReference ? null : await render(doc);
+const Content = rendered?.Content;
+const headings = isShortcutReference
+  ? shortcutReferenceHeadings
+  : rendered?.headings ?? [];
 ---
 <Docs
   title={doc.data.title}
@@ -19,5 +26,5 @@ const { Content, headings } = await render(doc);
   headings={headings}
   currentId={doc.id}
 >
-  <Content />
+  {isShortcutReference ? <ShortcutReference /> : Content && <Content />}
 </Docs>

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "plannotator",

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -55,6 +55,7 @@ import type { ArchivedPlan } from '@plannotator/ui/components/sidebar/ArchiveBro
 import { PlanDiffViewer } from '@plannotator/ui/components/plan-diff/PlanDiffViewer';
 import type { PlanDiffMode } from '@plannotator/ui/components/plan-diff/PlanDiffModeSwitcher';
 import { DEMO_PLAN_CONTENT } from './demoPlan';
+import { annotateSettingsShortcutRegistry, planReviewSettingsShortcutRegistry, usePlanEditorShortcuts } from './shortcuts';
 
 type NoteAutoSaveResults = {
   obsidian?: boolean;
@@ -146,17 +147,17 @@ const App: React.FC = () => {
     }
   }, [sidebar.activeTab]);
 
-  // Clear diff view on Escape key
-  useEffect(() => {
-    if (!isPlanDiffActive) return;
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        setIsPlanDiffActive(false);
-      }
-    };
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [isPlanDiffActive]);
+  usePlanEditorShortcuts({
+    target: 'document',
+    handlers: {
+      exitPlanDiff: {
+        when: () => isPlanDiffActive,
+        handle: () => {
+          setIsPlanDiffActive(false);
+        },
+      },
+    },
+  });
 
   // Plan diff computation
   const planDiff = usePlanDiff(markdown, previousPlan, versionInfo);
@@ -714,66 +715,127 @@ const App: React.FC = () => {
     }
   };
 
+  const isPlanShortcutTarget = (e: KeyboardEvent) => {
+    const tag = (e.target as HTMLElement)?.tagName;
+    return tag !== 'INPUT' && tag !== 'TEXTAREA';
+  };
+
   // Global keyboard shortcuts (Cmd/Ctrl+Enter to submit)
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      // Only handle Cmd/Ctrl+Enter
-      if (e.key !== 'Enter' || !(e.metaKey || e.ctrlKey)) return;
+  usePlanEditorShortcuts({
+    handlers: {
+      submitPlan: {
+        when: (e) => {
+          // Don't intercept if typing in an input/textarea
+          if (!isPlanShortcutTarget(e)) return false;
 
-      // Don't intercept if typing in an input/textarea
-      const tag = (e.target as HTMLElement)?.tagName;
-      if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+          // Don't intercept if any modal is open
+          if (showExport || showImport || showFeedbackPrompt || showClaudeCodeWarning ||
+              showAgentWarning || showPermissionModeSetup || pendingPasteImage) return false;
 
-      // Don't intercept if any modal is open
-      if (showExport || showImport || showFeedbackPrompt || showClaudeCodeWarning ||
-          showAgentWarning || showPermissionModeSetup || pendingPasteImage) return;
+          // Don't intercept if already submitted or submitting
+          if (submitted || isSubmitting) return false;
 
-      // Don't intercept if already submitted or submitting
-      if (submitted || isSubmitting) return;
+          // Don't intercept in demo/share mode (no API)
+          if (!isApiMode) return false;
 
-      // Don't intercept in demo/share mode (no API)
-      if (!isApiMode) return;
+          // Don't submit while viewing a linked doc
+          if (linkedDocHook.isActive) return false;
 
-      // Don't submit while viewing a linked doc
-      if (linkedDocHook.isActive) return;
+          // Don't use the plan submit action in annotate mode
+          if (annotateMode) return false;
 
-      e.preventDefault();
+          return true;
+        },
+        handle: (e) => {
+          e.preventDefault();
 
-      // Annotate mode: always send feedback (empty = "no feedback" message)
-      if (annotateMode) {
-        handleAnnotateFeedback();
-        return;
-      }
-
-      // No annotations → Approve, otherwise → Send Feedback
-      const docAnnotations = linkedDocHook.getDocAnnotations();
-      const hasDocAnnotations = Array.from(docAnnotations.values()).some(
-        (d) => d.annotations.length > 0 || d.globalAttachments.length > 0
-      );
-      if (annotations.length === 0 && editorAnnotations.length === 0 && !hasDocAnnotations) {
-        // Check if agent exists for OpenCode users
-        if (origin === 'opencode') {
-          const warning = getAgentWarning();
-          if (warning) {
-            setAgentWarningMessage(warning);
-            setShowAgentWarning(true);
-            return;
+          const docAnnotations = linkedDocHook.getDocAnnotations();
+          const hasDocAnnotations = Array.from(docAnnotations.values()).some(
+            (d) => d.annotations.length > 0 || d.globalAttachments.length > 0
+          );
+          if (annotations.length === 0 && editorAnnotations.length === 0 && !hasDocAnnotations) {
+            if (origin === 'opencode') {
+              const warning = getAgentWarning();
+              if (warning) {
+                setAgentWarningMessage(warning);
+                setShowAgentWarning(true);
+                return;
+              }
+            }
+            handleApprove();
+          } else {
+            handleDeny();
           }
-        }
-        handleApprove();
-      } else {
-        handleDeny();
-      }
-    };
+        },
+      },
+      submitAnnotations: {
+        when: (e) => {
+          // Don't intercept if typing in an input/textarea
+          if (!isPlanShortcutTarget(e)) return false;
 
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [
-    showExport, showImport, showFeedbackPrompt, showClaudeCodeWarning, showAgentWarning,
-    showPermissionModeSetup, pendingPasteImage,
-    submitted, isSubmitting, isApiMode, linkedDocHook.isActive, annotations.length, annotateMode,
-    origin, getAgentWarning,
-  ]);
+          // Don't intercept if any modal is open
+          if (showExport || showImport || showFeedbackPrompt || showClaudeCodeWarning ||
+              showAgentWarning || showPermissionModeSetup || pendingPasteImage) return false;
+
+          // Don't intercept if already submitted or submitting
+          if (submitted || isSubmitting) return false;
+
+          // Don't intercept in demo/share mode (no API)
+          if (!isApiMode) return false;
+
+          // Don't submit while viewing a linked doc
+          if (linkedDocHook.isActive) return false;
+
+          // Only use the annotation submit action in annotate mode
+          if (!annotateMode) return false;
+
+          return true;
+        },
+        handle: (e) => {
+          e.preventDefault();
+
+          handleAnnotateFeedback();
+        },
+      },
+      // Cmd/Ctrl+S keyboard shortcut — save to default notes app
+      quickSave: {
+        when: (e) => {
+          // Don't intercept if typing in an input/textarea
+          if (!isPlanShortcutTarget(e)) return false;
+
+          // Don't intercept if any modal is open
+          if (showExport || showFeedbackPrompt || showClaudeCodeWarning ||
+              showAgentWarning || showPermissionModeSetup || pendingPasteImage) return false;
+
+          // Don't intercept after submission or in demo/share mode (no API)
+          if (submitted || !isApiMode) return false;
+
+          return true;
+        },
+        handle: (e) => {
+          e.preventDefault();
+
+          const defaultApp = getDefaultNotesApp();
+          const obsOk = isObsidianConfigured();
+          const bearOk = getBearSettings().enabled;
+          const octOk = isOctarineConfigured();
+
+          if (defaultApp === 'download') {
+            handleDownloadAnnotations();
+          } else if (defaultApp === 'obsidian' && obsOk) {
+            handleQuickSaveToNotes('obsidian');
+          } else if (defaultApp === 'bear' && bearOk) {
+            handleQuickSaveToNotes('bear');
+          } else if (defaultApp === 'octarine' && octOk) {
+            handleQuickSaveToNotes('octarine');
+          } else {
+            setInitialExportTab('notes');
+            setShowExport(true);
+          }
+        },
+      },
+    },
+  });
 
   const handleAddAnnotation = (ann: Annotation) => {
     setAnnotations(prev => [...prev, ann]);
@@ -914,47 +976,6 @@ const App: React.FC = () => {
     setTimeout(() => setNoteSaveToast(null), 3000);
   };
 
-  // Cmd/Ctrl+S keyboard shortcut — save to default notes app
-  useEffect(() => {
-    const handleSaveShortcut = (e: KeyboardEvent) => {
-      if (e.key !== 's' || !(e.metaKey || e.ctrlKey)) return;
-
-      const tag = (e.target as HTMLElement)?.tagName;
-      if (tag === 'INPUT' || tag === 'TEXTAREA') return;
-
-      if (showExport || showFeedbackPrompt || showClaudeCodeWarning ||
-          showAgentWarning || showPermissionModeSetup || pendingPasteImage) return;
-
-      if (submitted || !isApiMode) return;
-
-      e.preventDefault();
-
-      const defaultApp = getDefaultNotesApp();
-      const obsOk = isObsidianConfigured();
-      const bearOk = getBearSettings().enabled;
-      const octOk = isOctarineConfigured();
-
-      if (defaultApp === 'download') {
-        handleDownloadAnnotations();
-      } else if (defaultApp === 'obsidian' && obsOk) {
-        handleQuickSaveToNotes('obsidian');
-      } else if (defaultApp === 'bear' && bearOk) {
-        handleQuickSaveToNotes('bear');
-      } else if (defaultApp === 'octarine' && octOk) {
-        handleQuickSaveToNotes('octarine');
-      } else {
-        setInitialExportTab('notes');
-        setShowExport(true);
-      }
-    };
-
-    window.addEventListener('keydown', handleSaveShortcut);
-    return () => window.removeEventListener('keydown', handleSaveShortcut);
-  }, [
-    showExport, showFeedbackPrompt, showClaudeCodeWarning, showAgentWarning,
-    showPermissionModeSetup, pendingPasteImage,
-    submitted, isApiMode, markdown, annotationsOutput,
-  ]);
 
   // Close export dropdown on click outside
   useEffect(() => {
@@ -1122,7 +1143,7 @@ const App: React.FC = () => {
             {/* Desktop buttons — hidden on mobile */}
             <div className="hidden md:flex items-center gap-2">
               <ModeToggle />
-              {!linkedDocHook.isActive && <Settings taterMode={taterMode} onTaterModeChange={handleTaterModeChange} onIdentityChange={handleIdentityChange} origin={origin} onUIPreferencesChange={setUiPrefs} externalOpen={mobileSettingsOpen} onExternalClose={() => setMobileSettingsOpen(false)} />}
+              {!linkedDocHook.isActive && <Settings taterMode={taterMode} onTaterModeChange={handleTaterModeChange} onIdentityChange={handleIdentityChange} origin={origin} shortcutRegistry={annotateMode ? annotateSettingsShortcutRegistry : planReviewSettingsShortcutRegistry} onUIPreferencesChange={setUiPrefs} externalOpen={mobileSettingsOpen} onExternalClose={() => setMobileSettingsOpen(false)} />}
 
               <button
                 onClick={() => setIsPanelOpen(!isPanelOpen)}

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "exports": {
     ".": "./App.tsx",
-    "./styles": "./index.css"
+    "./styles": "./index.css",
+    "./shortcuts": "./shortcuts.ts"
   },
   "dependencies": {
     "@plannotator/ui": "workspace:*",

--- a/packages/editor/shortcuts.ts
+++ b/packages/editor/shortcuts.ts
@@ -1,0 +1,98 @@
+import {
+  annotationToolbarShortcuts,
+  commentPopoverShortcuts,
+  createShortcutRegistry,
+  createShortcutScopeHook,
+  defineShortcutScope,
+  imageAnnotatorShortcuts,
+  inputMethodShortcuts,
+  viewerShortcuts,
+  type ShortcutSurface,
+} from '@plannotator/ui/shortcuts';
+
+export const planEditorShortcuts = defineShortcutScope({
+  id: 'plan-editor',
+  title: 'Plan Editor',
+  shortcuts: {
+    submitPlan: {
+      description: 'Approve / Send feedback',
+      bindings: ['Mod+Enter'],
+      section: 'Actions',
+      hint: 'Approves when there are no annotations and sends feedback when there are.',
+      displayOrder: 10,
+    },
+    submitAnnotations: {
+      description: 'Send annotations',
+      bindings: ['Mod+Enter'],
+      section: 'Actions',
+      displayOrder: 10,
+    },
+    quickSave: {
+      description: 'Save to notes app',
+      bindings: ['Mod+S'],
+      section: 'Actions',
+      hint: 'Opens Export if no default notes app is configured.',
+      displayOrder: 20,
+    },
+    exitPlanDiff: {
+      description: 'Close diff view',
+      bindings: ['Escape'],
+      section: 'Actions',
+      hint: 'Available while plan diff is open.',
+      displayOrder: 30,
+    },
+  },
+});
+
+export const usePlanEditorShortcuts = createShortcutScopeHook(planEditorShortcuts);
+
+const planReviewEditorSettingsShortcuts = defineShortcutScope({
+  id: 'plan-review-editor-settings',
+  title: 'Plan Editor',
+  shortcuts: {
+    submitPlan: planEditorShortcuts.shortcuts.submitPlan,
+    quickSave: planEditorShortcuts.shortcuts.quickSave,
+    exitPlanDiff: planEditorShortcuts.shortcuts.exitPlanDiff,
+  },
+});
+
+const annotateEditorSettingsShortcuts = defineShortcutScope({
+  id: 'annotate-editor-settings',
+  title: 'Annotate Editor',
+  shortcuts: {
+    submitAnnotations: planEditorShortcuts.shortcuts.submitAnnotations,
+    quickSave: planEditorShortcuts.shortcuts.quickSave,
+  },
+});
+
+const sharedPlanSurfaceShortcuts = [
+  inputMethodShortcuts,
+  annotationToolbarShortcuts,
+  viewerShortcuts,
+  commentPopoverShortcuts,
+  imageAnnotatorShortcuts,
+] as const;
+
+export const planReviewSettingsShortcutRegistry = createShortcutRegistry([
+  planReviewEditorSettingsShortcuts,
+  ...sharedPlanSurfaceShortcuts,
+] as const);
+
+export const annotateSettingsShortcutRegistry = createShortcutRegistry([
+  annotateEditorSettingsShortcuts,
+  ...sharedPlanSurfaceShortcuts,
+] as const);
+
+export const planReviewSurface: ShortcutSurface = {
+  slug: 'plan-review',
+  title: 'Plan review',
+  description: 'Shortcuts surfaced by the plan review UI.',
+  registry: planReviewSettingsShortcutRegistry,
+};
+
+export const annotateSurface: ShortcutSurface = {
+  slug: 'annotate-mode',
+  title: 'Annotate mode',
+  description: 'Shortcuts surfaced by the standalone annotation UI.',
+  registry: annotateSettingsShortcutRegistry,
+};

--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -35,7 +35,8 @@ import { exportReviewFeedback } from './utils/exportFeedback';
 import type { DiffFile } from './types';
 import type { DiffOption, WorktreeInfo, GitContext } from '@plannotator/shared/types';
 import type { PRMetadata } from '@plannotator/shared/pr-provider';
-import { altKey } from '@plannotator/ui/utils/platform';
+import { formatShortcutBindingText, formatShortcutBindingTokens, getShortcutPlatform } from '@plannotator/ui/shortcuts';
+import { reviewEditorShortcuts, reviewSettingsShortcutRegistry, useReviewEditorShortcuts, useReviewEditorDoubleTap } from './shortcuts';
 
 declare const __APP_VERSION__: string;
 
@@ -320,47 +321,123 @@ const ReviewApp: React.FC = () => {
     defaultWidth: 256, minWidth: 160, maxWidth: 400, side: 'left',
   });
   const isResizing = panelResize.isDragging || fileTreeResize.isDragging;
+  const isReviewShortcutTarget = (e: KeyboardEvent) => {
+    const tag = (e.target as HTMLElement)?.tagName;
+    return tag !== 'INPUT' && tag !== 'TEXTAREA';
+  };
 
   // Global keyboard shortcuts
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      // Cmd/Ctrl+F to focus search (only when sidebar is rendered)
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'f' && !isTypingTarget(e.target)) {
-        if (files.length > 1 || gitContext?.diffOptions) {
+  useReviewEditorShortcuts({
+    handlers: {
+      focusSearch: {
+        // Cmd/Ctrl+F to focus search (only when sidebar is rendered)
+        when: (e) => !isTypingTarget(e.target) && (files.length > 1 || !!gitContext?.diffOptions),
+        handle: (e) => {
           e.preventDefault();
           openSearch();
-        }
-        return;
-      }
+        },
+      },
+      nextSearchMatch: {
+        // Enter/F3 to step through search matches
+        when: (e) => searchMatches.length > 0 && !isTypingTarget(e.target),
+        handle: (e) => {
+          e.preventDefault();
+          stepSearchMatch(1);
+        },
+      },
+      prevSearchMatch: {
+        when: (e) => searchMatches.length > 0 && !isTypingTarget(e.target),
+        handle: (e) => {
+          e.preventDefault();
+          stepSearchMatch(-1);
+        },
+      },
+      clearSearch: {
+        // Escape closes modals, destination menu, or clears search
+        when: () => showDestinationMenu || showExportModal || !!searchQuery,
+        handle: () => {
+          if (showDestinationMenu) {
+            setShowDestinationMenu(false);
+          } else if (showExportModal) {
+            setShowExportModal(false);
+          } else if (searchQuery) {
+            clearSearch();
+          }
+        },
+      },
+      copyDiff: {
+        // Cmd/Ctrl+Shift+C to copy diff
+        handle: (e) => {
+          e.preventDefault();
+          handleCopyDiff();
+        },
+      },
+      submit: {
+        // Cmd/Ctrl+Enter keyboard shortcut to approve or send feedback
+        when: (e) => {
+          // Platform comment dialog: allow Cmd+Enter from any target (including textarea)
+          if (platformCommentDialog) {
+            if (submitted || isPlatformActioning) return false;
+            const isApproveAction = platformCommentDialog.action === 'approve';
+            return isApproveAction || totalAnnotationCount > 0 || !!platformGeneralComment.trim();
+          }
+          // Normal: only from non-input targets
+          if (!isReviewShortcutTarget(e)) return false;
+          if (showExportModal || showNoAnnotationsDialog || showApproveWarning) return false;
+          if (submitted || isSendingFeedback || isApproving || isPlatformActioning) return false;
+          if (!origin) return false;
+          return true;
+        },
+        handle: (e) => {
+          e.preventDefault();
 
-      // Enter/F3 to step through search matches
-      if ((e.key === 'Enter' || e.key === 'F3') && searchMatches.length > 0 && !isTypingTarget(e.target)) {
-        e.preventDefault();
-        stepSearchMatch(e.shiftKey ? -1 : 1);
-        return;
-      }
+          // Platform comment dialog submission
+          if (platformCommentDialog) {
+            const { action } = platformCommentDialog;
+            setPlatformCommentDialog(null);
+            handlePlatformAction(action, platformGeneralComment);
+            return;
+          }
 
-      // Escape closes modals or clears search
-      if (e.key === 'Escape') {
-        if (showDestinationMenu) {
-          setShowDestinationMenu(false);
-        } else if (showExportModal) {
-          setShowExportModal(false);
-        } else if (searchQuery) {
-          clearSearch();
-        }
-      }
-      // Cmd/Ctrl+Shift+C to copy diff
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'c') {
-        e.preventDefault();
-        handleCopyDiff();
-      }
-    };
+          if (platformMode) {
+            // Platform mode: No annotations → Approve, otherwise → Post Review
+            const isOwnPR = !!platformUser && prMetadata?.author === platformUser;
+            if (totalAnnotationCount === 0 && !isOwnPR) {
+              setPlatformGeneralComment('');
+              setPlatformCommentDialog({ action: 'approve' });
+            } else {
+              setPlatformGeneralComment('');
+              setPlatformCommentDialog({ action: 'comment' });
+            }
+          } else {
+            // Agent mode: No annotations → Approve, otherwise → Send Feedback
+            if (totalAnnotationCount === 0) {
+              handleApprove();
+            } else {
+              handleSendFeedback();
+            }
+          }
+        },
+      },
+    },
+  });
 
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [showExportModal, showDestinationMenu, searchQuery, searchMatches, openSearch, stepSearchMatch, clearSearch, files, gitContext?.diffOptions]);
+  // Double-tap Alt to toggle review destination (PR mode only)
+  useReviewEditorDoubleTap({
+    handlers: {
+      toggleDestination: {
+        when: (e) => !!prMetadata && isReviewShortcutTarget(e),
+        handle: () => {
+          setReviewDestination(prev => {
+            const next = prev === 'platform' ? 'agent' : 'platform';
+            storage.setItem('plannotator-review-dest', next);
+            setPlatformActionError(null);
+            return next;
+          });
+        },
+      },
+    },
+  });
 
   // Get annotations for active file
   const activeFileAnnotations = useMemo(() => {
@@ -846,97 +923,6 @@ const ReviewApp: React.FC = () => {
     }
   }, [buildPRReviewPayload, platformOpenPR]);
 
-  // Double-tap Option/Alt to toggle review destination (PR mode only)
-  useEffect(() => {
-    if (!prMetadata) return;
-    let lastAltUp = 0;
-    const DOUBLE_TAP_WINDOW = 300;
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== 'Alt' || e.repeat) return;
-      const tag = (e.target as HTMLElement)?.tagName;
-      if (tag === 'INPUT' || tag === 'TEXTAREA') return;
-    };
-
-    const handleKeyUp = (e: KeyboardEvent) => {
-      if (e.key !== 'Alt') return;
-      const now = Date.now();
-      if (now - lastAltUp < DOUBLE_TAP_WINDOW) {
-        setReviewDestination(prev => {
-          const next = prev === 'platform' ? 'agent' : 'platform';
-          storage.setItem('plannotator-review-dest', next);
-          setPlatformActionError(null);
-          return next;
-        });
-        lastAltUp = 0;
-      } else {
-        lastAltUp = now;
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    window.addEventListener('keyup', handleKeyUp);
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown);
-      window.removeEventListener('keyup', handleKeyUp);
-    };
-  }, [prMetadata]);
-
-  // Cmd/Ctrl+Enter keyboard shortcut to approve or send feedback
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== 'Enter' || !(e.metaKey || e.ctrlKey)) return;
-
-      // If the GitHub comment dialog is open, Cmd+Enter submits it
-      if (platformCommentDialog) {
-        if (submitted || isPlatformActioning) return;
-        const isApproveAction = platformCommentDialog.action === 'approve';
-        const canSubmit = isApproveAction || totalAnnotationCount > 0 || platformGeneralComment.trim();
-        if (!canSubmit) return;
-        e.preventDefault();
-        const { action } = platformCommentDialog;
-        setPlatformCommentDialog(null);
-        handlePlatformAction(action, platformGeneralComment);
-        return;
-      }
-
-      const tag = (e.target as HTMLElement)?.tagName;
-      if (tag === 'INPUT' || tag === 'TEXTAREA') return;
-      if (showExportModal || showNoAnnotationsDialog || showApproveWarning) return;
-      if (submitted || isSendingFeedback || isApproving || isPlatformActioning) return;
-      if (!origin) return; // Demo mode
-
-      e.preventDefault();
-
-      if (platformMode) {
-        // GitHub mode: No annotations → Approve on GitHub, otherwise → Post Review
-        const isOwnPR = !!platformUser && prMetadata?.author === platformUser;
-        if (totalAnnotationCount === 0 && !isOwnPR) {
-          setPlatformGeneralComment('');
-          setPlatformCommentDialog({ action: 'approve' });
-        } else {
-          setPlatformGeneralComment('');
-          setPlatformCommentDialog({ action: 'comment' });
-        }
-      } else {
-        // Agent mode: No annotations → Approve, otherwise → Send Feedback
-        if (totalAnnotationCount === 0) {
-          handleApprove();
-        } else {
-          handleSendFeedback();
-        }
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [
-    showExportModal, showNoAnnotationsDialog, showApproveWarning,
-    platformCommentDialog, platformGeneralComment,
-    submitted, isSendingFeedback, isApproving, isPlatformActioning,
-    origin, platformMode, platformUser, prMetadata, totalAnnotationCount,
-    handleApprove, handleSendFeedback, handlePlatformAction
-  ]);
 
   if (isLoading) {
     return (
@@ -1033,7 +1019,7 @@ const ReviewApp: React.FC = () => {
             <button
               onClick={handleCopyDiff}
               className="px-2 py-1 md:px-2.5 rounded-md text-xs font-medium bg-muted hover:bg-muted/80 transition-colors flex items-center gap-1.5"
-              title="Copy all raw diffs (Cmd+Shift+C)"
+              title={`Copy all raw diffs (${formatShortcutBindingText(reviewEditorShortcuts.shortcuts.copyDiff.bindings[0], getShortcutPlatform())})`}
             >
               {copyFeedback === 'Diff copied!' ? (
                 <>
@@ -1110,8 +1096,8 @@ const ReviewApp: React.FC = () => {
                           </button>
                           <div className="border-t border-border/50 mt-1 pt-1 px-3 py-1">
                             <span className="text-[10px] text-muted-foreground/40">
-                              <kbd className="inline-flex items-center justify-center min-w-[18px] h-[16px] px-1 rounded bg-muted border border-border/60 border-b-[2px] text-[9px] font-mono leading-none text-foreground/60 shadow-sm">{altKey}</kbd>
-                              <kbd className="inline-flex items-center justify-center min-w-[18px] h-[16px] px-1 rounded bg-muted border border-border/60 border-b-[2px] text-[9px] font-mono leading-none text-foreground/60 shadow-sm ml-0.5">{altKey}</kbd>
+                              <kbd className="inline-flex items-center justify-center min-w-[18px] h-[16px] px-1 rounded bg-muted border border-border/60 border-b-[2px] text-[9px] font-mono leading-none text-foreground/60 shadow-sm">{formatShortcutBindingTokens('Alt', getShortcutPlatform())[0]}</kbd>
+                              <kbd className="inline-flex items-center justify-center min-w-[18px] h-[16px] px-1 rounded bg-muted border border-border/60 border-b-[2px] text-[9px] font-mono leading-none text-foreground/60 shadow-sm ml-0.5">{formatShortcutBindingTokens('Alt', getShortcutPlatform())[0]}</kbd>
                               <span className="ml-1.5">to toggle</span>
                             </span>
                           </div>
@@ -1251,6 +1237,7 @@ const ReviewApp: React.FC = () => {
               onTaterModeChange={() => {}}
               onIdentityChange={handleIdentityChange}
               origin={origin}
+              shortcutRegistry={reviewSettingsShortcutRegistry}
               mode="review"
               aiProviders={aiProviders}
             />

--- a/packages/review-editor/annotationToolbar.shortcuts.ts
+++ b/packages/review-editor/annotationToolbar.shortcuts.ts
@@ -1,0 +1,29 @@
+import { createShortcutScopeHook, defineShortcutScope } from '@plannotator/ui/shortcuts';
+
+export const reviewAnnotationToolbarShortcuts = defineShortcutScope({
+  id: 'review-annotation-toolbar',
+  title: 'Review Annotation Toolbar',
+  shortcuts: {
+    submitComment: {
+      description: 'Submit comment',
+      bindings: ['Mod+Enter'],
+      section: 'Annotations',
+      displayOrder: 10,
+    },
+    indentSuggestedCode: {
+      description: 'Indent suggested code',
+      bindings: ['Tab'],
+      section: 'Annotations',
+      displayOrder: 20,
+    },
+    cancel: {
+      description: 'Close comment editor',
+      bindings: ['Escape'],
+      section: 'Annotations',
+      hint: 'Available while the review comment editor is open.',
+      displayOrder: 30,
+    },
+  },
+});
+
+export const useReviewAnnotationToolbarShortcuts = createShortcutScopeHook(reviewAnnotationToolbarShortcuts);

--- a/packages/review-editor/components/AITab.tsx
+++ b/packages/review-editor/components/AITab.tsx
@@ -8,7 +8,8 @@ import { CountBadge } from './CountBadge';
 import { CopyButton } from './CopyButton';
 import { PermissionCard } from './PermissionCard';
 import { AIConfigBar } from './AIConfigBar';
-import { submitHint } from '@plannotator/ui/utils/platform';
+import { dispatchShortcutEvent, formatShortcutBindingText, getShortcutPlatform } from '@plannotator/ui/shortcuts';
+import { reviewAnnotationToolbarShortcuts } from '../annotationToolbar.shortcuts';
 
 interface AIProviderInfo {
   id: string;
@@ -312,17 +313,22 @@ const GeneralInput: React.FC<{
           style={{ maxHeight: 120 }}
           disabled={disabled}
           onKeyDown={(e) => {
-            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !e.nativeEvent.isComposing && !disabled) {
-              e.preventDefault();
-              onSubmit();
-            }
+            dispatchShortcutEvent(reviewAnnotationToolbarShortcuts, {
+              submitComment: {
+                when: (event) => !event.isComposing && !disabled,
+                handle: (event) => {
+                  event.preventDefault();
+                  onSubmit();
+                },
+              },
+            }, e.nativeEvent);
           }}
         />
         <button
           onClick={onSubmit}
           disabled={disabled || !value.trim()}
           className="p-1.5 mb-px rounded-md text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed transition-colors flex-shrink-0"
-          title={`Send (${submitHint})`}
+          title={`Send (${formatShortcutBindingText(reviewAnnotationToolbarShortcuts.shortcuts.submitComment.bindings[0], getShortcutPlatform())})`}
         >
           <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M6 12L3.269 3.126A59.768 59.768 0 0121.485 12 59.77 59.77 0 013.27 20.876L5.999 12zm0 0h7.5" />

--- a/packages/review-editor/components/AnnotationToolbar.tsx
+++ b/packages/review-editor/components/AnnotationToolbar.tsx
@@ -5,6 +5,8 @@ import { formatLineRange } from '../utils/formatLineRange';
 import { AskAIInput } from './AskAIInput';
 import { SparklesIcon } from './SparklesIcon';
 import type { AIChatEntry } from '../hooks/useAIChat';
+import { dispatchShortcutEvent } from '@plannotator/ui/shortcuts';
+import { reviewAnnotationToolbarShortcuts } from '../annotationToolbar.shortcuts';
 
 interface AnnotationToolbarProps {
   toolbarState: ToolbarState;
@@ -122,11 +124,17 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
             rows={3}
             autoFocus
             onKeyDown={(e) => {
-              if (e.key === 'Escape') {
-                onDismiss();
-              } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !e.nativeEvent.isComposing) {
-                onSubmit();
-              }
+              dispatchShortcutEvent(reviewAnnotationToolbarShortcuts, {
+                cancel: () => {
+                  onDismiss();
+                },
+                submitComment: {
+                  when: (event) => !event.isComposing,
+                  handle: () => {
+                    onSubmit();
+                  },
+                },
+              }, e.nativeEvent);
             }}
           />
 
@@ -154,11 +162,17 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
                 autoFocus
                 spellCheck={false}
                 onKeyDown={(e) => {
-                  if (e.key === 'Tab') {
-                    handleTabIndent(e);
-                  } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !e.nativeEvent.isComposing) {
-                    onSubmit();
-                  }
+                  dispatchShortcutEvent(reviewAnnotationToolbarShortcuts, {
+                    indentSuggestedCode: () => {
+                      handleTabIndent(e);
+                    },
+                    submitComment: {
+                      when: (event) => !event.isComposing,
+                      handle: () => {
+                        onSubmit();
+                      },
+                    },
+                  }, e.nativeEvent);
                 }}
               />
             </div>

--- a/packages/review-editor/components/AskAIInput.tsx
+++ b/packages/review-editor/components/AskAIInput.tsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import { formatLineRange } from '../utils/formatLineRange';
 import { SparklesIcon } from './SparklesIcon';
 import type { AIChatEntry } from '../hooks/useAIChat';
-import { submitHint } from '@plannotator/ui/utils/platform';
+import { dispatchShortcutEvent, formatShortcutBindingText, getShortcutPlatform } from '@plannotator/ui/shortcuts';
+import { reviewAnnotationToolbarShortcuts } from '../annotationToolbar.shortcuts';
 
 interface AskAIInputProps {
   lineStart: number;
@@ -65,11 +66,17 @@ export const AskAIInput: React.FC<AskAIInputProps> = ({
         autoFocus
         disabled={isLoading}
         onKeyDown={(e) => {
-          if (e.key === 'Escape') {
-            onCancel();
-          } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !e.nativeEvent.isComposing) {
-            handleSubmit();
-          }
+          dispatchShortcutEvent(reviewAnnotationToolbarShortcuts, {
+            cancel: () => {
+              onCancel();
+            },
+            submitComment: {
+              when: (event) => !event.isComposing,
+              handle: () => {
+                handleSubmit();
+              },
+            },
+          }, e.nativeEvent);
         }}
       />
 
@@ -92,7 +99,7 @@ export const AskAIInput: React.FC<AskAIInputProps> = ({
           onClick={handleSubmit}
           disabled={!question.trim() || isLoading}
           className="review-toolbar-btn primary disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1 ml-auto"
-          title={`Ask (${submitHint})`}
+          title={`Ask (${formatShortcutBindingText(reviewAnnotationToolbarShortcuts.shortcuts.submitComment.bindings[0], getShortcutPlatform())})`}
         >
           {isLoading ? (
             <>

--- a/packages/review-editor/components/FileTree.tsx
+++ b/packages/review-editor/components/FileTree.tsx
@@ -5,6 +5,9 @@ import { buildFileTree, getAncestorPaths, getAllFolderPaths } from '../utils/bui
 import { FileTreeNodeItem } from './FileTreeNode';
 import { getReviewSearchSideLabel, type ReviewSearchFileGroup, type ReviewSearchMatch } from '../utils/reviewSearch';
 import type { DiffFile } from '../types';
+import { dispatchShortcutEvent } from '@plannotator/ui/shortcuts';
+import { useReviewFileTreeShortcuts } from '../fileTree.shortcuts';
+import { reviewEditorShortcuts } from '../shortcuts';
 
 interface FileTreeProps {
   files: DiffFile[];
@@ -67,36 +70,44 @@ export const FileTree: React.FC<FileTreeProps> = ({
   onSelectSearchMatch,
   onStepSearchMatch,
 }) => {
-  // Keyboard navigation: j/k or arrow keys
-  const handleKeyDown = useCallback((e: KeyboardEvent) => {
-    if (!enableKeyboardNav) return;
+  const isFileTreeShortcutTarget = (target: EventTarget | null) => !(target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement);
 
-    // Don't interfere with input fields
-    if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
-      return;
-    }
+  const canHandleFileTreeShortcut = (e: KeyboardEvent) => enableKeyboardNav && isFileTreeShortcutTarget(e.target);
 
-    if (e.key === 'j' || e.key === 'ArrowDown') {
-      e.preventDefault();
-      const nextIndex = Math.min(activeFileIndex + 1, files.length - 1);
-      onSelectFile(nextIndex);
-    } else if (e.key === 'k' || e.key === 'ArrowUp') {
-      e.preventDefault();
-      const prevIndex = Math.max(activeFileIndex - 1, 0);
-      onSelectFile(prevIndex);
-    } else if (e.key === 'Home') {
-      e.preventDefault();
-      onSelectFile(0);
-    } else if (e.key === 'End') {
-      e.preventDefault();
-      onSelectFile(files.length - 1);
-    }
-  }, [enableKeyboardNav, activeFileIndex, files.length, onSelectFile]);
-
-  useEffect(() => {
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [handleKeyDown]);
+  useReviewFileTreeShortcuts({
+    handlers: {
+      nextFile: {
+        when: canHandleFileTreeShortcut,
+        handle: (e) => {
+          e.preventDefault();
+          const nextIndex = Math.min(activeFileIndex + 1, files.length - 1);
+          onSelectFile(nextIndex);
+        },
+      },
+      prevFile: {
+        when: canHandleFileTreeShortcut,
+        handle: (e) => {
+          e.preventDefault();
+          const prevIndex = Math.max(activeFileIndex - 1, 0);
+          onSelectFile(prevIndex);
+        },
+      },
+      firstFile: {
+        when: canHandleFileTreeShortcut,
+        handle: (e) => {
+          e.preventDefault();
+          onSelectFile(0);
+        },
+      },
+      lastFile: {
+        when: canHandleFileTreeShortcut,
+        handle: (e) => {
+          e.preventDefault();
+          onSelectFile(files.length - 1);
+        },
+      },
+    },
+  });
 
   const annotationCountMap = useMemo(() => {
     const map = new Map<string, number>();
@@ -162,22 +173,33 @@ export const FileTree: React.FC<FileTreeProps> = ({
               value={searchQuery}
               onChange={(e) => onSearchChange(e.target.value)}
               onKeyDown={(e) => {
-                if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'f') {
-                  e.preventDefault();
-                  return;
-                }
-                if (e.key === 'Enter' && searchMatches.length > 0) {
-                  e.preventDefault();
-                  onStepSearchMatch?.(e.shiftKey ? -1 : 1);
-                }
-                if (e.key === 'Escape') {
-                  e.preventDefault();
-                  if (searchQuery) {
-                    onSearchClear?.();
-                  } else {
-                    (e.target as HTMLInputElement).blur();
-                  }
-                }
+                dispatchShortcutEvent(reviewEditorShortcuts, {
+                  focusSearch: () => {
+                    e.preventDefault();
+                  },
+                  nextSearchMatch: {
+                    when: () => searchMatches.length > 0,
+                    handle: () => {
+                      e.preventDefault();
+                      onStepSearchMatch?.(1);
+                    },
+                  },
+                  prevSearchMatch: {
+                    when: () => searchMatches.length > 0,
+                    handle: () => {
+                      e.preventDefault();
+                      onStepSearchMatch?.(-1);
+                    },
+                  },
+                  clearSearch: () => {
+                    e.preventDefault();
+                    if (searchQuery) {
+                      onSearchClear?.();
+                    } else {
+                      (e.target as HTMLInputElement).blur();
+                    }
+                  },
+                }, e.nativeEvent);
               }}
               placeholder="Search diff..."
               className={`w-full pl-7 py-1.5 bg-muted rounded-md text-xs text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-primary/50 ${searchQuery ? 'pr-14' : 'pr-7'}`}

--- a/packages/review-editor/components/SuggestionModal.tsx
+++ b/packages/review-editor/components/SuggestionModal.tsx
@@ -3,6 +3,8 @@ import { HighlightedCode } from './HighlightedCode';
 import { ToolbarState } from '../hooks/useAnnotationToolbar';
 import { useTabIndent } from '../hooks/useTabIndent';
 import { detectLanguage } from '../utils/detectLanguage';
+import { dispatchShortcutEvent } from '@plannotator/ui/shortcuts';
+import { reviewAnnotationToolbarShortcuts } from '../annotationToolbar.shortcuts';
 
 interface SuggestionModalProps {
   filePath: string;
@@ -103,11 +105,14 @@ export const SuggestionModal: React.FC<SuggestionModalProps> = ({
               autoFocus
               spellCheck={false}
               onKeyDown={(e) => {
-                if (e.key === 'Escape') {
-                  onClose();
-                } else if (e.key === 'Tab') {
-                  handleTabIndent(e);
-                }
+                dispatchShortcutEvent(reviewAnnotationToolbarShortcuts, {
+                  cancel: () => {
+                    onClose();
+                  },
+                  indentSuggestedCode: () => {
+                    handleTabIndent(e);
+                  },
+                }, e.nativeEvent);
               }}
             />
           </div>

--- a/packages/review-editor/fileTree.shortcuts.ts
+++ b/packages/review-editor/fileTree.shortcuts.ts
@@ -1,0 +1,34 @@
+import { createShortcutScopeHook, defineShortcutScope } from '@plannotator/ui/shortcuts';
+
+export const reviewFileTreeShortcuts = defineShortcutScope({
+  id: 'review-file-tree',
+  title: 'File Navigation',
+  shortcuts: {
+    nextFile: {
+      description: 'Next file',
+      bindings: ['J', 'ArrowDown'],
+      section: 'File Navigation',
+      displayOrder: 10,
+    },
+    prevFile: {
+      description: 'Previous file',
+      bindings: ['K', 'ArrowUp'],
+      section: 'File Navigation',
+      displayOrder: 20,
+    },
+    firstFile: {
+      description: 'First file',
+      bindings: ['Home'],
+      section: 'File Navigation',
+      displayOrder: 30,
+    },
+    lastFile: {
+      description: 'Last file',
+      bindings: ['End'],
+      section: 'File Navigation',
+      displayOrder: 40,
+    },
+  },
+});
+
+export const useReviewFileTreeShortcuts = createShortcutScopeHook(reviewFileTreeShortcuts);

--- a/packages/review-editor/package.json
+++ b/packages/review-editor/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "exports": {
     ".": "./App.tsx",
-    "./styles": "./index.css"
+    "./styles": "./index.css",
+    "./shortcuts": "./shortcuts.ts"
   },
   "dependencies": {
     "@plannotator/shared": "workspace:*",

--- a/packages/review-editor/shortcuts.ts
+++ b/packages/review-editor/shortcuts.ts
@@ -1,0 +1,70 @@
+import { createDoubleTapShortcutsHook, createShortcutRegistry, createShortcutScopeHook, defineShortcutScope, type ShortcutSurface } from '@plannotator/ui/shortcuts';
+import { reviewAnnotationToolbarShortcuts } from './annotationToolbar.shortcuts';
+import { reviewFileTreeShortcuts } from './fileTree.shortcuts';
+
+export const reviewEditorShortcuts = defineShortcutScope({
+  id: 'review-editor',
+  title: 'Review Editor',
+  shortcuts: {
+    submit: {
+      description: 'Approve / Send feedback',
+      bindings: ['Mod+Enter'],
+      section: 'Actions',
+      displayOrder: 10,
+    },
+    copyDiff: {
+      description: 'Copy raw diff',
+      bindings: ['Mod+Shift+C'],
+      section: 'Actions',
+      displayOrder: 20,
+    },
+    focusSearch: {
+      description: 'Focus search',
+      bindings: ['Mod+F'],
+      section: 'Search',
+      hint: 'Available when the file tree search bar is shown.',
+      displayOrder: 10,
+    },
+    nextSearchMatch: {
+      description: 'Next search result',
+      bindings: ['Enter', 'F3'],
+      section: 'Search',
+      displayOrder: 20,
+    },
+    prevSearchMatch: {
+      description: 'Previous search result',
+      bindings: ['Shift+Enter', 'Shift+F3'],
+      section: 'Search',
+      displayOrder: 30,
+    },
+    clearSearch: {
+      description: 'Clear search / close panel',
+      bindings: ['Escape'],
+      section: 'Search',
+      displayOrder: 40,
+    },
+    toggleDestination: {
+      description: 'Toggle review destination',
+      bindings: ['Alt Alt'],
+      section: 'Actions',
+      hint: 'Double-tap to switch between platform and agent in PR review mode.',
+      displayOrder: 30,
+    },
+  },
+});
+
+export const useReviewEditorShortcuts = createShortcutScopeHook(reviewEditorShortcuts);
+export const useReviewEditorDoubleTap = createDoubleTapShortcutsHook(reviewEditorShortcuts);
+
+export const reviewSettingsShortcutRegistry = createShortcutRegistry([
+  reviewEditorShortcuts,
+  reviewFileTreeShortcuts,
+  reviewAnnotationToolbarShortcuts,
+] as const);
+
+export const codeReviewSurface: ShortcutSurface = {
+  slug: 'code-review',
+  title: 'Code review',
+  description: 'Shortcuts surfaced by the code review UI.',
+  registry: reviewSettingsShortcutRegistry,
+};

--- a/packages/ui/components/AnnotationPanel.tsx
+++ b/packages/ui/components/AnnotationPanel.tsx
@@ -4,6 +4,7 @@ import { isCurrentUser } from '../utils/identity';
 import { ImageThumbnail } from './ImageThumbnail';
 import { EditorAnnotationCard } from './EditorAnnotationCard';
 import { useIsMobile } from '../hooks/useIsMobile';
+import { commentPopoverShortcuts, dispatchShortcutEvent } from '../shortcuts';
 
 interface PanelProps {
   isOpen: boolean;
@@ -277,13 +278,19 @@ const AnnotationCard: React.FC<{
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !e.nativeEvent.isComposing) {
-      e.preventDefault();
-      handleSaveEdit();
-    } else if (e.key === 'Escape') {
-      e.preventDefault();
-      handleCancelEdit();
-    }
+    dispatchShortcutEvent(commentPopoverShortcuts, {
+      submit: {
+        when: (event) => !event.isComposing,
+        handle: (event) => {
+          event.preventDefault();
+          handleSaveEdit();
+        },
+      },
+      cancel: (event) => {
+        event.preventDefault();
+        handleCancelEdit();
+      },
+    }, e.nativeEvent);
   };
 
   const typeConfig = {

--- a/packages/ui/components/AnnotationToolbar.tsx
+++ b/packages/ui/components/AnnotationToolbar.tsx
@@ -4,6 +4,7 @@ import { createPortal } from "react-dom";
 import { useDismissOnOutsideAndEscape } from "../hooks/useDismissOnOutsideAndEscape";
 import { type QuickLabel, getQuickLabels } from "../utils/quickLabels";
 import { FloatingQuickLabelPicker } from "./FloatingQuickLabelPicker";
+import { getShortcutDigit, useAnnotationToolbarShortcuts } from "../shortcuts";
 
 type PositionMode = 'center-above' | 'top-right';
 
@@ -103,42 +104,51 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
     };
   }, [element, positionMode, closeOnScrollOut, onClose]);
 
-  // Type-to-comment + Alt+N / bare digit quick label shortcuts
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.isComposing) return;
-      if (isEditableElement(e.target) || isEditableElement(document.activeElement)) return;
+  const canHandleToolbarShortcut = (e: KeyboardEvent) => {
+    if (showQuickLabels) return false;
+    if (e.isComposing) return false;
+    if (isEditableElement(e.target) || isEditableElement(document.activeElement)) return false;
+    return true;
+  };
 
-      // When picker is open, let FloatingQuickLabelPicker own all keyboard input
-      if (showQuickLabels) return;
+  const canApplyQuickLabel = (e: KeyboardEvent) => {
+    if (!canHandleToolbarShortcut(e)) return false;
+    const digit = getShortcutDigit(e);
+    const index = digit === null ? Number.NaN : digit === 0 ? 9 : digit - 1;
+    return !!onQuickLabel && index >= 0 && index < quickLabels.length;
+  };
 
-      if (e.key === "Escape") {
-        onClose();
-        return;
-      }
+  const canTypeToComment = (e: KeyboardEvent) => {
+    if (!canHandleToolbarShortcut(e)) return false;
+    if (e.key === 'Tab' || e.key === 'Enter') return false;
+    return e.key.length === 1;
+  };
 
-      // Alt+N applies quick label (picker closed)
-      const isDigit = (e.code >= 'Digit1' && e.code <= 'Digit9') || e.code === 'Digit0';
-      if (isDigit && !e.ctrlKey && !e.metaKey && e.altKey) {
-        e.preventDefault();
-        const digit = parseInt(e.code.slice(5), 10);
-        const index = digit === 0 ? 9 : digit - 1;
-        if (index < quickLabels.length) {
-          onQuickLabel?.(quickLabels[index]);
-        }
-        return;
-      }
-
-      if (e.ctrlKey || e.metaKey || e.altKey) return;
-      if (e.key === "Tab" || e.key === "Enter") return;
-      if (e.key.length !== 1) return;
-
-      onRequestComment?.(e.key);
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [onClose, onRequestComment, onQuickLabel, quickLabels, showQuickLabels]);
+  useAnnotationToolbarShortcuts({
+    handlers: {
+      close: {
+        when: canHandleToolbarShortcut,
+        handle: () => {
+          onClose();
+        },
+      },
+      applyQuickLabel: {
+        when: canApplyQuickLabel,
+        handle: (e) => {
+          const digit = getShortcutDigit(e);
+          if (digit === null) return;
+          e.preventDefault();
+          onQuickLabel?.(quickLabels[digit === 0 ? 9 : digit - 1]);
+        },
+      },
+      typeToComment: {
+        when: canTypeToComment,
+        handle: (e) => {
+          onRequestComment?.(e.key);
+        },
+      },
+    },
+  });
 
   useDismissOnOutsideAndEscape({
     enabled: !showQuickLabels,

--- a/packages/ui/components/CommentPopover.tsx
+++ b/packages/ui/components/CommentPopover.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import type { ImageAttachment } from '../types';
 import { AttachmentsButton } from './AttachmentsButton';
-import { submitHint } from '../utils/platform';
+import { commentPopoverShortcuts, dispatchShortcutEvent, formatShortcutBindingText, getShortcutPlatform } from '../shortcuts';
 
 interface CommentPopoverProps {
   /** Element to anchor the popover near (re-reads position on scroll) */
@@ -106,19 +106,23 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
   }, [text, images, onSubmit]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Escape') {
-      e.stopPropagation();
-      if (mode === 'dialog') {
-        setMode('popover');
-      } else {
-        onClose();
-      }
-      return;
-    }
-    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !e.nativeEvent.isComposing) {
-      e.preventDefault();
-      handleSubmit();
-    }
+    dispatchShortcutEvent(commentPopoverShortcuts, {
+      cancel: () => {
+        e.stopPropagation();
+        if (mode === 'dialog') {
+          setMode('popover');
+        } else {
+          onClose();
+        }
+      },
+      submit: {
+        when: (event) => !event.isComposing,
+        handle: () => {
+          e.preventDefault();
+          handleSubmit();
+        },
+      },
+    }, e.nativeEvent);
   };
 
   const headerLabel = isGlobal
@@ -128,6 +132,10 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
       : 'Comment';
 
   const canSubmit = text.trim().length > 0 || images.length > 0;
+  const shortcutHint = formatShortcutBindingText(
+    commentPopoverShortcuts.shortcuts.submit.bindings[0],
+    getShortcutPlatform(),
+  );
 
   if (mode === 'dialog') {
     return createPortal(
@@ -198,7 +206,7 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
               />
             </div>
             <div className="flex items-center gap-3">
-              <span className="text-[10px] text-muted-foreground">{submitHint}</span>
+              <span className="text-[10px] text-muted-foreground">{shortcutHint}</span>
               <button
                 onClick={handleSubmit}
                 disabled={!canSubmit}
@@ -290,7 +298,7 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
           />
         </div>
         <div className="flex items-center gap-3">
-          <span className="text-[10px] text-muted-foreground">{submitHint}</span>
+          <span className="text-[10px] text-muted-foreground">{shortcutHint}</span>
           <button
             onClick={handleSubmit}
             disabled={!canSubmit}

--- a/packages/ui/components/FloatingQuickLabelPicker.tsx
+++ b/packages/ui/components/FloatingQuickLabelPicker.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import { type QuickLabel, getQuickLabels } from '../utils/quickLabels';
 import { QuickLabelDropdown } from './QuickLabelDropdown';
+import { getShortcutDigit, useAnnotationToolbarShortcuts } from '../shortcuts';
 
 interface FloatingQuickLabelPickerProps {
   anchorEl: HTMLElement;
@@ -52,6 +53,11 @@ export const FloatingQuickLabelPicker: React.FC<FloatingQuickLabelPickerProps> =
   const [position, setPosition] = useState<{ top: number; left: number; flipAbove: boolean } | null>(null);
   const ref = useRef<HTMLDivElement>(null);
   const quickLabels = useMemo(() => getQuickLabels(), []);
+  const canApplyQuickLabelFromPicker = (e: KeyboardEvent) => {
+    const digit = getShortcutDigit(e);
+    const index = digit === null ? Number.NaN : digit === 0 ? 9 : digit - 1;
+    return index >= 0 && index < quickLabels.length;
+  };
 
   // Position tracking
   useEffect(() => {
@@ -65,28 +71,23 @@ export const FloatingQuickLabelPicker: React.FC<FloatingQuickLabelPickerProps> =
     };
   }, [anchorEl, cursorHint]);
 
-  // Keyboard: 1-9/0 or Alt+1-9/0 to apply label, Escape to dismiss
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
+  useAnnotationToolbarShortcuts({
+    handlers: {
+      close: (e) => {
         e.preventDefault();
         onDismiss();
-        return;
-      }
-      // Accept bare digit or Alt+digit — picker is open so digits mean labels
-      const isDigit = (e.code >= 'Digit1' && e.code <= 'Digit9') || e.code === 'Digit0';
-      if (isDigit && !e.ctrlKey && !e.metaKey) {
-        e.preventDefault();
-        const digit = parseInt(e.code.slice(5), 10);
-        const index = digit === 0 ? 9 : digit - 1;
-        if (index < quickLabels.length) {
-          onSelect(quickLabels[index]);
-        }
-      }
-    };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [onDismiss, onSelect, quickLabels]);
+      },
+      applyQuickLabelFromPicker: {
+        when: canApplyQuickLabelFromPicker,
+        handle: (e) => {
+          const digit = getShortcutDigit(e);
+          if (digit === null) return;
+          e.preventDefault();
+          onSelect(quickLabels[digit === 0 ? 9 : digit - 1]);
+        },
+      },
+    },
+  });
 
   // Click outside to dismiss
   useEffect(() => {

--- a/packages/ui/components/ImageAnnotator/Toolbar.tsx
+++ b/packages/ui/components/ImageAnnotator/Toolbar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Tool } from './types';
 import { COLORS } from './types';
+import { formatShortcutBindingText, getShortcutPlatform, imageAnnotatorShortcuts } from '../../shortcuts';
 
 interface ToolbarProps {
   tool: Tool;
@@ -69,9 +70,9 @@ const CheckIcon = () => (
 );
 
 const TOOLS: { id: Tool; icon: React.FC; label: string }[] = [
-  { id: 'pen', icon: PenIcon, label: 'Pen (1)' },
-  { id: 'arrow', icon: ArrowIcon, label: 'Arrow (2)' },
-  { id: 'circle', icon: CircleIcon, label: 'Circle (3)' },
+  { id: 'pen', icon: PenIcon, label: 'Pen' },
+  { id: 'arrow', icon: ArrowIcon, label: 'Arrow' },
+  { id: 'circle', icon: CircleIcon, label: 'Circle' },
 ];
 
 const STROKE_SIZES = [3, 6, 10, 16, 24];
@@ -91,6 +92,14 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   const currentSizeIndex = STROKE_SIZES.indexOf(strokeSize);
   const canDecrease = currentSizeIndex > 0;
   const canIncrease = currentSizeIndex < STROKE_SIZES.length - 1;
+  const platform = getShortcutPlatform();
+  const toolShortcutTitle = {
+    pen: formatShortcutBindingText(imageAnnotatorShortcuts.shortcuts.penTool.bindings[0], platform),
+    arrow: formatShortcutBindingText(imageAnnotatorShortcuts.shortcuts.arrowTool.bindings[0], platform),
+    circle: formatShortcutBindingText(imageAnnotatorShortcuts.shortcuts.circleTool.bindings[0], platform),
+  } as const;
+  const undoShortcutTitle = formatShortcutBindingText(imageAnnotatorShortcuts.shortcuts.undo.bindings[0], platform);
+  const saveShortcutTitle = formatShortcutBindingText(imageAnnotatorShortcuts.shortcuts.save.bindings[0], platform);
 
   return (
     <div className="flex items-center gap-2 px-3 py-2 bg-popover border border-border rounded-lg shadow-xl">
@@ -101,7 +110,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
             key={id}
             type="button"
             onClick={() => onToolChange(id)}
-            title={label}
+            title={`${label} (${toolShortcutTitle[id]})`}
             className={`p-1.5 rounded transition-colors ${
               tool === id
                 ? 'bg-primary text-primary-foreground'
@@ -182,7 +191,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
         type="button"
         onClick={onUndo}
         disabled={!canUndo}
-        title="Undo (Cmd+Z)"
+        title={`Undo (${undoShortcutTitle})`}
         className={`p-1.5 rounded transition-colors ${
           canUndo
             ? 'hover:bg-muted text-muted-foreground hover:text-foreground'
@@ -208,7 +217,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
       <button
         type="button"
         onClick={onSave}
-        title="Save (Esc)"
+        title={`Save (${saveShortcutTitle})`}
         className="p-1.5 rounded transition-colors bg-success text-success-foreground hover:opacity-90"
       >
         <CheckIcon />

--- a/packages/ui/components/ImageAnnotator/index.tsx
+++ b/packages/ui/components/ImageAnnotator/index.tsx
@@ -1,25 +1,31 @@
-import React, { useState, useCallback, useEffect, useRef } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
 import { Canvas } from './Canvas';
 import { Toolbar } from './Toolbar';
 import { renderStroke } from './utils';
-import type { Point, Stroke, Tool, AnnotatorState } from './types';
+import type { Point, AnnotatorState } from './types';
 import { DEFAULT_STATE } from './types';
+import { useImageAnnotatorShortcuts } from '../../shortcuts';
 
 interface ImageAnnotatorProps {
   imageSrc: string;
   isOpen: boolean;
   onAccept: (blob: Blob, hasDrawings: boolean, name: string) => Promise<void>;
   onClose: () => void;
-  /** Pre-populated image name (derived from filename) */
   initialName?: string;
 }
 
-export const ImageAnnotator: React.FC<ImageAnnotatorProps> = ({
+interface OpenImageAnnotatorProps {
+  imageSrc: string;
+  onAccept: (blob: Blob, hasDrawings: boolean, name: string) => Promise<void>;
+  onClose: () => void;
+  initialName: string;
+}
+
+const OpenImageAnnotator: React.FC<OpenImageAnnotatorProps> = ({
   imageSrc,
-  isOpen,
   onAccept,
   onClose,
-  initialName = '',
+  initialName,
 }) => {
   const [state, setState] = useState<AnnotatorState>(DEFAULT_STATE);
   const [saving, setSaving] = useState(false);
@@ -27,53 +33,105 @@ export const ImageAnnotator: React.FC<ImageAnnotatorProps> = ({
   const imageRef = useRef<HTMLImageElement | null>(null);
   const nameInputRef = useRef<HTMLInputElement>(null);
 
-  // Reset state when dialog opens
-  useEffect(() => {
-    if (isOpen) {
-      setState(DEFAULT_STATE);
-      setName(initialName);
-    }
-  }, [isOpen, initialName]);
+  const isAnnotatorTextInputTarget = (target: EventTarget | null) => target instanceof HTMLElement && target.tagName === 'INPUT';
 
-  // Keyboard shortcuts
-  useEffect(() => {
-    if (!isOpen) return;
+  const handleUndo = useCallback(() => {
+    setState(s => ({
+      ...s,
+      strokes: s.strokes.slice(0, -1),
+    }));
+  }, []);
 
-    const handleKeyDown = (e: KeyboardEvent) => {
-      // Don't intercept when typing in the name input
-      const target = e.target as HTMLElement;
-      if (target.tagName === 'INPUT') {
-        if (e.key === 'Escape') {
-          // Blur and let the next Escape close
-          target.blur();
-          e.preventDefault();
+  const handleAccept = useCallback(async () => {
+    if (saving) return;
+    setSaving(true);
+
+    try {
+      const img = imageRef.current;
+      if (!img) {
+        onClose();
+        return;
+      }
+
+      const hasDrawings = state.strokes.length > 0;
+      const finalName = name.trim() || initialName || 'image';
+
+      if (!hasDrawings) {
+        const response = await fetch(imageSrc);
+        const blob = await response.blob();
+        await onAccept(blob, false, finalName);
+        onClose();
+        return;
+      }
+
+      const canvas = document.createElement('canvas');
+      const ctx = canvas.getContext('2d')!;
+
+      canvas.width = img.naturalWidth;
+      canvas.height = img.naturalHeight;
+      ctx.drawImage(img, 0, 0);
+
+      const scale = img.naturalWidth / img.clientWidth;
+      state.strokes.forEach(stroke => {
+        renderStroke(ctx, stroke, scale);
+      });
+
+      canvas.toBlob(async (blob) => {
+        if (blob) {
+          await onAccept(blob, true, finalName);
         }
-        return;
-      }
+        onClose();
+      }, 'image/png');
+    } catch (err) {
+      console.error('Failed to save annotated image:', err);
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  }, [imageSrc, initialName, name, onAccept, onClose, saving, state.strokes]);
 
-      // Escape or Enter to accept
-      if (e.key === 'Escape' || e.key === 'Enter') {
+  useImageAnnotatorShortcuts({
+    handlers: {
+      save: (e) => {
+        const target = e.target as HTMLElement;
+        if (target.tagName === 'INPUT') {
+          if (e.key === 'Escape') {
+            target.blur();
+            e.preventDefault();
+          }
+          return;
+        }
+
         e.preventDefault();
-        handleAccept();
-        return;
-      }
-
-      // Cmd+Z to undo
-      if ((e.metaKey || e.ctrlKey) && e.key === 'z') {
-        e.preventDefault();
-        handleUndo();
-        return;
-      }
-
-      // 1/2/3 to switch tools
-      if (e.key === '1') setState(s => ({ ...s, tool: 'pen' }));
-      if (e.key === '2') setState(s => ({ ...s, tool: 'arrow' }));
-      if (e.key === '3') setState(s => ({ ...s, tool: 'circle' }));
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen, state.strokes]);
+        void handleAccept();
+      },
+      undo: {
+        when: (e) => !isAnnotatorTextInputTarget(e.target),
+        handle: (e) => {
+          e.preventDefault();
+          handleUndo();
+        },
+      },
+      penTool: {
+        when: (e) => !isAnnotatorTextInputTarget(e.target),
+        handle: () => {
+          setState(s => ({ ...s, tool: 'pen' }));
+        },
+      },
+      arrowTool: {
+        when: (e) => !isAnnotatorTextInputTarget(e.target),
+        handle: () => {
+          setState(s => ({ ...s, tool: 'arrow' }));
+        },
+      },
+      circleTool: {
+        when: (e) => !isAnnotatorTextInputTarget(e.target),
+        handle: () => {
+          setState(s => ({ ...s, tool: 'circle' }));
+        },
+      },
+    },
+  });
 
   const handleStrokeStart = useCallback((point: Point) => {
     const id = crypto.randomUUID();
@@ -115,13 +173,6 @@ export const ImageAnnotator: React.FC<ImageAnnotatorProps> = ({
     });
   }, []);
 
-  const handleUndo = useCallback(() => {
-    setState(s => ({
-      ...s,
-      strokes: s.strokes.slice(0, -1),
-    }));
-  }, []);
-
   const handleClear = useCallback(() => {
     setState(s => ({
       ...s,
@@ -134,69 +185,11 @@ export const ImageAnnotator: React.FC<ImageAnnotatorProps> = ({
     imageRef.current = img;
   }, []);
 
-  const handleAccept = async () => {
-    if (saving) return;
-    setSaving(true);
-
-    try {
-      const img = imageRef.current;
-      if (!img) {
-        onClose();
-        return;
-      }
-
-      const hasDrawings = state.strokes.length > 0;
-      const finalName = name.trim() || initialName || 'image';
-
-      // If no drawings, just pass through original image
-      if (!hasDrawings) {
-        const response = await fetch(imageSrc);
-        const blob = await response.blob();
-        await onAccept(blob, false, finalName);
-        onClose();
-        return;
-      }
-
-      // Composite image + drawings
-      const canvas = document.createElement('canvas');
-      const ctx = canvas.getContext('2d')!;
-
-      canvas.width = img.naturalWidth;
-      canvas.height = img.naturalHeight;
-
-      // Draw original image
-      ctx.drawImage(img, 0, 0);
-
-      // Scale factor from display size to natural size
-      const scale = img.naturalWidth / img.clientWidth;
-
-      // Draw all strokes at full resolution
-      state.strokes.forEach(stroke => {
-        renderStroke(ctx, stroke, scale);
-      });
-
-      // Convert to blob
-      canvas.toBlob(async (blob) => {
-        if (blob) {
-          await onAccept(blob, true, finalName);
-        }
-        onClose();
-      }, 'image/png');
-    } catch (err) {
-      console.error('Failed to save annotated image:', err);
-      onClose();
-    } finally {
-      setSaving(false);
-    }
-  };
-
   const handleBackdropClick = (e: React.MouseEvent) => {
     if (e.target === e.currentTarget) {
-      handleAccept();
+      void handleAccept();
     }
   };
-
-  if (!isOpen) return null;
 
   return (
     <div
@@ -204,9 +197,7 @@ export const ImageAnnotator: React.FC<ImageAnnotatorProps> = ({
       data-popover-layer
       onClick={handleBackdropClick}
     >
-      {/* Canvas with image and toolbar */}
       <div className="relative flex flex-col items-center gap-3" onClick={(e) => e.stopPropagation()}>
-        {/* Toolbar - above image */}
         <Toolbar
           tool={state.tool}
           color={state.color}
@@ -217,7 +208,7 @@ export const ImageAnnotator: React.FC<ImageAnnotatorProps> = ({
           onStrokeSizeChange={(strokeSize) => setState(s => ({ ...s, strokeSize }))}
           onUndo={handleUndo}
           onClear={handleClear}
-          onSave={handleAccept}
+          onSave={() => void handleAccept()}
         />
 
         <Canvas
@@ -232,7 +223,6 @@ export const ImageAnnotator: React.FC<ImageAnnotatorProps> = ({
           onImageLoad={handleImageLoad}
         />
 
-        {/* Image name input */}
         {initialName && (
           <div className="flex items-center gap-2 w-full max-w-xs">
             <label className="text-xs text-muted-foreground whitespace-nowrap">Name</label>
@@ -244,7 +234,7 @@ export const ImageAnnotator: React.FC<ImageAnnotatorProps> = ({
               onKeyDown={(e) => {
                 if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
                   e.preventDefault();
-                  handleAccept();
+                  void handleAccept();
                 }
               }}
               className="flex-1 px-2 py-1 text-xs bg-muted/50 border border-border rounded-md text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
@@ -253,19 +243,36 @@ export const ImageAnnotator: React.FC<ImageAnnotatorProps> = ({
           </div>
         )}
 
-        {/* Accept hint */}
         <div className="text-xs text-muted-foreground">
           Press <kbd className="px-1.5 py-0.5 bg-muted rounded text-foreground">Esc</kbd> or <kbd className="px-1.5 py-0.5 bg-muted rounded text-foreground">Enter</kbd> or click outside to accept
         </div>
       </div>
 
-      {/* Loading overlay */}
       {saving && (
         <div className="absolute inset-0 flex items-center justify-center bg-background/50">
           <div className="text-sm text-muted-foreground">Saving...</div>
         </div>
       )}
     </div>
+  );
+};
+
+export const ImageAnnotator: React.FC<ImageAnnotatorProps> = ({
+  imageSrc,
+  isOpen,
+  onAccept,
+  onClose,
+  initialName = '',
+}) => {
+  if (!isOpen) return null;
+
+  return (
+    <OpenImageAnnotator
+      imageSrc={imageSrc}
+      onAccept={onAccept}
+      onClose={onClose}
+      initialName={initialName}
+    />
   );
 };
 

--- a/packages/ui/components/KeyboardShortcuts.tsx
+++ b/packages/ui/components/KeyboardShortcuts.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
-import { isMac, modKey, altKey } from '../utils/platform';
-
-/* ─── Key cap component ─── */
+import {
+  formatShortcutBindingTokens,
+  getShortcutPlatform,
+  listRegistryShortcutSections,
+  type ShortcutRegistry,
+} from '../shortcuts';
 
 const Kbd: React.FC<{ children: React.ReactNode; wide?: boolean }> = ({ children, wide }) => (
   <kbd
@@ -13,21 +16,32 @@ const Kbd: React.FC<{ children: React.ReactNode; wide?: boolean }> = ({ children
   </kbd>
 );
 
-/* ─── Key combo renderer ─── */
+const KeyCombo: React.FC<{ binding: string }> = ({ binding }) => {
+  const keys = formatShortcutBindingTokens(binding, getShortcutPlatform());
 
-const Keys: React.FC<{ keys: string[] }> = ({ keys }) => (
-  <span className="inline-flex items-center gap-0.5">
-    {keys.map((k, i) => (
-      <Kbd key={i} wide={k.length > 1}>{k}</Kbd>
+  return (
+    <span className="inline-flex items-center gap-0.5">
+      {keys.map((key, index) => (
+        <Kbd key={`${binding}-${index}`} wide={key.length > 1}>{key}</Kbd>
+      ))}
+    </span>
+  );
+};
+
+const ShortcutBindings: React.FC<{ bindings: string[] }> = ({ bindings }) => (
+  <span className="inline-flex items-center gap-1.5 flex-wrap justify-end">
+    {bindings.map((binding, index) => (
+      <React.Fragment key={binding}>
+        {index > 0 && <span className="text-[10px] text-muted-foreground/60">or</span>}
+        <KeyCombo binding={binding} />
+      </React.Fragment>
     ))}
   </span>
 );
 
-/* ─── Shortcut row ─── */
-
-const ShortcutRow: React.FC<{ keys: string[]; desc: string; hint?: string }> = ({ keys, desc, hint }) => (
-  <div className="flex items-center justify-between py-1">
-    <span className="text-xs text-muted-foreground">
+const ShortcutRow: React.FC<{ bindings: string[]; desc: string; hint?: string }> = ({ bindings, desc, hint }) => (
+  <div className="flex items-center justify-between gap-4 py-1">
+    <span className="text-xs text-muted-foreground min-w-0">
       {desc}
       {hint && (
         <span className="relative group ml-1 inline-flex">
@@ -38,11 +52,9 @@ const ShortcutRow: React.FC<{ keys: string[]; desc: string; hint?: string }> = (
         </span>
       )}
     </span>
-    <Keys keys={keys} />
+    <ShortcutBindings bindings={bindings} />
   </div>
 );
-
-/* ─── Section ─── */
 
 const Section: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => (
   <div className="space-y-0.5">
@@ -53,102 +65,24 @@ const Section: React.FC<{ title: string; children: React.ReactNode }> = ({ title
   </div>
 );
 
-/* ─── Platform-aware key names ─── */
+export const KeyboardShortcuts: React.FC<{ shortcutRegistry: ShortcutRegistry }> = ({ shortcutRegistry }) => {
+  const sections = listRegistryShortcutSections(shortcutRegistry);
 
-const enter = isMac ? '⏎' : '↵';
-
-/* ─── Shortcut data ─── */
-
-interface Shortcut {
-  keys: string[];
-  desc: string;
-  hint?: string;
-}
-
-interface ShortcutSection {
-  title: string;
-  shortcuts: Shortcut[];
-}
-
-const planShortcuts: ShortcutSection[] = [
-  {
-    title: 'Actions',
-    shortcuts: [
-      { keys: [modKey, enter], desc: 'Submit / Approve' },
-      { keys: [modKey, 'S'], desc: 'Save to notes app' },
-      { keys: ['Esc'], desc: 'Close dialog' },
-    ],
-  },
-  {
-    title: 'Input Method',
-    shortcuts: [
-      { keys: [altKey, 'hold'], desc: 'Temporarily switch mode', hint: 'Hold to switch between Select and Pinpoint, release to revert' },
-      { keys: [altKey, altKey], desc: 'Toggle mode', hint: 'Double-tap to permanently switch between Select and Pinpoint' },
-    ],
-  },
-  {
-    title: 'Annotations',
-    shortcuts: [
-      { keys: ['a-z'], desc: 'Start typing comment', hint: 'When the annotation toolbar is open, any letter key opens the comment editor with that character' },
-      { keys: [altKey, '1-0'], desc: 'Apply quick label', hint: 'Instantly applies the Nth preset label (0 = 10th). When the label picker is open, bare digits also work.' },
-      { keys: [modKey, enter], desc: 'Submit comment' },
-      { keys: [modKey, 'C'], desc: 'Copy selected text' },
-      { keys: ['Esc'], desc: 'Close toolbar / Cancel' },
-    ],
-  },
-  {
-    title: 'Image Annotator',
-    shortcuts: [
-      { keys: ['1'], desc: 'Pen tool' },
-      { keys: ['2'], desc: 'Arrow tool' },
-      { keys: ['3'], desc: 'Circle tool' },
-      { keys: [modKey, 'Z'], desc: 'Undo' },
-      { keys: [enter], desc: 'Finish' },
-      { keys: ['Esc'], desc: 'Cancel' },
-    ],
-  },
-];
-
-const reviewShortcuts: ShortcutSection[] = [
-  {
-    title: 'Actions',
-    shortcuts: [
-      { keys: [modKey, enter], desc: 'Approve / Send feedback' },
-      { keys: [altKey, altKey], desc: 'Toggle destination', hint: 'Double-tap to switch between GitHub and Agent in PR review mode' },
-      { keys: [modKey, '⇧', 'C'], desc: 'Toggle comment mode' },
-      { keys: ['Esc'], desc: 'Collapse sidebar' },
-    ],
-  },
-  {
-    title: 'File Navigation',
-    shortcuts: [
-      { keys: ['J'], desc: 'Next file' },
-      { keys: ['K'], desc: 'Previous file' },
-      { keys: ['Home'], desc: 'First file' },
-      { keys: ['End'], desc: 'Last file' },
-    ],
-  },
-  {
-    title: 'Annotations',
-    shortcuts: [
-      { keys: [modKey, enter], desc: 'Submit comment' },
-      { keys: ['Tab'], desc: 'Indent in editor' },
-      { keys: ['Esc'], desc: 'Close toolbar / Cancel' },
-    ],
-  },
-];
-
-/* ─── Exported panel ─── */
-
-export const KeyboardShortcuts: React.FC<{ mode: 'plan' | 'review' }> = ({ mode }) => {
-  const sections = mode === 'review' ? reviewShortcuts : planShortcuts;
+  if (sections.length === 0) {
+    return <div className="text-xs text-muted-foreground">No shortcuts are available in this view.</div>;
+  }
 
   return (
     <div className="space-y-4">
       {sections.map((section) => (
         <Section key={section.title} title={section.title}>
-          {section.shortcuts.map((s, i) => (
-            <ShortcutRow key={i} keys={s.keys} desc={s.desc} hint={s.hint} />
+          {section.shortcuts.map((shortcut) => (
+            <ShortcutRow
+              key={`${shortcut.scopeId}-${shortcut.actionId}`}
+              bindings={shortcut.bindings}
+              desc={shortcut.description}
+              hint={shortcut.hint}
+            />
           ))}
         </Section>
       ))}

--- a/packages/ui/components/Settings.tsx
+++ b/packages/ui/components/Settings.tsx
@@ -53,10 +53,10 @@ import {
 } from '../utils/defaultNotesApp';
 import { useAgents } from '../hooks/useAgents';
 import { KeyboardShortcuts } from './KeyboardShortcuts';
+import { annotationToolbarShortcuts, formatShortcutBindingText, getShortcutPlatform, type ShortcutRegistry } from '../shortcuts';
 import { type QuickLabel, getQuickLabels, saveQuickLabels, resetQuickLabels, DEFAULT_QUICK_LABELS, getLabelColors, LABEL_COLOR_MAP } from '../utils/quickLabels';
 import { hasNewSettings, markNewSettingsSeen } from '../utils/newSettingsHint';
 import { ThemeTab } from './ThemeTab';
-import { isMac, modKey, altKey } from '../utils/platform';
 import { getAIProviderSettings } from '../utils/aiProvider';
 import { AISettingsTab } from './AISettingsTab';
 import {
@@ -72,6 +72,7 @@ interface SettingsProps {
   onTaterModeChange: (enabled: boolean) => void;
   onIdentityChange?: (oldIdentity: string, newIdentity: string) => void;
   origin?: 'claude-code' | 'opencode' | 'pi' | 'codex' | null;
+  shortcutRegistry: ShortcutRegistry;
   /** Mode determines which settings are shown. 'plan' shows all, 'review' shows only identity + agent switching */
   mode?: 'plan' | 'review';
   onUIPreferencesChange?: (prefs: UIPreferences) => void;
@@ -82,7 +83,7 @@ interface SettingsProps {
   aiProviders?: Array<{ id: string; name: string; capabilities: Record<string, boolean> }>;
 }
 
-export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange, onIdentityChange, origin, mode = 'plan', onUIPreferencesChange, externalOpen, onExternalClose, aiProviders = [] }) => {
+export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange, onIdentityChange, origin, shortcutRegistry, mode = 'plan', onUIPreferencesChange, externalOpen, onExternalClose, aiProviders = [] }) => {
   const [showDialog, setShowDialog] = useState(false);
   const [activeTab, setActiveTab] = useState<SettingsTab>('general');
   const [identity, setIdentity] = useState('');
@@ -109,6 +110,8 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
   const [aiProvider, setAiProvider] = useState<string | null>(null);
   const [fileBrowserSettings, setFileBrowserSettings] = useState<FileBrowserSettings>({ enabled: false, directories: [] });
   const [newDirPath, setNewDirPath] = useState('');
+  const shortcutPlatform = getShortcutPlatform();
+
 
   // Fetch available agents for OpenCode
   const { agents: availableAgents, validateAgent, getAgentWarning } = useAgents(origin ?? null);
@@ -794,7 +797,7 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
                       <div>
                         <div className="text-sm font-medium">Default Save Action</div>
                         <div className="text-xs text-muted-foreground">
-                          Used for keyboard shortcut ({modKey}+S)
+                          Used for keyboard shortcut ({formatShortcutBindingText('Mod+S', shortcutPlatform)})
                         </div>
                       </div>
                       <select
@@ -812,8 +815,8 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
                         {defaultNotesApp === 'ask'
                           ? 'Opens Export dialog with Notes tab'
                           : defaultNotesApp === 'download'
-                            ? `${modKey}+S downloads the annotations file`
-                            : `${modKey}+S saves directly to ${{ obsidian: 'Obsidian', bear: 'Bear', octarine: 'Octarine' }[defaultNotesApp] ?? defaultNotesApp}`}
+                            ? `${formatShortcutBindingText('Mod+S', shortcutPlatform)} downloads the annotations file`
+                            : `${formatShortcutBindingText('Mod+S', shortcutPlatform)} saves directly to ${{ obsidian: 'Obsidian', bear: 'Bear', octarine: 'Octarine' }[defaultNotesApp] ?? defaultNotesApp}`}
                       </div>
                     </div>
 
@@ -960,8 +963,8 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
                                   <option key={c} value={c}>{c}</option>
                                 ))}
                               </select>
-                              <span className="text-[10px] text-muted-foreground/50 font-mono w-8 text-center flex-shrink-0">
-                                {index < 10 ? `${altKey}${isMac ? '' : '+'}${index === 9 ? '0' : index + 1}` : ''}
+                              <span className="text-[10px] text-muted-foreground/50 font-mono w-12 text-center flex-shrink-0">
+                                {index < 10 ? formatShortcutBindingText(`Alt+${index === 9 ? '0' : index + 1}`, shortcutPlatform) : ''}
                               </span>
                               <button
                                 onClick={() => {
@@ -1048,15 +1051,13 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
                     )}
 
                     <div className="text-[10px] text-muted-foreground/70">
-                      Use {altKey}{isMac ? '' : '+'}1 through {altKey}{isMac ? '' : '+'}0 when the annotation toolbar is visible to apply a label instantly.
+                      Use {formatShortcutBindingText(annotationToolbarShortcuts.shortcuts.applyQuickLabel.bindings[0], shortcutPlatform)} when the annotation toolbar is visible to apply a label instantly.
                     </div>
                   </>
                 )}
 
                 {/* === SHORTCUTS TAB === */}
-                {activeTab === 'shortcuts' && (
-                  <KeyboardShortcuts mode={mode} />
-                )}
+                {activeTab === 'shortcuts' && <KeyboardShortcuts shortcutRegistry={shortcutRegistry} />}
 
                 {/* === AI TAB === */}
                 {activeTab === 'ai' && (

--- a/packages/ui/components/Viewer.tsx
+++ b/packages/ui/components/Viewer.tsx
@@ -28,6 +28,7 @@ import { CommentPopover } from './CommentPopover';
 import { TaterSpriteSitting } from './TaterSpriteSitting';
 import { AttachmentsButton } from './AttachmentsButton';
 import { GraphvizBlock } from './GraphvizBlock';
+import { useViewerShortcuts } from '../shortcuts';
 import { MermaidBlock } from './MermaidBlock';
 import { getImageSrc } from './ImageThumbnail';
 import { isGraphvizLanguage, isMermaidLanguage } from './diagramLanguages';
@@ -261,31 +262,27 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
     return () => observer.disconnect();
   }, [stickyActions]);
 
-  // Cmd+C / Ctrl+C keyboard shortcut for copying selected text
-  useEffect(() => {
-    const handleKeyDown = async (e: KeyboardEvent) => {
-      // Check for Cmd+C (Mac) or Ctrl+C (Windows/Linux)
-      if ((e.metaKey || e.ctrlKey) && e.key === 'c') {
-        // Don't intercept if typing in an input/textarea
-        const tag = (e.target as HTMLElement)?.tagName;
-        if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+  const selectionText = toolbarState?.selectionText;
 
-        // If we have an active selection with captured text, use that
-        if (toolbarState?.selectionText) {
+  useViewerShortcuts({
+    target: 'document',
+    handlers: {
+      copySelection: {
+        when: (e) => {
+          const tag = (e.target as HTMLElement)?.tagName;
+          return tag !== 'INPUT' && tag !== 'TEXTAREA' && !!selectionText;
+        },
+        handle: async (e) => {
           e.preventDefault();
           try {
-            await navigator.clipboard.writeText(toolbarState.selectionText);
+            await navigator.clipboard.writeText(selectionText!);
           } catch (err) {
             console.error('Failed to copy:', err);
           }
-        }
-        // Otherwise let the browser handle default copy behavior
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [toolbarState]);
+        },
+      },
+    },
+  });
 
   // Imperative handle — delegates to hook, extends removeHighlight for code blocks
   useImperativeHandle(ref, () => ({

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,6 +6,7 @@
     "./components/*": "./components/*.tsx",
     "./utils/*": "./utils/*.ts",
     "./hooks/*": "./hooks/*.ts",
+    "./shortcuts": "./shortcuts/index.ts",
     "./types": "./types.ts",
     "./theme": "./theme.css"
   },

--- a/packages/ui/shortcuts.test.ts
+++ b/packages/ui/shortcuts.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it } from 'bun:test';
+import { annotateSettingsShortcutRegistry, planEditorShortcuts, planReviewSettingsShortcutRegistry } from '../editor/shortcuts';
+import { reviewSettingsShortcutRegistry } from '../review-editor/shortcuts';
+import {
+  createShortcutRegistry,
+  defineShortcutScope,
+  dispatchShortcutEvent,
+  formatShortcutBindingText,
+  formatShortcutBindingTokens,
+  getShortcut,
+  listRegistryShortcutSections,
+  matchesKeyName,
+  matchesShortcutBinding,
+  parseDoubleTapBinding,
+  validateShortcutRegistry,
+} from './shortcuts';
+
+describe('shortcuts', () => {
+  it('formats bindings for docs and keycaps', () => {
+    expect(formatShortcutBindingText('Mod+Enter')).toBe('Cmd/Ctrl+Enter');
+    expect(formatShortcutBindingText('Alt hold')).toBe('Hold Alt');
+    expect(formatShortcutBindingText('Alt Alt')).toBe('Double-tap Alt');
+    expect(formatShortcutBindingText('Alt Alt', 'mac')).toBe('Double-tap Option');
+    expect(formatShortcutBindingTokens('Mod+Enter', 'mac')).toEqual(['⌘', '⏎']);
+    expect(formatShortcutBindingTokens('Mod+Enter', 'non-mac')).toEqual(['Ctrl', '↵']);
+    expect(formatShortcutBindingTokens('Alt Alt', 'mac')).toEqual(['⌥', '×2']);
+    expect(formatShortcutBindingTokens('Alt Alt', 'non-mac')).toEqual(['Alt', '×2']);
+  });
+
+  it('validates duplicate scope ids and non-normalized tokens', () => {
+    const duplicateScope = defineShortcutScope({
+      id: 'dup',
+      title: 'Duplicate',
+      shortcuts: {
+        submit: {
+          description: 'Submit',
+          bindings: ['Mod+Enter'],
+          section: 'Actions',
+        },
+      },
+    });
+
+    const badScope = defineShortcutScope({
+      id: 'bad',
+      title: 'Bad',
+      shortcuts: {
+        broken: {
+          description: 'Broken',
+          bindings: ['Cmd+Enter'],
+          section: 'Actions',
+        },
+        missingCopy: {
+          description: '',
+          bindings: ['Mod+C'],
+          section: '',
+        },
+      },
+    });
+
+    const errors = validateShortcutRegistry([duplicateScope, duplicateScope, badScope]);
+
+    expect(errors).toContain('Duplicate shortcut scope id: dup');
+    expect(errors.some(error => error.includes('Cmd'))).toBe(true);
+    expect(errors).toContain('Shortcut bad.missingCopy is missing a section.');
+    expect(errors).toContain('Shortcut bad.missingCopy is missing a description.');
+    expect(() => createShortcutRegistry([duplicateScope, duplicateScope])).toThrow();
+  });
+
+  it('lists plan review, annotate, and review sections from assembled registries', () => {
+    const planReviewSections = listRegistryShortcutSections(planReviewSettingsShortcutRegistry);
+    const annotateSections = listRegistryShortcutSections(annotateSettingsShortcutRegistry);
+    const reviewSections = listRegistryShortcutSections(reviewSettingsShortcutRegistry);
+
+    expect(planReviewSections.map(section => section.title)).toEqual([
+      'Actions',
+      'Input Method',
+      'Annotations',
+      'Image Annotator',
+    ]);
+
+    expect(annotateSections.map(section => section.title)).toEqual([
+      'Actions',
+      'Input Method',
+      'Annotations',
+      'Image Annotator',
+    ]);
+
+    expect(getShortcut(planReviewSettingsShortcutRegistry, 'plan-review-editor-settings', 'submitPlan')?.description).toBe('Approve / Send feedback');
+    expect(getShortcut(planReviewSettingsShortcutRegistry, 'plan-review-editor-settings', 'submitAnnotations')).toBeUndefined();
+    expect(getShortcut(annotateSettingsShortcutRegistry, 'annotate-editor-settings', 'submitAnnotations')?.description).toBe('Send annotations');
+    expect(getShortcut(annotateSettingsShortcutRegistry, 'annotate-editor-settings', 'submitPlan')).toBeUndefined();
+
+    expect(reviewSections.map(section => section.title)).toEqual([
+      'Actions',
+      'Search',
+      'File Navigation',
+      'Annotations',
+    ]);
+  });
+
+  it('matches normalized runtime bindings', () => {
+    const submitEvent = { key: 'Enter', ctrlKey: true, metaKey: false, shiftKey: false, altKey: false, code: 'Enter' } as KeyboardEvent;
+    const reverseSearchEvent = { key: 'F3', ctrlKey: false, metaKey: false, shiftKey: true, altKey: false, code: 'F3' } as KeyboardEvent;
+    const typeEvent = { key: 'A', ctrlKey: false, metaKey: false, shiftKey: true, altKey: false, code: 'KeyA' } as KeyboardEvent;
+    const quickLabelEvent = { key: '3', ctrlKey: false, metaKey: false, shiftKey: false, altKey: true, code: 'Digit3' } as KeyboardEvent;
+    const macOptionQuickLabelEvent = { key: '£', ctrlKey: false, metaKey: false, shiftKey: false, altKey: true, code: 'Digit3' } as KeyboardEvent;
+    const wrongEvent = { key: 'Enter', ctrlKey: false, metaKey: false, shiftKey: false, altKey: true, code: 'Enter' } as KeyboardEvent;
+
+    expect(matchesShortcutBinding(submitEvent, 'Mod+Enter')).toBe(true);
+    expect(matchesShortcutBinding(reverseSearchEvent, 'Shift+F3')).toBe(true);
+    expect(matchesShortcutBinding(typeEvent, 'A-Z')).toBe(true);
+    expect(matchesShortcutBinding(quickLabelEvent, 'Alt+1-0')).toBe(true);
+    expect(matchesShortcutBinding(macOptionQuickLabelEvent, 'Alt+1-0')).toBe(true);
+    expect(matchesShortcutBinding(wrongEvent, 'Mod+Enter')).toBe(false);
+  });
+
+  it('dispatches matching registry actions', () => {
+    const calls: string[] = [];
+    const event = { key: 'Enter', ctrlKey: true, metaKey: false, shiftKey: false, altKey: false } as KeyboardEvent;
+
+    const handled = dispatchShortcutEvent(planReviewSettingsShortcutRegistry[0], {
+      submitPlan: () => calls.push('submitPlan'),
+      quickSave: () => calls.push('quickSave'),
+    }, event);
+
+    expect(handled).toBe(true);
+    expect(calls).toEqual(['submitPlan']);
+  });
+
+  it('can dispatch annotate submit after plan submit declines the same binding', () => {
+    const calls: string[] = [];
+    const event = {
+      key: 'Enter',
+      ctrlKey: true,
+      metaKey: false,
+      shiftKey: false,
+      altKey: false,
+      preventDefault: () => calls.push('preventDefault'),
+    } as unknown as KeyboardEvent;
+
+    const handled = dispatchShortcutEvent(planEditorShortcuts, {
+      submitPlan: {
+        when: () => false,
+        handle: () => calls.push('submitPlan'),
+      },
+      submitAnnotations: {
+        when: () => true,
+        handle: () => {
+          event.preventDefault();
+          calls.push('submitAnnotations');
+        },
+      },
+    }, event);
+
+    expect(handled).toBe(true);
+    expect(calls).toEqual(['preventDefault', 'submitAnnotations']);
+  });
+
+  it('supports guarded handlers and continues after a failed guard', () => {
+    const guardedScope = defineShortcutScope({
+      id: 'guarded',
+      title: 'Guarded',
+      shortcuts: {
+        primary: {
+          description: 'Primary',
+          bindings: ['Enter'],
+          section: 'Actions',
+          preventDefault: true,
+        },
+        fallback: {
+          description: 'Fallback',
+          bindings: ['Enter'],
+          section: 'Actions',
+          preventDefault: true,
+        },
+      },
+    });
+
+    const calls: string[] = [];
+    const event = {
+      key: 'Enter',
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      altKey: false,
+      preventDefault: () => calls.push('preventDefault'),
+    } as unknown as KeyboardEvent;
+
+    const handled = dispatchShortcutEvent(guardedScope, {
+      primary: {
+        when: () => false,
+        handle: () => calls.push('primary'),
+      },
+      fallback: {
+        when: () => true,
+        handle: () => calls.push('fallback'),
+      },
+    }, event);
+
+    expect(handled).toBe(true);
+    expect(calls).toEqual(['preventDefault', 'fallback']);
+  });
+
+  it('parses double-tap bindings', () => {
+    expect(parseDoubleTapBinding('Alt Alt')).toBe('Alt');
+    expect(parseDoubleTapBinding('Shift Shift')).toBe('Shift');
+    expect(parseDoubleTapBinding('Alt hold')).toBeNull();
+    expect(parseDoubleTapBinding('Mod+Enter')).toBeNull();
+    expect(parseDoubleTapBinding('Alt Shift')).toBeNull(); // different keys
+    expect(parseDoubleTapBinding('Alt+Shift Alt+Shift')).toBeNull(); // multi-key groups
+  });
+
+  it('matches key names for sequential binding support', () => {
+    const altEvent = { key: 'Alt' } as KeyboardEvent;
+    const shiftEvent = { key: 'Shift' } as KeyboardEvent;
+    const metaEvent = { key: 'Meta' } as KeyboardEvent;
+    const ctrlEvent = { key: 'Control' } as KeyboardEvent;
+
+    expect(matchesKeyName(altEvent, 'Alt')).toBe(true);
+    expect(matchesKeyName(altEvent, 'Shift')).toBe(false);
+    expect(matchesKeyName(shiftEvent, 'Shift')).toBe(true);
+    expect(matchesKeyName(metaEvent, 'Mod')).toBe(true);
+    expect(matchesKeyName(ctrlEvent, 'Mod')).toBe(true);
+  });
+
+  it('does not handle or prevent default when a guard fails', () => {
+    const guardedScope = defineShortcutScope({
+      id: 'guarded-skip',
+      title: 'Guarded Skip',
+      shortcuts: {
+        save: {
+          description: 'Save',
+          bindings: ['Mod+S'],
+          section: 'Actions',
+          preventDefault: true,
+        },
+      },
+    });
+
+    let preventDefaultCalls = 0;
+    const event = {
+      key: 's',
+      ctrlKey: true,
+      metaKey: false,
+      shiftKey: false,
+      altKey: false,
+      preventDefault: () => {
+        preventDefaultCalls += 1;
+      },
+    } as unknown as KeyboardEvent;
+
+    const handled = dispatchShortcutEvent(guardedScope, {
+      save: {
+        when: () => false,
+        handle: () => {
+          throw new Error('should not run');
+        },
+      },
+    }, event);
+
+    expect(handled).toBe(false);
+    expect(preventDefaultCalls).toBe(0);
+  });
+});

--- a/packages/ui/shortcuts/annotationToolbar.shortcuts.ts
+++ b/packages/ui/shortcuts/annotationToolbar.shortcuts.ts
@@ -1,0 +1,39 @@
+import { defineShortcutScope } from './core';
+import { createShortcutScopeHook } from './runtime';
+
+export const annotationToolbarShortcuts = defineShortcutScope({
+  id: 'annotation-toolbar',
+  title: 'Annotation Toolbar',
+  shortcuts: {
+    typeToComment: {
+      description: 'Start comment',
+      bindings: ['A-Z'],
+      section: 'Annotations',
+      hint: 'Typing a letter opens the comment editor with that character.',
+      displayOrder: 10,
+    },
+    applyQuickLabel: {
+      description: 'Apply toolbar label',
+      bindings: ['Alt+1-0'],
+      section: 'Annotations',
+      hint: 'Applies the matching preset label while the annotation toolbar is open.',
+      displayOrder: 20,
+    },
+    applyQuickLabelFromPicker: {
+      description: 'Apply picker label',
+      bindings: ['1-0'],
+      section: 'Annotations',
+      hint: 'Available while the quick label picker is open.',
+      displayOrder: 30,
+    },
+    close: {
+      description: 'Close toolbar',
+      bindings: ['Escape'],
+      section: 'Annotations',
+      hint: 'Available while the annotation toolbar is open.',
+      displayOrder: 40,
+    },
+  },
+});
+
+export const useAnnotationToolbarShortcuts = createShortcutScopeHook(annotationToolbarShortcuts);

--- a/packages/ui/shortcuts/commentPopover.shortcuts.ts
+++ b/packages/ui/shortcuts/commentPopover.shortcuts.ts
@@ -1,0 +1,21 @@
+import { defineShortcutScope } from './core';
+
+export const commentPopoverShortcuts = defineShortcutScope({
+  id: 'comment-popover',
+  title: 'Comment Editor',
+  shortcuts: {
+    submit: {
+      description: 'Submit comment',
+      bindings: ['Mod+Enter'],
+      section: 'Annotations',
+      displayOrder: 30,
+    },
+    cancel: {
+      description: 'Close comment',
+      bindings: ['Escape'],
+      section: 'Annotations',
+      hint: 'Available while the comment editor is open.',
+      displayOrder: 40,
+    },
+  },
+});

--- a/packages/ui/shortcuts/core.ts
+++ b/packages/ui/shortcuts/core.ts
@@ -1,0 +1,386 @@
+export type ShortcutPlatform = 'mac' | 'non-mac' | 'cross-platform';
+
+export interface ShortcutDefinition {
+  description: string;
+  /** Alternative bindings for the same action, shown as “or” in the shortcuts UI. */
+  bindings: string[];
+  section: string;
+  hint?: string;
+  preventDefault?: boolean;
+  /** Stable help-menu ordering within a section, without relying on object key order. */
+  displayOrder?: number;
+}
+
+export interface ShortcutScopeDefinition<TAction extends string = string> {
+  id: string;
+  title: string;
+  shortcuts: Record<TAction, ShortcutDefinition>;
+}
+
+export interface ShortcutEntry extends ShortcutDefinition {
+  scopeId: string;
+  scopeTitle: string;
+  actionId: string;
+}
+
+export interface ShortcutSection {
+  title: string;
+  shortcuts: ShortcutEntry[];
+}
+
+export type ShortcutRegistry = readonly ShortcutScopeDefinition[];
+
+export interface ShortcutSurface {
+  slug: string;
+  title: string;
+  description: string;
+  registry: ShortcutRegistry;
+}
+
+const NAMED_TOKENS = new Set([
+  'Mod',
+  'Shift',
+  'Alt',
+  'Enter',
+  'Escape',
+  'Tab',
+  'Space',
+  'Backspace',
+  'Delete',
+  'ArrowUp',
+  'ArrowDown',
+  'ArrowLeft',
+  'ArrowRight',
+  'Home',
+  'End',
+  'A-Z',
+  '1-0',
+  'hold',
+]);
+
+for (let n = 1; n <= 12; n += 1) {
+  NAMED_TOKENS.add(`F${n}`);
+}
+
+const MODIFIER_TOKENS = new Set(['Mod', 'Shift', 'Alt']);
+
+export function defineShortcutScope<TAction extends string>(scope: ShortcutScopeDefinition<TAction>): ShortcutScopeDefinition<TAction> {
+  return scope;
+}
+
+function isSingleLetter(token: string): boolean {
+  return /^[A-Z]$/.test(token);
+}
+
+function isSingleDigit(token: string): boolean {
+  return /^[0-9]$/.test(token);
+}
+
+function getBindingTokens(binding: string): string[] {
+  return binding.trim().split(/[+\s]+/).filter(Boolean);
+}
+
+function getBindingGroups(binding: string): string[][] {
+  return binding.trim().split(/\s+/).filter(Boolean).map(group => group.split('+').filter(Boolean));
+}
+
+/**
+ * Parse a double-tap binding like `"Alt Alt"` and return the key name.
+ * Returns null for non-double-tap bindings.
+ */
+export function parseDoubleTapBinding(binding: string): string | null {
+  const groups = getBindingGroups(binding);
+  if (groups.length !== 2) return null;
+  if (groups[0].length !== 1 || groups[1].length !== 1) return null;
+  if (groups[0][0] !== groups[1][0]) return null;
+  if (groups[1][0] === 'hold') return null;
+  return groups[0][0];
+}
+
+/**
+ * Check if a KeyboardEvent matches a named key token (for sequential/stateful matching).
+ * Unlike `matchesShortcutBinding`, this matches a single key identity without modifier checks.
+ */
+export function matchesKeyName(event: KeyboardEvent, keyName: string): boolean {
+  if (keyName === 'Alt') return event.key === 'Alt';
+  if (keyName === 'Shift') return event.key === 'Shift';
+  if (keyName === 'Mod') return event.key === 'Meta' || event.key === 'Control';
+  return matchesKeyToken(event, keyName);
+}
+
+function isNormalizedToken(token: string): boolean {
+  return NAMED_TOKENS.has(token) || isSingleLetter(token) || isSingleDigit(token);
+}
+
+function normalizeShortcutEntry(
+  scope: ShortcutScopeDefinition,
+  actionId: string,
+  shortcut: ShortcutDefinition,
+): ShortcutEntry {
+  return {
+    ...shortcut,
+    scopeId: scope.id,
+    scopeTitle: scope.title,
+    actionId,
+  };
+}
+
+export function listScopeShortcuts(
+  scope: ShortcutScopeDefinition,
+  options?: { actionIds?: readonly string[] },
+): ShortcutEntry[] {
+  const allowedActionIds = options?.actionIds ? new Set(options.actionIds) : null;
+  const shortcuts: ShortcutEntry[] = [];
+
+  for (const [actionId, shortcut] of Object.entries(scope.shortcuts)) {
+    if (allowedActionIds && !allowedActionIds.has(actionId)) continue;
+
+    shortcuts.push(normalizeShortcutEntry(scope, actionId, shortcut));
+  }
+
+  return shortcuts;
+}
+
+export function validateShortcutRegistry(registry: ShortcutRegistry): string[] {
+  const errors: string[] = [];
+  const scopeIds = new Set<string>();
+
+  for (const scope of registry) {
+    if (scopeIds.has(scope.id)) {
+      errors.push(`Duplicate shortcut scope id: ${scope.id}`);
+    }
+    scopeIds.add(scope.id);
+
+    for (const [actionId, shortcut] of Object.entries(scope.shortcuts)) {
+      const id = `${scope.id}.${actionId}`;
+
+      if (!shortcut.section.trim()) {
+        errors.push(`Shortcut ${id} is missing a section.`);
+      }
+
+      if (!shortcut.description.trim()) {
+        errors.push(`Shortcut ${id} is missing a description.`);
+      }
+
+      if (shortcut.bindings.length === 0) {
+        errors.push(`Shortcut ${id} must define at least one binding.`);
+      }
+
+      for (const binding of shortcut.bindings) {
+        if (!binding.trim()) {
+          errors.push(`Shortcut ${id} contains an empty binding.`);
+          continue;
+        }
+
+        for (const token of getBindingTokens(binding)) {
+          if (!isNormalizedToken(token)) {
+            errors.push(`Shortcut ${id} uses non-normalized token \`${token}\` in binding \`${binding}\`.`);
+          }
+        }
+      }
+    }
+  }
+
+  return errors;
+}
+
+export function createShortcutRegistry<TRegistry extends ShortcutRegistry>(registry: TRegistry): TRegistry {
+  const errors = validateShortcutRegistry(registry);
+  if (errors.length > 0) {
+    throw new Error(`Invalid shortcut registry:\n- ${errors.join('\n- ')}`);
+  }
+  return registry;
+}
+
+export function mergeShortcutRegistries(...registries: ShortcutRegistry[]): ShortcutRegistry {
+  return createShortcutRegistry(registries.flat());
+}
+
+export function getShortcutScope(registry: ShortcutRegistry, scopeId: string): ShortcutScopeDefinition | undefined {
+  return registry.find(scope => scope.id === scopeId);
+}
+
+export function getShortcut(
+  registry: ShortcutRegistry,
+  scopeId: string,
+  actionId: string,
+): ShortcutEntry | undefined {
+  const scope = getShortcutScope(registry, scopeId);
+  const shortcut = scope?.shortcuts[actionId];
+  return scope && shortcut ? normalizeShortcutEntry(scope, actionId, shortcut) : undefined;
+}
+
+export function listRegistryShortcuts(registry: ShortcutRegistry): ShortcutEntry[] {
+  const shortcuts: ShortcutEntry[] = [];
+
+  for (const scope of registry) {
+    shortcuts.push(...listScopeShortcuts(scope));
+  }
+
+  return shortcuts;
+}
+
+export function listShortcutSections(shortcuts: readonly ShortcutEntry[]): ShortcutSection[] {
+  const sections = new Map<string, ShortcutEntry[]>();
+
+  for (const shortcut of shortcuts) {
+    const existing = sections.get(shortcut.section);
+    if (existing) {
+      existing.push(shortcut);
+    } else {
+      sections.set(shortcut.section, [shortcut]);
+    }
+  }
+
+  return Array.from(sections.entries()).map(([title, sectionShortcuts]) => ({
+    title,
+    shortcuts: [...sectionShortcuts].sort((a, b) => (a.displayOrder ?? 0) - (b.displayOrder ?? 0) || a.description.localeCompare(b.description)),
+  }));
+}
+
+export function listRegistryShortcutSections(registry: ShortcutRegistry): ShortcutSection[] {
+  return listShortcutSections(listRegistryShortcuts(registry));
+}
+
+export function getShortcutPlatform(): Exclude<ShortcutPlatform, 'cross-platform'> {
+  if (typeof navigator === 'undefined') return 'non-mac';
+  return /Mac|iPhone|iPad/.test(navigator.platform) ? 'mac' : 'non-mac';
+}
+
+function formatKeycapToken(token: string, platform: Exclude<ShortcutPlatform, 'cross-platform'>): string {
+  if (platform === 'mac') {
+    if (token === 'Mod') return '⌘';
+    if (token === 'Alt') return '⌥';
+    if (token === 'Shift') return '⇧';
+    if (token === 'Enter') return '⏎';
+    if (token === 'Escape') return 'Esc';
+  }
+
+  if (platform === 'non-mac') {
+    if (token === 'Mod') return 'Ctrl';
+    if (token === 'Enter') return '↵';
+    if (token === 'Escape') return 'Esc';
+  }
+
+  return token;
+}
+
+function formatTextToken(token: string, platform: ShortcutPlatform): string {
+  if (token === 'Mod') {
+    if (platform === 'mac') return 'Cmd';
+    if (platform === 'non-mac') return 'Ctrl';
+    return 'Cmd/Ctrl';
+  }
+
+  if (token === 'Alt') {
+    return platform === 'mac' ? 'Option' : 'Alt';
+  }
+
+  if (token === 'Escape') return 'Escape';
+  if (token === 'hold') return 'hold';
+  return token;
+}
+
+export function formatShortcutBindingTokens(
+  binding: string,
+  platform: Exclude<ShortcutPlatform, 'cross-platform'> = getShortcutPlatform(),
+): string[] {
+  const doubleTapKey = parseDoubleTapBinding(binding);
+  if (doubleTapKey) {
+    return [formatKeycapToken(doubleTapKey, platform), '×2'];
+  }
+
+  return getBindingTokens(binding).map(token => formatKeycapToken(token, platform));
+}
+
+export function formatShortcutBindingText(
+  binding: string,
+  platform: ShortcutPlatform = 'cross-platform',
+): string {
+  const groups = getBindingGroups(binding);
+
+  if (groups.length === 2 && groups[1].length === 1 && groups[1][0] === 'hold' && groups[0].length === 1) {
+    return `Hold ${formatTextToken(groups[0][0], platform)}`;
+  }
+
+  const doubleTapKey = parseDoubleTapBinding(binding);
+  if (doubleTapKey) {
+    return `Double-tap ${formatTextToken(doubleTapKey, platform)}`;
+  }
+
+  return groups
+    .map(group => group.map(token => formatTextToken(token, platform)).join('+'))
+    .join(' then ');
+}
+
+export function formatShortcutBindingsText(
+  bindings: string[],
+  platform: ShortcutPlatform = 'cross-platform',
+): string {
+  return bindings.map(binding => formatShortcutBindingText(binding, platform)).join(' or ');
+}
+
+function getDigitCode(event: KeyboardEvent): string | null {
+  const code = typeof event.code === 'string' ? event.code : '';
+  const match = code.match(/^Digit([0-9])$/);
+  return match ? match[1] : null;
+}
+
+export function getShortcutDigit(event: KeyboardEvent): number | null {
+  const parsed = Number.parseInt(event.key, 10);
+  if (!Number.isNaN(parsed)) return parsed;
+
+  const digitCode = getDigitCode(event);
+  return digitCode === null ? null : Number.parseInt(digitCode, 10);
+}
+
+function matchesKeyToken(event: KeyboardEvent, token: string): boolean {
+  const key = event.key.length === 1 ? event.key.toUpperCase() : event.key;
+  const shortcutDigit = getShortcutDigit(event);
+
+  if (token === 'A-Z') {
+    return /^[A-Z]$/.test(key);
+  }
+
+  if (token === '1-0') {
+    return /^[0-9]$/.test(key) || shortcutDigit !== null;
+  }
+
+  if (isSingleLetter(token)) {
+    return key === token;
+  }
+
+  if (isSingleDigit(token)) {
+    return key === token || String(shortcutDigit ?? '') === token;
+  }
+
+  return key === token;
+}
+
+export function matchesShortcutBinding(event: KeyboardEvent, binding: string): boolean {
+  if (binding.includes(' ') || binding.includes('hold')) {
+    return false;
+  }
+
+  const tokens = binding.split('+').filter(Boolean);
+  if (tokens.length === 0) return false;
+
+  const requiresMod = tokens.includes('Mod');
+  const requiresShift = tokens.includes('Shift');
+  const requiresAlt = tokens.includes('Alt');
+  const keyTokens = tokens.filter(token => !MODIFIER_TOKENS.has(token));
+  if (keyTokens.length !== 1) return false;
+
+  const keyToken = keyTokens[0];
+  const shiftMatches = requiresShift === event.shiftKey || (!requiresShift && keyToken === 'A-Z' && event.shiftKey);
+
+  if (requiresMod !== (event.metaKey || event.ctrlKey)) return false;
+  if (!shiftMatches) return false;
+  if (requiresAlt !== event.altKey) return false;
+
+  return matchesKeyToken(event, keyToken);
+}
+
+export function getMatchingShortcutBindingIndex(event: KeyboardEvent, bindings: string[]): number {
+  return bindings.findIndex(binding => matchesShortcutBinding(event, binding));
+}

--- a/packages/ui/shortcuts/imageAnnotator.shortcuts.ts
+++ b/packages/ui/shortcuts/imageAnnotator.shortcuts.ts
@@ -1,0 +1,42 @@
+import { defineShortcutScope } from './core';
+import { createShortcutScopeHook } from './runtime';
+
+export const imageAnnotatorShortcuts = defineShortcutScope({
+  id: 'image-annotator',
+  title: 'Image Annotator',
+  shortcuts: {
+    penTool: {
+      description: 'Pen tool',
+      bindings: ['1'],
+      section: 'Image Annotator',
+      displayOrder: 10,
+    },
+    arrowTool: {
+      description: 'Arrow tool',
+      bindings: ['2'],
+      section: 'Image Annotator',
+      displayOrder: 20,
+    },
+    circleTool: {
+      description: 'Circle tool',
+      bindings: ['3'],
+      section: 'Image Annotator',
+      displayOrder: 30,
+    },
+    undo: {
+      description: 'Undo',
+      bindings: ['Mod+Z'],
+      section: 'Image Annotator',
+      displayOrder: 40,
+    },
+    save: {
+      description: 'Save and close annotator',
+      bindings: ['Enter', 'Escape'],
+      section: 'Image Annotator',
+      hint: 'Escape blurs the image name field first when it is focused.',
+      displayOrder: 50,
+    },
+  },
+});
+
+export const useImageAnnotatorShortcuts = createShortcutScopeHook(imageAnnotatorShortcuts);

--- a/packages/ui/shortcuts/index.ts
+++ b/packages/ui/shortcuts/index.ts
@@ -1,0 +1,7 @@
+export * from './core';
+export * from './runtime';
+export { annotationToolbarShortcuts, useAnnotationToolbarShortcuts } from './annotationToolbar.shortcuts';
+export { commentPopoverShortcuts } from './commentPopover.shortcuts';
+export { imageAnnotatorShortcuts, useImageAnnotatorShortcuts } from './imageAnnotator.shortcuts';
+export { inputMethodShortcuts } from './inputMethod.shortcuts';
+export { viewerShortcuts, useViewerShortcuts } from './viewer.shortcuts';

--- a/packages/ui/shortcuts/inputMethod.shortcuts.ts
+++ b/packages/ui/shortcuts/inputMethod.shortcuts.ts
@@ -1,0 +1,22 @@
+import { defineShortcutScope } from './core';
+
+export const inputMethodShortcuts = defineShortcutScope({
+  id: 'input-method',
+  title: 'Input Method',
+  shortcuts: {
+    temporarySwitch: {
+      description: 'Temporarily switch input method',
+      bindings: ['Alt hold'],
+      section: 'Input Method',
+      hint: 'Hold Alt to switch between Select and Pinpoint, then release to revert.',
+      displayOrder: 10,
+    },
+    toggleSwitch: {
+      description: 'Toggle input method',
+      bindings: ['Alt Alt'],
+      section: 'Input Method',
+      hint: 'Double-tap Alt to switch between Select and Pinpoint until you toggle again.',
+      displayOrder: 20,
+    },
+  },
+});

--- a/packages/ui/shortcuts/runtime.ts
+++ b/packages/ui/shortcuts/runtime.ts
@@ -1,0 +1,193 @@
+import { useEffect, useRef } from 'react';
+import type { ShortcutDefinition, ShortcutScopeDefinition } from './core';
+import { matchesKeyName, matchesShortcutBinding, parseDoubleTapBinding } from './core';
+
+type ShortcutActionId<TScope extends ShortcutScopeDefinition<any>> = keyof TScope['shortcuts'] & string;
+
+export interface ShortcutHandlerConfig {
+  when?: (event: KeyboardEvent) => boolean;
+  handle: (event: KeyboardEvent) => void;
+}
+
+export type ShortcutHandler = ((event: KeyboardEvent) => void) | ShortcutHandlerConfig;
+
+export type ShortcutHandlers<TScope extends ShortcutScopeDefinition<any>> = Partial<
+  Record<ShortcutActionId<TScope>, ShortcutHandler>
+>;
+
+type ShortcutEventTarget = 'window' | 'document' | EventTarget | null;
+
+export interface UseShortcutScopeOptions<TScope extends ShortcutScopeDefinition<any>> {
+  scope: TScope;
+  handlers: ShortcutHandlers<TScope>;
+  target?: ShortcutEventTarget;
+  stopOnMatch?: boolean;
+  listenerOptions?: boolean | AddEventListenerOptions;
+}
+
+function normalizeShortcutHandler(handler: ShortcutHandler): ShortcutHandlerConfig {
+  if (typeof handler === 'function') {
+    return { handle: handler };
+  }
+
+  return handler;
+}
+
+export function dispatchShortcutEvent<TScope extends ShortcutScopeDefinition<any>>(
+  scope: TScope,
+  handlers: ShortcutHandlers<TScope>,
+  event: KeyboardEvent,
+  options?: { stopOnMatch?: boolean },
+): boolean {
+  const stopOnMatch = options?.stopOnMatch ?? true;
+  let handled = false;
+
+  for (const [actionId, shortcut] of Object.entries(scope.shortcuts) as Array<[
+    ShortcutActionId<TScope>,
+    ShortcutDefinition,
+  ]>) {
+    const handler = handlers[actionId];
+    if (!handler) continue;
+    if (!shortcut.bindings.some(binding => matchesShortcutBinding(event, binding))) continue;
+
+    const { when, handle } = normalizeShortcutHandler(handler);
+    if (when && !when(event)) continue;
+
+    if (shortcut.preventDefault) {
+      event.preventDefault();
+    }
+
+    handle(event);
+    handled = true;
+
+    if (stopOnMatch) {
+      return true;
+    }
+  }
+
+  return handled;
+}
+
+function getEventTarget(target: ShortcutEventTarget): EventTarget | null {
+  if (target === 'window') {
+    return typeof window === 'undefined' ? null : window;
+  }
+  if (target === 'document') {
+    return typeof document === 'undefined' ? null : document;
+  }
+  return target;
+}
+
+export function useShortcutScope<TScope extends ShortcutScopeDefinition<any>>({
+  scope,
+  handlers,
+  target = 'window',
+  stopOnMatch = true,
+  listenerOptions,
+}: UseShortcutScopeOptions<TScope>) {
+  const handlersRef = useRef(handlers);
+
+  useEffect(() => {
+    handlersRef.current = handlers;
+  }, [handlers]);
+
+  useEffect(() => {
+    const eventTarget = getEventTarget(target);
+    if (!eventTarget || !('addEventListener' in eventTarget)) return;
+
+    const handleKeyDown = (event: Event) => {
+      dispatchShortcutEvent(scope, handlersRef.current, event as KeyboardEvent, { stopOnMatch });
+    };
+
+    eventTarget.addEventListener('keydown', handleKeyDown as EventListener, listenerOptions);
+    return () => {
+      eventTarget.removeEventListener('keydown', handleKeyDown as EventListener, listenerOptions);
+    };
+  }, [listenerOptions, scope, stopOnMatch, target]);
+}
+
+export function createShortcutScopeHook<TScope extends ShortcutScopeDefinition<any>>(scope: TScope) {
+  return function useScopedShortcutScope(options: Omit<UseShortcutScopeOptions<TScope>, 'scope'>) {
+    useShortcutScope({ scope, ...options });
+  };
+}
+
+// --- Double-tap shortcut support ---
+
+export type DoubleTapHandlers<TScope extends ShortcutScopeDefinition<any>> = Partial<
+  Record<ShortcutActionId<TScope>, ShortcutHandler>
+>;
+
+export interface UseDoubleTapShortcutsOptions<TScope extends ShortcutScopeDefinition<any>> {
+  scope: TScope;
+  handlers: DoubleTapHandlers<TScope>;
+  /** Max gap between two key releases to count as a double-tap (default: 300ms). */
+  window?: number;
+}
+
+/**
+ * Hook for handling double-tap shortcuts (bindings like `"Alt Alt"`).
+ *
+ * Double-tap is detected on keyup: if the same key is released twice
+ * within `window` ms, the handler fires. Regular (keydown) bindings
+ * in the same scope are ignored — use `useShortcutScope` for those.
+ */
+export function useDoubleTapShortcuts<TScope extends ShortcutScopeDefinition<any>>({
+  scope,
+  handlers,
+  window: tapWindow = 300,
+}: UseDoubleTapShortcutsOptions<TScope>) {
+  const handlersRef = useRef(handlers);
+  useEffect(() => { handlersRef.current = handlers; }, [handlers]);
+
+  useEffect(() => {
+    // Pre-parse which actions have double-tap bindings
+    const doubleTapActions: Array<{ actionId: ShortcutActionId<TScope>; keyName: string }> = [];
+    for (const [actionId, shortcut] of Object.entries(scope.shortcuts) as Array<[
+      ShortcutActionId<TScope>,
+      ShortcutDefinition,
+    ]>) {
+      for (const binding of shortcut.bindings) {
+        const keyName = parseDoubleTapBinding(binding);
+        if (keyName) {
+          doubleTapActions.push({ actionId, keyName });
+        }
+      }
+    }
+
+    if (doubleTapActions.length === 0) return;
+
+    // Track last keyup timestamp per key
+    const lastKeyUp = new Map<string, number>();
+
+    const handleKeyUp = (event: KeyboardEvent) => {
+      for (const { actionId, keyName } of doubleTapActions) {
+        if (!matchesKeyName(event, keyName)) continue;
+
+        const handler = handlersRef.current[actionId];
+        if (!handler) continue;
+
+        const { when, handle } = normalizeShortcutHandler(handler);
+        if (when && !when(event)) continue;
+
+        const now = Date.now();
+        const prev = lastKeyUp.get(keyName) ?? 0;
+        if (now - prev < tapWindow) {
+          handle(event);
+          lastKeyUp.set(keyName, 0); // reset so triple-tap doesn't re-fire
+        } else {
+          lastKeyUp.set(keyName, now);
+        }
+      }
+    };
+
+    window.addEventListener('keyup', handleKeyUp);
+    return () => window.removeEventListener('keyup', handleKeyUp);
+  }, [scope, tapWindow]);
+}
+
+export function createDoubleTapShortcutsHook<TScope extends ShortcutScopeDefinition<any>>(scope: TScope) {
+  return function useScopedDoubleTap(options: Omit<UseDoubleTapShortcutsOptions<TScope>, 'scope'>) {
+    useDoubleTapShortcuts({ scope, ...options });
+  };
+}

--- a/packages/ui/shortcuts/viewer.shortcuts.ts
+++ b/packages/ui/shortcuts/viewer.shortcuts.ts
@@ -1,0 +1,17 @@
+import { defineShortcutScope } from './core';
+import { createShortcutScopeHook } from './runtime';
+
+export const viewerShortcuts = defineShortcutScope({
+  id: 'viewer',
+  title: 'Viewer',
+  shortcuts: {
+    copySelection: {
+      description: 'Copy selected text',
+      bindings: ['Mod+C'],
+      section: 'Annotations',
+      displayOrder: 25,
+    },
+  },
+});
+
+export const useViewerShortcuts = createShortcutScopeHook(viewerShortcuts);


### PR DESCRIPTION
## Background

I wanted to add a shortcut, and when I started to look into the code, I felt an enormous itch to not add another shortcut until there was a more sustainable solution. So, I spent a few good hours on it over the weekend to try to design a usable system.

I am more than happy to iterate on this, if this is something you are interested in :)

Sorry for the amount of code in this PR, but I wanted to make a proper solution ^^

## Summary

- Introduces a centralized keyboard shortcut registry (packages/ui/shortcuts/) with typed scope definitions, a binding parser, and runtime dispatcher — replacing scattered ad-hoc keydown handlers across the codebase
- Migrates plan editor, review editor, and shared UI components to use registry-based shortcuts
- KeyboardShortcuts.tsx help modal now renders dynamically from the registry instead of hardcoded lists
- Each app (editor, review-editor) defines its own shortcut scopes and composes them into a surface-level registry
- Marketing site gets an Astro component that auto-generates shortcut reference docs from the registry