### PR TITLE
feat(viewer): show color swatches next to hex color codes in plans

### DIFF
--- a/packages/ui/components/Viewer.tsx
+++ b/packages/ui/components/Viewer.tsx
@@ -836,6 +836,25 @@ const InlineMarkdown: React.FC<{ text: string; onOpenLinkedDoc?: (path: string) 
       continue;
     }
 
+    // Hex color swatch — 3/4-digit forms need an a-f letter to avoid matching issue refs like #123.
+    match = remaining.match(/^(#(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6}|(?=[0-9a-fA-F]*[a-fA-F])[0-9a-fA-F]{4}|(?=[0-9a-fA-F]*[a-fA-F])[0-9a-fA-F]{3}))(?![0-9a-fA-F\w])/);
+    if (match) {
+      const hex = match[1];
+      parts.push(
+        <span key={key++} className="inline-flex items-center gap-1 align-middle">
+          <span
+            className="inline-block w-3.5 h-3.5 rounded-sm border border-black/20 dark:border-white/20 flex-shrink-0"
+            style={{ backgroundColor: hex }}
+            title={hex}
+          />
+          <code className="px-1.5 py-0.5 rounded bg-muted text-sm font-mono">{hex}</code>
+        </span>
+      );
+      remaining = remaining.slice(match[0].length);
+      previousChar = match[0][match[0].length - 1] || previousChar;
+      continue;
+    }
+
     // Wikilinks: [[filename]] or [[filename|display text]]
     match = remaining.match(/^\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/);
     if (match) {
@@ -972,7 +991,7 @@ const InlineMarkdown: React.FC<{ text: string; onOpenLinkedDoc?: (path: string) 
     }
 
     // Find next special character or consume one regular character
-    const nextSpecial = remaining.slice(1).search(/[\*_`\[!~\\<]/);
+    const nextSpecial = remaining.slice(1).search(/[\*_`\[!~\\<#]/);
     if (nextSpecial === -1) {
       parts.push(remaining);
       previousChar = remaining[remaining.length - 1] || previousChar;


### PR DESCRIPTION
## Summary

When a plan contains a hex color value (`#rgb`, `#rrggbb`, `#rgba`, `#rrggbbaa`), the `InlineMarkdown` renderer now displays a small filled swatch inline — immediately to the left of the monospace hex code — so the actual color is visible at a glance without leaving the document.

This is especially useful for **frontend development plans** where colours are frequently referenced (design tokens, Tailwind overrides, CSS variables, component palette decisions). Without this, reviewers have to mentally decode hex strings or open a colour picker just to follow the author's intent.

**Before:** `use #ff6600 for the CTA button`
**After:** `use 🟧 #ff6600 for the CTA button` *(small inline swatch, not an emoji)*

## What changed

**`packages/ui/components/Viewer.tsx`** — two edits, ~20 lines total:

1. **New pattern block** in the `InlineMarkdown` loop (after inline-code, before wikilinks):
   - Matches `#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa` with a negative lookahead that prevents false-positives on URL anchors (`#section`), CSS id selectors (`#sidebar`), and any identifier that continues with word characters.
   - Renders a `14×14` rounded swatch (`<span style={{ backgroundColor: hex }}>`) followed by the hex code in a `<code>` tag.

2. **`nextSpecial` regex** now includes `#` so the scanner stops at a `#` mid-sentence rather than swallowing it as plain text.

## Security notes

- **No CSS injection risk.** `style={{ backgroundColor: hex }}` uses React's JS-object style prop, not raw `cssText`. React sets individual CSS properties, so it is not possible to break out into arbitrary CSS via this value.
- **Value is regex-constrained.** The only string that ever reaches `backgroundColor` is `#` followed by exactly 3, 4, 6, or 8 hex digits (`[0-9a-fA-F]`). Payloads like `expression()`, `url()`, or `;color:red` suffixes are structurally impossible to inject.
- **No `innerHTML` or `dangerouslySetInnerHTML`.** All rendering is via React JSX — standard XSS protections apply.
- **No ReDoS risk.** The regex uses fixed-length alternatives checked from longest to shortest with no nested quantifiers.

## Tests

`packages/ui/components/hexColorSwatch.test.ts` — 19 tests, all passing (`bun test`):

| Group | What is tested |
|-------|----------------|
| Valid colors | 3-, 4-, 6-, 8-digit hex; mixed case; word-boundary termination |
| No false positives | 5- and 7-digit sequences, non-hex chars, bare `#`, URL anchors, CSS id names, 9+ digit strings |
| Surrounding context | Color mid-sentence, followed by punctuation, two colors in sequence |
| Security | Injection payloads never reach `backgroundColor`; captured value always passes strict `/^#[0-9a-fA-F]{3,8}$/` check |

```
bun test packages/ui/components/hexColorSwatch.test.ts
 19 pass
  0 fail
```