### PR TITLE
don't change current agent

### DIFF
--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -465,14 +465,6 @@ Do NOT proceed with implementation until your plan is approved.`);
 
             if (shouldSwitchAgent) {
               try {
-                await ctx.client.tui.executeCommand({
-                  body: { command: "agent_cycle" },
-                });
-              } catch {
-                // Silently fail
-              }
-
-              try {
                 await ctx.client.session.prompt({
                   path: { id: context.sessionID },
                   body: {


### PR DESCRIPTION
agent_cycle is not the correct command as the user may have several agents defined, not only build and plan.

I do think that the changes introduced in #40 make sense, that is "not only run the plan with the build agent, but also switch the agent to build" - but in its current format, it is simply buggy as it assumes only a build and plan agent.

I checked the opencode sourcecode and I'm not sure what is the alternative. Cycle and validate that the current agent is the target agent, if not repeat?!