### PR TITLE
ci: smoke-test compiled binaries before release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,44 @@ jobs:
           bun build apps/paste-service/targets/bun.ts --compile --target=bun-windows-arm64 --outfile plannotator-paste-win32-arm64.exe
           sha256sum plannotator-paste-win32-arm64.exe > plannotator-paste-win32-arm64.exe.sha256
 
+      - name: Smoke-test linux-x64 binary
+        run: |
+          chmod +x plannotator-linux-x64
+
+          # 1. --help: proves binary loads and arg parsing works
+          ./plannotator-linux-x64 --help
+
+          # Helper: start server, poll endpoint for 200, kill
+          smoke_test_server() {
+            local LABEL="$1" PORT="$2" ENDPOINT="$3"
+            shift 3
+            # Start the binary in background
+            PLANNOTATOR_PORT=$PORT "$@" &
+            local PID=$!
+            # Poll until the API responds (up to 10s)
+            local OK=0
+            for i in $(seq 1 20); do
+              if curl -sf "http://localhost:${PORT}${ENDPOINT}" -o /dev/null 2>/dev/null; then
+                OK=1; break
+              fi
+              sleep 0.5
+            done
+            kill $PID 2>/dev/null; wait $PID 2>/dev/null || true
+            if [ "$OK" = "0" ]; then
+              echo "FAIL: $LABEL did not respond on :${PORT}${ENDPOINT}"
+              exit 1
+            fi
+            echo "OK: $LABEL — :${PORT}${ENDPOINT} responded"
+          }
+
+          # 2. review: exercises full server startup (imports, bundled HTML, git diff, HTTP)
+          smoke_test_server "plannotator review" 19500 "/api/diff" \
+            ./plannotator-linux-x64 review
+
+          # 3. annotate: exercises annotate server path with a real file
+          smoke_test_server "plannotator annotate" 19501 "/api/plan" \
+            ./plannotator-linux-x64 annotate README.md
+
       - name: Upload artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:


### PR DESCRIPTION
## Summary

- Adds a smoke-test step to the release pipeline build job, between binary compilation and artifact upload
- Tests the linux-x64 binary three ways: `--help` (binary loads), `review` (full server startup with git diff + HTTP binding), `annotate README.md` (annotate server startup with file reading)
- If any test fails, artifacts never get uploaded — blocking attestation, release, and npm publish downstream

Catches the class of bug where `bun build --compile` succeeds but the binary crashes on launch (missing imports, broken bundling, missing embedded HTML).

## Test plan

- [ ] PR triggers the release workflow dry-run — verify the new smoke-test step passes
- [ ] Confirm downstream steps (upload, npm-publish dry-run) still complete