### PR TITLE
feat: add Perforce (P4) pending changelist diff support

### DIFF
--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -63,7 +63,7 @@ import {
   startAnnotateServer,
   handleAnnotateServerReady,
 } from "@plannotator/server/annotate";
-import { getGitContext, runGitDiff } from "@plannotator/server/git";
+import { type DiffType, getVcsContext, runVcsDiff } from "@plannotator/server/vcs";
 import { parsePRUrl, checkPRAuth, fetchPR, getCliName, getCliInstallUrl, getMRLabel, getMRNumberLabel, getDisplayRepo } from "@plannotator/server/pr";
 import { writeRemoteShareLink } from "@plannotator/server/share-url";
 import { resolveMarkdownFile, hasMarkdownFiles } from "@plannotator/shared/resolve-file";
@@ -190,8 +190,9 @@ if (args[0] === "sessions") {
   let rawPatch: string;
   let gitRef: string;
   let diffError: string | undefined;
-  let gitContext: Awaited<ReturnType<typeof getGitContext>> | undefined;
+  let gitContext: Awaited<ReturnType<typeof getVcsContext>> | undefined;
   let prMetadata: Awaited<ReturnType<typeof fetchPR>>["metadata"] | undefined;
+  let initialDiffType: DiffType | undefined;
 
   if (isPRMode) {
     // --- PR Review Mode ---
@@ -232,8 +233,9 @@ if (args[0] === "sessions") {
     }
   } else {
     // --- Local Review Mode ---
-    gitContext = await getGitContext();
-    const diffResult = await runGitDiff("uncommitted", gitContext.defaultBranch);
+    gitContext = await getVcsContext();
+    initialDiffType = gitContext.vcsType === "p4" ? "p4-default" : "uncommitted";
+    const diffResult = await runVcsDiff(initialDiffType, gitContext.defaultBranch);
     rawPatch = diffResult.patch;
     gitRef = diffResult.label;
     diffError = diffResult.error;
@@ -247,7 +249,7 @@ if (args[0] === "sessions") {
     gitRef,
     error: diffError,
     origin: detectedOrigin,
-    diffType: isPRMode ? undefined : "uncommitted",
+    diffType: isPRMode ? undefined : (initialDiffType ?? "uncommitted"),
     gitContext,
     prMetadata,
     sharingEnabled,

--- a/packages/server/p4.ts
+++ b/packages/server/p4.ts
@@ -1,0 +1,396 @@
+/**
+ * Perforce (P4) utilities for code review
+ *
+ * Provides pending changelist diff support for Perforce workspaces.
+ * Mirrors the structure of git.ts for consistent VCS abstraction.
+ */
+
+import {
+  type DiffResult,
+  type DiffType,
+  type GitCommandResult,
+  type GitContext,
+  parseP4DiffType,
+  validateFilePath,
+} from "@plannotator/shared/review-core";
+
+// --- P4 command runner ---
+
+async function runP4(
+  args: string[],
+  options?: { cwd?: string },
+): Promise<GitCommandResult> {
+  const proc = Bun.spawn(["p4", ...args], {
+    cwd: options?.cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  return { stdout, stderr, exitCode };
+}
+
+// --- Path helpers ---
+
+function normalizePath(p: string): string {
+  return p.replace(/\\/g, "/");
+}
+
+function toRelativePath(absPath: string, normalizedRoot: string): string {
+  const normalized = normalizePath(absPath);
+  if (normalized.startsWith(normalizedRoot + "/")) {
+    return normalized.slice(normalizedRoot.length + 1);
+  }
+  if (normalized.startsWith(normalizedRoot)) {
+    return normalized.slice(normalizedRoot.length);
+  }
+  return normalized;
+}
+
+// --- P4 workspace detection (cached) ---
+
+export interface P4WorkspaceInfo {
+  clientName: string;
+  clientRoot: string;
+  /** clientRoot with backslashes normalized to forward slashes */
+  normalizedRoot: string;
+  userName: string;
+  serverAddress: string;
+}
+
+const workspaceCache = new Map<string, { info: P4WorkspaceInfo | null; ts: number }>();
+const CACHE_TTL_MS = 30_000;
+
+export async function detectP4Workspace(
+  cwd?: string,
+): Promise<P4WorkspaceInfo | null> {
+  const key = cwd ?? process.cwd();
+  const cached = workspaceCache.get(key);
+  if (cached && Date.now() - cached.ts < CACHE_TTL_MS) {
+    return cached.info;
+  }
+
+  const result = await runP4(["info"], { cwd });
+  if (result.exitCode !== 0) {
+    workspaceCache.set(key, { info: null, ts: Date.now() });
+    return null;
+  }
+
+  const info: Record<string, string> = {};
+  for (const line of result.stdout.split("\n")) {
+    const colonIdx = line.indexOf(": ");
+    if (colonIdx !== -1) {
+      info[line.slice(0, colonIdx).trim()] = line.slice(colonIdx + 2).trim();
+    }
+  }
+
+  const clientName = info["Client name"];
+  const clientRoot = info["Client root"];
+  const userName = info["User name"];
+  const serverAddress = info["Server address"];
+
+  if (!clientName || !clientRoot) {
+    workspaceCache.set(key, { info: null, ts: Date.now() });
+    return null;
+  }
+
+  const wsInfo: P4WorkspaceInfo = {
+    clientName,
+    clientRoot,
+    normalizedRoot: normalizePath(clientRoot).replace(/\/$/, ""),
+    userName,
+    serverAddress,
+  };
+  workspaceCache.set(key, { info: wsInfo, ts: Date.now() });
+  return wsInfo;
+}
+
+// --- P4 context (GitContext compatible) ---
+
+export async function getP4Context(cwd?: string): Promise<GitContext> {
+  const workspace = await detectP4Workspace(cwd);
+  if (!workspace) {
+    return {
+      currentBranch: "",
+      defaultBranch: "",
+      diffOptions: [],
+      worktrees: [],
+      cwd,
+      vcsType: "p4",
+    };
+  }
+
+  const diffOptions: GitContext["diffOptions"] = [];
+
+  // Check default changelist has files
+  const [defaultOpened, changesResult] = await Promise.all([
+    runP4(["opened", "-c", "default"], { cwd }),
+    runP4(["changes", "-s", "pending", "-u", workspace.userName, "-c", workspace.clientName], { cwd }),
+  ]);
+
+  if (defaultOpened.exitCode === 0 && defaultOpened.stdout.trim()) {
+    diffOptions.push({ id: "p4-default", label: "Default changelist" });
+  }
+
+  // Collect numbered changelists, then check which have files
+  if (changesResult.exitCode === 0) {
+    const candidates: { clNumber: string; desc: string }[] = [];
+    for (const line of changesResult.stdout.trim().split("\n")) {
+      if (!line) continue;
+      const match = line.match(/^Change (\d+) on .+? by .+? \*?'(.*)'\s*$/);
+      if (match) {
+        const desc = match[2].length > 40 ? match[2].slice(0, 40) + "..." : match[2];
+        candidates.push({ clNumber: match[1], desc });
+      }
+    }
+
+    // Check all changelists for opened files in parallel
+    const checks = await Promise.all(
+      candidates.map(({ clNumber }) => runP4(["opened", "-c", clNumber], { cwd })),
+    );
+
+    for (let i = 0; i < candidates.length; i++) {
+      if (checks[i].exitCode === 0 && checks[i].stdout.trim()) {
+        diffOptions.push({
+          id: `p4-changelist:${candidates[i].clNumber}`,
+          label: `CL ${candidates[i].clNumber}: ${candidates[i].desc}`,
+        });
+      }
+    }
+  }
+
+  return {
+    currentBranch: workspace.clientName,
+    defaultBranch: "",
+    diffOptions,
+    worktrees: [],
+    cwd: cwd ?? workspace.clientRoot,
+    vcsType: "p4",
+  };
+}
+
+// --- P4 diff ---
+
+/**
+ * Convert P4 diff output to git-compatible unified diff format.
+ *
+ * P4 `diff -du` outputs:
+ *   --- //depot/path/file.cpp\tdate
+ *   +++ C:\Workspace\client\path\file.cpp\tdate
+ *   @@ hunks @@
+ *
+ * Converted to:
+ *   diff --git a/relative/file.cpp b/relative/file.cpp
+ *   --- a/relative/file.cpp
+ *   +++ b/relative/file.cpp
+ *   @@ hunks @@
+ */
+function convertP4DiffToGitFormat(
+  rawOutput: string,
+  normalizedRoot: string,
+): string {
+  const lines = rawOutput.split("\n");
+  const result: string[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Match ==== separator (some P4 versions use this)
+    const separatorMatch = line.match(/^==== .+#\d+ - (.+?) ====/);
+    if (separatorMatch) {
+      const relativePath = toRelativePath(separatorMatch[1], normalizedRoot);
+      result.push(`diff --git a/${relativePath} b/${relativePath}`);
+      continue;
+    }
+
+    // Match --- line: starts a new file diff
+    if (line.startsWith("--- ") && !line.startsWith("--- a/")) {
+      // Determine relative path from +++ line (local path, more reliable)
+      const nextLine = lines[i + 1];
+      let relativePath: string;
+      if (nextLine && nextLine.startsWith("+++ ")) {
+        const localPath = nextLine.slice(4).split("\t")[0];
+        relativePath = toRelativePath(localPath, normalizedRoot);
+      } else {
+        const rawPath = line.slice(4).split("\t")[0];
+        relativePath = toRelativePath(rawPath, normalizedRoot);
+      }
+
+      result.push(`diff --git a/${relativePath} b/${relativePath}`);
+      result.push(`--- a/${relativePath}`);
+      continue;
+    }
+
+    if (line.startsWith("+++ ") && !line.startsWith("+++ b/")) {
+      const localPath = line.slice(4).split("\t")[0];
+      const relativePath = toRelativePath(localPath, normalizedRoot);
+      result.push(`+++ b/${relativePath}`);
+      continue;
+    }
+
+    result.push(line);
+  }
+
+  return result.join("\n");
+}
+
+/**
+ * Get unified diff for new files (p4 add) that have no depot version yet.
+ */
+async function getNewFileDiff(
+  localPath: string,
+  relativePath: string,
+): Promise<string> {
+  try {
+    const content = await Bun.file(localPath).text();
+    const lines = content.split("\n");
+    const header = [
+      `diff --git a/${relativePath} b/${relativePath}`,
+      "new file mode 100644",
+      "--- /dev/null",
+      `+++ b/${relativePath}`,
+      `@@ -0,0 +1,${lines.length} @@`,
+    ];
+    return header.join("\n") + "\n" + lines.map((l) => `+${l}`).join("\n");
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Batch-resolve depot paths to local paths via a single `p4 where` call.
+ * Returns a map from depot path to { localPath, relativePath }.
+ */
+async function batchResolveDepotPaths(
+  depotPaths: string[],
+  normalizedRoot: string,
+  cwd?: string,
+): Promise<Map<string, { localPath: string; relativePath: string }>> {
+  const result = new Map<string, { localPath: string; relativePath: string }>();
+  if (depotPaths.length === 0) return result;
+
+  const whereResult = await runP4(["where", ...depotPaths], { cwd });
+  if (whereResult.exitCode !== 0) return result;
+
+  const outputLines = whereResult.stdout.trim().split("\n");
+  for (let i = 0; i < outputLines.length && i < depotPaths.length; i++) {
+    const whereOutput = outputLines[i];
+    const rootIdx = whereOutput.indexOf(normalizePath(normalizedRoot).length > 0 ? normalizedRoot : "NOMATCH");
+    // Find the local path by looking for the client root
+    const clientRootBackslash = normalizedRoot.replace(/\//g, "\\");
+    const bsIdx = whereOutput.indexOf(clientRootBackslash);
+    const fwIdx = whereOutput.indexOf(normalizedRoot);
+    const idx = bsIdx !== -1 ? bsIdx : fwIdx;
+    if (idx === -1) continue;
+
+    const localPath = normalizePath(whereOutput.slice(idx));
+    const relativePath = toRelativePath(localPath, normalizedRoot);
+    result.set(depotPaths[i], { localPath, relativePath });
+  }
+
+  return result;
+}
+
+export async function runP4Diff(
+  diffType: DiffType,
+  cwd?: string,
+): Promise<DiffResult> {
+  const workspace = await detectP4Workspace(cwd);
+  if (!workspace) {
+    return { patch: "", label: "P4 error", error: "Not in a Perforce workspace" };
+  }
+
+  const parsed = parseP4DiffType(diffType);
+  if (!parsed) {
+    return { patch: "", label: "Unknown diff type" };
+  }
+
+  try {
+    const label = parsed.changelist === "default"
+      ? "Default changelist"
+      : `Changelist ${parsed.changelist}`;
+
+    const openedArgs = parsed.changelist === "default"
+      ? ["opened", "-c", "default"]
+      : ["opened", "-c", parsed.changelist];
+    const openedResult = await runP4(openedArgs, { cwd });
+
+    if (openedResult.exitCode !== 0 || !openedResult.stdout.trim()) {
+      return { patch: "", label, error: openedResult.stderr || undefined };
+    }
+
+    const diffDepotPaths: string[] = [];
+    const addedDepotPaths: string[] = [];
+
+    for (const line of openedResult.stdout.trim().split("\n")) {
+      if (!line) continue;
+      // Skip binary files — type in parentheses, e.g. "(binary)", "(binary+l)"
+      const typeMatch = line.match(/\((\S+)\)\s*(by\s|$)/);
+      if (typeMatch && typeMatch[1].startsWith("binary")) continue;
+      const depotPath = line.split("#")[0];
+      if (!depotPath) continue;
+      if (line.includes(" - add ")) {
+        addedDepotPaths.push(depotPath);
+      } else {
+        diffDepotPaths.push(depotPath);
+      }
+    }
+
+    let patch = "";
+
+    if (diffDepotPaths.length > 0) {
+      const diffResult = await runP4(["diff", "-du", ...diffDepotPaths], { cwd });
+      if (diffResult.exitCode === 0 || diffResult.stdout.trim()) {
+        patch = convertP4DiffToGitFormat(diffResult.stdout, workspace.normalizedRoot);
+      }
+    }
+
+    // Handle newly added files (p4 add) — they don't appear in p4 diff
+    if (addedDepotPaths.length > 0) {
+      const resolved = await batchResolveDepotPaths(addedDepotPaths, workspace.normalizedRoot, cwd);
+      for (const depotPath of addedDepotPaths) {
+        const mapping = resolved.get(depotPath);
+        if (!mapping) continue;
+        const newFilePatch = await getNewFileDiff(mapping.localPath, mapping.relativePath);
+        if (newFilePatch) {
+          patch += (patch ? "\n" : "") + newFilePatch;
+        }
+      }
+    }
+
+    return { patch, label };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { patch: "", label: "P4 error", error: message };
+  }
+}
+
+// --- File content retrieval ---
+
+export async function getP4FileContentsForDiff(
+  diffType: DiffType,
+  filePath: string,
+  cwd?: string,
+): Promise<{ oldContent: string | null; newContent: string | null }> {
+  const workspace = await detectP4Workspace(cwd);
+  if (!workspace) return { oldContent: null, newContent: null };
+
+  validateFilePath(filePath);
+
+  const fullLocalPath = `${workspace.normalizedRoot}/${filePath}`;
+
+  const [printResult, newContent] = await Promise.all([
+    runP4(["print", "-q", `${fullLocalPath}#have`], { cwd }),
+    Bun.file(fullLocalPath).text().catch(() => null),
+  ]);
+
+  return {
+    oldContent: printResult.exitCode === 0 ? printResult.stdout : null,
+    newContent,
+  };
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -13,6 +13,8 @@
     "./browser": "./browser.ts",
     "./storage": "./storage.ts",
     "./git": "./git.ts",
+    "./p4": "./p4.ts",
+    "./vcs": "./vcs.ts",
     "./repo": "./repo.ts",
     "./share-url": "./share-url.ts",
     "./sessions": "./sessions.ts",

--- a/packages/server/review.ts
+++ b/packages/server/review.ts
@@ -11,7 +11,7 @@
 
 import { isRemoteSession, getServerPort } from "./remote";
 import type { Origin } from "@plannotator/shared/agents";
-import { type DiffType, type GitContext, runVcsDiff, getVcsFileContentsForDiff, gitAddFile, gitResetFile, parseWorktreeDiffType, validateFilePath, isP4DiffType } from "./vcs";
+import { type DiffType, type GitContext, runVcsDiff, getVcsFileContentsForDiff, canStageFiles, stageFile, unstageFile, resolveVcsCwd, validateFilePath } from "./vcs";
 import { getRepoInfo } from "./repo";
 import { handleImage, handleUpload, handleAgents, handleServerReady, handleDraftSave, handleDraftLoad, handleDraftDelete, handleFavicon, type OpencodeClient } from "./shared-handlers";
 import { contentHash, deleteDraft } from "./draft";
@@ -112,11 +112,7 @@ export async function startReviewServer(
     mode: "review",
     getServerUrl: () => serverUrl,
     getCwd: () => {
-      if (currentDiffType.startsWith("worktree:")) {
-        const parsed = parseWorktreeDiffType(currentDiffType);
-        if (parsed) return parsed.path;
-      }
-      return gitContext?.cwd ?? process.cwd();
+      return resolveVcsCwd(currentDiffType, gitContext?.cwd) ?? process.cwd();
     },
   });
 
@@ -198,11 +194,7 @@ export async function startReviewServer(
       registry: aiRegistry,
       sessionManager: aiSessionManager,
       getCwd: () => {
-        if (currentDiffType.startsWith("worktree:")) {
-          const parsed = parseWorktreeDiffType(currentDiffType);
-          if (parsed) return parsed.path;
-        }
-        return gitContext?.cwd ?? process.cwd();
+        return resolveVcsCwd(currentDiffType, gitContext?.cwd) ?? process.cwd();
       },
     });
   }
@@ -380,11 +372,11 @@ export async function startReviewServer(
             return Response.json(result);
           }
 
-          // API: Git add / reset (stage / unstage) a file (disabled in PR mode and P4)
+          // API: Stage / unstage a file (disabled when VCS doesn't support it)
           if (url.pathname === "/api/git-add" && req.method === "POST") {
-            if (isPRMode || isP4DiffType(currentDiffType)) {
+            if (isPRMode || !canStageFiles(currentDiffType)) {
               return Response.json(
-                { error: isPRMode ? "Not available for PR reviews" : "Staging not available for Perforce" },
+                { error: "Staging not available" },
                 { status: 400 },
               );
             }
@@ -394,25 +386,17 @@ export async function startReviewServer(
                 return Response.json({ error: "Missing filePath" }, { status: 400 });
               }
 
-              // Determine cwd for worktree support
-              let cwd: string | undefined;
-              if (currentDiffType.startsWith("worktree:")) {
-                const parsed = parseWorktreeDiffType(currentDiffType);
-                if (parsed) cwd = parsed.path;
-              }
-              if (!cwd) {
-                cwd = gitContext?.cwd;
-              }
+              const cwd = resolveVcsCwd(currentDiffType, gitContext?.cwd);
 
               if (body.undo) {
-                await gitResetFile(body.filePath, cwd);
+                await unstageFile(currentDiffType, body.filePath, cwd);
               } else {
-                await gitAddFile(body.filePath, cwd);
+                await stageFile(currentDiffType, body.filePath, cwd);
               }
 
               return Response.json({ ok: true });
             } catch (err) {
-              const message = err instanceof Error ? err.message : "Failed to git add";
+              const message = err instanceof Error ? err.message : "Failed to stage file";
               return Response.json({ error: message }, { status: 500 });
             }
           }

--- a/packages/server/review.ts
+++ b/packages/server/review.ts
@@ -11,7 +11,7 @@
 
 import { isRemoteSession, getServerPort } from "./remote";
 import type { Origin } from "@plannotator/shared/agents";
-import { type DiffType, type GitContext, runGitDiff, getFileContentsForDiff, gitAddFile, gitResetFile, parseWorktreeDiffType, validateFilePath } from "./git";
+import { type DiffType, type GitContext, runVcsDiff, getVcsFileContentsForDiff, gitAddFile, gitResetFile, parseWorktreeDiffType, validateFilePath, isP4DiffType } from "./vcs";
 import { getRepoInfo } from "./repo";
 import { handleImage, handleUpload, handleAgents, handleServerReady, handleDraftSave, handleDraftLoad, handleDraftDelete, handleFavicon, type OpencodeClient } from "./shared-handlers";
 import { contentHash, deleteDraft } from "./draft";
@@ -26,7 +26,7 @@ import { isWSL } from "./browser";
 // Re-export utilities
 export { isRemoteSession, getServerPort } from "./remote";
 export { openBrowser } from "./browser";
-export { type DiffType, type DiffOption, type GitContext, type WorktreeInfo } from "./git";
+export { type DiffType, type DiffOption, type GitContext, type WorktreeInfo } from "./vcs";
 export { type PRMetadata } from "./pr";
 export { handleServerReady as handleReviewServerReady } from "./shared-handlers";
 
@@ -304,7 +304,7 @@ export async function startReviewServer(
               const defaultCwd = gitContext?.cwd;
 
               // Run the new diff
-              const result = await runGitDiff(newDiffType, defaultBranch, defaultCwd);
+              const result = await runVcsDiff(newDiffType, defaultBranch, defaultCwd);
 
               // Update state
               currentPatch = result.patch;
@@ -370,7 +370,7 @@ export async function startReviewServer(
 
             const defaultBranch = gitContext?.defaultBranch || "main";
             const defaultCwd = gitContext?.cwd;
-            const result = await getFileContentsForDiff(
+            const result = await getVcsFileContentsForDiff(
               currentDiffType,
               defaultBranch,
               filePath,
@@ -380,11 +380,11 @@ export async function startReviewServer(
             return Response.json(result);
           }
 
-          // API: Git add / reset (stage / unstage) a file (disabled in PR mode)
+          // API: Git add / reset (stage / unstage) a file (disabled in PR mode and P4)
           if (url.pathname === "/api/git-add" && req.method === "POST") {
-            if (isPRMode) {
+            if (isPRMode || isP4DiffType(currentDiffType)) {
               return Response.json(
-                { error: "Not available for PR reviews" },
+                { error: isPRMode ? "Not available for PR reviews" : "Staging not available for Perforce" },
                 { status: 400 },
               );
             }

--- a/packages/server/vcs.ts
+++ b/packages/server/vcs.ts
@@ -1,0 +1,107 @@
+/**
+ * VCS dispatch layer
+ *
+ * Auto-detects Git or Perforce and routes to the appropriate backend.
+ * Provides a unified interface for the review server.
+ */
+
+import {
+  type DiffResult,
+  type DiffType,
+  type GitContext,
+  isP4DiffType,
+} from "@plannotator/shared/review-core";
+
+import {
+  getGitContext,
+  runGitDiff,
+  getFileContentsForDiff as gitGetFileContentsForDiff,
+  gitAddFile,
+  gitResetFile,
+  parseWorktreeDiffType,
+  validateFilePath,
+} from "./git";
+
+import {
+  detectP4Workspace,
+  getP4Context,
+  runP4Diff,
+  getP4FileContentsForDiff,
+} from "./p4";
+
+export type VcsBackend = "git" | "p4";
+
+// Re-export types and utilities consumers need
+export type {
+  DiffType,
+  DiffOption,
+  GitContext,
+  WorktreeInfo,
+} from "./git";
+
+export { parseWorktreeDiffType, validateFilePath } from "./git";
+export { gitAddFile, gitResetFile } from "./git";
+export { isP4DiffType } from "@plannotator/shared/review-core";
+
+// Cache detected VCS per cwd
+const vcsCache = new Map<string, VcsBackend>();
+
+export async function detectVcs(cwd?: string): Promise<VcsBackend> {
+  const key = cwd ?? process.cwd();
+  const cached = vcsCache.get(key);
+  if (cached) return cached;
+
+  // Try git first — only need exit code, ignore output
+  const proc = Bun.spawn(["git", "rev-parse", "--is-inside-work-tree"], {
+    cwd: cwd ?? undefined,
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  const exitCode = await proc.exited;
+
+  if (exitCode === 0) {
+    vcsCache.set(key, "git");
+    return "git";
+  }
+
+  // Try P4
+  const p4Info = await detectP4Workspace(cwd);
+  if (p4Info) {
+    vcsCache.set(key, "p4");
+    return "p4";
+  }
+
+  // Default to git (existing behavior)
+  vcsCache.set(key, "git");
+  return "git";
+}
+
+export async function getVcsContext(cwd?: string): Promise<GitContext> {
+  const vcs = await detectVcs(cwd);
+  if (vcs === "p4") return getP4Context(cwd);
+  return getGitContext(cwd);
+}
+
+export async function runVcsDiff(
+  diffType: DiffType,
+  defaultBranch: string = "main",
+  cwd?: string,
+): Promise<DiffResult> {
+  if (isP4DiffType(diffType)) {
+    return runP4Diff(diffType, cwd);
+  }
+  return runGitDiff(diffType, defaultBranch, cwd);
+}
+
+export async function getVcsFileContentsForDiff(
+  diffType: DiffType,
+  defaultBranch: string,
+  filePath: string,
+  oldPath?: string,
+  cwd?: string,
+): Promise<{ oldContent: string | null; newContent: string | null }> {
+  if (isP4DiffType(diffType)) {
+    return getP4FileContentsForDiff(diffType, filePath, cwd);
+  }
+  return gitGetFileContentsForDiff(diffType, defaultBranch, filePath, oldPath, cwd);
+}

--- a/packages/server/vcs.ts
+++ b/packages/server/vcs.ts
@@ -1,15 +1,19 @@
 /**
  * VCS dispatch layer
  *
- * Auto-detects Git or Perforce and routes to the appropriate backend.
- * Provides a unified interface for the review server.
+ * Provides a provider-based abstraction over version control systems.
+ * Each VCS (Git, P4, etc.) registers as a provider. The dispatch layer
+ * auto-detects the active VCS and routes operations accordingly.
+ *
+ * To add a new VCS:
+ * 1. Implement the VcsProvider interface
+ * 2. Add it to the `providers` array below (detection order matters)
  */
 
 import {
   type DiffResult,
   type DiffType,
   type GitContext,
-  isP4DiffType,
 } from "@plannotator/shared/review-core";
 
 import {
@@ -29,9 +33,117 @@ import {
   getP4FileContentsForDiff,
 } from "./p4";
 
-export type VcsBackend = "git" | "p4";
+// --- VCS Provider interface ---
 
-// Re-export types and utilities consumers need
+export interface VcsProvider {
+  /** Unique identifier for this VCS backend */
+  readonly id: string;
+
+  /** Detect whether the given directory is managed by this VCS */
+  detect(cwd?: string): Promise<boolean>;
+
+  /** Check if a DiffType belongs to this provider */
+  ownsDiffType(diffType: string): boolean;
+
+  /** Build context with branch info and available diff options */
+  getContext(cwd?: string): Promise<GitContext>;
+
+  /** Get unified diff patch for the given diff type */
+  runDiff(diffType: DiffType, defaultBranch: string, cwd?: string): Promise<DiffResult>;
+
+  /** Get old/new file contents for hunk expansion */
+  getFileContents(
+    diffType: DiffType,
+    defaultBranch: string,
+    filePath: string,
+    oldPath?: string,
+    cwd?: string,
+  ): Promise<{ oldContent: string | null; newContent: string | null }>;
+
+  /** Stage a file (optional — not all VCS support staging) */
+  stageFile?(filePath: string, cwd?: string): Promise<void>;
+
+  /** Unstage a file (optional — not all VCS support staging) */
+  unstageFile?(filePath: string, cwd?: string): Promise<void>;
+
+  /** Resolve effective cwd from a diff type (e.g. worktree path) */
+  resolveCwd?(diffType: string, fallbackCwd?: string): string | undefined;
+}
+
+// --- Git provider ---
+
+const GIT_DIFF_TYPES = new Set(["uncommitted", "staged", "unstaged", "last-commit", "branch"]);
+
+const gitProvider: VcsProvider = {
+  id: "git",
+
+  async detect(cwd?: string): Promise<boolean> {
+    const proc = Bun.spawn(["git", "rev-parse", "--is-inside-work-tree"], {
+      cwd: cwd ?? undefined,
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    return (await proc.exited) === 0;
+  },
+
+  ownsDiffType(diffType: string): boolean {
+    return GIT_DIFF_TYPES.has(diffType) || diffType.startsWith("worktree:");
+  },
+
+  getContext: getGitContext,
+
+  runDiff(diffType: DiffType, defaultBranch: string, cwd?: string) {
+    return runGitDiff(diffType, defaultBranch, cwd);
+  },
+
+  getFileContents(diffType, defaultBranch, filePath, oldPath?, cwd?) {
+    return gitGetFileContentsForDiff(diffType, defaultBranch, filePath, oldPath, cwd);
+  },
+
+  stageFile: gitAddFile,
+  unstageFile: gitResetFile,
+
+  resolveCwd(diffType: string, fallbackCwd?: string): string | undefined {
+    if (diffType.startsWith("worktree:")) {
+      const parsed = parseWorktreeDiffType(diffType);
+      if (parsed) return parsed.path;
+    }
+    return fallbackCwd;
+  },
+};
+
+// --- P4 provider ---
+
+const p4Provider: VcsProvider = {
+  id: "p4",
+
+  async detect(cwd?: string): Promise<boolean> {
+    return (await detectP4Workspace(cwd)) !== null;
+  },
+
+  ownsDiffType(diffType: string): boolean {
+    return diffType === "p4-default" || diffType.startsWith("p4-changelist:");
+  },
+
+  getContext: getP4Context,
+
+  runDiff(diffType: DiffType, _defaultBranch: string, cwd?: string) {
+    return runP4Diff(diffType, cwd);
+  },
+
+  getFileContents(diffType, _defaultBranch, filePath, _oldPath?, cwd?) {
+    return getP4FileContentsForDiff(diffType, filePath, cwd);
+  },
+
+  // P4 has no staging concept — stageFile/unstageFile intentionally omitted
+};
+
+// --- Provider registry ---
+
+/** Providers in detection priority order. First match wins. */
+const providers: VcsProvider[] = [gitProvider, p4Provider];
+
+// Re-export types consumers need
 export type {
   DiffType,
   DiffOption,
@@ -40,46 +152,42 @@ export type {
 } from "./git";
 
 export { parseWorktreeDiffType, validateFilePath } from "./git";
-export { gitAddFile, gitResetFile } from "./git";
-export { isP4DiffType } from "@plannotator/shared/review-core";
 
-// Cache detected VCS per cwd
-const vcsCache = new Map<string, VcsBackend>();
+// --- Detection cache ---
 
-export async function detectVcs(cwd?: string): Promise<VcsBackend> {
+const vcsCache = new Map<string, VcsProvider>();
+
+/** Detect which VCS manages the given directory */
+export async function detectVcs(cwd?: string): Promise<VcsProvider> {
   const key = cwd ?? process.cwd();
   const cached = vcsCache.get(key);
   if (cached) return cached;
 
-  // Try git first — only need exit code, ignore output
-  const proc = Bun.spawn(["git", "rev-parse", "--is-inside-work-tree"], {
-    cwd: cwd ?? undefined,
-    stdout: "ignore",
-    stderr: "ignore",
-  });
-  const exitCode = await proc.exited;
-
-  if (exitCode === 0) {
-    vcsCache.set(key, "git");
-    return "git";
-  }
-
-  // Try P4
-  const p4Info = await detectP4Workspace(cwd);
-  if (p4Info) {
-    vcsCache.set(key, "p4");
-    return "p4";
+  for (const provider of providers) {
+    if (await provider.detect(cwd)) {
+      vcsCache.set(key, provider);
+      return provider;
+    }
   }
 
   // Default to git (existing behavior)
-  vcsCache.set(key, "git");
-  return "git";
+  vcsCache.set(key, gitProvider);
+  return gitProvider;
 }
 
+/** Find the provider that owns a given diff type */
+function getProviderForDiffType(diffType: string): VcsProvider {
+  for (const provider of providers) {
+    if (provider.ownsDiffType(diffType)) return provider;
+  }
+  return gitProvider;
+}
+
+// --- Public API ---
+
 export async function getVcsContext(cwd?: string): Promise<GitContext> {
-  const vcs = await detectVcs(cwd);
-  if (vcs === "p4") return getP4Context(cwd);
-  return getGitContext(cwd);
+  const provider = await detectVcs(cwd);
+  return provider.getContext(cwd);
 }
 
 export async function runVcsDiff(
@@ -87,10 +195,8 @@ export async function runVcsDiff(
   defaultBranch: string = "main",
   cwd?: string,
 ): Promise<DiffResult> {
-  if (isP4DiffType(diffType)) {
-    return runP4Diff(diffType, cwd);
-  }
-  return runGitDiff(diffType, defaultBranch, cwd);
+  const provider = getProviderForDiffType(diffType);
+  return provider.runDiff(diffType, defaultBranch, cwd);
 }
 
 export async function getVcsFileContentsForDiff(
@@ -100,8 +206,47 @@ export async function getVcsFileContentsForDiff(
   oldPath?: string,
   cwd?: string,
 ): Promise<{ oldContent: string | null; newContent: string | null }> {
-  if (isP4DiffType(diffType)) {
-    return getP4FileContentsForDiff(diffType, filePath, cwd);
+  const provider = getProviderForDiffType(diffType);
+  return provider.getFileContents(diffType, defaultBranch, filePath, oldPath, cwd);
+}
+
+/** Check if the given diff type supports file staging */
+export function canStageFiles(diffType: string): boolean {
+  const provider = getProviderForDiffType(diffType);
+  return provider.stageFile !== undefined;
+}
+
+/** Stage a file. Throws if the VCS doesn't support staging. */
+export async function stageFile(
+  diffType: string,
+  filePath: string,
+  cwd?: string,
+): Promise<void> {
+  const provider = getProviderForDiffType(diffType);
+  if (!provider.stageFile) {
+    throw new Error(`Staging not available for ${provider.id}`);
   }
-  return gitGetFileContentsForDiff(diffType, defaultBranch, filePath, oldPath, cwd);
+  return provider.stageFile(filePath, cwd);
+}
+
+/** Unstage a file. Throws if the VCS doesn't support staging. */
+export async function unstageFile(
+  diffType: string,
+  filePath: string,
+  cwd?: string,
+): Promise<void> {
+  const provider = getProviderForDiffType(diffType);
+  if (!provider.unstageFile) {
+    throw new Error(`Unstaging not available for ${provider.id}`);
+  }
+  return provider.unstageFile(filePath, cwd);
+}
+
+/** Resolve the effective cwd for a diff type (e.g. worktree paths) */
+export function resolveVcsCwd(
+  diffType: string,
+  fallbackCwd?: string,
+): string | undefined {
+  const provider = getProviderForDiffType(diffType);
+  return provider.resolveCwd?.(diffType, fallbackCwd) ?? fallbackCwd;
 }

--- a/packages/shared/review-core.ts
+++ b/packages/shared/review-core.ts
@@ -13,7 +13,9 @@ export type DiffType =
   | "unstaged"
   | "last-commit"
   | "branch"
-  | `worktree:${string}`;
+  | `worktree:${string}`
+  | "p4-default"
+  | `p4-changelist:${string}`;
 
 export interface DiffOption {
   id: string;
@@ -32,6 +34,7 @@ export interface GitContext {
   diffOptions: DiffOption[];
   worktrees: WorktreeInfo[];
   cwd?: string;
+  vcsType?: "git" | "p4";
 }
 
 export interface DiffResult {
@@ -509,4 +512,18 @@ export async function gitResetFile(
 ): Promise<void> {
   validateFilePath(filePath);
   await ensureGitSuccess(runtime, ["reset", "HEAD", "--", filePath], cwd);
+}
+
+export function parseP4DiffType(
+  diffType: string,
+): { changelist: string | "default" } | null {
+  if (diffType === "p4-default") return { changelist: "default" };
+  if (diffType.startsWith("p4-changelist:")) {
+    return { changelist: diffType.slice("p4-changelist:".length) };
+  }
+  return null;
+}
+
+export function isP4DiffType(diffType: string): boolean {
+  return parseP4DiffType(diffType) !== null;
 }


### PR DESCRIPTION
## Summary
- Add Perforce workspace detection and pending changelist diff support for code review
- Introduce `VcsProvider` interface with Git and P4 implementations, enabling extensible VCS support via a provider registry pattern
- Auto-detect Git vs P4 workspace and route diff/file-content/staging operations to the appropriate backend

## Details
- **New files**: `packages/server/p4.ts` (P4 runtime), `packages/server/vcs.ts` (VCS dispatch layer)
- **P4 features**: workspace detection with TTL cache, default + numbered changelist diffs, binary file exclusion, `p4 add` (new file) support, batch `p4 where` resolution
- **DiffType additions**: `p4-default`, `p4-changelist:<N>`
- **Staging**: disabled for P4 (no staging concept); Git staging unchanged
- **Breaking changes**: None — existing Git behavior is preserved

## Test plan
- [ ] Verify Git-based code review still works as before
- [ ] Test in a Perforce workspace: default changelist appears in diff dropdown
- [ ] Test numbered changelists with files appear in dropdown
- [ ] Verify binary files are excluded from P4 diffs
- [ ] Verify staging UI is hidden/disabled in P4 mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)