### PR TITLE
fix(ui): right resize handle no longer covers scrollbar

### DIFF
--- a/packages/ui/components/ResizeHandle.tsx
+++ b/packages/ui/components/ResizeHandle.tsx
@@ -3,9 +3,9 @@ import type { ResizeHandleProps as BaseProps } from '../hooks/useResizablePanel'
 
 interface Props extends BaseProps {
   className?: string;
-  /** Controls which direction the touch area extends to avoid covering adjacent scrollbars.
-   *  'left' = handle is on the right edge of the left sidebar, touch area extends leftward.
-   *  'right' = handle is on the left edge of the right panel, touch area extends rightward. */
+  /** Touch area extends rightward to avoid covering scrollbars on the right
+   *  edge of the left-adjacent panel. 'right' uses zero left encroachment
+   *  since the scrollbar is immediately adjacent; 'left' allows slight overlap. */
   side?: 'left' | 'right';
 }
 
@@ -28,7 +28,7 @@ export const ResizeHandle: React.FC<Props> = ({
     <div
       className={`absolute inset-y-0 ${
         side === 'left' ? '-right-2 -left-1' :
-        side === 'right' ? '-left-2 -right-1' :
+        side === 'right' ? '-right-3 left-0' :
         '-inset-x-2'
       }`}
       onMouseDown={onMouseDown}


### PR DESCRIPTION
## Summary
- Commit `3ac3d5b` ("sidebar resize handle touch area") swapped the touch area bias so the right `ResizeHandle` (`side="right"`) extended 8px **left** into the content area, covering the 6px scrollbar — users could see the scrollbar but couldn't grab it
- Changed `side="right"` from `-left-2 -right-1` to `left-0 -right-3` so the touch target has zero left encroachment and extends entirely into the sidebar panel

Fixes #354 (regression)

## Test plan
- [ ] Open code review with a long file — scrollbar on right edge is easily grabbable
- [ ] Resize the annotation panel via the right drag handle — still works
- [ ] Open plan editor with long content — same scrollbar behavior
- [ ] Left sidebar resize handle still works and doesn't cover FileTree scrollbar