### PR TITLE
feat: add Clean Contrast, Code Fork, and Midnight themes

### DIFF
--- a/packages/ui/theme.css
+++ b/packages/ui/theme.css
@@ -19,6 +19,9 @@
 @import "./themes/terminal.css";
 @import "./themes/tokyo-night.css";
 @import "./themes/tinacious.css";
+@import "./themes/cursor.css";
+@import "./themes/cursor-hc.css";
+@import "./themes/cursor-midnight.css";
 @import "./print.css";
 
 /* Tailwind bridge — maps CSS vars to utility classes */

--- a/packages/ui/themes/cursor-hc.css
+++ b/packages/ui/themes/cursor-hc.css
@@ -1,0 +1,34 @@
+/* Clean Contrast — single dark-only theme */
+.theme-cursor-hc,
+.theme-cursor-hc.light {
+  --background: #0A0A0A;
+  --foreground: #D8DEE9;
+  --card: #1a1a1a;
+  --card-foreground: #ECEFF4;
+  --popover: #1a1a1a;
+  --popover-foreground: #ECEFF4;
+  --primary: #88C0D0;
+  --primary-foreground: #000000;
+  --secondary: #434C5E;
+  --secondary-foreground: #ECEFF4;
+  --muted: #2A2A2A;
+  --muted-foreground: #CCCCCC;
+  --accent: #EBCB8B;
+  --accent-foreground: #000000;
+  --destructive: #BF616A;
+  --destructive-foreground: #ECEFF4;
+  --border: #404040;
+  --input: #2A2A2A;
+  --ring: #88C0D0;
+  --success: #A3BE8C;
+  --success-foreground: #000000;
+  --warning: #EBCB8B;
+  --warning-foreground: #000000;
+
+  --font-sans: system-ui, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Consolas, monospace;
+  --radius: 0.5rem;
+
+  --code-bg: #1a1a1a;
+  --focus-highlight: #88C0D0;
+}

--- a/packages/ui/themes/cursor-midnight.css
+++ b/packages/ui/themes/cursor-midnight.css
@@ -1,0 +1,34 @@
+/* Cursor Midnight — single dark-only theme */
+.theme-cursor-midnight,
+.theme-cursor-midnight.light {
+  --background: #1e2127;
+  --foreground: #D8DEE9;
+  --card: #272c36;
+  --card-foreground: #D8DEE9;
+  --popover: #20242c;
+  --popover-foreground: #D8DEE9;
+  --primary: #88C0D0;
+  --primary-foreground: #1d2128;
+  --secondary: #434C5E;
+  --secondary-foreground: #D8DEE9;
+  --muted: #272c36;
+  --muted-foreground: #7b88a1;
+  --accent: #8FBCBB;
+  --accent-foreground: #1d2128;
+  --destructive: #BF616A;
+  --destructive-foreground: #ECEFF4;
+  --border: #3a4050;
+  --input: #272c36;
+  --ring: #88C0D0;
+  --success: #A3BE8C;
+  --success-foreground: #1d2128;
+  --warning: #EBCB8B;
+  --warning-foreground: #1d2128;
+
+  --font-sans: system-ui, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Consolas, monospace;
+  --radius: 0.5rem;
+
+  --code-bg: #191c22;
+  --focus-highlight: #8FBCBB;
+}

--- a/packages/ui/themes/cursor.css
+++ b/packages/ui/themes/cursor.css
@@ -1,0 +1,62 @@
+/* Code Fork — dark + light, based on Cursor's default themes */
+.theme-cursor {
+  --background: #181818;
+  --foreground: #E4E4E4;
+  --card: #1e1e1e;
+  --card-foreground: #E4E4E4;
+  --popover: #141414;
+  --popover-foreground: #E4E4E4;
+  --primary: #81A1C1;
+  --primary-foreground: #141414;
+  --secondary: #2a2a2a;
+  --secondary-foreground: #E4E4E4;
+  --muted: #252525;
+  --muted-foreground: #a0a0a0;
+  --accent: #88C0D0;
+  --accent-foreground: #141414;
+  --destructive: #E34671;
+  --destructive-foreground: #E4E4E4;
+  --border: #333333;
+  --input: #252525;
+  --ring: #81A1C1;
+  --success: #3FA266;
+  --success-foreground: #141414;
+  --warning: #D2943E;
+  --warning-foreground: #141414;
+
+  --font-sans: system-ui, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Consolas, monospace;
+  --radius: 0.5rem;
+
+  --code-bg: #141414;
+  --focus-highlight: #88C0D0;
+}
+
+.theme-cursor.light {
+  --background: #FCFCFC;
+  --foreground: #141414;
+  --card: #F3F3F3;
+  --card-foreground: #141414;
+  --popover: #F3F3F3;
+  --popover-foreground: #141414;
+  --primary: #3C7CAB;
+  --primary-foreground: #FCFCFC;
+  --secondary: #E8E8E8;
+  --secondary-foreground: #141414;
+  --muted: #EDEDED;
+  --muted-foreground: #6a6a6a;
+  --accent: #4C7F8C;
+  --accent-foreground: #FCFCFC;
+  --destructive: #CF2D56;
+  --destructive-foreground: #FCFCFC;
+  --border: #DDDDDD;
+  --input: #EDEDED;
+  --ring: #3C7CAB;
+  --success: #1F8A65;
+  --success-foreground: #FCFCFC;
+  --warning: #C08532;
+  --warning-foreground: #141414;
+
+  --code-bg: #F3F3F3;
+  --focus-highlight: #3C7CAB;
+}

--- a/packages/ui/utils/themeRegistry.ts
+++ b/packages/ui/utils/themeRegistry.ts
@@ -69,6 +69,26 @@ export const BUILT_IN_THEMES: ThemeInfo[] = [
     },
   },
   {
+    id: 'cursor-hc',
+    name: 'Clean Contrast',
+    builtIn: true,
+    modeSupport: 'dark-only',
+    colors: {
+      dark: { primary: '#88C0D0', secondary: '#434C5E', accent: '#EBCB8B', background: '#0A0A0A', foreground: '#D8DEE9' },
+      light: { primary: '#88C0D0', secondary: '#434C5E', accent: '#EBCB8B', background: '#0A0A0A', foreground: '#D8DEE9' },
+    },
+  },
+  {
+    id: 'cursor',
+    name: 'Code Fork',
+    builtIn: true,
+    modeSupport: 'both',
+    colors: {
+      dark: { primary: '#81A1C1', secondary: '#2a2a2a', accent: '#88C0D0', background: '#181818', foreground: '#E4E4E4' },
+      light: { primary: '#3C7CAB', secondary: '#E8E8E8', accent: '#4C7F8C', background: '#FCFCFC', foreground: '#141414' },
+    },
+  },
+  {
     id: 'doom-64',
     name: 'Doom 64',
     builtIn: true,
@@ -106,6 +126,16 @@ export const BUILT_IN_THEMES: ThemeInfo[] = [
     colors: {
       dark: { primary: '#ffd866', secondary: '#5b595c', accent: '#78dce8', background: '#2d2a2e', foreground: '#fcfcfa' },
       light: { primary: '#ffd866', secondary: '#5b595c', accent: '#78dce8', background: '#2d2a2e', foreground: '#fcfcfa' },
+    },
+  },
+  {
+    id: 'cursor-midnight',
+    name: 'Midnight',
+    builtIn: true,
+    modeSupport: 'dark-only',
+    colors: {
+      dark: { primary: '#88C0D0', secondary: '#434C5E', accent: '#8FBCBB', background: '#1e2127', foreground: '#D8DEE9' },
+      light: { primary: '#88C0D0', secondary: '#434C5E', accent: '#8FBCBB', background: '#1e2127', foreground: '#D8DEE9' },
     },
   },
   {


### PR DESCRIPTION
## Summary
- Adds three new color themes derived from Cursor's palettes: **Clean Contrast** (dark-only), **Code Fork** (dark + light), and **Midnight** (dark-only)
- New CSS theme files in `packages/ui/themes/` with full token sets
- Registered in `themeRegistry.ts` in alphabetical order with preview swatches
- Imported in `theme.css`

## Test plan
- [ ] Open settings → Theme tab, verify all three themes appear in alphabetical order
- [ ] Select each theme and confirm colors apply correctly
- [ ] Verify Code Fork works in both dark and light modes
- [ ] Verify Clean Contrast and Midnight stay dark-only regardless of mode toggle