### PR TITLE
fix(annotate): support @ markdown file references

### DIFF
--- a/packages/server/resolve-file.test.ts
+++ b/packages/server/resolve-file.test.ts
@@ -106,6 +106,33 @@ describe("resolveMarkdownFile", () => {
     });
   });
 
+  test("resolves @ filename via fallback when @ file does not exist", async () => {
+    const root = createTempProject({ "README.md": "# Hello" });
+    const result = resolveMarkdownFile("@README.md", root);
+    expect(result).toEqual({
+      kind: "found",
+      path: resolve(root, "README.md"),
+    });
+  });
+
+  test("prioritizes real @ filename before fallback", async () => {
+    const root = createTempProject({ "@README.md": "# At" });
+    const result = resolveMarkdownFile("@README.md", root);
+    expect(result).toEqual({
+      kind: "found",
+      path: resolve(root, "@README.md"),
+    });
+  });
+
+  test("resolves quoted @ filename", async () => {
+    const root = createTempProject({ "README.md": "# Hello" });
+    const result = resolveMarkdownFile('"@README.md"', root);
+    expect(result).toEqual({
+      kind: "found",
+      path: resolve(root, "README.md"),
+    });
+  });
+
   test("resolves relative paths with Windows separators", async () => {
     const root = createTempProject({ "docs/test-plan.md": "# Test plan\n" });
     const result = resolveMarkdownFile("docs\\test-plan.md", root);
@@ -143,6 +170,19 @@ describe("resolveMarkdownFile", () => {
     const result = resolveMarkdownFile("plan.md", root);
     expect(result.kind).toBe("ambiguous");
     if (result.kind === "ambiguous") {
+      expect(result.matches).toHaveLength(2);
+    }
+  });
+
+  test("returns ambiguous in @ fallback when target exists multiple times", async () => {
+    const root = createTempProject({
+      "docs/plan.md": "# Plan 1",
+      "api/plan.md": "# Plan 2",
+    });
+    const result = resolveMarkdownFile("@plan.md", root);
+    expect(result.kind).toBe("ambiguous");
+    if (result.kind === "ambiguous") {
+      expect(result.input).toBe("@plan.md");
       expect(result.matches).toHaveLength(2);
     }
   });
@@ -188,6 +228,12 @@ describe("resolveMarkdownFile", () => {
     const root = createTempProject();
     const result = resolveMarkdownFile("nope.md", root);
     expect(result.kind).toBe("not_found");
+  });
+
+  test("returns not_found for @ path that cannot be resolved", async () => {
+    const root = createTempProject();
+    const result = resolveMarkdownFile("@nope.md", root);
+    expect(result).toEqual({ kind: "not_found", input: "@nope.md" });
   });
 
   test("handles deeply nested files", async () => {

--- a/packages/shared/resolve-file.ts
+++ b/packages/shared/resolve-file.ts
@@ -78,6 +78,20 @@ function isSearchableMarkdownPath(input: string): boolean {
 	return MARKDOWN_PATH_REGEX.test(input.trim());
 }
 
+function stripWrappingQuotes(input: string): string {
+	if (input.length < 2) {
+		return input;
+	}
+
+	const first = input[0];
+	const last = input[input.length - 1];
+	if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+		return input.slice(1, -1);
+	}
+
+	return input;
+}
+
 /** Check if a path looks like a Windows absolute path (e.g. C:\ or C:/) */
 function hasWindowsDriveLetter(input: string): boolean {
 	return /^[a-zA-Z]:[/\\]/.test(input);
@@ -155,12 +169,10 @@ export function isAbsoluteMarkdownPath(
  * @param input - User-provided path (absolute, relative, or bare filename)
  * @param projectRoot - Project root directory to search within
  */
-export function resolveMarkdownFile(
+function resolveMarkdownFileCore(
 	input: string,
 	projectRoot: string,
 ): ResolveResult {
-	// Trim whitespace/CR that may leak from Windows shell pipelines
-	input = input.trim();
 	const normalizedInput = normalizeMarkdownPathInput(input);
 	const searchInput = normalizeSeparators(normalizedInput);
 	const isBareFilename = !searchInput.includes("/");
@@ -216,6 +228,47 @@ export function resolveMarkdownFile(
 	}
 
 	return { kind: "not_found", input };
+}
+
+/**
+ * Resolve a markdown file path within a project root.
+ *
+ * @param input - User-provided path (absolute, relative, or bare filename)
+ * @param projectRoot - Project root directory to search within
+ */
+export function resolveMarkdownFile(
+	input: string,
+	projectRoot: string,
+): ResolveResult {
+	const originalInput = input.trim();
+	const unquotedInput = stripWrappingQuotes(originalInput);
+
+	const primary = resolveMarkdownFileCore(unquotedInput, projectRoot);
+	if (primary.kind === "found") {
+		return primary;
+	}
+	if (primary.kind === "ambiguous") {
+		return { ...primary, input: originalInput };
+	}
+
+	if (!unquotedInput.startsWith("@")) {
+		return { kind: "not_found", input: originalInput };
+	}
+
+	const normalizedInput = unquotedInput.replace(/^@+/, "");
+	if (!normalizedInput) {
+		return { kind: "not_found", input: originalInput };
+	}
+
+	const fallback = resolveMarkdownFileCore(normalizedInput, projectRoot);
+	if (fallback.kind === "found") {
+		return fallback;
+	}
+	if (fallback.kind === "ambiguous") {
+		return { ...fallback, input: originalInput };
+	}
+
+	return { kind: "not_found", input: originalInput };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fixes markdown path resolution for annotate when the input uses OpenCode-style file references like `@file.md`.
- Adds a safe fallback in the shared resolver: try the original input first, and only if it is `not_found`, retry after stripping leading `@`.

## Problem

In OpenCode, `/plannotator-annotate README.md` worked, but `/plannotator-annotate @README.md` failed to open annotate mode for the file.
The shared resolver treated `@README.md` as a literal filename and returned `not_found` when only `README.md` existed.

## Root Cause

`resolveMarkdownFile` in `packages/shared/resolve-file.ts` did not support `@`-prefixed file reference syntax.

## Changes

- Refactored current resolution logic into an internal core function (`resolveMarkdownFileCore`).
- Kept `resolveMarkdownFile` as a wrapper that now:
  - trims input
  - accepts wrapped quotes (`"..."` / `'...'`)
  - runs primary resolution using the original normalized input
  - if primary result is `not_found` and input starts with `@`, retries with leading `@` removed
  - preserves the original user input in `not_found`/`ambiguous` responses for clearer logs/errors

## Why this is safe

- If a real file named `@spec.md` (or similar) exists, it is found by the primary lookup and returned directly.
- `@` normalization is only applied after the primary lookup fails.
- Existing non-`@` behavior remains unchanged.
- The fix lives in shared resolver logic, so it is consistent across surfaces that reuse it (annotate + `/api/doc` paths).

## Tests

Added coverage in `packages/server/resolve-file.test.ts`:

- resolves `@README.md` via fallback when `@README.md` does not exist
- prioritizes real `@README.md` when it exists
- resolves quoted input `"@README.md"`
- returns `not_found` for `@nope.md`
- returns `ambiguous` for fallback case like `@plan.md` with multiple `plan.md` matches

Validation run:

- `bun test packages/server/resolve-file.test.ts` (pass)

## Scope

- `packages/shared/resolve-file.ts`
- `packages/server/resolve-file.test.ts`

No command template changes were required.
