### PR TITLE
Fix for RSS feed, for the blog

### DIFF
--- a/apps/marketing/src/layouts/Base.astro
+++ b/apps/marketing/src/layouts/Base.astro
@@ -39,6 +39,7 @@ import '../styles/global.css';
 
     <meta name="robots" content="index, follow" />
     <link rel="canonical" href={canonical} />
+    <link rel="alternate" type="application/rss+xml" title="Plannotator Blog" href="/rss.xml" />
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
An easy one: RSS link for the blog added.

Advertise the blog feed in the shared marketing layout so feed readers and browsers can discover it automatically.