### PR TITLE
fix: add idleTimeout: 0 to all Bun.serve() calls

### DIFF
--- a/packages/server/annotate.ts
+++ b/packages/server/annotate.ts
@@ -126,6 +126,7 @@ export async function startAnnotateServer(
     try {
       server = Bun.serve({
         port: configuredPort,
+        idleTimeout: 0,
 
         async fetch(req) {
           const url = new URL(req.url);

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -201,6 +201,7 @@ export async function startPlannotatorServer(
     try {
       server = Bun.serve({
         port: configuredPort,
+        idleTimeout: 0,
 
         async fetch(req) {
           const url = new URL(req.url);

--- a/packages/server/review.ts
+++ b/packages/server/review.ts
@@ -247,6 +247,7 @@ export async function startReviewServer(
     try {
       server = Bun.serve({
         port: configuredPort,
+        idleTimeout: 0,
 
         async fetch(req) {
           const url = new URL(req.url);


### PR DESCRIPTION
## Summary

All three Plannotator servers (`index.ts`, `review.ts`, `annotate.ts`) call `Bun.serve()` without passing `idleTimeout`, inheriting Bun's 10-second default. Any request or connection idle for >10s gets killed with:

```
bun.serve: request timed out after 10 seconds, Pass `idleTimeout` to configure
```

This hits plan review (user takes >10s to review), code review (slow AI provider responses), and the annotation server's SSE connections.

OpenCode's own server already sets `idleTimeout: 0` in `packages/opencode/src/server/server.ts`. This PR does the same for Plannotator's three servers.

### What's changed

- `packages/server/index.ts` — add `idleTimeout: 0` to plan server's `Bun.serve()`
- `packages/server/review.ts` — add `idleTimeout: 0` to review server's `Bun.serve()`
- `packages/server/annotate.ts` — add `idleTimeout: 0` to annotate server's `Bun.serve()`

### Note

`PLANNOTATOR_PLAN_TIMEOUT_SECONDS` (PR #223) controls the application-level plan review timeout — a different layer. It does not prevent this Bun HTTP idle timeout.

## Test plan

- [ ] Start plan review, wait >10s before approving/denying → no timeout error
- [ ] Start code review with a slow AI response → no timeout error
- [ ] Use annotation server SSE endpoint → connection stays alive
- [ ] Existing timeout behavior (`PLANNOTATOR_PLAN_TIMEOUT_SECONDS`) still works as expected