### PR TITLE
fix(skill): trim compound skill description under 250-char limit

### DIFF
--- a/apps/skills/plannotator-compound/SKILL.md
+++ b/apps/skills/plannotator-compound/SKILL.md
@@ -1,13 +1,10 @@
 ---
 name: plannotator-compound
+disable-model-invocation: true
 description: >
   Analyze a user's Plannotator plan archive to extract denial patterns, feedback
   taxonomy, evolution over time, and actionable prompt improvements — then produce
-  a polished HTML dashboard report. Use this skill when the user says things like
-  "/compound-planning", "analyze my plans", "plan analysis", "what are my denial
-  patterns", "why do my plans get denied", "compound planning report", "plan
-  insights", or "analyze my planning data". This is a user-invoked skill only —
-  do not trigger automatically. The user must explicitly request it.
+  a polished HTML dashboard report.
 ---
 
 # Compound Planning Analysis


### PR DESCRIPTION
## Summary
- Trims `plannotator-compound` skill description from 455 to 185 characters (under the new 250-char cap in Claude Code 2.1.86)
- Adds `disable-model-invocation: true` frontmatter to properly prevent auto-triggering, replacing contradictory prose that both listed trigger phrases and said "do not trigger automatically"
- Removes redundant trigger phrase list and invocation instructions from description

Closes #412

## Test plan
- [ ] Verify skill still appears in `/skills` listing without truncation
- [ ] Verify skill triggers correctly when user explicitly invokes it
- [ ] Verify skill does not auto-trigger on related prompts