### PR TITLE
fix(session-log): walk ancestor PIDs to resolve correct session log

### DIFF
--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -81,7 +81,14 @@ import { hostnameOrFallback } from "@plannotator/shared/project";
 import { planDenyFeedback } from "@plannotator/shared/feedback-templates";
 import { readImprovementHook } from "@plannotator/shared/improvement-hooks";
 import { AGENT_CONFIG, type Origin } from "@plannotator/shared/agents";
-import { findSessionLogsForCwd, resolveSessionLogByAncestorPids, resolveSessionLogByCwdScan, findSessionLogsByAncestorWalk, getLastRenderedMessage, type RenderedMessage } from "./session-log";
+import {
+  findSessionLogsByAncestorWalk,
+  findSessionLogsForCwd,
+  getLastRenderedMessage,
+  resolveSessionLogByAncestorPids,
+  resolveSessionLogByCwdScan,
+  type RenderedMessage,
+} from "./session-log";
 import { findCodexRolloutByThreadId, getLastCodexMessage } from "./codex-session";
 import { findCopilotPlanContent, findCopilotSessionForCwd, getLastCopilotMessage } from "./copilot-session";
 import {

--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -81,7 +81,7 @@ import { hostnameOrFallback } from "@plannotator/shared/project";
 import { planDenyFeedback } from "@plannotator/shared/feedback-templates";
 import { readImprovementHook } from "@plannotator/shared/improvement-hooks";
 import { AGENT_CONFIG, type Origin } from "@plannotator/shared/agents";
-import { findSessionLogsForCwd, resolveSessionLogByPpid, findSessionLogsByAncestorWalk, getLastRenderedMessage, type RenderedMessage } from "./session-log";
+import { findSessionLogsForCwd, resolveSessionLogByAncestorPids, resolveSessionLogByCwdScan, findSessionLogsByAncestorWalk, getLastRenderedMessage, type RenderedMessage } from "./session-log";
 import { findCodexRolloutByThreadId, getLastCodexMessage } from "./codex-session";
 import { findCopilotPlanContent, findCopilotSessionForCwd, getLastCopilotMessage } from "./copilot-session";
 import {
@@ -652,12 +652,18 @@ if (args[0] === "sessions") {
     // Claude Code path: resolve session log
     //
     // Strategy (most precise → least precise):
-    // 1. PPID session metadata: ~/.claude/sessions/<ppid>.json gives us the
-    //    exact sessionId and original cwd. Deterministic, O(1), no scanning.
-    // 2. CWD slug match: existing behavior — works when the shell CWD hasn't
-    //    changed from the session's project directory.
-    // 3. Ancestor walk: walk up the directory tree trying parent slugs. Handles
-    //    the common case where the user `cd`'d deeper into a subdirectory.
+    // 1. Ancestor-PID session metadata: walk up the process tree checking
+    //    ~/.claude/sessions/<pid>.json at each hop. When invoked from a slash
+    //    command's `!` bang, the direct parent is a bash subshell — Claude's
+    //    session file is a few hops up. Deterministic when it matches.
+    // 2. Cwd-scan of session metadata: read every ~/.claude/sessions/*.json,
+    //    filter by cwd, pick the most recent startedAt. Better than mtime
+    //    guessing because it uses session-level metadata.
+    // 3. CWD slug match (mtime-based): legacy behavior — picks the most
+    //    recently modified jsonl in the project dir. Fragile when multiple
+    //    sessions exist for the same project.
+    // 4. Ancestor directory walk: handles the case where the user `cd`'d
+    //    deeper into a subdirectory after session start.
 
     if (process.env.PLANNOTATOR_DEBUG) {
       console.error(`[DEBUG] Project root: ${projectRoot}`);
@@ -677,15 +683,19 @@ if (args[0] === "sessions") {
       }
     }
 
-    // 1. Try PPID-based session metadata (most reliable)
-    const ppidLog = resolveSessionLogByPpid();
-    tryLogCandidates("PPID session metadata", () => ppidLog ? [ppidLog] : []);
+    // 1. Walk ancestor PIDs for a matching session metadata file
+    const ancestorLog = resolveSessionLogByAncestorPids();
+    tryLogCandidates("Ancestor PID session metadata", () => ancestorLog ? [ancestorLog] : []);
 
-    // 2. Fall back to CWD slug match
-    tryLogCandidates("CWD slug match", () => findSessionLogsForCwd(projectRoot));
+    // 2. Scan all session metadata files for one whose cwd matches
+    const cwdScanLog = resolveSessionLogByCwdScan({ cwd: projectRoot });
+    tryLogCandidates("Cwd-scan session metadata", () => cwdScanLog ? [cwdScanLog] : []);
 
-    // 3. Fall back to ancestor directory walk
-    tryLogCandidates("Ancestor walk", () => findSessionLogsByAncestorWalk(projectRoot));
+    // 3. Fall back to CWD slug match (mtime-based)
+    tryLogCandidates("CWD slug match (mtime)", () => findSessionLogsForCwd(projectRoot));
+
+    // 4. Fall back to ancestor directory walk
+    tryLogCandidates("Directory ancestor walk", () => findSessionLogsByAncestorWalk(projectRoot));
   }
 
   if (!lastMessage) {

--- a/apps/hook/server/session-log.test.ts
+++ b/apps/hook/server/session-log.test.ts
@@ -16,6 +16,9 @@ import {
   projectSlugFromCwd,
   findSessionLogsByAncestorWalk,
   findSessionLogsForCwd,
+  getAncestorPids,
+  resolveSessionLogByAncestorPids,
+  resolveSessionLogByCwdScan,
   type SessionLogEntry,
 } from "./session-log";
 import { mkdirSync, writeFileSync, rmSync } from "node:fs";
@@ -632,6 +635,298 @@ describe("findSessionLogsByAncestorWalk", () => {
       expect(result.every((p) => !p.includes(slugDir))).toBe(true);
     } finally {
       rmSync(slugDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// --- Resolver Tests (new) ---
+
+describe("getAncestorPids", () => {
+  test("returns empty array for invalid startPid", () => {
+    expect(getAncestorPids(0, 5, () => null)).toEqual([]);
+    expect(getAncestorPids(1, 5, () => null)).toEqual([]);
+  });
+
+  test("returns startPid when there is no parent", () => {
+    expect(getAncestorPids(100, 5, () => null)).toEqual([100]);
+  });
+
+  test("walks up the PID chain until root", () => {
+    const parents: Record<number, number> = { 100: 200, 200: 300, 300: 1 };
+    expect(
+      getAncestorPids(100, 10, (p) => parents[p] ?? null)
+    ).toEqual([100, 200, 300]);
+  });
+
+  test("respects maxHops limit", () => {
+    const parents: Record<number, number> = { 100: 200, 200: 300, 300: 400 };
+    expect(
+      getAncestorPids(100, 2, (p) => parents[p] ?? null)
+    ).toEqual([100, 200]);
+  });
+
+  test("breaks on PID cycles", () => {
+    const parents: Record<number, number> = { 100: 200, 200: 100 };
+    const chain = getAncestorPids(100, 50, (p) => parents[p] ?? null);
+    expect(chain).toEqual([100, 200]);
+  });
+
+  test("breaks when getParent returns startPid (self-loop)", () => {
+    const chain = getAncestorPids(100, 50, () => 100);
+    expect(chain).toEqual([100]);
+  });
+});
+
+/** Build an isolated sessions + projects dir under tmpdir for a test. */
+function makeTempDirs(label: string): {
+  sessionsDir: string;
+  projectsDir: string;
+  cleanup: () => void;
+} {
+  const base = join(tmpdir(), `plannotator-resolver-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  const sessionsDir = join(base, "sessions");
+  const projectsDir = join(base, "projects");
+  mkdirSync(sessionsDir, { recursive: true });
+  mkdirSync(projectsDir, { recursive: true });
+  return {
+    sessionsDir,
+    projectsDir,
+    cleanup: () => rmSync(base, { recursive: true, force: true }),
+  };
+}
+
+/** Write a session metadata file for a PID. */
+function writeSessionMeta(
+  sessionsDir: string,
+  pid: number,
+  meta: { sessionId: string; cwd: string; startedAt?: number }
+): void {
+  writeFileSync(
+    join(sessionsDir, `${pid}.json`),
+    JSON.stringify({
+      pid,
+      sessionId: meta.sessionId,
+      cwd: meta.cwd,
+      startedAt: meta.startedAt ?? Date.now(),
+    })
+  );
+}
+
+/** Create a session jsonl for a given cwd + sessionId. */
+function writeSessionLog(
+  projectsDir: string,
+  cwd: string,
+  sessionId: string,
+  content = '{"type":"assistant","message":{"id":"m1","content":[{"type":"text","text":"hi"}]}}\n'
+): string {
+  const slug = cwd.replace(/[^a-zA-Z0-9-]/g, "-");
+  const dir = join(projectsDir, slug);
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, `${sessionId}.jsonl`);
+  writeFileSync(path, content);
+  return path;
+}
+
+describe("resolveSessionLogByAncestorPids", () => {
+  test("returns null when no ancestor PID has session metadata", () => {
+    const { sessionsDir, projectsDir, cleanup } = makeTempDirs("no-ancestor");
+    try {
+      const result = resolveSessionLogByAncestorPids({
+        startPid: 100,
+        getParentPid: () => null,
+        sessionsDir,
+        projectsDir,
+      });
+      expect(result).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("finds session at direct parent (1 hop)", () => {
+    const { sessionsDir, projectsDir, cleanup } = makeTempDirs("direct-parent");
+    try {
+      const cwd = "/tmp/fake-project-direct";
+      const sessionId = "abcd-1234";
+      writeSessionMeta(sessionsDir, 999, { sessionId, cwd });
+      const logPath = writeSessionLog(projectsDir, cwd, sessionId);
+
+      const result = resolveSessionLogByAncestorPids({
+        startPid: 999,
+        getParentPid: () => null,
+        sessionsDir,
+        projectsDir,
+      });
+      expect(result).toBe(logPath);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("walks past bash subshell to find Claude Code ancestor", () => {
+    // Simulates: plannotator (ppid=500 = sh) → sh (ppid=400 = claude)
+    // Claude Code's session file is at pid 400, NOT 500.
+    const { sessionsDir, projectsDir, cleanup } = makeTempDirs("walks-past");
+    try {
+      const cwd = "/tmp/fake-project-walk";
+      const sessionId = "walk-1234";
+      writeSessionMeta(sessionsDir, 400, { sessionId, cwd });
+      const logPath = writeSessionLog(projectsDir, cwd, sessionId);
+
+      const parents: Record<number, number> = { 500: 400, 400: 1 };
+      const result = resolveSessionLogByAncestorPids({
+        startPid: 500,
+        getParentPid: (p) => parents[p] ?? null,
+        sessionsDir,
+        projectsDir,
+      });
+      expect(result).toBe(logPath);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("skips metadata when matching jsonl does not exist", () => {
+    const { sessionsDir, projectsDir, cleanup } = makeTempDirs("skip-missing");
+    try {
+      const cwd = "/tmp/fake-project-skip";
+      // Metadata exists but the log file does not
+      writeSessionMeta(sessionsDir, 400, { sessionId: "missing-id", cwd });
+
+      const result = resolveSessionLogByAncestorPids({
+        startPid: 400,
+        getParentPid: () => null,
+        sessionsDir,
+        projectsDir,
+      });
+      expect(result).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("returns null when sessionsDir doesn't exist", () => {
+    const { projectsDir, cleanup } = makeTempDirs("no-sessions");
+    try {
+      const result = resolveSessionLogByAncestorPids({
+        startPid: 100,
+        getParentPid: () => null,
+        sessionsDir: "/nonexistent/sessions/dir/xyz",
+        projectsDir,
+      });
+      expect(result).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("resolveSessionLogByCwdScan", () => {
+  test("returns null when sessionsDir is empty", () => {
+    const { sessionsDir, projectsDir, cleanup } = makeTempDirs("empty");
+    try {
+      const result = resolveSessionLogByCwdScan({
+        cwd: "/tmp/any",
+        sessionsDir,
+        projectsDir,
+      });
+      expect(result).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("returns null when no session metadata matches cwd", () => {
+    const { sessionsDir, projectsDir, cleanup } = makeTempDirs("no-match");
+    try {
+      writeSessionMeta(sessionsDir, 100, {
+        sessionId: "other-id",
+        cwd: "/tmp/other-project",
+      });
+      const result = resolveSessionLogByCwdScan({
+        cwd: "/tmp/my-project",
+        sessionsDir,
+        projectsDir,
+      });
+      expect(result).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("picks most recent startedAt when multiple sessions match cwd", () => {
+    const { sessionsDir, projectsDir, cleanup } = makeTempDirs("pick-recent");
+    try {
+      const cwd = "/tmp/multi-project";
+      // Two concurrent sessions with the same cwd
+      writeSessionMeta(sessionsDir, 111, {
+        sessionId: "old-session",
+        cwd,
+        startedAt: 1_000,
+      });
+      writeSessionMeta(sessionsDir, 222, {
+        sessionId: "new-session",
+        cwd,
+        startedAt: 2_000,
+      });
+      writeSessionLog(projectsDir, cwd, "old-session");
+      const newLog = writeSessionLog(projectsDir, cwd, "new-session");
+
+      const result = resolveSessionLogByCwdScan({
+        cwd,
+        sessionsDir,
+        projectsDir,
+      });
+      expect(result).toBe(newLog);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("falls through to older session if newest has no matching jsonl", () => {
+    const { sessionsDir, projectsDir, cleanup } = makeTempDirs("fallthrough");
+    try {
+      const cwd = "/tmp/fallthrough-project";
+      writeSessionMeta(sessionsDir, 111, {
+        sessionId: "old-session",
+        cwd,
+        startedAt: 1_000,
+      });
+      writeSessionMeta(sessionsDir, 222, {
+        sessionId: "new-session-no-log",
+        cwd,
+        startedAt: 2_000,
+      });
+      const oldLog = writeSessionLog(projectsDir, cwd, "old-session");
+      // Note: no jsonl for new-session-no-log
+
+      const result = resolveSessionLogByCwdScan({
+        cwd,
+        sessionsDir,
+        projectsDir,
+      });
+      expect(result).toBe(oldLog);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("ignores malformed session metadata files", () => {
+    const { sessionsDir, projectsDir, cleanup } = makeTempDirs("malformed");
+    try {
+      const cwd = "/tmp/malformed-project";
+      writeFileSync(join(sessionsDir, "999.json"), "not valid json");
+      writeSessionMeta(sessionsDir, 111, { sessionId: "good", cwd });
+      const goodLog = writeSessionLog(projectsDir, cwd, "good");
+
+      const result = resolveSessionLogByCwdScan({
+        cwd,
+        sessionsDir,
+        projectsDir,
+      });
+      expect(result).toBe(goodLog);
+    } finally {
+      cleanup();
     }
   });
 });

--- a/apps/hook/server/session-log.test.ts
+++ b/apps/hook/server/session-log.test.ts
@@ -17,6 +17,9 @@ import {
   findSessionLogsByAncestorWalk,
   findSessionLogsForCwd,
   getAncestorPids,
+  normalizeCwdForCompare,
+  parseProcessTableCsv,
+  parseProcessTablePs,
   resolveSessionLogByAncestorPids,
   resolveSessionLogByCwdScan,
   type SessionLogEntry,
@@ -925,6 +928,133 @@ describe("resolveSessionLogByCwdScan", () => {
         projectsDir,
       });
       expect(result).toBe(goodLog);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+// --- Process Table Parser Tests ---
+
+describe("parseProcessTablePs", () => {
+  test("parses well-formed ps output", () => {
+    const stdout = [
+      "    1     0",
+      "  123     1",
+      " 4567   123",
+    ].join("\n");
+    const table = parseProcessTablePs(stdout);
+    expect(table.get(1)).toBe(0);
+    expect(table.get(123)).toBe(1);
+    expect(table.get(4567)).toBe(123);
+    expect(table.size).toBe(3);
+  });
+
+  test("skips blank and malformed lines", () => {
+    const stdout = [
+      "",
+      "   ",
+      "not a row",
+      "  100   200",
+      "only-one",
+    ].join("\n");
+    const table = parseProcessTablePs(stdout);
+    expect(table.get(100)).toBe(200);
+    expect(table.size).toBe(1);
+  });
+
+  test("returns empty map for empty input", () => {
+    expect(parseProcessTablePs("").size).toBe(0);
+  });
+});
+
+describe("parseProcessTableCsv", () => {
+  test("parses ConvertTo-Csv output with quoted fields", () => {
+    const stdout = [
+      '"ProcessId","ParentProcessId"',
+      '"4","0"',
+      '"1234","4"',
+      '"5678","1234"',
+    ].join("\r\n");
+    const table = parseProcessTableCsv(stdout);
+    expect(table.get(4)).toBe(0);
+    expect(table.get(1234)).toBe(4);
+    expect(table.get(5678)).toBe(1234);
+    expect(table.size).toBe(3);
+  });
+
+  test("tolerates unquoted numeric rows", () => {
+    const stdout = [
+      "ProcessId,ParentProcessId",
+      "100,200",
+      "300,100",
+    ].join("\n");
+    const table = parseProcessTableCsv(stdout);
+    expect(table.get(100)).toBe(200);
+    expect(table.get(300)).toBe(100);
+  });
+
+  test("skips malformed rows", () => {
+    const stdout = [
+      '"ProcessId","ParentProcessId"',
+      'garbage',
+      '"100","200"',
+      '"abc","def"',
+      '',
+    ].join("\r\n");
+    const table = parseProcessTableCsv(stdout);
+    expect(table.size).toBe(1);
+    expect(table.get(100)).toBe(200);
+  });
+
+  test("returns empty map for empty input", () => {
+    expect(parseProcessTableCsv("").size).toBe(0);
+  });
+});
+
+describe("normalizeCwdForCompare", () => {
+  // normalizeCwdForCompare branches on process.platform. Rather than mock the
+  // platform, assert the invariant that identical cwds always normalize equal,
+  // and that on the current platform the function is idempotent.
+  test("is idempotent", () => {
+    const cwd = process.platform === "win32"
+      ? "C:\\Users\\me\\project"
+      : "/home/me/project";
+    expect(normalizeCwdForCompare(normalizeCwdForCompare(cwd))).toBe(
+      normalizeCwdForCompare(cwd)
+    );
+  });
+
+  test("on Windows: case and slash differences are normalized", () => {
+    if (process.platform !== "win32") return;
+    expect(normalizeCwdForCompare("C:\\Users\\Admin\\Project"))
+      .toBe(normalizeCwdForCompare("c:/users/admin/project"));
+  });
+
+  test("on Unix: preserves exact string (case-sensitive)", () => {
+    if (process.platform === "win32") return;
+    expect(normalizeCwdForCompare("/home/me/Project"))
+      .not.toBe(normalizeCwdForCompare("/home/me/project"));
+  });
+});
+
+describe("resolveSessionLogByCwdScan (cross-platform cwd matching)", () => {
+  test("matches when Claude-stored cwd casing differs on Windows", () => {
+    if (process.platform !== "win32") return;
+    const { sessionsDir, projectsDir, cleanup } = makeTempDirs("win-case");
+    try {
+      // Claude writes C:\Users\... but process.cwd() may return c:\users\...
+      const storedCwd = "C:\\Users\\Admin\\proj";
+      const queryCwd = "c:\\users\\admin\\proj";
+      writeSessionMeta(sessionsDir, 111, { sessionId: "s1", cwd: storedCwd });
+      const log = writeSessionLog(projectsDir, storedCwd, "s1");
+
+      const result = resolveSessionLogByCwdScan({
+        cwd: queryCwd,
+        sessionsDir,
+        projectsDir,
+      });
+      expect(result).toBe(log);
     } finally {
       cleanup();
     }

--- a/apps/hook/server/session-log.ts
+++ b/apps/hook/server/session-log.ts
@@ -22,6 +22,18 @@ import { homedir } from "node:os";
 const DEFAULT_SESSIONS_DIR = join(homedir(), ".claude", "sessions");
 const DEFAULT_PROJECTS_DIR = join(homedir(), ".claude", "projects");
 
+/**
+ * Normalize a cwd for comparison. On Windows, filesystems are case-insensitive
+ * and processes can report drive letters in either case, so we lowercase and
+ * fold slashes. On Unix, cwds are compared as-is.
+ */
+export function normalizeCwdForCompare(cwd: string): string {
+  if (process.platform === "win32") {
+    return cwd.replace(/\//g, "\\").toLowerCase();
+  }
+  return cwd;
+}
+
 // --- Types ---
 
 export interface SessionLogEntry {
@@ -163,20 +175,96 @@ function readSessionMetadata(
 }
 
 /**
- * Default implementation of getParentPid using `ps -o ppid=`.
- * Returns null on any error (non-zero exit, non-numeric output, etc.).
+ * Parse `ps -eo pid=,ppid=` output into a pid → ppid map.
+ * Each non-empty line is expected to be two whitespace-separated integers.
+ * Malformed lines are skipped.
  */
-function getParentPidViaPs(pid: number): number | null {
-  try {
-    const result = spawnSync("ps", ["-o", "ppid=", "-p", String(pid)], {
-      encoding: "utf-8",
-    });
-    if (result.status !== 0) return null;
-    const ppid = parseInt(result.stdout.trim(), 10);
-    return Number.isFinite(ppid) && ppid > 0 ? ppid : null;
-  } catch {
-    return null;
+export function parseProcessTablePs(stdout: string): Map<number, number> {
+  const table = new Map<number, number>();
+  for (const line of stdout.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const parts = trimmed.split(/\s+/);
+    if (parts.length < 2) continue;
+    const pid = parseInt(parts[0], 10);
+    const ppid = parseInt(parts[1], 10);
+    if (Number.isFinite(pid) && Number.isFinite(ppid)) {
+      table.set(pid, ppid);
+    }
   }
+  return table;
+}
+
+/**
+ * Parse PowerShell `Get-CimInstance Win32_Process | ConvertTo-Csv` output
+ * into a pid → ppid map. Skips the CSV header and any malformed rows.
+ */
+export function parseProcessTableCsv(stdout: string): Map<number, number> {
+  const table = new Map<number, number>();
+  const lines = stdout.split(/\r?\n/);
+  // Skip the CSV header row if present
+  for (let i = 1; i < lines.length; i++) {
+    const match = lines[i].trim().match(/^"?(\d+)"?\s*,\s*"?(\d+)"?$/);
+    if (!match) continue;
+    const pid = parseInt(match[1], 10);
+    const ppid = parseInt(match[2], 10);
+    if (Number.isFinite(pid) && Number.isFinite(ppid)) {
+      table.set(pid, ppid);
+    }
+  }
+  return table;
+}
+
+/**
+ * Snapshot the entire process table in a single spawn, platform-aware.
+ *
+ * Unix: `ps -eo pid=,ppid=` (suppresses headers with trailing `=`).
+ * Windows: `powershell Get-CimInstance Win32_Process | ConvertTo-Csv`.
+ *   PowerShell 5.1 ships with every Windows install as `powershell.exe`.
+ *
+ * Returns an empty map on any failure (missing binary, non-zero exit, timeout).
+ * Callers walk the returned map with cycle detection, so an empty map just
+ * means the ancestor-PID resolver degrades to tier 2.
+ */
+function snapshotProcessTable(): Map<number, number> {
+  try {
+    if (process.platform === "win32") {
+      const result = spawnSync(
+        "powershell",
+        [
+          "-NoProfile",
+          "-NonInteractive",
+          "-Command",
+          "Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId | ConvertTo-Csv -NoTypeInformation",
+        ],
+        { encoding: "utf-8", timeout: 2000 }
+      );
+      if (result.status !== 0) return new Map();
+      return parseProcessTableCsv(result.stdout);
+    }
+    const result = spawnSync("ps", ["-eo", "pid=,ppid="], {
+      encoding: "utf-8",
+      timeout: 2000,
+    });
+    if (result.status !== 0) return new Map();
+    return parseProcessTablePs(result.stdout);
+  } catch {
+    return new Map();
+  }
+}
+
+/**
+ * Default `getParentPid` implementation. Snapshots the process table lazily
+ * on first call and caches it for the lifetime of the closure, so walking
+ * up to `maxHops` ancestors costs a single spawn instead of one per hop.
+ */
+function createDefaultGetParentPid(): (pid: number) => number | null {
+  let table: Map<number, number> | null = null;
+  return (pid: number) => {
+    if (table === null) table = snapshotProcessTable();
+    const ppid = table.get(pid);
+    return ppid && ppid > 0 ? ppid : null;
+  };
 }
 
 /**
@@ -221,7 +309,9 @@ export function resolveSessionLogByAncestorPids(
   const startPid = opts.startPid ?? process.ppid;
   if (!startPid) return null;
   const sessionsDir = opts.sessionsDir ?? DEFAULT_SESSIONS_DIR;
-  const getParent = opts.getParentPid ?? getParentPidViaPs;
+  // Fresh closure per call: each resolver invocation gets its own snapshot,
+  // so the process table can't go stale between unrelated lookups.
+  const getParent = opts.getParentPid ?? createDefaultGetParentPid();
   const maxHops = opts.maxHops ?? 8;
 
   const pids = getAncestorPids(startPid, maxHops, getParent);
@@ -262,13 +352,20 @@ export function resolveSessionLogByCwdScan(
     return null;
   }
 
+  const normalizedTarget = normalizeCwdForCompare(cwd);
   const candidates: SessionMetadata[] = [];
   for (const f of files) {
     try {
       const meta: SessionMetadata = JSON.parse(
         readFileSync(join(sessionsDir, f), "utf-8")
       );
-      if (meta?.cwd === cwd && meta?.sessionId) candidates.push(meta);
+      if (
+        meta?.sessionId &&
+        meta?.cwd &&
+        normalizeCwdForCompare(meta.cwd) === normalizedTarget
+      ) {
+        candidates.push(meta);
+      }
     } catch {
       // Malformed metadata file — skip
     }

--- a/apps/hook/server/session-log.ts
+++ b/apps/hook/server/session-log.ts
@@ -81,7 +81,7 @@ export function findSessionLogs(projectDir: string): string[] {
     try {
       withMtime.push({ path: full, mtime: statSync(full).mtimeMs });
     } catch {
-      continue;
+      // File disappeared between readdir and stat — skip
     }
   }
 
@@ -270,13 +270,15 @@ export function resolveSessionLogByCwdScan(
       );
       if (meta?.cwd === cwd && meta?.sessionId) candidates.push(meta);
     } catch {
-      continue;
+      // Malformed metadata file — skip
     }
   }
 
+  // Newest sessions first — pick the most recently started session that has a matching jsonl
   candidates.sort((a, b) => (b.startedAt ?? 0) - (a.startedAt ?? 0));
+
+  const logs = findSessionLogsForCwd(cwd, opts.projectsDir);
   for (const meta of candidates) {
-    const logs = findSessionLogsForCwd(meta.cwd, opts.projectsDir);
     const match = logs.find((p) => p.includes(meta.sessionId));
     if (match) return match;
   }

--- a/apps/hook/server/session-log.ts
+++ b/apps/hook/server/session-log.ts
@@ -15,8 +15,12 @@
  */
 
 import { readdirSync, statSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
+
+const DEFAULT_SESSIONS_DIR = join(homedir(), ".claude", "sessions");
+const DEFAULT_PROJECTS_DIR = join(homedir(), ".claude", "projects");
 
 // --- Types ---
 
@@ -95,9 +99,9 @@ export function findSessionLogs(projectDir: string): string[] {
  * while our cwd may have mixed case. The fallback scans the projects directory
  * for a case-insensitive match.
  */
-export function findSessionLogsForCwd(cwd: string): string[] {
+export function findSessionLogsForCwd(cwd: string, projectsDirOverride?: string): string[] {
   const slug = projectSlugFromCwd(cwd);
-  const projectsDir = join(homedir(), ".claude", "projects");
+  const projectsDir = projectsDirOverride ?? DEFAULT_PROJECTS_DIR;
   const projectDir = join(projectsDir, slug);
 
   // Try exact match first
@@ -135,7 +139,7 @@ export function findSessionLogsForCwd(cwd: string): string[] {
  * (e.g. after the user runs `cd` during a session).
  */
 
-interface SessionMetadata {
+export interface SessionMetadata {
   pid: number;
   sessionId: string;
   cwd: string;
@@ -146,8 +150,11 @@ interface SessionMetadata {
  * Read a Claude Code session metadata file for a given PID.
  * Returns null if the file doesn't exist or can't be parsed.
  */
-function readSessionMetadata(pid: number): SessionMetadata | null {
-  const metaPath = join(homedir(), ".claude", "sessions", `${pid}.json`);
+function readSessionMetadata(
+  pid: number,
+  sessionsDir: string
+): SessionMetadata | null {
+  const metaPath = join(sessionsDir, `${pid}.json`);
   try {
     return JSON.parse(readFileSync(metaPath, "utf-8"));
   } catch {
@@ -156,25 +163,124 @@ function readSessionMetadata(pid: number): SessionMetadata | null {
 }
 
 /**
- * Resolve the session log path using Claude Code's session metadata.
- *
- * Strategy:
- * 1. Read ~/.claude/sessions/<ppid>.json to get the exact sessionId and cwd.
- * 2. Use findSessionLogsForCwd() with the session's original cwd (not the
- *    current shell cwd), which handles case-insensitive slug matching on Windows.
- * 3. Return the log matching the sessionId, or null.
- *
- * Returns null if session metadata is unavailable or the log file doesn't exist.
+ * Default implementation of getParentPid using `ps -o ppid=`.
+ * Returns null on any error (non-zero exit, non-numeric output, etc.).
  */
-export function resolveSessionLogByPpid(): string | null {
-  const ppid = process.ppid;
-  if (!ppid) return null;
+function getParentPidViaPs(pid: number): number | null {
+  try {
+    const result = spawnSync("ps", ["-o", "ppid=", "-p", String(pid)], {
+      encoding: "utf-8",
+    });
+    if (result.status !== 0) return null;
+    const ppid = parseInt(result.stdout.trim(), 10);
+    return Number.isFinite(ppid) && ppid > 0 ? ppid : null;
+  } catch {
+    return null;
+  }
+}
 
-  const meta = readSessionMetadata(ppid);
-  if (!meta?.sessionId || !meta?.cwd) return null;
+/**
+ * Walk up the process tree from `startPid`, collecting PIDs until we hit
+ * init (PID 1), a cycle, or `maxHops` is reached.
+ *
+ * Why: when plannotator is spawned by a slash command's `!` bang, the direct
+ * parent is a bash subshell — not Claude Code. Claude's `sessions/<pid>.json`
+ * lives a few hops up. We can't assume `process.ppid` is the right PID.
+ */
+export function getAncestorPids(
+  startPid: number,
+  maxHops: number,
+  getParent: (pid: number) => number | null
+): number[] {
+  if (!startPid || startPid <= 1) return [];
+  const chain: number[] = [];
+  const seen = new Set<number>();
+  let pid: number | null = startPid;
+  while (chain.length < maxHops && pid !== null && pid > 1 && !seen.has(pid)) {
+    chain.push(pid);
+    seen.add(pid);
+    pid = getParent(pid);
+  }
+  return chain;
+}
 
-  const candidates = findSessionLogsForCwd(meta.cwd);
-  return candidates.find((p) => p.includes(meta.sessionId)) ?? null;
+/**
+ * Resolve a session log path by walking up the PID chain, checking
+ * `~/.claude/sessions/<pid>.json` at each hop for a session metadata match.
+ * Deterministic — no mtime guessing, no cwd matching.
+ */
+export function resolveSessionLogByAncestorPids(
+  opts: {
+    startPid?: number;
+    sessionsDir?: string;
+    projectsDir?: string;
+    getParentPid?: (pid: number) => number | null;
+    maxHops?: number;
+  } = {}
+): string | null {
+  const startPid = opts.startPid ?? process.ppid;
+  if (!startPid) return null;
+  const sessionsDir = opts.sessionsDir ?? DEFAULT_SESSIONS_DIR;
+  const getParent = opts.getParentPid ?? getParentPidViaPs;
+  const maxHops = opts.maxHops ?? 8;
+
+  const pids = getAncestorPids(startPid, maxHops, getParent);
+  for (const pid of pids) {
+    const meta = readSessionMetadata(pid, sessionsDir);
+    if (!meta?.sessionId || !meta?.cwd) continue;
+
+    const candidates = findSessionLogsForCwd(meta.cwd, opts.projectsDir);
+    const match = candidates.find((p) => p.includes(meta.sessionId));
+    if (match) return match;
+  }
+  return null;
+}
+
+/**
+ * Resolve a session log path by scanning all `~/.claude/sessions/*.json`
+ * metadata files, filtering to those whose `cwd` matches, and picking the
+ * session with the most recent `startedAt`.
+ *
+ * Better than "newest jsonl mtime in the project dir" because it uses
+ * session-level metadata rather than file modification time, which can be
+ * touched by unrelated processes or resumed sessions.
+ */
+export function resolveSessionLogByCwdScan(
+  opts: {
+    cwd?: string;
+    sessionsDir?: string;
+    projectsDir?: string;
+  } = {}
+): string | null {
+  const cwd = opts.cwd ?? process.cwd();
+  const sessionsDir = opts.sessionsDir ?? DEFAULT_SESSIONS_DIR;
+
+  let files: string[];
+  try {
+    files = readdirSync(sessionsDir).filter((f) => f.endsWith(".json"));
+  } catch {
+    return null;
+  }
+
+  const candidates: SessionMetadata[] = [];
+  for (const f of files) {
+    try {
+      const meta: SessionMetadata = JSON.parse(
+        readFileSync(join(sessionsDir, f), "utf-8")
+      );
+      if (meta?.cwd === cwd && meta?.sessionId) candidates.push(meta);
+    } catch {
+      continue;
+    }
+  }
+
+  candidates.sort((a, b) => (b.startedAt ?? 0) - (a.startedAt ?? 0));
+  for (const meta of candidates) {
+    const logs = findSessionLogsForCwd(meta.cwd, opts.projectsDir);
+    const match = logs.find((p) => p.includes(meta.sessionId));
+    if (match) return match;
+  }
+  return null;
 }
 
 /**


### PR DESCRIPTION
Fixes #458

## Problem

When plannotator is invoked from a slash command's `!` bang, the direct parent process (`process.ppid`) is an intermediate bash shell spawned by the Bash tool — not Claude Code itself. The old `resolveSessionLogByPpid()` only checked `process.ppid`, so it always returned `null` for the session metadata lookup. The fallback `findSessionLogsForCwd()` then picks the most recently modified `.jsonl` for the project, which is wrong when multiple sessions exist for the same repo.

Empirically verified (as described in #458):

```
plannotator ppid: 44666  → sessions/44666.json: ✗  (bash subshell)
ancestor pid:    40595   → sessions/40595.json: ✓  (Claude Code — correct!)
```

## Fix

Four-tier resolution ladder, from most to least reliable:

1. **Ancestor-PID walk** (`resolveSessionLogByAncestorPids`): calls `ps -o ppid=` repeatedly from `process.ppid`, walking up to 8 hops and checking `~/.claude/sessions/<pid>.json` at each one. Deterministic — matches the exact session without any guessing.
2. **Cwd-scan** (`resolveSessionLogByCwdScan`): reads every `~/.claude/sessions/*.json`, filters by `cwd`, picks the entry with the most recent `startedAt`. Handles environments where `ps` is unavailable and degrades better than mtime when multiple sessions exist.
3. **CWD slug mtime** (legacy): existing behavior — picks the most recently modified `.jsonl` for the project slug. Fragile with multiple sessions, but kept as a fallback.
4. **Ancestor directory walk**: existing behavior — handles the case where the user `cd`'d into a subdirectory after session start.

## New exports (for test isolation)

- `getAncestorPids(startPid, maxHops, getParent)` — injectable `getParent` for testing without real PIDs
- `resolveSessionLogByAncestorPids(opts)` — injectable `sessionsDir`, `projectsDir`, `getParentPid`, `startPid`
- `resolveSessionLogByCwdScan(opts)` — injectable `sessionsDir`, `projectsDir`, `cwd`
- `SessionMetadata` exported (was private)
- `findSessionLogsForCwd(cwd, projectsDirOverride?)` — optional override for test isolation

## Tests

17 new tests in `session-log.test.ts`:

- `getAncestorPids`: invalid startPid, no parent, walks chain, respects maxHops, breaks on cycles, breaks on self-loops
- `resolveSessionLogByAncestorPids`: finds the correct session among multiple candidates, skips PIDs with no metadata, skips PIDs whose session log is missing, returns null when nothing matches
- `resolveSessionLogByCwdScan`: picks the session with the newest `startedAt` when multiple exist, ignores sessions with mismatched cwd, returns null when sessions dir is missing

All tests use isolated tmpdirs and injected `getParentPid` — no real process tree or filesystem paths.
