### PR TITLE
Disable model invocation for plannotator commands

### DIFF
--- a/apps/hook/commands/plannotator-annotate.md
+++ b/apps/hook/commands/plannotator-annotate.md
@@ -1,6 +1,7 @@
 ---
 description: Open interactive annotation UI for a markdown file or folder
 allowed-tools: Bash(plannotator:*)
+disable-model-invocation: true
 ---
 
 ## Markdown Annotations

--- a/apps/hook/commands/plannotator-archive.md
+++ b/apps/hook/commands/plannotator-archive.md
@@ -1,6 +1,7 @@
 ---
 description: Browse saved plan decisions in the archive
 allowed-tools: Bash(plannotator:*)
+disable-model-invocation: true
 ---
 
 ## Plan Archive

--- a/apps/hook/commands/plannotator-last.md
+++ b/apps/hook/commands/plannotator-last.md
@@ -1,6 +1,7 @@
 ---
 description: Annotate the last rendered assistant message
 allowed-tools: Bash(plannotator:*)
+disable-model-invocation: true
 ---
 
 ## Message Annotations

--- a/apps/hook/commands/plannotator-review.md
+++ b/apps/hook/commands/plannotator-review.md
@@ -1,6 +1,7 @@
 ---
 description: Open interactive code review for current changes or a PR URL
 allowed-tools: Bash(plannotator:*)
+disable-model-invocation: true
 ---
 
 ## Code Review Feedback


### PR DESCRIPTION
## Summary
Added `disable-model-invocation: true` configuration to all plannotator command definitions to prevent automatic model invocation when these commands are executed.

## Changes
- **plannotator-annotate.md**: Added `disable-model-invocation: true` to command metadata
- **plannotator-archive.md**: Added `disable-model-invocation: true` to command metadata
- **plannotator-last.md**: Added `disable-model-invocation: true` to command metadata
- **plannotator-review.md**: Added `disable-model-invocation: true` to command metadata

## Details
This change ensures that all plannotator commands operate in a non-interactive model mode, preventing the AI model from being automatically invoked during command execution. This is consistent across all four plannotator command variants and allows these tools to function independently without triggering model responses.
