### PR TITLE
Fix Pi plan tool scoping

### DIFF
--- a/apps/marketing/src/content/blog/plannotator-meets-pi.md
+++ b/apps/marketing/src/content/blog/plannotator-meets-pi.md
@@ -41,21 +41,21 @@ Start plan mode with `pi --plan` or toggle it mid-session with `/plannotator` or
 - **Read-only access** — `read`, `grep`, `find`, `ls` all work normally
 - **Bash is gated** — every command is checked against a safety allowlist before execution. `cat`, `git status`, `ls`, `find`, `rg` pass. `rm`, `git commit`, `npm install`, `sudo` don't. The allowlist is pattern-based, not a simple command list — it catches destructive commands even in pipes or subshells.
 - **Writes restricted to the plan file** — the agent can write to `PLAN.md` (or a custom path via `--plan-file`) but nowhere else. Edits to other files are blocked.
-- **`exit_plan_mode` tool available** — this is how the agent signals the plan is ready for review.
+- **`plannotator_submit_plan` tool available** — this is how the agent signals the plan is ready for review.
 
-The agent explores your codebase using read-only tools, drafts a plan as a markdown checklist in `PLAN.md`, and calls `exit_plan_mode` when ready. The planning prompt instructs the agent to work iteratively — explore, update the plan, ask questions, repeat — rather than dumping a fully-formed plan in one shot.
+The agent explores your codebase using read-only tools, drafts a plan as a markdown checklist in `PLAN.md`, and calls `plannotator_submit_plan` when ready. The planning prompt instructs the agent to work iteratively — explore, update the plan, ask questions, repeat — rather than dumping a fully-formed plan in one shot.
 
 Because the plan lives on disk as a regular file, you can open it in your editor alongside the terminal. Git tracks it. Your team can read it in a PR.
 
 ### Review phase
 
-When the agent calls `exit_plan_mode`, the extension reads `PLAN.md` from disk, starts a local HTTP server, and opens the Plannotator browser UI. You see the rendered plan with all the annotation tools — comments, deletions, replacements, insertions.
+When the agent calls `plannotator_submit_plan`, the extension reads `PLAN.md` from disk, starts a local HTTP server, and opens the Plannotator browser UI. You see the rendered plan with all the annotation tools — comments, deletions, replacements, insertions.
 
 Three outcomes:
 
 - **Approve** — the extension transitions to the executing phase. The agent gets full tool access.
 - **Approve with notes** — same transition, but the annotation feedback is included in the tool response as implementation guidance. The agent sees your notes and incorporates them.
-- **Deny with annotations** — the extension stays in planning. The agent receives your structured feedback and is told to use `edit` (not `write`) to make targeted revisions, then call `exit_plan_mode` again.
+- **Deny with annotations** — the extension stays in planning. The agent receives your structured feedback and is told to use `edit` (not `write`) to make targeted revisions, then call `plannotator_submit_plan` again.
 
 This loop continues until you approve. Each round, the agent refines the plan based on your specific annotations rather than vague instructions.
 
@@ -103,7 +103,7 @@ Plannotator now supports three coding agents — Claude Code, OpenCode, and Pi �
 |---|---|---|---|
 | **Integration type** | PermissionRequest hook | Plugin with tools + events | Extension with tools + events |
 | **Plan mode** | Built into Claude Code | Built into OpenCode | Provided by the extension |
-| **Review trigger** | `ExitPlanMode` hook event | `submit_plan` tool call | `exit_plan_mode` tool call |
+| **Review trigger** | `ExitPlanMode` hook event | `submit_plan` tool call | `plannotator_submit_plan` tool call |
 | **Server runtime** | Bun | Bun | Node.js (via jiti) |
 | **Feedback delivery** | stdout JSON decision | `session.prompt()` API | `sendUserMessage()` API |
 | **Tool gating** | Not needed (Claude Code handles it) | Not needed (OpenCode handles it) | Extension manages tool restrictions |

--- a/apps/pi-extension/README.md
+++ b/apps/pi-extension/README.md
@@ -55,7 +55,7 @@ In plan mode the agent is restricted — destructive commands are blocked, write
 - [ ] Update error messages in the UI
 ```
 
-When the agent calls `exit_plan_mode`, the Plannotator UI opens in your browser. You can:
+When the agent calls `plannotator_submit_plan`, the Plannotator UI opens in your browser. You can:
 
 - **Approve** the plan to begin execution
 - **Deny with annotations** to send structured feedback back to the agent

--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -2,9 +2,9 @@
  * Plannotator Pi Extension — File-based plan mode with visual browser review.
  *
  * Plans are written to PLAN.md on disk (git-trackable, editor-visible).
- * The agent calls exit_plan_mode to request approval; the user reviews
- * the plan in the Plannotator browser UI and can approve, deny with
- * annotations, or request changes.
+ * The agent calls plannotator_submit_plan to request approval; the user
+ * reviews the plan in the Plannotator browser UI and can approve, deny
+ * with annotations, or request changes.
  *
  * Features:
  * - /plannotator command or Ctrl+Alt+P to toggle
@@ -12,7 +12,7 @@
  * - --plan-file flag to customize the plan file path
  * - Bash unrestricted during planning (prompt-guided)
  * - Write restricted to plan file only during planning
- * - exit_plan_mode tool with browser-based visual approval
+ * - plannotator_submit_plan tool with browser-based visual approval
  * - [DONE:n] markers for execution progress tracking
  * - /plannotator-review command for code review
  * - /plannotator-annotate command for markdown annotation
@@ -46,6 +46,12 @@ import {
 	startPlanReviewServer,
 	startReviewServer,
 } from "./server.js";
+import {
+	getToolsForPhase,
+	PLAN_SUBMIT_TOOL,
+	type Phase,
+	stripPlanningOnlyTools,
+} from "./tool-scope.js";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -76,11 +82,6 @@ try {
 } catch {
 	// HTML not built yet — review feature will be unavailable
 }
-
-/** Extra tools to ensure are available during planning (on top of whatever is already active). */
-const PLANNING_EXTRA_TOOLS = ["grep", "find", "ls", "exit_plan_mode"];
-
-type Phase = "idle" | "planning" | "executing";
 
 function isAssistantMessage(m: AgentMessage): m is AssistantMessage {
 	return m.role === "assistant" && Array.isArray(m.content);
@@ -177,28 +178,19 @@ export default function plannotator(pi: ExtensionAPI): void {
 	}
 
 	function persistState(): void {
-		pi.appendEntry("plannotator", { phase, planFilePath });
+		pi.appendEntry("plannotator", { phase, planFilePath, preplanTools });
 	}
 
 	/** Apply tool visibility for the current phase, preserving tools from other extensions. */
 	function applyToolsForPhase(): void {
-		if (phase === "planning") {
-			const base = preplanTools ?? pi.getActiveTools();
-			const toolSet = new Set(base);
-			for (const t of PLANNING_EXTRA_TOOLS) toolSet.add(t);
-			pi.setActiveTools([...toolSet]);
-		} else if (preplanTools) {
-			// Restore pre-plan tool set (removes exit_plan_mode, etc.)
-			pi.setActiveTools(preplanTools);
-			preplanTools = null;
-		}
-		// If no preplanTools (e.g. session restore to executing/idle), leave tools as-is
+		const baseTools = stripPlanningOnlyTools(preplanTools ?? pi.getActiveTools());
+		pi.setActiveTools(getToolsForPhase(baseTools, phase));
 	}
 
 	function enterPlanning(ctx: ExtensionContext): void {
 		phase = "planning";
 		checklistItems = [];
-		preplanTools = pi.getActiveTools();
+		preplanTools = stripPlanningOnlyTools(pi.getActiveTools());
 		applyToolsForPhase();
 		updateStatus(ctx);
 		updateWidget(ctx);
@@ -212,6 +204,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 		phase = "idle";
 		checklistItems = [];
 		applyToolsForPhase();
+		preplanTools = null;
 		updateStatus(ctx);
 		updateWidget(ctx);
 		persistState();
@@ -519,14 +512,14 @@ export default function plannotator(pi: ExtensionAPI): void {
 		handler: async (ctx) => togglePlanMode(ctx),
 	});
 
-	// ── exit_plan_mode Tool ──────────────────────────────────────────────
+	// ── plannotator_submit_plan Tool ────────────────────────────────────
 
 	pi.registerTool({
-		name: "exit_plan_mode",
-		label: "Exit Plan Mode",
+		name: PLAN_SUBMIT_TOOL,
+		label: "Submit Plan",
 		description:
-			"Submit your plan for user review. " +
-			"Call this after drafting or revising your plan file. " +
+			"Submit your Plannotator plan for user review. " +
+			"Call this only while Plannotator planning mode is active, after drafting or revising your plan file. " +
 			"The user will review the plan in a visual browser UI and can approve, deny with feedback, or annotate it. " +
 			"If denied, use the edit tool to make targeted revisions (not write), then call this again.",
 		parameters: Type.Object({
@@ -561,7 +554,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 					content: [
 						{
 							type: "text",
-							text: `Error: ${planFilePath} does not exist. Write your plan using the write tool first, then call exit_plan_mode again.`,
+							text: `Error: ${planFilePath} does not exist. Write your plan using the write tool first, then call ${PLAN_SUBMIT_TOOL} again.`,
 						},
 					],
 					details: { approved: false },
@@ -573,7 +566,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 					content: [
 						{
 							type: "text",
-							text: `Error: ${planFilePath} is empty. Write your plan first, then call exit_plan_mode again.`,
+							text: `Error: ${planFilePath} is empty. Write your plan first, then call ${PLAN_SUBMIT_TOOL} again.`,
 						},
 					],
 					details: { approved: false },
@@ -587,6 +580,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 			if (!ctx.hasUI || !planHtmlContent) {
 				phase = "executing";
 				applyToolsForPhase();
+				preplanTools = null;
 				persistState();
 				return {
 					content: [
@@ -624,6 +618,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 			if (result.approved) {
 				phase = "executing";
 				applyToolsForPhase();
+				preplanTools = null;
 				updateStatus(ctx);
 				updateWidget(ctx);
 				persistState();
@@ -664,7 +659,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 				content: [
 					{
 						type: "text",
-						text: planDenyFeedback(feedbackText, "exit_plan_mode", {
+						text: planDenyFeedback(feedbackText, PLAN_SUBMIT_TOOL, {
 							planFilePath,
 						}),
 					},
@@ -712,7 +707,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 					content: `[PLANNOTATOR - PLANNING PHASE]
 You are in plan mode. You MUST NOT make any changes to the codebase — no edits, no commits, no installs, no destructive commands. The ONLY file you may write to or edit is the plan file: ${planFilePath}.
 
-Available tools: read, bash, grep, find, ls, write (${planFilePath} only), edit (${planFilePath} only), exit_plan_mode
+Available tools: read, bash, grep, find, ls, write (${planFilePath} only), edit (${planFilePath} only), ${PLAN_SUBMIT_TOOL}
 
 Do not run destructive bash commands (rm, git push, npm install, etc.) — focus on reading and exploring the codebase. Web fetching (curl, wget) is fine.
 
@@ -755,20 +750,20 @@ Keep the plan concise enough to scan quickly, but detailed enough to execute eff
 
 ### When to Submit
 
-Your plan is ready when you've addressed all ambiguities and it covers: what to change, which files to modify, what existing code to reuse, and how to verify. Call exit_plan_mode to submit for review.
+Your plan is ready when you've addressed all ambiguities and it covers: what to change, which files to modify, what existing code to reuse, and how to verify. Call ${PLAN_SUBMIT_TOOL} to submit for review.
 
 ### Revising After Feedback
 
 When the user denies a plan with feedback:
 1. Read ${planFilePath} to see the current plan.
 2. Use the edit tool to make targeted changes addressing the feedback — do NOT rewrite the entire file.
-3. Call exit_plan_mode again to resubmit.
+3. Call ${PLAN_SUBMIT_TOOL} again to resubmit.
 
 ### Ending Your Turn
 
 Your turn should only end by either:
 - Asking the user a question to gather more information.
-- Calling exit_plan_mode when the plan is ready for review.
+- Calling ${PLAN_SUBMIT_TOOL} when the plan is ready for review.
 
 Do not end your turn without doing one of these two things.`,
 					display: false,
@@ -867,6 +862,7 @@ Execute each step in order. After completing a step, include [DONE:n] in your re
 			phase = "idle";
 			checklistItems = [];
 			applyToolsForPhase();
+			preplanTools = null;
 			updateStatus(ctx);
 			updateWidget(ctx);
 			persistState();
@@ -893,11 +889,14 @@ Execute each step in order. After completing a step, include [DONE:n] in your re
 				(e: { type: string; customType?: string }) =>
 					e.type === "custom" && e.customType === "plannotator",
 			)
-			.pop() as { data?: { phase: Phase; planFilePath?: string } } | undefined;
+			.pop() as {
+				data?: { phase: Phase; planFilePath?: string; preplanTools?: string[] | null };
+			} | undefined;
 
 		if (stateEntry?.data) {
 			phase = stateEntry.data.phase ?? phase;
 			planFilePath = stateEntry.data.planFilePath ?? planFilePath;
+			preplanTools = stateEntry.data.preplanTools ?? preplanTools;
 		}
 
 		// Rebuild execution state from disk + session messages
@@ -934,10 +933,9 @@ Execute each step in order. After completing a step, include [DONE:n] in your re
 			}
 		}
 
-		// Apply tool restrictions for current phase
-		if (phase === "planning") {
-			applyToolsForPhase();
-		}
+		// Re-apply tool visibility on startup/resume so planning-only tools stay hidden
+		// outside planning and pre-plan tool state is restored after approvals.
+		applyToolsForPhase();
 
 		updateStatus(ctx);
 		updateWidget(ctx);

--- a/apps/pi-extension/tool-scope.test.ts
+++ b/apps/pi-extension/tool-scope.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import {
+	getToolsForPhase,
+	PLAN_SUBMIT_TOOL,
+	stripPlanningOnlyTools,
+} from "./tool-scope";
+
+describe("pi plan tool scoping", () => {
+	test("planning phase adds the submit tool and discovery helpers", () => {
+		expect(getToolsForPhase(["read", "bash", "edit", "write"], "planning")).toEqual([
+			"read",
+			"bash",
+			"edit",
+			"write",
+			"grep",
+			"find",
+			"ls",
+			PLAN_SUBMIT_TOOL,
+		]);
+	});
+
+	test("idle and executing phases strip the planning-only submit tool", () => {
+		const leakedTools = ["read", "bash", "grep", PLAN_SUBMIT_TOOL, "write"];
+
+		expect(getToolsForPhase(leakedTools, "idle")).toEqual([
+			"read",
+			"bash",
+			"grep",
+			"write",
+		]);
+		expect(getToolsForPhase(leakedTools, "executing")).toEqual([
+			"read",
+			"bash",
+			"grep",
+			"write",
+		]);
+	});
+
+	test("stripping planning-only tools preserves unrelated tools", () => {
+		expect(stripPlanningOnlyTools([PLAN_SUBMIT_TOOL, "todo", "question", "read"])).toEqual([
+			"todo",
+			"question",
+			"read",
+		]);
+	});
+});

--- a/apps/pi-extension/tool-scope.ts
+++ b/apps/pi-extension/tool-scope.ts
@@ -1,0 +1,24 @@
+export type Phase = "idle" | "planning" | "executing";
+
+export const PLAN_SUBMIT_TOOL = "plannotator_submit_plan";
+export const PLANNING_DISCOVERY_TOOLS = ["grep", "find", "ls"] as const;
+
+const PLANNING_ONLY_TOOLS = new Set<string>([PLAN_SUBMIT_TOOL]);
+
+export function stripPlanningOnlyTools(tools: readonly string[]): string[] {
+	return tools.filter((tool) => !PLANNING_ONLY_TOOLS.has(tool));
+}
+
+export function getToolsForPhase(
+	baseTools: readonly string[],
+	phase: Phase,
+): string[] {
+	const tools = stripPlanningOnlyTools(baseTools);
+	if (phase !== "planning") {
+		return [...new Set(tools)];
+	}
+
+	return [
+		...new Set([...tools, ...PLANNING_DISCOVERY_TOOLS, PLAN_SUBMIT_TOOL]),
+	];
+}

--- a/packages/shared/feedback-templates.test.ts
+++ b/packages/shared/feedback-templates.test.ts
@@ -9,12 +9,12 @@ describe("feedback-templates", () => {
    */
   test("plan deny is identical across integrations (modulo tool name)", () => {
     const normalize = (s: string) =>
-      s.replace(/ExitPlanMode|submit_plan|exit_plan_mode/g, "TOOL");
+      s.replace(/ExitPlanMode|submit_plan|exit_plan_mode|plannotator_submit_plan/g, "TOOL");
 
     const feedback = "## 1. Remove auth section\n> Not needed anymore.";
     const hook = normalize(planDenyFeedback(feedback, "ExitPlanMode"));
     const opencode = normalize(planDenyFeedback(feedback, "submit_plan"));
-    const pi = normalize(planDenyFeedback(feedback, "exit_plan_mode"));
+    const pi = normalize(planDenyFeedback(feedback, "plannotator_submit_plan"));
 
     expect(hook).toBe(opencode);
     expect(opencode).toBe(pi);
@@ -53,13 +53,13 @@ describe("feedback-templates", () => {
   });
 
   test("plan deny can include a plan file hint for file-based integrations", () => {
-    const result = planDenyFeedback("feedback", "exit_plan_mode", {
+    const result = planDenyFeedback("feedback", "plannotator_submit_plan", {
       planFilePath: "plans/auth.md",
     });
 
     expect(result).toContain("plans/auth.md");
     expect(result).toContain("edit this file");
-    expect(result).toContain("exit_plan_mode");
+    expect(result).toContain("plannotator_submit_plan");
   });
 
 });


### PR DESCRIPTION
## Summary
- rename the Pi plan submission tool to `plannotator_submit_plan`
- hide the plan submission tool outside planning mode by recomputing active tools per phase
- persist and restore the pre-plan tool set so resume/approval paths don't leak planning-only tools
- update Pi-facing docs/tests for the new tool name

## Testing
- `bun test packages/shared/feedback-templates.test.ts apps/pi-extension/tool-scope.test.ts`
- `bun test apps/pi-extension`

Closes #386.
