### PR TITLE
feat: add Roam Research integration

### DIFF
--- a/apps/pi-extension/server/integrations.ts
+++ b/apps/pi-extension/server/integrations.ts
@@ -13,28 +13,60 @@ import {
 	type BearConfig,
 	type OctarineConfig,
 	type IntegrationResult,
+	type RoamConfig,
+	type RoamSuggestionPage,
+	type RoamSuggestionsResult,
 	extractTitle,
 	generateFrontmatter,
 	generateFilename,
 	generateOctarineFrontmatter,
+	generatePageTitle,
+	formatRoamDailyNotePage,
+	majorMinorMatches,
+	normalizeRoamSuggestionsToPages,
+	normalizeRoamDailyNoteParent,
+	frontmatterToAttributeBlocks,
+	stripFrontmatter,
+	stripRoamMetadataTags,
 	stripH1,
 	buildHashtags,
 	buildBearContent,
 	detectObsidianVaults,
+	ROAM_API_VERSION,
+	DEFAULT_ROAM_PARENT_BLOCK,
 } from "../generated/integrations-common.js";
 import { sanitizeTag } from "../generated/project.js";
 import { resolveUserPath } from "../generated/resolve-file.js";
+import { callRoamLocalApi } from "./roam-client.js";
 
-export type { ObsidianConfig, BearConfig, OctarineConfig, IntegrationResult };
+export type {
+	ObsidianConfig,
+	BearConfig,
+	OctarineConfig,
+	RoamConfig,
+	RoamSuggestionPage,
+	RoamSuggestionsResult,
+	IntegrationResult,
+};
 export {
+	ROAM_API_VERSION,
 	extractTitle,
 	generateFrontmatter,
 	generateFilename,
 	generateOctarineFrontmatter,
+	generatePageTitle,
+	formatRoamDailyNotePage,
+	majorMinorMatches,
+	normalizeRoamSuggestionsToPages,
+	normalizeRoamDailyNoteParent,
+	frontmatterToAttributeBlocks,
+	stripFrontmatter,
+	stripRoamMetadataTags,
 	stripH1,
 	buildHashtags,
 	buildBearContent,
 	detectObsidianVaults,
+	DEFAULT_ROAM_PARENT_BLOCK,
 };
 
 /** Detect project name from git or cwd (sync). Used by extractTags for note integrations. */
@@ -167,6 +199,116 @@ export async function saveToBear(
 			error: err instanceof Error ? err.message : "Unknown error",
 		};
 	}
+}
+
+export async function saveToRoam(
+	config: RoamConfig,
+): Promise<IntegrationResult> {
+	try {
+		const { frontmatter } = stripFrontmatter(config.plan);
+		const title = generatePageTitle(
+			config.plan,
+			config.titleFormat,
+			config.titleSeparator,
+		);
+		const markdownBlock = buildRoamMarkdownBlock(config.plan);
+		const contentMarkdown = [
+			frontmatterToAttributeBlocks(frontmatter),
+			markdownBlock,
+		]
+			.filter((section) => section.trim().length > 0)
+			.join("\n\n");
+
+		if (config.saveLocation === "daily-note") {
+			const createPlanBlockResult = await callRoamLocalApi<{ uids?: string[] }>(
+				config,
+				"data.block.fromMarkdown",
+				[
+					{
+						location: {
+							order: "last",
+							"page-title": {
+								"daily-note-page": formatRoamDailyNotePage(new Date()),
+							},
+							"nest-under-str": normalizeRoamDailyNoteParent(
+								config.dailyNoteParent,
+							),
+						},
+						"markdown-string": title,
+					},
+				],
+			);
+
+			const planBlockUid = createPlanBlockResult.uids?.[0];
+			if (!planBlockUid) {
+				return {
+					success: false,
+					error: "Roam did not return a block UID for the saved plan",
+				};
+			}
+
+			await callRoamLocalApi<{ uids?: string[] }>(
+				config,
+				"data.block.fromMarkdown",
+				[
+					{
+						location: {
+							order: "last",
+							"parent-uid": planBlockUid,
+						},
+						"markdown-string": contentMarkdown,
+					},
+				],
+			);
+
+			return {
+				success: true,
+				path: `roam:${config.graphType}:${config.graphName}/${planBlockUid}`,
+			};
+		}
+
+		const markdown = [
+			DEFAULT_ROAM_PARENT_BLOCK,
+			contentMarkdown,
+		]
+			.filter((section) => section.trim().length > 0)
+			.join("\n\n");
+
+		const result = await callRoamLocalApi<{
+			uid?: string;
+			title?: string;
+			page?: { uid?: string; title?: string };
+		}>(
+			config,
+			"data.page.fromMarkdown",
+			[
+				{
+					page: { title },
+					"markdown-string": markdown,
+				},
+			],
+		);
+
+		const pathId = result.page?.uid ?? result.uid ?? result.page?.title ?? result.title ?? title;
+		return {
+			success: true,
+			path: `roam:${config.graphType}:${config.graphName}/${pathId}`,
+		};
+	} catch (err) {
+		return {
+			success: false,
+			error: err instanceof Error ? err.message : "Unknown error",
+		};
+	}
+}
+
+function buildRoamMarkdownBlock(markdown: string): string {
+	const longestBacktickRun = Math.max(
+		0,
+		...[...markdown.matchAll(/`+/g)].map((match) => match[0].length),
+	);
+	const fence = "`".repeat(Math.max(3, longestBacktickRun + 1));
+	return `${fence}markdown\n${markdown.trimEnd()}\n${fence}`;
 }
 
 export async function saveToOctarine(

--- a/apps/pi-extension/server/reference.ts
+++ b/apps/pi-extension/server/reference.ts
@@ -22,7 +22,21 @@ import {
 	buildFileTree,
 	FILE_BROWSER_EXCLUDED,
 } from "../generated/reference-common.js";
-import { detectObsidianVaults } from "../generated/integrations-common.js";
+import {
+	detectObsidianVaults,
+	normalizeRoamSuggestionsToPages,
+	stripRoamMetadataTags,
+	type RoamSuggestionsResult,
+} from "../generated/integrations-common.js";
+import {
+	callRoamLocalApi,
+	callRoamLocalApiEnvelope,
+	RoamAuthError,
+	RoamClientError,
+	RoamConnectionError,
+	RoamTimeoutError,
+	RoamVersionMismatchError,
+} from "./roam-client.js";
 import {
 	isAbsoluteUserPath,
 	isCodeFilePath,
@@ -338,6 +352,136 @@ export function handleObsidianDocRequest(res: Res, url: URL): void {
 	} catch {
 		json(res, { error: "Failed to read file" }, 500);
 	}
+}
+
+export async function handleRoamTest(req: IncomingMessage, res: Res, url: URL): Promise<void> {
+	try {
+		const config = parseRoamRequest(req, url);
+		const response = await callRoamLocalApiEnvelope<Record<string, unknown>>(
+			config,
+			"ui.mainWindow.getOpenView",
+			[],
+			{ timeoutMs: 5_000 },
+		);
+		json(res, {
+			ok: true,
+			apiVersion: response.apiVersion,
+			graphName: config.graphName,
+		});
+	} catch (error) {
+		roamErrorResponse(res, error);
+	}
+}
+
+export async function handleRoamPages(req: IncomingMessage, res: Res, url: URL): Promise<void> {
+	try {
+		const config = parseRoamRequest(req, url);
+		const result = await callRoamLocalApi<
+			{ suggestions?: RoamSuggestionsResult } | RoamSuggestionsResult
+		>(
+			config,
+			"data.ai.search",
+			[{ query: "", scope: "pages", limit: 100, includePath: false }],
+			{ timeoutMs: 10_000 },
+		);
+		const suggestions = "suggestions" in (result ?? {})
+			? (result as { suggestions?: RoamSuggestionsResult }).suggestions ?? {}
+			: (result ?? {}) as RoamSuggestionsResult;
+		const tree = normalizeRoamSuggestionsToPages(suggestions ?? {}).map((page) => ({
+			name: page.title,
+			path: page.uid,
+			type: "file" as const,
+		}));
+		json(res, { tree });
+	} catch (error) {
+		roamErrorResponse(res, error);
+	}
+}
+
+export async function handleRoamDoc(req: IncomingMessage, res: Res, url: URL): Promise<void> {
+	try {
+		const config = parseRoamRequest(req, url);
+		const uid = url.searchParams.get("uid");
+		if (!uid) {
+			json(res, { error: "Missing uid parameter" }, 400);
+			return;
+		}
+		const result = await callRoamLocalApi<{ markdown?: string } | string>(
+			config,
+			"data.ai.getPage",
+			[{ uid }],
+			{ timeoutMs: 10_000 },
+		);
+		const rawMarkdown = typeof result === "string" ? result : result.markdown ?? "";
+		json(res, {
+			markdown: stripRoamMetadataTags(rawMarkdown),
+			filepath: `roam:${config.graphType}:${config.graphName}/${uid}`,
+		});
+	} catch (error) {
+		roamErrorResponse(res, error);
+	}
+}
+
+function parseRoamRequest(
+	req: IncomingMessage,
+	url: URL,
+): {
+	graphName: string;
+	graphType: "hosted" | "offline";
+	token: string;
+	port: number;
+} {
+	const graphName = url.searchParams.get("graphName")?.trim();
+	const graphType = url.searchParams.get("graphType") === "offline" ? "offline" : "hosted";
+	const authHeader = req.headers.authorization;
+	const tokenFromHeader = Array.isArray(authHeader)
+		? authHeader[0]?.replace(/^Bearer\s+/i, "").trim()
+		: authHeader?.replace(/^Bearer\s+/i, "").trim();
+	const tokenFromQuery = url.searchParams.get("token")?.trim();
+	const token = tokenFromHeader || tokenFromQuery;
+	const port = Number(url.searchParams.get("port") || "3333");
+
+	if (!graphName) {
+		throw new RoamClientError("Missing graphName parameter");
+	}
+	if (!token) {
+		throw new RoamAuthError("Missing Roam API token");
+	}
+	if (!Number.isFinite(port) || port < 1 || port > 65535) {
+		throw new RoamClientError("Invalid Roam API port");
+	}
+
+	return {
+		graphName,
+		graphType,
+		token,
+		port: Math.trunc(port),
+	};
+}
+
+function roamErrorResponse(res: Res, error: unknown): void {
+	if (error instanceof RoamAuthError) {
+		json(res, { error: error.message }, 401);
+		return;
+	}
+	if (error instanceof RoamVersionMismatchError) {
+		json(res, { error: error.message, actualVersion: error.actualVersion }, 409);
+		return;
+	}
+	if (error instanceof RoamTimeoutError) {
+		json(res, { error: error.message }, 504);
+		return;
+	}
+	if (error instanceof RoamConnectionError) {
+		json(res, { error: error.message }, 503);
+		return;
+	}
+	if (error instanceof RoamClientError) {
+		json(res, { error: error.message }, 502);
+		return;
+	}
+	const message = error instanceof Error ? error.message : "Unknown Roam error";
+	json(res, { error: message }, 500);
 }
 
 export function handleFileBrowserRequest(res: Res, url: URL): void {

--- a/apps/pi-extension/server/roam-client.test.ts
+++ b/apps/pi-extension/server/roam-client.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { ROAM_API_VERSION } from "../../../packages/shared/integrations-common.ts";
+import { callRoamLocalApi } from "./roam-client.ts";
+
+let activeServer: ReturnType<typeof Bun.serve> | null = null;
+
+afterEach(() => {
+	activeServer?.stop(true);
+	activeServer = null;
+});
+
+function startRoamServer(
+	fetch: (req: Request) => Response | Promise<Response>,
+): number {
+	activeServer = Bun.serve({
+		port: 0,
+		fetch,
+	});
+	return activeServer.port;
+}
+
+describe("callRoamLocalApi", () => {
+	test("posts to the local Roam API with bearer auth, offline graph query, and expectedApiVersion", async () => {
+		let seen: {
+			pathname: string;
+			search: string;
+			auth: string | null;
+			body: unknown;
+		} | null = null;
+
+		const port = startRoamServer(async (req) => {
+			const url = new URL(req.url);
+			seen = {
+				pathname: url.pathname,
+				search: url.search,
+				auth: req.headers.get("authorization"),
+				body: await req.json(),
+			};
+			return Response.json({
+				apiVersion: ROAM_API_VERSION,
+				result: { ok: true },
+			});
+		});
+
+		const result = await callRoamLocalApi(
+			{
+				graphName: "my-graph",
+				graphType: "offline",
+				token: "secret-token",
+				port,
+			},
+			"data.ai.search",
+			[{ query: "" }],
+		);
+
+		expect(result).toEqual({ ok: true });
+		expect(seen).toEqual({
+			pathname: "/api/my-graph",
+			search: "?type=offline",
+			auth: "Bearer secret-token",
+			body: {
+				action: "data.ai.search",
+				args: [{ query: "" }],
+				expectedApiVersion: ROAM_API_VERSION,
+			},
+		});
+	});
+});

--- a/apps/pi-extension/server/roam-client.ts
+++ b/apps/pi-extension/server/roam-client.ts
@@ -1,0 +1,219 @@
+const DEFAULT_TIMEOUT_MS = 10_000;
+const ROAM_API_VERSION = "1.1.2";
+
+interface RoamConfigShape {
+	graphName: string;
+	graphType: "hosted" | "offline";
+	token: string;
+	port: number;
+}
+
+export interface RoamRequestConfig {
+	graphName: string;
+	graphType: "hosted" | "offline";
+	token: string;
+	port: number;
+}
+
+export class RoamClientError extends Error {
+	override cause?: unknown;
+
+	constructor(message: string, options?: { cause?: unknown }) {
+		super(message);
+		this.name = new.target.name;
+		this.cause = options?.cause;
+	}
+}
+
+export class RoamConnectionError extends RoamClientError {}
+export class RoamAuthError extends RoamClientError {}
+export class RoamTimeoutError extends RoamClientError {}
+
+export class RoamVersionMismatchError extends RoamClientError {
+	actualVersion?: string;
+
+	constructor(message: string, options?: { actualVersion?: string; cause?: unknown }) {
+		super(message, options);
+		this.actualVersion = options?.actualVersion;
+	}
+}
+
+interface RoamEnvelope<T> {
+	success?: boolean;
+	result?: T;
+	error?: string;
+	message?: string;
+	apiVersion?: string;
+	actualApiVersion?: string;
+	version?: string;
+}
+
+export async function callRoamLocalApi<T>(
+	config:
+		| RoamRequestConfig
+		| Pick<RoamConfigShape, "graphName" | "graphType" | "token" | "port">,
+	action: string,
+	args: unknown[],
+	options: { timeoutMs?: number } = {},
+): Promise<T> {
+	const payload = await callRoamLocalApiEnvelope<T>(config, action, args, options);
+	return payload.result;
+}
+
+export async function callRoamLocalApiEnvelope<T>(
+	config:
+		| RoamRequestConfig
+		| Pick<RoamConfigShape, "graphName" | "graphType" | "token" | "port">,
+	action: string,
+	args: unknown[],
+	options: { timeoutMs?: number } = {},
+): Promise<{ result: T; apiVersion?: string }> {
+	const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+	const controller = new AbortController();
+	let didTimeout = false;
+	const timeout = setTimeout(() => {
+		didTimeout = true;
+		controller.abort("timeout");
+	}, timeoutMs);
+
+	try {
+		const response = await fetch(buildRoamUrl(config), {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${config.token}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				action,
+				args,
+				expectedApiVersion: ROAM_API_VERSION,
+			}),
+			signal: controller.signal,
+		});
+
+		const payload = await parseRoamResponse<T>(response);
+		const actualVersion = extractApiVersion(payload);
+		if (actualVersion && !majorMinorMatches(actualVersion, ROAM_API_VERSION)) {
+			throw new RoamVersionMismatchError(
+				`Roam API version mismatch: expected ${ROAM_API_VERSION}, got ${actualVersion}`,
+				{ actualVersion },
+			);
+		}
+
+		if (response.status === 401 || response.status === 403) {
+			throw new RoamAuthError(
+				extractErrorMessage(payload, "Roam authentication failed"),
+			);
+		}
+
+		if (!response.ok) {
+			throw new RoamClientError(
+				extractErrorMessage(
+					payload,
+					`Roam request failed with status ${response.status}`,
+				),
+			);
+		}
+
+		if (payload.success === false) {
+			throw new RoamClientError(
+				extractErrorMessage(payload, "Roam request failed"),
+			);
+		}
+
+		return {
+			result: (payload?.result ?? payload) as T,
+			apiVersion: actualVersion,
+		};
+	} catch (error) {
+		if (error instanceof RoamClientError) {
+			throw error;
+		}
+		if (didTimeout || isAbortError(error)) {
+			throw new RoamTimeoutError(
+				`Roam request timed out after ${timeoutMs}ms`,
+				{ cause: error },
+			);
+		}
+		throw new RoamConnectionError("Unable to reach the Roam local API", {
+			cause: error,
+		});
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+function buildRoamUrl(config: RoamRequestConfig): string {
+	const url = new URL(
+		`http://127.0.0.1:${config.port}/api/${encodeURIComponent(config.graphName)}`,
+	);
+	if (config.graphType === "offline") {
+		url.searchParams.set("type", "offline");
+	}
+	return url.toString();
+}
+
+async function parseRoamResponse<T>(response: Response): Promise<RoamEnvelope<T>> {
+	const text = await response.text();
+	if (!text) {
+		return {};
+	}
+
+	try {
+		return JSON.parse(text) as RoamEnvelope<T>;
+	} catch {
+		return { error: text };
+	}
+}
+
+function extractApiVersion(payload: RoamEnvelope<unknown> | undefined): string | undefined {
+	if (!payload || typeof payload !== "object") {
+		return undefined;
+	}
+	if (typeof payload.actualApiVersion === "string") return payload.actualApiVersion;
+	if (typeof payload.apiVersion === "string") return payload.apiVersion;
+	if (typeof payload.version === "string") return payload.version;
+	return undefined;
+}
+
+function extractErrorMessage(
+	payload: RoamEnvelope<unknown> | undefined,
+	fallback: string,
+): string {
+	if (!payload || typeof payload !== "object") {
+		return fallback;
+	}
+	if (typeof payload.error === "string" && payload.error.trim()) return payload.error;
+	if (typeof payload.message === "string" && payload.message.trim()) {
+		return payload.message;
+	}
+	return fallback;
+}
+
+function isAbortError(error: unknown): boolean {
+	return error instanceof DOMException
+		? error.name === "AbortError"
+		: error instanceof Error && error.name === "AbortError";
+}
+
+function majorMinorMatches(a: string, b: string): boolean {
+	const parsedA = parseMajorMinorVersion(a);
+	const parsedB = parseMajorMinorVersion(b);
+	if (!parsedA || !parsedB) {
+		return false;
+	}
+
+	return parsedA.major === parsedB.major && parsedA.minor === parsedB.minor;
+}
+
+function parseMajorMinorVersion(version: string): { major: number; minor: number } | null {
+	const match = version.trim().match(/^(\d+)\.(\d+)(?:\.\d+)?(?:[-+].*)?$/);
+	if (!match) {
+		return null;
+	}
+
+	return {
+		major: Number(match[1]),
+		minor: Number(match[2]),
+	};
+}

--- a/apps/pi-extension/server/serverAnnotate.ts
+++ b/apps/pi-extension/server/serverAnnotate.ts
@@ -23,6 +23,9 @@ import {
 	handleObsidianVaultsRequest,
 	handleObsidianFilesRequest,
 	handleObsidianDocRequest,
+	handleRoamDoc,
+	handleRoamPages,
+	handleRoamTest,
 } from "./reference.js";
 import { warmFileListCache } from "../generated/resolve-file.js";
 import { createExternalAnnotationHandler } from "./external-annotations.js";
@@ -152,6 +155,12 @@ export async function startAnnotateServer(options: {
 			handleObsidianFilesRequest(res, url);
 		} else if (url.pathname === "/api/reference/obsidian/doc" && req.method === "GET") {
 			handleObsidianDocRequest(res, url);
+		} else if (url.pathname === "/api/roam/test" && req.method === "GET") {
+			await handleRoamTest(req, res, url);
+		} else if (url.pathname === "/api/reference/roam/pages" && req.method === "GET") {
+			await handleRoamPages(req, res, url);
+		} else if (url.pathname === "/api/reference/roam/doc" && req.method === "GET") {
+			await handleRoamDoc(req, res, url);
 		} else if (url.pathname === "/api/reference/files" && req.method === "GET") {
 			handleFileBrowserRequest(res, url);
 		} else if (url.pathname === "/favicon.svg") {

--- a/apps/pi-extension/server/serverPlan.ts
+++ b/apps/pi-extension/server/serverPlan.ts
@@ -31,9 +31,11 @@ import {
 	type IntegrationResult,
 	type ObsidianConfig,
 	type OctarineConfig,
+	type RoamConfig,
 	saveToBear,
 	saveToObsidian,
 	saveToOctarine,
+	saveToRoam,
 } from "./integrations.js";
 import { listenOnPort } from "./network.js";
 
@@ -48,6 +50,9 @@ import {
 	handleObsidianDocRequest,
 	handleObsidianFilesRequest,
 	handleObsidianVaultsRequest,
+	handleRoamDoc,
+	handleRoamPages,
+	handleRoamTest,
 } from "./reference.js";
 import { warmFileListCache } from "../generated/resolve-file.js";
 
@@ -281,6 +286,12 @@ export async function startPlanReviewServer(options: {
 			handleObsidianFilesRequest(res, url);
 		} else if (url.pathname === "/api/reference/obsidian/doc" && req.method === "GET") {
 			handleObsidianDocRequest(res, url);
+		} else if (url.pathname === "/api/roam/test" && req.method === "GET") {
+			await handleRoamTest(req, res, url);
+		} else if (url.pathname === "/api/reference/roam/pages" && req.method === "GET") {
+			await handleRoamPages(req, res, url);
+		} else if (url.pathname === "/api/reference/roam/doc" && req.method === "GET") {
+			await handleRoamDoc(req, res, url);
 		} else if (url.pathname === "/api/reference/files" && req.method === "GET") {
 			handleFileBrowserRequest(res, url);
 		} else if (
@@ -326,6 +337,7 @@ export async function startPlanReviewServer(options: {
 				obsidian?: IntegrationResult;
 				bear?: IntegrationResult;
 				octarine?: IntegrationResult;
+				roam?: IntegrationResult;
 			} = {};
 			try {
 				const body = await parseBody(req);
@@ -333,6 +345,7 @@ export async function startPlanReviewServer(options: {
 				const obsConfig = body.obsidian as ObsidianConfig | undefined;
 				const bearConfig = body.bear as BearConfig | undefined;
 				const octConfig = body.octarine as OctarineConfig | undefined;
+				const roamConfig = body.roam as RoamConfig | undefined;
 				if (obsConfig?.vaultPath && obsConfig?.plan) {
 					promises.push(
 						saveToObsidian(obsConfig).then((r) => {
@@ -351,6 +364,18 @@ export async function startPlanReviewServer(options: {
 					promises.push(
 						saveToOctarine(octConfig).then((r) => {
 							results.octarine = r;
+						}),
+					);
+				}
+				if (
+					roamConfig?.graphName &&
+					roamConfig?.token &&
+					roamConfig?.port &&
+					roamConfig?.plan
+				) {
+					promises.push(
+						saveToRoam(roamConfig).then((r) => {
+							results.roam = r;
 						}),
 					);
 				}
@@ -392,6 +417,7 @@ export async function startPlanReviewServer(options: {
 				const obsConfig = body.obsidian as ObsidianConfig | undefined;
 				const bearConfig = body.bear as BearConfig | undefined;
 				const octConfig = body.octarine as OctarineConfig | undefined;
+				const roamConfig = body.roam as RoamConfig | undefined;
 				if (obsConfig?.vaultPath && obsConfig?.plan) {
 					integrationPromises.push(
 						saveToObsidian(obsConfig).then((r) => {
@@ -410,6 +436,18 @@ export async function startPlanReviewServer(options: {
 					integrationPromises.push(
 						saveToOctarine(octConfig).then((r) => {
 							integrationResults.octarine = r;
+						}),
+					);
+				}
+				if (
+					roamConfig?.graphName &&
+					roamConfig?.token &&
+					roamConfig?.port &&
+					roamConfig?.plan
+				) {
+					integrationPromises.push(
+						saveToRoam(roamConfig).then((r) => {
+							integrationResults.roam = r;
 						}),
 					);
 				}

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -27,9 +27,10 @@ import { CompletionOverlay } from '@plannotator/ui/components/CompletionOverlay'
 import { useUpdateCheck } from '@plannotator/ui/hooks/useUpdateCheck';
 import { PlanAIAnnouncementDialog } from '@plannotator/ui/components/PlanAIAnnouncementDialog';
 import { LookAndFeelAnnouncementDialog } from '@plannotator/ui/components/LookAndFeelAnnouncementDialog';
-import { getObsidianSettings, getEffectiveVaultPath, isObsidianConfigured, CUSTOM_PATH_SENTINEL } from '@plannotator/ui/utils/obsidian';
+import { getObsidianSettings, getEffectiveVaultPath, isObsidianConfigured, CUSTOM_PATH_SENTINEL, isVaultBrowserEnabled } from '@plannotator/ui/utils/obsidian';
 import { getBearSettings } from '@plannotator/ui/utils/bear';
 import { getOctarineSettings, isOctarineConfigured } from '@plannotator/ui/utils/octarine';
+import { getRoamSettings, isRoamBrowserEnabled, isRoamConfigured } from '@plannotator/ui/utils/roam';
 import { getDefaultNotesApp } from '@plannotator/ui/utils/defaultNotesApp';
 import { getAgentSwitchSettings, getEffectiveAgentName } from '@plannotator/ui/utils/agentSwitch';
 import { getPlanSaveSettings } from '@plannotator/ui/utils/planSave';
@@ -72,7 +73,6 @@ import { useExternalAnnotations } from '@plannotator/ui/hooks/useExternalAnnotat
 import { useExternalAnnotationHighlights } from '@plannotator/ui/hooks/useExternalAnnotationHighlights';
 import { buildPlanAgentInstructions } from '@plannotator/ui/utils/planAgentInstructions';
 import { useFileBrowser } from '@plannotator/ui/hooks/useFileBrowser';
-import { isVaultBrowserEnabled } from '@plannotator/ui/utils/obsidian';
 import { isFileBrowserEnabled, getFileBrowserSettings } from '@plannotator/ui/utils/fileBrowser';
 import { generateId } from '@plannotator/ui/utils/generateId';
 import { SidebarTabs } from '@plannotator/ui/components/sidebar/SidebarTabs';
@@ -110,6 +110,7 @@ type NoteAutoSaveResults = {
   obsidian?: boolean;
   bear?: boolean;
   octarine?: boolean;
+  roam?: boolean;
 };
 
 type MessageAnnotationState = {
@@ -560,15 +561,20 @@ const App: React.FC = () => {
     }
   }, [canUseWideMode, exitWideMode, wideModeType]);
 
-  // Markdown file browser (also handles vault dirs via isVault flag)
+  // Markdown file browser (regular files, Obsidian, and Roam sources)
   const fileBrowser = useFileBrowser();
   const vaultPath = useMemo(() => {
     if (!isVaultBrowserEnabled()) return '';
     return getEffectiveVaultPath(getObsidianSettings());
   }, [uiPrefs]);
+  const roamSettings = useMemo(() => getRoamSettings(), [uiPrefs, mobileSettingsOpen]);
+  const roamDirPath = useMemo(() => {
+    if (!isRoamBrowserEnabled()) return '';
+    return `roam:${roamSettings.graphType}:${roamSettings.graphName}`;
+  }, [roamSettings]);
   const showFilesTab = useMemo(
-    () => !!projectRoot || isFileBrowserEnabled() || isVaultBrowserEnabled(),
-    [projectRoot, uiPrefs]
+    () => !!projectRoot || isFileBrowserEnabled() || isVaultBrowserEnabled() || isRoamBrowserEnabled(),
+    [projectRoot, uiPrefs, roamDirPath, mobileSettingsOpen]
   );
   const fileBrowserDirs = useMemo(() => {
     const projectDirs = projectRoot ? [projectRoot] : [];
@@ -583,27 +589,32 @@ const App: React.FC = () => {
     if (!showFilesTab) fileBrowser.setActiveFile(null);
   }, [showFilesTab]);
 
-  // When vault is disabled, prune any stale vault dirs immediately
+  // When optional sources are disabled, prune any stale source dirs immediately
   useEffect(() => {
-    if (!vaultPath) fileBrowser.clearVaultDirs();
-  }, [vaultPath]);
+    if (!vaultPath) fileBrowser.clearSource('obsidian');
+  }, [vaultPath, fileBrowser]);
+
+  useEffect(() => {
+    if (!roamDirPath) fileBrowser.clearSource('roam');
+  }, [roamDirPath, fileBrowser]);
 
   useEffect(() => {
     if (sidebar.activeTab === 'files' && showFilesTab) {
       // Load regular dirs
       if (fileBrowserDirs.length > 0) {
-        const regularLoaded = fileBrowser.dirs.filter(d => !d.isVault).map(d => d.path);
+        const regularLoaded = fileBrowser.dirs.filter(d => d.source === 'files').map(d => d.path);
         const needsRegular = fileBrowserDirs.some(d => !regularLoaded.includes(d))
           || regularLoaded.some(d => !fileBrowserDirs.includes(d));
         if (needsRegular) fileBrowser.fetchAll(fileBrowserDirs);
       }
-      // Load vault dir; addVaultDir atomically replaces any existing vault entry so
-      // switching vault paths never accumulates stale sections
-      if (vaultPath && !fileBrowser.dirs.find(d => d.isVault && d.path === vaultPath && !d.error)) {
-        fileBrowser.addVaultDir(vaultPath);
+      if (vaultPath && !fileBrowser.dirs.find(d => d.source === 'obsidian' && d.path === vaultPath && !d.error)) {
+        fileBrowser.addObsidianDir(vaultPath);
+      }
+      if (roamDirPath && !fileBrowser.dirs.find(d => d.source === 'roam' && d.path === roamDirPath && !d.error)) {
+        fileBrowser.addRoamDir(roamSettings);
       }
     }
-  }, [sidebar.activeTab, showFilesTab, fileBrowserDirs, vaultPath]);
+  }, [sidebar.activeTab, showFilesTab, fileBrowserDirs, vaultPath, roamDirPath, roamSettings, fileBrowser]);
 
   const buildCurrentMessageState = React.useCallback((): MessageAnnotationState | null => {
     if (annotateSource !== 'message' || !selectedMessageId) return null;
@@ -712,9 +723,14 @@ const App: React.FC = () => {
 
   const handleFileBrowserSelect = React.useCallback((absolutePath: string, dirPath: string) => {
     const dirState = fileBrowser.dirs.find(d => d.path === dirPath);
-    const buildUrl = dirState?.isVault
-      ? (path: string) => `/api/reference/obsidian/doc?vaultPath=${encodeURIComponent(dirPath)}&path=${encodeURIComponent(path)}`
-      : (path: string) => `/api/doc?path=${encodeURIComponent(path)}&base=${encodeURIComponent(dirPath)}${convertHtml ? '&convert=1' : ''}`;
+    const buildUrl = dirState?.source === 'obsidian'
+      ? (path: string) => `/api/reference/obsidian/doc?vaultPath=${encodeURIComponent(dirPath)}&path=${encodeURIComponent(path.startsWith(`${dirPath}/`) ? path.slice(dirPath.length + 1) : path)}`
+      : dirState?.source === 'roam' && dirState.roamMeta
+        ? (path: string) => {
+            const uid = path.startsWith(`${dirPath}/`) ? path.slice(dirPath.length + 1) : path;
+            return `/api/reference/roam/doc?graphName=${encodeURIComponent(dirState.roamMeta!.graphName)}&graphType=${encodeURIComponent(dirState.roamMeta!.graphType)}&port=${encodeURIComponent(String(dirState.roamMeta!.port))}&token=${encodeURIComponent(dirState.roamMeta!.token)}&uid=${encodeURIComponent(uid)}`;
+          }
+        : (path: string) => `/api/doc?path=${encodeURIComponent(path)}&base=${encodeURIComponent(dirPath)}${convertHtml ? '&convert=1' : ''}`;
     linkedDocHook.open(absolutePath, buildUrl, 'files');
     fileBrowser.setActiveFile(absolutePath);
   }, [linkedDocHook, fileBrowser, convertHtml]);
@@ -722,10 +738,17 @@ const App: React.FC = () => {
   // Route linked doc opens through the correct endpoint based on current context
   const handleOpenLinkedDoc = React.useCallback((docPath: string) => {
     const activeDirState = fileBrowser.dirs.find(d => d.path === fileBrowser.activeDirPath);
-    if (activeDirState?.isVault && fileBrowser.activeDirPath) {
+    if (activeDirState?.source === 'obsidian' && fileBrowser.activeDirPath) {
       linkedDocHook.open(docPath, (path) =>
-        `/api/reference/obsidian/doc?vaultPath=${encodeURIComponent(fileBrowser.activeDirPath!)}&path=${encodeURIComponent(path)}`
+        `/api/reference/obsidian/doc?vaultPath=${encodeURIComponent(fileBrowser.activeDirPath!)}&path=${encodeURIComponent(path.startsWith(`${fileBrowser.activeDirPath!}/`) ? path.slice(fileBrowser.activeDirPath!.length + 1) : path)}`
       );
+    } else if (activeDirState?.source === 'roam' && activeDirState.roamMeta) {
+      linkedDocHook.open(docPath, (path) => {
+        const uid = path.startsWith(`${fileBrowser.activeDirPath!}/`)
+          ? path.slice(fileBrowser.activeDirPath!.length + 1)
+          : path;
+        return `/api/reference/roam/doc?graphName=${encodeURIComponent(activeDirState.roamMeta!.graphName)}&graphType=${encodeURIComponent(activeDirState.roamMeta!.graphType)}&port=${encodeURIComponent(String(activeDirState.roamMeta!.port))}&token=${encodeURIComponent(activeDirState.roamMeta!.token)}&uid=${encodeURIComponent(uid)}`;
+      });
     } else if (fileBrowser.activeFile && fileBrowser.activeDirPath) {
       // When viewing a file browser doc, resolve links relative to current file's directory
       const baseDir = linkedDocHook.filepath?.replace(/\/[^/]+$/, '') || fileBrowser.activeDirPath;
@@ -1188,7 +1211,7 @@ const App: React.FC = () => {
     if (!isApiMode || !markdown || isSharedSession || annotateMode || archive.archiveMode) return;
     if (autoSaveAttempted.current) return;
 
-    const body: { obsidian?: object; bear?: object; octarine?: object } = {};
+    const body: { obsidian?: object; bear?: object; octarine?: object; roam?: object } = {};
     const targets: string[] = [];
 
     const obsSettings = getObsidianSettings();
@@ -1226,6 +1249,22 @@ const App: React.FC = () => {
       targets.push('Octarine');
     }
 
+    const roamSettings = getRoamSettings();
+    if (roamSettings.autoSave && isRoamConfigured()) {
+      body.roam = {
+        graphName: roamSettings.graphName,
+        graphType: roamSettings.graphType,
+        token: roamSettings.token,
+        port: roamSettings.port || 3333,
+        plan: markdown,
+        saveLocation: roamSettings.saveLocation,
+        dailyNoteParent: roamSettings.dailyNoteParent,
+        ...(roamSettings.titleFormat && { titleFormat: roamSettings.titleFormat }),
+        ...(roamSettings.titleSeparator && roamSettings.titleSeparator !== 'space' && { titleSeparator: roamSettings.titleSeparator }),
+      };
+      targets.push('Roam');
+    }
+
     if (targets.length === 0) return;
     autoSaveAttempted.current = true;
 
@@ -1240,6 +1279,7 @@ const App: React.FC = () => {
           ...(body.obsidian ? { obsidian: Boolean(data.results?.obsidian?.success) } : {}),
           ...(body.bear ? { bear: Boolean(data.results?.bear?.success) } : {}),
           ...(body.octarine ? { octarine: Boolean(data.results?.octarine?.success) } : {}),
+          ...(body.roam ? { roam: Boolean(data.results?.roam?.success) } : {}),
         };
         autoSaveResultsRef.current = results;
 
@@ -1323,13 +1363,14 @@ const App: React.FC = () => {
       const obsidianSettings = getObsidianSettings();
       const bearSettings = getBearSettings();
       const octarineSettings = getOctarineSettings();
+      const roamSettings = getRoamSettings();
       const planSaveSettings = getPlanSaveSettings();
-      const autoSaveResults = bearSettings.autoSave && autoSavePromiseRef.current
+      const autoSaveResults = (bearSettings.autoSave || roamSettings.autoSave) && autoSavePromiseRef.current
         ? await autoSavePromiseRef.current
         : autoSaveResultsRef.current;
 
       // Build request body - include integrations if enabled
-      const body: { obsidian?: object; bear?: object; octarine?: object; feedback?: string; agentSwitch?: string; planSave?: { enabled: boolean; customPath?: string }; permissionMode?: string } = {};
+      const body: { obsidian?: object; bear?: object; octarine?: object; roam?: object; feedback?: string; agentSwitch?: string; planSave?: { enabled: boolean; customPath?: string }; permissionMode?: string } = {};
 
       // Include permission mode for Claude Code
       if (origin === 'claude-code') {
@@ -1373,6 +1414,22 @@ const App: React.FC = () => {
           plan: markdown,
           workspace: octarineSettings.workspace,
           folder: octarineSettings.folder || 'plannotator',
+        };
+      }
+
+      // Roam creates a new page/container each time, so don't send it again on approve
+      // if the arrival auto-save already succeeded.
+      if (isRoamConfigured() && !(roamSettings.autoSave && autoSaveResults.roam)) {
+        body.roam = {
+          graphName: roamSettings.graphName,
+          graphType: roamSettings.graphType,
+          token: roamSettings.token,
+          port: roamSettings.port || 3333,
+          plan: markdown,
+          saveLocation: roamSettings.saveLocation,
+          dailyNoteParent: roamSettings.dailyNoteParent,
+          ...(roamSettings.titleFormat && { titleFormat: roamSettings.titleFormat }),
+          ...(roamSettings.titleSeparator && roamSettings.titleSeparator !== 'space' && { titleSeparator: roamSettings.titleSeparator }),
         };
       }
 
@@ -1949,8 +2006,8 @@ const App: React.FC = () => {
     toast.success('Downloaded annotations');
   };
 
-  const handleQuickSaveToNotes = async (target: 'obsidian' | 'bear' | 'octarine') => {
-    const body: { obsidian?: object; bear?: object; octarine?: object } = {};
+  const handleQuickSaveToNotes = async (target: 'obsidian' | 'bear' | 'octarine' | 'roam') => {
+    const body: { obsidian?: object; bear?: object; octarine?: object; roam?: object } = {};
 
     if (target === 'obsidian') {
       const s = getObsidianSettings();
@@ -1981,8 +2038,28 @@ const App: React.FC = () => {
         folder: os.folder || 'plannotator',
       };
     }
+    if (target === 'roam') {
+      const rs = getRoamSettings();
+      body.roam = {
+        graphName: rs.graphName,
+        graphType: rs.graphType,
+        token: rs.token,
+        port: rs.port || 3333,
+        plan: markdown,
+        saveLocation: rs.saveLocation,
+        dailyNoteParent: rs.dailyNoteParent,
+        ...(rs.titleFormat && { titleFormat: rs.titleFormat }),
+        ...(rs.titleSeparator && rs.titleSeparator !== 'space' && { titleSeparator: rs.titleSeparator }),
+      };
+    }
 
-    const targetName = target === 'obsidian' ? 'Obsidian' : target === 'bear' ? 'Bear' : 'Octarine';
+    const targetName = target === 'obsidian'
+      ? 'Obsidian'
+      : target === 'bear'
+        ? 'Bear'
+        : target === 'octarine'
+          ? 'Octarine'
+          : 'Roam';
     try {
       const res = await fetch('/api/save-notes', {
         method: 'POST',
@@ -2045,6 +2122,7 @@ const App: React.FC = () => {
       const obsOk = isObsidianConfigured();
       const bearOk = getBearSettings().enabled;
       const octOk = isOctarineConfigured();
+      const roamOk = isRoamConfigured();
 
       if (defaultApp === 'download') {
         handleDownloadAnnotations();
@@ -2054,6 +2132,8 @@ const App: React.FC = () => {
         handleQuickSaveToNotes('bear');
       } else if (defaultApp === 'octarine' && octOk) {
         handleQuickSaveToNotes('octarine');
+      } else if (defaultApp === 'roam' && roamOk) {
+        handleQuickSaveToNotes('roam');
       } else {
         setInitialExportTab('notes');
         setShowExport(true);
@@ -2185,6 +2265,7 @@ const App: React.FC = () => {
   const handleSaveToObsidian = useCallback(() => headerHandlersRef.current.handleQuickSaveToNotes('obsidian'), []);
   const handleSaveToOctarine = useCallback(() => headerHandlersRef.current.handleQuickSaveToNotes('octarine'), []);
   const handleSaveToBear = useCallback(() => headerHandlersRef.current.handleQuickSaveToNotes('bear'), []);
+  const handleSaveToRoam = useCallback(() => headerHandlersRef.current.handleQuickSaveToNotes('roam'), []);
 
   const planMaxWidth = useMemo(() => {
     const widths: Record<PlanWidth, number> = { compact: 832, default: 1040, wide: 1280 };
@@ -2283,6 +2364,7 @@ const App: React.FC = () => {
           onSaveToObsidian={handleSaveToObsidian}
           onSaveToBear={handleSaveToBear}
           onSaveToOctarine={handleSaveToOctarine}
+          onSaveToRoam={handleSaveToRoam}
           appVersion={typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : '0.0.0'}
           updateInfo={updateInfo}
           isWSL={isWSL}
@@ -2290,6 +2372,7 @@ const App: React.FC = () => {
           obsidianConfigured={isObsidianConfigured()}
           bearConfigured={getBearSettings().enabled}
           octarineConfigured={isOctarineConfigured()}
+          roamConfigured={isRoamConfigured()}
         />
 
         {/* Linked document error banner */}
@@ -2349,7 +2432,24 @@ const App: React.FC = () => {
                 fileBrowser={fileBrowser}
                 onFilesSelectFile={handleFileBrowserSelect}
                 onFilesFetchAll={() => fileBrowser.fetchAll(fileBrowserDirs)}
-                onFilesRetryVaultDir={(vaultPath) => fileBrowser.addVaultDir(vaultPath)}
+                onFilesRetryVaultDir={(dirPath) => {
+                  const dir = fileBrowser.dirs.find(d => d.path === dirPath);
+                  if (dir?.source === 'obsidian') fileBrowser.addObsidianDir(dirPath);
+                  else if (dir?.source === 'roam' && dir.roamMeta) {
+                    fileBrowser.addRoamDir({
+                      enabled: true,
+                      graphName: dir.roamMeta.graphName,
+                      graphType: dir.roamMeta.graphType,
+                      token: dir.roamMeta.token,
+                      port: dir.roamMeta.port,
+                      titleSeparator: 'space',
+                      saveLocation: 'page',
+                      dailyNoteParent: '[[Plannotator Plans]]',
+                      autoSave: false,
+                      referenceBrowserEnabled: true,
+                    });
+                  }
+                }}
                 hasFileAnnotations={hasFileAnnotations}
                 showVersionsTab={versionInfo !== null && versionInfo.totalVersions > 1}
                 versionInfo={versionInfo}
@@ -2568,7 +2668,17 @@ const App: React.FC = () => {
                     maxWidth={annotateReaderMaxWidth}
                     onOpenLinkedDoc={handleOpenLinkedDoc}
                     onOpenCodeFile={codeFilePopout.open}
-                    linkedDocInfo={linkedDocHook.isActive ? { filepath: linkedDocHook.filepath!, onBack: handleLinkedDocBack, label: fileBrowser.dirs.find(d => d.path === fileBrowser.activeDirPath)?.isVault ? 'Vault File' : fileBrowser.activeFile ? 'File' : undefined, backLabel } : null}
+                    linkedDocInfo={linkedDocHook.isActive ? {
+                      filepath: linkedDocHook.filepath!,
+                      onBack: handleLinkedDocBack,
+                      label: (() => {
+                        const activeDir = fileBrowser.dirs.find(d => d.path === fileBrowser.activeDirPath);
+                        if (activeDir?.source === 'obsidian') return 'Vault File';
+                        if (activeDir?.source === 'roam') return 'Roam Page';
+                        return fileBrowser.activeFile ? 'File' : undefined;
+                      })(),
+                      backLabel,
+                    } : null}
                     imageBaseDir={imageBaseDir}
                     codePathBaseDir={activeDocBaseDir}
                     copyLabel={annotateSource === 'message' ? 'Copy message' : annotateSource === 'file' || annotateSource === 'folder' ? 'Copy file' : undefined}

--- a/packages/editor/components/AppHeader.tsx
+++ b/packages/editor/components/AppHeader.tsx
@@ -79,6 +79,7 @@ interface AppHeaderProps {
   onSaveToObsidian: () => void;
   onSaveToBear: () => void;
   onSaveToOctarine: () => void;
+  onSaveToRoam: () => void;
 
   // PlanHeaderMenu config
   appVersion: string;
@@ -88,6 +89,7 @@ interface AppHeaderProps {
   obsidianConfigured: boolean;
   bearConfigured: boolean;
   octarineConfigured: boolean;
+  roamConfigured: boolean;
 }
 
 export const AppHeader = React.memo<AppHeaderProps>(({
@@ -148,6 +150,7 @@ export const AppHeader = React.memo<AppHeaderProps>(({
   onSaveToObsidian,
   onSaveToBear,
   onSaveToOctarine,
+  onSaveToRoam,
   appVersion,
   updateInfo,
   isWSL,
@@ -155,6 +158,7 @@ export const AppHeader = React.memo<AppHeaderProps>(({
   obsidianConfigured,
   bearConfigured,
   octarineConfigured,
+  roamConfigured,
 }) => {
   return (
     <header data-app-header="true" className="h-12 flex items-center justify-between px-2 md:px-4 border-b border-border/50 bg-card/50 backdrop-blur-xl sticky top-0 z-[50]">
@@ -359,12 +363,14 @@ export const AppHeader = React.memo<AppHeaderProps>(({
           onSaveToObsidian={onSaveToObsidian}
           onSaveToBear={onSaveToBear}
           onSaveToOctarine={onSaveToOctarine}
+          onSaveToRoam={onSaveToRoam}
           sharingEnabled={canShareCurrentSession}
           isApiMode={isApiMode}
           agentInstructionsEnabled={agentInstructionsEnabled}
           obsidianConfigured={!goalSetupMode && obsidianConfigured}
           bearConfigured={!goalSetupMode && bearConfigured}
           octarineConfigured={!goalSetupMode && octarineConfigured}
+          roamConfigured={!goalSetupMode && roamConfigured}
         />
       </div>
     </header>

--- a/packages/server/annotate.ts
+++ b/packages/server/annotate.ts
@@ -15,7 +15,17 @@ import { isRemoteSession, getServerHostname, getServerPort } from "./remote";
 import { getRepoInfo } from "./repo";
 import type { Origin } from "@plannotator/shared/agents";
 import { handleImage, handleUpload, handleServerReady, handleDraftSave, handleDraftLoad, handleDraftDelete, handleFavicon } from "./shared-handlers";
-import { handleDoc, handleDocExists, handleFileBrowserFiles, handleObsidianVaults, handleObsidianFiles, handleObsidianDoc } from "./reference-handlers";
+import {
+  handleDoc,
+  handleDocExists,
+  handleFileBrowserFiles,
+  handleObsidianVaults,
+  handleObsidianFiles,
+  handleObsidianDoc,
+  handleRoamTest,
+  handleRoamPages,
+  handleRoamDoc,
+} from "./reference-handlers";
 import { warmFileListCache } from "@plannotator/shared/resolve-file";
 import { contentHash, deleteDraft } from "./draft";
 import { createExternalAnnotationHandler } from "./external-annotations";
@@ -257,6 +267,21 @@ export async function startAnnotateServer(
           // API: Read an Obsidian vault document
           if (url.pathname === "/api/reference/obsidian/doc" && req.method === "GET") {
             return handleObsidianDoc(req);
+          }
+
+          // API: Test Roam local API connectivity
+          if (url.pathname === "/api/roam/test" && req.method === "GET") {
+            return handleRoamTest(req);
+          }
+
+          // API: List Roam pages
+          if (url.pathname === "/api/reference/roam/pages" && req.method === "GET") {
+            return handleRoamPages(req);
+          }
+
+          // API: Read a Roam page by uid
+          if (url.pathname === "/api/reference/roam/doc" && req.method === "GET") {
+            return handleRoamDoc(req);
           }
 
           // API: List markdown files in a directory as a tree

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -20,9 +20,11 @@ import {
   saveToObsidian,
   saveToBear,
   saveToOctarine,
+  saveToRoam,
   type ObsidianConfig,
   type BearConfig,
   type OctarineConfig,
+  type RoamConfig,
   type IntegrationResult,
 } from "./integrations";
 import {
@@ -46,7 +48,17 @@ import { readImprovementHook, getImprovementHookExpectedPath } from "@plannotato
 import { composeImproveContext } from "@plannotator/shared/pfm-reminder";
 import { handleImage, handleUpload, handleAgents, handleServerReady, handleDraftSave, handleDraftLoad, handleDraftDelete, handleFavicon, type OpencodeClient } from "./shared-handlers";
 import { contentHash, deleteDraft } from "./draft";
-import { handleDoc, handleDocExists, handleObsidianVaults, handleObsidianFiles, handleObsidianDoc, handleFileBrowserFiles } from "./reference-handlers";
+import {
+  handleDoc,
+  handleDocExists,
+  handleObsidianVaults,
+  handleObsidianFiles,
+  handleObsidianDoc,
+  handleFileBrowserFiles,
+  handleRoamTest,
+  handleRoamPages,
+  handleRoamDoc,
+} from "./reference-handlers";
 import { warmFileListCache } from "@plannotator/shared/resolve-file";
 import { createEditorAnnotationHandler } from "./editor-annotations";
 import { createExternalAnnotationHandler } from "./external-annotations";
@@ -388,6 +400,21 @@ export async function startPlannotatorServer(
             return handleObsidianDoc(req);
           }
 
+          // API: Test Roam local API connectivity
+          if (url.pathname === "/api/roam/test" && req.method === "GET") {
+            return handleRoamTest(req);
+          }
+
+          // API: List Roam pages
+          if (url.pathname === "/api/reference/roam/pages" && req.method === "GET") {
+            return handleRoamPages(req);
+          }
+
+          // API: Read a Roam page by uid
+          if (url.pathname === "/api/reference/roam/doc" && req.method === "GET") {
+            return handleRoamDoc(req);
+          }
+
           // API: List markdown files in a directory as a tree
           if (url.pathname === "/api/reference/files" && req.method === "GET") {
             return handleFileBrowserFiles(req);
@@ -434,13 +461,14 @@ export async function startPlannotatorServer(
 
           // API: Save to notes (decoupled from approve/deny)
           if (url.pathname === "/api/save-notes" && req.method === "POST") {
-            const results: { obsidian?: IntegrationResult; bear?: IntegrationResult; octarine?: IntegrationResult } = {};
+            const results: { obsidian?: IntegrationResult; bear?: IntegrationResult; octarine?: IntegrationResult; roam?: IntegrationResult } = {};
 
             try {
               const body = (await req.json()) as {
                 obsidian?: ObsidianConfig;
                 bear?: BearConfig;
                 octarine?: OctarineConfig;
+                roam?: RoamConfig;
               };
 
               // Run integrations in parallel — they're independent
@@ -453,6 +481,9 @@ export async function startPlannotatorServer(
               }
               if (body.octarine?.plan && body.octarine?.workspace) {
                 promises.push(saveToOctarine(body.octarine).then(r => { results.octarine = r; }));
+              }
+              if (body.roam?.graphName && body.roam?.token && body.roam?.port && body.roam?.plan) {
+                promises.push(saveToRoam(body.roam).then(r => { results.roam = r; }));
               }
               await Promise.allSettled(promises);
 
@@ -482,6 +513,7 @@ export async function startPlannotatorServer(
                 obsidian?: ObsidianConfig;
                 bear?: BearConfig;
                 octarine?: OctarineConfig;
+                roam?: RoamConfig;
                 feedback?: string;
                 agentSwitch?: string;
                 planSave?: { enabled: boolean; customPath?: string };
@@ -520,6 +552,9 @@ export async function startPlannotatorServer(
               }
               if (body.octarine?.plan && body.octarine?.workspace) {
                 integrationPromises.push(saveToOctarine(body.octarine).then(r => { integrationResults.octarine = r; }));
+              }
+              if (body.roam?.graphName && body.roam?.token && body.roam?.port && body.roam?.plan) {
+                integrationPromises.push(saveToRoam(body.roam).then(r => { integrationResults.roam = r; }));
               }
               await Promise.allSettled(integrationPromises);
 

--- a/packages/server/integrations.test.ts
+++ b/packages/server/integrations.test.ts
@@ -11,6 +11,13 @@ import {
   stripH1,
   buildHashtags,
   buildBearContent,
+  generateFilename,
+  stripFrontmatter,
+  frontmatterToAttributeBlocks,
+  stripRoamMetadataTags,
+  majorMinorMatches,
+  generatePageTitle,
+  normalizeRoamSuggestionsToPages,
 } from "./integrations";
 
 describe("extractTitle", () => {
@@ -168,5 +175,135 @@ describe("extractTags", () => {
   test("limits to 7 tags", async () => {
     const tags = await extractTags("# One Two Three Four\n\n```go\n```\n```python\n```\n```ruby\n```\n```swift\n```");
     expect(tags.length).toBeLessThanOrEqual(7);
+  });
+});
+
+describe("Roam helpers", () => {
+  test("stripFrontmatter returns parsed frontmatter and body", () => {
+    const input = [
+      "---",
+      "created: 2026-04-09T14:30:00.000Z",
+      "source: plannotator",
+      "tags: [plannotator, auth]",
+      "---",
+      "",
+      "# Implementation Plan: Auth Flow",
+      "",
+      "Body",
+    ].join("\n");
+    const result = stripFrontmatter(input);
+
+    expect(result.frontmatter).toEqual({
+      created: "2026-04-09T14:30:00.000Z",
+      source: "plannotator",
+      tags: ["plannotator", "auth"],
+    });
+    expect(result.body).toBe("# Implementation Plan: Auth Flow\n\nBody");
+  });
+
+  test("stripFrontmatter handles CRLF line endings", () => {
+    const input = [
+      "---",
+      "created: 2026-04-09T14:30:00.000Z",
+      "source: plannotator",
+      "tags: [plannotator, auth]",
+      "---",
+      "",
+      "# Implementation Plan: Auth Flow",
+      "",
+      "Body",
+    ].join("\r\n");
+    const result = stripFrontmatter(input);
+
+    expect(result.frontmatter).toEqual({
+      created: "2026-04-09T14:30:00.000Z",
+      source: "plannotator",
+      tags: ["plannotator", "auth"],
+    });
+    expect(result.body).toBe("# Implementation Plan: Auth Flow\r\n\r\nBody");
+  });
+
+  test("frontmatterToAttributeBlocks renders Roam attributes", () => {
+    expect(
+      frontmatterToAttributeBlocks({
+        created: "2026-04-09T14:30:00.000Z",
+        source: "plannotator",
+        tags: ["plannotator", "auth"],
+        owner: "alice",
+      }),
+    ).toBe(
+      [
+        "created:: [[April 9th, 2026]]",
+        "source:: plannotator",
+        "tags:: [[plannotator]], [[auth]]",
+        "owner:: alice",
+      ].join("\n"),
+    );
+  });
+
+  test("stripRoamMetadataTags removes wrappers but preserves content", () => {
+    expect(
+      stripRoamMetadataTags('<roam uid="abc123">## Heading\n\nBody</roam>'),
+    ).toBe("## Heading\n\nBody");
+  });
+
+  test("generatePageTitle keeps the Obsidian format but drops .md", () => {
+    const markdown = "# Implementation Plan: Auth Flow\n\nBody";
+    const filename = generateFilename(markdown, "{title} - {Mon} {D}, {YYYY} {h}-{mm}{ampm}");
+    const title = generatePageTitle(markdown, "{title} - {Mon} {D}, {YYYY} {h}-{mm}{ampm}");
+    expect(title).toBe(filename.replace(/\.md$/, ""));
+    expect(title.endsWith(".md")).toBe(false);
+  });
+
+  test("majorMinorMatches ignores patch versions only", () => {
+    expect(majorMinorMatches("1.2.3", "1.2.9")).toBe(true);
+    expect(majorMinorMatches("1.2.3", "1.3.0")).toBe(false);
+    expect(majorMinorMatches("1.2.3", "2.2.3")).toBe(false);
+  });
+
+  test("normalizeRoamSuggestionsToPages keeps stable uid/title pairs", () => {
+    const result = normalizeRoamSuggestionsToPages({
+      recentlyEditedPages: [
+        { uid: "edit-1", title: "Edited Page", editedAt: "2026-04-09T19:00:00.000Z" },
+      ],
+      recentlyOpenedByUser: [
+        {
+          uid: "open-1",
+          title: "Working Set",
+          type: "page",
+          openedAt: "2026-04-09T18:00:00.000Z",
+        },
+        {
+          uid: "open-ignored",
+          title: "Block Result",
+          type: "block",
+          openedAt: "2026-04-09T17:00:00.000Z",
+        },
+      ],
+    });
+
+    expect(result).toEqual([
+      { uid: "edit-1", title: "Edited Page", sortAt: "2026-04-09T19:00:00.000Z" },
+      { uid: "open-1", title: "Working Set", sortAt: "2026-04-09T18:00:00.000Z" },
+    ]);
+  });
+
+  test("normalizeRoamSuggestionsToPages keeps the newest timestamp for duplicate pages", () => {
+    const result = normalizeRoamSuggestionsToPages({
+      recentlyEditedPages: [
+        { uid: "same-1", title: "Edited Page", editedAt: "2026-04-09T18:00:00.000Z" },
+      ],
+      recentlyOpenedByUser: [
+        {
+          uid: "same-1",
+          title: "Edited Page",
+          openedAt: "2026-04-09T19:00:00.000Z",
+        },
+      ],
+    });
+
+    expect(result).toEqual([
+      { uid: "same-1", title: "Edited Page", sortAt: "2026-04-09T19:00:00.000Z" },
+    ]);
   });
 });

--- a/packages/server/integrations.ts
+++ b/packages/server/integrations.ts
@@ -12,19 +12,60 @@ import {
 	type BearConfig,
 	type OctarineConfig,
 	type IntegrationResult,
+	type RoamConfig,
+	type RoamSuggestionPage,
+	type RoamSuggestionsResult,
 	extractTitle,
 	generateFrontmatter,
 	generateFilename,
 	generateOctarineFrontmatter,
+	generatePageTitle,
+	formatRoamDailyNotePage,
+	majorMinorMatches,
+	normalizeRoamSuggestionsToPages,
+	normalizeRoamDailyNoteParent,
+	frontmatterToAttributeBlocks,
+	stripFrontmatter,
+	stripRoamMetadataTags,
 	stripH1,
 	buildHashtags,
 	buildBearContent,
 	detectObsidianVaults,
+	ROAM_API_VERSION,
+	DEFAULT_ROAM_PARENT_BLOCK,
 } from "@plannotator/shared/integrations-common";
 import { resolveUserPath } from "@plannotator/shared/resolve-file";
+import { callRoamLocalApi } from "./roam-client";
 
-export type { ObsidianConfig, BearConfig, OctarineConfig, IntegrationResult };
-export { detectObsidianVaults, extractTitle, generateFrontmatter, generateFilename, generateOctarineFrontmatter, stripH1, buildHashtags, buildBearContent };
+export type {
+	ObsidianConfig,
+	BearConfig,
+	OctarineConfig,
+	RoamConfig,
+	RoamSuggestionPage,
+	RoamSuggestionsResult,
+	IntegrationResult,
+};
+export {
+	ROAM_API_VERSION,
+	detectObsidianVaults,
+	extractTitle,
+	generateFrontmatter,
+	generateFilename,
+	generateOctarineFrontmatter,
+	generatePageTitle,
+	formatRoamDailyNotePage,
+	majorMinorMatches,
+	normalizeRoamSuggestionsToPages,
+	normalizeRoamDailyNoteParent,
+	frontmatterToAttributeBlocks,
+	stripFrontmatter,
+	stripRoamMetadataTags,
+	stripH1,
+	buildHashtags,
+	buildBearContent,
+	DEFAULT_ROAM_PARENT_BLOCK,
+};
 
 /**
  * Extract tags from markdown content using simple heuristics
@@ -179,6 +220,117 @@ export async function saveToBear(
 		const message = err instanceof Error ? err.message : "Unknown error";
 		return { success: false, error: message };
 	}
+}
+
+/**
+ * Save plan to Roam Research via the local API.
+ */
+export async function saveToRoam(
+	config: RoamConfig,
+): Promise<IntegrationResult> {
+	try {
+		const { frontmatter } = stripFrontmatter(config.plan);
+		const title = generatePageTitle(
+			config.plan,
+			config.titleFormat,
+			config.titleSeparator,
+		);
+		const markdownBlock = buildRoamMarkdownBlock(config.plan);
+		const contentMarkdown = [
+			frontmatterToAttributeBlocks(frontmatter),
+			markdownBlock,
+		]
+			.filter((section) => section.trim().length > 0)
+			.join("\n\n");
+
+		if (config.saveLocation === "daily-note") {
+			const createPlanBlockResult = await callRoamLocalApi<{ uids?: string[] }>(
+				config,
+				"data.block.fromMarkdown",
+				[
+					{
+						location: {
+							order: "last",
+							"page-title": {
+								"daily-note-page": formatRoamDailyNotePage(new Date()),
+							},
+							"nest-under-str": normalizeRoamDailyNoteParent(
+								config.dailyNoteParent,
+							),
+						},
+						"markdown-string": title,
+					},
+				],
+			);
+
+			const planBlockUid = createPlanBlockResult.uids?.[0];
+			if (!planBlockUid) {
+				return {
+					success: false,
+					error: "Roam did not return a block UID for the saved plan",
+				};
+			}
+
+			await callRoamLocalApi<{ uids?: string[] }>(
+				config,
+				"data.block.fromMarkdown",
+				[
+					{
+						location: {
+							order: "last",
+							"parent-uid": planBlockUid,
+						},
+						"markdown-string": contentMarkdown,
+					},
+				],
+			);
+
+			return {
+				success: true,
+				path: `roam:${config.graphType}:${config.graphName}/${planBlockUid}`,
+			};
+		}
+
+		const markdown = [
+			DEFAULT_ROAM_PARENT_BLOCK,
+			contentMarkdown,
+		]
+			.filter((section) => section.trim().length > 0)
+			.join("\n\n");
+
+		const result = await callRoamLocalApi<{
+			uid?: string;
+			title?: string;
+			page?: { uid?: string; title?: string };
+		}>(
+			config,
+			"data.page.fromMarkdown",
+			[
+				{
+					page: { title },
+					"markdown-string": markdown,
+				},
+			],
+		);
+
+		const pathId = result.page?.uid ?? result.uid ?? result.page?.title ?? result.title ?? title;
+		return {
+			success: true,
+			path: `roam:${config.graphType}:${config.graphName}/${pathId}`,
+		};
+	} catch (err) {
+		const message = err instanceof Error ? err.message : "Unknown error";
+		return { success: false, error: message };
+	}
+}
+
+function buildRoamMarkdownBlock(markdown: string): string {
+	const longestBacktickRun = Math.max(
+		0,
+		...[...markdown.matchAll(/`+/g)].map((match) => match[0].length),
+	);
+	const fence = "`".repeat(Math.max(3, longestBacktickRun + 1));
+	return `${fence}markdown\n${markdown.trimEnd()}\n${fence}`;
 }
 
 /**

--- a/packages/server/reference-handlers.ts
+++ b/packages/server/reference-handlers.ts
@@ -9,7 +9,21 @@ import { existsSync, statSync } from "fs";
 import { resolve } from "path";
 import { buildFileTree, FILE_BROWSER_EXCLUDED } from "@plannotator/shared/reference-common";
 import { parseCodePath } from "@plannotator/shared/code-file";
-import { detectObsidianVaults } from "./integrations";
+import {
+	detectObsidianVaults,
+	normalizeRoamSuggestionsToPages,
+	stripRoamMetadataTags,
+	type RoamSuggestionsResult,
+} from "./integrations";
+import {
+	callRoamLocalApi,
+	callRoamLocalApiEnvelope,
+	RoamClientError,
+	RoamAuthError,
+	RoamConnectionError,
+	RoamTimeoutError,
+	RoamVersionMismatchError,
+} from "./roam-client";
 import {
 	isAbsoluteUserPath,
 	isCodeFilePath,
@@ -361,6 +375,129 @@ export async function handleObsidianDoc(req: Request): Promise<Response> {
 	} catch {
 		return Response.json({ error: "Failed to read file" }, { status: 500 });
 	}
+}
+
+/** Probe the Roam local API by asking the main window for its open view. */
+export async function handleRoamTest(req: Request): Promise<Response> {
+	try {
+		const config = parseRoamRequest(req);
+		const response = await callRoamLocalApiEnvelope<Record<string, unknown>>(
+			config,
+			"ui.mainWindow.getOpenView",
+			[],
+			{ timeoutMs: 5_000 },
+		);
+		return Response.json({
+			ok: true,
+			apiVersion: response.apiVersion,
+			graphName: config.graphName,
+		});
+	} catch (error) {
+		return roamErrorResponse(error);
+	}
+}
+
+/** List Roam pages from the local API's suggestion payload. */
+export async function handleRoamPages(req: Request): Promise<Response> {
+	try {
+		const config = parseRoamRequest(req);
+		const result = await callRoamLocalApi<
+			{ suggestions?: RoamSuggestionsResult } | RoamSuggestionsResult
+		>(
+			config,
+			"data.ai.search",
+			[{ query: "", scope: "pages", limit: 100, includePath: false }],
+			{ timeoutMs: 10_000 },
+		);
+		const suggestions = "suggestions" in (result ?? {})
+			? (result as { suggestions?: RoamSuggestionsResult }).suggestions ?? {}
+			: (result ?? {}) as RoamSuggestionsResult;
+		const tree = normalizeRoamSuggestionsToPages(suggestions ?? {}).map((page) => ({
+			name: page.title,
+			path: page.uid,
+			type: "file" as const,
+		}));
+		return Response.json({ tree });
+	} catch (error) {
+		return roamErrorResponse(error);
+	}
+}
+
+/** Read a Roam page by uid and strip local API metadata wrappers before returning it. */
+export async function handleRoamDoc(req: Request): Promise<Response> {
+	try {
+		const config = parseRoamRequest(req);
+		const url = new URL(req.url);
+		const uid = url.searchParams.get("uid");
+		if (!uid) {
+			return Response.json({ error: "Missing uid parameter" }, { status: 400 });
+		}
+		const result = await callRoamLocalApi<{ markdown?: string } | string>(
+			config,
+			"data.ai.getPage",
+			[{ uid }],
+			{ timeoutMs: 10_000 },
+		);
+		const rawMarkdown = typeof result === "string" ? result : result.markdown ?? "";
+		return Response.json({
+			markdown: stripRoamMetadataTags(rawMarkdown),
+			filepath: `roam:${config.graphType}:${config.graphName}/${uid}`,
+		});
+	} catch (error) {
+		return roamErrorResponse(error);
+	}
+}
+
+function parseRoamRequest(req: Request): {
+	graphName: string;
+	graphType: "hosted" | "offline";
+	token: string;
+	port: number;
+} {
+	const url = new URL(req.url);
+	const graphName = url.searchParams.get("graphName")?.trim();
+	const graphType = url.searchParams.get("graphType") === "offline" ? "offline" : "hosted";
+	const tokenFromHeader = req.headers.get("authorization")?.replace(/^Bearer\s+/i, "").trim();
+	const tokenFromQuery = url.searchParams.get("token")?.trim();
+	const token = tokenFromHeader || tokenFromQuery;
+	const port = Number(url.searchParams.get("port") || "3333");
+
+	if (!graphName) {
+		throw new RoamClientError("Missing graphName parameter");
+	}
+	if (!token) {
+		throw new RoamAuthError("Missing Roam API token");
+	}
+	if (!Number.isFinite(port) || port < 1 || port > 65535) {
+		throw new RoamClientError("Invalid Roam API port");
+	}
+
+	return {
+		graphName,
+		graphType,
+		token,
+		port: Math.trunc(port),
+	};
+}
+
+function roamErrorResponse(error: unknown): Response {
+	if (error instanceof RoamAuthError) {
+		return Response.json({ error: error.message }, { status: 401 });
+	}
+	if (error instanceof RoamVersionMismatchError) {
+		return Response.json({ error: error.message, actualVersion: error.actualVersion }, { status: 409 });
+	}
+	if (error instanceof RoamTimeoutError) {
+		return Response.json({ error: error.message }, { status: 504 });
+	}
+	if (error instanceof RoamConnectionError) {
+		return Response.json({ error: error.message }, { status: 503 });
+	}
+	if (error instanceof RoamClientError) {
+		return Response.json({ error: error.message }, { status: 502 });
+	}
+	const message = error instanceof Error ? error.message : "Unknown Roam error";
+	return Response.json({ error: message }, { status: 500 });
 }
 
 // --- File Browser ---

--- a/packages/server/roam-client.test.ts
+++ b/packages/server/roam-client.test.ts
@@ -1,0 +1,332 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { ROAM_API_VERSION, formatRoamDailyNotePage, saveToRoam } from "./integrations";
+import {
+	callRoamLocalApi,
+	RoamAuthError,
+	RoamConnectionError,
+	RoamTimeoutError,
+	RoamVersionMismatchError,
+} from "./roam-client";
+
+let activeServer: ReturnType<typeof Bun.serve> | null = null;
+
+afterEach(() => {
+	activeServer?.stop(true);
+	activeServer = null;
+});
+
+function startRoamServer(
+	fetch: (req: Request) => Response | Promise<Response>,
+): number {
+	activeServer = Bun.serve({
+		port: 0,
+		fetch,
+	});
+	return activeServer.port;
+}
+
+describe("callRoamLocalApi", () => {
+	test("posts to the local Roam API with auth, offline query, and expectedApiVersion", async () => {
+		let seen: {
+			pathname: string;
+			search: string;
+			auth: string | null;
+			body: unknown;
+		} | null = null;
+
+		const port = startRoamServer(async (req) => {
+			seen = {
+				pathname: new URL(req.url).pathname,
+				search: new URL(req.url).search,
+				auth: req.headers.get("authorization"),
+				body: await req.json(),
+			};
+			return Response.json({
+				apiVersion: ROAM_API_VERSION,
+				result: { ok: true },
+			});
+		});
+
+		const result = await callRoamLocalApi(
+			{
+				graphName: "my-graph",
+				graphType: "offline",
+				token: "secret-token",
+				port,
+			},
+			"data.ai.search",
+			[{ query: "" }],
+		);
+
+		expect(result).toEqual({ ok: true });
+		expect(seen).toEqual({
+			pathname: "/api/my-graph",
+			search: "?type=offline",
+			auth: "Bearer secret-token",
+			body: {
+				action: "data.ai.search",
+				args: [{ query: "" }],
+				expectedApiVersion: ROAM_API_VERSION,
+			},
+		});
+	});
+
+	test("raises a typed auth error for 401 responses", async () => {
+		const port = startRoamServer(() =>
+			Response.json({ error: "Unauthorized" }, { status: 401 }),
+		);
+
+		await expect(
+			callRoamLocalApi(
+				{
+					graphName: "my-graph",
+					graphType: "hosted",
+					token: "bad-token",
+					port,
+				},
+				"ui.mainWindow.getOpenView",
+				{},
+			),
+		).rejects.toBeInstanceOf(RoamAuthError);
+	});
+
+	test("raises a typed timeout error when the local API hangs", async () => {
+		const port = startRoamServer(async () => {
+			await Bun.sleep(50);
+			return Response.json({ apiVersion: ROAM_API_VERSION, result: { ok: true } });
+		});
+
+		await expect(
+			callRoamLocalApi(
+				{
+					graphName: "my-graph",
+					graphType: "hosted",
+					token: "secret-token",
+					port,
+				},
+				"ui.mainWindow.getOpenView",
+				{},
+				{ timeoutMs: 5 },
+			),
+		).rejects.toBeInstanceOf(RoamTimeoutError);
+	});
+
+	test("raises a typed version mismatch error when the API version is incompatible", async () => {
+		const port = startRoamServer(() =>
+			Response.json({
+				apiVersion: "2.0.0",
+				result: { ok: true },
+			}),
+		);
+
+		await expect(
+			callRoamLocalApi(
+				{
+					graphName: "my-graph",
+					graphType: "hosted",
+					token: "secret-token",
+					port,
+				},
+				"ui.mainWindow.getOpenView",
+				{},
+			),
+		).rejects.toBeInstanceOf(RoamVersionMismatchError);
+	});
+
+	test("raises a typed connection error when the local API is unavailable", async () => {
+		const unusedServer = Bun.serve({
+			port: 0,
+			fetch: () => Response.json({ ok: true }),
+		});
+		const port = unusedServer.port;
+		unusedServer.stop(true);
+
+		await expect(
+			callRoamLocalApi(
+				{
+					graphName: "missing-graph",
+					graphType: "hosted",
+					token: "secret-token",
+					port,
+				},
+				"ui.mainWindow.getOpenView",
+				{},
+				{ timeoutMs: 25 },
+			),
+		).rejects.toBeInstanceOf(RoamConnectionError);
+	});
+});
+
+describe("saveToRoam", () => {
+	const planWithFrontmatter = [
+		"---",
+		"created: 2026-04-09T14:30:00.000Z",
+		"source: plannotator",
+		"tags: [plannotator, auth]",
+		"owner: alice",
+		"---",
+		"",
+		"# Implementation Plan: Auth Flow",
+		"",
+		"## Context",
+		"Ship it",
+	].join("\n");
+
+	const planMarkdownBlock = [
+		"```markdown",
+		planWithFrontmatter,
+		"```",
+	].join("\n");
+
+	test("sends attribute blocks, the Plannotator marker, a fenced markdown block, and returns a roam path", async () => {
+		let seenBody: unknown = null;
+		const port = startRoamServer(async (req) => {
+			seenBody = await req.json();
+			return Response.json({
+				apiVersion: ROAM_API_VERSION,
+				result: { uid: "page-uid-123" },
+			});
+		});
+
+		const result = await saveToRoam({
+			graphName: "work-notes",
+			graphType: "offline",
+			token: "secret-token",
+			port,
+			titleFormat: "{title}",
+			plan: planWithFrontmatter,
+		});
+
+		expect(result).toEqual({
+			success: true,
+			path: "roam:offline:work-notes/page-uid-123",
+		});
+		expect(seenBody).toEqual({
+			action: "data.page.fromMarkdown",
+			args: [
+				{
+					page: { title: "Auth Flow" },
+					"markdown-string": [
+						"[[Plannotator Plans]]",
+						"",
+						"created:: [[April 9th, 2026]]",
+						"source:: plannotator",
+						"tags:: [[plannotator]], [[auth]]",
+						"owner:: alice",
+						"",
+						planMarkdownBlock,
+					].join("\n"),
+				},
+			],
+			expectedApiVersion: ROAM_API_VERSION,
+		});
+	});
+
+	test("saves to today's daily note under a nested plans block when configured", async () => {
+		const seenBodies: unknown[] = [];
+		const port = startRoamServer(async (req) => {
+			seenBodies.push(await req.json());
+			return Response.json({
+				apiVersion: ROAM_API_VERSION,
+				result: { uids: seenBodies.length === 1 ? ["plan-block-uid"] : ["content-block-uid"] },
+			});
+		});
+
+		const result = await saveToRoam({
+			graphName: "work-notes",
+			graphType: "hosted",
+			token: "secret-token",
+			port,
+			titleFormat: "{title}",
+			saveLocation: "daily-note",
+			dailyNoteParent: "[[Plannotator Plans]]",
+			plan: planWithFrontmatter,
+		});
+
+		expect(result).toEqual({
+			success: true,
+			path: "roam:hosted:work-notes/plan-block-uid",
+		});
+		expect(seenBodies).toEqual([
+			{
+				action: "data.block.fromMarkdown",
+				args: [
+					{
+						location: {
+							order: "last",
+							"page-title": { "daily-note-page": formatRoamDailyNotePage(new Date()) },
+							"nest-under-str": "[[Plannotator Plans]]",
+						},
+						"markdown-string": "Auth Flow",
+					},
+				],
+				expectedApiVersion: ROAM_API_VERSION,
+			},
+			{
+				action: "data.block.fromMarkdown",
+				args: [
+					{
+						location: {
+							order: "last",
+							"parent-uid": "plan-block-uid",
+						},
+						"markdown-string": [
+							"created:: [[April 9th, 2026]]",
+							"source:: plannotator",
+							"tags:: [[plannotator]], [[auth]]",
+							"owner:: alice",
+							"",
+							planMarkdownBlock,
+						].join("\n"),
+					},
+				],
+				expectedApiVersion: ROAM_API_VERSION,
+			},
+		]);
+	});
+
+	test("uses a longer fence when the plan contains triple backtick code fences", async () => {
+		let seenBody: unknown = null;
+		const port = startRoamServer(async (req) => {
+			seenBody = await req.json();
+			return Response.json({
+				apiVersion: ROAM_API_VERSION,
+				result: { uid: "page-uid-123" },
+			});
+		});
+		const plan = [
+			"# Implementation Plan: Auth Flow",
+			"",
+			"```ts",
+			"console.log('hello');",
+			"```",
+		].join("\n");
+
+		await saveToRoam({
+			graphName: "work-notes",
+			graphType: "offline",
+			token: "secret-token",
+			port,
+			titleFormat: "{title}",
+			plan,
+		});
+
+		expect(seenBody).toEqual({
+			action: "data.page.fromMarkdown",
+			args: [
+				{
+					page: { title: "Auth Flow" },
+					"markdown-string": [
+						"[[Plannotator Plans]]",
+						"",
+						"````markdown",
+						plan,
+						"````",
+					].join("\n"),
+				},
+			],
+			expectedApiVersion: ROAM_API_VERSION,
+		});
+	});
+});

--- a/packages/server/roam-client.ts
+++ b/packages/server/roam-client.ts
@@ -1,0 +1,191 @@
+import {
+	ROAM_API_VERSION,
+	majorMinorMatches,
+	type RoamConfig,
+} from "../shared/integrations-common.ts";
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+export interface RoamRequestConfig {
+	graphName: string;
+	graphType: "hosted" | "offline";
+	token: string;
+	port: number;
+}
+
+export class RoamClientError extends Error {
+	override cause?: unknown;
+
+	constructor(message: string, options?: { cause?: unknown }) {
+		super(message);
+		this.name = new.target.name;
+		this.cause = options?.cause;
+	}
+}
+
+export class RoamConnectionError extends RoamClientError {}
+export class RoamAuthError extends RoamClientError {}
+export class RoamTimeoutError extends RoamClientError {}
+
+export class RoamVersionMismatchError extends RoamClientError {
+	actualVersion?: string;
+
+	constructor(message: string, options?: { actualVersion?: string; cause?: unknown }) {
+		super(message, options);
+		this.actualVersion = options?.actualVersion;
+	}
+}
+
+interface RoamEnvelope<T> {
+	success?: boolean;
+	result?: T;
+	error?: string;
+	message?: string;
+	apiVersion?: string;
+	actualApiVersion?: string;
+	version?: string;
+}
+
+export async function callRoamLocalApi<T>(
+	config: RoamRequestConfig | Pick<RoamConfig, "graphName" | "graphType" | "token" | "port">,
+	action: string,
+	args: unknown[],
+	options: { timeoutMs?: number } = {},
+): Promise<T> {
+	const payload = await callRoamLocalApiEnvelope<T>(config, action, args, options);
+	return payload.result;
+}
+
+export async function callRoamLocalApiEnvelope<T>(
+	config: RoamRequestConfig | Pick<RoamConfig, "graphName" | "graphType" | "token" | "port">,
+	action: string,
+	args: unknown[],
+	options: { timeoutMs?: number } = {},
+): Promise<{ result: T; apiVersion?: string }> {
+	const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+	const controller = new AbortController();
+	let didTimeout = false;
+	const timeout = setTimeout(() => {
+		didTimeout = true;
+		controller.abort("timeout");
+	}, timeoutMs);
+
+	try {
+		const response = await fetch(buildRoamUrl(config), {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${config.token}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				action,
+				args,
+				expectedApiVersion: ROAM_API_VERSION,
+			}),
+			signal: controller.signal,
+		});
+
+		const payload = await parseRoamResponse<T>(response);
+		const actualVersion = extractApiVersion(payload);
+		if (actualVersion && !majorMinorMatches(actualVersion, ROAM_API_VERSION)) {
+			throw new RoamVersionMismatchError(
+				`Roam API version mismatch: expected ${ROAM_API_VERSION}, got ${actualVersion}`,
+				{ actualVersion },
+			);
+		}
+
+		if (response.status === 401 || response.status === 403) {
+			throw new RoamAuthError(
+				extractErrorMessage(payload, "Roam authentication failed"),
+			);
+		}
+
+		if (!response.ok) {
+			throw new RoamClientError(
+				extractErrorMessage(
+					payload,
+					`Roam request failed with status ${response.status}`,
+				),
+			);
+		}
+
+		if (payload.success === false) {
+			throw new RoamClientError(
+				extractErrorMessage(payload, "Roam request failed"),
+			);
+		}
+
+		return {
+			result: (payload?.result ?? payload) as T,
+			apiVersion: actualVersion,
+		};
+	} catch (error) {
+		if (error instanceof RoamClientError) {
+			throw error;
+		}
+		if (didTimeout || isAbortError(error)) {
+			throw new RoamTimeoutError(
+				`Roam request timed out after ${timeoutMs}ms`,
+				{ cause: error },
+			);
+		}
+		throw new RoamConnectionError("Unable to reach the Roam local API", {
+			cause: error,
+		});
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+function buildRoamUrl(config: RoamRequestConfig): string {
+	const url = new URL(
+		`http://127.0.0.1:${config.port}/api/${encodeURIComponent(config.graphName)}`,
+	);
+	if (config.graphType === "offline") {
+		url.searchParams.set("type", "offline");
+	}
+	return url.toString();
+}
+
+async function parseRoamResponse<T>(response: Response): Promise<RoamEnvelope<T>> {
+	const text = await response.text();
+	if (!text) {
+		return {};
+	}
+
+	try {
+		return JSON.parse(text) as RoamEnvelope<T>;
+	} catch {
+		return { error: text };
+	}
+}
+
+function extractApiVersion(payload: RoamEnvelope<unknown> | undefined): string | undefined {
+	if (!payload || typeof payload !== "object") {
+		return undefined;
+	}
+	if (typeof payload.actualApiVersion === "string") return payload.actualApiVersion;
+	if (typeof payload.apiVersion === "string") return payload.apiVersion;
+	if (typeof payload.version === "string") return payload.version;
+	return undefined;
+}
+
+function extractErrorMessage(
+	payload: RoamEnvelope<unknown> | undefined,
+	fallback: string,
+): string {
+	if (!payload || typeof payload !== "object") {
+		return fallback;
+	}
+	if (typeof payload.error === "string" && payload.error.trim()) return payload.error;
+	if (typeof payload.message === "string" && payload.message.trim()) {
+		return payload.message;
+	}
+	return fallback;
+}
+
+function isAbortError(error: unknown): boolean {
+	return error instanceof DOMException
+		? error.name === "AbortError"
+		: error instanceof Error && error.name === "AbortError";
+}

--- a/packages/server/roam-reference.test.ts
+++ b/packages/server/roam-reference.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { ROAM_API_VERSION } from "./integrations";
+import {
+	handleRoamDoc,
+	handleRoamPages,
+	handleRoamTest,
+} from "./reference-handlers";
+
+let activeServer: ReturnType<typeof Bun.serve> | null = null;
+
+afterEach(() => {
+	activeServer?.stop(true);
+	activeServer = null;
+});
+
+function startRoamServer(
+	fetch: (req: Request) => Response | Promise<Response>,
+): number {
+	activeServer = Bun.serve({
+		port: 0,
+		fetch,
+	});
+	return activeServer.port;
+}
+
+describe("Roam reference handlers", () => {
+	test("handleRoamTest calls ui.mainWindow.getOpenView", async () => {
+		let seenBody: unknown = null;
+		let seenAuth: string | null = null;
+		const port = startRoamServer(async (req) => {
+			seenAuth = req.headers.get("authorization");
+			seenBody = await req.json();
+			return Response.json({
+				apiVersion: ROAM_API_VERSION,
+				result: { graphName: "work-notes", view: "page" },
+			});
+		});
+
+		const res = await handleRoamTest(
+			new Request(
+				`http://localhost/api/roam/test?graphName=work-notes&graphType=offline&port=${port}`,
+				{
+					headers: { Authorization: "Bearer secret-token" },
+				},
+			),
+		);
+
+		expect(res.status).toBe(200);
+		expect(seenAuth).toBe("Bearer secret-token");
+		expect(seenBody).toEqual({
+			action: "ui.mainWindow.getOpenView",
+			args: [],
+			expectedApiVersion: ROAM_API_VERSION,
+		});
+		expect(await res.json()).toEqual({
+			ok: true,
+			apiVersion: ROAM_API_VERSION,
+			graphName: "work-notes",
+		});
+	});
+
+	test("handleRoamPages normalizes suggestion objects into stable page rows", async () => {
+		let seenBody: unknown = null;
+		const port = startRoamServer(async (req) => {
+			seenBody = await req.json();
+			return Response.json({
+				apiVersion: ROAM_API_VERSION,
+				result: {
+					suggestions: {
+						recentlyEditedPages: [
+							{
+								uid: "page-2",
+								title: "Edited Later",
+								editedAt: "2026-04-09T19:00:00.000Z",
+							},
+						],
+						recentlyOpenedByUser: [
+							{
+								uid: "page-1",
+								title: "Opened Earlier",
+								type: "page",
+								openedAt: "2026-04-09T18:00:00.000Z",
+							},
+							{
+								uid: "ignored-block",
+								title: "Block",
+								type: "block",
+								openedAt: "2026-04-09T20:00:00.000Z",
+							},
+						],
+					},
+				},
+			});
+		});
+
+		const res = await handleRoamPages(
+			new Request(
+				`http://localhost/api/reference/roam/pages?graphName=work-notes&graphType=hosted&port=${port}`,
+				{
+					headers: { Authorization: "Bearer secret-token" },
+				},
+			),
+		);
+
+		expect(seenBody).toEqual({
+			action: "data.ai.search",
+			args: [{ query: "", scope: "pages", limit: 100, includePath: false }],
+			expectedApiVersion: ROAM_API_VERSION,
+		});
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({
+			tree: [
+				{
+					name: "Edited Later",
+					path: "page-2",
+					type: "file",
+				},
+				{
+					name: "Opened Earlier",
+					path: "page-1",
+					type: "file",
+				},
+			],
+		});
+	});
+
+	test("handleRoamDoc loads a page by uid and strips roam metadata tags", async () => {
+		let seenBody: unknown = null;
+		const port = startRoamServer(async (req) => {
+			seenBody = await req.json();
+			return Response.json({
+				apiVersion: ROAM_API_VERSION,
+				result: {
+					markdown: '<roam uid="abc123">## Heading\n\nBody</roam>',
+				},
+			});
+		});
+
+		const res = await handleRoamDoc(
+			new Request(
+				`http://localhost/api/reference/roam/doc?graphName=work-notes&graphType=offline&port=${port}&uid=abc123`,
+				{
+					headers: { Authorization: "Bearer secret-token" },
+				},
+			),
+		);
+
+		expect(seenBody).toEqual({
+			action: "data.ai.getPage",
+			args: [{ uid: "abc123" }],
+			expectedApiVersion: ROAM_API_VERSION,
+		});
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({
+			markdown: "## Heading\n\nBody",
+			filepath: "roam:offline:work-notes/abc123",
+		});
+	});
+
+	test("handleRoamDoc accepts the token as a query parameter for linked-doc fetches", async () => {
+		let seenAuth: string | null = null;
+		const port = startRoamServer(async (req) => {
+			seenAuth = req.headers.get("authorization");
+			return Response.json({
+				apiVersion: ROAM_API_VERSION,
+				result: {
+					markdown: "# Page",
+				},
+			});
+		});
+
+		const res = await handleRoamDoc(
+			new Request(
+				`http://localhost/api/reference/roam/doc?graphName=work-notes&graphType=hosted&port=${port}&token=secret-token&uid=abc123`,
+			),
+		);
+
+		expect(seenAuth).toBe("Bearer secret-token");
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({
+			markdown: "# Page",
+			filepath: "roam:hosted:work-notes/abc123",
+		});
+	});
+
+	test("handleRoamTest maps generic upstream failures to a server error", async () => {
+		const port = startRoamServer(() =>
+			Response.json({ error: "Boom" }, { status: 500 }),
+		);
+
+		const res = await handleRoamTest(
+			new Request(
+				`http://localhost/api/roam/test?graphName=work-notes&graphType=hosted&port=${port}`,
+				{
+					headers: { Authorization: "Bearer secret-token" },
+				},
+			),
+		);
+
+		expect(res.status).toBe(502);
+		expect(await res.json()).toEqual({ error: "Boom" });
+	});
+});

--- a/packages/shared/integrations-common.ts
+++ b/packages/shared/integrations-common.ts
@@ -23,11 +23,26 @@ export interface OctarineConfig {
 	folder: string;
 }
 
+export interface RoamConfig {
+	graphName: string;
+	graphType: "hosted" | "offline";
+	token: string;
+	port: number;
+	plan: string;
+	titleFormat?: string;
+	titleSeparator?: "space" | "dash" | "underscore";
+	saveLocation?: "page" | "daily-note";
+	dailyNoteParent?: string;
+}
+
 export interface IntegrationResult {
 	success: boolean;
 	error?: string;
 	path?: string;
 }
+
+export const ROAM_API_VERSION = "1.1.2";
+export const DEFAULT_ROAM_PARENT_BLOCK = "[[Plannotator Plans]]";
 
 /**
  * Detect Obsidian vaults by reading Obsidian's config file
@@ -198,6 +213,250 @@ export function generateFilename(
 	}
 
 	return sanitized.endsWith(".md") ? sanitized : `${sanitized}.md`;
+}
+
+export function stripFrontmatter(markdown: string): {
+	frontmatter: Record<string, unknown>;
+	body: string;
+} {
+	const match = markdown.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+	if (!match) {
+		return { frontmatter: {}, body: markdown };
+	}
+
+	const frontmatter: Record<string, unknown> = {};
+	const lines = match[1].split(/\r?\n/);
+
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i];
+		const keyValueMatch = line.match(/^([A-Za-z0-9_-]+):(?:\s*(.*))?$/);
+		if (!keyValueMatch) {
+			continue;
+		}
+
+		const key = keyValueMatch[1];
+		const inlineValue = keyValueMatch[2] ?? "";
+		if (inlineValue) {
+			frontmatter[key] = parseFrontmatterScalar(inlineValue);
+			continue;
+		}
+
+		const arrayValues: string[] = [];
+		let j = i + 1;
+		while (j < lines.length) {
+			const listMatch = lines[j].match(/^\s*-\s+(.*)$/);
+			if (!listMatch) {
+				break;
+			}
+			arrayValues.push(listMatch[1]);
+			j++;
+		}
+
+		if (arrayValues.length > 0) {
+			frontmatter[key] = arrayValues.map(parseFrontmatterScalar);
+			i = j - 1;
+			continue;
+		}
+
+		frontmatter[key] = "";
+	}
+
+	return {
+		frontmatter,
+		body: markdown.slice(match[0].length).replace(/^(?:\r?\n)+/, ""),
+	};
+}
+
+function parseFrontmatterScalar(
+	value: string,
+): string | boolean | number | string[] {
+	const trimmed = value.trim();
+	if (trimmed === "true") return true;
+	if (trimmed === "false") return false;
+	if (/^-?\d+(?:\.\d+)?$/.test(trimmed)) return Number(trimmed);
+	if (/^\[(.*)\]$/.test(trimmed)) {
+		const content = trimmed.slice(1, -1).trim();
+		if (!content) return [];
+		return content
+			.split(",")
+			.map((item) => item.trim().replace(/^["']|["']$/g, ""))
+			.filter((item) => item.length > 0);
+	}
+	return trimmed;
+}
+
+export function frontmatterToAttributeBlocks(
+	frontmatter: Record<string, unknown>,
+): string {
+	const lines: string[] = [];
+
+	for (const [key, value] of Object.entries(frontmatter)) {
+		if (value == null || value === "") continue;
+		if (key === "created" && typeof value === "string") {
+			lines.push(`created:: ${formatRoamCreatedValue(value)}`);
+			continue;
+		}
+		if (key === "tags") {
+			lines.push(`tags:: ${formatRoamTagsValue(value)}`);
+			continue;
+		}
+		lines.push(`${key}:: ${formatRoamAttributeValue(value)}`);
+	}
+
+	return lines.join("\n");
+}
+
+function formatRoamAttributeValue(value: unknown): string {
+	if (value === null || value === undefined) {
+		return "";
+	}
+	if (typeof value === "string") {
+		return value;
+	}
+	if (typeof value === "number" || typeof value === "boolean") {
+		return String(value);
+	}
+	if (Array.isArray(value)) {
+		return value.map((item) => formatRoamAttributeValue(item)).join(", ");
+	}
+	return JSON.stringify(value);
+}
+
+export function stripRoamMetadataTags(markdown: string): string {
+	return markdown
+		.replace(/<roam\b[^>]*\/>/gi, "")
+		.replace(/<roam\b[^>]*>([\s\S]*?)<\/roam>/gi, "$1");
+}
+
+export function majorMinorMatches(a: string, b: string): boolean {
+	const parsedA = parseMajorMinorVersion(a);
+	const parsedB = parseMajorMinorVersion(b);
+	if (!parsedA || !parsedB) {
+		return false;
+	}
+
+	return parsedA.major === parsedB.major && parsedA.minor === parsedB.minor;
+}
+
+function parseMajorMinorVersion(version: string): { major: number; minor: number } | null {
+	const match = version.trim().match(/^(\d+)\.(\d+)(?:\.\d+)?(?:[-+].*)?$/);
+	if (!match) {
+		return null;
+	}
+
+	return {
+		major: Number(match[1]),
+		minor: Number(match[2]),
+	};
+}
+
+export function generatePageTitle(
+	markdown: string,
+	format?: string,
+	separator?: "space" | "dash" | "underscore",
+): string {
+	return generateFilename(markdown, format, separator).replace(/\.md$/, "");
+}
+
+export function formatRoamDailyNotePage(date: Date): string {
+	const month = String(date.getMonth() + 1).padStart(2, "0");
+	const day = String(date.getDate()).padStart(2, "0");
+	const year = String(date.getFullYear());
+	return `${month}-${day}-${year}`;
+}
+
+export function normalizeRoamDailyNoteParent(value?: string | null): string {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : DEFAULT_ROAM_PARENT_BLOCK;
+}
+
+export interface RoamSuggestionPage {
+	uid: string;
+	title: string;
+	sortAt: string;
+}
+
+export interface RoamEditedPage {
+	uid: string;
+	title: string;
+	editedAt?: string;
+}
+
+export interface RoamOpenedPage {
+	uid?: string;
+	title: string;
+	type?: string;
+	openedAt?: string;
+}
+
+export interface RoamSuggestionsResult {
+	recentlyEditedPages?: RoamEditedPage[];
+	recentlyOpenedByUser?: RoamOpenedPage[];
+}
+
+export function normalizeRoamSuggestionsToPages(
+	result: RoamSuggestionsResult,
+): RoamSuggestionPage[] {
+	const pages = new Map<string, RoamSuggestionPage>();
+	for (const page of result.recentlyEditedPages ?? []) {
+		if (!page.uid || !page.title) continue;
+		pages.set(page.uid, {
+			uid: page.uid,
+			title: page.title,
+			sortAt: page.editedAt ?? "",
+		});
+	}
+
+	for (const page of result.recentlyOpenedByUser ?? []) {
+		if ((page.type && page.type !== "page") || !page.uid || !page.title) continue;
+		const existing = pages.get(page.uid);
+		if (!existing) {
+			pages.set(page.uid, {
+				uid: page.uid,
+				title: page.title,
+				sortAt: page.openedAt ?? "",
+			});
+			continue;
+		}
+
+		pages.set(page.uid, {
+			...existing,
+			sortAt: getMoreRecentSortAt(existing.sortAt, page.openedAt ?? ""),
+		});
+	}
+
+	return Array.from(pages.values()).sort((a, b) =>
+		b.sortAt.localeCompare(a.sortAt),
+	);
+}
+
+function formatRoamCreatedValue(value: string): string {
+	const date = new Date(value);
+	if (Number.isNaN(date.getTime())) {
+		return value;
+	}
+
+	const month = date.toLocaleString("en-US", { month: "long" });
+	const day = date.getDate();
+	return `[[${month} ${day}${getOrdinalSuffix(day)}, ${date.getFullYear()}]]`;
+}
+
+function formatRoamTagsValue(value: unknown): string {
+	if (Array.isArray(value)) {
+		return value.map((tag) => `[[${String(tag)}]]`).join(", ");
+	}
+	return `[[${String(value)}]]`;
+}
+
+function getOrdinalSuffix(day: number): string {
+	if (day % 10 === 1 && day % 100 !== 11) return "st";
+	if (day % 10 === 2 && day % 100 !== 12) return "nd";
+	if (day % 10 === 3 && day % 100 !== 13) return "rd";
+	return "th";
+}
+
+function getMoreRecentSortAt(a: string, b: string): string {
+	return a.localeCompare(b) >= 0 ? a : b;
 }
 
 // --- Bear Integration ---

--- a/packages/ui/components/ExportModal.test.tsx
+++ b/packages/ui/components/ExportModal.test.tsx
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { storage } from "../utils/storage";
+import { saveRoamSettings } from "../utils/roam";
+import { ExportModal } from "./ExportModal";
+
+const keys = [
+  "plannotator-obsidian-enabled",
+  "plannotator-obsidian-vault-path",
+  "plannotator-obsidian-folder",
+  "plannotator-obsidian-filename-format",
+  "plannotator-obsidian-filename-separator",
+  "plannotator-bear-enabled",
+  "plannotator-bear-tags",
+  "plannotator-bear-tag-position",
+  "plannotator-octarine-enabled",
+  "plannotator-octarine-workspace",
+  "plannotator-octarine-folder",
+  "plannotator-roam-enabled",
+  "plannotator-roam-graph-name",
+  "plannotator-roam-graph-type",
+  "plannotator-roam-token",
+  "plannotator-roam-port",
+  "plannotator-roam-title-format",
+  "plannotator-roam-title-separator",
+  "plannotator-roam-autosave",
+  "plannotator-roam-reference-browser",
+];
+
+let cookieStore = new Map<string, string>();
+
+beforeEach(() => {
+  cookieStore = new Map();
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      get cookie() {
+        return Array.from(cookieStore.entries())
+          .map(([key, value]) => `${key}=${value}`)
+          .join("; ");
+      },
+      set cookie(value: string) {
+        const [pair, ...directives] = value.split(";").map((part) => part.trim());
+        const [key, rawValue = ""] = pair.split("=");
+        if (!key) return;
+        if (directives.some((directive) => directive.toLowerCase() === "max-age=0")) {
+          cookieStore.delete(key);
+          return;
+        }
+        cookieStore.set(key, rawValue);
+      },
+    },
+  });
+
+  for (const key of keys) {
+    storage.removeItem(key);
+  }
+});
+
+describe("ExportModal", () => {
+  test("shows Roam in the Notes tab when Roam is configured", () => {
+    saveRoamSettings({
+      enabled: true,
+      graphName: "my-graph",
+      graphType: "hosted",
+      token: "secret-token",
+      port: 3333,
+      titleSeparator: "space",
+      saveLocation: "daily-note",
+      dailyNoteParent: "[[Plannotator Plans]]",
+      autoSave: true,
+      referenceBrowserEnabled: true,
+    });
+
+    const html = renderToStaticMarkup(
+      <ExportModal
+        isOpen
+        onClose={() => {}}
+        shareUrl="https://example.com/share"
+        shareUrlSize="1 KB"
+        annotationsOutput="No annotations"
+        annotationCount={0}
+        markdown="# Plan"
+        isApiMode
+        initialTab="notes"
+      />,
+    );
+
+    expect(html).toContain("Roam");
+    expect(html).toContain("my-graph");
+    expect(html).toContain("today&#x27;s Daily Note");
+  });
+});

--- a/packages/ui/components/ExportModal.tsx
+++ b/packages/ui/components/ExportModal.tsx
@@ -10,6 +10,7 @@ import React, { useState, useEffect } from 'react';
 import { getObsidianSettings, getEffectiveVaultPath } from '../utils/obsidian';
 import { getBearSettings } from '../utils/bear';
 import { getOctarineSettings } from '../utils/octarine';
+import { getRoamSettings } from '../utils/roam';
 import { wrapFeedbackForAgent } from '../utils/parser';
 import { OverlayScrollArea } from './OverlayScrollArea';
 
@@ -37,7 +38,7 @@ interface ExportModalProps {
 
 type Tab = 'share' | 'annotations' | 'notes';
 
-type SaveTarget = 'obsidian' | 'bear' | 'octarine';
+type SaveTarget = 'obsidian' | 'bear' | 'octarine' | 'roam';
 type SaveStatus = 'idle' | 'saving' | 'success' | 'error';
 
 export const ExportModal: React.FC<ExportModalProps> = ({
@@ -60,7 +61,7 @@ export const ExportModal: React.FC<ExportModalProps> = ({
   const defaultTab = initialTab || (sharingEnabled ? 'share' : 'annotations');
   const [activeTab, setActiveTab] = useState<Tab>(defaultTab);
   const [copied, setCopied] = useState<'short' | 'full' | 'annotations' | false>(false);
-  const [saveStatus, setSaveStatus] = useState<Record<SaveTarget, SaveStatus>>({ obsidian: 'idle', bear: 'idle', octarine: 'idle' });
+  const [saveStatus, setSaveStatus] = useState<Record<SaveTarget, SaveStatus>>({ obsidian: 'idle', bear: 'idle', octarine: 'idle', roam: 'idle' });
   const [saveErrors, setSaveErrors] = useState<Record<string, string>>({});
 
   // Reset tab when modal opens
@@ -73,7 +74,7 @@ export const ExportModal: React.FC<ExportModalProps> = ({
   // Reset save status when modal opens
   useEffect(() => {
     if (isOpen) {
-      setSaveStatus({ obsidian: 'idle', bear: 'idle', octarine: 'idle' });
+      setSaveStatus({ obsidian: 'idle', bear: 'idle', octarine: 'idle', roam: 'idle' });
       setSaveErrors({});
     }
   }, [isOpen]);
@@ -84,10 +85,12 @@ export const ExportModal: React.FC<ExportModalProps> = ({
   const obsidianSettings = getObsidianSettings();
   const bearSettings = getBearSettings();
   const octarineSettings = getOctarineSettings();
+  const roamSettings = getRoamSettings();
   const effectiveVaultPath = getEffectiveVaultPath(obsidianSettings);
   const isObsidianReady = obsidianSettings.enabled && effectiveVaultPath.trim().length > 0;
   const isBearReady = bearSettings.enabled;
   const isOctarineReady = octarineSettings.enabled && octarineSettings.workspace.trim().length > 0;
+  const isRoamReady = roamSettings.enabled && roamSettings.graphName.trim().length > 0 && roamSettings.token.trim().length > 0;
 
   const handleCopy = async (text: string, which: 'short' | 'full' | 'annotations') => {
     try {
@@ -124,7 +127,7 @@ export const ExportModal: React.FC<ExportModalProps> = ({
     setSaveStatus(prev => ({ ...prev, [target]: 'saving' }));
     setSaveErrors(prev => { const next = { ...prev }; delete next[target]; return next; });
 
-    const body: { obsidian?: object; bear?: object; octarine?: object } = {};
+    const body: { obsidian?: object; bear?: object; octarine?: object; roam?: object } = {};
 
     if (target === 'obsidian') {
       body.obsidian = {
@@ -143,6 +146,19 @@ export const ExportModal: React.FC<ExportModalProps> = ({
         plan: markdown,
         workspace: octarineSettings.workspace,
         folder: octarineSettings.folder || 'plannotator',
+      };
+    }
+    if (target === 'roam') {
+      body.roam = {
+        graphName: roamSettings.graphName,
+        graphType: roamSettings.graphType,
+        token: roamSettings.token,
+        port: roamSettings.port || 3333,
+        plan: markdown,
+        saveLocation: roamSettings.saveLocation,
+        dailyNoteParent: roamSettings.dailyNoteParent,
+        ...(roamSettings.titleFormat && { titleFormat: roamSettings.titleFormat }),
+        ...(roamSettings.titleSeparator && roamSettings.titleSeparator !== 'space' && { titleSeparator: roamSettings.titleSeparator }),
       };
     }
 
@@ -172,10 +188,11 @@ export const ExportModal: React.FC<ExportModalProps> = ({
     if (isObsidianReady) targets.push('obsidian');
     if (isBearReady) targets.push('bear');
     if (isOctarineReady) targets.push('octarine');
+    if (isRoamReady) targets.push('roam');
     await Promise.all(targets.map(t => handleSaveToNotes(t)));
   };
 
-  const readyCount = [isObsidianReady, isBearReady, isOctarineReady].filter(Boolean).length;
+  const readyCount = [isObsidianReady, isBearReady, isOctarineReady, isRoamReady].filter(Boolean).length;
 
   // Determine which tabs to show
   const showTabs = sharingEnabled || showNotesTab;
@@ -501,12 +518,57 @@ export const ExportModal: React.FC<ExportModalProps> = ({
                 )}
               </div>
 
+              {/* Roam */}
+              <div className="border border-border rounded-lg p-3 space-y-2">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className={`w-2 h-2 rounded-full ${isRoamReady ? 'bg-success' : 'bg-muted-foreground/30'}`} />
+                    <span className="text-sm font-medium">Roam</span>
+                  </div>
+                  {isRoamReady ? (
+                    <button
+                      onClick={() => handleSaveToNotes('roam')}
+                      disabled={saveStatus.roam === 'saving'}
+                      className={`px-3 py-1 rounded-md text-xs font-medium transition-all ${
+                        saveStatus.roam === 'success'
+                          ? 'bg-success/15 text-success'
+                          : saveStatus.roam === 'error'
+                            ? 'bg-destructive/15 text-destructive'
+                            : saveStatus.roam === 'saving'
+                              ? 'bg-muted text-muted-foreground opacity-50'
+                              : 'bg-primary text-primary-foreground hover:opacity-90'
+                      }`}
+                    >
+                      {saveStatus.roam === 'saving' ? 'Saving...'
+                        : saveStatus.roam === 'success' ? 'Saved'
+                        : saveStatus.roam === 'error' ? 'Failed'
+                        : 'Save'}
+                    </button>
+                  ) : (
+                    <span className="text-xs text-muted-foreground">Not configured</span>
+                  )}
+                </div>
+                {isRoamReady && (
+                  <div className="text-[10px] text-muted-foreground/70">
+                    {roamSettings.graphName} ({roamSettings.graphType}) · {roamSettings.saveLocation === 'daily-note' ? `today's Daily Note -> ${roamSettings.dailyNoteParent}` : 'new page'}
+                  </div>
+                )}
+                {!isRoamReady && (
+                  <div className="text-[10px] text-muted-foreground/70">
+                    Enable in Settings &gt; Saving &gt; Roam
+                  </div>
+                )}
+                {saveErrors.roam && (
+                  <div className="text-[10px] text-destructive">{saveErrors.roam}</div>
+                )}
+              </div>
+
               {/* Save All button */}
               {readyCount >= 2 && (
                 <div className="flex justify-end">
                   <button
                     onClick={handleSaveAll}
-                    disabled={saveStatus.obsidian === 'saving' || saveStatus.bear === 'saving' || saveStatus.octarine === 'saving'}
+                    disabled={saveStatus.obsidian === 'saving' || saveStatus.bear === 'saving' || saveStatus.octarine === 'saving' || saveStatus.roam === 'saving'}
                     className="px-3 py-1.5 rounded-md text-xs font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity disabled:opacity-50"
                   >
                     Save All

--- a/packages/ui/components/PlanHeaderMenu.tsx
+++ b/packages/ui/components/PlanHeaderMenu.tsx
@@ -28,12 +28,14 @@ interface PlanHeaderMenuProps {
   onSaveToObsidian: () => void;
   onSaveToBear: () => void;
   onSaveToOctarine: () => void;
+  onSaveToRoam: () => void;
   sharingEnabled: boolean;
   isApiMode: boolean;
   agentInstructionsEnabled: boolean;
   obsidianConfigured: boolean;
   bearConfigured: boolean;
   octarineConfigured: boolean;
+  roamConfigured: boolean;
 }
 
 export const PlanHeaderMenu: React.FC<PlanHeaderMenuProps> = ({
@@ -51,19 +53,21 @@ export const PlanHeaderMenu: React.FC<PlanHeaderMenuProps> = ({
   onSaveToObsidian,
   onSaveToBear,
   onSaveToOctarine,
+  onSaveToRoam,
   sharingEnabled,
   isApiMode,
   agentInstructionsEnabled,
   obsidianConfigured,
   bearConfigured,
   octarineConfigured,
+  roamConfigured,
 }) => {
   const { theme, setTheme } = useTheme();
 
   const showUpdateDot = !!updateInfo?.updateAvailable && !updateInfo.dismissed;
 
   const anyNotesAppConfigured =
-    isApiMode && (obsidianConfigured || bearConfigured || octarineConfigured);
+    isApiMode && (obsidianConfigured || bearConfigured || octarineConfigured || roamConfigured);
 
   return (
     <ActionMenu
@@ -224,6 +228,16 @@ export const PlanHeaderMenu: React.FC<PlanHeaderMenuProps> = ({
                   label="Save to Octarine"
                 />
               )}
+              {roamConfigured && (
+                <ActionMenuItem
+                  onClick={() => {
+                    closeMenu();
+                    onSaveToRoam();
+                  }}
+                  icon={<NoteIcon />}
+                  label="Save to Roam"
+                />
+              )}
             </>
           )}
 
@@ -296,4 +310,3 @@ const NoteIcon = () => (
     <path strokeLinecap="round" strokeLinejoin="round" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
   </svg>
 );
-

--- a/packages/ui/components/Settings.tsx
+++ b/packages/ui/components/Settings.tsx
@@ -27,6 +27,12 @@ import {
   type OctarineSettings,
 } from '../utils/octarine';
 import {
+  getRoamSettings,
+  normalizeRoamPort,
+  saveRoamSettings,
+  type RoamSettings,
+} from '../utils/roam';
+import {
   getAgentSwitchSettings,
   saveAgentSwitchSettings,
   AGENT_OPTIONS,
@@ -71,7 +77,13 @@ import {
   type FileBrowserSettings,
 } from '../utils/fileBrowser';
 
-type SettingsTab = 'general' | 'theme' | 'git' | 'display' | 'saving' | 'labels' | 'shortcuts' | 'ai' | 'files' | 'obsidian' | 'bear' | 'octarine' | 'comments' | 'hooks';
+type SettingsTab = 'general' | 'theme' | 'git' | 'display' | 'saving' | 'labels' | 'shortcuts' | 'ai' | 'files' | 'obsidian' | 'bear' | 'octarine' | 'roam' | 'comments' | 'hooks';
+
+type RoamTestStatus =
+  | { state: 'idle' }
+  | { state: 'loading' }
+  | { state: 'success'; apiVersion: string; graphName: string }
+  | { state: 'error'; message: string };
 
 interface SettingsProps {
   taterMode: boolean;
@@ -637,6 +649,19 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
   const [vaultsLoading, setVaultsLoading] = useState(false);
   const [bear, setBear] = useState<BearSettings>({ enabled: false, customTags: '', tagPosition: 'append', autoSave: false });
   const [octarine, setOctarine] = useState<OctarineSettings>({ enabled: false, workspace: '', folder: 'plannotator', autoSave: false });
+  const [roam, setRoam] = useState<RoamSettings>({
+    enabled: false,
+    graphName: '',
+    graphType: 'hosted',
+    token: '',
+    port: 3333,
+    titleSeparator: 'space',
+    saveLocation: 'page',
+    dailyNoteParent: '[[Plannotator Plans]]',
+    autoSave: false,
+    referenceBrowserEnabled: false,
+  });
+  const [roamTestStatus, setRoamTestStatus] = useState<RoamTestStatus>({ state: 'idle' });
   const [agent, setAgent] = useState<AgentSwitchSettings>({ switchTo: 'build' });
   const [planSave, setPlanSave] = useState<PlanSaveSettings>({ enabled: true, customPath: null });
   const [uiPrefs, setUiPrefs] = useState<UIPreferences>({ tocEnabled: true, stickyActionsEnabled: true, planWidth: 'compact' });
@@ -680,12 +705,18 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
   const integrationTabs: { id: SettingsTab; label: string }[] = [
     { id: 'files', label: 'Files' },
     ...(mode === 'plan'
-      ? [{ id: 'obsidian' as SettingsTab, label: 'Obsidian' }, { id: 'bear' as SettingsTab, label: 'Bear' }, { id: 'octarine' as SettingsTab, label: 'Octarine' }]
+      ? [
+          { id: 'obsidian' as SettingsTab, label: 'Obsidian' },
+          { id: 'bear' as SettingsTab, label: 'Bear' },
+          { id: 'octarine' as SettingsTab, label: 'Octarine' },
+          { id: 'roam' as SettingsTab, label: 'Roam' },
+        ]
       : []),
   ];
   const obsidianDefaultSaveAvailable = obsidian.enabled && getEffectiveVaultPath(obsidian).trim().length > 0;
   const bearDefaultSaveAvailable = bear.enabled;
   const octarineDefaultSaveAvailable = octarine.enabled && octarine.workspace.trim().length > 0;
+  const roamDefaultSaveAvailable = roam.enabled && roam.graphName.trim().length > 0 && roam.token.trim().length > 0;
 
   // Sync external open state
   useEffect(() => {
@@ -701,6 +732,8 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
       setObsidian(getObsidianSettings());
       setBear(getBearSettings());
       setOctarine(getOctarineSettings());
+      setRoam(getRoamSettings());
+      setRoamTestStatus({ state: 'idle' });
       setAgent(getAgentSwitchSettings());
       setPlanSave(getPlanSaveSettings());
       setUiPrefs(getUIPreferences());
@@ -727,7 +760,8 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
       defaultNotesApp === 'download' ||
       (defaultNotesApp === 'obsidian' && obsidianDefaultSaveAvailable) ||
       (defaultNotesApp === 'bear' && bearDefaultSaveAvailable) ||
-      (defaultNotesApp === 'octarine' && octarineDefaultSaveAvailable);
+      (defaultNotesApp === 'octarine' && octarineDefaultSaveAvailable) ||
+      (defaultNotesApp === 'roam' && roamDefaultSaveAvailable);
 
     if (!defaultSaveAvailable) {
       setDefaultNotesApp('ask');
@@ -739,6 +773,7 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
     obsidianDefaultSaveAvailable,
     bearDefaultSaveAvailable,
     octarineDefaultSaveAvailable,
+    roamDefaultSaveAvailable,
   ]);
 
   // Fetch detected vaults when Obsidian is enabled
@@ -792,6 +827,39 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
     const newSettings = { ...octarine, ...updates };
     setOctarine(newSettings);
     saveOctarineSettings(newSettings);
+  };
+
+  const handleRoamChange = (updates: Partial<RoamSettings>) => {
+    const newSettings = {
+      ...roam,
+      ...updates,
+      port: normalizeRoamPort(updates.port ?? roam.port),
+    };
+    setRoam(newSettings);
+    saveRoamSettings(newSettings);
+    setRoamTestStatus({ state: 'idle' });
+  };
+
+  const handleRoamTestConnection = async () => {
+    setRoamTestStatus({ state: 'loading' });
+    try {
+      const res = await fetch(
+        `/api/roam/test?graphName=${encodeURIComponent(roam.graphName)}&graphType=${encodeURIComponent(roam.graphType)}&port=${encodeURIComponent(String(normalizeRoamPort(roam.port)))}`,
+        { headers: { Authorization: `Bearer ${roam.token}` } },
+      );
+      const data = await res.json();
+      if (data.ok) {
+        setRoamTestStatus({
+          state: 'success',
+          apiVersion: data.apiVersion,
+          graphName: data.graphName,
+        });
+      } else {
+        setRoamTestStatus({ state: 'error', message: data.error || 'Connection failed' });
+      }
+    } catch {
+      setRoamTestStatus({ state: 'error', message: 'Failed to connect to server' });
+    }
   };
 
   const handleAgentChange = (switchTo: AgentSwitchSettings['switchTo'], customName?: string) => {
@@ -1407,13 +1475,14 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
                         {obsidianDefaultSaveAvailable && <option value="obsidian">Obsidian</option>}
                         {bearDefaultSaveAvailable && <option value="bear">Bear</option>}
                         {octarineDefaultSaveAvailable && <option value="octarine">Octarine</option>}
+                        {roamDefaultSaveAvailable && <option value="roam">Roam</option>}
                       </select>
                       <div className="text-[10px] text-muted-foreground/70">
                         {defaultNotesApp === 'ask'
                           ? 'Opens Export dialog with Notes tab'
                           : defaultNotesApp === 'download'
                             ? `${modKey}+S downloads the annotations file`
-                            : `${modKey}+S saves directly to ${{ obsidian: 'Obsidian', bear: 'Bear', octarine: 'Octarine' }[defaultNotesApp] ?? defaultNotesApp}`}
+                            : `${modKey}+S saves directly to ${{ obsidian: 'Obsidian', bear: 'Bear', octarine: 'Octarine', roam: 'Roam' }[defaultNotesApp] ?? defaultNotesApp}`}
                       </div>
                     </div>
 
@@ -1460,6 +1529,20 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
                         <span className="flex items-center gap-2">
                           <span className={`text-[10px] font-medium ${octarine.enabled ? 'text-primary' : 'text-muted-foreground/50'}`}>
                             {octarine.enabled ? 'Enabled' : 'Off'}
+                          </span>
+                          <svg className="w-3.5 h-3.5 text-muted-foreground/40 group-hover:text-muted-foreground transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+                          </svg>
+                        </span>
+                      </button>
+                      <button
+                        onClick={() => setActiveTab('roam')}
+                        className="w-full flex items-center justify-between px-3 py-2.5 bg-muted/50 hover:bg-muted rounded-lg text-sm transition-colors group"
+                      >
+                        <span className="text-foreground">Roam</span>
+                        <span className="flex items-center gap-2">
+                          <span className={`text-[10px] font-medium ${roam.enabled ? 'text-primary' : 'text-muted-foreground/50'}`}>
+                            {roam.enabled ? 'Enabled' : 'Off'}
                           </span>
                           <svg className="w-3.5 h-3.5 text-muted-foreground/40 group-hover:text-muted-foreground transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                             <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
@@ -2038,6 +2121,161 @@ tags: [plan, ...]
                             }`} />
                           </button>
                         </div>
+                      </div>
+                    )}
+                  </>
+                )}
+
+                {/* === ROAM TAB === */}
+                {activeTab === 'roam' && (
+                  <>
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <div className="text-sm font-medium">Roam</div>
+                        <div className="text-xs text-muted-foreground">
+                          Save plans to Roam Desktop and browse recent pages
+                        </div>
+                      </div>
+                      <button
+                        role="switch"
+                        aria-checked={roam.enabled}
+                        onClick={() => handleRoamChange({ enabled: !roam.enabled })}
+                        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                          roam.enabled ? 'bg-primary' : 'bg-muted'
+                        }`}
+                      >
+                        <span
+                          className={`inline-block h-4 w-4 transform rounded-full bg-white shadow-sm transition-transform ${
+                            roam.enabled ? 'translate-x-6' : 'translate-x-1'
+                          }`}
+                        />
+                      </button>
+                    </div>
+                    {roam.enabled && (
+                      <div className="mt-3 space-y-3">
+                        <div className="space-y-1.5 pl-0.5">
+                          <label className="text-xs text-muted-foreground">Graph Name</label>
+                          <input
+                            type="text"
+                            value={roam.graphName}
+                            onChange={(e) => handleRoamChange({ graphName: e.target.value })}
+                            placeholder="my-graph"
+                            className="w-full px-3 py-2 bg-muted rounded-lg text-xs font-mono placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-primary/50"
+                          />
+                        </div>
+                        <div className="space-y-1.5 pl-0.5">
+                          <label className="text-xs text-muted-foreground">Graph Type</label>
+                          <select
+                            value={roam.graphType}
+                            onChange={(e) => handleRoamChange({ graphType: e.target.value as RoamSettings['graphType'] })}
+                            className="w-full px-3 py-2 bg-muted rounded-lg text-xs focus:outline-none focus:ring-1 focus:ring-primary/50"
+                          >
+                            <option value="hosted">Hosted</option>
+                            <option value="offline">Offline</option>
+                          </select>
+                        </div>
+                        <div className="space-y-1.5 pl-0.5">
+                          <label className="text-xs text-muted-foreground">Local API Token</label>
+                          <input
+                            type="password"
+                            value={roam.token}
+                            onChange={(e) => handleRoamChange({ token: e.target.value })}
+                            placeholder="roam-graph-local-token-..."
+                            className="w-full px-3 py-2 bg-muted rounded-lg text-xs font-mono placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-primary/50"
+                          />
+                        </div>
+                        <div className="space-y-1.5 pl-0.5">
+                          <label className="text-xs text-muted-foreground">Local API Port</label>
+                          <input
+                            type="number"
+                            value={roam.port}
+                            onChange={(e) => handleRoamChange({ port: normalizeRoamPort(e.target.value) })}
+                            className="w-full px-3 py-2 bg-muted rounded-lg text-xs font-mono focus:outline-none focus:ring-1 focus:ring-primary/50"
+                          />
+                        </div>
+                        <button
+                          onClick={handleRoamTestConnection}
+                          disabled={roamTestStatus.state === 'loading'}
+                          className="px-3 py-2 rounded-lg text-xs font-medium bg-primary text-primary-foreground disabled:opacity-60"
+                        >
+                          {roamTestStatus.state === 'loading' ? 'Testing...' : 'Test Connection'}
+                        </button>
+                        {roamTestStatus.state === 'success' && (
+                          <div className="text-[10px] text-success">
+                            Connected to {roamTestStatus.graphName} · API {roamTestStatus.apiVersion}
+                          </div>
+                        )}
+                        {roamTestStatus.state === 'error' && (
+                          <div className="text-[10px] text-destructive">
+                            {roamTestStatus.message}
+                          </div>
+                        )}
+
+                        <div className="border-t border-border/30" />
+
+                        <div className="space-y-1.5 pl-0.5">
+                          <label className="text-xs text-muted-foreground">Save Location</label>
+                          <select
+                            value={roam.saveLocation}
+                            onChange={(e) => handleRoamChange({ saveLocation: e.target.value as RoamSettings['saveLocation'] })}
+                            className="w-full px-3 py-2 bg-muted rounded-lg text-xs focus:outline-none focus:ring-1 focus:ring-primary/50"
+                          >
+                            <option value="page">New Page</option>
+                            <option value="daily-note">Today's Daily Note</option>
+                          </select>
+                          <div className="text-[10px] text-muted-foreground/70">
+                            Saved plan contents are stored in a fenced markdown block.
+                          </div>
+                        </div>
+                        {roam.saveLocation === 'daily-note' && (
+                          <div className="space-y-1.5 pl-0.5">
+                            <label className="text-xs text-muted-foreground">Daily Note Parent Block</label>
+                            <input
+                              type="text"
+                              value={roam.dailyNoteParent}
+                              onChange={(e) => handleRoamChange({ dailyNoteParent: e.target.value })}
+                              placeholder="[[Plannotator Plans]]"
+                              className="w-full px-3 py-2 bg-muted rounded-lg text-xs font-mono placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-primary/50"
+                            />
+                          </div>
+                        )}
+                        <div className="space-y-1.5 pl-0.5">
+                          <label className="text-xs text-muted-foreground">Plan Title Format</label>
+                          <input
+                            type="text"
+                            value={roam.titleFormat || ''}
+                            onChange={(e) => handleRoamChange({ titleFormat: e.target.value || undefined })}
+                            placeholder={DEFAULT_FILENAME_FORMAT}
+                            className="w-full px-3 py-2 bg-muted rounded-lg text-xs font-mono placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-primary/50"
+                          />
+                        </div>
+                        <div className="space-y-1.5 pl-0.5">
+                          <label className="text-xs text-muted-foreground">Title Separator</label>
+                          <select
+                            value={roam.titleSeparator || 'space'}
+                            onChange={(e) => handleRoamChange({ titleSeparator: e.target.value as RoamSettings['titleSeparator'] })}
+                            className="w-full px-3 py-2 bg-muted rounded-lg text-xs focus:outline-none focus:ring-1 focus:ring-primary/50"
+                          >
+                            <option value="space">Spaces</option>
+                            <option value="dash">Dashes (-)</option>
+                            <option value="underscore">Underscores (_)</option>
+                          </select>
+                        </div>
+
+                        <div className="border-t border-border/30" />
+
+                        <ToggleSwitch
+                          checked={roam.autoSave}
+                          onChange={(value) => handleRoamChange({ autoSave: value })}
+                          label="Auto-save on Plan Arrival"
+                          description="Save to Roam before you approve or deny"
+                        />
+                        <ToggleSwitch
+                          checked={roam.referenceBrowserEnabled}
+                          onChange={(value) => handleRoamChange({ referenceBrowserEnabled: value })}
+                          label="Reference Browser"
+                          description="Browse recent Roam pages from the sidebar"
+                        />
                       </div>
                     )}
                   </>

--- a/packages/ui/components/sidebar/FileBrowser.test.tsx
+++ b/packages/ui/components/sidebar/FileBrowser.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { DirState } from "../../hooks/useFileBrowser";
+import { FileBrowser } from "./FileBrowser";
+
+describe("FileBrowser", () => {
+  test("renders a readable Roam source section while keeping page titles and uid keys distinct", () => {
+    const html = renderToStaticMarkup(
+      <FileBrowser
+        dirs={[
+          {
+            path: "roam:hosted:work-notes",
+            name: "work-notes",
+            tree: [
+              {
+                name: "Daily Notes",
+                path: "abc123",
+                type: "file",
+              },
+            ],
+            isLoading: false,
+            error: null,
+            source: "roam",
+            roamMeta: {
+              graphName: "work-notes",
+              graphType: "hosted",
+              token: "secret-token",
+              port: 3333,
+            },
+          },
+        ] as unknown as DirState[]}
+        expandedFolders={new Set()}
+        onToggleFolder={() => {}}
+        collapsedDirs={new Set()}
+        onToggleCollapse={() => {}}
+        onSelectFile={() => {}}
+        activeFile={null}
+        onFetchAll={() => {}}
+      />,
+    );
+
+    expect(html).toContain("Roam");
+    expect(html).toContain("work-notes");
+    expect(html).toContain("Daily Notes");
+    expect(html).toContain('title="abc123"');
+  });
+});

--- a/packages/ui/components/sidebar/FileBrowser.tsx
+++ b/packages/ui/components/sidebar/FileBrowser.tsx
@@ -20,7 +20,7 @@ interface FileBrowserProps {
   onSelectFile: (absolutePath: string, dirPath: string) => void;
   activeFile: string | null;
   onFetchAll: () => void;
-  onRetryVaultDir?: (vaultPath: string) => void;
+  onRetryVaultDir?: (dirPath: string) => void;
   annotationCounts?: Map<string, number>;
   highlightedFiles?: Set<string>;
 }
@@ -217,6 +217,7 @@ export const FileBrowser: React.FC<FileBrowserProps> = ({
       )}
       {dirs.map((dir) => {
         const isCollapsed = collapsedDirs.has(dir.path);
+        const sourceLabel = dir.source === "roam" ? "Roam" : dir.source === "obsidian" ? "Obsidian" : null;
         return (
           <div key={dir.path}>
             <button
@@ -233,7 +234,12 @@ export const FileBrowser: React.FC<FileBrowserProps> = ({
               >
                 <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
               </svg>
-              {dir.isVault && <ObsidianIconRaw className="w-[11px] h-[13px] flex-shrink-0 opacity-70" />}
+              {dir.source === "obsidian" && <ObsidianIconRaw className="w-[11px] h-[13px] flex-shrink-0 opacity-70" />}
+              {sourceLabel && (
+                <span className="text-[9px] font-semibold uppercase tracking-wider text-muted-foreground/70">
+                  {sourceLabel}
+                </span>
+              )}
               <div className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider truncate">
                 {dir.name}
               </div>
@@ -245,7 +251,7 @@ export const FileBrowser: React.FC<FileBrowserProps> = ({
                 onToggleFolder={onToggleFolder}
                 onSelectFile={onSelectFile}
                 activeFile={activeFile}
-                onRetry={dir.isVault && onRetryVaultDir ? () => onRetryVaultDir(dir.path) : onFetchAll}
+                onRetry={dir.source !== "files" && onRetryVaultDir ? () => onRetryVaultDir(dir.path) : onFetchAll}
                 annotationCounts={annotationCounts}
                 highlightedFiles={highlightedFiles}
               />

--- a/packages/ui/hooks/useFileBrowser.ts
+++ b/packages/ui/hooks/useFileBrowser.ts
@@ -1,14 +1,15 @@
 /**
  * File Browser Hook
  *
- * Manages multiple directory file trees for the sidebar Files tab.
- * Each directory gets its own tree, loading, and error state.
- * Vault directories are supported via the isVault flag — they fetch
- * from the Obsidian vault endpoint instead of the generic files endpoint.
+ * Manages multiple file-browser sources for the sidebar Files tab.
+ * Each source gets its own tree, loading, and error state.
  */
 
 import { useState, useCallback } from "react";
 import type { VaultNode } from "../types";
+import type { RoamSettings } from "../utils/roam";
+
+export type DirSource = "files" | "obsidian" | "roam";
 
 export interface DirState {
   path: string;
@@ -16,8 +17,13 @@ export interface DirState {
   tree: VaultNode[];
   isLoading: boolean;
   error: string | null;
-  /** When true, fetches via /api/reference/obsidian/files and opens docs via /api/reference/obsidian/doc */
-  isVault?: boolean;
+  source: DirSource;
+  roamMeta?: {
+    graphName: string;
+    graphType: "hosted" | "offline";
+    token: string;
+    port: number;
+  };
 }
 
 export interface UseFileBrowserReturn {
@@ -28,8 +34,9 @@ export interface UseFileBrowserReturn {
   toggleCollapse: (dirPath: string) => void;
   fetchTree: (dirPath: string) => void;
   fetchAll: (directories: string[]) => void;
-  addVaultDir: (vaultPath: string) => void;
-  clearVaultDirs: () => void;
+  addObsidianDir: (vaultPath: string) => void;
+  addRoamDir: (settings: RoamSettings) => void;
+  clearSource: (source: DirSource) => void;
   activeFile: string | null;
   activeDirPath: string | null;
   setActiveFile: (path: string | null) => void;
@@ -60,7 +67,17 @@ export function useFileBrowser(): UseFileBrowserReturn {
           d.path === dirPath ? { ...d, isLoading: true, error: null } : d
         );
       }
-      return [...prev, { path: dirPath, name, tree: [], isLoading: true, error: null }];
+      return [
+        ...prev,
+        {
+          path: dirPath,
+          name,
+          tree: [],
+          isLoading: true,
+          error: null,
+          source: "files",
+        },
+      ];
     });
 
     try {
@@ -105,32 +122,43 @@ export function useFileBrowser(): UseFileBrowserReturn {
     (directories: string[]) => {
       setDirs((prev) => {
         // Preserve any vault dirs that were already loaded
-        const vaultDirs = prev.filter((d) => d.isVault);
+        const nonFileDirs = prev.filter((d) => d.source !== "files");
         const regularDirs = directories.map((path) => ({
           path,
           name: path.split("/").pop() || path,
           tree: [],
           isLoading: false,
           error: null,
+          source: "files" as const,
         }));
-        return [...regularDirs, ...vaultDirs];
+        return [...regularDirs, ...nonFileDirs];
       });
       directories.forEach((d) => fetchTree(d));
     },
     [fetchTree]
   );
 
-  const clearVaultDirs = useCallback(() => {
-    setDirs((prev) => prev.filter((d) => !d.isVault));
+  const clearSource = useCallback((source: DirSource) => {
+    setDirs((prev) => prev.filter((d) => d.source !== source));
   }, []);
 
-  const addVaultDir = useCallback(async (vaultPath: string) => {
+  const addObsidianDir = useCallback(async (vaultPath: string) => {
     const name = vaultPath.split("/").pop() || vaultPath;
 
-    // Atomically replace any existing vault dirs (handles vault path change without accumulating stale entries)
+    // Atomically replace any existing Obsidian dirs (handles vault path change without accumulating stale entries)
     setDirs((prev) => {
-      const nonVaultDirs = prev.filter((d) => !d.isVault);
-      return [...nonVaultDirs, { path: vaultPath, name, tree: [], isLoading: true, error: null, isVault: true }];
+      const otherDirs = prev.filter((d) => d.source !== "obsidian");
+      return [
+        ...otherDirs,
+        {
+          path: vaultPath,
+          name,
+          tree: [],
+          isLoading: true,
+          error: null,
+          source: "obsidian",
+        },
+      ];
     });
 
     try {
@@ -150,7 +178,9 @@ export function useFileBrowser(): UseFileBrowserReturn {
 
       setDirs((prev) =>
         prev.map((d) =>
-          d.path === vaultPath ? { ...d, tree: data.tree, isLoading: false, isVault: true } : d
+          d.path === vaultPath
+            ? { ...d, tree: data.tree, isLoading: false, source: "obsidian" }
+            : d
         )
       );
 
@@ -167,6 +197,82 @@ export function useFileBrowser(): UseFileBrowserReturn {
         prev.map((d) =>
           d.path === vaultPath ? { ...d, isLoading: false, error: "Failed to connect to server" } : d
         )
+      );
+    }
+  }, []);
+
+  const addRoamDir = useCallback(async (settings: RoamSettings) => {
+    const key = `roam:${settings.graphType}:${settings.graphName}`;
+
+    setDirs((prev) => {
+      const otherDirs = prev.filter((d) => d.source !== "roam");
+      return [
+        ...otherDirs,
+        {
+          path: key,
+          name: settings.graphName,
+          tree: [],
+          isLoading: true,
+          error: null,
+          source: "roam",
+          roamMeta: {
+            graphName: settings.graphName,
+            graphType: settings.graphType,
+            token: settings.token,
+            port: settings.port || 3333,
+          },
+        },
+      ];
+    });
+
+    try {
+      const res = await fetch(
+        `/api/reference/roam/pages?graphName=${encodeURIComponent(settings.graphName)}&graphType=${encodeURIComponent(settings.graphType)}&port=${encodeURIComponent(String(settings.port || 3333))}`,
+        {
+          headers: {
+            Authorization: `Bearer ${settings.token}`,
+          },
+        },
+      );
+      const data = await res.json();
+
+      if (!res.ok || data.error) {
+        setDirs((prev) =>
+          prev.map((d) =>
+            d.path === key
+              ? { ...d, isLoading: false, error: data.error || "Failed to load" }
+              : d,
+          ),
+        );
+        return;
+      }
+
+      setDirs((prev) =>
+        prev.map((d) =>
+          d.path === key
+            ? {
+                ...d,
+                tree: data.tree,
+                isLoading: false,
+                error: null,
+                source: "roam",
+                roamMeta: {
+                  graphName: settings.graphName,
+                  graphType: settings.graphType,
+                  token: settings.token,
+                  port: settings.port || 3333,
+                },
+              }
+            : d,
+        ),
+      );
+    } catch {
+      setDirs((prev) =>
+        prev.map((d) =>
+          d.path === key
+            ? { ...d, isLoading: false, error: "Failed to connect to server" }
+            : d,
+        ),
       );
     }
   }, []);
@@ -191,8 +297,9 @@ export function useFileBrowser(): UseFileBrowserReturn {
     toggleCollapse,
     fetchTree,
     fetchAll,
-    addVaultDir,
-    clearVaultDirs,
+    addObsidianDir,
+    addRoamDir,
+    clearSource,
     activeFile,
     activeDirPath: activeFile ? (dirs.find((d) => activeFile.startsWith(d.path + "/"))?.path ?? null) : null,
     setActiveFile,

--- a/packages/ui/utils/defaultNotesApp.test.ts
+++ b/packages/ui/utils/defaultNotesApp.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { storage } from "./storage";
+import { getDefaultNotesApp, saveDefaultNotesApp } from "./defaultNotesApp";
+
+const STORAGE_KEY = "plannotator-default-notes-app";
+
+let cookieStore = new Map<string, string>();
+
+beforeEach(() => {
+  cookieStore = new Map();
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      get cookie() {
+        return Array.from(cookieStore.entries())
+          .map(([key, value]) => `${key}=${value}`)
+          .join("; ");
+      },
+      set cookie(value: string) {
+        const [pair, ...directives] = value.split(";").map((part) => part.trim());
+        const [key, rawValue = ""] = pair.split("=");
+        if (!key) return;
+        if (directives.some((directive) => directive.toLowerCase() === "max-age=0")) {
+          cookieStore.delete(key);
+          return;
+        }
+        cookieStore.set(key, rawValue);
+      },
+    },
+  });
+  storage.removeItem(STORAGE_KEY);
+});
+
+describe("Default notes app preference", () => {
+  test("falls back to ask for invalid stored values", () => {
+    storage.setItem(STORAGE_KEY, "not-a-real-app");
+
+    expect(getDefaultNotesApp()).toBe("ask");
+  });
+
+  test("persists valid notes app choices", () => {
+    saveDefaultNotesApp("roam");
+
+    expect(getDefaultNotesApp()).toBe("roam");
+  });
+});

--- a/packages/ui/utils/defaultNotesApp.ts
+++ b/packages/ui/utils/defaultNotesApp.ts
@@ -8,13 +8,19 @@
 import { storage } from './storage';
 
 const STORAGE_KEY = 'plannotator-default-notes-app';
+const DEFAULT_NOTES_APPS = ['obsidian', 'bear', 'octarine', 'roam', 'download', 'ask'] as const;
 
-export type DefaultNotesApp = 'obsidian' | 'bear' | 'octarine' | 'download' | 'ask';
+export type DefaultNotesApp = 'obsidian' | 'bear' | 'octarine' | 'roam' | 'download' | 'ask';
+
+function isDefaultNotesApp(value: string | null): value is DefaultNotesApp {
+  return value !== null && DEFAULT_NOTES_APPS.includes(value as DefaultNotesApp);
+}
 
 export function getDefaultNotesApp(): DefaultNotesApp {
-  return (storage.getItem(STORAGE_KEY) as DefaultNotesApp) || 'ask';
+  const stored = storage.getItem(STORAGE_KEY);
+  return isDefaultNotesApp(stored) ? stored : 'ask';
 }
 
 export function saveDefaultNotesApp(app: DefaultNotesApp): void {
-  storage.setItem(STORAGE_KEY, app);
+  storage.setItem(STORAGE_KEY, isDefaultNotesApp(app) ? app : 'ask');
 }

--- a/packages/ui/utils/roam.test.ts
+++ b/packages/ui/utils/roam.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { storage } from "./storage";
+import {
+  getRoamSettings,
+  isRoamBrowserEnabled,
+  isRoamConfigured,
+  saveRoamSettings,
+} from "./roam";
+
+const keys = [
+  "plannotator-roam-enabled",
+  "plannotator-roam-graph-name",
+  "plannotator-roam-graph-type",
+  "plannotator-roam-token",
+  "plannotator-roam-port",
+  "plannotator-roam-title-format",
+  "plannotator-roam-title-separator",
+  "plannotator-roam-save-location",
+  "plannotator-roam-daily-note-parent",
+  "plannotator-roam-autosave",
+  "plannotator-roam-reference-browser",
+];
+
+let cookieStore = new Map<string, string>();
+
+beforeEach(() => {
+  cookieStore = new Map();
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      get cookie() {
+        return Array.from(cookieStore.entries())
+          .map(([key, value]) => `${key}=${value}`)
+          .join("; ");
+      },
+      set cookie(value: string) {
+        const [pair, ...directives] = value.split(";").map((part) => part.trim());
+        const [key, rawValue = ""] = pair.split("=");
+        if (!key) return;
+        if (directives.some((directive) => directive.toLowerCase() === "max-age=0")) {
+          cookieStore.delete(key);
+          return;
+        }
+        cookieStore.set(key, rawValue);
+      },
+    },
+  });
+  for (const key of keys) {
+    storage.removeItem(key);
+  }
+});
+
+describe("Roam settings helpers", () => {
+  test("saveRoamSettings persists and restores Roam settings", () => {
+    saveRoamSettings({
+      enabled: true,
+      graphName: "my-graph",
+      graphType: "offline",
+      token: "secret-token",
+      port: 3333,
+      titleFormat: "{title}",
+      titleSeparator: "dash",
+      saveLocation: "daily-note",
+      dailyNoteParent: "[[Custom Plans]]",
+      autoSave: true,
+      referenceBrowserEnabled: true,
+    });
+
+    expect(getRoamSettings()).toEqual({
+      enabled: true,
+      graphName: "my-graph",
+      graphType: "offline",
+      token: "secret-token",
+      port: 3333,
+      titleFormat: "{title}",
+      titleSeparator: "dash",
+      saveLocation: "daily-note",
+      dailyNoteParent: "[[Custom Plans]]",
+      autoSave: true,
+      referenceBrowserEnabled: true,
+    });
+  });
+
+  test("getRoamSettings normalizes invalid cookie values", () => {
+    storage.setItem("plannotator-roam-graph-type", "cloud");
+    storage.setItem("plannotator-roam-title-separator", "comma");
+    storage.setItem("plannotator-roam-save-location", "sidebar");
+    storage.setItem("plannotator-roam-port", "70000");
+    storage.setItem("plannotator-roam-daily-note-parent", "");
+
+    expect(getRoamSettings()).toMatchObject({
+      graphType: "hosted",
+      titleSeparator: "space",
+      saveLocation: "page",
+      dailyNoteParent: "[[Plannotator Plans]]",
+      port: 3333,
+    });
+  });
+
+  test("saveRoamSettings clamps invalid ports before persisting", () => {
+    saveRoamSettings({
+      enabled: true,
+      graphName: "my-graph",
+      graphType: "offline",
+      token: "secret-token",
+      port: 70000,
+      titleSeparator: "dash",
+      saveLocation: "page",
+      dailyNoteParent: "[[Plannotator Plans]]",
+      autoSave: false,
+      referenceBrowserEnabled: false,
+    });
+
+    expect(storage.getItem("plannotator-roam-port")).toBe("3333");
+    expect(getRoamSettings().port).toBe(3333);
+  });
+
+  test("isRoamConfigured and isRoamBrowserEnabled require the right settings", () => {
+    expect(isRoamConfigured()).toBe(false);
+    expect(isRoamBrowserEnabled()).toBe(false);
+
+    saveRoamSettings({
+      enabled: true,
+      graphName: "my-graph",
+      graphType: "hosted",
+      token: "secret-token",
+      port: 3333,
+      titleSeparator: "space",
+      saveLocation: "page",
+      dailyNoteParent: "[[Plannotator Plans]]",
+      autoSave: false,
+      referenceBrowserEnabled: true,
+    });
+
+    expect(isRoamConfigured()).toBe(true);
+    expect(isRoamBrowserEnabled()).toBe(true);
+  });
+});

--- a/packages/ui/utils/roam.ts
+++ b/packages/ui/utils/roam.ts
@@ -1,0 +1,127 @@
+/**
+ * Roam Integration Utility
+ *
+ * Cookie-backed settings for Roam Desktop local API integration.
+ */
+
+import type { FilenameSeparator } from './obsidian';
+import { storage } from './storage';
+
+const STORAGE_KEY_ENABLED = 'plannotator-roam-enabled';
+const STORAGE_KEY_GRAPH_NAME = 'plannotator-roam-graph-name';
+const STORAGE_KEY_GRAPH_TYPE = 'plannotator-roam-graph-type';
+const STORAGE_KEY_TOKEN = 'plannotator-roam-token';
+const STORAGE_KEY_PORT = 'plannotator-roam-port';
+const STORAGE_KEY_TITLE_FORMAT = 'plannotator-roam-title-format';
+const STORAGE_KEY_TITLE_SEPARATOR = 'plannotator-roam-title-separator';
+const STORAGE_KEY_SAVE_LOCATION = 'plannotator-roam-save-location';
+const STORAGE_KEY_DAILY_NOTE_PARENT = 'plannotator-roam-daily-note-parent';
+const STORAGE_KEY_AUTOSAVE = 'plannotator-roam-autosave';
+const STORAGE_KEY_BROWSER = 'plannotator-roam-reference-browser';
+
+const DEFAULT_ROAM_PORT = 3333;
+const DEFAULT_ROAM_PARENT_BLOCK = '[[Plannotator Plans]]';
+const VALID_GRAPH_TYPES = ['hosted', 'offline'] as const;
+const VALID_TITLE_SEPARATORS: FilenameSeparator[] = ['space', 'dash', 'underscore'];
+const VALID_SAVE_LOCATIONS = ['page', 'daily-note'] as const;
+
+function isGraphType(value: string | null): value is RoamSettings['graphType'] {
+  return value !== null && (VALID_GRAPH_TYPES as readonly string[]).includes(value);
+}
+
+function isTitleSeparator(value: string | null): value is FilenameSeparator {
+  return value !== null && VALID_TITLE_SEPARATORS.includes(value as FilenameSeparator);
+}
+
+function isSaveLocation(value: string | null): value is RoamSettings['saveLocation'] {
+  return value !== null && VALID_SAVE_LOCATIONS.includes(value as RoamSettings['saveLocation']);
+}
+
+function normalizeDailyNoteParent(value: string | null | undefined): string {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : DEFAULT_ROAM_PARENT_BLOCK;
+}
+
+export function normalizeRoamPort(port: string | number | null | undefined): number {
+  const raw = typeof port === 'string' ? port.trim() : port;
+
+  if (raw === null || raw === undefined || raw === '') {
+    return DEFAULT_ROAM_PORT;
+  }
+
+  const value = typeof raw === 'number' ? raw : Number(raw);
+  if (!Number.isFinite(value)) {
+    return DEFAULT_ROAM_PORT;
+  }
+
+  const normalized = Math.trunc(value);
+  if (normalized < 1 || normalized > 65535) {
+    return DEFAULT_ROAM_PORT;
+  }
+
+  return normalized;
+}
+
+export interface RoamSettings {
+  enabled: boolean;
+  graphName: string;
+  graphType: 'hosted' | 'offline';
+  token: string;
+  port: number;
+  titleFormat?: string;
+  titleSeparator: FilenameSeparator;
+  saveLocation: 'page' | 'daily-note';
+  dailyNoteParent: string;
+  autoSave: boolean;
+  referenceBrowserEnabled: boolean;
+}
+
+export function getRoamSettings(): RoamSettings {
+  const storedGraphType = storage.getItem(STORAGE_KEY_GRAPH_TYPE);
+  const storedTitleSeparator = storage.getItem(STORAGE_KEY_TITLE_SEPARATOR);
+  const storedSaveLocation = storage.getItem(STORAGE_KEY_SAVE_LOCATION);
+
+  return {
+    enabled: storage.getItem(STORAGE_KEY_ENABLED) === 'true',
+    graphName: storage.getItem(STORAGE_KEY_GRAPH_NAME) ?? '',
+    graphType: isGraphType(storedGraphType) ? storedGraphType : 'hosted',
+    token: storage.getItem(STORAGE_KEY_TOKEN) ?? '',
+    port: normalizeRoamPort(storage.getItem(STORAGE_KEY_PORT)),
+    titleFormat: storage.getItem(STORAGE_KEY_TITLE_FORMAT) || undefined,
+    titleSeparator: isTitleSeparator(storedTitleSeparator) ? storedTitleSeparator : 'space',
+    saveLocation: isSaveLocation(storedSaveLocation) ? storedSaveLocation : 'page',
+    dailyNoteParent: normalizeDailyNoteParent(storage.getItem(STORAGE_KEY_DAILY_NOTE_PARENT)),
+    autoSave: storage.getItem(STORAGE_KEY_AUTOSAVE) === 'true',
+    referenceBrowserEnabled: storage.getItem(STORAGE_KEY_BROWSER) === 'true',
+  };
+}
+
+export function saveRoamSettings(settings: RoamSettings): void {
+  const normalizedPort = normalizeRoamPort(settings.port);
+  const normalizedGraphType = isGraphType(settings.graphType) ? settings.graphType : 'hosted';
+  const normalizedTitleSeparator = isTitleSeparator(settings.titleSeparator) ? settings.titleSeparator : 'space';
+  const normalizedSaveLocation = isSaveLocation(settings.saveLocation) ? settings.saveLocation : 'page';
+  const normalizedDailyNoteParent = normalizeDailyNoteParent(settings.dailyNoteParent);
+
+  storage.setItem(STORAGE_KEY_ENABLED, String(settings.enabled));
+  storage.setItem(STORAGE_KEY_GRAPH_NAME, settings.graphName);
+  storage.setItem(STORAGE_KEY_GRAPH_TYPE, normalizedGraphType);
+  storage.setItem(STORAGE_KEY_TOKEN, settings.token);
+  storage.setItem(STORAGE_KEY_PORT, String(normalizedPort));
+  storage.setItem(STORAGE_KEY_TITLE_FORMAT, settings.titleFormat || '');
+  storage.setItem(STORAGE_KEY_TITLE_SEPARATOR, normalizedTitleSeparator);
+  storage.setItem(STORAGE_KEY_SAVE_LOCATION, normalizedSaveLocation);
+  storage.setItem(STORAGE_KEY_DAILY_NOTE_PARENT, normalizedDailyNoteParent);
+  storage.setItem(STORAGE_KEY_AUTOSAVE, String(settings.autoSave));
+  storage.setItem(STORAGE_KEY_BROWSER, String(settings.referenceBrowserEnabled));
+}
+
+export function isRoamConfigured(): boolean {
+  const settings = getRoamSettings();
+  return settings.enabled && settings.graphName.trim().length > 0 && settings.token.trim().length > 0;
+}
+
+export function isRoamBrowserEnabled(): boolean {
+  const settings = getRoamSettings();
+  return isRoamConfigured() && settings.referenceBrowserEnabled;
+}


### PR DESCRIPTION
## Summary
- Add Roam Research as a notes integration, following the existing Obsidian pattern
- Uses the Roam Desktop local API shape from current `roam-tools` for page creation, block creation, search, and page reads
- Saves plan contents inside a fenced `markdown` block in Roam, while keeping parsed frontmatter as searchable Roam attributes outside the block
- Includes settings UI, reference browser, export/default-save support, and parity coverage for both Bun and Pi server runtimes

## Test Plan
- [x] `bun test packages/server/roam-client.test.ts packages/server/roam-reference.test.ts packages/server/integrations.test.ts packages/ui/utils/roam.test.ts packages/ui/utils/defaultNotesApp.test.ts packages/ui/components/ExportModal.test.tsx packages/ui/components/sidebar/FileBrowser.test.tsx apps/pi-extension/server/roam-client.test.ts`
- [x] `bun run typecheck`
- [x] `bun test` (1414 tests)
- [x] `bun run --cwd apps/review build && bun run build:hook && bun run build:opencode`
