### PR TITLE
feat(skill): compound planning — incremental reports, agent routing, improvement hook

### DIFF
--- a/apps/skills/plannotator-compound/SKILL.md
+++ b/apps/skills/plannotator-compound/SKILL.md
@@ -233,10 +233,10 @@ datasets), proceed with the reduction. Reduction agents should use `model: "sonn
 
 The approach depends on how many extraction files were produced:
 
-**Small (≤ 6 extraction files):** Launch a single Sonnet agent to read all
-extraction files and produce the full analysis.
+**Standard (≤ 20 extraction files):** Launch a single Sonnet agent to read all
+extraction files and produce the full analysis. This covers most datasets.
 
-**Large (7+ extraction files):** Use a two-stage reduce:
+**Large (21+ extraction files):** Use a two-stage reduce:
 
 1. **Stage 1 — Partial reduces:** Split the extraction files into groups of 4-6.
    Launch parallel Sonnet agents, each reading one group and producing a partial


### PR DESCRIPTION
## Summary
- **Incremental reports**: Detects previous reports, offers to only analyze new files since last report (saves tokens). Output filenames are versioned (`-v2`, `-v3`, etc.)
- **Haiku/Sonnet agent routing**: Extraction (Phase 2) uses Haiku agents for speed; reduction (Phase 3) uses Sonnet for analytical reasoning, with two-stage reduce for large datasets
- **Improvement hook (Phase 6)**: After the report, offers to write corrective prompt instructions to `~/.plannotator/compound/enterplanmode-improve-hook.txt` for automatic injection into future planning sessions. Handles existing hooks with replace/merge/keep options

## Test plan
- [ ] Run skill with no previous report — should produce `compound-planning-report.html` (no version suffix)
- [ ] Run skill again — should detect previous report, offer incremental vs full, output as `-v2`
- [ ] Verify incremental mode filters files by cutoff date
- [ ] Verify Phase 6 creates the improvement hook file
- [ ] Run again to verify existing hook reconciliation (replace/merge/keep)