### PR TITLE
fix(commands): use background Bash to avoid shell timeout killing servers

### DIFF
--- a/apps/hook/commands/plannotator-annotate.md
+++ b/apps/hook/commands/plannotator-annotate.md
@@ -4,9 +4,11 @@ allowed-tools: Bash(plannotator:*)
 disable-model-invocation: true
 ---
 
-## Markdown Annotations
+## Instructions
 
-!`plannotator annotate $ARGUMENTS`
+Run `plannotator annotate $ARGUMENTS` using the Bash tool with `run_in_background: true`. This starts an annotation server and opens the browser. The user will annotate the document and submit feedback — this may take a long time.
+
+**Wait for the background task to complete before proceeding.** Do not interrupt or take other actions while the user is annotating.
 
 ## Your task
 

--- a/apps/hook/commands/plannotator-last.md
+++ b/apps/hook/commands/plannotator-last.md
@@ -4,9 +4,11 @@ allowed-tools: Bash(plannotator:*)
 disable-model-invocation: true
 ---
 
-## Message Annotations
+## Instructions
 
-!`plannotator annotate-last $ARGUMENTS`
+Run `plannotator annotate-last $ARGUMENTS` using the Bash tool with `run_in_background: true`. This starts an annotation server and opens the browser. The user will annotate the message and submit feedback — this may take a long time.
+
+**Wait for the background task to complete before proceeding.** Do not interrupt or take other actions while the user is annotating.
 
 ## Your task
 

--- a/apps/hook/commands/plannotator-review.md
+++ b/apps/hook/commands/plannotator-review.md
@@ -4,10 +4,12 @@ allowed-tools: Bash(plannotator:*)
 disable-model-invocation: true
 ---
 
-## Code Review Feedback
+## Instructions
 
-!`plannotator review $ARGUMENTS`
+Run `plannotator review $ARGUMENTS` using the Bash tool with `run_in_background: true`. This starts a review server and opens the browser. The user will review code and submit feedback — this may take a long time.
+
+**Wait for the background task to complete before proceeding.** Do not interrupt or take other actions while the user is reviewing.
 
 ## Your task
 
-If the review above contains feedback or annotations, address them. If no changes were requested, acknowledge and continue.
+When the command finishes, read its output. If it contains feedback or annotations, address them. If no changes were requested, acknowledge and continue.


### PR DESCRIPTION
## Summary

- Replace `!` shell preprocessing with `run_in_background: true` Bash instructions in review, annotate, and annotate-last slash commands
- Fixes servers being killed after ~2 minutes due to Claude Code's shell preprocessing timeout
- Prevents annotation loss when the server dies mid-review

## Problem

The `/plannotator-review`, `/plannotator-annotate`, and `/plannotator-last` slash commands use the `!` preprocessing syntax, which runs `plannotator` as a blocking shell command. The server blocks on `waitForDecision()` until the user submits, but Claude Code's shell preprocessing has a ~120s timeout that kills the process during long sessions.

Plan mode doesn't have this issue because it uses a PermissionRequest hook with a 96-hour timeout (`hooks.json`).

When the process is killed:
1. The draft file survives on disk, but only contains annotations up to the last successful auto-save
2. Auto-save failures are silent (`.catch(() => {})`), so the user has no indication their work isn't being saved
3. Reopening recovers partial annotations but anything after the last save is lost

## Fix

Replace `!`plannotator review $ARGUMENTS`` with skill instructions that tell Claude to run the command via the Bash tool with `run_in_background: true`. Background Bash tasks have no timeout and notify Claude when complete.

No server code changes, no build required — only the 3 `.md` skill files are modified.

## Test results

Tested with `run_in_background: true` Bash tasks (the approach this PR uses). Both servers survived 135 seconds (past the old 120s kill threshold) and successfully captured annotations on submission:

| Test | Survived 135s | Annotations submitted | Feedback captured |
|------|:---:|:---:|:---:|
| `plannotator review` | Yes | Yes | Yes — review feedback on diff |
| `plannotator annotate` | Yes | Yes | Yes — annotation on markdown |

### Review output (after 135s wait):
```
# Code Review Feedback

## test.txt

### Line 1 (new) — ``hello world`` (chars 0-11)
test

The reviewer has identified issues above. You must address all of them.
```

### Annotate output (after 135s wait):
```
# File Feedback

I've reviewed this file and have 1 piece of feedback:

## 1. Feedback on: "Test file"
> test
```

## Environment

- Claude Code v2.1.108
- Plannotator v0.19.0
- macOS 26.4
