### PR TITLE
feat: detect OpenCode origin + activate PLANNOTATOR_ORIGIN override

### DIFF
--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -80,7 +80,7 @@ import { detectProjectName } from "@plannotator/server/project";
 import { hostnameOrFallback } from "@plannotator/shared/project";
 import { planDenyFeedback } from "@plannotator/shared/feedback-templates";
 import { readImprovementHook } from "@plannotator/shared/improvement-hooks";
-import type { Origin } from "@plannotator/shared/agents";
+import { AGENT_CONFIG, type Origin } from "@plannotator/shared/agents";
 import { findSessionLogsForCwd, resolveSessionLogByPpid, findSessionLogsByAncestorWalk, getLastRenderedMessage, type RenderedMessage } from "./session-log";
 import { findCodexRolloutByThreadId, getLastCodexMessage } from "./codex-session";
 import { findCopilotPlanContent, findCopilotSessionForCwd, getLastCopilotMessage } from "./copilot-session";
@@ -140,10 +140,21 @@ const shareBaseUrl = process.env.PLANNOTATOR_SHARE_URL || undefined;
 const pasteApiUrl = process.env.PLANNOTATOR_PASTE_URL || undefined;
 
 // Detect calling agent from environment variables set by agent runtimes.
-// Priority: Codex > Copilot CLI > Claude Code (default fallback)
+// Priority:
+//   PLANNOTATOR_ORIGIN (explicit override, validated against AGENT_CONFIG)
+//   > Codex (CODEX_THREAD_ID)
+//   > Copilot CLI (COPILOT_CLI)
+//   > OpenCode (OPENCODE)
+//   > Claude Code (default fallback)
+//
+// To add a new agent, also add an entry to AGENT_CONFIG in
+// packages/shared/agents.ts (see header comment there).
+const originOverride = process.env.PLANNOTATOR_ORIGIN as Origin | undefined;
 const detectedOrigin: Origin =
+  (originOverride && originOverride in AGENT_CONFIG) ? originOverride :
   process.env.CODEX_THREAD_ID ? "codex" :
   process.env.COPILOT_CLI ? "copilot-cli" :
+  process.env.OPENCODE ? "opencode" :
   "claude-code";
 
 if (args[0] === "sessions") {

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -6,7 +6,10 @@
  * Environment variables:
  *   PLANNOTATOR_REMOTE - Set to "1"/"true" for remote, "0"/"false" for local
  *   PLANNOTATOR_PORT   - Fixed port to use (default: random locally, 19432 for remote)
- *   PLANNOTATOR_ORIGIN - Origin identifier ("claude-code" or "opencode")
+ *   PLANNOTATOR_ORIGIN - Explicit origin override; validated against AGENT_CONFIG
+ *                        in packages/shared/agents.ts. Supported values:
+ *                        "claude-code", "opencode", "codex", "copilot-cli",
+ *                        "gemini-cli", "pi".
  */
 
 import type { Origin } from "@plannotator/shared/agents";
@@ -271,10 +274,10 @@ export async function startPlannotatorServer(
                 sharingEnabled,
                 shareBaseUrl,
                 isWSL: wslFlag,
-                serverConfig: getServerConfig(gitUser),
+                serverConfig: getServerConfig(gitUser, project),
               });
             }
-            return Response.json({ plan, origin, permissionMode, sharingEnabled, shareBaseUrl, pasteApiUrl, repoInfo, previousPlan, versionInfo, projectRoot: process.cwd(), isWSL: wslFlag, serverConfig: getServerConfig(gitUser) });
+            return Response.json({ plan, origin, permissionMode, sharingEnabled, shareBaseUrl, pasteApiUrl, repoInfo, previousPlan, versionInfo, projectRoot: process.cwd(), isWSL: wslFlag, serverConfig: getServerConfig(gitUser, project) });
           }
 
           // API: Serve a linked markdown document

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -274,10 +274,10 @@ export async function startPlannotatorServer(
                 sharingEnabled,
                 shareBaseUrl,
                 isWSL: wslFlag,
-                serverConfig: getServerConfig(gitUser, project),
+                serverConfig: getServerConfig(gitUser),
               });
             }
-            return Response.json({ plan, origin, permissionMode, sharingEnabled, shareBaseUrl, pasteApiUrl, repoInfo, previousPlan, versionInfo, projectRoot: process.cwd(), isWSL: wslFlag, serverConfig: getServerConfig(gitUser, project) });
+            return Response.json({ plan, origin, permissionMode, sharingEnabled, shareBaseUrl, pasteApiUrl, repoInfo, previousPlan, versionInfo, projectRoot: process.cwd(), isWSL: wslFlag, serverConfig: getServerConfig(gitUser) });
           }
 
           // API: Serve a linked markdown document


### PR DESCRIPTION
## Summary

- Add OpenCode (`process.env.OPENCODE`) to the origin detection chain in `apps/hook/server/index.ts`. Without this, every OpenCode invocation defaults to `"claude-code"` and loads the wrong UI variant (missing agent-switch toggle, wrong badge).
- Activate `PLANNOTATOR_ORIGIN` as an explicit override. The comment in `packages/server/index.ts` already documented this variable, but it was never read. It is now honored at the top of the detection chain and validated against `AGENT_CONFIG` so invalid values fall through to env-based detection.

## Context

The `'opencode'` origin key is already defined in `packages/shared/agents.ts` (`AGENT_CONFIG`), complete with a UI badge class — the detection chain was the last missing piece. The header comment of that file explicitly calls out the extension point:

> *"If detection is via environment variable, add it to the detection chain in `apps/hook/server/index.ts` (detectedOrigin constant)"*

This PR closes that gap. It also turns the `PLANNOTATOR_ORIGIN` comment in `packages/server/index.ts` from a dead symbol into a live override (useful for testing and edge-case forcing).

## Detection priority after this change

```
PLANNOTATOR_ORIGIN > Codex (CODEX_THREAD_ID) > Copilot CLI (COPILOT_CLI) > OpenCode (OPENCODE) > Claude Code (default)
```

## Why `OPENCODE=1` specifically

Among OpenCode's runtime env vars (`OPENCODE`, `OPENCODE_RUN_ID`, `OPENCODE_PID`, `OPENCODE_PROCESS_ROLE`, `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT`), `OPENCODE=1` is the canonical runtime flag — set unconditionally by the OpenCode binary, not session- or role-specific. Matches the existing pattern (`CODEX_THREAD_ID`, `COPILOT_CLI`).

## Scope

Single-point fix — all five existing `detectedOrigin` consumers (lines 405, 568, 694, 741, 999) pick up the new chain automatically. No changes to UI components, the `Origin` type, `AGENT_CONFIG`, or any other agent-specific code paths.

## Test Plan

Headless detection tests (7/7 pass locally):

| Scenario | Env | Expected | Got |
|---|---|---|---|
| OpenCode only | `OPENCODE=1` | `opencode` | ✓ |
| Default fallback | (none) | `claude-code` | ✓ |
| Codex wins over OpenCode | `CODEX_THREAD_ID=... OPENCODE=1` | `codex` | ✓ |
| Copilot wins over OpenCode | `COPILOT_CLI=1 OPENCODE=1` | `copilot-cli` | ✓ |
| Override valid | `PLANNOTATOR_ORIGIN=claude-code OPENCODE=1` | `claude-code` | ✓ |
| Override invalid | `PLANNOTATOR_ORIGIN=fake OPENCODE=1` | `opencode` (falls through) | ✓ |
| Override without env | `PLANNOTATOR_ORIGIN=gemini-cli` | `gemini-cli` | ✓ |

## Docs

Comment block at `apps/hook/server/index.ts:142-151` updated with the full priority order and cross-reference to `AGENT_CONFIG`. Comment at `packages/server/index.ts:9` updated from "(claude-code or opencode)" to the full supported-values list.