### PR TITLE
feat(ui): quieter plan diffs on prose edits

### DIFF
--- a/apps/hook/dev-mock-api.ts
+++ b/apps/hook/dev-mock-api.ts
@@ -483,9 +483,9 @@ module.exports = { authenticate };
 
 ---
 
-## ⑯ Known Limitation — Word Swap Inside a Multi-Word Bold Phrase
+## ⑯ Fixed — Word Swap Inside a Multi-Word Bold Phrase
 
-> **What to watch for (this is a known glitch):** When a single word inside a multi-word bold phrase changes — like **preliminary analysis** becoming **final analysis** — the engine splits the bold markers across the change boundary. You will likely see raw \`**\` asterisks rendered as literal text and the word "analysis" lose its bold styling. This is a boundary case we haven't fixed yet; it was surfaced by an adversarial audit of the engine.
+> **What to watch for:** When a single word inside a multi-word bold phrase changes — like **preliminary analysis** becoming **final analysis** — the diff engine atomizes the whole balanced \`**…**\` pair so it renders as a clean old-bold-struck + new-bold-green swap. Previously the closing \`**\` orphaned into unchanged-tail text and rendered as a literal asterisk; that limitation is resolved.
 
 Before the leadership steering committee signs off on the external rollout phase, the team must complete a full pass over the **preliminary analysis** of load testing results, confirm that the error budget still permits the planned migration window, and escalate any unresolved dependencies to the program lead. Any open question at this stage must be either resolved or formally deferred to the post-launch review with named owners and dates.
 

--- a/packages/editor/demoPlanDiffDemo.ts
+++ b/packages/editor/demoPlanDiffDemo.ts
@@ -239,9 +239,9 @@ export async function authenticate(request: Request): Promise<AuthContext | null
 
 ---
 
-## ⑯ Known Limitation — Word Swap Inside a Multi-Word Bold Phrase
+## ⑯ Fixed — Word Swap Inside a Multi-Word Bold Phrase
 
-> **What to watch for (this is a known glitch):** When a single word inside a multi-word bold phrase changes — like **preliminary analysis** becoming **final analysis** — the engine splits the bold markers across the change boundary. You will likely see raw \`**\` asterisks rendered as literal text and the word "analysis" lose its bold styling. This is a boundary case we haven't fixed yet; it was surfaced by an adversarial audit of the engine.
+> **What to watch for:** When a single word inside a multi-word bold phrase changes — like **preliminary analysis** becoming **final analysis** — the diff engine atomizes the whole balanced \`**…**\` pair so it renders as a clean old-bold-struck + new-bold-green swap. Previously the closing \`**\` orphaned into unchanged-tail text and rendered as a literal asterisk; that limitation is resolved.
 
 Before the leadership steering committee signs off on the external rollout phase, the team must complete a full pass over the **final analysis** of load testing results, confirm that the error budget still permits the planned migration window, and escalate any unresolved dependencies to the program lead. Any open question at this stage must be either resolved or formally deferred to the post-launch review with named owners and dates.
 

--- a/packages/ui/utils/planDiffEngine.test.ts
+++ b/packages/ui/utils/planDiffEngine.test.ts
@@ -296,6 +296,80 @@ describe("computeInlineDiff — emphasis pair atomization (A3)", () => {
   });
 });
 
+describe("computeInlineDiff — hyphenated compound atomization", () => {
+  test("letter-letter compound swaps whole token (ninety-five → ninety-nine)", () => {
+    const r = computeInlineDiff(
+      "at least ninety-five percent",
+      "at least ninety-nine percent"
+    );
+    expect(r).not.toBeNull();
+    const u = unify(r!);
+    expect(u).toContain("<del>ninety-five</del>");
+    expect(u).toContain("<ins>ninety-nine</ins>");
+    // No partial-word fragmentation.
+    expect(u).not.toContain("<del>five</del>");
+    expect(u).not.toContain("<ins>nine</ins>");
+    expect(u).not.toMatch(/PLDIFFHY/);
+  });
+
+  test("digit-letter compound swaps whole token (64-byte → 2048-bit)", () => {
+    const r = computeInlineDiff(
+      "a 64-byte value",
+      "a 2048-bit value"
+    );
+    expect(r).not.toBeNull();
+    const u = unify(r!);
+    expect(u).toContain("<del>64-byte</del>");
+    expect(u).toContain("<ins>2048-bit</ins>");
+    expect(u).not.toMatch(/PLDIFFHY/);
+  });
+
+  test("multi-hyphen compound atomizes fully (state-of-the-art → state-of-the-craft)", () => {
+    const r = computeInlineDiff(
+      "the state-of-the-art approach",
+      "the state-of-the-craft approach"
+    );
+    expect(r).not.toBeNull();
+    const u = unify(r!);
+    expect(u).toContain("<del>state-of-the-art</del>");
+    expect(u).toContain("<ins>state-of-the-craft</ins>");
+    expect(u).not.toMatch(/PLDIFFHY/);
+  });
+
+  test("hyphenated compound unchanged between versions stays unchanged", () => {
+    const r = computeInlineDiff(
+      "the cookie-based flow runs nightly",
+      "the cookie-based flow runs daily"
+    );
+    expect(r).not.toBeNull();
+    const u = unify(r!);
+    // Compound must be intact in unchanged context — no PLDIFFHY leak.
+    expect(u).toContain("cookie-based");
+    expect(u).toContain("<del>nightly</del>");
+    expect(u).toContain("<ins>daily</ins>");
+    expect(u).not.toMatch(/PLDIFFHY/);
+  });
+
+  test("leading/trailing dash is not substituted (em-dash-like prose)", () => {
+    // A dash with no word char on one side is a separator, not a compound.
+    const r = computeInlineDiff("foo - bar end", "foo - baz end");
+    expect(r).not.toBeNull();
+    const u = unify(r!);
+    expect(u).toContain("<del>bar</del>");
+    expect(u).toContain("<ins>baz</ins>");
+    expect(u).not.toMatch(/PLDIFFHY/);
+  });
+
+  test("hyphens inside bold phrase stay atomic via emphasis pass, not corrupted", () => {
+    const r = computeInlineDiff("**cookie-based** flow", "**token-based** flow");
+    expect(r).not.toBeNull();
+    const u = unify(r!);
+    expect(u).toContain("<del>**cookie-based**</del>");
+    expect(u).toContain("<ins>**token-based**</ins>");
+    expect(u).not.toMatch(/PLDIFFHY/);
+  });
+});
+
 describe("computeInlineDiff — coalescing pass (Commit 2)", () => {
   test("two adjacent swaps separated by a single space coalesce into one swap", () => {
     const r = computeInlineDiff("foo bar baz", "qux quux baz");

--- a/packages/ui/utils/planDiffEngine.test.ts
+++ b/packages/ui/utils/planDiffEngine.test.ts
@@ -296,6 +296,111 @@ describe("computeInlineDiff — emphasis pair atomization (A3)", () => {
   });
 });
 
+describe("computeInlineDiff — coalescing pass (Commit 2)", () => {
+  test("two adjacent swaps separated by a single space coalesce into one swap", () => {
+    const r = computeInlineDiff("foo bar baz", "qux quux baz");
+    expect(r).not.toBeNull();
+    const u = unify(r!);
+    // Both word swaps merge into a single phrase swap ending at the
+    // unchanged tail ` baz`.
+    expect(u).toContain("<del>foo bar</del><ins>qux quux</ins>");
+    expect(u).toContain(" baz");
+  });
+
+  test("three adjacent swaps (the motivating paragraph example) coalesce", () => {
+    // Parens act as hard boundaries because they aren't in the thin set.
+    const r = computeInlineDiff(
+      "(and the originating case)",
+      "(and a small set of admins who opted in)"
+    );
+    expect(r).not.toBeNull();
+    const u = unify(r!);
+    expect(u).toBe(
+      "(and <del>the originating case</del><ins>a small set of admins who opted in</ins>)"
+    );
+  });
+
+  test("single isolated swap stays word-level (no coalescing)", () => {
+    const r = computeInlineDiff("the quick brown fox", "the slow brown fox");
+    expect(r).not.toBeNull();
+    const u = unify(r!);
+    // Only the `quick` → `slow` change should be diffed; `brown fox` must
+    // stay as unchanged text.
+    expect(u).toContain("<del>quick</del>");
+    expect(u).toContain("<ins>slow</ins>");
+    expect(u).toContain(" brown fox");
+    // No accidental absorption of `brown fox` into a combined swap.
+    expect(u).not.toContain("quick brown fox");
+    expect(u).not.toContain("slow brown fox");
+  });
+
+  test("asymmetric coalesce: two removes + one add in dirty run", () => {
+    const r = computeInlineDiff("foo bar baz end", "foo newword end");
+    expect(r).not.toBeNull();
+    const u = unify(r!);
+    // `bar` and `baz` both removed, `newword` added — coalesce absorbs the
+    // intervening space into the combined swap. The trailing space to the
+    // unchanged `end` gets pulled into the ins/del because jsdiff pairs
+    // `baz ` with `newword ` as a single token-level swap.
+    expect(u).toContain("<del>bar baz");
+    expect(u).toContain("<ins>newword");
+    expect(u).toContain("end");
+  });
+
+  test("swap + swap separated by a comma coalesces (thin punctuation)", () => {
+    const r = computeInlineDiff("alpha, beta end", "gamma, delta end");
+    expect(r).not.toBeNull();
+    const u = unify(r!);
+    expect(u).toContain("<del>alpha, beta</del><ins>gamma, delta</ins>");
+  });
+
+  test("swap + swap separated by unchanged word does NOT coalesce", () => {
+    const r = computeInlineDiff("foo bar baz qux end", "zap bar zip end");
+    expect(r).not.toBeNull();
+    const u = unify(r!);
+    // `bar` unchanged word between the two swaps must block coalescing.
+    expect(u).toContain("<del>foo</del>");
+    expect(u).toContain("<ins>zap</ins>");
+    expect(u).toContain(" bar ");
+    expect(u).toContain("<del>baz qux");
+    expect(u).toContain("<ins>zip");
+    // Sanity: not a single combined swap across `bar`.
+    expect(u).not.toContain("<del>foo bar baz qux</del>");
+  });
+
+  test("swap + swap separated by an unchanged inline link does NOT coalesce", () => {
+    // The link is an atomic unchanged token whose value is the whole
+    // `[text](url)` string — that contains non-thin chars (`[`, `]`, `(`,
+    // `)`), so it blocks coalescing.
+    const r = computeInlineDiff(
+      "see foo [docs](https://example.com) bar end",
+      "see zop [docs](https://example.com) zip end"
+    );
+    expect(r).not.toBeNull();
+    const u = unify(r!);
+    expect(u).toContain("<del>foo</del>");
+    expect(u).toContain("<ins>zop</ins>");
+    expect(u).toContain("[docs](https://example.com)");
+    expect(u).toContain("<del>bar</del>");
+    expect(u).toContain("<ins>zip</ins>");
+    // Not coalesced across the link.
+    expect(u).not.toContain("<del>foo [docs]");
+  });
+
+  test("multi-word bold phrase swap via coalescing-rescue (Case 2 wrap)", () => {
+    // `foo bar baz` → `foo **bar baz**`: without coalescing, atomization
+    // leaves `bar` and `baz` as two word tokens on the old side but
+    // `**bar baz**` as one atomic pair on the new side, producing
+    // alternating removes/adds that coalescing folds back into a single
+    // clean phrase swap.
+    const r = computeInlineDiff("foo bar baz end", "foo **bar baz** end");
+    expect(r).not.toBeNull();
+    const u = unify(r!);
+    expect(u).toContain("<del>bar baz");
+    expect(u).toContain("<ins>**bar baz**");
+  });
+});
+
 describe("computeInlineDiff — broader integration", () => {
   test("code-span swap adjacent to unchanged text still renders cleanly", () => {
     const r = computeInlineDiff("Call `foo()` now.", "Call `bar()` now.");

--- a/packages/ui/utils/planDiffEngine.test.ts
+++ b/packages/ui/utils/planDiffEngine.test.ts
@@ -134,6 +134,12 @@ describe("computeInlineDiff — token content", () => {
   });
 
   test("unified string round-trip preserves delimiter pair around diff tags", () => {
+    // After pair-based emphasis atomization, the whole `**phrase**`
+    // becomes one atomic token on each side — so the unified string
+    // starts with `<del>**important**</del>` rather than
+    // `**<del>important</del>...**`. Visual render is equivalent because
+    // `<del>` recurses into `InlineMarkdown` and the inner `**…**` parses
+    // as bold.
     const result = computeInlineDiff(
       "**important** text\n",
       "**critical** text\n"
@@ -146,10 +152,196 @@ describe("computeInlineDiff — token content", () => {
         return t.value;
       })
       .join("");
-    expect(unified.startsWith("**")).toBe(true);
-    expect(unified.includes("** text")).toBe(true);
-    expect(unified).toContain("<ins>critical</ins>");
-    expect(unified).toContain("<del>important</del>");
+    expect(unified).toContain("<del>**important**</del>");
+    expect(unified).toContain("<ins>**critical**</ins>");
+    expect(unified).toContain(" text");
+  });
+});
+
+// Helper to build a unified <ins>/<del>-wrapped string from a computeInlineDiff
+// result for readable assertions in tests below.
+function unify(result: { tokens: import("./planDiffEngine").InlineDiffToken[] }) {
+  return result.tokens
+    .map((t) => {
+      if (t.type === "added") return `<ins>${t.value}</ins>`;
+      if (t.type === "removed") return `<del>${t.value}</del>`;
+      return t.value;
+    })
+    .join("");
+}
+
+describe("computeInlineDiff — emphasis pair atomization (A3)", () => {
+  test("single-word bold swap atomizes as one phrase per side", () => {
+    const r = computeInlineDiff("**old** end", "**new** end");
+    expect(r).not.toBeNull();
+    expect(unify(r!)).toBe("<del>**old**</del><ins>**new**</ins> end");
+  });
+
+  test("multi-word bold with one-word change renders as balanced bold swap", () => {
+    // The demo case: `**preliminary analysis**` → `**final analysis**`.
+    // Before this fix, the closing `**` orphaned into unchanged-tail,
+    // leaving raw literal asterisks in the rendered view.
+    const r = computeInlineDiff(
+      "Review the **preliminary analysis** today.",
+      "Review the **final analysis** today."
+    );
+    expect(r).not.toBeNull();
+    const u = unify(r!);
+    expect(u).toContain("<del>**preliminary analysis**</del>");
+    expect(u).toContain("<ins>**final analysis**</ins>");
+    // No literal unbalanced `**` outside diff tags.
+    expect(u).not.toMatch(/\*\*[^*]*\*\*/g.test(
+      u.replace(/<(?:ins|del)>[\s\S]*?<\/(?:ins|del)>/g, "")
+    ) ? /.*/ : /never/);
+  });
+
+  test("multi-word bold, both words change, renders as phrase swap", () => {
+    const r = computeInlineDiff("**foo bar**", "**baz qux**");
+    expect(r).not.toBeNull();
+    expect(unify(r!)).toBe("<del>**foo bar**</del><ins>**baz qux**</ins>");
+  });
+
+  test("italic `*…*` swap atomizes per pair", () => {
+    const r = computeInlineDiff("*italic* stuff", "*bold* stuff");
+    expect(r).not.toBeNull();
+    expect(unify(r!)).toBe("<del>*italic*</del><ins>*bold*</ins> stuff");
+  });
+
+  test("strikethrough `~~…~~` swap atomizes per pair", () => {
+    const r = computeInlineDiff("~~strike~~", "~~gone~~");
+    expect(r).not.toBeNull();
+    expect(unify(r!)).toBe("<del>~~strike~~</del><ins>~~gone~~</ins>");
+  });
+
+  test("bold-alt `__…__` swap atomizes per pair", () => {
+    const r = computeInlineDiff("__alt bold__", "__new stuff__");
+    expect(r).not.toBeNull();
+    expect(unify(r!)).toBe("<del>__alt bold__</del><ins>__new stuff__</ins>");
+  });
+
+  test("italic-alt `_…_` swap atomizes per pair", () => {
+    const r = computeInlineDiff("_alt italic_", "_new_");
+    expect(r).not.toBeNull();
+    expect(unify(r!)).toBe("<del>_alt italic_</del><ins>_new_</ins>");
+  });
+
+  test("word-boundary guard: `my__var__name` → `my__var__names` leaves intraword `__` alone", () => {
+    // Markdown doesn't treat intraword `__` as bold delimiters, so the pair
+    // regex must not consume them. Verify the diff treats both sides as
+    // single identifiers rather than mis-sentinelizing them.
+    const r = computeInlineDiff("my__var__name", "my__var__names");
+    expect(r).not.toBeNull();
+    const u = unify(r!);
+    // The exact diff shape can vary, but no token should contain an
+    // unmatched sentinel fragment and the full identifiers must survive
+    // the round-trip.
+    expect(u).toContain("my__var__name");
+    expect(u).toContain("my__var__names");
+    expect(u).not.toMatch(/PLDIFFEMPH/);
+  });
+
+  test("word-boundary guard: single-underscore intraword preserved (`snake_case`)", () => {
+    const r = computeInlineDiff("snake_case", "snake_casey");
+    expect(r).not.toBeNull();
+    const u = unify(r!);
+    expect(u).toContain("snake_case");
+    expect(u).toContain("snake_casey");
+    expect(u).not.toMatch(/PLDIFFEMPH/);
+  });
+
+  test("nested triple `***foo***` atomizes as one token", () => {
+    const r = computeInlineDiff("***foo***", "***bar***");
+    expect(r).not.toBeNull();
+    expect(unify(r!)).toBe("<del>***foo***</del><ins>***bar***</ins>");
+  });
+
+  test("nested triple with multi-word inside", () => {
+    const r = computeInlineDiff("***foo bar***", "***baz qux***");
+    expect(r).not.toBeNull();
+    expect(unify(r!)).toBe(
+      "<del>***foo bar***</del><ins>***baz qux***</ins>"
+    );
+  });
+
+  test("stray unbalanced `**` in arithmetic context is preserved as literal", () => {
+    // `2**3` (exponent in prose) must not be mis-matched. Only the real
+    // balanced `**bold**` should atomize.
+    const r = computeInlineDiff(
+      "2**3 and **bold** text",
+      "2**4 and **bold** text"
+    );
+    expect(r).not.toBeNull();
+    const u = unify(r!);
+    // `**bold**` unchanged
+    expect(u).toContain("**bold**");
+    // The stray `**` preserved literally; the 3→4 swap shows normally
+    expect(u).toContain("<del>3</del>");
+    expect(u).toContain("<ins>4</ins>");
+  });
+
+  test("existing code-span sentinel format is not corrupted", () => {
+    // Two paragraphs both containing inline code spans — the diff should
+    // still round-trip the code spans correctly with the pair atomization
+    // layered on top.
+    const r = computeInlineDiff(
+      "Call `foo()` inside **bold text** here.",
+      "Call `bar()` inside **bold text** here."
+    );
+    expect(r).not.toBeNull();
+    const u = unify(r!);
+    expect(u).toContain("<del>`foo()`</del>");
+    expect(u).toContain("<ins>`bar()`</ins>");
+    expect(u).toContain("**bold text**");
+    expect(u).not.toMatch(/PLDIFF(?:CODE|LINK|EMPH)/);
+  });
+});
+
+describe("computeInlineDiff — broader integration", () => {
+  test("code-span swap adjacent to unchanged text still renders cleanly", () => {
+    const r = computeInlineDiff("Call `foo()` now.", "Call `bar()` now.");
+    expect(r).not.toBeNull();
+    const u = unify(r!);
+    expect(u).toBe("Call <del>`foo()`</del><ins>`bar()`</ins> now.");
+  });
+
+  test("link URL swap atomizes the whole link", () => {
+    const r = computeInlineDiff("See [docs](old)", "See [docs](new)");
+    expect(r).not.toBeNull();
+    const u = unify(r!);
+    expect(u).toBe("See <del>[docs](old)</del><ins>[docs](new)</ins>");
+  });
+
+  test("heading modification populates inlineTokens with heading wrap", () => {
+    const r = computeInlineDiff("## **Plan** v1\n", "## **Plan** v2\n");
+    expect(r).not.toBeNull();
+    expect(r!.wrap.type).toBe("heading");
+    expect(r!.wrap.level).toBe(2);
+    const u = unify(r!);
+    expect(u).toContain("v");
+    expect(u).toContain("<del>");
+    expect(u).toContain("<ins>");
+  });
+
+  test("computePlanDiff end-to-end with bold-phrase change produces one modified block with balanced inline tokens", () => {
+    const old =
+      "Review the **preliminary analysis** of load testing results today.\n";
+    const neu = "Review the **final analysis** of load testing results today.\n";
+    const { blocks } = computePlanDiff(old, neu);
+    const mod = blocks.find((b) => b.type === "modified");
+    expect(mod).toBeDefined();
+    expect(mod!.inlineTokens).toBeDefined();
+    const u = mod!.inlineTokens!
+      .map((t) =>
+        t.type === "added"
+          ? `<ins>${t.value}</ins>`
+          : t.type === "removed"
+            ? `<del>${t.value}</del>`
+            : t.value
+      )
+      .join("");
+    // Balanced bold pair on each side of the diff — no orphan delimiters.
+    expect(u).toContain("<del>**preliminary analysis**</del>");
+    expect(u).toContain("<ins>**final analysis**</ins>");
   });
 });
 

--- a/packages/ui/utils/planDiffEngine.ts
+++ b/packages/ui/utils/planDiffEngine.ts
@@ -302,6 +302,91 @@ function restoreEmphasisPairs(
   return value.replace(PAIR_SENTINEL_PATTERN, (m) => pairMap.get(m) ?? m);
 }
 
+// Coalescing pass (Commit 2). After `diffWordsWithSpace` and sentinel
+// restoration, adjacent word-level changes separated by only "thin"
+// unchanged tokens (whitespace + closed punctuation) get merged into a
+// single phrase-level swap. This turns alternating red/green word-noise
+// into a readable before/after, and rescues the A3 regression where
+// mashed sentinel-plus-word tokens would otherwise render as fragmented
+// literal delimiters inside colored tags.
+//
+// Definitions (from the design doc):
+//   - change site: contiguous non-unchanged run
+//   - thin unchanged: value consists only of whitespace + { , . ; : — – " ' }
+//     (parens/brackets EXCLUDED so inline links stay as hard boundaries)
+//   - dirty run: maximal sequence of change sites joined by thin-unchanged
+// Coalesce when a dirty run has ≥2 change sites (asymmetric counts allowed).
+// Single-site dirty runs pass through so isolated swaps keep word-level
+// highlighting.
+const THIN_UNCHANGED_RE =
+  /^[\s,.;:—–"'‘’“”]+$/;
+
+function isChangeToken(t: InlineDiffToken): boolean {
+  return t.type !== "unchanged";
+}
+
+function isThinUnchangedToken(t: InlineDiffToken): boolean {
+  return t.type === "unchanged" && THIN_UNCHANGED_RE.test(t.value);
+}
+
+function coalesceChangeTokens(tokens: InlineDiffToken[]): InlineDiffToken[] {
+  const out: InlineDiffToken[] = [];
+  let i = 0;
+  while (i < tokens.length) {
+    if (!isChangeToken(tokens[i])) {
+      out.push(tokens[i]);
+      i++;
+      continue;
+    }
+    // Scan first change site.
+    let lastChangeEnd = i;
+    while (
+      lastChangeEnd + 1 < tokens.length &&
+      isChangeToken(tokens[lastChangeEnd + 1])
+    ) {
+      lastChangeEnd++;
+    }
+    let siteCount = 1;
+    while (true) {
+      let scan = lastChangeEnd + 1;
+      while (scan < tokens.length && isThinUnchangedToken(tokens[scan])) scan++;
+      if (scan < tokens.length && isChangeToken(tokens[scan])) {
+        let newEnd = scan;
+        while (
+          newEnd + 1 < tokens.length &&
+          isChangeToken(tokens[newEnd + 1])
+        ) {
+          newEnd++;
+        }
+        lastChangeEnd = newEnd;
+        siteCount++;
+      } else {
+        break;
+      }
+    }
+    if (siteCount >= 2) {
+      let removedText = "";
+      let addedText = "";
+      for (let j = i; j <= lastChangeEnd; j++) {
+        const t = tokens[j];
+        if (t.type === "removed") removedText += t.value;
+        else if (t.type === "added") addedText += t.value;
+        else {
+          removedText += t.value;
+          addedText += t.value;
+        }
+      }
+      if (removedText.length > 0)
+        out.push({ type: "removed", value: removedText });
+      if (addedText.length > 0) out.push({ type: "added", value: addedText });
+    } else {
+      for (let j = i; j <= lastChangeEnd; j++) out.push(tokens[j]);
+    }
+    i = lastChangeEnd + 1;
+  }
+  return out;
+}
+
 function wrapFromBlock(block: Block): InlineDiffWrap {
   if (block.type === "heading") {
     return { type: "heading", level: block.level };
@@ -369,13 +454,20 @@ export function computeInlineDiff(
   substB = substituteEmphasisPairs(substB, pairMap, pairToId);
 
   const changes = diffWordsWithSpace(substA, substB);
-  const tokens: InlineDiffToken[] = changes.map((c) => ({
+  const rawTokens: InlineDiffToken[] = changes.map((c) => ({
     type: c.added ? "added" : c.removed ? "removed" : "unchanged",
     value: restoreCodeSpans(
       restoreLinks(restoreEmphasisPairs(c.value, pairMap), linkMap),
       codeMap
     ),
   }));
+
+  // Coalesce adjacent change sites separated by thin unchanged context into
+  // single phrase-level swaps. Turns alternating red/green word-noise into
+  // a readable before/after, and rescues the Case-2 regression where
+  // wrapping a previously-plain phrase in emphasis would otherwise surface
+  // as fragmented literal delimiters inside colored tags.
+  const tokens = coalesceChangeTokens(rawTokens);
 
   // Build the render wrapper from the NEW block so ordered-list items that
   // renumbered (e.g., 3. → 4. because a step was inserted above) display the

--- a/packages/ui/utils/planDiffEngine.ts
+++ b/packages/ui/utils/planDiffEngine.ts
@@ -302,6 +302,33 @@ function restoreEmphasisPairs(
   return value.replace(PAIR_SENTINEL_PATTERN, (m) => pairMap.get(m) ?? m);
 }
 
+// Hyphen sentinel. Hyphens between word chars (e.g. `ninety-five`,
+// `64-byte`, `state-of-the-art`) are semantic compound words, not two
+// tokens. `diffWordsWithSpace` splits on word boundaries, so without
+// this pass `ninety-five` → `ninety-nine` fragments into an unchanged
+// `ninety-` prefix and a swapped `five`/`nine` suffix, producing
+// visually noisy partial-word diffs that confuse readers.
+//
+// Replace each infix hyphen with a word-char marker before diffing and
+// restore afterwards. The sentinel is a fixed string (no per-instance
+// id) because all hyphens restore to the same character — uniqueness
+// isn't needed, only opacity to the word-boundary tokenizer.
+//
+// Runs AFTER the code/link/emphasis sentinel passes so hyphens inside
+// those constructs (e.g. `**state-of-the-art**`, `[link-text](url)`)
+// are already hidden and not re-processed here.
+const HYPHEN_SENTINEL = "PLDIFFHYZZ";
+const HYPHEN_SENTINEL_PATTERN = /PLDIFFHYZZ/g;
+const HYPHEN_INFIX_PATTERN = /(?<=\w)-(?=\w)/g;
+
+function substituteHyphens(text: string): string {
+  return text.replace(HYPHEN_INFIX_PATTERN, HYPHEN_SENTINEL);
+}
+
+function restoreHyphens(value: string): string {
+  return value.replace(HYPHEN_SENTINEL_PATTERN, "-");
+}
+
 // Coalescing pass (Commit 2). After `diffWordsWithSpace` and sentinel
 // restoration, adjacent word-level changes separated by only "thin"
 // unchanged tokens (whitespace + closed punctuation) get merged into a
@@ -434,11 +461,16 @@ export function computeInlineDiff(
   //      diffs atomically, avoiding the fragmented/unbalanced-delimiter
   //      output that whitespace-splitting `diffWordsWithSpace` produces
   //      for multi-word emphasis changes.
+  //   4. Infix hyphens — replace `-` between word chars with a word-char
+  //      marker so hyphenated compounds (`ninety-five`, `64-byte`,
+  //      `state-of-the-art`) diff as single atomic tokens instead of
+  //      fragmenting into an unchanged prefix + swapped suffix.
   //
   // Code spans are substituted first so that a backticked literal like
   // `[fake](link)` is treated as code and not accidentally captured by the
   // link regex; similarly, code and link sentinels are opaque to the
-  // emphasis-pair regex. Restorations run in reverse order afterwards.
+  // emphasis-pair regex. Hyphens run last so that hyphens inside those
+  // constructs are already hidden. Restorations run in reverse order.
   const codeMap = new Map<string, string>();
   const codeToId = new Map<string, number>();
   const linkMap = new Map<string, string>();
@@ -452,12 +484,17 @@ export function computeInlineDiff(
   substB = substituteLinks(substB, linkMap, linkToId);
   substA = substituteEmphasisPairs(substA, pairMap, pairToId);
   substB = substituteEmphasisPairs(substB, pairMap, pairToId);
+  substA = substituteHyphens(substA);
+  substB = substituteHyphens(substB);
 
   const changes = diffWordsWithSpace(substA, substB);
   const rawTokens: InlineDiffToken[] = changes.map((c) => ({
     type: c.added ? "added" : c.removed ? "removed" : "unchanged",
     value: restoreCodeSpans(
-      restoreLinks(restoreEmphasisPairs(c.value, pairMap), linkMap),
+      restoreLinks(
+        restoreEmphasisPairs(restoreHyphens(c.value), pairMap),
+        linkMap
+      ),
       codeMap
     ),
   }));

--- a/packages/ui/utils/planDiffEngine.ts
+++ b/packages/ui/utils/planDiffEngine.ts
@@ -221,6 +221,87 @@ function restoreFencedBlocks(
   return value.replace(FENCE_SENTINEL_PATTERN, (m) => fenceMap.get(m) ?? m);
 }
 
+// Inline-emphasis sentinels. Each balanced markdown emphasis pair
+// (`**...**`, `__...__`, `~~...~~`, `*...*`, `_..._`) gets a unique
+// word-char sentinel before `diffWordsWithSpace` runs so that:
+//
+//   - The whole phrase diffs as a single atomic token (sentinels contain
+//     no whitespace, and `diffWordsWithSpace` splits on whitespace).
+//   - Identical phrases on both sides pair as unchanged via sentinel
+//     identity; different phrases pair as a single remove + add.
+//
+// This is the "pair" form of atomization discussed in the bold-phrase
+// design doc: it reliably handles both single-word (`**important**`) and
+// multi-word (`**preliminary analysis**`) emphasis without fragmenting
+// the closing delimiter into unchanged-tail tokens, which the earlier
+// single-delimiter substitution couldn't achieve.
+//
+// Pair matching uses CommonMark-ish flanking rules: opening delimiter
+// must not be preceded by a word char and must be followed by a non-space
+// char; closing delimiter must be preceded by a non-space char and not
+// followed by a word char. Content is matched lazily. Stray unbalanced
+// delimiters (e.g., `2**3` arithmetic) don't match and are left verbatim,
+// preserving existing behaviour.
+//
+// Longest-first ordering (`**`/`__`/`~~` before `*`/`_`) prevents single
+// delimiters from eating the inside of a double-delim pair.
+const PAIR_SENTINEL_PREFIX = "PLDIFFEMPH";
+const PAIR_SENTINEL_PATTERN = /PLDIFFEMPH\d+ZZ/g;
+
+const PAIR_PATTERNS: Array<{ delim: string; regex: RegExp }> = [
+  // Triples first so `***foo***` (bold+italic) atomizes as one token
+  // instead of being split into `**` pair plus a leftover `*`.
+  { delim: "***", regex: /(?<!\w)\*\*\*(\S(?:[\s\S]*?\S)?)\*\*\*(?!\w)/g },
+  {
+    delim: "___",
+    regex: /(?<![A-Za-z0-9])___(\S(?:[\s\S]*?\S)?)___(?![A-Za-z0-9])/g,
+  },
+  { delim: "**", regex: /(?<!\w)\*\*(\S(?:[\s\S]*?\S)?)\*\*(?!\w)/g },
+  // `__` with word-boundary guard to protect intraword underscores
+  // (e.g., `my__var__name`). Same for `_` below.
+  {
+    delim: "__",
+    regex: /(?<![A-Za-z0-9])__(\S(?:[\s\S]*?\S)?)__(?![A-Za-z0-9])/g,
+  },
+  { delim: "~~", regex: /(?<!\w)~~(\S(?:[\s\S]*?\S)?)~~(?!\w)/g },
+  { delim: "*", regex: /(?<!\w)\*(\S(?:[^*]*?\S)?)\*(?!\w)/g },
+  {
+    delim: "_",
+    regex: /(?<![A-Za-z0-9])_(\S(?:[^_]*?\S)?)_(?![A-Za-z0-9])/g,
+  },
+];
+
+function pairSentinelFor(id: number): string {
+  return `${PAIR_SENTINEL_PREFIX}${id}ZZ`;
+}
+
+function substituteEmphasisPairs(
+  text: string,
+  pairMap: Map<string, string>,
+  pairToId: Map<string, number>
+): string {
+  for (const { regex } of PAIR_PATTERNS) {
+    text = text.replace(regex, (match) => {
+      let id = pairToId.get(match);
+      if (id === undefined) {
+        id = pairToId.size;
+        pairMap.set(pairSentinelFor(id), match);
+        pairToId.set(match, id);
+      }
+      return pairSentinelFor(id);
+    });
+  }
+  return text;
+}
+
+function restoreEmphasisPairs(
+  value: string,
+  pairMap: Map<string, string>
+): string {
+  if (pairMap.size === 0) return value;
+  return value.replace(PAIR_SENTINEL_PATTERN, (m) => pairMap.get(m) ?? m);
+}
+
 function wrapFromBlock(block: Block): InlineDiffWrap {
   if (block.type === "heading") {
     return { type: "heading", level: block.level };
@@ -258,29 +339,42 @@ export function computeInlineDiff(
   if (!INLINE_DIFFABLE_TYPES.has(a.type)) return null;
   if (!structuralFieldsMatch(a, b)) return null;
 
-  // Atomic passes before word-diffing:
+  // Atomic passes before word-diffing (longest-lived sentinels first):
   //   1. Inline code spans — protect backtick-wrapped content so diff markers
   //      never land between backticks (see SENTINEL_PREFIX comment).
   //   2. Markdown links [text](url) — protect the whole link so diff markers
   //      never land inside the link's bracketed text or parenthesized href.
+  //   3. Balanced emphasis pairs (**…**, __…__, ~~…~~, *…*, _…_) — replace
+  //      each whole pair with a unique word-char sentinel so the phrase
+  //      diffs atomically, avoiding the fragmented/unbalanced-delimiter
+  //      output that whitespace-splitting `diffWordsWithSpace` produces
+  //      for multi-word emphasis changes.
   //
   // Code spans are substituted first so that a backticked literal like
   // `[fake](link)` is treated as code and not accidentally captured by the
-  // link regex. Restorations run in reverse order afterwards.
+  // link regex; similarly, code and link sentinels are opaque to the
+  // emphasis-pair regex. Restorations run in reverse order afterwards.
   const codeMap = new Map<string, string>();
   const codeToId = new Map<string, number>();
   const linkMap = new Map<string, string>();
   const linkToId = new Map<string, number>();
+  const pairMap = new Map<string, string>();
+  const pairToId = new Map<string, number>();
 
   let substA = substituteCodeSpans(a.content, codeMap, codeToId);
   let substB = substituteCodeSpans(b.content, codeMap, codeToId);
   substA = substituteLinks(substA, linkMap, linkToId);
   substB = substituteLinks(substB, linkMap, linkToId);
+  substA = substituteEmphasisPairs(substA, pairMap, pairToId);
+  substB = substituteEmphasisPairs(substB, pairMap, pairToId);
 
   const changes = diffWordsWithSpace(substA, substB);
   const tokens: InlineDiffToken[] = changes.map((c) => ({
     type: c.added ? "added" : c.removed ? "removed" : "unchanged",
-    value: restoreCodeSpans(restoreLinks(c.value, linkMap), codeMap),
+    value: restoreCodeSpans(
+      restoreLinks(restoreEmphasisPairs(c.value, pairMap), linkMap),
+      codeMap
+    ),
   }));
 
   // Build the render wrapper from the NEW block so ordered-list items that


### PR DESCRIPTION
I appreciate you adding #565 for #560 which has made finding changes easier in my plans - but I wanted to make reading my diffs even easier 😀 

Plan diffs use `diffWordsWithSpace`, which breaks on word boundaries. For most edits that's the right level of granularity, but it struggles with three specific shapes: markdown emphasis delimiters, adjacent word-level swaps, and hyphenated compounds. The results are technically correct but hard to read at a glance. This PR layers three passes on top of the existing engine to fix them.

## The three cases

**Bold phrase swaps (known issue ⑯).** For `**preliminary analysis**` → `**final analysis**`, the opening `**` attaches to the first word-run while the closing `**` slides into the unchanged tail. The result has no balanced `**…**` pair outside the `<del>`/`<ins>` wrappers, so `InlineMarkdown`'s bold regex misses it and the asterisks render literally.

**Adjacent word swaps.** When a rewritten sentence changes several nearby words, each swap is highlighted independently. Output alternates red and green between thin spaces — accurate, but the eye can't pick out the shape of the edit.

**Hyphenated compounds.** `ninety-five` → `ninety-nine` diffs as an unchanged `ninety-` prefix and a swapped `five`/`nine` suffix. The hyphen ends up on the wrong side of the change and the compound reads as two separate tokens.

## What changed

- **`9e2eace` — balanced emphasis pairs.** Before diffing, replace each balanced `**…**`, `__…__`, `~~…~~`, `*…*`, `_…_` (and the triple forms) with a unique word-char sentinel. Restore after. Same pattern used by the existing code-span and link passes. Pair matching follows CommonMark's flanking rules so stray asterisks like `2**3` aren't captured.
- **`f455ac6` — coalesce adjacent change sites.** After the diff returns, walk the token stream and merge any run of two or more change sites separated only by "thin" unchanged tokens (whitespace, `, . ; : — – " '`). Isolated swaps pass through, which keeps word-level highlighting for the common case. Parens and brackets remain hard boundaries so inline links aren't absorbed into coalesced runs.
- **`b004737` — hyphen atomization.** A final sentinel pass replaces infix hyphens between word chars with a fixed marker. Leading and trailing dashes, and em-dash-like separators (a dash with whitespace on one side), are left alone.

## Before and after

### The clearest demonstration is case ③ — a paragraph with many adjacent word-level changes. Before, the output interleaves red and green at the word level. After, each side reads as one coherent phrase:

<img width="3200" height="1610" alt="before-03-inline-code" src="https://github.com/user-attachments/assets/fde95116-e157-448e-b25a-c300185f9b87" />
<img width="3200" height="1610" alt="after-03-inline-code" src="https://github.com/user-attachments/assets/25170ddf-1a82-4e33-9e50-dd23ae6d47a8" />


### Case ① — scattered edits, including the two-word "load balancer" → "service mesh" swap and the `ninety-five` → `ninety-nine` compound:

<img width="3200" height="1610" alt="before-01-scattered-edits" src="https://github.com/user-attachments/assets/8273d385-a015-4516-b1db-27b001ac5247" />
<img width="3200" height="1610" alt="after-01-scattered-edits" src="https://github.com/user-attachments/assets/d0c68fce-9ea3-4073-bdce-b2c1092e4b2e" />


### Case ② — bold phrases (a quieter improvement; included for completeness):

<img width="3200" height="1610" alt="before-02-bold-phrases" src="https://github.com/user-attachments/assets/05fa0d75-4079-4dba-9462-08d0e5516b2c" />
<img width="3200" height="1610" alt="after-02-bold-phrases" src="https://github.com/user-attachments/assets/91bdaef5-ac3e-4b1e-9067-206e5f521a0b" />



### Case ⑯ — the previously-known bold-phrase limitation, now resolved. Before: literal `**` asterisks leak out and `analysis` loses its weight. After: a clean bold-struck → bold-green swap:

<img width="3200" height="1610" alt="before-16-bold-phrase" src="https://github.com/user-attachments/assets/cc297635-e849-4d05-b753-b99244cc57f3" />
<img width="3200" height="1610" alt="after-16-bold-phrase" src="https://github.com/user-attachments/assets/9810f6a4-a66b-49ae-98a9-2a733b9d8d8d" />


## Approaches considered an discarded

Rather than inventing my own I looked at existing algorithms first and Google's diff-match-patch came up as an alternative: a 45kb dependency using Myers diff with semantic cleanup, and well-tested. I considered it, but it's character-level by default, which would fragment `ninety-five` → `ninety-nine` more than the current approach does, plus the library's documented word-mode is a DIY tokeniser, so every token-shape decision in this PR would still need to be made after the swap.

## Test plan

All tested locally and working.

- [ ] `bun test packages/ui/utils/planDiffEngine.test.ts` passes. Covers each atomization pass, the coalescing rules, and anti-regressions for isolated swaps and hard boundaries.
- [ ] The ⑯ demo at `packages/editor/demoPlanDiffDemo.ts:244` renders as a single bold-struck → bold-green swap.
- [ ] A paragraph with three adjacent word swaps coalesces into one phrase-level change.
- [ ] An isolated single-word swap still highlights at word level.
- [ ] A swap next to an unchanged inline link splits cleanly at the link boundary.
- [ ] Annotation capture in `PlanCleanDiffView` continues to work — block-level, so it should be unaffected, but worth a manual check.