### PR TITLE
fix(review): resolve repo root for untracked file discovery

### DIFF
--- a/packages/shared/review-core.test.ts
+++ b/packages/shared/review-core.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve as resolvePath } from "node:path";
 import {
@@ -86,6 +86,31 @@ describe("review-core", () => {
     expect(result.patch).toContain("diff --git a/tracked.txt b/tracked.txt");
     expect(result.patch).toContain("diff --git a/untracked.txt b/untracked.txt");
     expect(result.patch).toContain("+++ b/untracked.txt");
+  });
+
+  test("uncommitted diff includes untracked files when CWD is a subdirectory", async () => {
+    const repoDir = initRepo();
+
+    mkdirSync(join(repoDir, "packages", "infra", "lib"), { recursive: true });
+    writeFileSync(join(repoDir, "packages", "infra", "lib", "Stack.ts"), "new stack\n", "utf-8");
+
+    writeFileSync(join(repoDir, "root-new.txt"), "root untracked\n", "utf-8");
+    mkdirSync(join(repoDir, ".github", "workflows"), { recursive: true });
+    writeFileSync(join(repoDir, ".github", "workflows", "ci.yml"), "name: CI\n", "utf-8");
+
+    writeFileSync(join(repoDir, "tracked.txt"), "after\n", "utf-8");
+
+    // Runtime whose default CWD is a subdirectory (simulates a hook process
+    // that inherits an agent CWD inside a monorepo package)
+    const subCwd = join(repoDir, "packages", "infra");
+    const runtime = makeRuntime(subCwd);
+
+    const result = await runGitDiff(runtime, "uncommitted", "main");
+
+    expect(result.patch).toContain("diff --git a/tracked.txt b/tracked.txt");
+    expect(result.patch).toContain("diff --git a/packages/infra/lib/Stack.ts b/packages/infra/lib/Stack.ts");
+    expect(result.patch).toContain("diff --git a/root-new.txt b/root-new.txt");
+    expect(result.patch).toContain("diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml");
   });
 
   test("unstaged diff includes untracked files", async () => {

--- a/packages/shared/review-core.ts
+++ b/packages/shared/review-core.ts
@@ -174,9 +174,20 @@ async function getUntrackedFileDiffs(
   dstPrefix = "b/",
   cwd?: string,
 ): Promise<string> {
+  // git ls-files scopes to the CWD subtree and returns CWD-relative paths,
+  // unlike git diff HEAD which always covers the full repo with root-relative
+  // paths.  Resolve the repo root so untracked files from the entire repo are
+  // included and their paths match the tracked-diff output.
+  const toplevelResult = await runtime.runGit(
+    ["rev-parse", "--show-toplevel"],
+    { cwd },
+  );
+  const rootCwd =
+    toplevelResult.exitCode === 0 ? toplevelResult.stdout.trim() : cwd;
+
   const lsResult = await runtime.runGit(
     ["ls-files", "--others", "--exclude-standard"],
-    { cwd },
+    { cwd: rootCwd },
   );
   if (lsResult.exitCode !== 0) return "";
 
@@ -199,7 +210,7 @@ async function getUntrackedFileDiffs(
           "/dev/null",
           file,
         ],
-        { cwd },
+        { cwd: rootCwd },
       );
       return diffResult.stdout;
     }),


### PR DESCRIPTION
## Summary

- Resolve repo root in `getUntrackedFileDiffs` so `git ls-files` lists all untracked files, not just those under the process CWD
- Use the resolved root as CWD for `git diff --no-index` so paths are root-relative, matching tracked-diff output
- Add regression test that runs `runGitDiff` from a subdirectory

## Problem

`git ls-files --others --exclude-standard` scopes to the CWD subtree and returns CWD-relative paths. `git diff HEAD` always covers the full repo with root-relative paths. When the hook process inherits a subdirectory CWD (e.g., an agent that `cd`'d into `packages/foo/`), untracked files outside that subtree are silently dropped and the one that is found gets a wrong relative path in the diff header.

## AI

Note that I used Opus 4.6 to assist with identifying, filing the GitHub issue, and the TDD-resolution of this bug.

Fixes #449