### PR TITLE
Update print menu label and add PDF save instructions

### DIFF
--- a/packages/ui/components/PlanHeaderMenu.tsx
+++ b/packages/ui/components/PlanHeaderMenu.tsx
@@ -151,7 +151,8 @@ export const PlanHeaderMenu: React.FC<PlanHeaderMenuProps> = ({
               onPrint();
             }}
             icon={<PrintIcon />}
-            label="Print Plan"
+            label="Print / Save as PDF"
+            subtitle="Choose 'Save as PDF' in the print dialog"
           />
           {sharingEnabled && (
             <ActionMenuItem


### PR DESCRIPTION
## Summary
Updated the print action menu item to clarify that users can save as PDF through the print dialog, and added helpful instructions to guide users on how to do so.

## Changes
- Changed the action menu label from "Print Plan" to "Print / Save as PDF" to better reflect the available functionality
- Added a subtitle with instructions: "Choose 'Save as PDF' in the print dialog" to help users discover the PDF export capability

## Details
This change improves the discoverability of the PDF export feature by making it clear that users can save the plan as a PDF through the existing print dialog, rather than requiring a separate export function. The subtitle provides clear guidance on how to access this feature.
