### PR TITLE
Fix plan tool scoping import

### DIFF
--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -53,7 +53,7 @@ import {
 	PLAN_SUBMIT_TOOL,
 	type Phase,
 	stripPlanningOnlyTools,
-} from "./tool-scope.js";
+} from "./tool-scope.ts";
 
 // ── Types ──────────────────────────────────────────────────────────────
 

--- a/apps/pi-extension/package.json
+++ b/apps/pi-extension/package.json
@@ -21,6 +21,7 @@
   "files": [
     "index.ts",
     "server.ts",
+    "tool-scope.ts",
     "server/",
     "generated/",
     "README.md",


### PR DESCRIPTION
When running `pi update`, I get this error:

```
Failed to load extension "/opt/homebrew/lib/node_modules/@plannotator/pi-extension": Failed to load extension: Cannot find module './tool-scope.js'
Require stack:
- /opt/homebrew/lib/node_modules/@plannotator/pi-extension/index.ts
```

Fixes #391 