### PR TITLE
Add annotate wide mode

### DIFF
--- a/apps/hook/vite.config.ts
+++ b/apps/hook/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, '.'),
+      '@plannotator/shared': path.resolve(__dirname, '../../packages/shared'),
       '@plannotator/ui': path.resolve(__dirname, '../../packages/ui'),
       '@plannotator/editor/styles': path.resolve(__dirname, '../../packages/editor/index.css'),
       '@plannotator/editor': path.resolve(__dirname, '../../packages/editor/App.tsx'),

--- a/apps/review/vite.config.ts
+++ b/apps/review/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, '.'),
+      '@plannotator/shared': path.resolve(__dirname, '../../packages/shared'),
       '@plannotator/ui': path.resolve(__dirname, '../../packages/ui'),
       '@plannotator/review-editor/styles': path.resolve(__dirname, '../../packages/review-editor/index.css'),
       '@plannotator/review-editor': path.resolve(__dirname, '../../packages/review-editor/App.tsx'),

--- a/bun.lock
+++ b/bun.lock
@@ -199,6 +199,7 @@
       "dependencies": {
         "@plannotator/shared": "workspace:*",
         "@plannotator/web-highlighter": "^0.8.1",
+        "@radix-ui/react-tooltip": "^1.2.8",
         "@viz-js/viz": "^3.25.0",
         "diff": "^8.0.3",
         "highlight.js": "^11.11.1",
@@ -465,6 +466,14 @@
 
     "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 
+    "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "^1.7.5", "@floating-ui/utils": "^0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
+
+    "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
     "@google/genai": ["@google/genai@1.42.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-+3nlMTcrQufbQ8IumGkOphxD5Pd5kKyJOzLcnY0/1IuE8upJk5aLmoexZ2BJhBp1zAjRJMEB4a2CJwKI9e2EYw=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
@@ -682,6 +691,48 @@
     "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
+
+    "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
+
+    "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w=="],
+
+    "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
+
+    "@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+
+    "@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.11", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-escape-keydown": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg=="],
+
+    "@radix-ui/react-id": ["@radix-ui/react-id@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg=="],
+
+    "@radix-ui/react-popper": ["@radix-ui/react-popper@1.2.8", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-rect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw=="],
+
+    "@radix-ui/react-portal": ["@radix-ui/react-portal@1.1.9", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ=="],
+
+    "@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.5", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ=="],
+
+    "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
+    "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-tooltip": ["@radix-ui/react-tooltip@1.2.8", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg=="],
+
+    "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="],
+
+    "@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.2", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg=="],
+
+    "@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA=="],
+
+    "@radix-ui/react-use-escape-keydown": ["@radix-ui/react-use-escape-keydown@1.1.1", "", { "dependencies": { "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g=="],
+
+    "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ=="],
+
+    "@radix-ui/react-use-rect": ["@radix-ui/react-use-rect@1.1.1", "", { "dependencies": { "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w=="],
+
+    "@radix-ui/react-use-size": ["@radix-ui/react-use-size@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ=="],
+
+    "@radix-ui/react-visually-hidden": ["@radix-ui/react-visually-hidden@1.2.3", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug=="],
+
+    "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.53", "", {}, "sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ=="],
 

--- a/docs/adversarial_rubric.md
+++ b/docs/adversarial_rubric.md
@@ -1,0 +1,61 @@
+# Adversarial Rubric
+
+Last Updated: 2026-04-17
+
+This rubric captures the main adversarial and drift vectors for Plannotator's review and annotation surfaces. It is intended for milestone reviews, especially for UI state changes that can unintentionally cross plan, annotate, archive, and review modes.
+
+## Data Boundaries
+
+| Boundary | Format | Validation | Failure Mode |
+| --- | --- | --- | --- |
+| `/api/plan`, `/api/feedback`, `/api/draft`, `/api/upload` between browser and Bun server | JSON, multipart form data, markdown text | Per-endpoint parsing in `packages/server/index.ts`, `packages/server/annotate.ts`, `packages/server/shared-handlers.ts` | Invalid payloads can silently fall back to demo/empty state or reject late in the flow |
+| Linked-doc file resolution via `/api/doc` and Obsidian doc endpoints | Relative/absolute markdown paths | `packages/server/reference-handlers.ts`, `packages/shared/resolve-file.ts` normalize and constrain paths | Path confusion can open the wrong file or expose unintended content if guards drift |
+| Share/import URLs and paste payloads | URL hash, compressed JSON, encrypted blobs | `packages/ui/utils/sharing.ts` parses, decompresses, decrypts, and reconstructs annotations | Malformed share payloads can break annotation restore or produce partial state |
+| External annotations stream and snapshot APIs | SSE + JSON annotations | `packages/server/external-annotations.ts`, shared annotation types in `packages/shared/external-annotation.ts` | Unsanitized/invalid annotation payloads can corrupt UI state or highlight bookkeeping |
+| Cookie-backed UI preferences | Strings in `document.cookie` | `packages/ui/utils/storage.ts`, `packages/ui/utils/uiPreferences.ts`, `packages/ui/config/settings.ts` coerce to enums/bools | Invalid cookie values can create inconsistent mode/layout defaults across sessions |
+
+## Type Coercion Vectors
+
+| Coercion | Location | Risk | Test Exists? |
+| --- | --- | --- | --- |
+| Cookie string → boolean / enum | `packages/ui/utils/uiPreferences.ts`, `packages/ui/config/settings.ts` | Invalid values can silently select unsafe defaults or inconsistent layout state | Partial |
+| URL hash / paste payload → structured annotations | `packages/ui/utils/sharing.ts` | Malformed arrays or unexpected tuple shapes can restore incomplete/shifted annotations | Partial |
+| Query/path input → resolved markdown path | `packages/shared/resolve-file.ts` | Separator normalization and basename fallback can drift from intended trust boundary | Yes |
+| External annotation JSON → internal annotation model | `packages/shared/external-annotation.ts` | Missing/extra fields can degrade rendering or selection restoration | Partial |
+| Resize/cap values → persisted panel widths | `packages/ui/hooks/useResizablePanel.ts` | Invalid saved widths can distort layout or hide controls | No |
+
+## Trust Assumptions
+
+| Assumption | What Breaks | Severity | Test Exists? |
+| --- | --- | --- | --- |
+| Annotate-only UI changes will not leak into plan/review/archive modes | Hidden controls or layout regressions in other surfaces | HIGH | No |
+| Session-scoped UI modes restore the user’s prior layout exactly | Users lose sidebar/panel context or hidden state drifts | HIGH | No |
+| Shared workspace aliases stay aligned across app Vite configs | Local builds fail even though workspace packages compile | MEDIUM | No |
+| Linked-doc navigation only needs the sidebar capabilities it declares | Runtime mismatches if hook expectations drift | MEDIUM | No |
+| Cookie defaults are benign when malformed or missing | Surprising startup state, especially around sidebar and panel behavior | LOW | Partial |
+
+## Cascade Risks
+
+| Cascade Point | Blast Radius | Isolation | Test Exists? |
+| --- | --- | --- | --- |
+| Viewer/layout mode toggles in `packages/editor/App.tsx` | Can affect annotate, plan, linked-doc, archive, and sticky-header behavior at once | Manual branching by `annotateMode`, `archiveMode`, `isPlanDiffActive` | No |
+| Sticky header lane width calculations | Reader chrome can diverge from document width and overlay controls incorrectly | Separate `StickyHeaderLane` component with measured widths | No |
+| Linked-doc state swap and cached annotations | Annotation state can leak between source doc and linked doc | `useLinkedDoc` caches/restores per file | No |
+| External annotation highlight replay | DOM highlights can desync when switching linked docs or diff mode | `useExternalAnnotationHighlights` and explicit reset hooks | Partial |
+
+## Registry Drift Risks
+
+| Registry | Code Location | Drift Detection | Last Verified |
+| --- | --- | --- | --- |
+| Hook/review app workspace aliases | `apps/hook/vite.config.ts`, `apps/review/vite.config.ts` | Manual build of both apps | 2026-04-17 |
+| Public API endpoint docs vs runtime endpoints | `AGENTS.md`, marketing docs, `packages/server/*.ts` | Manual review + endpoint additions in PR review | 2026-04-17 |
+| Shared package exports vs app imports | `packages/shared/package.json` and app/package imports | Typecheck/build | 2026-04-17 |
+| UI preference keys vs Settings UI | `packages/ui/utils/uiPreferences.ts`, `packages/ui/components/Settings.tsx` | Manual review | 2026-04-17 |
+
+## Learned Vectors
+
+| Vector | Source Milestone | Category | Recurrence |
+| --- | --- | --- | --- |
+| Session-scoped layout modes can mutate hidden panel state unless every reopen path exits the mode first | `feat/annotate-wide-mode` | Cascade / Trust Assumption | Likely |
+| Annotate-only controls must be explicitly gated to avoid leaking into plan/review surfaces through shared components | `feat/annotate-wide-mode` | Trust Assumption | Likely |
+| Build-time alias drift can look like a feature regression even when the code change is correct | `feat/annotate-wide-mode` | Registry Drift | Likely |

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -38,6 +38,7 @@ import { ResizeHandle } from '@plannotator/ui/components/ResizeHandle';
 import { OverlayScrollArea } from '@plannotator/ui/components/OverlayScrollArea';
 import { ScrollViewportContext } from '@plannotator/ui/hooks/useScrollViewport';
 import { useOverlayViewport } from '@plannotator/ui/hooks/useOverlayViewport';
+import { useIsMobile } from '@plannotator/ui/hooks/useIsMobile';
 import { PlanHeaderMenu } from '@plannotator/ui/components/PlanHeaderMenu';
 import {
   getPermissionModeSettings,
@@ -47,7 +48,7 @@ import {
 import { PermissionModeSetup } from '@plannotator/ui/components/PermissionModeSetup';
 import { ImageAnnotator } from '@plannotator/ui/components/ImageAnnotator';
 import { deriveImageName } from '@plannotator/ui/components/AttachmentsButton';
-import { useSidebar } from '@plannotator/ui/hooks/useSidebar';
+import { useSidebar, type SidebarTab } from '@plannotator/ui/hooks/useSidebar';
 import { usePlanDiff, type VersionInfo } from '@plannotator/ui/hooks/usePlanDiff';
 import { useLinkedDoc } from '@plannotator/ui/hooks/useLinkedDoc';
 import { useAnnotationDraft } from '@plannotator/ui/hooks/useAnnotationDraft';
@@ -71,6 +72,7 @@ import type { PlanDiffMode } from '@plannotator/ui/components/plan-diff/PlanDiff
 // same env var on the server side so V2/V3 stay paired.
 import { DEMO_PLAN_CONTENT as DEFAULT_DEMO_PLAN_CONTENT } from './demoPlan';
 import { DIFF_DEMO_PLAN_CONTENT } from './demoPlanDiffDemo';
+import { canUseAnnotateWideMode, resolveWideModeExitLayout, type WideModeLayoutSnapshot } from './wideMode';
 const USE_DIFF_DEMO =
   import.meta.env.VITE_DIFF_DEMO === '1' ||
   import.meta.env.VITE_DIFF_DEMO === 'true';
@@ -160,6 +162,9 @@ const App: React.FC = () => {
   const [pasteApiUrl, setPasteApiUrl] = useState<string | undefined>(undefined);
   const [repoInfo, setRepoInfo] = useState<{ display: string; branch?: string } | null>(null);
   const [projectRoot, setProjectRoot] = useState<string | null>(null);
+  const [isWideMode, setIsWideMode] = useState(false);
+  const wideModeSnapshotRef = useRef<WideModeLayoutSnapshot | null>(null);
+  const lastAppliedTocEnabledRef = useRef(uiPrefs.tocEnabled);
 
   useEffect(() => {
     document.title = repoInfo ? `${repoInfo.display} · Plannotator` : "Plannotator";
@@ -171,6 +176,7 @@ const App: React.FC = () => {
   const [planDiffMode, setPlanDiffMode] = useState<PlanDiffMode>('clean');
   const [previousPlan, setPreviousPlan] = useState<string | null>(null);
   const [versionInfo, setVersionInfo] = useState<VersionInfo | null>(null);
+  const isMobile = useIsMobile();
 
   const viewerRef = useRef<ViewerHandle>(null);
   // containerRef + scrollViewport both point at the OverlayScrollbars
@@ -196,14 +202,67 @@ const App: React.FC = () => {
   // Sidebar (shared TOC + Version Browser)
   const sidebar = useSidebar(getUIPreferences().tocEnabled);
 
-  // Sync sidebar open state when preference changes in Settings
-  useEffect(() => {
-    if (uiPrefs.tocEnabled) {
-      sidebar.open('toc');
+  const exitWideMode = useCallback((options?: {
+    restore?: boolean;
+    sidebarTab?: SidebarTab;
+    panelOpen?: boolean;
+  }) => {
+    if (!isWideMode) {
+      if (options?.sidebarTab) sidebar.open(options.sidebarTab);
+      if (options?.panelOpen === true) setIsPanelOpen(true);
+      else if (options?.panelOpen === false) setIsPanelOpen(false);
+      return;
+    }
+
+    const snapshot = wideModeSnapshotRef.current;
+    const layout = resolveWideModeExitLayout(snapshot, options);
+
+    setIsWideMode(false);
+    wideModeSnapshotRef.current = null;
+
+    if (layout.sidebarOpen && layout.sidebarTab) {
+      sidebar.open(layout.sidebarTab);
     } else {
       sidebar.close();
     }
-  }, [uiPrefs.tocEnabled]);
+
+    if (layout.panelOpen !== undefined) {
+      setIsPanelOpen(layout.panelOpen);
+    }
+  }, [isWideMode, sidebar.close, sidebar.open]);
+
+  const openSidebarTab = useCallback((tab: SidebarTab) => {
+    if (isWideMode) {
+      exitWideMode({ restore: false, sidebarTab: tab, panelOpen: false });
+      return;
+    }
+    sidebar.open(tab);
+  }, [exitWideMode, isWideMode, sidebar.open]);
+
+  const toggleSidebarTab = useCallback((tab: SidebarTab) => {
+    if (isWideMode) {
+      exitWideMode({ restore: false, sidebarTab: tab, panelOpen: false });
+      return;
+    }
+    sidebar.toggleTab(tab);
+  }, [exitWideMode, isWideMode, sidebar.toggleTab]);
+
+  const handleAnnotationPanelToggle = useCallback(() => {
+    if (isWideMode) {
+      exitWideMode({ restore: false, panelOpen: true });
+      return;
+    }
+    setIsPanelOpen(prev => !prev);
+  }, [exitWideMode, isWideMode]);
+
+  // Sync sidebar open state when preference changes in Settings
+  useEffect(() => {
+    if (isWideMode) return;
+    if (lastAppliedTocEnabledRef.current === uiPrefs.tocEnabled) return;
+    lastAppliedTocEnabledRef.current = uiPrefs.tocEnabled;
+    if (uiPrefs.tocEnabled) sidebar.open('toc');
+    else sidebar.close();
+  }, [isWideMode, sidebar.close, sidebar.open, uiPrefs.tocEnabled]);
 
   // Clear diff view when switching away from versions tab
   useEffect(() => {
@@ -227,11 +286,23 @@ const App: React.FC = () => {
   // Plan diff computation
   const planDiff = usePlanDiff(markdown, previousPlan, versionInfo);
 
+  const linkedDocSidebar = useMemo(() => ({
+    ...sidebar,
+    open: openSidebarTab,
+    toggleTab: toggleSidebarTab,
+  }), [
+    openSidebarTab,
+    sidebar.activeTab,
+    sidebar.close,
+    sidebar.isOpen,
+    toggleSidebarTab,
+  ]);
+
   // Linked document navigation
   const linkedDocHook = useLinkedDoc({
     markdown, annotations, selectedAnnotationId, globalAttachments,
     setMarkdown, setAnnotations, setSelectedAnnotationId, setGlobalAttachments,
-    viewerRef, sidebar, sourceFilePath,
+    viewerRef, sidebar: linkedDocSidebar, sourceFilePath,
   });
 
   // Archive browser
@@ -239,6 +310,40 @@ const App: React.FC = () => {
     markdown, viewerRef, linkedDocHook,
     setMarkdown, setAnnotations, setSelectedAnnotationId, setSubmitted,
   });
+
+  const canUseWideMode = useMemo(() => canUseAnnotateWideMode({
+    annotateMode,
+    archiveMode: archive.archiveMode,
+    isPlanDiffActive,
+  }), [annotateMode, archive.archiveMode, isPlanDiffActive]);
+
+  const enterWideMode = useCallback(() => {
+    if (!canUseWideMode || isWideMode) return;
+
+    wideModeSnapshotRef.current = {
+      sidebarIsOpen: sidebar.isOpen,
+      sidebarTab: sidebar.activeTab,
+      panelOpen: isPanelOpen,
+    };
+
+    setIsWideMode(true);
+    sidebar.close();
+    setIsPanelOpen(false);
+  }, [canUseWideMode, isPanelOpen, isWideMode, sidebar.activeTab, sidebar.close, sidebar.isOpen]);
+
+  const toggleWideMode = useCallback(() => {
+    if (isWideMode) {
+      exitWideMode();
+    } else {
+      enterWideMode();
+    }
+  }, [enterWideMode, exitWideMode, isWideMode]);
+
+  useEffect(() => {
+    if (!canUseWideMode && isWideMode) {
+      exitWideMode();
+    }
+  }, [canUseWideMode, exitWideMode, isWideMode]);
 
   // Markdown file browser (also handles vault dirs via isVault flag)
   const fileBrowser = useFileBrowser();
@@ -378,7 +483,7 @@ const App: React.FC = () => {
     if (filePaths.size === 0) return;
     // Open sidebar to the files tab so the flash is visible
     if (!sidebar.isOpen || sidebar.activeTab !== 'files') {
-      sidebar.open('files');
+      openSidebarTab('files');
     }
     // Cancel any pending clear from a previous flash
     if (flashTimerRef.current) clearTimeout(flashTimerRef.current);
@@ -388,7 +493,7 @@ const App: React.FC = () => {
       setHighlightedFiles(filePaths);
       flashTimerRef.current = setTimeout(() => setHighlightedFiles(undefined), 1200);
     });
-  }, [allAnnotationCounts, sidebar, hasFileAnnotations]);
+  }, [allAnnotationCounts, openSidebarTab, sidebar, hasFileAnnotations]);
 
   // Context-aware back label for linked doc navigation
   const backLabel = annotateSource === 'folder' ? 'file list'
@@ -963,14 +1068,16 @@ const App: React.FC = () => {
   const handleAddAnnotation = (ann: Annotation) => {
     setAnnotations(prev => [...prev, ann]);
     setSelectedAnnotationId(ann.id);
-    setIsPanelOpen(true);
+    if (!isWideMode) {
+      setIsPanelOpen(true);
+    }
   };
 
-  // Stable reference — the Viewer's highlighter useEffect depends on this
+  // Keep selection behavior explicit across mobile/wide-mode transitions.
   const handleSelectAnnotation = React.useCallback((id: string | null) => {
     setSelectedAnnotationId(id);
-    if (id && window.innerWidth < 768) setIsPanelOpen(true);
-  }, []);
+    if (id && isMobile && !isWideMode) setIsPanelOpen(true);
+  }, [isMobile, isWideMode]);
 
   // Core annotation removal — highlight cleanup + state filter + selection clear
   const removeAnnotation = (id: string) => {
@@ -1250,6 +1357,7 @@ const App: React.FC = () => {
     const widths: Record<PlanWidth, number> = { compact: 832, default: 1040, wide: 1280 };
     return widths[uiPrefs.planWidth] ?? 832;
   }, [uiPrefs.planWidth]);
+  const annotateReaderMaxWidth = canUseWideMode && isWideMode ? null : planMaxWidth;
 
 
   return (
@@ -1387,7 +1495,7 @@ const App: React.FC = () => {
 
             {/* Annotations panel toggle — top-level header button */}
             <button
-              onClick={() => setIsPanelOpen(!isPanelOpen)}
+              onClick={handleAnnotationPanelToggle}
               className={`p-1.5 rounded-md text-xs font-medium transition-all ${
                 isPanelOpen
                   ? 'bg-primary/15 text-primary'
@@ -1462,10 +1570,10 @@ const App: React.FC = () => {
           {/* Tater sprites — inside content wrapper so z-0 stacking context applies */}
           {taterMode && <TaterSpriteRunning />}
           {/* Left Sidebar: collapsed tab flags (when sidebar is closed) */}
-          {!sidebar.isOpen && (
+          {!isWideMode && !sidebar.isOpen && (
             <SidebarTabs
               activeTab={sidebar.activeTab}
-              onToggleTab={sidebar.toggleTab}
+              onToggleTab={toggleSidebarTab}
               hasDiff={planDiff.hasPreviousVersion}
               showVersionsTab={versionInfo !== null && versionInfo.totalVersions > 1}
               showFilesTab={showFilesTab && !archive.archiveMode}
@@ -1480,7 +1588,7 @@ const App: React.FC = () => {
               <SidebarContainer
                 activeTab={sidebar.activeTab}
                 onTabChange={(tab) => {
-                  sidebar.toggleTab(tab);
+                  toggleSidebarTab(tab);
                   if (tab === 'archive' && !archive.archiveMode) archive.fetchPlans();
                 }}
                 onClose={sidebar.close}
@@ -1525,7 +1633,7 @@ const App: React.FC = () => {
           {/* Document Area */}
           <OverlayScrollArea
             element="main"
-            className={`flex-1 min-w-0 bg-grid ${!sidebar.isOpen ? 'lg:pl-[30px]' : ''}`}
+            className={`flex-1 min-w-0 bg-grid ${!sidebar.isOpen && !isWideMode ? 'lg:pl-[30px]' : ''}`}
             data-print-region="document"
             onViewportReady={handleViewportReady}
           >
@@ -1559,20 +1667,26 @@ const App: React.FC = () => {
                   hasPreviousVersion={planDiff.hasPreviousVersion}
                   onPlanDiffToggle={() => setIsPlanDiffActive(!isPlanDiffActive)}
                   archiveInfo={archive.currentInfo}
-                  maxWidth={planMaxWidth}
+                  maxWidth={annotateReaderMaxWidth}
+                  showWideMode={canUseWideMode}
+                  wideMode={isWideMode}
+                  onWideModeToggle={toggleWideMode}
                   remountToken={linkedDocHook.isActive ? `doc:${linkedDocHook.filepath}` : 'plan'}
                 />
               )}
 
               {/* Annotation Toolstrip (hidden during plan diff and archive mode) */}
               {!isPlanDiffActive && !archive.archiveMode && (
-                <div data-print-hide className="w-full mb-3 md:mb-4 flex items-center justify-start" style={{ maxWidth: planMaxWidth }}>
+                <div data-print-hide className="w-full mb-3 md:mb-4 flex items-center justify-start" style={annotateReaderMaxWidth == null ? undefined : { maxWidth: annotateReaderMaxWidth }}>
                   <AnnotationToolstrip
                     inputMethod={inputMethod}
                     onInputMethodChange={handleInputMethodChange}
                     mode={editorMode}
                     onModeChange={handleEditorModeChange}
                     taterMode={taterMode}
+                    showWideMode={canUseWideMode}
+                    wideMode={isWideMode}
+                    onWideModeToggle={toggleWideMode}
                   />
                 </div>
               )}
@@ -1632,7 +1746,7 @@ const App: React.FC = () => {
                   onPlanDiffToggle={() => setIsPlanDiffActive(!isPlanDiffActive)}
                   hasPreviousVersion={!linkedDocHook.isActive && planDiff.hasPreviousVersion}
                   showDemoBadge={!isApiMode && !isLoadingShared && !isSharedSession}
-                  maxWidth={planMaxWidth}
+                  maxWidth={annotateReaderMaxWidth}
                   onOpenLinkedDoc={handleOpenLinkedDoc}
                   linkedDocInfo={linkedDocHook.isActive ? { filepath: linkedDocHook.filepath!, onBack: handleLinkedDocBack, label: fileBrowser.dirs.find(d => d.path === fileBrowser.activeDirPath)?.isVault ? 'Vault File' : fileBrowser.activeFile ? 'File' : undefined, backLabel } : null}
                   imageBaseDir={imageBaseDir}
@@ -1648,11 +1762,11 @@ const App: React.FC = () => {
           </OverlayScrollArea>
 
           {/* Resize Handle */}
-          {isPanelOpen && <ResizeHandle {...panelResize.handleProps} className="hidden md:block" side="right" />}
+          {isPanelOpen && !isWideMode && <ResizeHandle {...panelResize.handleProps} className="hidden md:block" side="right" />}
 
           {/* Annotation Panel */}
           <AnnotationPanel
-            isOpen={isPanelOpen}
+            isOpen={isPanelOpen && !isWideMode}
             blocks={blocks}
             annotations={allAnnotations}
             selectedId={selectedAnnotationId}

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -8,6 +8,7 @@ import { ImportModal } from '@plannotator/ui/components/ImportModal';
 import { ConfirmDialog } from '@plannotator/ui/components/ConfirmDialog';
 import { Annotation, Block, EditorMode, type InputMethod, type ImageAttachment, type ActionsLabelMode } from '@plannotator/ui/types';
 import { ThemeProvider } from '@plannotator/ui/components/ThemeProvider';
+import { Tooltip, TooltipProvider } from '@plannotator/ui/components/Tooltip';
 import { AnnotationToolstrip } from '@plannotator/ui/components/AnnotationToolstrip';
 import { StickyHeaderLane } from '@plannotator/ui/components/StickyHeaderLane';
 import { TaterSpriteRunning } from '@plannotator/ui/components/TaterSpriteRunning';
@@ -72,7 +73,7 @@ import type { PlanDiffMode } from '@plannotator/ui/components/plan-diff/PlanDiff
 // same env var on the server side so V2/V3 stay paired.
 import { DEMO_PLAN_CONTENT as DEFAULT_DEMO_PLAN_CONTENT } from './demoPlan';
 import { DIFF_DEMO_PLAN_CONTENT } from './demoPlanDiffDemo';
-import { canUseAnnotateWideMode, resolveWideModeExitLayout, type WideModeLayoutSnapshot } from './wideMode';
+import { canUseAnnotateWideMode, resolveWideModeExitLayout, type WideModeLayoutSnapshot, type WideModeType } from './wideMode';
 const USE_DIFF_DEMO =
   import.meta.env.VITE_DIFF_DEMO === '1' ||
   import.meta.env.VITE_DIFF_DEMO === 'true';
@@ -162,7 +163,7 @@ const App: React.FC = () => {
   const [pasteApiUrl, setPasteApiUrl] = useState<string | undefined>(undefined);
   const [repoInfo, setRepoInfo] = useState<{ display: string; branch?: string } | null>(null);
   const [projectRoot, setProjectRoot] = useState<string | null>(null);
-  const [isWideMode, setIsWideMode] = useState(false);
+  const [wideModeType, setWideModeType] = useState<WideModeType | null>(null);
   const wideModeSnapshotRef = useRef<WideModeLayoutSnapshot | null>(null);
   const lastAppliedTocEnabledRef = useRef(uiPrefs.tocEnabled);
 
@@ -207,7 +208,7 @@ const App: React.FC = () => {
     sidebarTab?: SidebarTab;
     panelOpen?: boolean;
   }) => {
-    if (!isWideMode) {
+    if (wideModeType === null) {
       if (options?.sidebarTab) sidebar.open(options.sidebarTab);
       if (options?.panelOpen === true) setIsPanelOpen(true);
       else if (options?.panelOpen === false) setIsPanelOpen(false);
@@ -217,7 +218,7 @@ const App: React.FC = () => {
     const snapshot = wideModeSnapshotRef.current;
     const layout = resolveWideModeExitLayout(snapshot, options);
 
-    setIsWideMode(false);
+    setWideModeType(null);
     wideModeSnapshotRef.current = null;
 
     if (layout.sidebarOpen && layout.sidebarTab) {
@@ -229,40 +230,40 @@ const App: React.FC = () => {
     if (layout.panelOpen !== undefined) {
       setIsPanelOpen(layout.panelOpen);
     }
-  }, [isWideMode, sidebar.close, sidebar.open]);
+  }, [wideModeType, sidebar.close, sidebar.open]);
 
   const openSidebarTab = useCallback((tab: SidebarTab) => {
-    if (isWideMode) {
+    if (wideModeType !== null) {
       exitWideMode({ restore: false, sidebarTab: tab, panelOpen: false });
       return;
     }
     sidebar.open(tab);
-  }, [exitWideMode, isWideMode, sidebar.open]);
+  }, [exitWideMode, wideModeType, sidebar.open]);
 
   const toggleSidebarTab = useCallback((tab: SidebarTab) => {
-    if (isWideMode) {
+    if (wideModeType !== null) {
       exitWideMode({ restore: false, sidebarTab: tab, panelOpen: false });
       return;
     }
     sidebar.toggleTab(tab);
-  }, [exitWideMode, isWideMode, sidebar.toggleTab]);
+  }, [exitWideMode, wideModeType, sidebar.toggleTab]);
 
   const handleAnnotationPanelToggle = useCallback(() => {
-    if (isWideMode) {
+    if (wideModeType !== null) {
       exitWideMode({ restore: false, panelOpen: true });
       return;
     }
     setIsPanelOpen(prev => !prev);
-  }, [exitWideMode, isWideMode]);
+  }, [exitWideMode, wideModeType]);
 
   // Sync sidebar open state when preference changes in Settings
   useEffect(() => {
-    if (isWideMode) return;
+    if (wideModeType !== null) return;
     if (lastAppliedTocEnabledRef.current === uiPrefs.tocEnabled) return;
     lastAppliedTocEnabledRef.current = uiPrefs.tocEnabled;
     if (uiPrefs.tocEnabled) sidebar.open('toc');
     else sidebar.close();
-  }, [isWideMode, sidebar.close, sidebar.open, uiPrefs.tocEnabled]);
+  }, [wideModeType, sidebar.close, sidebar.open, uiPrefs.tocEnabled]);
 
   // Clear diff view when switching away from versions tab
   useEffect(() => {
@@ -317,33 +318,33 @@ const App: React.FC = () => {
     isPlanDiffActive,
   }), [annotateMode, archive.archiveMode, isPlanDiffActive]);
 
-  const enterWideMode = useCallback(() => {
-    if (!canUseWideMode || isWideMode) return;
-
-    wideModeSnapshotRef.current = {
-      sidebarIsOpen: sidebar.isOpen,
-      sidebarTab: sidebar.activeTab,
-      panelOpen: isPanelOpen,
-    };
-
-    setIsWideMode(true);
+  const enterViewMode = useCallback((type: WideModeType) => {
+    if (!canUseWideMode) return;
+    if (wideModeType === null) {
+      wideModeSnapshotRef.current = {
+        sidebarIsOpen: sidebar.isOpen,
+        sidebarTab: sidebar.activeTab,
+        panelOpen: isPanelOpen,
+      };
+    }
+    setWideModeType(type);
     sidebar.close();
     setIsPanelOpen(false);
-  }, [canUseWideMode, isPanelOpen, isWideMode, sidebar.activeTab, sidebar.close, sidebar.isOpen]);
+  }, [canUseWideMode, isPanelOpen, wideModeType, sidebar.activeTab, sidebar.close, sidebar.isOpen]);
 
-  const toggleWideMode = useCallback(() => {
-    if (isWideMode) {
+  const toggleViewMode = useCallback((type: WideModeType) => {
+    if (wideModeType === type) {
       exitWideMode();
     } else {
-      enterWideMode();
+      enterViewMode(type);
     }
-  }, [enterWideMode, exitWideMode, isWideMode]);
+  }, [enterViewMode, exitWideMode, wideModeType]);
 
   useEffect(() => {
-    if (!canUseWideMode && isWideMode) {
+    if (!canUseWideMode && wideModeType !== null) {
       exitWideMode();
     }
-  }, [canUseWideMode, exitWideMode, isWideMode]);
+  }, [canUseWideMode, exitWideMode, wideModeType]);
 
   // Markdown file browser (also handles vault dirs via isVault flag)
   const fileBrowser = useFileBrowser();
@@ -1068,7 +1069,7 @@ const App: React.FC = () => {
   const handleAddAnnotation = (ann: Annotation) => {
     setAnnotations(prev => [...prev, ann]);
     setSelectedAnnotationId(ann.id);
-    if (!isWideMode) {
+    if (wideModeType === null) {
       setIsPanelOpen(true);
     }
   };
@@ -1076,8 +1077,8 @@ const App: React.FC = () => {
   // Keep selection behavior explicit across mobile/wide-mode transitions.
   const handleSelectAnnotation = React.useCallback((id: string | null) => {
     setSelectedAnnotationId(id);
-    if (id && isMobile && !isWideMode) setIsPanelOpen(true);
-  }, [isMobile, isWideMode]);
+    if (id && isMobile && wideModeType === null) setIsPanelOpen(true);
+  }, [isMobile, wideModeType]);
 
   // Core annotation removal — highlight cleanup + state filter + selection clear
   const removeAnnotation = (id: string) => {
@@ -1357,11 +1358,12 @@ const App: React.FC = () => {
     const widths: Record<PlanWidth, number> = { compact: 832, default: 1040, wide: 1280 };
     return widths[uiPrefs.planWidth] ?? 832;
   }, [uiPrefs.planWidth]);
-  const annotateReaderMaxWidth = canUseWideMode && isWideMode ? null : planMaxWidth;
+  const annotateReaderMaxWidth = canUseWideMode && wideModeType === 'wide' ? null : planMaxWidth;
 
 
   return (
     <ThemeProvider defaultTheme="dark">
+      <TooltipProvider delayDuration={900} skipDelayDuration={200} disableHoverableContent>
       <div data-print-region="root" className="h-screen flex flex-col bg-background overflow-hidden">
         {/* Minimal Header */}
         <header className="h-12 flex items-center justify-between px-2 md:px-4 border-b border-border/50 bg-card/50 backdrop-blur-xl sticky top-0 z-[50]">
@@ -1570,7 +1572,7 @@ const App: React.FC = () => {
           {/* Tater sprites — inside content wrapper so z-0 stacking context applies */}
           {taterMode && <TaterSpriteRunning />}
           {/* Left Sidebar: collapsed tab flags (when sidebar is closed) */}
-          {!isWideMode && !sidebar.isOpen && (
+          {wideModeType === null && !sidebar.isOpen && (
             <SidebarTabs
               activeTab={sidebar.activeTab}
               onToggleTab={toggleSidebarTab}
@@ -1633,7 +1635,7 @@ const App: React.FC = () => {
           {/* Document Area */}
           <OverlayScrollArea
             element="main"
-            className={`flex-1 min-w-0 bg-grid ${!sidebar.isOpen && !isWideMode ? 'lg:pl-[30px]' : ''}`}
+            className={`flex-1 min-w-0 bg-grid ${!sidebar.isOpen && wideModeType === null ? 'lg:pl-[30px]' : ''}`}
             data-print-region="document"
             onViewportReady={handleViewportReady}
           >
@@ -1668,9 +1670,6 @@ const App: React.FC = () => {
                   onPlanDiffToggle={() => setIsPlanDiffActive(!isPlanDiffActive)}
                   archiveInfo={archive.currentInfo}
                   maxWidth={annotateReaderMaxWidth}
-                  showWideMode={canUseWideMode}
-                  wideMode={isWideMode}
-                  onWideModeToggle={toggleWideMode}
                   remountToken={linkedDocHook.isActive ? `doc:${linkedDocHook.filepath}` : 'plan'}
                 />
               )}
@@ -1684,9 +1683,6 @@ const App: React.FC = () => {
                     mode={editorMode}
                     onModeChange={handleEditorModeChange}
                     taterMode={taterMode}
-                    showWideMode={canUseWideMode}
-                    wideMode={isWideMode}
-                    onWideModeToggle={toggleWideMode}
                   />
                 </div>
               )}
@@ -1722,7 +1718,40 @@ const App: React.FC = () => {
                 </div>
               )}
               {/* Normal Plan View — always mounted, hidden during diff mode */}
-              <div className="w-full flex justify-center" style={{ display: (isPlanDiffActive && planDiff.diffBlocks) || (annotateSource === 'folder' && !markdown && !linkedDocHook.isActive) ? 'none' : undefined }}>
+              <div className="w-full flex justify-center relative" style={{ display: (isPlanDiffActive && planDiff.diffBlocks) || (annotateSource === 'folder' && !markdown && !linkedDocHook.isActive) ? 'none' : undefined }}>
+                {canUseWideMode && !isPlanDiffActive && !archive.archiveMode && (
+                  <div
+                    data-print-hide
+                    className="absolute -top-5 left-0 right-0 mx-auto w-full flex justify-end pointer-events-none"
+                    style={annotateReaderMaxWidth === null ? undefined : { maxWidth: annotateReaderMaxWidth ?? 832 }}
+                  >
+                    <div className={`pointer-events-auto flex items-center gap-1.5 text-[11px] tracking-wide ${taterMode ? 'mr-[60px]' : 'mr-[4px]'}`}>
+                      {(['wide', 'focus'] as const).map((type, i) => (
+                        <React.Fragment key={type}>
+                          {i > 0 && <span aria-hidden className="text-muted-foreground/30 select-none">|</span>}
+                          <Tooltip
+                            side="top"
+                            align="end"
+                            content={type === 'wide' ? 'Hide panels and expand document width' : 'Hide panels, keep document width'}
+                          >
+                            <button
+                              type="button"
+                              onClick={() => toggleViewMode(type)}
+                              aria-pressed={wideModeType === type}
+                              className={`cursor-pointer rounded-sm transition-colors duration-150 outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background active:opacity-80 ${
+                                wideModeType === type
+                                  ? 'text-foreground'
+                                  : 'text-muted-foreground/50 hover:text-muted-foreground'
+                              }`}
+                            >
+                              {type.charAt(0).toUpperCase() + type.slice(1)}
+                            </button>
+                          </Tooltip>
+                        </React.Fragment>
+                      ))}
+                    </div>
+                  </div>
+                )}
                 <Viewer
                   key={linkedDocHook.isActive ? `doc:${linkedDocHook.filepath}` : 'plan'}
                   ref={viewerRef}
@@ -1762,11 +1791,11 @@ const App: React.FC = () => {
           </OverlayScrollArea>
 
           {/* Resize Handle */}
-          {isPanelOpen && !isWideMode && <ResizeHandle {...panelResize.handleProps} className="hidden md:block" side="right" />}
+          {isPanelOpen && wideModeType === null && <ResizeHandle {...panelResize.handleProps} className="hidden md:block" side="right" />}
 
           {/* Annotation Panel */}
           <AnnotationPanel
-            isOpen={isPanelOpen && !isWideMode}
+            isOpen={isPanelOpen && wideModeType === null}
             blocks={blocks}
             annotations={allAnnotations}
             selectedId={selectedAnnotationId}
@@ -1955,6 +1984,7 @@ const App: React.FC = () => {
           }}
         />
       </div>
+      </TooltipProvider>
     </ThemeProvider>
   );
 };

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -313,10 +313,9 @@ const App: React.FC = () => {
   });
 
   const canUseWideMode = useMemo(() => canUseAnnotateWideMode({
-    annotateMode,
     archiveMode: archive.archiveMode,
     isPlanDiffActive,
-  }), [annotateMode, archive.archiveMode, isPlanDiffActive]);
+  }), [archive.archiveMode, isPlanDiffActive]);
 
   const enterViewMode = useCallback((type: WideModeType) => {
     if (!canUseWideMode) return;

--- a/packages/editor/wideMode.test.ts
+++ b/packages/editor/wideMode.test.ts
@@ -12,40 +12,24 @@ const snapshot: WideModeLayoutSnapshot = {
 };
 
 describe('canUseAnnotateWideMode', () => {
-  test('enables wide mode in both annotate and plan review, excluding archive and diff', () => {
+  test('enables wide mode outside archive and diff', () => {
     expect(canUseAnnotateWideMode({
-      annotateMode: true,
       archiveMode: false,
       isPlanDiffActive: false,
     })).toBe(true);
 
     expect(canUseAnnotateWideMode({
-      annotateMode: false,
-      archiveMode: false,
-      isPlanDiffActive: false,
-    })).toBe(true);
-
-    expect(canUseAnnotateWideMode({
-      annotateMode: true,
       archiveMode: true,
       isPlanDiffActive: false,
     })).toBe(false);
 
     expect(canUseAnnotateWideMode({
-      annotateMode: false,
-      archiveMode: true,
-      isPlanDiffActive: false,
-    })).toBe(false);
-
-    expect(canUseAnnotateWideMode({
-      annotateMode: true,
       archiveMode: false,
       isPlanDiffActive: true,
     })).toBe(false);
 
     expect(canUseAnnotateWideMode({
-      annotateMode: false,
-      archiveMode: false,
+      archiveMode: true,
       isPlanDiffActive: true,
     })).toBe(false);
   });

--- a/packages/editor/wideMode.test.ts
+++ b/packages/editor/wideMode.test.ts
@@ -12,7 +12,7 @@ const snapshot: WideModeLayoutSnapshot = {
 };
 
 describe('canUseAnnotateWideMode', () => {
-  test('only enables wide mode in annotate mode outside archive and diff', () => {
+  test('enables wide mode in both annotate and plan review, excluding archive and diff', () => {
     expect(canUseAnnotateWideMode({
       annotateMode: true,
       archiveMode: false,
@@ -23,7 +23,7 @@ describe('canUseAnnotateWideMode', () => {
       annotateMode: false,
       archiveMode: false,
       isPlanDiffActive: false,
-    })).toBe(false);
+    })).toBe(true);
 
     expect(canUseAnnotateWideMode({
       annotateMode: true,
@@ -32,7 +32,19 @@ describe('canUseAnnotateWideMode', () => {
     })).toBe(false);
 
     expect(canUseAnnotateWideMode({
+      annotateMode: false,
+      archiveMode: true,
+      isPlanDiffActive: false,
+    })).toBe(false);
+
+    expect(canUseAnnotateWideMode({
       annotateMode: true,
+      archiveMode: false,
+      isPlanDiffActive: true,
+    })).toBe(false);
+
+    expect(canUseAnnotateWideMode({
+      annotateMode: false,
       archiveMode: false,
       isPlanDiffActive: true,
     })).toBe(false);

--- a/packages/editor/wideMode.test.ts
+++ b/packages/editor/wideMode.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  canUseAnnotateWideMode,
+  resolveWideModeExitLayout,
+  type WideModeLayoutSnapshot,
+} from './wideMode';
+
+const snapshot: WideModeLayoutSnapshot = {
+  sidebarIsOpen: true,
+  sidebarTab: 'files',
+  panelOpen: true,
+};
+
+describe('canUseAnnotateWideMode', () => {
+  test('only enables wide mode in annotate mode outside archive and diff', () => {
+    expect(canUseAnnotateWideMode({
+      annotateMode: true,
+      archiveMode: false,
+      isPlanDiffActive: false,
+    })).toBe(true);
+
+    expect(canUseAnnotateWideMode({
+      annotateMode: false,
+      archiveMode: false,
+      isPlanDiffActive: false,
+    })).toBe(false);
+
+    expect(canUseAnnotateWideMode({
+      annotateMode: true,
+      archiveMode: true,
+      isPlanDiffActive: false,
+    })).toBe(false);
+
+    expect(canUseAnnotateWideMode({
+      annotateMode: true,
+      archiveMode: false,
+      isPlanDiffActive: true,
+    })).toBe(false);
+  });
+});
+
+describe('resolveWideModeExitLayout', () => {
+  test('restores the saved sidebar tab and panel by default', () => {
+    expect(resolveWideModeExitLayout(snapshot)).toEqual({
+      sidebarOpen: true,
+      sidebarTab: 'files',
+      panelOpen: true,
+    });
+  });
+
+  test('opens an explicit sidebar target and can keep the panel closed', () => {
+    expect(resolveWideModeExitLayout(snapshot, {
+      restore: false,
+      sidebarTab: 'toc',
+      panelOpen: false,
+    })).toEqual({
+      sidebarOpen: true,
+      sidebarTab: 'toc',
+      panelOpen: false,
+    });
+  });
+
+  test('honors an explicit panel reopen without restoring the sidebar snapshot', () => {
+    expect(resolveWideModeExitLayout(snapshot, {
+      restore: false,
+      panelOpen: true,
+    })).toEqual({
+      sidebarOpen: false,
+      sidebarTab: null,
+      panelOpen: true,
+    });
+  });
+
+  test('keeps the panel closed when leaving wide mode without restore', () => {
+    expect(resolveWideModeExitLayout(snapshot, {
+      restore: false,
+    })).toEqual({
+      sidebarOpen: false,
+      sidebarTab: null,
+      panelOpen: undefined,
+    });
+  });
+
+  test('falls back to a closed layout when the snapshot is missing', () => {
+    expect(resolveWideModeExitLayout(null)).toEqual({
+      sidebarOpen: false,
+      sidebarTab: null,
+      panelOpen: false,
+    });
+  });
+});

--- a/packages/editor/wideMode.ts
+++ b/packages/editor/wideMode.ts
@@ -1,0 +1,48 @@
+import type { SidebarTab } from '@plannotator/ui/hooks/useSidebar';
+
+export type WideModeLayoutSnapshot = {
+  sidebarIsOpen: boolean;
+  sidebarTab: SidebarTab;
+  panelOpen: boolean;
+};
+
+export type WideModeExitOptions = {
+  restore?: boolean;
+  sidebarTab?: SidebarTab;
+  panelOpen?: boolean;
+};
+
+export type WideModeExitLayout = {
+  sidebarOpen: boolean;
+  sidebarTab: SidebarTab | null;
+  panelOpen?: boolean;
+};
+
+export function canUseAnnotateWideMode(options: {
+  annotateMode: boolean;
+  archiveMode: boolean;
+  isPlanDiffActive: boolean;
+}): boolean {
+  return options.annotateMode && !options.archiveMode && !options.isPlanDiffActive;
+}
+
+export function resolveWideModeExitLayout(
+  snapshot: WideModeLayoutSnapshot | null,
+  options?: WideModeExitOptions,
+): WideModeExitLayout {
+  const restore = options?.restore !== false;
+
+  if (options?.sidebarTab) {
+    return {
+      sidebarOpen: true,
+      sidebarTab: options.sidebarTab,
+      panelOpen: options.panelOpen,
+    };
+  }
+
+  return {
+    sidebarOpen: restore ? (snapshot?.sidebarIsOpen ?? false) : false,
+    sidebarTab: restore && snapshot?.sidebarIsOpen ? snapshot.sidebarTab : null,
+    panelOpen: options?.panelOpen ?? (restore ? (snapshot?.panelOpen ?? false) : undefined),
+  };
+}

--- a/packages/editor/wideMode.ts
+++ b/packages/editor/wideMode.ts
@@ -1,4 +1,5 @@
 import type { SidebarTab } from '@plannotator/ui/hooks/useSidebar';
+export type { WideModeType } from '@plannotator/ui/types';
 
 export type WideModeLayoutSnapshot = {
   sidebarIsOpen: boolean;
@@ -23,7 +24,7 @@ export function canUseAnnotateWideMode(options: {
   archiveMode: boolean;
   isPlanDiffActive: boolean;
 }): boolean {
-  return options.annotateMode && !options.archiveMode && !options.isPlanDiffActive;
+  return !options.archiveMode && !options.isPlanDiffActive;
 }
 
 export function resolveWideModeExitLayout(

--- a/packages/editor/wideMode.ts
+++ b/packages/editor/wideMode.ts
@@ -20,7 +20,6 @@ export type WideModeExitLayout = {
 };
 
 export function canUseAnnotateWideMode(options: {
-  annotateMode: boolean;
   archiveMode: boolean;
   isPlanDiffActive: boolean;
 }): boolean {

--- a/packages/ui/components/AnnotationToolstrip.tsx
+++ b/packages/ui/components/AnnotationToolstrip.tsx
@@ -8,6 +8,9 @@ interface AnnotationToolstripProps {
   mode: EditorMode;
   onModeChange: (mode: EditorMode) => void;
   taterMode?: boolean;
+  showWideMode?: boolean;
+  wideMode?: boolean;
+  onWideModeToggle?: () => void;
   /**
    * Compact mode: used inside the sticky header lane. Buttons only expand for
    * the active mode (no hover expansion), gap is tightened, and the help link
@@ -28,6 +31,9 @@ export const AnnotationToolstrip: React.FC<AnnotationToolstripProps> = ({
   mode,
   onModeChange,
   taterMode,
+  showWideMode = false,
+  wideMode = false,
+  onWideModeToggle,
   compact = false,
   iconOnly = false,
 }) => {
@@ -142,6 +148,29 @@ export const AnnotationToolstrip: React.FC<AnnotationToolstripProps> = ({
               </svg>
             }
           />
+          {showWideMode && onWideModeToggle && (
+            <ToolstripButton
+              active={wideMode}
+              onClick={onWideModeToggle}
+              label="Wide"
+              color="primary"
+              mounted={mounted}
+              compact={compact}
+              iconOnly={iconOnly}
+              icon={
+                <svg className="w-3.5 h-3.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M3 8V5h3" />
+                  <path d="M21 8V5h-3" />
+                  <path d="M3 16v3h3" />
+                  <path d="M21 16v3h-3" />
+                  <path d="M8 5H6" />
+                  <path d="M18 5h-2" />
+                  <path d="M8 19H6" />
+                  <path d="M18 19h-2" />
+                </svg>
+              }
+            />
+          )}
         </div>
 
         {/* Help */}

--- a/packages/ui/components/AnnotationToolstrip.tsx
+++ b/packages/ui/components/AnnotationToolstrip.tsx
@@ -8,9 +8,6 @@ interface AnnotationToolstripProps {
   mode: EditorMode;
   onModeChange: (mode: EditorMode) => void;
   taterMode?: boolean;
-  showWideMode?: boolean;
-  wideMode?: boolean;
-  onWideModeToggle?: () => void;
   /**
    * Compact mode: used inside the sticky header lane. Buttons only expand for
    * the active mode (no hover expansion), gap is tightened, and the help link
@@ -31,9 +28,6 @@ export const AnnotationToolstrip: React.FC<AnnotationToolstripProps> = ({
   mode,
   onModeChange,
   taterMode,
-  showWideMode = false,
-  wideMode = false,
-  onWideModeToggle,
   compact = false,
   iconOnly = false,
 }) => {
@@ -148,29 +142,6 @@ export const AnnotationToolstrip: React.FC<AnnotationToolstripProps> = ({
               </svg>
             }
           />
-          {showWideMode && onWideModeToggle && (
-            <ToolstripButton
-              active={wideMode}
-              onClick={onWideModeToggle}
-              label="Wide"
-              color="primary"
-              mounted={mounted}
-              compact={compact}
-              iconOnly={iconOnly}
-              icon={
-                <svg className="w-3.5 h-3.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M3 8V5h3" />
-                  <path d="M21 8V5h-3" />
-                  <path d="M3 16v3h3" />
-                  <path d="M21 16v3h-3" />
-                  <path d="M8 5H6" />
-                  <path d="M18 5h-2" />
-                  <path d="M8 19H6" />
-                  <path d="M18 19h-2" />
-                </svg>
-              }
-            />
-          )}
         </div>
 
         {/* Help */}

--- a/packages/ui/components/StickyHeaderLane.tsx
+++ b/packages/ui/components/StickyHeaderLane.tsx
@@ -62,6 +62,9 @@ interface StickyHeaderLaneProps {
   mode: EditorMode;
   onModeChange: (mode: EditorMode) => void;
   taterMode?: boolean;
+  showWideMode?: boolean;
+  wideMode?: boolean;
+  onWideModeToggle?: () => void;
 
   // Badge state
   repoInfo?: { display: string; branch?: string } | null;
@@ -72,7 +75,7 @@ interface StickyHeaderLaneProps {
   archiveInfo?: { status: 'approved' | 'denied' | 'unknown'; timestamp: string; title: string } | null;
 
   // Layout
-  maxWidth?: number;
+  maxWidth?: number | null;
 
   // Re-query token for the [data-sticky-actions] ResizeObserver. When the
   // Viewer remounts (e.g., toggling a linked doc), its `data-sticky-actions`
@@ -89,6 +92,9 @@ export const StickyHeaderLane: React.FC<StickyHeaderLaneProps> = ({
   mode,
   onModeChange,
   taterMode,
+  showWideMode = false,
+  wideMode = false,
+  onWideModeToggle,
   repoInfo,
   planDiffStats,
   isPlanDiffActive,
@@ -196,7 +202,7 @@ export const StickyHeaderLane: React.FC<StickyHeaderLaneProps> = ({
         className={`sticky z-[60] w-full self-center pointer-events-none ${
           isNarrow ? 'top-[52px] md:top-[60px]' : 'top-3'
         }`}
-        style={{ maxWidth, height: 0 }}
+        style={maxWidth == null ? { height: 0 } : { maxWidth, height: 0 }}
       >
         {/* Responsive bar.
 
@@ -239,6 +245,9 @@ export const StickyHeaderLane: React.FC<StickyHeaderLaneProps> = ({
               mode={mode}
               onModeChange={onModeChange}
               taterMode={taterMode}
+              showWideMode={showWideMode}
+              wideMode={wideMode}
+              onWideModeToggle={onWideModeToggle}
               compact
               iconOnly={isNarrow || isToolstripIconOnly}
             />

--- a/packages/ui/components/StickyHeaderLane.tsx
+++ b/packages/ui/components/StickyHeaderLane.tsx
@@ -62,9 +62,6 @@ interface StickyHeaderLaneProps {
   mode: EditorMode;
   onModeChange: (mode: EditorMode) => void;
   taterMode?: boolean;
-  showWideMode?: boolean;
-  wideMode?: boolean;
-  onWideModeToggle?: () => void;
 
   // Badge state
   repoInfo?: { display: string; branch?: string } | null;
@@ -92,9 +89,6 @@ export const StickyHeaderLane: React.FC<StickyHeaderLaneProps> = ({
   mode,
   onModeChange,
   taterMode,
-  showWideMode = false,
-  wideMode = false,
-  onWideModeToggle,
   repoInfo,
   planDiffStats,
   isPlanDiffActive,
@@ -245,9 +239,6 @@ export const StickyHeaderLane: React.FC<StickyHeaderLaneProps> = ({
               mode={mode}
               onModeChange={onModeChange}
               taterMode={taterMode}
-              showWideMode={showWideMode}
-              wideMode={wideMode}
-              onWideModeToggle={onWideModeToggle}
               compact
               iconOnly={isNarrow || isToolstripIconOnly}
             />

--- a/packages/ui/components/Tooltip.tsx
+++ b/packages/ui/components/Tooltip.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import * as RadixTooltip from '@radix-ui/react-tooltip';
+
+export const TooltipProvider = RadixTooltip.Provider;
+
+interface TooltipProps {
+  content: React.ReactNode;
+  children: React.ReactNode;
+  side?: 'top' | 'right' | 'bottom' | 'left';
+  align?: 'start' | 'center' | 'end';
+  delayDuration?: number;
+  sideOffset?: number;
+}
+
+export const Tooltip: React.FC<TooltipProps> = ({
+  content,
+  children,
+  side = 'top',
+  align = 'center',
+  delayDuration,
+  sideOffset = 8,
+}) => (
+  <RadixTooltip.Root delayDuration={delayDuration}>
+    <RadixTooltip.Trigger asChild>{children}</RadixTooltip.Trigger>
+    <RadixTooltip.Portal>
+      <RadixTooltip.Content
+        side={side}
+        align={align}
+        sideOffset={sideOffset}
+        className="z-50 px-2 py-1 text-xs bg-popover text-popover-foreground border border-border rounded shadow-md whitespace-nowrap origin-[var(--radix-tooltip-content-transform-origin)] transition-[opacity,transform] duration-150 ease-out data-[state=closed]:opacity-0 data-[state=closed]:scale-95 data-[state=delayed-open]:opacity-100 data-[state=delayed-open]:scale-100 data-[state=instant-open]:opacity-100 data-[state=instant-open]:scale-100"
+      >
+        {content}
+      </RadixTooltip.Content>
+    </RadixTooltip.Portal>
+  </RadixTooltip.Root>
+);

--- a/packages/ui/components/Viewer.tsx
+++ b/packages/ui/components/Viewer.tsx
@@ -66,8 +66,8 @@ interface ViewerProps {
   hasPreviousVersion?: boolean;
   /** Show amber "Demo" badge (portal mode, no shared content loaded) */
   showDemoBadge?: boolean;
-  /** Max width in px for the plan card (from plan width setting) */
-  maxWidth?: number;
+  /** Max width in px for the plan card; null removes the cap entirely. */
+  maxWidth?: number | null;
   /** Label for the copy button (default: "Copy plan") */
   copyLabel?: string;
   /**
@@ -443,7 +443,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
   }, []);
 
   return (
-    <div className="relative z-50 w-full" style={maxWidth ? { maxWidth } : { maxWidth: 832 }}>
+    <div className="relative z-50 w-full" style={maxWidth === null ? undefined : { maxWidth: maxWidth ?? 832 }}>
       {taterMode && <TaterSpriteSitting />}
       <article
         ref={containerRef}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@plannotator/shared": "workspace:*",
     "@plannotator/web-highlighter": "^0.8.1",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@viz-js/viz": "^3.25.0",
     "diff": "^8.0.3",
     "highlight.js": "^11.11.1",

--- a/packages/ui/types.ts
+++ b/packages/ui/types.ts
@@ -18,6 +18,8 @@ export type InputMethod = 'drag' | 'pinpoint';
  */
 export type ActionsLabelMode = 'full' | 'short' | 'icon';
 
+export type WideModeType = 'wide' | 'focus';
+
 export interface ImageAttachment {
   path: string;
   name: string;


### PR DESCRIPTION
## Summary
Adds an annotate-only wide mode so wide tables can be reviewed and annotated without the left TOC or right annotations panel consuming horizontal space.

## Why
Plannotator's annotate view is hard to use on wide markdown tables because the reader stays capped while both side panels remain available. This change adds a focused reading mode for annotate sessions that expands the document area and keeps annotation flows working without reopening the right panel.

## What changed
- add a wide-mode toggle beside the lightning-bolt action in the annotate toolstrip and sticky header lane
- gate the feature to annotate mode only so plan review, diff, archive, linked-doc non-annotate flows, and review-editor do not gain new UI
- collapse the left sidebar, hide left collapsed tab flags, hide the right annotations panel and resize handle, and remove the annotate reader width cap while wide mode is active
- restore the exact pre-wide sidebar/panel layout when wide mode is turned off
- exit wide mode before any explicit sidebar or annotations-panel reopen action
- add focused helper/test coverage for annotate-wide-mode gating and layout restore rules
- add the missing `@plannotator/shared` Vite alias in the hook/review apps so local builds stay green from this checkout
- add an adversarial rubric file required for red-team auditing of this milestone

## Verification
- `bun test packages/editor/wideMode.test.ts`
- `bun x tsc --noEmit -p packages/shared/tsconfig.json && bun x tsc --noEmit -p packages/ai/tsconfig.json && bun x tsc --noEmit -p packages/server/tsconfig.json`
- `bun run --cwd apps/review build`
- `bun run build:hook`
- manual local plugin swap and roundtrip validation between installed production plugin and local `apps/hook`

## Local test notes
After swapping Claude's installed Plannotator plugin to this branch locally, annotate mode now exposes the wide-mode toggle next to the lightning bolt. Toggling it should hide both side panels, widen the reader, keep the right panel hidden while creating annotations, and restore the previous layout when toggled off.