### PR TITLE
docs: document diff type switcher in code review

### DIFF
--- a/apps/marketing/src/content/docs/commands/code-review.md
+++ b/apps/marketing/src/content/docs/commands/code-review.md
@@ -1,16 +1,16 @@
 ---
 title: "Code Review"
-description: "The /plannotator-review slash command for reviewing uncommitted code changes or GitHub pull requests."
+description: "The /plannotator-review slash command for reviewing local changes, comparing branches, or reviewing GitHub pull requests."
 sidebar:
   order: 11
 section: "Commands"
 ---
 
-The `/plannotator-review` command opens an interactive code review UI for your uncommitted changes or a GitHub pull request.
+The `/plannotator-review` command opens an interactive code review UI for your local changes or a GitHub pull request.
 
 ## Usage
 
-**Review uncommitted changes:**
+**Review local changes:**
 
 ```
 /plannotator-review
@@ -33,7 +33,7 @@ User runs /plannotator-review
         ↓
 Agent runs: plannotator review
         ↓
-git diff captures unstaged changes
+git diff captures changes
         ↓
 Review server starts, opens browser with diff viewer
         ↓
@@ -60,14 +60,26 @@ Send Feedback → PR context included in feedback
 Approve → "LGTM" sent to agent
 ```
 
+## Switching diff types
+
+By default the review opens showing uncommitted changes, but you can switch what you're comparing using the diff type dropdown in the toolbar. The available options are:
+
+- **Uncommitted changes** - everything that differs from HEAD, including untracked files
+- **Staged changes** - only what's in the staging area (what `git commit` would include)
+- **Unstaged changes** - working tree changes that haven't been staged yet, plus untracked files
+- **Last commit** - the diff introduced by the most recent commit
+- **vs main** (or your default branch) - all committed changes on your branch compared to the base branch. This gives you the same view you'd see on a pull request, without needing to push or create one. Only appears when you're on a branch other than the default.
+
+If you're working on a feature branch and want to see everything you've done before opening a PR, switch to the "vs main" option. It's a good way to do a self-review of your full branch diff.
+
 ## The diff viewer
 
 The review UI shows your changes in a familiar diff format:
 
-- **File tree sidebar** — Navigate between changed files
-- **Viewed tracking** — Mark files as viewed to track progress
-- **Unified diff** — See additions and deletions in context
-- **Annotation tools** — Same annotation types as plan review (delete, replace, comment, insert)
+- **File tree sidebar** for navigating between changed files
+- **Viewed tracking** to mark files as reviewed and track your progress
+- **Unified diff** showing additions and deletions in context
+- **Annotation tools** with the same annotation types as plan review (delete, replace, comment, insert)
 
 ## Annotating code
 
@@ -81,25 +93,25 @@ When an AI provider is available, the diff viewer includes inline AI chat. Selec
 
 Plannotator supports multiple AI providers. Providers are auto-detected based on which CLI tools are installed on your system:
 
-- **Claude** — Requires the `claude` CLI ([Claude Code](https://docs.anthropic.com/en/docs/claude-code))
-- **Codex** — Requires the `codex` CLI ([OpenAI Codex](https://github.com/openai/codex))
-- **Pi** — Requires the `pi` CLI ([Pi](https://github.com/mariozechner/pi-coding-agent))
-- **OpenCode** — Requires the `opencode` CLI ([OpenCode](https://opencode.ai))
+- **Claude** requires the `claude` CLI ([Claude Code](https://docs.anthropic.com/en/docs/claude-code))
+- **Codex** requires the `codex` CLI ([OpenAI Codex](https://github.com/openai/codex))
+- **Pi** requires the `pi` CLI ([Pi](https://github.com/mariozechner/pi-coding-agent))
+- **OpenCode** requires the `opencode` CLI ([OpenCode](https://opencode.ai))
 
-All providers can be available simultaneously. Plannotator does not manage API keys — you must be authenticated with each CLI independently (`claude` uses `~/.claude/` credentials, `codex` uses `OPENAI_API_KEY`, `pi` and `opencode` use their own local configuration).
+All providers can be available simultaneously. Plannotator does not manage API keys, so you must be authenticated with each CLI independently (`claude` uses `~/.claude/` credentials, `codex` uses `OPENAI_API_KEY`, `pi` and `opencode` use their own local configuration).
 
 ### Choosing a provider
 
 When multiple providers are available, set your default in **Settings → AI**. The AI tab shows all detected providers as selectable cards. Your choice persists across sessions.
 
-If only one provider is installed, it's used automatically — no configuration needed.
+If only one provider is installed, it's used automatically with no configuration needed.
 
 ## Submitting feedback
 
-- **Send Feedback** — Formats your annotations and sends them to the agent
-- **Approve** — Sends "LGTM" to the agent, indicating the changes look good
+- **Send Feedback** formats your annotations and sends them to the agent
+- **Approve** sends "LGTM" to the agent, indicating the changes look good
 
-After submission, the agent receives your feedback and can act on it — fixing issues, explaining decisions, or making the requested changes.
+After submission, the agent receives your feedback and can act on it, whether that's fixing issues, explaining decisions, or making the requested changes.
 
 ## Server API
 


### PR DESCRIPTION
## Summary

- Adds a new "Switching diff types" section documenting the toolbar dropdown and all five diff type options (uncommitted, staged, unstaged, last commit, vs main)
- Calls out that "vs main" gives a PR-like branch diff view without needing to push or create a PR
- Updates framing from "uncommitted changes" to "local changes" throughout

Closes #397