### PR TITLE
fix(review): expand file tree folders by default on initial render (#473)

### DIFF
--- a/packages/review-editor/components/FileTree.tsx
+++ b/packages/review-editor/components/FileTree.tsx
@@ -130,7 +130,7 @@ export const FileTree: React.FC<FileTreeProps> = ({
 
   const tree = useMemo(() => buildFileTree(files), [files]);
 
-  const [expandedFolders, setExpandedFolders] = useState<Set<string>>(new Set());
+  const [expandedFolders, setExpandedFolders] = useState<Set<string>>(() => new Set(getAllFolderPaths(tree)));
   const [prevTree, setPrevTree] = useState(tree);
 
   // Expand all folders when tree changes (initial render + diff switch)


### PR DESCRIPTION
## Summary

- Fix file tree folders starting collapsed on initial render by initializing `expandedFolders` state with all folder paths instead of an empty set

Fixes #473

---

> This PR was generated with assistance from Claude Code.