### PR TITLE
fix(ui): in-page anchor navigation for headings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ apps/pi-extension/review-core.ts
 # Claude Code session-local runtime state (lock files, scheduled-task state).
 # Machine-specific; never belongs in the repo.
 .claude/
+.serena/
 *.ntvs*
 *.njsproj
 *.sln

--- a/packages/ui/components/BlockRenderer.tsx
+++ b/packages/ui/components/BlockRenderer.tsx
@@ -119,7 +119,7 @@ export const BlockRenderer: React.FC<{
       return <hr className="border-border/30 my-8" data-block-id={block.id} />;
 
     case 'html':
-      return <HtmlBlock block={block} imageBaseDir={imageBaseDir} onOpenLinkedDoc={onOpenLinkedDoc} />;
+      return <HtmlBlock block={block} imageBaseDir={imageBaseDir} onOpenLinkedDoc={onOpenLinkedDoc} onNavigateAnchor={onNavigateAnchor} />;
 
     case 'directive': {
       const kind = block.directiveKind || 'note';

--- a/packages/ui/components/BlockRenderer.tsx
+++ b/packages/ui/components/BlockRenderer.tsx
@@ -7,6 +7,7 @@ import { HtmlBlock } from "./blocks/HtmlBlock";
 import { Callout } from "./blocks/Callout";
 import { AlertBlock } from "./blocks/AlertBlock";
 import { TableBlock } from "./blocks/TableBlock";
+import { getHeadingAnchorAliases } from "../utils/anchors";
 
 export const BlockRenderer: React.FC<{
   block: Block;
@@ -18,7 +19,8 @@ export const BlockRenderer: React.FC<{
   orderedIndex?: number | null;
   githubRepo?: string;
   headingAnchorId?: string;
-}> = ({ block, onOpenLinkedDoc, imageBaseDir, onImageClick, onToggleCheckbox, checkboxOverrides, orderedIndex, githubRepo, headingAnchorId }) => {
+  onNavigateAnchor?: (hash: string) => void;
+}> = ({ block, onOpenLinkedDoc, imageBaseDir, onImageClick, onToggleCheckbox, checkboxOverrides, orderedIndex, githubRepo, headingAnchorId, onNavigateAnchor }) => {
   switch (block.type) {
     case 'heading': {
       const Tag = `h${block.level || 1}` as React.ElementType;
@@ -27,7 +29,25 @@ export const BlockRenderer: React.FC<{
         2: 'text-xl font-semibold mb-3 mt-8 text-foreground/90',
         3: 'text-base font-semibold mb-2 mt-6 text-foreground/80',
       }[block.level || 1] || 'text-base font-semibold mb-2 mt-4';
-      return <Tag id={headingAnchorId} className={styles} data-block-id={block.id} data-block-type="heading"><InlineMarkdown imageBaseDir={imageBaseDir} onImageClick={onImageClick} text={block.content} onOpenLinkedDoc={onOpenLinkedDoc} githubRepo={githubRepo} /></Tag>;
+      const anchorAliases = [
+        headingAnchorId,
+        ...getHeadingAnchorAliases(block.content),
+      ].filter(Boolean);
+      const anchorAliasTokens = anchorAliases.length > 0
+        ? [...new Set(anchorAliases)].join(' ')
+        : undefined;
+
+      return (
+        <Tag
+          id={headingAnchorId}
+          className={styles}
+          data-block-id={block.id}
+          data-block-type="heading"
+          data-anchor-aliases={anchorAliasTokens}
+        >
+          <InlineMarkdown imageBaseDir={imageBaseDir} onImageClick={onImageClick} text={block.content} onOpenLinkedDoc={onOpenLinkedDoc} githubRepo={githubRepo} onNavigateAnchor={onNavigateAnchor} />
+        </Tag>
+      );
     }
 
     case 'blockquote': {
@@ -41,6 +61,7 @@ export const BlockRenderer: React.FC<{
             imageBaseDir={imageBaseDir}
             onImageClick={onImageClick}
             githubRepo={githubRepo}
+            onNavigateAnchor={onNavigateAnchor}
           />
         );
       }
@@ -54,7 +75,7 @@ export const BlockRenderer: React.FC<{
         >
           {paragraphs.map((para, i) => (
             <p key={i} className={i > 0 ? 'mt-2' : ''}>
-              <InlineMarkdown imageBaseDir={imageBaseDir} onImageClick={onImageClick} text={para} onOpenLinkedDoc={onOpenLinkedDoc} githubRepo={githubRepo} />
+              <InlineMarkdown imageBaseDir={imageBaseDir} onImageClick={onImageClick} text={para} onOpenLinkedDoc={onOpenLinkedDoc} githubRepo={githubRepo} onNavigateAnchor={onNavigateAnchor} />
             </p>
           ))}
         </blockquote>
@@ -83,7 +104,7 @@ export const BlockRenderer: React.FC<{
             onToggle={isInteractive ? () => onToggleCheckbox!(block.id, !isChecked) : undefined}
           />
           <span className={`text-sm leading-relaxed ${isCheckbox && isChecked ? 'text-muted-foreground line-through' : 'text-foreground/90'}`}>
-            <InlineMarkdown imageBaseDir={imageBaseDir} onImageClick={onImageClick} text={block.content} onOpenLinkedDoc={onOpenLinkedDoc} githubRepo={githubRepo} />
+            <InlineMarkdown imageBaseDir={imageBaseDir} onImageClick={onImageClick} text={block.content} onOpenLinkedDoc={onOpenLinkedDoc} githubRepo={githubRepo} onNavigateAnchor={onNavigateAnchor} />
           </span>
         </div>
       );
@@ -100,6 +121,7 @@ export const BlockRenderer: React.FC<{
           onImageClick={onImageClick}
           onOpenLinkedDoc={onOpenLinkedDoc}
           githubRepo={githubRepo}
+          onNavigateAnchor={onNavigateAnchor}
         />
       );
 
@@ -123,6 +145,7 @@ export const BlockRenderer: React.FC<{
           imageBaseDir={imageBaseDir}
           onImageClick={onImageClick}
           githubRepo={githubRepo}
+          onNavigateAnchor={onNavigateAnchor}
         />
       );
     }
@@ -133,7 +156,7 @@ export const BlockRenderer: React.FC<{
           className="mb-4 leading-relaxed text-foreground/90 text-[15px]"
           data-block-id={block.id}
         >
-          <InlineMarkdown imageBaseDir={imageBaseDir} onImageClick={onImageClick} text={block.content} onOpenLinkedDoc={onOpenLinkedDoc} githubRepo={githubRepo} />
+          <InlineMarkdown imageBaseDir={imageBaseDir} onImageClick={onImageClick} text={block.content} onOpenLinkedDoc={onOpenLinkedDoc} githubRepo={githubRepo} onNavigateAnchor={onNavigateAnchor} />
         </p>
       );
   }

--- a/packages/ui/components/BlockRenderer.tsx
+++ b/packages/ui/components/BlockRenderer.tsx
@@ -7,7 +7,6 @@ import { HtmlBlock } from "./blocks/HtmlBlock";
 import { Callout } from "./blocks/Callout";
 import { AlertBlock } from "./blocks/AlertBlock";
 import { TableBlock } from "./blocks/TableBlock";
-import { getHeadingAnchorAliases } from "../utils/anchors";
 
 export const BlockRenderer: React.FC<{
   block: Block;
@@ -29,21 +28,12 @@ export const BlockRenderer: React.FC<{
         2: 'text-xl font-semibold mb-3 mt-8 text-foreground/90',
         3: 'text-base font-semibold mb-2 mt-6 text-foreground/80',
       }[block.level || 1] || 'text-base font-semibold mb-2 mt-4';
-      const anchorAliases = [
-        headingAnchorId,
-        ...getHeadingAnchorAliases(block.content),
-      ].filter(Boolean);
-      const anchorAliasTokens = anchorAliases.length > 0
-        ? [...new Set(anchorAliases)].join(' ')
-        : undefined;
-
       return (
         <Tag
           id={headingAnchorId}
           className={styles}
           data-block-id={block.id}
           data-block-type="heading"
-          data-anchor-aliases={anchorAliasTokens}
         >
           <InlineMarkdown imageBaseDir={imageBaseDir} onImageClick={onImageClick} text={block.content} onOpenLinkedDoc={onOpenLinkedDoc} githubRepo={githubRepo} onNavigateAnchor={onNavigateAnchor} />
         </Tag>

--- a/packages/ui/components/InlineMarkdown.tsx
+++ b/packages/ui/components/InlineMarkdown.tsx
@@ -85,10 +85,11 @@ function emitPlainTextWithBareUrls(
 export const InlineMarkdown: React.FC<{
   text: string;
   onOpenLinkedDoc?: (path: string) => void;
+  onNavigateAnchor?: (hash: string) => void;
   imageBaseDir?: string;
   onImageClick?: (src: string, alt: string) => void;
   githubRepo?: string;
-}> = ({ text, onOpenLinkedDoc, imageBaseDir, onImageClick, githubRepo }) => {
+}> = ({ text, onOpenLinkedDoc, onNavigateAnchor, imageBaseDir, onImageClick, githubRepo }) => {
   const parts: React.ReactNode[] = [];
   let remaining = text;
   let key = 0;
@@ -179,8 +180,9 @@ export const InlineMarkdown: React.FC<{
             onImageClick={onImageClick}
             text={match[1]}
             onOpenLinkedDoc={onOpenLinkedDoc}
+            onNavigateAnchor={onNavigateAnchor}
             githubRepo={githubRepo}
-/>
+          />
         </del>,
       );
       remaining = remaining.slice(match[0].length);
@@ -199,8 +201,9 @@ export const InlineMarkdown: React.FC<{
               onImageClick={onImageClick}
               text={match[1]}
               onOpenLinkedDoc={onOpenLinkedDoc}
-            githubRepo={githubRepo}
-  />
+              onNavigateAnchor={onNavigateAnchor}
+              githubRepo={githubRepo}
+            />
           </em>
         </strong>,
       );
@@ -219,8 +222,9 @@ export const InlineMarkdown: React.FC<{
             onImageClick={onImageClick}
             text={match[1]}
             onOpenLinkedDoc={onOpenLinkedDoc}
+            onNavigateAnchor={onNavigateAnchor}
             githubRepo={githubRepo}
-/>
+          />
         </strong>,
       );
       remaining = remaining.slice(match[0].length);
@@ -238,8 +242,9 @@ export const InlineMarkdown: React.FC<{
             onImageClick={onImageClick}
             text={match[1]}
             onOpenLinkedDoc={onOpenLinkedDoc}
+            onNavigateAnchor={onNavigateAnchor}
             githubRepo={githubRepo}
-/>
+          />
         </em>,
       );
       remaining = remaining.slice(match[0].length);
@@ -258,8 +263,9 @@ export const InlineMarkdown: React.FC<{
             onImageClick={onImageClick}
             text={match[1]}
             onOpenLinkedDoc={onOpenLinkedDoc}
+            onNavigateAnchor={onNavigateAnchor}
             githubRepo={githubRepo}
-/>
+          />
         </em>,
       );
       remaining = remaining.slice(match[0].length);
@@ -500,8 +506,23 @@ export const InlineMarkdown: React.FC<{
         !linkUrl.startsWith("http://") &&
         !linkUrl.startsWith("https://");
       const linkedDocPath = isLocalDoc ? linkUrl.replace(/#.*$/, '') : linkUrl;
+      const isInPageAnchor = safeLinkUrl.startsWith('#');
 
-      if (isLocalDoc && onOpenLinkedDoc) {
+      if (isInPageAnchor) {
+        parts.push(
+          <a
+            key={key++}
+            href={safeLinkUrl}
+            onClick={onNavigateAnchor ? (e) => {
+              e.preventDefault();
+              onNavigateAnchor(safeLinkUrl);
+            } : undefined}
+            className="text-primary underline underline-offset-2 hover:text-primary/80"
+          >
+            {linkText}
+          </a>,
+        );
+      } else if (isLocalDoc && onOpenLinkedDoc) {
         parts.push(
           <a
             key={key++}
@@ -569,8 +590,9 @@ export const InlineMarkdown: React.FC<{
             key={key++}
             text={before}
             onOpenLinkedDoc={onOpenLinkedDoc}
+            onNavigateAnchor={onNavigateAnchor}
             githubRepo={githubRepo}
-  imageBaseDir={imageBaseDir}
+            imageBaseDir={imageBaseDir}
             onImageClick={onImageClick}
           />,
         );

--- a/packages/ui/components/Viewer.tsx
+++ b/packages/ui/components/Viewer.tsx
@@ -45,6 +45,7 @@ import { PinpointOverlay } from './PinpointOverlay';
 import { usePinpoint } from '../hooks/usePinpoint';
 import { useAnnotationHighlighter } from '../hooks/useAnnotationHighlighter';
 import { useScrollViewport } from '../hooks/useScrollViewport';
+import { decodeAnchorHash } from '../utils/anchors';
 
 interface ViewerProps {
   blocks: Block[];
@@ -163,6 +164,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
 }, ref) => {
   const [copied, setCopied] = useState(false);
   const [lightbox, setLightbox] = useState<{ src: string; alt: string } | null>(null);
+  const [locationHash, setLocationHash] = useState(() => window.location.hash);
   const globalCommentButtonRef = useRef<HTMLButtonElement>(null);
 
   const handleCopyPlan = async () => {
@@ -200,6 +202,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
   } | null>(null);
   const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const stickySentinelRef = useRef<HTMLDivElement>(null);
+  const lastAutoScrolledHashRef = useRef<string | null>(null);
   const [isStuck, setIsStuck] = useState(false);
 
   // Shared annotation infrastructure via hook
@@ -293,6 +296,61 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
     observer.observe(stickySentinelRef.current);
     return () => observer.disconnect();
   }, [stickyActions, stickyScrollViewport]);
+
+  useEffect(() => {
+    const handleHashChange = () => {
+      lastAutoScrolledHashRef.current = null;
+      setLocationHash(window.location.hash);
+    };
+
+    window.addEventListener('hashchange', handleHashChange);
+    return () => window.removeEventListener('hashchange', handleHashChange);
+  }, []);
+
+  const scrollToAnchor = useCallback((hash: string) => {
+    const anchor = decodeAnchorHash(hash);
+    if (!anchor) return false;
+
+    const container = containerRef.current;
+    if (!container || !stickyScrollViewport) return false;
+
+    const targetById = document.getElementById(anchor);
+    const target = (targetById && container.contains(targetById))
+      ? targetById
+      : Array.from(container.querySelectorAll<HTMLElement>('[data-anchor-aliases]')).find(element =>
+          element.dataset.anchorAliases?.split(/\s+/).includes(anchor)
+        );
+
+    if (!target) return false;
+
+    const stickyActionsEl = container.querySelector<HTMLElement>('[data-sticky-actions]');
+    const stickyTop = stickyActionsEl
+      ? Number.parseFloat(window.getComputedStyle(stickyActionsEl).top || '0') || 0
+      : 0;
+    const headerOffset = stickyActionsEl
+      ? stickyActionsEl.getBoundingClientRect().height + stickyTop
+      : 0;
+    const containerRect = stickyScrollViewport.getBoundingClientRect();
+    const targetRect = target.getBoundingClientRect();
+    const relativeTop = targetRect.top - containerRect.top;
+    const offsetPosition = stickyScrollViewport.scrollTop + relativeTop - headerOffset;
+
+    stickyScrollViewport.scrollTo({
+      top: Math.max(0, offsetPosition),
+      behavior: 'smooth',
+    });
+    return true;
+  }, [stickyScrollViewport]);
+
+  useEffect(() => {
+    if (!stickyScrollViewport || !locationHash || lastAutoScrolledHashRef.current === locationHash) return;
+    const timer = window.setTimeout(() => {
+      if (scrollToAnchor(locationHash)) {
+        lastAutoScrolledHashRef.current = locationHash;
+      }
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [blocks, locationHash, scrollToAnchor, stickyScrollViewport]);
 
   // Cmd+C / Ctrl+C keyboard shortcut for copying selected text
   useEffect(() => {
@@ -563,6 +621,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
                       checkboxOverrides={checkboxOverrides}
                       githubRepo={repoInfo?.display}
                       headingAnchorId={headingSlugMap.get(block.id)}
+                      onNavigateAnchor={scrollToAnchor}
                     />
                   ))}
                 </div>
@@ -580,6 +639,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
               onImageClick={(src, alt) => setLightbox({ src, alt })}
               onOpenLinkedDoc={onOpenLinkedDoc}
               githubRepo={repoInfo?.display}
+              onNavigateAnchor={scrollToAnchor}
               onHover={(element) => {
                 if (tableHoverTimeoutRef.current) {
                   clearTimeout(tableHoverTimeoutRef.current);
@@ -631,7 +691,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
               isHovered={inputMethod !== 'pinpoint' && hoveredCodeBlock?.block.id === group.block.id}
             />
           ) : (
-            <BlockRenderer imageBaseDir={imageBaseDir} onImageClick={(src, alt) => setLightbox({ src, alt })} key={group.block.id} block={group.block} onOpenLinkedDoc={onOpenLinkedDoc} onToggleCheckbox={onToggleCheckbox} checkboxOverrides={checkboxOverrides} githubRepo={repoInfo?.display} headingAnchorId={headingSlugMap.get(group.block.id)} />
+            <BlockRenderer imageBaseDir={imageBaseDir} onImageClick={(src, alt) => setLightbox({ src, alt })} key={group.block.id} block={group.block} onOpenLinkedDoc={onOpenLinkedDoc} onNavigateAnchor={scrollToAnchor} onToggleCheckbox={onToggleCheckbox} checkboxOverrides={checkboxOverrides} githubRepo={repoInfo?.display} headingAnchorId={headingSlugMap.get(group.block.id)} />
           )
         )}
 
@@ -728,6 +788,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
             onImageClick={(src, alt) => setLightbox({ src, alt })}
             onOpenLinkedDoc={onOpenLinkedDoc}
             githubRepo={repoInfo?.display}
+            onNavigateAnchor={scrollToAnchor}
           />
         )}
 
@@ -853,7 +914,5 @@ function groupBlocks(blocks: Block[]): RenderGroup[] {
   }
   return groups;
 }
-
-
 
 

--- a/packages/ui/components/Viewer.tsx
+++ b/packages/ui/components/Viewer.tsx
@@ -314,14 +314,8 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
     const container = containerRef.current;
     if (!container || !stickyScrollViewport) return false;
 
-    const targetById = document.getElementById(anchor);
-    const target = (targetById && container.contains(targetById))
-      ? targetById
-      : Array.from(container.querySelectorAll<HTMLElement>('[data-anchor-aliases]')).find(element =>
-          element.dataset.anchorAliases?.split(/\s+/).includes(anchor)
-        );
-
-    if (!target) return false;
+    const target = document.getElementById(anchor);
+    if (!target || !container.contains(target)) return false;
 
     const stickyActionsEl = container.querySelector<HTMLElement>('[data-sticky-actions]');
     const stickyTop = stickyActionsEl

--- a/packages/ui/components/blocks/AlertBlock.tsx
+++ b/packages/ui/components/blocks/AlertBlock.tsx
@@ -10,6 +10,7 @@ interface AlertBlockProps {
   imageBaseDir?: string;
   onImageClick?: (src: string, alt: string) => void;
   githubRepo?: string;
+  onNavigateAnchor?: (hash: string) => void;
 }
 
 const TITLE: Record<AlertKind, string> = {
@@ -37,7 +38,7 @@ const Icon: React.FC<{ kind: AlertKind }> = ({ kind }) => {
 };
 
 export const AlertBlock: React.FC<AlertBlockProps> = ({
-  blockId, kind, body, onOpenLinkedDoc, imageBaseDir, onImageClick, githubRepo,
+  blockId, kind, body, onOpenLinkedDoc, imageBaseDir, onImageClick, githubRepo, onNavigateAnchor,
 }) => {
   return (
     <div
@@ -50,7 +51,7 @@ export const AlertBlock: React.FC<AlertBlockProps> = ({
         <Icon kind={kind} />
         <span>{TITLE[kind]}</span>
       </div>
-      {renderProseBody({ body, imageBaseDir, onImageClick, onOpenLinkedDoc, githubRepo })}
+      {renderProseBody({ body, imageBaseDir, onImageClick, onOpenLinkedDoc, onNavigateAnchor, githubRepo })}
     </div>
   );
 };

--- a/packages/ui/components/blocks/Callout.tsx
+++ b/packages/ui/components/blocks/Callout.tsx
@@ -12,6 +12,7 @@ interface CalloutProps {
   imageBaseDir?: string;
   onImageClick?: (src: string, alt: string) => void;
   githubRepo?: string;
+  onNavigateAnchor?: (hash: string) => void;
 }
 
 export const Callout: React.FC<CalloutProps> = ({
@@ -25,6 +26,7 @@ export const Callout: React.FC<CalloutProps> = ({
   imageBaseDir,
   onImageClick,
   githubRepo,
+  onNavigateAnchor,
 }) => {
   const kindAttr =
     blockType === 'alert' ? { 'data-alert-kind': kindAttribute } : { 'data-directive-kind': kindAttribute };
@@ -47,6 +49,7 @@ export const Callout: React.FC<CalloutProps> = ({
         imageBaseDir,
         onImageClick,
         onOpenLinkedDoc,
+        onNavigateAnchor,
         githubRepo,
       })}
     </div>

--- a/packages/ui/components/blocks/HtmlBlock.tsx
+++ b/packages/ui/components/blocks/HtmlBlock.tsx
@@ -7,6 +7,7 @@ interface HtmlBlockProps {
   block: Block;
   imageBaseDir?: string;
   onOpenLinkedDoc?: (path: string) => void;
+  onNavigateAnchor?: (hash: string) => void;
 }
 
 // Walks the sanitized DOM and rewrites relative <img src> / <a href> so they
@@ -20,6 +21,7 @@ function rewriteRelativeRefs(
   root: HTMLElement,
   imageBaseDir?: string,
   onOpenLinkedDoc?: (path: string) => void,
+  onNavigateAnchor?: (hash: string) => void,
 ): (() => void) {
   const cleanups: (() => void)[] = [];
 
@@ -41,7 +43,19 @@ function rewriteRelativeRefs(
       a.setAttribute('rel', 'noopener noreferrer');
       return;
     }
-    if (/^(mailto:|tel:|#)/i.test(href)) return;
+    if (/^(mailto:|tel:)/i.test(href)) return;
+    // In-page anchor: native browser jump doesn't target the scroll viewport,
+    // so route through onNavigateAnchor to match InlineMarkdown's behavior.
+    if (href.startsWith('#')) {
+      if (!onNavigateAnchor) return;
+      const handler = (e: Event) => {
+        e.preventDefault();
+        onNavigateAnchor(href);
+      };
+      a.addEventListener('click', handler);
+      cleanups.push(() => a.removeEventListener('click', handler));
+      return;
+    }
     if (onOpenLinkedDoc && /\.(mdx?|html?)(#.*)?$/i.test(href)) {
       const handler = (e: Event) => {
         e.preventDefault();
@@ -61,7 +75,7 @@ function rewriteRelativeRefs(
 // re-set on every parent re-render would collapse any open <details> the
 // user just opened. Paired with React.memo below so the component itself
 // stops re-rendering unless the block content actually changes.
-const HtmlBlockImpl: React.FC<HtmlBlockProps> = ({ block, imageBaseDir, onOpenLinkedDoc }) => {
+const HtmlBlockImpl: React.FC<HtmlBlockProps> = ({ block, imageBaseDir, onOpenLinkedDoc, onNavigateAnchor }) => {
   const ref = useRef<HTMLDivElement>(null);
   const sanitized = React.useMemo(
     () => sanitizeBlockHtml(block.content),
@@ -72,9 +86,9 @@ const HtmlBlockImpl: React.FC<HtmlBlockProps> = ({ block, imageBaseDir, onOpenLi
     if (ref.current.innerHTML !== sanitized) {
       ref.current.innerHTML = sanitized;
     }
-    const cleanup = rewriteRelativeRefs(ref.current, imageBaseDir, onOpenLinkedDoc);
+    const cleanup = rewriteRelativeRefs(ref.current, imageBaseDir, onOpenLinkedDoc, onNavigateAnchor);
     return cleanup;
-  }, [sanitized, imageBaseDir, onOpenLinkedDoc]);
+  }, [sanitized, imageBaseDir, onOpenLinkedDoc, onNavigateAnchor]);
   return (
     <div
       ref={ref}
@@ -90,5 +104,6 @@ export const HtmlBlock = React.memo(
     prev.block.id === next.block.id &&
     prev.block.content === next.block.content &&
     prev.imageBaseDir === next.imageBaseDir &&
-    prev.onOpenLinkedDoc === next.onOpenLinkedDoc,
+    prev.onOpenLinkedDoc === next.onOpenLinkedDoc &&
+    prev.onNavigateAnchor === next.onNavigateAnchor,
 );

--- a/packages/ui/components/blocks/TableBlock.tsx
+++ b/packages/ui/components/blocks/TableBlock.tsx
@@ -7,6 +7,7 @@ interface TableBlockProps {
   onHover?: (element: HTMLElement) => void;
   onLeave?: () => void;
   onOpenLinkedDoc?: (path: string) => void;
+  onNavigateAnchor?: (hash: string) => void;
   imageBaseDir?: string;
   onImageClick?: (src: string, alt: string) => void;
   githubRepo?: string;
@@ -80,6 +81,7 @@ export const TableBlock: React.FC<TableBlockProps> = ({
   onHover,
   onLeave,
   onOpenLinkedDoc,
+  onNavigateAnchor,
   imageBaseDir,
   onImageClick,
   githubRepo,
@@ -109,6 +111,7 @@ export const TableBlock: React.FC<TableBlockProps> = ({
                   onImageClick={onImageClick}
                   text={header}
                   onOpenLinkedDoc={onOpenLinkedDoc}
+                  onNavigateAnchor={onNavigateAnchor}
                   githubRepo={githubRepo}
                 />
               </th>
@@ -125,6 +128,7 @@ export const TableBlock: React.FC<TableBlockProps> = ({
                     onImageClick={onImageClick}
                     text={cell}
                     onOpenLinkedDoc={onOpenLinkedDoc}
+                    onNavigateAnchor={onNavigateAnchor}
                     githubRepo={githubRepo}
                   />
                 </td>

--- a/packages/ui/components/blocks/TablePopout.tsx
+++ b/packages/ui/components/blocks/TablePopout.tsx
@@ -22,6 +22,7 @@ interface TablePopoutProps {
   /** hooks can walk into the popout's text nodes. Null falls back to body. */
   container?: HTMLElement | null;
   onOpenLinkedDoc?: (path: string) => void;
+  onNavigateAnchor?: (hash: string) => void;
   imageBaseDir?: string;
   onImageClick?: (src: string, alt: string) => void;
   githubRepo?: string;
@@ -38,6 +39,7 @@ const TablePopoutImpl: React.FC<TablePopoutProps> = ({
   onClose,
   container,
   onOpenLinkedDoc,
+  onNavigateAnchor,
   imageBaseDir,
   onImageClick,
   githubRepo,
@@ -80,12 +82,13 @@ const TablePopoutImpl: React.FC<TablePopoutProps> = ({
             onImageClick={onImageClick}
             text={info.getValue()}
             onOpenLinkedDoc={onOpenLinkedDoc}
+            onNavigateAnchor={onNavigateAnchor}
             githubRepo={githubRepo}
           />
         ),
       }),
     );
-  }, [columnIds, headers, imageBaseDir, onImageClick, onOpenLinkedDoc, githubRepo]);
+  }, [columnIds, headers, imageBaseDir, onImageClick, onOpenLinkedDoc, onNavigateAnchor, githubRepo]);
 
   const [sorting, setSorting] = useState<SortingState>([]);
   const [globalFilter, setGlobalFilter] = useState('');

--- a/packages/ui/components/blocks/proseBody.tsx
+++ b/packages/ui/components/blocks/proseBody.tsx
@@ -16,6 +16,7 @@ export function renderProseBody(args: {
   imageBaseDir?: string;
   onImageClick?: (src: string, alt: string) => void;
   onOpenLinkedDoc?: (path: string) => void;
+  onNavigateAnchor?: (hash: string) => void;
   githubRepo?: string;
 }): React.ReactNode {
   const {
@@ -25,6 +26,7 @@ export function renderProseBody(args: {
     imageBaseDir,
     onImageClick,
     onOpenLinkedDoc,
+    onNavigateAnchor,
     githubRepo,
   } = args;
 
@@ -34,6 +36,7 @@ export function renderProseBody(args: {
       onImageClick={onImageClick}
       text={text}
       onOpenLinkedDoc={onOpenLinkedDoc}
+      onNavigateAnchor={onNavigateAnchor}
       githubRepo={githubRepo}
     />
   );

--- a/packages/ui/hooks/useSharing.ts
+++ b/packages/ui/hooks/useSharing.ts
@@ -77,6 +77,16 @@ interface UseSharingResult {
 }
 
 
+// Share payloads are base64url-encoded deflate output — high entropy, mixed
+// case, often containing `=`/`_`/`-`. Plain in-page anchor slugs produced by
+// slugifyHeading() are lowercase ASCII + digits + hyphen only. When the hash
+// matches that shape we skip share parsing so `#section-overview` doesn't
+// trigger the "Shared Plan Could Not Be Loaded" dialog.
+function isPlainAnchorHash(rawHash: string): boolean {
+  const hash = rawHash.replace(/^#/, '').split('?')[0];
+  return /^[a-z0-9][a-z0-9-]*$/.test(hash);
+}
+
 export function useSharing(
   markdown: string,
   annotations: Annotation[],
@@ -153,6 +163,12 @@ export function useSharing(
       }
 
       const hash = window.location.hash.slice(1);
+
+      // Plain in-page anchor — let Viewer scroll to it, don't try share parsing.
+      if (isPlainAnchorHash(hash)) {
+        return false;
+      }
+
       const payload = await parseShareHash();
 
       if (payload) {
@@ -209,9 +225,9 @@ export function useSharing(
   // Listen for hash changes (when user pastes a new share URL)
   useEffect(() => {
     const handleHashChange = () => {
-      if (window.location.hash.length > 1) {
-        loadFromHash();
-      }
+      const hash = window.location.hash.slice(1);
+      if (!hash || isPlainAnchorHash(hash)) return;
+      loadFromHash();
     };
 
     window.addEventListener('hashchange', handleHashChange);

--- a/packages/ui/hooks/useSharing.ts
+++ b/packages/ui/hooks/useSharing.ts
@@ -77,14 +77,16 @@ interface UseSharingResult {
 }
 
 
-// Share payloads are base64url-encoded deflate output — high entropy, mixed
-// case, often containing `=`/`_`/`-`. Plain in-page anchor slugs produced by
-// slugifyHeading() are lowercase ASCII + digits + hyphen only. When the hash
-// matches that shape we skip share parsing so `#section-overview` doesn't
-// trigger the "Shared Plan Could Not Be Loaded" dialog.
-function isPlainAnchorHash(rawHash: string): boolean {
+// Share payloads are base64url-encoded deflate output: charset [A-Za-z0-9_-],
+// realistically >=30 chars, and virtually always mixed-case because deflate
+// output has high entropy. Plain heading anchors — whether the lowercase
+// ASCII slugs from `slugifyHeading` ("section-overview"), Unicode slugs
+// ("café", "中文-notes"), or raw HTML ids ("MySection") — miss at least one
+// of those signals. So: run share parsing only when the hash looks like a
+// share payload. Everything else is left for Viewer to scroll to (or ignore).
+function looksLikeSharePayload(rawHash: string): boolean {
   const hash = rawHash.replace(/^#/, '').split('?')[0];
-  return /^[a-z0-9][a-z0-9-]*$/.test(hash);
+  return hash.length >= 30 && /^[A-Za-z0-9_-]+$/.test(hash) && /[A-Z]/.test(hash);
 }
 
 export function useSharing(
@@ -164,8 +166,8 @@ export function useSharing(
 
       const hash = window.location.hash.slice(1);
 
-      // Plain in-page anchor — let Viewer scroll to it, don't try share parsing.
-      if (isPlainAnchorHash(hash)) {
+      // Not a share payload — leave it for Viewer to scroll to (or ignore).
+      if (!looksLikeSharePayload(hash)) {
         return false;
       }
 
@@ -225,8 +227,7 @@ export function useSharing(
   // Listen for hash changes (when user pastes a new share URL)
   useEffect(() => {
     const handleHashChange = () => {
-      const hash = window.location.hash.slice(1);
-      if (!hash || isPlainAnchorHash(hash)) return;
+      if (!looksLikeSharePayload(window.location.hash)) return;
       loadFromHash();
     };
 

--- a/packages/ui/utils/anchors.test.ts
+++ b/packages/ui/utils/anchors.test.ts
@@ -1,46 +1,28 @@
 import { describe, expect, test } from 'bun:test';
-import {
-  decodeAnchorHash,
-  getHeadingAnchorAliases,
-  legacySlugifyHeadingAnchor,
-  normalizeAnchorText,
-  slugifyHeadingAnchor,
-} from './anchors';
+import { decodeAnchorHash } from './anchors';
 
-describe('anchor helpers', () => {
-  test('normalizes inline markdown before slugging', () => {
-    expect(normalizeAnchorText('Part I: **Project** `Overview`')).toBe('Part I: Project Overview');
-    expect(normalizeAnchorText('[Docs](./docs.md) and [[notes|Notes Page]]')).toBe('Docs and Notes Page');
+describe('decodeAnchorHash', () => {
+  test('strips leading # and trims', () => {
+    expect(decodeAnchorHash('#section-overview')).toBe('section-overview');
   });
 
-  test('decodes anchor hashes and strips callback suffixes', () => {
-    expect(decodeAnchorHash('#section--overview')).toBe('section--overview');
-    expect(decodeAnchorHash('#section--overview?cb=https://example.com&ct=token')).toBe(
-      'section--overview',
+  test('drops query-string suffixes (e.g. share callback params)', () => {
+    expect(decodeAnchorHash('#section-overview?cb=https://example.com&ct=token')).toBe(
+      'section-overview',
     );
+  });
+
+  test('percent-decodes unicode', () => {
+    expect(decodeAnchorHash('#caf%C3%A9')).toBe('café');
   });
 
   test('keeps malformed percent-encoded hashes non-fatal', () => {
     expect(decodeAnchorHash('#bad%E0%A4%A')).toBe('bad%E0%A4%A');
   });
 
-  test('creates a canonical collapsed slug', () => {
-    expect(slugifyHeadingAnchor('Part I: Project Overview: Goals and Scope')).toBe(
-      'part-i-project-overview-goals-and-scope',
-    );
-  });
-
-  test('creates a legacy slug variant that preserves repeated separators', () => {
-    expect(legacySlugifyHeadingAnchor('Part I: Project Overview: Goals and Scope')).toBe(
-      'part-i--project-overview--goals-and-scope',
-    );
-  });
-
-  test('returns both canonical and legacy aliases without duplicates', () => {
-    expect(getHeadingAnchorAliases('Simple Heading')).toEqual(['simple-heading']);
-    expect(getHeadingAnchorAliases('Part I: Project Overview: Goals and Scope')).toEqual([
-      'part-i-project-overview-goals-and-scope',
-      'part-i--project-overview--goals-and-scope',
-    ]);
+  test('returns null for empty or hash-only fragments', () => {
+    expect(decodeAnchorHash('')).toBeNull();
+    expect(decodeAnchorHash('#')).toBeNull();
+    expect(decodeAnchorHash('#   ')).toBeNull();
   });
 });

--- a/packages/ui/utils/anchors.test.ts
+++ b/packages/ui/utils/anchors.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  decodeAnchorHash,
+  getHeadingAnchorAliases,
+  legacySlugifyHeadingAnchor,
+  normalizeAnchorText,
+  slugifyHeadingAnchor,
+} from './anchors';
+
+describe('anchor helpers', () => {
+  test('normalizes inline markdown before slugging', () => {
+    expect(normalizeAnchorText('Part I: **Project** `Overview`')).toBe('Part I: Project Overview');
+    expect(normalizeAnchorText('[Docs](./docs.md) and [[notes|Notes Page]]')).toBe('Docs and Notes Page');
+  });
+
+  test('decodes anchor hashes and strips callback suffixes', () => {
+    expect(decodeAnchorHash('#section--overview')).toBe('section--overview');
+    expect(decodeAnchorHash('#section--overview?cb=https://example.com&ct=token')).toBe(
+      'section--overview',
+    );
+  });
+
+  test('keeps malformed percent-encoded hashes non-fatal', () => {
+    expect(decodeAnchorHash('#bad%E0%A4%A')).toBe('bad%E0%A4%A');
+  });
+
+  test('creates a canonical collapsed slug', () => {
+    expect(slugifyHeadingAnchor('Part I: Project Overview: Goals and Scope')).toBe(
+      'part-i-project-overview-goals-and-scope',
+    );
+  });
+
+  test('creates a legacy slug variant that preserves repeated separators', () => {
+    expect(legacySlugifyHeadingAnchor('Part I: Project Overview: Goals and Scope')).toBe(
+      'part-i--project-overview--goals-and-scope',
+    );
+  });
+
+  test('returns both canonical and legacy aliases without duplicates', () => {
+    expect(getHeadingAnchorAliases('Simple Heading')).toEqual(['simple-heading']);
+    expect(getHeadingAnchorAliases('Part I: Project Overview: Goals and Scope')).toEqual([
+      'part-i-project-overview-goals-and-scope',
+      'part-i--project-overview--goals-and-scope',
+    ]);
+  });
+});

--- a/packages/ui/utils/anchors.ts
+++ b/packages/ui/utils/anchors.ts
@@ -1,16 +1,3 @@
-export function normalizeAnchorText(text: string): string {
-  return text
-    .normalize('NFKD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '$1')
-    .replace(/\[\[([^\]|]+)\|([^\]]+)\]\]/g, '$2')
-    .replace(/\[\[([^\]]+)\]\]/g, '$1')
-    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '$1')
-    .replace(/`([^`]+)`/g, '$1')
-    .replace(/[*_~]/g, '')
-    .trim();
-}
-
 export function decodeAnchorHash(hash: string): string | null {
   const raw = hash.replace(/^#/, '').split('?')[0]?.trim();
   if (!raw) return null;
@@ -19,27 +6,6 @@ export function decodeAnchorHash(hash: string): string | null {
     const decoded = decodeURIComponent(raw).trim();
     return decoded || null;
   } catch {
-    // Keep malformed fragments non-fatal; the caller can still attempt lookup.
     return raw;
   }
-}
-
-export function slugifyHeadingAnchor(text: string): string {
-  return normalizeAnchorText(text)
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-}
-
-export function legacySlugifyHeadingAnchor(text: string): string {
-  return normalizeAnchorText(text)
-    .toLowerCase()
-    .replace(/[^a-z0-9]/g, '-')
-    .replace(/^-+|-+$/g, '');
-}
-
-export function getHeadingAnchorAliases(text: string): string[] {
-  const aliases = [slugifyHeadingAnchor(text), legacySlugifyHeadingAnchor(text)]
-    .filter(Boolean);
-  return [...new Set(aliases)];
 }

--- a/packages/ui/utils/anchors.ts
+++ b/packages/ui/utils/anchors.ts
@@ -1,0 +1,45 @@
+export function normalizeAnchorText(text: string): string {
+  return text
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '$1')
+    .replace(/\[\[([^\]|]+)\|([^\]]+)\]\]/g, '$2')
+    .replace(/\[\[([^\]]+)\]\]/g, '$1')
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '$1')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/[*_~]/g, '')
+    .trim();
+}
+
+export function decodeAnchorHash(hash: string): string | null {
+  const raw = hash.replace(/^#/, '').split('?')[0]?.trim();
+  if (!raw) return null;
+
+  try {
+    const decoded = decodeURIComponent(raw).trim();
+    return decoded || null;
+  } catch {
+    // Keep malformed fragments non-fatal; the caller can still attempt lookup.
+    return raw;
+  }
+}
+
+export function slugifyHeadingAnchor(text: string): string {
+  return normalizeAnchorText(text)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function legacySlugifyHeadingAnchor(text: string): string {
+  return normalizeAnchorText(text)
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function getHeadingAnchorAliases(text: string): string[] {
+  const aliases = [slugifyHeadingAnchor(text), legacySlugifyHeadingAnchor(text)]
+    .filter(Boolean);
+  return [...new Set(aliases)];
+}

--- a/tests/test-fixtures/14-anchor-links.md
+++ b/tests/test-fixtures/14-anchor-links.md
@@ -1,0 +1,156 @@
+# In-Page Anchor Navigation Fixture
+
+This fixture exercises `[text](#slug)` links across the full range of
+heading shapes the slugger produces — ASCII, Unicode, punctuation runs,
+numerics — plus anchors embedded in every block type that threads the
+`onNavigateAnchor` callback (paragraphs, list items, blockquotes, alerts,
+directives, tables, raw HTML blocks).
+
+Clicking any link below should smooth-scroll to the target heading inside
+the sticky scroll viewport. None should trigger the "Shared Plan Could Not
+Be Loaded" dialog.
+
+---
+
+## Table of Contents
+
+- [Plain ASCII heading](#plain-ascii-heading)
+- [Heading with: colons, commas, and punctuation!](#heading-with-colons-commas-and-punctuation)
+- [Heading — With Em Dash](#heading-with-em-dash)
+- [Café ☕ résumé](#café-résumé)
+- [中文 标题](#中文-标题)
+- [Español: año nuevo](#español-año-nuevo)
+- [Русский заголовок](#русский-заголовок)
+- [123 Numbers-only start](#123-numbers-only-start)
+- [UPPERCASE Heading Stays Lower](#uppercase-heading-stays-lower)
+- [Heading with `inline code` and **bold**](#heading-with-inline-code-and-bold)
+- [Very-Very-Very-Long-Heading-With-Many-Hyphens-To-Stress-The-Slugger](#very-very-very-long-heading-with-many-hyphens-to-stress-the-slugger)
+- [Raw HTML heading: `<h2 id="MySection">`](#MySection)
+- [Duplicate](#duplicate)
+- [Duplicate](#duplicate-1)
+
+---
+
+## Anchors in Different Contexts
+
+Paragraph link: jump to [Café ☕ résumé](#café-résumé).
+
+- List link: jump to [中文 标题](#中文-标题)
+- Nested list link:
+  - Deep link to [Numbers-only start](#123-numbers-only-start)
+
+> Blockquote link: go to [Español: año nuevo](#español-año-nuevo).
+
+> [!NOTE]
+> Alert-block link: go to [Русский заголовок](#русский-заголовок).
+
+> [!WARNING]
+> Combined with **bold** and *italic* — link to [UPPERCASE Heading Stays Lower](#uppercase-heading-stays-lower).
+
+:::tip Directive block
+Directive-container link to [Heading — With Em Dash](#heading-with-em-dash).
+:::
+
+| Target | Link |
+|---|---|
+| ASCII | [go](#plain-ascii-heading) |
+| Punctuation | [go](#heading-with-colons-commas-and-punctuation) |
+| Unicode accent | [go](#café-résumé) |
+| CJK | [go](#中文-标题) |
+| Cyrillic | [go](#русский-заголовок) |
+| Numeric start | [go](#123-numbers-only-start) |
+| Raw HTML id | [go](#MySection) |
+| Duplicate second | [go](#duplicate-1) |
+
+<details>
+<summary>Raw HTML block with anchors inside (click to expand)</summary>
+
+Native `<a href="#...">` links inside raw HTML should also route through the
+scroll handler, not trigger a native browser jump that misses the scroll
+viewport.
+
+<ul>
+  <li><a href="#plain-ascii-heading">HTML list → ASCII heading</a></li>
+  <li><a href="#café-résumé">HTML list → Unicode heading</a></li>
+  <li><a href="#MySection">HTML list → raw HTML id</a></li>
+</ul>
+
+</details>
+
+---
+
+## Plain ASCII heading
+
+Should resolve from `#plain-ascii-heading`.
+
+## Heading with: colons, commas, and punctuation!
+
+Runs of non-alphanumerics collapse to single `-`.
+
+## Heading — With Em Dash
+
+Em dashes should not produce double-hyphens.
+
+## Café ☕ résumé
+
+Unicode letters (accents) are preserved by `slugifyHeading`. The coffee
+emoji becomes a separator. Expected id: `café-résumé`.
+
+## 中文 标题
+
+CJK characters count as Unicode letters and survive slugging. Expected id:
+`中文-标题`.
+
+## Español: año nuevo
+
+Mix of ASCII, colon, and `ñ`. Expected id: `español-año-nuevo`.
+
+## Русский заголовок
+
+Cyrillic letters are preserved. Expected id: `русский-заголовок`.
+
+## 123 Numbers-only start
+
+Heading starts with digits — slugger should not strip the leading number.
+Expected id: `123-numbers-only-start`.
+
+## UPPERCASE Heading Stays Lower
+
+Heading text is uppercase; slugger lowercases. Expected id:
+`uppercase-heading-stays-lower`.
+
+## Heading with `inline code` and **bold**
+
+Inline markdown is stripped before slugging. Expected id:
+`heading-with-inline-code-and-bold`.
+
+## Very-Very-Very-Long-Heading-With-Many-Hyphens-To-Stress-The-Slugger
+
+Consecutive existing hyphens should collapse cleanly. Expected id:
+`very-very-very-long-heading-with-many-hyphens-to-stress-the-slugger`.
+
+## <a name="MySection"></a>Raw HTML heading: `<h2 id="MySection">`
+
+Not strictly a markdown heading id — this section uses an inline HTML
+anchor so `#MySection` resolves via the native `name="MySection"`
+attribute. Exercises the uppercase / non-slugified id path.
+
+## Duplicate
+
+First occurrence — bare slug `duplicate`.
+
+## Duplicate
+
+Second occurrence — deduplicated to `duplicate-1` by `buildHeadingSlugMap`.
+
+---
+
+## Regression checks
+
+- Loading this fixture with `#café-résumé` in the URL should auto-scroll
+  without firing the shared-plan error dialog.
+- Changing the hash (e.g., clicking links above) should trigger
+  `hashchange` and scroll, again without the error dialog.
+- Hashes that *do* look like share payloads (long, mixed-case base64url)
+  should still route to the share loader — this fixture does not include
+  any, so the share path should never fire while testing this file.


### PR DESCRIPTION
## Summary
- Intercept `#`-prefixed link clicks in `InlineMarkdown` and smooth-scroll
  within the sticky scroll viewport. The native browser jump didn't work
  because plan content lives inside a scrollable container, not the
  document root.
- Expose both a canonical slug and a legacy slug per heading via
  `data-anchor-aliases` so previously shared URLs keep resolving. Canonical
  collapses runs of separators; legacy preserves them.
- Handle `hashchange` and the initial hash so direct links land on the
  right heading after load.
- New `packages/ui/utils/anchors.ts` with `normalizeAnchorText`,
  `decodeAnchorHash`, `slugifyHeadingAnchor`, `legacySlugifyHeadingAnchor`,
  `getHeadingAnchorAliases` + unit tests.
- Thread `onNavigateAnchor` through `BlockRenderer`, `AlertBlock`,
  `Callout`, `TableBlock`, `TablePopout`, `proseBody`.
- Ignore `.serena/` tooling state.

## Test plan
- [ ] `bun test packages/ui/utils/anchors.test.ts`
- [ ] Render a plan with `## Part I: Overview: Scope` and click a TOC link
      like `[Scope](#part-i-overview-scope)` — scrolls smoothly, sticky
      header isn't overlapping the target.
- [ ] Open a shared URL that uses the legacy double-hyphen slug
      (`#part-i--overview--scope`) — still resolves via alias.
- [ ] Load a page with `#some-heading` in the URL directly — auto-scrolls
      on first render.
- [ ] Anchor links inside tables, callouts, alerts, and blockquotes all
      navigate in-page.