### PR TITLE
feat: Sync github Viewed files

### DIFF
--- a/apps/pi-extension/server/pr.ts
+++ b/apps/pi-extension/server/pr.ts
@@ -10,7 +10,9 @@ import {
 	fetchPRContext as fetchPRContextCore,
 	fetchPR as fetchPRCore,
 	fetchPRFileContent as fetchPRFileContentCore,
+	fetchPRViewedFiles as fetchPRViewedFilesCore,
 	getUser as getUserCore,
+	markPRFilesViewed as markPRFilesViewedCore,
 	type PRRef,
 	type PRReviewFileComment,
 	type PRRuntime,
@@ -88,4 +90,17 @@ export function submitPRReview(
 		body,
 		fileComments,
 	);
+}
+
+export function fetchPRViewedFiles(ref: PRRef): Promise<Record<string, boolean>> {
+	return fetchPRViewedFilesCore(prRuntime, ref);
+}
+
+export function markPRFilesViewed(
+	ref: PRRef,
+	prNodeId: string,
+	filePaths: string[],
+	viewed: boolean,
+): Promise<void> {
+	return markPRFilesViewedCore(prRuntime, ref, prNodeId, filePaths, viewed);
 }

--- a/apps/pi-extension/server/serverReview.ts
+++ b/apps/pi-extension/server/serverReview.ts
@@ -47,7 +47,9 @@ import { listenOnPort } from "./network.js";
 import {
 	fetchPRContext,
 	fetchPRFileContent,
+	fetchPRViewedFiles,
 	getPRUser,
+	markPRFilesViewed,
 	submitPRReview,
 } from "./pr.js";
 import { getRepoInfo } from "./project.js";
@@ -119,6 +121,19 @@ export async function startReviewServer(options: {
 	const isPRMode = !!prMeta;
 	const prRef = prMeta ? prRefFromMetadata(prMeta) : null;
 	const platformUser = prRef ? await getPRUser(prRef) : null;
+
+	// Fetch GitHub viewed file state (non-blocking — errors are silently ignored)
+	let initialViewedFiles: string[] = [];
+	if (isPRMode && prRef) {
+		try {
+			const viewedMap = await fetchPRViewedFiles(prRef);
+			initialViewedFiles = Object.entries(viewedMap)
+				.filter(([, isViewed]) => isViewed)
+				.map(([path]) => path);
+		} catch {
+			// Non-fatal: viewed state is best-effort
+		}
+	}
 	const repoInfo = prMeta
 		? {
 				display: getDisplayRepo(prMeta),
@@ -280,6 +295,7 @@ export async function startReviewServer(options: {
 				shareBaseUrl,
 				repoInfo,
 				...(isPRMode && { prMetadata: prMeta, platformUser }),
+				...(isPRMode && initialViewedFiles.length > 0 && { viewedFiles: initialViewedFiles }),
 				...(currentError ? { error: currentError } : {}),
 			});
 		} else if (url.pathname === "/api/diff/switch" && req.method === "POST") {
@@ -350,6 +366,39 @@ export async function startReviewServer(options: {
 					{
 						error:
 							err instanceof Error ? err.message : "Failed to submit PR review",
+					},
+					500,
+				);
+			}
+		} else if (url.pathname === "/api/pr-viewed" && req.method === "POST") {
+			if (!isPRMode || !prMeta || !prRef) {
+				json(res, { error: "Not in PR mode" }, 400);
+				return;
+			}
+			if (prMeta.platform !== "github") {
+				json(res, { error: "Viewed sync only supported for GitHub" }, 400);
+				return;
+			}
+			const prNodeId = prMeta.prNodeId;
+			if (!prNodeId) {
+				json(res, { error: "PR node ID not available" }, 400);
+				return;
+			}
+			try {
+				const body = await parseBody(req);
+				await markPRFilesViewed(
+					prRef,
+					prNodeId,
+					body.filePaths as string[],
+					body.viewed as boolean,
+				);
+				json(res, { ok: true });
+			} catch (err) {
+				json(
+					res,
+					{
+						error:
+							err instanceof Error ? err.message : "Failed to update viewed state",
 					},
 					500,
 				);

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "plannotator",
@@ -61,7 +62,7 @@
     },
     "apps/opencode-plugin": {
       "name": "@plannotator/opencode",
-      "version": "0.14.5",
+      "version": "0.15.2",
       "dependencies": {
         "@opencode-ai/plugin": "^1.1.10",
       },
@@ -83,7 +84,7 @@
     },
     "apps/pi-extension": {
       "name": "@plannotator/pi-extension",
-      "version": "0.14.5",
+      "version": "0.15.2",
       "peerDependencies": {
         "@mariozechner/pi-coding-agent": ">=0.53.0",
       },
@@ -168,7 +169,7 @@
     },
     "packages/server": {
       "name": "@plannotator/server",
-      "version": "0.14.5",
+      "version": "0.15.2",
       "dependencies": {
         "@plannotator/ai": "workspace:*",
         "@plannotator/shared": "workspace:*",

--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -386,6 +386,7 @@ const ReviewApp: React.FC = () => {
         repoInfo?: { display: string; branch?: string };
         prMetadata?: PRMetadata;
         platformUser?: string;
+        viewedFiles?: string[];
         error?: string;
       }) => {
         const apiFiles = parseDiffToFiles(data.rawPatch);
@@ -406,6 +407,10 @@ const ReviewApp: React.FC = () => {
         if (data.repoInfo) setRepoInfo(data.repoInfo);
         if (data.prMetadata) setPrMetadata(data.prMetadata);
         if (data.platformUser) setPlatformUser(data.platformUser);
+        // Initialize viewed files from GitHub's state (set before draft restore so draft takes precedence)
+        if (data.viewedFiles && data.viewedFiles.length > 0) {
+          setViewedFiles(new Set(data.viewedFiles));
+        }
         if (data.error) setDiffError(data.error);
       })
       .catch(() => {
@@ -528,14 +533,26 @@ const ReviewApp: React.FC = () => {
   const handleToggleViewed = useCallback((filePath: string) => {
     setViewedFiles(prev => {
       const next = new Set(prev);
-      if (next.has(filePath)) {
-        next.delete(filePath);
-      } else {
+      const willBeViewed = !prev.has(filePath);
+      if (willBeViewed) {
         next.add(filePath);
+      } else {
+        next.delete(filePath);
+      }
+      // Sync viewed state to GitHub (fire and forget — best effort)
+      // Capture willBeViewed inside the callback to ensure correctness with React batching
+      if (prMetadata && prMetadata.platform === 'github') {
+        fetch('/api/pr-viewed', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ filePaths: [filePath], viewed: willBeViewed }),
+        }).catch(() => {
+          // Silently ignore — viewed sync is best-effort
+        });
       }
       return next;
     });
-  }, []);
+  }, [prMetadata]);
 
   // Derive worktree path and base diff type from the composite diffType string
   const { activeWorktreePath, activeDiffBase } = useMemo(() => {

--- a/packages/server/pr.ts
+++ b/packages/server/pr.ts
@@ -18,6 +18,8 @@ import {
   fetchPRContext as fetchPRContextCore,
   fetchPRFileContent as fetchPRFileContentCore,
   submitPRReview as submitPRReviewCore,
+  fetchPRViewedFiles as fetchPRViewedFilesCore,
+  markPRFilesViewed as markPRFilesViewedCore,
   prRefFromMetadata,
   getPlatformLabel,
   getMRLabel,
@@ -29,6 +31,7 @@ import {
 
 export type { PRRef, PRMetadata, PRContext, PRReviewFileComment } from "@plannotator/shared/pr-provider";
 export { prRefFromMetadata, getPlatformLabel, getMRLabel, getMRNumberLabel, getDisplayRepo, getCliName, getCliInstallUrl } from "@plannotator/shared/pr-provider";
+export type { GithubPRMetadata } from "@plannotator/shared/pr-provider";
 
 const runtime: PRRuntime = {
   async runCommand(cmd, args) {
@@ -104,4 +107,19 @@ export function submitPRReview(
   fileComments: PRReviewFileComment[],
 ): Promise<void> {
   return submitPRReviewCore(runtime, ref, headSha, action, body, fileComments);
+}
+
+export function fetchPRViewedFiles(
+  ref: PRRef,
+): Promise<Record<string, boolean>> {
+  return fetchPRViewedFilesCore(runtime, ref);
+}
+
+export function markPRFilesViewed(
+  ref: PRRef,
+  prNodeId: string,
+  filePaths: string[],
+  viewed: boolean,
+): Promise<void> {
+  return markPRFilesViewedCore(runtime, ref, prNodeId, filePaths, viewed);
 }

--- a/packages/server/review.ts
+++ b/packages/server/review.ts
@@ -15,7 +15,7 @@ import { getRepoInfo } from "./repo";
 import { handleImage, handleUpload, handleAgents, handleServerReady, handleDraftSave, handleDraftLoad, handleDraftDelete, handleFavicon, type OpencodeClient } from "./shared-handlers";
 import { contentHash, deleteDraft } from "./draft";
 import { createEditorAnnotationHandler } from "./editor-annotations";
-import { type PRMetadata, type PRReviewFileComment, fetchPRFileContent, fetchPRContext, submitPRReview, getPRUser, prRefFromMetadata, getDisplayRepo, getMRLabel, getMRNumberLabel } from "./pr";
+import { type PRMetadata, type PRReviewFileComment, fetchPRFileContent, fetchPRContext, submitPRReview, fetchPRViewedFiles, markPRFilesViewed, getPRUser, prRefFromMetadata, getDisplayRepo, getMRLabel, getMRNumberLabel } from "./pr";
 import { createAIEndpoints, ProviderRegistry, SessionManager, createProvider, type AIEndpoints, type PiSDKConfig } from "@plannotator/ai";
 
 // Re-export utilities
@@ -200,6 +200,23 @@ export async function startReviewServer(
   const prRef = isPRMode ? prRefFromMetadata(prMetadata) : null;
   const platformUser = prRef ? await getPRUser(prRef) : null;
 
+  // Fetch GitHub viewed file state (non-blocking — errors are silently ignored)
+  let initialViewedFiles: string[] = [];
+  if (isPRMode && prRef) {
+    console.log("[plannotator] Fetching PR viewed files for", prRef);
+    try {
+      const viewedMap = await fetchPRViewedFiles(prRef);
+      console.log("[plannotator] PR viewed files map:", viewedMap);
+      initialViewedFiles = Object.entries(viewedMap)
+        .filter(([, isViewed]) => isViewed)
+        .map(([path]) => path);
+      console.log("[plannotator] Initial viewed files:", initialViewedFiles);
+    } catch (err) {
+      // Non-fatal: viewed state is best-effort
+      console.warn("[plannotator] Could not fetch PR viewed files:", err instanceof Error ? err.message : err);
+    }
+  }
+
   // Decision promise
   let resolveDecision: (result: {
     approved: boolean;
@@ -239,6 +256,7 @@ export async function startReviewServer(
               shareBaseUrl,
               repoInfo,
               ...(isPRMode && { prMetadata, platformUser }),
+              ...(isPRMode && initialViewedFiles.length > 0 && { viewedFiles: initialViewedFiles }),
               ...(currentError && { error: currentError }),
             });
           }
@@ -455,6 +473,38 @@ export async function startReviewServer(
             } catch (err) {
               const message =
                 err instanceof Error ? err.message : "Failed to submit PR review";
+              return Response.json({ error: message }, { status: 500 });
+            }
+          }
+
+          // API: Mark/unmark PR files as viewed on GitHub (PR mode, GitHub only)
+          if (url.pathname === "/api/pr-viewed" && req.method === "POST") {
+            if (!isPRMode || !prMetadata) {
+              console.log("[plannotator] /api/pr-viewed: not in PR mode");
+              return Response.json({ error: "Not in PR mode" }, { status: 400 });
+            }
+            if (prMetadata.platform !== "github") {
+              console.log("[plannotator] /api/pr-viewed: platform is", prMetadata.platform, "(not github)");
+              return Response.json({ error: "Viewed sync only supported for GitHub" }, { status: 400 });
+            }
+            const prNodeId = prMetadata.prNodeId;
+            if (!prNodeId) {
+              console.log("[plannotator] /api/pr-viewed: prNodeId missing from metadata:", prMetadata);
+              return Response.json({ error: "PR node ID not available" }, { status: 400 });
+            }
+            try {
+              const body = (await req.json()) as {
+                filePaths: string[];
+                viewed: boolean;
+              };
+              console.log("[plannotator] /api/pr-viewed: marking", body.filePaths, "as viewed=", body.viewed, "prNodeId=", prNodeId);
+              await markPRFilesViewed(prRef!, prNodeId, body.filePaths, body.viewed);
+              console.log("[plannotator] /api/pr-viewed: success");
+              return Response.json({ ok: true });
+            } catch (err) {
+              const message =
+                err instanceof Error ? err.message : "Failed to update viewed state";
+              console.error("[plannotator] /api/pr-viewed error:", message);
               return Response.json({ error: message }, { status: 500 });
             }
           }

--- a/packages/shared/pr-github.ts
+++ b/packages/shared/pr-github.ts
@@ -56,7 +56,7 @@ export async function fetchGhPR(
     runtime.runCommand("gh", [
       "pr", "view", String(ref.number),
       "--repo", repo,
-      "--json", "title,author,baseRefName,headRefName,baseRefOid,headRefOid,url",
+      "--json", "id,title,author,baseRefName,headRefName,baseRefOid,headRefOid,url",
     ]),
   ]);
 
@@ -73,6 +73,7 @@ export async function fetchGhPR(
   }
 
   const raw = JSON.parse(viewResult.stdout) as {
+    id: string;
     title: string;
     author: { login: string };
     baseRefName: string;
@@ -87,6 +88,7 @@ export async function fetchGhPR(
     owner: ref.owner,
     repo: ref.repo,
     number: ref.number,
+    prNodeId: raw.id,
     title: raw.title,
     author: raw.author.login,
     baseBranch: raw.baseRefName,
@@ -205,6 +207,137 @@ export async function fetchGhPRFileContent(
     return Buffer.from(cleaned, "base64").toString("utf-8");
   } catch {
     return null;
+  }
+}
+
+// --- Viewed Files ---
+
+/**
+ * Fetch the per-file "viewed" state for a GitHub PR via GraphQL.
+ * Returns a map of { filePath: isViewed } where isViewed is true for
+ * VIEWED or DISMISSED states (i.e., the file was reviewed but may need
+ * re-review after new commits).
+ */
+export async function fetchGhPRViewedFiles(
+  runtime: PRRuntime,
+  ref: GhPRRef,
+): Promise<Record<string, boolean>> {
+  const query = `
+    query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) {
+          files(first: 100, after: $cursor) {
+            nodes {
+              path
+              viewerViewedState
+            }
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const result: Record<string, boolean> = {};
+  let cursor: string | null = null;
+
+  // Paginate through all files (GitHub returns max 100 per page)
+  do {
+    const args = [
+      "api", "graphql",
+      "-f", `query=${query}`,
+      "-F", `owner=${ref.owner}`,
+      "-F", `repo=${ref.repo}`,
+      "-F", `number=${ref.number}`,
+    ];
+    if (cursor) {
+      args.push("-F", `cursor=${cursor}`);
+    }
+
+    const res = await runtime.runCommand("gh", args);
+    if (res.exitCode !== 0) {
+      throw new Error(
+        `Failed to fetch PR viewed files: ${res.stderr.trim() || `exit code ${res.exitCode}`}`,
+      );
+    }
+
+    const data = JSON.parse(res.stdout) as {
+      data?: {
+        repository?: {
+          pullRequest?: {
+            files?: {
+              nodes: Array<{ path: string; viewerViewedState: string }>;
+              pageInfo: { hasNextPage: boolean; endCursor: string | null };
+            };
+          };
+        };
+      };
+      errors?: Array<{ message: string }>;
+    };
+
+    if (data.errors?.length) {
+      throw new Error(`GraphQL error: ${data.errors[0].message}`);
+    }
+
+    const files = data.data?.repository?.pullRequest?.files;
+    if (!files) break;
+
+    for (const node of files.nodes) {
+      // VIEWED = explicitly marked as viewed
+      // DISMISSED = was viewed but new commits arrived (still "was reviewed")
+      result[node.path] = node.viewerViewedState === "VIEWED" || node.viewerViewedState === "DISMISSED";
+    }
+
+    cursor = files.pageInfo.hasNextPage ? files.pageInfo.endCursor : null;
+  } while (cursor !== null);
+
+  return result;
+}
+
+/**
+ * Mark or unmark a set of files as viewed in a GitHub PR via GraphQL mutations.
+ * Uses Promise.allSettled so a single file failure doesn't block the rest.
+ * Throws only if ALL mutations fail.
+ */
+export async function markGhFilesViewed(
+  runtime: PRRuntime,
+  _ref: GhPRRef,
+  prNodeId: string,
+  filePaths: string[],
+  viewed: boolean,
+): Promise<void> {
+  if (filePaths.length === 0) return;
+
+  const mutationName = viewed ? "markFileAsViewed" : "unmarkFileAsViewed";
+  const mutation = `
+    mutation($id: ID!, $path: String!) {
+      ${mutationName}(input: { pullRequestId: $id, path: $path }) {
+        clientMutationId
+      }
+    }
+  `;
+
+  const results = await Promise.allSettled(
+    filePaths.map((path) =>
+      runtime.runCommandWithInput
+        ? runtime.runCommand("gh", [
+            "api", "graphql",
+            "-f", `query=${mutation}`,
+            "-F", `id=${prNodeId}`,
+            "-F", `path=${path}`,
+          ])
+        : Promise.reject(new Error("Runtime does not support commands")),
+    ),
+  );
+
+  const failures = results.filter((r): r is PromiseRejectedResult => r.status === "rejected");
+  if (failures.length === filePaths.length) {
+    throw new Error(
+      `Failed to ${mutationName} all files: ${failures[0].reason}`,
+    );
   }
 }
 

--- a/packages/shared/pr-provider.ts
+++ b/packages/shared/pr-provider.ts
@@ -8,7 +8,7 @@
  * execution so the logic is reusable across Bun and Node/jiti.
  */
 
-import { checkGhAuth, getGhUser, fetchGhPR, fetchGhPRContext, fetchGhPRFileContent, submitGhPRReview } from "./pr-github";
+import { checkGhAuth, getGhUser, fetchGhPR, fetchGhPRContext, fetchGhPRFileContent, submitGhPRReview, fetchGhPRViewedFiles, markGhFilesViewed } from "./pr-github";
 import { checkGlAuth, getGlUser, fetchGlMR, fetchGlMRContext, fetchGlFileContent, submitGlMRReview } from "./pr-gitlab";
 
 // --- Runtime Types ---
@@ -60,6 +60,8 @@ export interface GithubPRMetadata {
   owner: string;
   repo: string;
   number: number;
+  /** GraphQL node ID for the PR — used for markFileAsViewed mutations */
+  prNodeId?: string;
   title: string;
   author: string;
   baseBranch: string;
@@ -285,4 +287,33 @@ export async function submitPRReview(
 ): Promise<void> {
   if (ref.platform === "github") return submitGhPRReview(runtime, ref, headSha, action, body, fileComments);
   return submitGlMRReview(runtime, ref, headSha, action, body, fileComments);
+}
+
+/**
+ * Fetch per-file "viewed" state for a PR.
+ * GitHub: returns { filePath: isViewed } map.
+ * GitLab: always returns {} (no server-side viewed state API).
+ */
+export async function fetchPRViewedFiles(
+  runtime: PRRuntime,
+  ref: PRRef,
+): Promise<Record<string, boolean>> {
+  if (ref.platform === "github") return fetchGhPRViewedFiles(runtime, ref);
+  return {}; // GitLab has no server-side viewed state
+}
+
+/**
+ * Mark or unmark files as viewed in a PR.
+ * GitHub: fires markFileAsViewed / unmarkFileAsViewed GraphQL mutations.
+ * GitLab: no-op (no server-side viewed state API).
+ */
+export async function markPRFilesViewed(
+  runtime: PRRuntime,
+  ref: PRRef,
+  prNodeId: string,
+  filePaths: string[],
+  viewed: boolean,
+): Promise<void> {
+  if (ref.platform === "github") return markGhFilesViewed(runtime, ref, prNodeId, filePaths, viewed);
+  // GitLab: no-op
 }


### PR DESCRIPTION
Bidirectional sync between plannotator's file-viewed checkboxes and GitHub's native "Mark as viewed" feature:

On load: fetches per-file viewerViewedState via GraphQL and pre-populates the viewed checkmarks

On toggle: fires a background markFileAsViewed/unmarkFileAsViewed GraphQL mutation when a file is checked/unchecked

GitLab: no-op, GitLab's viewed state is localStorage-only with no API

Also adds prNodeId (GraphQL node ID) to GithubPRMetadata, fetched alongside existing gh pr view call, to be able to call github with the viewed status. Implemented across both the Bun server and Pi extension to maintain route parity.