### PR TITLE
fix(opencode): remove verbose logs that flood the TUI

### DIFF
--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -32,7 +32,6 @@ import {
   startAnnotateServer,
   handleAnnotateServerReady,
 } from "@plannotator/server/annotate";
-import { writeRemoteShareLink } from "@plannotator/server/share-url";
 import {
   handleReviewCommand,
   handleAnnotateCommand,
@@ -417,9 +416,6 @@ Do NOT proceed with implementation until your plan is approved.`);
             opencodeClient: ctx.client,
             onReady: async (url, isRemote, port) => {
               handleServerReady(url, isRemote, port);
-              if (isRemote && sharingEnabled) {
-                await writeRemoteShareLink(planContent, getShareBaseUrl(), "review the plan", "plan only").catch(() => {});
-              }
             },
           });
 

--- a/packages/server/review.ts
+++ b/packages/server/review.ts
@@ -210,17 +210,13 @@ export async function startReviewServer(
   // Fetch GitHub viewed file state (non-blocking — errors are silently ignored)
   let initialViewedFiles: string[] = [];
   if (isPRMode && prRef) {
-    console.log("[plannotator] Fetching PR viewed files for", prRef);
     try {
       const viewedMap = await fetchPRViewedFiles(prRef);
-      console.log("[plannotator] PR viewed files map:", viewedMap);
       initialViewedFiles = Object.entries(viewedMap)
         .filter(([, isViewed]) => isViewed)
         .map(([path]) => path);
-      console.log("[plannotator] Initial viewed files:", initialViewedFiles);
-    } catch (err) {
+    } catch {
       // Non-fatal: viewed state is best-effort
-      console.warn("[plannotator] Could not fetch PR viewed files:", err instanceof Error ? err.message : err);
     }
   }
 
@@ -509,16 +505,13 @@ export async function startReviewServer(
           // API: Mark/unmark PR files as viewed on GitHub (PR mode, GitHub only)
           if (url.pathname === "/api/pr-viewed" && req.method === "POST") {
             if (!isPRMode || !prMetadata) {
-              console.log("[plannotator] /api/pr-viewed: not in PR mode");
               return Response.json({ error: "Not in PR mode" }, { status: 400 });
             }
             if (prMetadata.platform !== "github") {
-              console.log("[plannotator] /api/pr-viewed: platform is", prMetadata.platform, "(not github)");
               return Response.json({ error: "Viewed sync only supported for GitHub" }, { status: 400 });
             }
             const prNodeId = prMetadata.prNodeId;
             if (!prNodeId) {
-              console.log("[plannotator] /api/pr-viewed: prNodeId missing from metadata:", prMetadata);
               return Response.json({ error: "PR node ID not available" }, { status: 400 });
             }
             try {
@@ -526,9 +519,7 @@ export async function startReviewServer(
                 filePaths: string[];
                 viewed: boolean;
               };
-              console.log("[plannotator] /api/pr-viewed: marking", body.filePaths, "as viewed=", body.viewed, "prNodeId=", prNodeId);
               await markPRFilesViewed(prRef!, prNodeId, body.filePaths, body.viewed);
-              console.log("[plannotator] /api/pr-viewed: success");
               return Response.json({ ok: true });
             } catch (err) {
               const message =


### PR DESCRIPTION
## Summary

- Remove `writeRemoteShareLink` stderr output from the OpenCode plugin — the base64-encoded share URL was flooding the TUI on remote sessions
- Strip leftover `console.log` debug statements from the PR viewed files feature in the review server

Closes #435

## Test plan

- [ ] Run OpenCode with `PLANNOTATOR_REMOTE=1` and `PLANNOTATOR_PORT=9999`, call `submit_plan` — confirm no share URL floods the TUI
- [ ] PR review with GitHub viewed files — confirm viewed state still syncs correctly without debug logs