### PR TITLE
fix(review): hide annotation toolbar when suggestion modal is open

### DIFF
--- a/packages/review-editor/components/DiffViewer.tsx
+++ b/packages/review-editor/components/DiffViewer.tsx
@@ -545,7 +545,7 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
           </div>
         </div>
 
-      {toolbar.toolbarState && (
+      {toolbar.toolbarState && !toolbar.showCodeModal && (
         <AnnotationToolbar
           toolbarState={toolbar.toolbarState}
           toolbarRef={toolbar.toolbarRef}


### PR DESCRIPTION
Prevent stacking dialogs by hiding the AnnotationToolbar when the SuggestionModal (expanded editor) is open, avoiding the original dialog from overlaying the fullpage dialog.

| Before | After |
|--------|--------|
| ![CleanShot 2026-04-02 at 11 18 54](https://github.com/user-attachments/assets/ef9aae8d-6dc3-497b-a236-2a35a3e23414) | ![CleanShot 2026-04-02 at 11 17 46](https://github.com/user-attachments/assets/9001a5b9-0c4f-470e-83cf-dd78b8a0729d) | 



