### PR TITLE
fix(opencode): reuse local server for review flows

### DIFF
--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -68,13 +68,32 @@ import {
 let _planHtml: string | null = null;
 let _reviewHtml: string | null = null;
 
+function resolveBundledHtmlPath(filename: string): string {
+  const candidates = [
+    path.join(import.meta.dir, filename),
+    path.join(import.meta.dir, "..", filename),
+  ];
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error(`Could not find bundled HTML asset: ${filename}`);
+}
+
+function readBundledHtml(filename: string): string {
+  return readFileSync(resolveBundledHtmlPath(filename), "utf-8");
+}
+
 function getPlanHtml(): string {
-  if (!_planHtml) _planHtml = readFileSync(path.join(import.meta.dir, "..", "plannotator.html"), "utf-8");
+  if (!_planHtml) _planHtml = readBundledHtml("plannotator.html");
   return _planHtml;
 }
 
 function getReviewHtml(): string {
-  if (!_reviewHtml) _reviewHtml = readFileSync(path.join(import.meta.dir, "..", "review-editor.html"), "utf-8");
+  if (!_reviewHtml) _reviewHtml = readBundledHtml("review-editor.html");
   return _reviewHtml;
 }
 
@@ -153,8 +172,8 @@ Only write and submit a plan once you have sufficient context.
 
 export const PlannotatorPlugin: Plugin = async (ctx) => {
   // Preload HTML in background — populates the sync cache before first use
-  Bun.file(path.join(import.meta.dir, "..", "plannotator.html")).text().then(h => { _planHtml = h; });
-  Bun.file(path.join(import.meta.dir, "..", "review-editor.html")).text().then(h => { _reviewHtml = h; });
+  Bun.file(resolveBundledHtmlPath("plannotator.html")).text().then(h => { _planHtml = h; });
+  Bun.file(resolveBundledHtmlPath("review-editor.html")).text().then(h => { _reviewHtml = h; });
 
   let cachedAgents: any[] | null = null;
 

--- a/apps/opencode-plugin/package.json
+++ b/apps/opencode-plugin/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "build": "cp ../hook/dist/index.html ./plannotator.html && cp ../review/dist/index.html ./review-editor.html && bun build index.ts --outfile dist/index.js --target bun --external @opencode-ai/plugin",
-    "postinstall": "mkdir -p ${XDG_CONFIG_HOME:-$HOME/.config}/opencode/command && cp ./commands/*.md ${XDG_CONFIG_HOME:-$HOME/.config}/opencode/command/ 2>/dev/null || true",
+    "postinstall": "mkdir -p ${XDG_CONFIG_HOME:-$HOME/.config}/opencode/commands && cp ./commands/*.md ${XDG_CONFIG_HOME:-$HOME/.config}/opencode/commands/ 2>/dev/null || true",
     "prepublishOnly": "bun run build"
   },
   "dependencies": {

--- a/packages/ai/providers/opencode-sdk.ts
+++ b/packages/ai/providers/opencode-sdk.ts
@@ -126,18 +126,29 @@ export class OpenCodeProvider implements AIProvider {
 		}
 	}
 
+	private getClient(): OpencodeClient {
+		if (!this.client) {
+			throw new Error("OpenCode client is not initialized.");
+		}
+		return this.client;
+	}
+
 	async createSession(options: CreateSessionOptions): Promise<AISession> {
 		await this.ensureServer();
+		const client = this.getClient();
 
-		const result = await this.client.session.create({
+		const result = await client.session.create({
 			query: { directory: options.cwd ?? this.config.cwd ?? process.cwd() },
 		});
 		const sessionData = result.data;
+		if (!sessionData) {
+			throw new Error("OpenCode did not return session data.");
+		}
 
 		const session = new OpenCodeSession({
 			sessionId: sessionData.id,
 			systemPrompt: buildSystemPrompt(options.context),
-			client: this.client,
+			client,
 			model: options.model,
 			parentSessionId: null,
 		});
@@ -146,21 +157,25 @@ export class OpenCodeProvider implements AIProvider {
 
 	async forkSession(options: CreateSessionOptions): Promise<AISession> {
 		await this.ensureServer();
+		const client = this.getClient();
 
 		const parentId = options.context.parent?.sessionId;
 		if (!parentId) {
 			throw new Error("Fork requires a parent session ID.");
 		}
 
-		const result = await this.client.session.fork({
+		const result = await client.session.fork({
 			path: { id: parentId },
 		});
 		const sessionData = result.data;
+		if (!sessionData) {
+			throw new Error("OpenCode did not return forked session data.");
+		}
 
 		return new OpenCodeSession({
 			sessionId: sessionData.id,
 			systemPrompt: buildSystemPrompt(options.context),
-			client: this.client,
+			client,
 			model: options.model,
 			parentSessionId: parentId,
 		});
@@ -168,14 +183,15 @@ export class OpenCodeProvider implements AIProvider {
 
 	async resumeSession(sessionId: string): Promise<AISession> {
 		await this.ensureServer();
+		const client = this.getClient();
 
 		// Verify session exists
-		await this.client.session.get({ path: { id: sessionId } });
+		await client.session.get({ path: { id: sessionId } });
 
 		return new OpenCodeSession({
 			sessionId,
 			systemPrompt: null,
-			client: this.client,
+			client,
 			model: undefined,
 			parentSessionId: null,
 		});
@@ -194,23 +210,24 @@ export class OpenCodeProvider implements AIProvider {
 	async fetchModels(): Promise<void> {
 		try {
 			await this.ensureServer();
+			const client = this.getClient();
 
-			const result = await this.client.provider.list({
+			const result = await client.provider.list({
 				query: { directory: this.config.cwd ?? process.cwd() },
 			});
 			const data = result.data;
-			const connected = new Set(data.connected as string[]);
-			const allProviders = data.all as Array<{
-				id: string;
-				models: Record<string, { id: string; providerID: string; name: string }>;
-			}>;
+			if (!data) {
+				return;
+			}
+			const connected = new Set(data.connected ?? []);
+			const allProviders = data.all ?? [];
 
 			const models: Array<{ id: string; label: string; default?: boolean }> = [];
 			for (const provider of allProviders) {
 				if (!connected.has(provider.id)) continue;
 				for (const model of Object.values(provider.models)) {
 					models.push({
-						id: `${model.providerID}/${model.id}`,
+						id: `${provider.id}/${model.id}`,
 						label: model.name ?? model.id,
 					});
 				}

--- a/packages/ai/providers/opencode-sdk.ts
+++ b/packages/ai/providers/opencode-sdk.ts
@@ -1,11 +1,13 @@
 /**
  * OpenCode provider — bridges Plannotator's AI layer with OpenCode's agent server.
  *
- * Uses @opencode-ai/sdk to spawn `opencode serve` and communicate via HTTP + SSE.
- * One server per provider, shared across all sessions. The user must have the
- * `opencode` CLI installed and authenticated.
+ * Uses @opencode-ai/sdk to connect to an existing `opencode serve` first and
+ * only spawns a new server when nothing is reachable. One server is shared
+ * across all sessions. The user must have the `opencode` CLI installed and
+ * authenticated.
  */
 
+import type { OpencodeClient } from "@opencode-ai/sdk";
 import { BaseSession } from "../base-session.ts";
 import { buildSystemPrompt } from "../context.ts";
 import type {
@@ -54,17 +56,17 @@ export class OpenCodeProvider implements AIProvider {
 	private config: OpenCodeConfig;
 	// biome-ignore lint/suspicious/noExplicitAny: SDK types not available at compile time
 	private server: { url: string; close: () => void } | null = null;
-	// biome-ignore lint/suspicious/noExplicitAny: SDK types not available at compile time
-	private client: any = null;
+	private client: OpencodeClient | null = null;
 	private startPromise: Promise<void> | null = null;
+	private lastAttachError: string | null = null;
 
 	constructor(config: OpenCodeConfig) {
 		this.config = config;
 	}
 
-	/** Lazy-spawn the OpenCode server and create the HTTP client. */
+	/** Attach to an existing OpenCode server or spawn one if needed. */
 	async ensureServer(): Promise<void> {
-		if (this.server && this.client) return;
+		if (this.client) return;
 		this.startPromise ??= this.doStart().catch((err) => {
 			this.startPromise = null;
 			throw err;
@@ -73,18 +75,55 @@ export class OpenCodeProvider implements AIProvider {
 	}
 
 	private async doStart(): Promise<void> {
+		this.lastAttachError = null;
 		const { createOpencodeServer, createOpencodeClient } = await getSDK();
+		const attachedClient = await this.tryAttachExistingServer(createOpencodeClient);
+		if (attachedClient) {
+			this.client = attachedClient;
+			return;
+		}
 
-		this.server = await createOpencodeServer({
-			hostname: this.config.hostname ?? "127.0.0.1",
-			...(this.config.port != null && { port: this.config.port }),
-			timeout: 15_000,
-		});
+		try {
+			this.server = await createOpencodeServer({
+				hostname: this.config.hostname ?? "127.0.0.1",
+				...(this.config.port != null && { port: this.config.port }),
+				timeout: 15_000,
+			});
+		} catch (err) {
+			const spawnMessage = err instanceof Error ? err.message : String(err);
+			if (this.lastAttachError) {
+				throw new Error(`${this.lastAttachError}\nFallback startup also failed: ${spawnMessage}`);
+			}
+			throw err;
+		}
 
 		this.client = createOpencodeClient({
 			baseUrl: this.server!.url,
 			directory: this.config.cwd ?? process.cwd(),
 		});
+	}
+
+	private async tryAttachExistingServer(
+		createOpencodeClient: (config?: { baseUrl?: string; directory?: string }) => OpencodeClient,
+	): Promise<OpencodeClient | null> {
+		const cwd = this.config.cwd ?? process.cwd();
+		const baseUrl = `http://${this.config.hostname ?? "127.0.0.1"}:${this.config.port ?? 4096}`;
+		const client = createOpencodeClient({
+			baseUrl,
+			directory: cwd,
+		});
+
+		try {
+			await client.config.get({
+				throwOnError: true,
+				signal: AbortSignal.timeout(1_000),
+			});
+			return client;
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			this.lastAttachError = `Failed to attach to existing OpenCode server at ${baseUrl}: ${message}`;
+			return null;
+		}
 	}
 
 	async createSession(options: CreateSessionOptions): Promise<AISession> {
@@ -146,9 +185,9 @@ export class OpenCodeProvider implements AIProvider {
 		if (this.server) {
 			this.server.close();
 			this.server = null;
-			this.client = null;
-			this.startPromise = null;
 		}
+		this.client = null;
+		this.startPromise = null;
 	}
 
 	/** Fetch available models from OpenCode. Call before registering the provider. */

--- a/packages/ai/types.ts
+++ b/packages/ai/types.ts
@@ -364,6 +364,6 @@ export interface OpenCodeConfig extends AIProviderConfig {
   type: "opencode-sdk";
   /** Hostname for the OpenCode server. Default: "127.0.0.1". */
   hostname?: string;
-  /** Port for the OpenCode server. Default: random. */
+  /** Port for the OpenCode server. Default: 4096. */
   port?: number;
 }

--- a/tests/manual/local/sandbox-opencode.sh
+++ b/tests/manual/local/sandbox-opencode.sh
@@ -1538,22 +1538,22 @@ echo ""
 
 # Set up local plugin via loader file
 echo "Setting up local plugin..."
-mkdir -p .opencode/plugin
+mkdir -p .opencode/plugins
 
 # Create a loader file that re-exports from the source
-# OpenCode only loads top-level .ts/.js files in the plugin directory
-cat > .opencode/plugin/plannotator.ts << EOF
+# OpenCode only loads top-level .ts/.js files in the plugins directory
+cat > .opencode/plugins/plannotator.ts << EOF
 // Loader for local Plannotator plugin development
 export * from "$PLUGIN_DIR/index.ts";
 EOF
 
-# Copy command files to local .opencode/command
-mkdir -p .opencode/command
-cp "$PLUGIN_DIR/commands/"*.md .opencode/command/
+# Copy command files to local .opencode/commands
+mkdir -p .opencode/commands
+cp "$PLUGIN_DIR/commands/"*.md .opencode/commands/
 
-# Also install to global command directory (some OpenCode versions need this)
-mkdir -p ~/.config/opencode/command
-cp "$PLUGIN_DIR/commands/"*.md ~/.config/opencode/command/ 2>/dev/null || true
+# Also install to global commands directory (some OpenCode versions need this)
+mkdir -p ~/.config/opencode/commands
+cp "$PLUGIN_DIR/commands/"*.md ~/.config/opencode/commands/ 2>/dev/null || true
 
 echo ""
 


### PR DESCRIPTION
## Summary
- try attaching the OpenCode review AI provider to the default local server at `127.0.0.1:4096` before spawning a new `opencode serve` . this should fix #513 and https://github.com/backnotprop/plannotator/issues/514
- fix the OpenCode plugin's bundled HTML lookup so source-loaded local plugin runs resolve `plannotator.html` and `review-editor.html` correctly
- update local sandbox and `postinstall` command paths to use the documented `plugins/` and `commands/` directories

The last 2 items were needed to fully test the `./tests/manual/local/sandbox-opencode.sh --keep` as otherwise i wasnt hitting the right bundled files. I also had to remove it from my global opencode config. 

## What I explored
- reproduced the original failure where the review AI path tried to start a second `opencode serve` and collided with an existing local server
- traced the OpenCode command flow in the sandbox and found a separate local-testing issue: the source-loaded plugin was resolving bundled HTML from the wrong directory, so local runs could fail before opening the UI

## Main issue

* When spawning the opencode serve command for a local server it stays open until someone kills it manually. Can confirm this by doing `pgrep -af opencode`. So on subsequent review commands the server was still running and hence the port conflict.

## Final approach
- keep the existing review command UX intact
- keep the fix minimal: attach to the default local OpenCode server if it exists, otherwise spawn a new one
- avoid extra host-specific plumbing and keep only the runtime changes needed for local plugin runs and server reuse

## Open questions

* I am not sure if your intention was to always generate a new opencode server. If thats the idea then we should kill the server when the review is done. I feel this might be problematic to be honest since we don't know where the ask might come from nor i am sure if there'a reliable way to kill the server after we are done. 
* I am not sure if we should be reusing the existing client as a fallback if it exists either. 
* Could make this more reliable and spawn to another port than 4096, but if we dont kill this correctly then we end up with many ports open spammable :D