### PR TITLE
fix(pi): loosen plan-mode write gate to directory scope

### DIFF
--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -53,6 +53,7 @@ import {
 } from "./plannotator-events.js";
 import {
 	getToolsForPhase,
+	isPlanWritePathAllowed,
 	PLAN_SUBMIT_TOOL,
 	type Phase,
 	stripPlanningOnlyTools,
@@ -703,24 +704,13 @@ export default function plannotator(pi: ExtensionAPI): void {
 	pi.on("tool_call", async (event, ctx) => {
 		if (phase !== "planning") return;
 
-		if (event.toolName === "write") {
-			const targetPath = resolve(ctx.cwd, event.input.path as string);
-			const allowedPath = resolvePlanPath(ctx.cwd);
-			if (targetPath !== allowedPath) {
+		if (event.toolName === "write" || event.toolName === "edit") {
+			const inputPath = event.input.path as string;
+			if (!isPlanWritePathAllowed(planFilePath, inputPath, ctx.cwd)) {
+				const verb = event.toolName === "write" ? "writes" : "edits";
 				return {
 					block: true,
-					reason: `Plannotator: writes are restricted to ${planFilePath} during planning. Blocked: ${event.input.path}`,
-				};
-			}
-		}
-
-		if (event.toolName === "edit") {
-			const targetPath = resolve(ctx.cwd, event.input.path as string);
-			const allowedPath = resolvePlanPath(ctx.cwd);
-			if (targetPath !== allowedPath) {
-				return {
-					block: true,
-					reason: `Plannotator: edits are restricted to ${planFilePath} during planning. Blocked: ${event.input.path}`,
+					reason: `Plannotator: ${verb} are restricted to ${planFilePath} during planning. Blocked: ${inputPath}`,
 				};
 			}
 		}

--- a/apps/pi-extension/tool-scope.test.ts
+++ b/apps/pi-extension/tool-scope.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
 	getToolsForPhase,
+	isPlanWritePathAllowed,
 	PLAN_SUBMIT_TOOL,
 	stripPlanningOnlyTools,
 } from "./tool-scope";
@@ -42,5 +43,37 @@ describe("pi plan tool scoping", () => {
 			"question",
 			"read",
 		]);
+	});
+});
+
+describe("plan write path gate", () => {
+	const cwd = "/r";
+
+	test("default PLAN.md allows exact file and blocks everything else", () => {
+		expect(isPlanWritePathAllowed("PLAN.md", "PLAN.md", cwd)).toBe(true);
+		expect(isPlanWritePathAllowed("PLAN.md", "src/app.ts", cwd)).toBe(false);
+	});
+
+	test("trailing-slash directory scopes to files inside", () => {
+		expect(isPlanWritePathAllowed("plans/", "plans/foo.md", cwd)).toBe(true);
+		expect(isPlanWritePathAllowed("plans/", "src/app.ts", cwd)).toBe(false);
+	});
+
+	test("bare directory name (no slash, no extension) scopes to files inside", () => {
+		expect(isPlanWritePathAllowed("plans", "plans/foo.md", cwd)).toBe(true);
+		expect(isPlanWritePathAllowed("plans", "src/app.ts", cwd)).toBe(false);
+	});
+
+	test("file inside a subdir allows siblings and blocks outside", () => {
+		expect(isPlanWritePathAllowed("plans/foo.md", "plans/bar.md", cwd)).toBe(true);
+		expect(isPlanWritePathAllowed("plans/foo.md", "src/app.ts", cwd)).toBe(false);
+	});
+
+	test("path traversal is rejected", () => {
+		expect(isPlanWritePathAllowed("plans/", "../../etc/passwd", cwd)).toBe(false);
+	});
+
+	test("absolute input paths resolve the same as relative", () => {
+		expect(isPlanWritePathAllowed("plans/", "/r/plans/foo.md", cwd)).toBe(true);
 	});
 });

--- a/apps/pi-extension/tool-scope.ts
+++ b/apps/pi-extension/tool-scope.ts
@@ -1,3 +1,5 @@
+import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path";
+
 export type Phase = "idle" | "planning" | "executing";
 
 export const PLAN_SUBMIT_TOOL = "plannotator_submit_plan";
@@ -21,4 +23,33 @@ export function getToolsForPhase(
 	return [
 		...new Set([...tools, ...PLANNING_DISCOVERY_TOOLS, PLAN_SUBMIT_TOOL]),
 	];
+}
+
+// Treat planFilePath as directory-scoped when it ends with a separator or its
+// basename has no extension (e.g. "plans/", "plans"). Otherwise scope is the
+// single file.
+function isPlanPathDirectoryScoped(planFilePath: string): boolean {
+	if (planFilePath.endsWith("/") || planFilePath.endsWith(sep)) return true;
+	const base = basename(planFilePath);
+	return base.length > 0 && !base.includes(".");
+}
+
+export function isPlanWritePathAllowed(
+	planFilePath: string,
+	inputPath: string,
+	cwd: string,
+): boolean {
+	const targetAbs = resolve(cwd, inputPath);
+	const allowedAbs = resolve(cwd, planFilePath);
+	if (targetAbs === allowedAbs) return true;
+
+	const dirScoped = isPlanPathDirectoryScoped(planFilePath);
+	const scopeDir = dirScoped ? allowedAbs : dirname(allowedAbs);
+
+	// Never scope to cwd root — a default like "PLAN.md" would otherwise unlock
+	// every file in the project.
+	if (resolve(scopeDir) === resolve(cwd)) return false;
+
+	const rel = relative(scopeDir, targetAbs);
+	return rel !== "" && !rel.startsWith("..") && !isAbsolute(rel);
 }


### PR DESCRIPTION
## Summary

- Plan-mode `write`/`edit` gate did an exact-path comparison against `planFilePath`, so `/plannotator plans/` blocked *every* file inside `plans/` and the agent fell back to `bash cat > file` to bypass it.
- Gate is now directory-scoped when `planFilePath` ends with a separator, has no file extension, or points to a subdirectory. Default `PLAN.md` behavior is unchanged.
- Extracted the logic to a pure function (`isPlanWritePathAllowed`) in `tool-scope.ts` with 6 new unit tests.

## Repro that now works

```
$ /plannotator plans/
$ "make a simple plan for snake game"
→ agent writes plans/snake_game_plan.md (allowed), no bash fallback
```

## Test plan

- [x] `bun test apps/pi-extension/tool-scope.test.ts` — 9 pass, 0 fail
- [x] `tsc --noEmit -p apps/pi-extension/tsconfig.json` — clean
- [ ] Manual: `/plannotator plans/` in a fresh project, confirm plan writes succeed
- [ ] Manual: `/plannotator PLAN.md` (default), confirm behavior unchanged and writes to `src/` still blocked
- [ ] Manual: `/plannotator plans/auth.md`, confirm sibling writes (`plans/notes.md`) allowed, writes outside blocked