### PR TITLE
feat: resizable split pane for diff viewer

### DIFF
--- a/.agents/skills/pierre-guard/SKILL.md
+++ b/.agents/skills/pierre-guard/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: pierre-guard
+description: Guard against breaking the @pierre/diffs integration in Plannotator's code review UI. Use this skill whenever modifying DiffViewer.tsx, upgrading the @pierre/diffs package, changing unsafeCSS injection, adding new props to FileDiff, or touching shadow DOM selectors or CSS variables that cross into Pierre's shadow boundary. Also trigger when someone asks "will this break the diff viewer", "is this safe to change", or when reviewing PRs that touch the review-editor package.
+---
+
+# Pierre Integration Guard
+
+Plannotator's code review UI wraps `@pierre/diffs` — an open-source diff renderer that uses Shadow DOM. The integration is concentrated in a single file but relies on undocumented internals (shadow DOM selectors, CSS variable names, grid layout assumptions). This skill helps verify changes don't break that contract.
+
+## Source of Truth
+
+- **Upstream repo**: https://github.com/pierrecomputer/pierre/tree/main/packages/diffs
+- **Local types**: `node_modules/@pierre/diffs/dist/` (`.d.ts` files)
+- **Integration point**: `packages/review-editor/components/DiffViewer.tsx`
+- **Current version**: check `packages/review-editor/package.json` for the pinned version
+
+Always verify against the upstream repo or local `.d.ts` files — don't rely on memory of the API shape.
+
+## What We Import
+
+```typescript
+import { FileDiff } from '@pierre/diffs/react';
+import { getSingularPatch, processFile } from '@pierre/diffs';
+```
+
+These are the only three imports. `DiffViewer.tsx` is the only file that touches Pierre.
+
+## API Surface to Guard
+
+### 1. Component Props (`FileDiff`)
+
+Read the current prop types from `node_modules/@pierre/diffs/dist/react/index.d.ts` or the upstream source. The props we use:
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `fileDiff` | `FileDiffMetadata` | From `getSingularPatch()` or `processFile()` |
+| `options` | `FileDiffOptions<T>` | See options table below |
+| `lineAnnotations` | `DiffLineAnnotation<T>[]` | `{ side, lineNumber, metadata }` |
+| `selectedLines` | `SelectedLineRange \| null` | `{ start, end, side }` |
+| `renderAnnotation` | `(ann) => ReactNode` | Custom inline annotation renderer |
+| `renderHoverUtility` | `(getHoveredLine) => ReactNode` | The `+` button on hover (deprecated upstream — watch for removal) |
+
+### 2. Options Object
+
+| Option | Value We Pass | Risk |
+|--------|--------------|------|
+| `themeType` | `'dark' \| 'light'` | Low — standard enum |
+| `unsafeCSS` | CSS string | **High** — targets internal selectors |
+| `diffStyle` | `'split' \| 'unified'` | Low — standard enum |
+| `diffIndicators` | `'bars'` | Low |
+| `hunkSeparators` | `'line-info'` | Low |
+| `enableLineSelection` | `true` | Low |
+| `enableHoverUtility` | `true` | Medium — deprecated prop |
+| `onLineSelectionEnd` | callback | Medium — signature could change |
+
+### 3. Shadow DOM Selectors (via `unsafeCSS`)
+
+These are the selectors we inject CSS rules against. They target `data-*` attributes inside Pierre's shadow DOM. If Pierre renames or removes any of these, our styling breaks silently.
+
+**Currently used:**
+- `:host` — shadow root
+- `[data-diff]` — root diff container
+- `[data-file]` — file wrapper
+- `[data-diffs-header]` — header bar
+- `[data-error-wrapper]` — error display
+- `[data-virtualizer-buffer]` — virtual scroll buffer
+- `[data-file-info]` — file metadata row
+- `[data-column-number]` — line number gutter
+- `[data-diffs-header] [data-title]` — title (we hide it)
+- `[data-diff-type='split']` — split layout mode
+- `[data-overflow='scroll']` / `[data-overflow='wrap']` — overflow mode
+
+### 4. CSS Variables We Override
+
+We override these `--diffs-*` variables to theme Pierre:
+
+- `--diffs-bg`, `--diffs-fg` — base colors
+- `--diffs-dark-bg`, `--diffs-light-bg` — theme-specific backgrounds
+- `--diffs-dark`, `--diffs-light` — theme-specific foregrounds
+
+### 5. CSS Variables We Inject (Custom)
+
+We set these on a wrapper div outside the shadow DOM, relying on CSS custom property inheritance:
+
+- `--split-left`, `--split-right` — control the split pane grid ratio
+
+The `unsafeCSS` grid override references these: `grid-template-columns: var(--split-left, 1fr) var(--split-right, 1fr)`. The `1fr` fallback ensures the layout is safe if the variables aren't set.
+
+### 6. Grid Layout Assumption
+
+Pierre's split view uses CSS Grid with `grid-template-columns: 1fr 1fr`. We override this for the resizable split pane. If Pierre changes its layout engine (e.g., to flexbox or a different grid structure), the override will stop working.
+
+**How to verify:** In the upstream source, search for `grid-template-columns` in the diff component styles.
+
+## Verification Checklist
+
+When reviewing changes that touch the Pierre integration, check:
+
+### Props & Types
+- [ ] Read the current `.d.ts` files to confirm prop names and types haven't changed
+- [ ] Check if `renderHoverUtility` is still supported (it's deprecated — may be removed)
+- [ ] Verify `DiffLineAnnotation` still uses `side: 'deletions' | 'additions'` (not `'old' | 'new'`)
+- [ ] Confirm `SelectedLineRange` shape: `{ start, end, side? }`
+
+### Shadow DOM Selectors
+- [ ] Grep the upstream source for each `data-*` attribute we target in `unsafeCSS`
+- [ ] If upgrading the package version, diff the old and new CSS/HTML output for renamed attributes
+- [ ] Test both `split` and `unified` views — selectors are layout-dependent
+
+### CSS Variables
+- [ ] Grep upstream for `--diffs-bg`, `--diffs-fg`, and other variables we override
+- [ ] Verify the variable names haven't been renamed or removed
+- [ ] Check that `!important` is still needed (Pierre may change specificity)
+
+### Theme Compliance
+- [ ] New UI elements must use theme tokens (`bg-border`, `bg-primary`, etc.), not hardcoded colors like `bg-blue-500`
+- [ ] The existing `ResizeHandle` component in `packages/ui/components/ResizeHandle.tsx` sets the visual convention — match it
+
+### Build & Runtime
+- [ ] Run `bun run dev:review` and verify the diff renders in both split and unified modes
+- [ ] Check the browser console for Pierre warnings (e.g., `parseLineType: Invalid firstChar`)
+- [ ] Test with add-only and delete-only files (Pierre doesn't render split grid for these)
+- [ ] If changing UI code, remember build order: `bun run --cwd apps/review build && bun run build:hook`
+
+## When Upgrading @pierre/diffs
+
+1. Check the upstream changelog / commit history at https://github.com/pierrecomputer/pierre
+2. Diff the `.d.ts` files between old and new versions:
+   ```bash
+   # Before upgrading, snapshot current types
+   cp -r node_modules/@pierre/diffs/dist /tmp/pierre-old
+   # After upgrading
+   diff -r /tmp/pierre-old node_modules/@pierre/diffs/dist
+   ```
+3. Search for renamed/removed data attributes in the new version
+4. Run through the full verification checklist above
+5. Test the resizable split pane — it depends on grid layout internals

--- a/packages/review-editor/components/DiffViewer.tsx
+++ b/packages/review-editor/components/DiffViewer.tsx
@@ -4,6 +4,7 @@ import { getSingularPatch, processFile } from '@pierre/diffs';
 import { CodeAnnotation, CodeAnnotationType, SelectedLineRange, DiffAnnotationMetadata } from '@plannotator/ui/types';
 import { useTheme } from '@plannotator/ui/components/ThemeProvider';
 import { CommentPopover } from '@plannotator/ui/components/CommentPopover';
+import { storage } from '@plannotator/ui/utils/storage';
 import { detectLanguage } from '../utils/detectLanguage';
 import { useAnnotationToolbar } from '../hooks/useAnnotationToolbar';
 import { FileHeader } from './FileHeader';
@@ -91,6 +92,57 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
   const { theme, colorTheme, resolvedMode } = useTheme();
   const containerRef = useRef<HTMLDivElement>(null);
   const [fileCommentAnchor, setFileCommentAnchor] = useState<HTMLElement | null>(null);
+
+  // Resizable split pane — only applies when Pierre renders a two-column grid
+  // (files with both additions and deletions). Add-only or delete-only files
+  // render as a single column even in split mode.
+  const isSplitLayout = useMemo(() => {
+    if (diffStyle !== 'split') return false;
+    let hasAdd = false, hasDel = false;
+    for (const line of patch.split('\n')) {
+      if (line[0] === '+' && !line.startsWith('+++')) hasAdd = true;
+      else if (line[0] === '-' && !line.startsWith('---')) hasDel = true;
+      if (hasAdd && hasDel) return true;
+    }
+    return false;
+  }, [patch, diffStyle]);
+
+  const [splitRatio, setSplitRatio] = useState(() => {
+    const saved = storage.getItem('review-split-ratio');
+    const n = saved ? Number(saved) : NaN;
+    return !Number.isNaN(n) && n >= 0.2 && n <= 0.8 ? n : 0.5;
+  });
+  const splitRatioRef = useRef(splitRatio);
+  splitRatioRef.current = splitRatio;
+  const [isDraggingSplit, setIsDraggingSplit] = useState(false);
+
+  const handleSplitDragStart = useCallback((e: React.PointerEvent) => {
+    e.preventDefault();
+    const container = containerRef.current;
+    if (!container) return;
+    const rect = container.getBoundingClientRect();
+    setIsDraggingSplit(true);
+
+    const onMove = (e: PointerEvent) => {
+      const ratio = (e.clientX - rect.left) / rect.width;
+      setSplitRatio(Math.min(0.8, Math.max(0.2, ratio)));
+    };
+
+    const onUp = () => {
+      setIsDraggingSplit(false);
+      document.removeEventListener('pointermove', onMove);
+      document.removeEventListener('pointerup', onUp);
+      storage.setItem('review-split-ratio', String(splitRatioRef.current));
+    };
+
+    document.addEventListener('pointermove', onMove);
+    document.addEventListener('pointerup', onUp);
+  }, []);
+
+  const resetSplitRatio = useCallback(() => {
+    setSplitRatio(0.5);
+    storage.setItem('review-split-ratio', '0.5');
+  }, []);
 
   const toolbar = useAnnotationToolbar({ patch, filePath, onLineSelection, onAddAnnotation, onEditAnnotation });
 
@@ -295,6 +347,10 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
           [data-file-info] { background-color: ${muted} !important; }
           [data-column-number] { background-color: ${bg} !important; }
           [data-diffs-header] [data-title] { display: none !important; }
+          [data-diff-type='split'][data-overflow='scroll'],
+          [data-diff-type='split'][data-overflow='wrap'] {
+            grid-template-columns: var(--split-left, 1fr) var(--split-right, 1fr) !important;
+          }
         `,
       });
     });
@@ -315,8 +371,24 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
         onFileComment={setFileCommentAnchor}
       />
 
-      <div ref={containerRef} className="flex-1 overflow-auto relative" onMouseMove={toolbar.handleMouseMove}>
-      <div className="p-4">
+      <div ref={containerRef} className={`flex-1 overflow-auto relative ${isDraggingSplit ? 'select-none' : ''}`} onMouseMove={toolbar.handleMouseMove}>
+      {isSplitLayout && (
+        <div
+          className="absolute top-0 bottom-0 z-10 cursor-col-resize group"
+          style={{ left: `${splitRatio * 100}%`, width: 9, marginLeft: -4 }}
+          onPointerDown={handleSplitDragStart}
+          onDoubleClick={resetSplitRatio}
+        >
+          <div className="absolute inset-y-0 left-1/2 w-px bg-border group-hover:bg-primary/50 group-active:bg-primary/70 transition-colors" />
+        </div>
+      )}
+      <div
+        className="p-4"
+        style={isSplitLayout ? {
+          '--split-left': `${splitRatio}fr`,
+          '--split-right': `${1 - splitRatio}fr`,
+        } as React.CSSProperties : undefined}
+      >
         <FileDiff
           key={filePath}
           fileDiff={augmentedDiff}


### PR DESCRIPTION
## Summary
- Adds a draggable divider between left/right panes in split diff view so users can resize each side
- Uses CSS custom properties that inherit into Pierre's shadow DOM — drag updates inline style vars, not `unsafeCSS`, so zero Pierre re-renders during drag
- Ratio clamped to 20-80%, persisted via cookie storage, double-click resets to 50/50
- Handle hidden for add-only/delete-only files (Pierre renders these as single-column even in split mode)
- Adds `pierre-guard` skill (`.agents/skills/`) documenting the full @pierre/diffs API surface we depend on

## Test plan
- [ ] `bun run dev:review` — open split diff view, drag the divider between panes
- [ ] Verify ratio persists after page refresh
- [ ] Double-click divider — should reset to 50/50
- [ ] Switch to unified view — divider should disappear
- [ ] Select an add-only or delete-only file — divider should not appear
- [ ] Verify theme colors on hover/active match expectations (uses `bg-primary` tokens)
- [ ] Check console for regressions (existing `parseLineType` warning is pre-existing)