### PR TITLE
docs(annotate): URL/HTML annotation docs, blog post, and promo video

### DIFF
--- a/apps/marketing/src/content/blog/annotate-any-web-page-or-html-file.md
+++ b/apps/marketing/src/content/blog/annotate-any-web-page-or-html-file.md
@@ -1,0 +1,58 @@
+---
+title: "Annotate Any Web Page or HTML File"
+description: "Plannotator's /plannotator-annotate command now accepts URLs and HTML files, not just markdown. Fetch any web page, convert it to markdown, and annotate it with structured feedback for your coding agent."
+date: 2026-04-12
+author: "backnotprop"
+tags: ["annotate", "url", "html", "jina-reader"]
+---
+
+**Plannotator is an open-source review UI for AI coding agents.** The `/plannotator-annotate` command now accepts URLs and HTML files alongside markdown, so you can pull in any external documentation, convert it on the fly, and send structured annotations back to your agent session.
+
+<video width="100%" style="aspect-ratio: 16/9; border-radius: 8px; margin-bottom: 1.5rem;" autoplay loop muted playsinline controls><source src="https://d17ygohy796f9l.cloudfront.net/videos/annotate-url.mp4" type="video/mp4" /></video>
+
+## The problem
+
+You're working with an agent that needs to implement against an external API or follow a specific guide. You could copy-paste the documentation into chat, but you lose structure. You could describe what you need freeform, but that's imprecise. What you actually want is to open the page, highlight the relevant sections, and send that annotated content directly to the agent.
+
+This was a [community-requested feature](https://github.com/backnotprop/plannotator/issues) that ships in [PR #545](https://github.com/backnotprop/plannotator/pull/545).
+
+## What you can do now
+
+```bash
+plannotator annotate https://docs.stripe.com/api      # remote URL
+plannotator annotate docs/guide.html                  # local HTML file
+plannotator annotate ./docs/                          # folder (now includes .html files)
+plannotator annotate https://... --no-jina            # direct fetch, no Jina
+```
+
+All inputs are converted to markdown before reaching the annotation editor. You annotate, highlight, comment, and when you click Send Annotations, structured feedback goes back to the agent session.
+
+Local HTML files are read from disk and converted via Turndown. Folders now show `.html` and `.htm` files alongside markdown in the file browser, with conversion happening on demand. A source attribution badge appears under the document title so you know what you're looking at.
+
+## How URL fetching works
+
+By default, URLs are fetched through [Jina Reader](https://jina.ai/reader/) (`r.jina.ai`). Jina handles JavaScript-rendered pages, strips navigation and boilerplate, and returns clean markdown. Most documentation sites work well with it.
+
+If the URL ends in `.md` or `.mdx`, Plannotator fetches it raw and skips conversion entirely.
+
+For cases where you want to skip Jina, use `--no-jina`. Plannotator will fetch the page directly and run Turndown locally.
+
+## Configuration
+
+Three ways to configure Jina behavior:
+
+- **CLI flag**: `plannotator annotate https://... --no-jina`
+- **Environment variable**: `PLANNOTATOR_JINA=0`
+- **Config file**: `~/.plannotator/config.json` with `{ "jina": false }`
+
+For higher rate limits (500 RPM instead of 20 RPM), set a `JINA_API_KEY`. Free keys are available from Jina and include 10M tokens.
+
+## Try it
+
+Install or update Plannotator:
+
+```bash
+curl -fsSL https://plannotator.ai/install.sh | bash
+```
+
+Then run the annotate command with any URL or HTML file. Annotate the relevant sections and send the feedback to your agent. Full docs at [plannotator.ai/docs](/docs/getting-started/installation/).

--- a/apps/marketing/src/content/docs/commands/annotate.md
+++ b/apps/marketing/src/content/docs/commands/annotate.md
@@ -1,50 +1,94 @@
 ---
 title: "Annotate"
-description: "The /plannotator-annotate slash command for annotating any markdown file."
+description: "The /plannotator-annotate slash command for annotating markdown files, HTML files, URLs, and folders."
 sidebar:
   order: 12
 section: "Commands"
 ---
 
-The `/plannotator-annotate` command opens any markdown file in the Plannotator annotation UI.
+The `/plannotator-annotate` command opens files, URLs, or folders in the Plannotator annotation UI.
 
-## Usage
+## What you can annotate
+
+| Input | Command | What happens |
+|-------|---------|--------------|
+| Markdown file | `plannotator annotate README.md` | Opens the file directly |
+| HTML file | `plannotator annotate docs/guide.html` | Converts to markdown via Turndown, then opens |
+| URL | `plannotator annotate https://docs.stripe.com/api` | Fetches the page, converts to markdown, then opens |
+| Folder | `plannotator annotate ./docs/` | Opens a file browser showing all `.md`, `.mdx`, `.html`, and `.htm` files |
 
 ### Slash command (inside an agent session)
 
 ```
 /plannotator-annotate path/to/file.md
+/plannotator-annotate https://docs.stripe.com/api
+/plannotator-annotate ./specs/
 ```
 
-The agent runs `plannotator annotate <file>` under the hood. The annotation UI opens in the browser. When you submit, feedback is returned to the agent as structured output.
+The agent runs `plannotator annotate <arg>` under the hood. The annotation UI opens in the browser. When you submit, feedback is returned to the agent as structured output.
 
 ### Standalone CLI (outside an agent session)
 
 ```bash
 plannotator annotate path/to/file.md
+plannotator annotate index.html
+plannotator annotate https://example.com/docs
+plannotator annotate ./docs/
 ```
 
-This starts a local server, opens the browser, and blocks until you submit. The formatted feedback is printed to stdout.
+Starts a local server, opens the browser, and blocks until you submit. Formatted feedback is printed to stdout.
 
-## How it works
+## Folders
 
+When you pass a folder, Plannotator opens a file browser showing all markdown and HTML files in the directory tree. Click any file to open it in the annotation UI. This is useful for annotating a set of specs, documentation, or your Obsidian vault.
+
+Build output directories like `_site/`, `public/`, `.docusaurus/`, and `node_modules/` are automatically excluded from the file browser.
+
+## URLs
+
+Fetching a URL converts the page to markdown before opening it in the annotation editor.
+
+### Jina Reader (default)
+
+By default, URLs are fetched through [Jina Reader](https://jina.ai/reader/) (`r.jina.ai`). Jina handles JavaScript-rendered pages and returns clean, reader-mode markdown. This works well for documentation sites, blog posts, and API references.
+
+Set `JINA_API_KEY` in your environment for higher rate limits (500 req/min vs 20 req/min unauthenticated). Free API keys are available from Jina.
+
+### Direct fetch (`--no-jina`)
+
+If you don't want to use Jina, pass `--no-jina`. Plannotator will fetch the HTML directly and convert it with Turndown. This is useful for pages behind authentication, internal docs, or when you just prefer not to route through a third-party service.
+
+```bash
+plannotator annotate https://internal.company.com/docs --no-jina
 ```
-User runs /plannotator-annotate README.md
-        ↓
-CLI reads README.md from disk
-        ↓
-Annotate server starts (random port)
-        ↓
-Browser opens, loads annotation UI
-        ↓
-/api/plan returns { plan: markdown, mode: "annotate" }
-        ↓
-User annotates → Send Annotations
-        ↓
-POST /api/feedback with exported feedback
-        ↓
-Server prints feedback to stdout, exits
-```
+
+### .md and .mdx URLs
+
+URLs ending in `.md` or `.mdx` are fetched as raw text with no conversion. If the server returns HTML instead (like GitHub's rendered markdown viewer), Plannotator falls through to Jina or Turndown automatically.
+
+### Local and private URLs
+
+URLs pointing to `localhost`, `127.x.x.x`, `10.x.x.x`, `192.168.x.x`, and other private or link-local addresses always use direct fetch. Jina is skipped automatically since it can't reach private networks.
+
+### Configuring Jina
+
+Three ways to disable Jina Reader, in priority order:
+
+1. **CLI flag:** `--no-jina`
+2. **Environment variable:** `PLANNOTATOR_JINA=0` or `PLANNOTATOR_JINA=false`
+3. **Config file:** `~/.plannotator/config.json` with `{ "jina": false }`
+
+If none of these are set, Jina is enabled by default.
+
+## HTML files
+
+Local `.html` and `.htm` files are read from disk and converted to markdown using [Turndown](https://github.com/mixmark-io/turndown) with GFM table support. `<script>`, `<style>`, and `<noscript>` tags are stripped before conversion.
+
+HTML files must be within your current working directory. Files outside the project root return a 403 error.
+
+## Source badge
+
+When annotating an HTML file or URL (not plain markdown), a small badge appears under the document title showing where the content came from. For URLs it shows the hostname (e.g. "stripe.com"). For HTML files it shows the filename (e.g. "guide.html").
 
 ## Annotate mode differences
 
@@ -55,7 +99,7 @@ The annotation UI in annotate mode works the same as plan review, with a few cha
 - `Cmd/Ctrl+Enter` sends annotations instead of approving
 - The completion screen says "Annotations Sent" instead of "Plan Approved"
 
-All annotation types work identically — deletions, replacements, comments, insertions, global comments, and image attachments.
+All annotation types work identically: deletions, replacements, comments, insertions, global comments, and image attachments.
 
 ## Feedback format
 
@@ -84,11 +128,20 @@ The agent receives this and can act on each annotation.
 
 | Endpoint | Method | Purpose |
 |----------|--------|---------|
-| `/api/plan` | GET | Returns `{ plan, mode: "annotate", filePath }` |
+| `/api/plan` | GET | Returns `{ plan, mode: "annotate", filePath, sourceInfo }` |
 | `/api/feedback` | POST | Submit annotations |
+| `/api/exit` | POST | Close session without feedback |
 | `/api/image` | GET | Serve image by path |
 | `/api/upload` | POST | Upload image attachment |
+| `/api/draft` | GET/POST/DELETE | Auto-save annotation drafts |
 
 ## Environment variables
 
-The annotate server respects the same environment variables as plan review. See the [environment variables reference](/docs/reference/environment-variables/).
+The annotate server respects the same environment variables as plan review, plus two specific to URL annotation:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PLANNOTATOR_JINA` | enabled | Set to `0` or `false` to disable Jina Reader for URL annotation. |
+| `JINA_API_KEY` | (none) | Optional Jina Reader API key for higher rate limits (500 RPM vs 20 RPM). |
+
+See the [environment variables reference](/docs/reference/environment-variables/) for all options.

--- a/apps/marketing/src/content/docs/reference/environment-variables.md
+++ b/apps/marketing/src/content/docs/reference/environment-variables.md
@@ -20,6 +20,13 @@ All Plannotator environment variables and their defaults.
 | `PLANNOTATOR_SHARE_URL` | `https://share.plannotator.ai` | Base URL for share links. Set this when self-hosting the share portal. |
 | `PLANNOTATOR_PLAN_TIMEOUT_SECONDS` | `345600` | OpenCode only. `submit_plan` wait timeout in seconds. Set `0` to disable timeout. |
 
+## Annotation variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PLANNOTATOR_JINA` | enabled | Set to `0` or `false` to disable Jina Reader for URL annotation. Set to `1` or `true` to enable (this is the default). Can also be set via `~/.plannotator/config.json` (`{ "jina": false }`) or per-invocation via `--no-jina`. |
+| `JINA_API_KEY` | (none) | Optional Jina Reader API key for higher rate limits. Without it: 20 req/min. With it: 500 req/min. Free keys available from [Jina](https://jina.ai/reader/) and include 10M tokens. |
+
 ## Paste service variables
 
 | Variable | Default | Description |


### PR DESCRIPTION
## Summary

- **Docs rewrite**: `annotate.md` now covers all four input types (URLs, HTML files, folders, markdown files) with sections on the Jina Reader pipeline, `--no-jina` flag, `JINA_API_KEY`, raw `.md` URL handling, and the source badge
- **Env vars reference**: Added `PLANNOTATOR_JINA` and `JINA_API_KEY` rows to `environment-variables.md`
- **Blog post**: "Annotate Any Web Page or HTML File" with embedded CloudFront video
- **Promo video**: New `apps/videos` Remotion composition — 23s, 1920×1080, mobile-optimized (large fonts, full-bleed). Rendered and uploaded to `plannotator-media` S3 / CloudFront at `videos/annotate-url.mp4`

## Test plan

- [ ] Visit `/docs/commands/annotate/` — verify all four input types are documented, Jina section is present, env vars table is correct
- [ ] Visit `/docs/reference/environment-variables/` — verify `PLANNOTATOR_JINA` and `JINA_API_KEY` rows appear under a new "Annotation variables" section
- [ ] Visit `/blog/annotate-any-web-page-or-html-file/` — verify video plays inline from CloudFront
- [ ] `bun run dev` in `apps/videos/` — preview composition in Remotion Studio