### PR TITLE
feat(review): add merge-base diff option for PR-style diffs

### DIFF
--- a/packages/server/vcs.ts
+++ b/packages/server/vcs.ts
@@ -72,7 +72,7 @@ export interface VcsProvider {
 
 // --- Git provider ---
 
-const GIT_DIFF_TYPES = new Set(["uncommitted", "staged", "unstaged", "last-commit", "branch"]);
+const GIT_DIFF_TYPES = new Set(["uncommitted", "staged", "unstaged", "last-commit", "branch", "merge-base"]);
 
 const gitProvider: VcsProvider = {
   id: "git",

--- a/packages/shared/review-core.ts
+++ b/packages/shared/review-core.ts
@@ -13,6 +13,7 @@ export type DiffType =
   | "unstaged"
   | "last-commit"
   | "branch"
+  | "merge-base"
   | `worktree:${string}`
   | "p4-default"
   | `p4-changelist:${string}`;
@@ -150,6 +151,7 @@ export async function getGitContext(
 
   if (currentBranch !== defaultBranch) {
     diffOptions.push({ id: "branch", label: `vs ${defaultBranch}` });
+    diffOptions.push({ id: "merge-base", label: `Current PR Diff` });
   }
 
   const [worktrees, currentTreePathResult] = await Promise.all([
@@ -385,6 +387,28 @@ export async function runGitDiff(
         break;
       }
 
+      case "merge-base": {
+        const mergeBaseResult = assertGitSuccess(
+          await runtime.runGit(["merge-base", defaultBranch, "HEAD"], { cwd }),
+          ["merge-base", defaultBranch, "HEAD"],
+        );
+        const mergeBase = mergeBaseResult.stdout.trim();
+        const mergeBaseDiffArgs = [
+          "diff",
+          "--no-ext-diff",
+          `${mergeBase}..HEAD`,
+          "--src-prefix=a/",
+          "--dst-prefix=b/",
+        ];
+        const mergeBaseDiff = assertGitSuccess(
+          await runtime.runGit(mergeBaseDiffArgs, { cwd }),
+          mergeBaseDiffArgs,
+        );
+        patch = mergeBaseDiff.stdout;
+        label = `PR diff vs ${defaultBranch}`;
+        break;
+      }
+
       default:
         return { patch: "", label: "Unknown diff type" };
     }
@@ -474,6 +498,14 @@ export async function getFileContentsForDiff(
         oldContent: await gitShow(defaultBranch, oldFilePath),
         newContent: await gitShow("HEAD", filePath),
       };
+    case "merge-base": {
+      const mbResult = await runtime.runGit(["merge-base", defaultBranch, "HEAD"], { cwd });
+      const mb = mbResult.exitCode === 0 ? mbResult.stdout.trim() : defaultBranch;
+      return {
+        oldContent: await gitShow(mb, oldFilePath),
+        newContent: await gitShow("HEAD", filePath),
+      };
+    }
     default:
       return { oldContent: null, newContent: null };
   }


### PR DESCRIPTION
## Summary

Adds a new **"Current PR Diff"** option to the diff type selector in the code review sidebar.

### Why?

The existing **"vs main"** option runs `git diff main..HEAD`, which diffs against the current tip of the default branch. If `main` has received new commits since you branched, those upstream changes appear in the diff — making it noisy and inconsistent with what you'd see on GitHub.

The new **"Current PR Diff"** option runs `git merge-base main HEAD` to find the common ancestor, then diffs from there (`git diff <merge-base>..HEAD`). This shows only the changes introduced on your branch — the same diff GitHub displays on a pull request.

### Changes

- Added `"merge-base"` to the `DiffType` union
- Added `"Current PR Diff"` option in `getGitContext()` (shown when on a non-default branch, alongside the existing "vs main" option)
- Added `case "merge-base"` in `runGitDiff()` — finds the merge-base commit, then diffs from it to HEAD
- Added `case "merge-base"` in `getFileContentsForDiff()` — uses the merge-base commit for old file content
- Added `"merge-base"` to `GIT_DIFF_TYPES` in the VCS dispatch layer