### PR TITLE
fix(annotate): include original file annotations when submitting from linked doc view

### DIFF
--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -134,6 +134,7 @@ const App: React.FC = () => {
   const [globalAttachments, setGlobalAttachments] = useState<ImageAttachment[]>([]);
   const [annotateMode, setAnnotateMode] = useState(false);
   const [annotateSource, setAnnotateSource] = useState<'file' | 'message' | 'folder' | null>(null);
+  const [sourceFilePath, setSourceFilePath] = useState<string | undefined>();
   const [imageBaseDir, setImageBaseDir] = useState<string | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -218,7 +219,7 @@ const App: React.FC = () => {
   const linkedDocHook = useLinkedDoc({
     markdown, annotations, selectedAnnotationId, globalAttachments,
     setMarkdown, setAnnotations, setSelectedAnnotationId, setGlobalAttachments,
-    viewerRef, sidebar,
+    viewerRef, sidebar, sourceFilePath,
   });
 
   // Archive browser
@@ -554,6 +555,9 @@ const App: React.FC = () => {
         }
         if (data.filePath) {
           setImageBaseDir(data.mode === 'annotate-folder' ? data.filePath : data.filePath.replace(/\/[^/]+$/, ''));
+          if (data.mode === 'annotate') {
+            setSourceFilePath(data.filePath);
+          }
         }
         if (data.sharingEnabled !== undefined) {
           setSharingEnabled(data.sharingEnabled);

--- a/packages/ui/hooks/useLinkedDoc.ts
+++ b/packages/ui/hooks/useLinkedDoc.ts
@@ -124,7 +124,11 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
             selectedAnnotationId,
             globalAttachments: [...globalAttachments],
           };
-          setDocAnnotationCount(annotations.length + globalAttachments.length);
+          let total = annotations.length + globalAttachments.length;
+          for (const cached of docCache.current.values()) {
+            total += cached.annotations.length + cached.globalAttachments.length;
+          }
+          setDocAnnotationCount(total);
         } else if (linkedDoc) {
           // Already viewing a linked doc — cache its annotations before moving on
           docCache.current.set(linkedDoc.filepath, {
@@ -235,8 +239,8 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
     // Include stashed original-file annotations when viewing a linked doc
     if (linkedDoc && savedPlanState.current && sourceFilePath) {
       result.set(sourceFilePath, {
-        annotations: savedPlanState.current.annotations,
-        globalAttachments: savedPlanState.current.globalAttachments,
+        annotations: [...savedPlanState.current.annotations],
+        globalAttachments: [...savedPlanState.current.globalAttachments],
       });
     }
     if (linkedDoc) {

--- a/packages/ui/hooks/useLinkedDoc.ts
+++ b/packages/ui/hooks/useLinkedDoc.ts
@@ -22,6 +22,9 @@ export interface UseLinkedDocOptions {
   setGlobalAttachments: (att: ImageAttachment[]) => void;
   viewerRef: React.RefObject<ViewerHandle | null>;
   sidebar: { open: (tab?: SidebarTab) => void };
+  /** Absolute path of the primary document — enables getDocAnnotations() to include
+   *  stashed original-file annotations when viewing a linked doc. */
+  sourceFilePath?: string;
 }
 
 interface SavedPlanState {
@@ -53,7 +56,7 @@ export interface UseLinkedDocReturn {
   dismissError: () => void;
   /** All linked doc annotations including the active doc's live state (keyed by filepath) */
   getDocAnnotations: () => Map<string, CachedDocState>;
-  /** Reactive count of cached linked doc annotations (updates on back()) */
+  /** Reactive count of annotations on non-active documents (updates on open() and back()) */
   docAnnotationCount: number;
 }
 
@@ -71,6 +74,7 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
     setGlobalAttachments,
     viewerRef,
     sidebar,
+    sourceFilePath,
   } = options;
 
   const [linkedDoc, setLinkedDoc] = useState<{ filepath: string } | null>(null);
@@ -120,12 +124,21 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
             selectedAnnotationId,
             globalAttachments: [...globalAttachments],
           };
+          setDocAnnotationCount(annotations.length + globalAttachments.length);
         } else if (linkedDoc) {
           // Already viewing a linked doc — cache its annotations before moving on
           docCache.current.set(linkedDoc.filepath, {
             annotations: [...annotations],
             globalAttachments: [...globalAttachments],
           });
+          let total = 0;
+          for (const cached of docCache.current.values()) {
+            total += cached.annotations.length + cached.globalAttachments.length;
+          }
+          if (savedPlanState.current) {
+            total += savedPlanState.current.annotations.length + savedPlanState.current.globalAttachments.length;
+          }
+          setDocAnnotationCount(total);
         }
 
         // Check cache for previous annotations on this file
@@ -219,6 +232,13 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
 
   const getDocAnnotations = useCallback((): Map<string, CachedDocState> => {
     const result = new Map(docCache.current);
+    // Include stashed original-file annotations when viewing a linked doc
+    if (linkedDoc && savedPlanState.current && sourceFilePath) {
+      result.set(sourceFilePath, {
+        annotations: savedPlanState.current.annotations,
+        globalAttachments: savedPlanState.current.globalAttachments,
+      });
+    }
     if (linkedDoc) {
       result.set(linkedDoc.filepath, {
         annotations: [...annotations],
@@ -226,7 +246,7 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
       });
     }
     return result;
-  }, [linkedDoc, annotations, globalAttachments]);
+  }, [linkedDoc, annotations, globalAttachments, sourceFilePath]);
 
   return {
     isActive: linkedDoc !== null,

--- a/packages/ui/hooks/useLinkedDoc.ts
+++ b/packages/ui/hooks/useLinkedDoc.ts
@@ -113,6 +113,18 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
           return;
         }
 
+        // Backlink detection: if a linked doc links back to the source file (e.g.,
+        // original.md → design.md → link back to original.md), opening it as a linked
+        // doc would create two competing Map entries for the same filepath in
+        // getDocAnnotations(), and the empty linked-doc entry would overwrite the
+        // stashed annotations. Instead, treat the backlink as a back() navigation —
+        // the current linked doc gets cached and the source file restores with its
+        // annotations intact.
+        if (sourceFilePath && data.filepath === sourceFilePath && savedPlanState.current) {
+          back();
+          return;
+        }
+
         // Clear web-highlighter marks before swapping content to prevent React DOM mismatch
         viewerRef.current?.clearAllHighlights();
 

--- a/packages/ui/hooks/useLinkedDoc.ts
+++ b/packages/ui/hooks/useLinkedDoc.ts
@@ -125,7 +125,8 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
             globalAttachments: [...globalAttachments],
           };
           let total = annotations.length + globalAttachments.length;
-          for (const cached of docCache.current.values()) {
+          for (const [fp, cached] of docCache.current.entries()) {
+            if (fp === data.filepath!) continue; // destination becomes active — don't double-count
             total += cached.annotations.length + cached.globalAttachments.length;
           }
           setDocAnnotationCount(total);
@@ -136,7 +137,8 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
             globalAttachments: [...globalAttachments],
           });
           let total = 0;
-          for (const cached of docCache.current.values()) {
+          for (const [fp, cached] of docCache.current.entries()) {
+            if (fp === data.filepath!) continue; // destination becomes active — don't double-count
             total += cached.annotations.length + cached.globalAttachments.length;
           }
           if (savedPlanState.current) {


### PR DESCRIPTION
## Summary

- Fixes a data loss bug where annotations on the original file were silently dropped when clicking "Send Annotations" while viewing a linked document in annotate mode
- `getDocAnnotations()` now includes stashed original-file annotations via a new `sourceFilePath` option on `useLinkedDoc`
- `docAnnotationCount` updates immediately on navigation (not only on `back()`), so button visibility and exit warnings reflect the true annotation count

## Root cause

`useLinkedDoc.open()` stashes original-file annotations into `savedPlanState` (a ref), then swaps React state to the linked doc's annotations. But `getDocAnnotations()` only read from `docCache` + the current linked doc — never from `savedPlanState`. The original file's annotations became invisible to the entire submission pipeline (`annotationsOutput` memo → `handleAnnotateFeedback` → `/api/feedback`).

Confirmed via runtime instrumentation: at submit time, `savedPlanState` held 1 annotation but `getDocAnnotations()` returned a Map without it.

## Scope

- **Plan mode**: Unaffected — buttons are already hidden while viewing linked docs, forcing `back()` first
- **Folder mode**: Unaffected — the "original" document is an empty shell with no annotations to lose
- **`annotate-last`**: Unaffected — no file path to key against

## Test plan

- [ ] `plannotator annotate original.md` where `original.md` links to `linked.md`
- [ ] Annotate original, follow link, annotate linked doc, click "Send Annotations" without navigating back
- [ ] Verify terminal output contains feedback from **both** files
- [ ] Verify navigating back then submitting still works correctly
- [ ] Verify folder annotation mode (`plannotator annotate <dir>`) is unaffected

Closes #535