### PR TITLE
feat(review): prefill suggested code textarea with selected code

### DIFF
--- a/packages/review-editor/components/AnnotationToolbar.tsx
+++ b/packages/review-editor/components/AnnotationToolbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { ToolbarState } from '../hooks/useAnnotationToolbar';
 import { useTabIndent } from '../hooks/useTabIndent';
@@ -17,6 +17,7 @@ interface AnnotationToolbarProps {
   setSuggestedCode: React.Dispatch<React.SetStateAction<string>>;
   showSuggestedCode: boolean;
   setShowSuggestedCode: (show: boolean) => void;
+  selectedOriginalCode?: string;
   isEditing?: boolean;
   setShowCodeModal: (show: boolean) => void;
   onSubmit: () => void;
@@ -41,6 +42,7 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
   setSuggestedCode,
   showSuggestedCode,
   setShowSuggestedCode,
+  selectedOriginalCode,
   isEditing = false,
   setShowCodeModal,
   onSubmit,
@@ -52,6 +54,7 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
   onViewAIResponse,
   aiHistoryMessages = [],
 }) => {
+  const suggestedCodeRef = useRef<HTMLTextAreaElement>(null);
   const handleTabIndent = useTabIndent(setSuggestedCode);
   const [askAIMode, setAskAIMode] = useState(false);
   const { dragPosition, dragHandleProps, wasDragged, reset: resetDrag } = useDraggable(toolbarRef);
@@ -158,6 +161,7 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
                 </button>
               </div>
               <textarea
+                ref={suggestedCodeRef}
                 value={suggestedCode}
                 onChange={(e) => setSuggestedCode(e.target.value)}
                 placeholder="Enter code suggestion..."
@@ -176,7 +180,22 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
             </div>
           ) : (
             <button
-              onClick={() => setShowSuggestedCode(true)}
+              onClick={() => {
+                setShowSuggestedCode(true);
+
+                const prefill = !suggestedCode && selectedOriginalCode;
+                if (prefill) {
+                  setSuggestedCode(selectedOriginalCode);
+
+                  // Focus at the end of the textarea
+                  requestAnimationFrame(() => {
+                    const ta = suggestedCodeRef.current;
+                    if (ta) {
+                      ta.setSelectionRange(ta.value.length, ta.value.length);
+                    }
+                  });
+                }
+              }}
               className="mt-2 text-xs text-muted-foreground hover:text-foreground flex items-center gap-1 transition-colors"
             >
               <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>

--- a/packages/review-editor/components/DiffViewer.tsx
+++ b/packages/review-editor/components/DiffViewer.tsx
@@ -555,6 +555,7 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
           setSuggestedCode={toolbar.setSuggestedCode}
           showSuggestedCode={toolbar.showSuggestedCode}
           setShowSuggestedCode={toolbar.setShowSuggestedCode}
+          selectedOriginalCode={toolbar.selectedOriginalCode}
           setShowCodeModal={toolbar.setShowCodeModal}
           isEditing={!!toolbar.editingAnnotationId}
           onSubmit={toolbar.handleSubmitAnnotation}


### PR DESCRIPTION
When user clicks "Add suggested code" button in an annotation comment, the textarea is now pre-filled with the original selected code, allowing them to edit from there instead of typing from scratch. The cursor is positioned at the end of the prefilled text using requestAnimationFrame to ensure proper focus after state updates.

| Before | After |
|--------|--------|
| ![CleanShot 2026-04-02 at 11 21 32](https://github.com/user-attachments/assets/923c584c-422b-48d0-aa93-b524cfcfc5bf) | ![CleanShot 2026-04-02 at 11 22 38](https://github.com/user-attachments/assets/bf941c6b-df54-4d5b-aef5-b671012f2238) | 