### PR TITLE
Add thumbs up quick label button to annotation toolbar

### DIFF
--- a/packages/ui/components/AnnotationToolbar.tsx
+++ b/packages/ui/components/AnnotationToolbar.tsx
@@ -218,17 +218,17 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
         {onQuickLabel && (
           <>
             <ToolbarButton
-              onClick={() => onQuickLabel(THUMBS_UP_LABEL)}
-              icon={<span className="block w-4 h-4 text-sm leading-4 text-center">👍</span>}
-              label="Looks good"
-              className="hover:bg-green-500/10"
-            />
-            <ToolbarButton
               ref={zapButtonRef}
               onClick={() => setShowQuickLabels(prev => !prev)}
               icon={<ZapIcon />}
               label="Quick label"
               className={showQuickLabels ? "text-amber-500 bg-amber-500/10" : "text-amber-500 hover:bg-amber-500/10"}
+            />
+            <ToolbarButton
+              onClick={() => onQuickLabel(THUMBS_UP_LABEL)}
+              icon={<span className="block w-4 h-4 text-sm leading-4 text-center">👍</span>}
+              label="Looks good"
+              className="hover:bg-green-500/10"
             />
             {showQuickLabels && zapButtonRef.current && (
               <FloatingQuickLabelPicker

--- a/packages/ui/components/AnnotationToolbar.tsx
+++ b/packages/ui/components/AnnotationToolbar.tsx
@@ -7,6 +7,13 @@ import { FloatingQuickLabelPicker } from "./FloatingQuickLabelPicker";
 
 type PositionMode = 'center-above' | 'top-right';
 
+const THUMBS_UP_LABEL: QuickLabel = {
+  id: 'thumbs-up',
+  emoji: '👍',
+  text: 'Looks good',
+  color: 'green',
+};
+
 const isEditableElement = (node: EventTarget | Element | null): boolean => {
   if (!(node instanceof Element)) return false;
   if (node.matches('input, textarea, select, [role="textbox"]')) return true;
@@ -210,6 +217,12 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
         />
         {onQuickLabel && (
           <>
+            <ToolbarButton
+              onClick={() => onQuickLabel(THUMBS_UP_LABEL)}
+              icon={<span className="block w-4 h-4 text-sm leading-4 text-center">👍</span>}
+              label="Looks good"
+              className="hover:bg-green-500/10"
+            />
             <ToolbarButton
               ref={zapButtonRef}
               onClick={() => setShowQuickLabels(prev => !prev)}


### PR DESCRIPTION
## Summary
Added a "Looks good" quick label button with a thumbs up emoji (👍) to the annotation toolbar, providing users with a quick way to mark content as approved.

## Key Changes
- Defined a new `THUMBS_UP_LABEL` constant with id, emoji, text, and green color styling
- Added a new toolbar button that triggers the `onQuickLabel` callback with the thumbs up label
- Positioned the button before the existing quick labels menu button
- Applied green hover styling (`hover:bg-green-500/10`) to match the label's semantic meaning

## Implementation Details
- The button uses the same `ToolbarButton` component as other toolbar actions
- The emoji is rendered as a centered span with appropriate sizing (w-4 h-4)
- The button is only rendered when `onQuickLabel` callback is provided, maintaining existing conditional rendering patterns