### PR TITLE
feat(annotate): replace --silent-approve with --hook

### DIFF
--- a/apps/hook/server/cli.ts
+++ b/apps/hook/server/cli.ts
@@ -15,7 +15,7 @@ export function formatTopLevelHelp(): string {
     "  plannotator --help",
     "  plannotator [--browser <name>]",
     "  plannotator review [PR_URL]",
-    "  plannotator annotate <file.md | file.html | https://... | folder/>  [--no-jina] [--gate] [--json] [--silent-approve]",
+    "  plannotator annotate <file.md | file.html | https://... | folder/>  [--no-jina] [--gate] [--json] [--hook]",
     "  plannotator last",
     "  plannotator archive",
     "  plannotator sessions",

--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -126,29 +126,32 @@ const cliNoJina = noJinaIdx !== -1;
 if (cliNoJina) args.splice(noJinaIdx, 1);
 
 // Annotate review-gate flags (#570): --gate adds an Approve button,
-// --json switches stdout to structured decision output, --silent-approve
-// suppresses the plaintext approve marker (naive hooks that treat any
-// stdout as a block signal opt in here to keep silence-is-permission).
+// --json switches stdout to structured decision output, --hook emits
+// hook-native JSON that works directly with Claude Code and Codex
+// PostToolUse/Stop hook protocols.
 const gateIdx = args.indexOf("--gate");
-const gateFlag = gateIdx !== -1;
+let gateFlag = gateIdx !== -1;
 if (gateFlag) args.splice(gateIdx, 1);
 const jsonIdx = args.indexOf("--json");
 const jsonFlag = jsonIdx !== -1;
 if (jsonFlag) args.splice(jsonIdx, 1);
-const silentApproveIdx = args.indexOf("--silent-approve");
-const silentApproveFlag = silentApproveIdx !== -1;
-if (silentApproveFlag) args.splice(silentApproveIdx, 1);
+const hookIdx = args.indexOf("--hook");
+const hookFlag = hookIdx !== -1;
+if (hookFlag) args.splice(hookIdx, 1);
+if (hookFlag) gateFlag = true;
 
 // Stdout matrix for annotate / annotate-last / copilot annotate-last (#570).
-// Plaintext mode:
-//   - Close emits empty stdout (naive PostToolUse / Stop hooks: empty = allow).
-//   - Approve emits "The user approved." so agents and templates can
-//     distinguish approval from close without needing --json. With
-//     --silent-approve, Approve also emits empty stdout (hook-friendly).
-//   - Send Annotations emits the plaintext feedback markdown.
-// --json switches to structured output across all three decisions;
-// --silent-approve has no effect in --json mode (JSON always routes by
-// decision field, so there's no ambiguity to silence).
+//
+// --hook (recommended for hooks):
+//   Approve/Close → empty stdout (hook passes, agent proceeds).
+//   Annotate → {"decision":"block","reason":"<feedback>"} (hook blocks).
+//   Works with both Claude Code and Codex hook protocols.
+//
+// --json (structured decisions for wrapper scripts):
+//   Emits {"decision":"approved|dismissed|annotated","feedback":"..."}.
+//
+// Plaintext (default):
+//   Close → empty. Approve → "The user approved." Annotate → feedback.
 export const APPROVED_PLAINTEXT_MARKER = "The user approved.";
 
 function emitAnnotateOutcome(result: {
@@ -156,6 +159,13 @@ function emitAnnotateOutcome(result: {
   exit?: boolean;
   approved?: boolean;
 }): void {
+  if (hookFlag) {
+    if (result.approved || result.exit) return;
+    if (result.feedback) {
+      console.log(JSON.stringify({ decision: "block", reason: result.feedback }));
+    }
+    return;
+  }
   if (jsonFlag) {
     if (result.approved) {
       console.log(JSON.stringify({ decision: "approved" }));
@@ -166,9 +176,9 @@ function emitAnnotateOutcome(result: {
     }
     return;
   }
-  if (result.exit) return; // empty stdout on close
+  if (result.exit) return;
   if (result.approved) {
-    if (!silentApproveFlag) console.log(APPROVED_PLAINTEXT_MARKER);
+    console.log(APPROVED_PLAINTEXT_MARKER);
     return;
   }
   if (result.feedback) console.log(result.feedback);
@@ -527,7 +537,7 @@ if (args[0] === "sessions") {
 
   const rawFilePath = args[1];
   if (!rawFilePath) {
-    console.error("Usage: plannotator annotate <file.md | file.html | https://... | folder/>  [--no-jina] [--gate] [--json] [--silent-approve]");
+    console.error("Usage: plannotator annotate <file.md | file.html | https://... | folder/>  [--no-jina] [--gate] [--json] [--hook]");
     process.exit(1);
   }
 

--- a/apps/marketing/src/content/docs/commands/annotate-last.md
+++ b/apps/marketing/src/content/docs/commands/annotate-last.md
@@ -75,7 +75,7 @@ The annotation UI in `annotate-last` mode works the same as `/plannotator-annota
 
 ## Flags
 
-`plannotator annotate-last` accepts the same `--gate`, `--json`, and `--silent-approve` flags as `plannotator annotate`. See [Annotate → Flags](/docs/commands/annotate/#flags) for the full matrix.
+`plannotator annotate-last` accepts the same `--gate`, `--json`, and `--hook` flags as `plannotator annotate`. See [Annotate → Flags](/docs/commands/annotate/#flags) for the full matrix.
 
 The common use case for `--gate` on annotate-last is a turn-by-turn review gate wired to a Stop hook:
 

--- a/apps/marketing/src/content/docs/commands/annotate.md
+++ b/apps/marketing/src/content/docs/commands/annotate.md
@@ -123,11 +123,11 @@ Switches stdout to a structured decision object so hooks can route programmatica
 
 `feedback` is only present when `decision === "annotated"`.
 
-### `--silent-approve`
+### `--hook`
 
-Suppresses the plaintext approve marker so Approve emits empty stdout instead of `The user approved.`. Use this with naive hooks that treat any non-empty stdout as a block signal. Approve and Close both become silent, and only Send Annotations blocks with feedback (silence-is-permission).
+Emits hook-native JSON that works directly with Claude Code and Codex PostToolUse/Stop hook protocols. Implies `--gate` (always three-button UX). Approve and Close emit empty stdout (hook passes), Send Annotations emits `{"decision":"block","reason":"<feedback>"}` (hook blocks with feedback).
 
-`--silent-approve` only affects plaintext mode. In `--json` mode, Approve continues to emit `{"decision":"approved"}` — JSON callers route on the `decision` field, so there's no ambiguity to silence.
+This is the recommended flag for hook integrations. If both `--hook` and `--json` are passed, `--hook` wins.
 
 ### Stdout matrix
 
@@ -135,13 +135,13 @@ Suppresses the plaintext approve marker so Approve emits empty stdout instead of
 |---|---|---|---|---|
 | *(none)* | 2-button | n/a | empty | feedback (plaintext) |
 | `--gate` | 3-button | `The user approved.` | empty | feedback (plaintext) |
-| `--gate --silent-approve` | 3-button | empty | empty | feedback (plaintext) |
 | `--json` | 2-button | n/a | `{"decision":"dismissed"}` | `{"decision":"annotated","feedback":"..."}` |
 | `--gate --json` | 3-button | `{"decision":"approved"}` | `{"decision":"dismissed"}` | `{"decision":"annotated","feedback":"..."}` |
+| `--hook` | 3-button | empty | empty | `{"decision":"block","reason":"..."}` |
 
-**Key property:** `--gate` plaintext output is unambiguous across three decisions — Close is empty, Send Annotations is feedback markdown, Approve is the line `The user approved.`. Drop the marker with `--silent-approve` when your hook treats any stdout as a block. Use `--json` when you want machine-readable decision objects instead of string matching.
+**Key property:** `--gate` plaintext output is unambiguous across three decisions. Use `--json` when you want machine-readable decision objects. Use `--hook` when wiring into Claude Code or Codex hooks directly.
 
-On OpenCode and Pi, `--json` and `--silent-approve` are silently accepted because those harnesses write back into the session directly rather than via stdout. The `--gate` flag behaves identically across all three harnesses.
+On OpenCode and Pi, `--json` and `--hook` are silently accepted because those harnesses write back into the session directly rather than via stdout. The `--gate` flag behaves identically across all three harnesses.
 
 See [Hook integration recipes](/docs/guides/hook-integration/) for ready-to-use PostToolUse and Stop hook examples.
 

--- a/apps/marketing/src/content/docs/guides/annotate-gates-and-json-responses.md
+++ b/apps/marketing/src/content/docs/guides/annotate-gates-and-json-responses.md
@@ -1,6 +1,6 @@
 ---
 title: "Annotate Gates and JSON Responses"
-description: "The --gate, --json, and --silent-approve flags extend plannotator annotate from a feedback tool into a structured review gate with machine-readable decisions. Use them to wire Plannotator into spec-driven workflows, Stop hooks, and agent pipelines."
+description: "The --gate, --json, and --hook flags extend plannotator annotate from a feedback tool into a structured review gate with machine-readable decisions. Use them to wire Plannotator into spec-driven workflows, Stop hooks, and agent pipelines."
 sidebar:
   order: 28
 section: "Guides"
@@ -12,7 +12,7 @@ section: "Guides"
 
 - **`--gate`** adds an Approve button to the annotation UI. The reviewer picks one of three decisions: approve, send annotations, or close.
 - **`--json`** emits every decision as a structured JSON object on stdout so hooks and plugins can route on the outcome without parsing free text.
-- **`--silent-approve`** suppresses the plaintext approve marker so Approve emits empty stdout. Naive hooks that treat any stdout as a block signal opt in here to keep silence-is-permission intact.
+- **`--hook`** emits hook-native JSON that works directly with Claude Code and Codex PostToolUse/Stop hook protocols. Implies `--gate`. Recommended for hook integrations.
 - The flags compose. Use any alone or together.
 - Identical semantics across every supported harness: Claude Code, Copilot CLI, Gemini CLI, OpenCode, Pi, and Codex.
 
@@ -23,9 +23,9 @@ section: "Guides"
 ──────────────────────────┼──────────────────┼─────────────────────────┼──────────────────────────┼───────────────────────────────────────────────
  (none)                   │  2-button        │  n/a                    │  empty                   │  feedback (plaintext)
  --gate                   │  3-button        │  `The user approved.`   │  empty                   │  feedback (plaintext)
- --gate --silent-approve  │  3-button        │  empty                  │  empty                   │  feedback (plaintext)
  --json                   │  2-button        │  n/a                    │  {"decision":"dismissed"}│  {"decision":"annotated","feedback":"..."}
  --gate --json            │  3-button        │  {"decision":"approved"}│  {"decision":"dismissed"}│  {"decision":"annotated","feedback":"..."}
+ --hook                   │  3-button        │  empty                  │  empty                   │  {"decision":"block","reason":"..."}
 ```
 
 ### JSON schema
@@ -70,7 +70,7 @@ A three-way review decision. The annotation UI adds an Approve button alongside 
 - **Send Annotations.** The reviewer has specific changes. The feedback is returned verbatim.
 - **Close.** The session ends without a decision. Neither a signal to the agent nor an instruction set.
 
-In plaintext mode, Approve emits the single line `The user approved.` on stdout so templates and agents can distinguish approval from close without needing `--json`. Close emits nothing. Send Annotations emits the feedback markdown. Hook authors who treat any non-empty stdout as a block signal can add `--silent-approve` to suppress the marker, or use `--json` for structured routing.
+In plaintext mode, Approve emits the single line `The user approved.` on stdout so templates and agents can distinguish approval from close without needing `--json`. Close emits nothing. Send Annotations emits the feedback markdown. For hook integrations, use `--hook` instead, which emits hook-native JSON directly.
 
 ## `--json`
 
@@ -82,17 +82,17 @@ Structured stdout. Every decision is emitted as a JSON object with a `decision` 
 - `--gate --json` unlocks all three decisions in structured form.
 - On OpenCode and Pi, `--json` is accepted silently. Those harnesses write back to the session directly rather than via stdout, so the flag has no effect there. Recipes remain portable.
 
-## `--silent-approve`
+## `--hook`
 
-Suppresses the plaintext approve marker. With `--gate --silent-approve`, Approve emits empty stdout (instead of `The user approved.`), matching Close. Send Annotations still emits feedback.
+Emits hook-native JSON that works directly with Claude Code and Codex PostToolUse/Stop hook protocols. Implies `--gate` (always three-button UX). If both `--hook` and `--json` are passed, `--hook` wins.
 
-This is the shape naive hooks want — the ones that treat any non-empty stdout as a block signal:
+- Approve → empty stdout → hook passes → agent proceeds.
+- Close → empty stdout → hook passes → agent proceeds.
+- Send Annotations → `{"decision":"block","reason":"<feedback>"}` → hook blocks with feedback.
 
-- Approve → empty → hook passes → agent proceeds.
-- Close → empty → hook passes → agent proceeds.
-- Send Annotations → feedback → hook blocks with that feedback as the reason.
+This is the recommended approach for hook integrations. The `{"decision":"block","reason":"..."}` format is the native protocol both Claude Code and Codex use for PostToolUse and Stop hooks. No wrapper script needed.
 
-`--silent-approve` only affects plaintext mode. In `--json` mode, Approve still emits `{"decision":"approved"}` — JSON callers route on the `decision` field, so there's no ambiguity to silence. The flag is accepted silently on OpenCode and Pi for the same reason `--json` is: those harnesses don't use stdout as the signal channel.
+The flag is accepted silently on OpenCode and Pi for the same reason `--json` is: those harnesses don't use stdout as the signal channel.
 
 ## Primary use cases
 

--- a/apps/marketing/src/content/docs/guides/hook-integration.md
+++ b/apps/marketing/src/content/docs/guides/hook-integration.md
@@ -6,13 +6,12 @@ sidebar:
 section: "Guides"
 ---
 
-The `--gate`, `--json`, and `--silent-approve` flags on `plannotator annotate` and `plannotator annotate-last` turn annotation into a structured review decision. This guide shows how to wire them into agent hooks so a human can gate the agent at specific points in a workflow.
+The `--gate`, `--json`, and `--hook` flags on `plannotator annotate` and `plannotator annotate-last` turn annotation into a structured review decision. This guide shows how to wire them into agent hooks so a human can gate the agent at specific points in a workflow.
 
 See [Annotate → Flags](/docs/commands/annotate/#flags) for the full stdout matrix. The short version:
 
+- `--hook` emits hook-native JSON that works directly with Claude Code and Codex hook protocols. Implies `--gate`. Recommended for hook integrations.
 - `--gate` adds a three-button UX (Approve / Send Annotations / Close).
-- Plaintext default: Approve emits the line `The user approved.`, Close emits empty stdout, Send Annotations emits the feedback markdown. Three distinguishable outputs without parsing JSON.
-- `--silent-approve` collapses Approve to empty stdout, matching Close. Use this with naive "any stdout = block" hooks so silence means permission.
 - `--json` emits every decision as a structured `{ "decision": "approved" | "annotated" | "dismissed", "feedback": "..." }` object.
 
 ## Recipe 1: PostToolUse spec gate
@@ -48,21 +47,21 @@ Behavior:
 - **Send Annotations** → feedback markdown on stdout. Claude Code reports the feedback back.
 - **Close** → empty stdout. Claude Code proceeds silently.
 
-### Silence-is-permission (`--silent-approve`)
+### Hook-native mode (`--hook`)
 
-If your hook treats any non-empty stdout as a block signal (spec-kit and similar naive PostToolUse hooks), add `--silent-approve` so Approve also emits empty stdout:
+For direct hook integration without a wrapper script, use `--hook`. It emits the JSON protocol that Claude Code and Codex hooks expect natively:
 
 ```json
-"command": "plannotator annotate \"$CLAUDE_TOOL_INPUT_file_path\" --gate --silent-approve"
+"command": "plannotator annotate \"$CLAUDE_TOOL_INPUT_file_path\" --hook"
 ```
 
-Behavior with the flag:
+Behavior:
 
 - **Approve** → empty stdout → hook passes → agent proceeds.
 - **Close** → empty stdout → hook passes → agent proceeds.
-- **Send Annotations** → feedback on stdout → hook blocks with feedback as the reason.
+- **Send Annotations** → `{"decision":"block","reason":"<feedback>"}` → hook blocks with feedback.
 
-Approve and Close collapse into the same "silent = allow" cell, which is what this class of hook expects. Only Send Annotations carries content the agent needs to react to.
+`--hook` implies `--gate` (three-button UX). This is the recommended approach for both Claude Code PostToolUse hooks and Codex hooks.
 
 ### Structured (`--json`)
 
@@ -119,7 +118,7 @@ Behavior:
 - **Send Annotations** → feedback on stdout → Claude Code re-prompts with the feedback.
 - **Close** → empty stdout → turn ends.
 
-Add `--silent-approve` if your Stop hook treats any stdout as a re-prompt trigger — Approve then emits empty stdout too, so only Send Annotations re-fires the turn with feedback.
+Use `--hook` instead of `--gate` if you want hook-native JSON. Approve and Close emit empty stdout, Send Annotations emits `{"decision":"block","reason":"..."}` which prevents the stop and re-prompts with feedback.
 
 ### Structured
 
@@ -133,7 +132,7 @@ The same `--gate` flag works in OpenCode's `/plannotator-annotate` and Pi's `/pl
 /plannotator-annotate spec.md --gate
 ```
 
-On those harnesses there is no stdout channel back to the agent — the plugin writes back via `session.prompt` (OpenCode) or `sendUserMessage` (Pi). Approve and Close both result in no session injection; Send Annotations injects the feedback. `--json` and `--silent-approve` are accepted silently on these harnesses so recipes stay portable.
+On those harnesses there is no stdout channel back to the agent — the plugin writes back via `session.prompt` (OpenCode) or `sendUserMessage` (Pi). Approve and Close both result in no session injection; Send Annotations injects the feedback. `--json` and `--hook` are accepted silently on these harnesses so recipes stay portable.
 
 Third-party Pi or OpenCode plugins that want explicit decision routing can read `approved` directly from the server's decision object:
 

--- a/apps/marketing/src/content/docs/guides/hook-integration.md
+++ b/apps/marketing/src/content/docs/guides/hook-integration.md
@@ -1,20 +1,20 @@
 ---
 title: "Hook Integration"
-description: "Wire Plannotator into Claude Code and Codex hooks for human-in-the-loop review gates on spec artifacts, code output, and agent turns."
+description: "Wire Plannotator into agent hooks for human-in-the-loop review gates on spec artifacts, code output, and agent turns. Works with Claude Code, Codex, OpenCode, and any agent that supports PostToolUse or Stop hooks."
 sidebar:
   order: 27
 section: "Guides"
 ---
 
-Plannotator can run as a hook command inside Claude Code and Codex. The agent writes a file or finishes a turn, the hook fires, and Plannotator opens a review UI in the browser. The reviewer approves, sends annotations, or dismisses. The hook blocks until a decision is made, then returns the result to the agent in the hook protocol's native format.
+Plannotator can run as a hook command inside any agent that supports lifecycle hooks. The agent writes a file or finishes a turn, the hook fires, and Plannotator opens a review UI in the browser. The reviewer approves, sends annotations, or dismisses. The hook blocks until a decision is made, then returns the result in the hook protocol's native format.
 
 One flag does everything:
 
 ```
-plannotator annotate "$CLAUDE_TOOL_INPUT_file_path" --hook
+plannotator annotate <file> --hook
 ```
 
-`--hook` implies `--gate` (three-button UX) and emits hook-native JSON. Approve and Close produce empty stdout (hook passes). Send Annotations produces `{"decision":"block","reason":"<feedback>"}` (hook blocks with feedback). Works with both Claude Code and Codex hook protocols.
+`--hook` implies `--gate` (three-button UX) and emits hook-native JSON. Approve and Close produce empty stdout (hook passes). Send Annotations produces `{"decision":"block","reason":"<feedback>"}` (hook blocks with feedback). This format is the native protocol for Claude Code, Codex, and any agent that uses `{"decision":"block"}` for hook signaling.
 
 ## How hooks see Plannotator
 
@@ -26,15 +26,18 @@ Agent hooks communicate via stdout and exit codes. Plannotator always exits `0`.
 | Close | empty | passes, agent proceeds |
 | Send Annotations | `{"decision":"block","reason":"<feedback>"}` | blocks, feedback shown to agent |
 
-The `{"decision":"block","reason":"..."}` format is the native protocol for both [Claude Code hooks](https://code.claude.com/docs/en/hooks) and [Codex hooks](https://developers.openai.com/codex/hooks). No wrapper script needed.
+The `{"decision":"block","reason":"..."}` format is the native hook protocol used by [Claude Code](https://code.claude.com/docs/en/hooks), [Codex](https://developers.openai.com/codex/hooks), and compatible agents. No wrapper script needed.
 
 ## Environment variables in hooks
 
-When a hook fires, the agent exposes tool inputs as environment variables. The most common one for Plannotator:
+When a hook fires, the agent exposes tool inputs as environment variables. The variable names depend on the agent:
 
-- **`$CLAUDE_TOOL_INPUT_file_path`** -- the file path the agent passed to the Write/Edit tool. Use this to tell Plannotator which file to annotate.
+| Agent | File path variable | Project root |
+|---|---|---|
+| Claude Code | `$CLAUDE_TOOL_INPUT_file_path` | `$CLAUDE_PROJECT_DIR` |
+| Codex | `$CODEX_TOOL_INPUT_file_path` | `$CODEX_PROJECT_DIR` |
 
-Other useful variables: `$CLAUDE_TOOL_INPUT_command` (Bash), `$CLAUDE_PROJECT_DIR` (project root). See your agent's hook documentation for the full list.
+The examples below use Claude Code's variable names. Substitute your agent's equivalents. See your agent's hook documentation for the full list of available variables.
 
 ## Recipe 1: Review every file the agent writes
 
@@ -115,15 +118,15 @@ Emits `{"decision":"approved|annotated|dismissed","feedback":"..."}` for every d
 
 See [Annotate Flags](/docs/commands/annotate/#flags) for the full stdout matrix.
 
-## OpenCode and Pi
+## Agents with built-in plugins
 
-The same flags work in OpenCode's `/plannotator-annotate` and Pi's `/plannotator-annotate`:
+OpenCode and Pi have native Plannotator plugins with slash commands:
 
 ```
 /plannotator-annotate spec.md --gate
 ```
 
-These harnesses don't use stdout for signaling -- the plugin writes directly to the session. Approve and Close skip injection; Send Annotations injects the feedback. `--hook` and `--json` are accepted silently so recipes stay portable across harnesses.
+These harnesses don't use stdout for signaling -- the plugin writes directly to the session. Approve and Close skip injection; Send Annotations injects the feedback. `--hook` and `--json` are accepted silently so recipes stay portable across all harnesses.
 
 ## Notes
 

--- a/apps/marketing/src/content/docs/guides/hook-integration.md
+++ b/apps/marketing/src/content/docs/guides/hook-integration.md
@@ -1,26 +1,46 @@
 ---
 title: "Hook Integration"
-description: "Use plannotator annotate and annotate-last as review gates from agent hooks — spec-driven workflows, turn-by-turn review, and more."
+description: "Wire Plannotator into Claude Code and Codex hooks for human-in-the-loop review gates on spec artifacts, code output, and agent turns."
 sidebar:
   order: 27
 section: "Guides"
 ---
 
-The `--gate`, `--json`, and `--hook` flags on `plannotator annotate` and `plannotator annotate-last` turn annotation into a structured review decision. This guide shows how to wire them into agent hooks so a human can gate the agent at specific points in a workflow.
+Plannotator can run as a hook command inside Claude Code and Codex. The agent writes a file or finishes a turn, the hook fires, and Plannotator opens a review UI in the browser. The reviewer approves, sends annotations, or dismisses. The hook blocks until a decision is made, then returns the result to the agent in the hook protocol's native format.
 
-See [Annotate → Flags](/docs/commands/annotate/#flags) for the full stdout matrix. The short version:
+One flag does everything:
 
-- `--hook` emits hook-native JSON that works directly with Claude Code and Codex hook protocols. Implies `--gate`. Recommended for hook integrations.
-- `--gate` adds a three-button UX (Approve / Send Annotations / Close).
-- `--json` emits every decision as a structured `{ "decision": "approved" | "annotated" | "dismissed", "feedback": "..." }` object.
+```
+plannotator annotate "$CLAUDE_TOOL_INPUT_file_path" --hook
+```
 
-## Recipe 1: PostToolUse spec gate
+`--hook` implies `--gate` (three-button UX) and emits hook-native JSON. Approve and Close produce empty stdout (hook passes). Send Annotations produces `{"decision":"block","reason":"<feedback>"}` (hook blocks with feedback). Works with both Claude Code and Codex hook protocols.
 
-Spec-driven frameworks (spec-kit, kiro, openspec) generate multiple markdown artifacts per feature — spec.md, plan.md, tasks.md, and so on — each needing human review before the agent builds from it. A PostToolUse hook on Write turns plannotator into a reviewer in the loop.
+## How hooks see Plannotator
 
-### Plaintext (naive)
+Agent hooks communicate via stdout and exit codes. Plannotator always exits `0`. The decision lives in stdout:
 
-Add to `.claude/hooks.json`:
+| Decision | Stdout | Hook behavior |
+|---|---|---|
+| Approve | empty | passes, agent proceeds |
+| Close | empty | passes, agent proceeds |
+| Send Annotations | `{"decision":"block","reason":"<feedback>"}` | blocks, feedback shown to agent |
+
+The `{"decision":"block","reason":"..."}` format is the native protocol for both [Claude Code hooks](https://code.claude.com/docs/en/hooks) and [Codex hooks](https://developers.openai.com/codex/hooks). No wrapper script needed.
+
+## Environment variables in hooks
+
+When a hook fires, the agent exposes tool inputs as environment variables. The most common one for Plannotator:
+
+- **`$CLAUDE_TOOL_INPUT_file_path`** -- the file path the agent passed to the Write/Edit tool. Use this to tell Plannotator which file to annotate.
+
+Other useful variables: `$CLAUDE_TOOL_INPUT_command` (Bash), `$CLAUDE_PROJECT_DIR` (project root). See your agent's hook documentation for the full list.
+
+## Recipe 1: Review every file the agent writes
+
+A PostToolUse hook on Write triggers Plannotator every time the agent creates or modifies a file. This is the core pattern for spec-driven frameworks (spec-kit, kiro, openspec) where each artifact needs human review before the agent builds from it.
+
+Add to `.claude/hooks.json` (or the equivalent for your agent):
 
 ```json
 {
@@ -31,7 +51,7 @@ Add to `.claude/hooks.json`:
         "hooks": [
           {
             "type": "command",
-            "command": "plannotator annotate \"$CLAUDE_TOOL_INPUT_file_path\" --gate",
+            "command": "plannotator annotate \"$CLAUDE_TOOL_INPUT_file_path\" --hook",
             "timeout": 345600
           }
         ]
@@ -41,57 +61,19 @@ Add to `.claude/hooks.json`:
 }
 ```
 
-Behavior:
+The `timeout` is 4 days in seconds. The hook blocks while the reviewer works in the browser, so set it high.
 
-- **Approve** → `The user approved.` on stdout. Claude Code reports the line back and proceeds.
-- **Send Annotations** → feedback markdown on stdout. Claude Code reports the feedback back.
-- **Close** → empty stdout. Claude Code proceeds silently.
+What happens:
 
-### Hook-native mode (`--hook`)
+1. Agent writes `spec.md`.
+2. PostToolUse hook fires, opens Plannotator in the browser.
+3. Reviewer reads the spec, adds inline annotations, clicks **Send Annotations**.
+4. Hook emits `{"decision":"block","reason":"<feedback>"}`. Agent sees the feedback and revises.
+5. Or reviewer clicks **Approve**. Hook emits nothing. Agent proceeds to the next task.
 
-For direct hook integration without a wrapper script, use `--hook`. It emits the JSON protocol that Claude Code and Codex hooks expect natively:
+## Recipe 2: Review every agent turn
 
-```json
-"command": "plannotator annotate \"$CLAUDE_TOOL_INPUT_file_path\" --hook"
-```
-
-Behavior:
-
-- **Approve** → empty stdout → hook passes → agent proceeds.
-- **Close** → empty stdout → hook passes → agent proceeds.
-- **Send Annotations** → `{"decision":"block","reason":"<feedback>"}` → hook blocks with feedback.
-
-`--hook` implies `--gate` (three-button UX). This is the recommended approach for both Claude Code PostToolUse hooks and Codex hooks.
-
-### Structured (`--json`)
-
-If you want to route on decision type explicitly — for example, only re-prompt on `annotated` and log `approved` vs `dismissed` separately — pipe through `jq` or a small shell wrapper:
-
-```bash
-#!/usr/bin/env bash
-# .claude/hooks/spec-gate.sh
-result=$(plannotator annotate "$CLAUDE_TOOL_INPUT_file_path" --gate --json)
-decision=$(echo "$result" | jq -r '.decision')
-feedback=$(echo "$result" | jq -r '.feedback // ""')
-
-case "$decision" in
-  approved|dismissed)
-    # empty stdout — hook passes through, agent proceeds
-    ;;
-  annotated)
-    # emit feedback on stdout so the hook blocks with it as the reason
-    echo "$feedback"
-    ;;
-esac
-```
-
-Exit code stays `0` for all three branches; signaling happens via stdout (empty = pass, non-empty = block). This mirrors the `--gate`-without-`--json` mode exactly — JSON just gives you a parsed decision for logging or conditional routing without changing the block contract.
-
-## Recipe 2: Stop-hook turn gate
-
-Wire `annotate-last` to Claude Code's Stop hook to pause every agent turn for human review.
-
-### Plaintext
+A Stop hook pauses the agent after every response for human review. Use `annotate-last` to open the agent's last message in Plannotator.
 
 ```json
 {
@@ -102,7 +84,7 @@ Wire `annotate-last` to Claude Code's Stop hook to pause every agent turn for hu
         "hooks": [
           {
             "type": "command",
-            "command": "plannotator annotate-last --gate",
+            "command": "plannotator annotate-last --hook",
             "timeout": 345600
           }
         ]
@@ -112,35 +94,39 @@ Wire `annotate-last` to Claude Code's Stop hook to pause every agent turn for hu
 }
 ```
 
-Behavior:
+- **Send Annotations** prevents the agent from stopping and re-prompts with feedback.
+- **Approve** or **Close** lets the turn end normally.
 
-- **Approve** → `The user approved.` on stdout. Turn ends; Claude Code reports the marker.
-- **Send Annotations** → feedback on stdout → Claude Code re-prompts with the feedback.
-- **Close** → empty stdout → turn ends.
+## Combining both
 
-Use `--hook` instead of `--gate` if you want hook-native JSON. Approve and Close emit empty stdout, Send Annotations emits `{"decision":"block","reason":"..."}` which prevents the stop and re-prompts with feedback.
+You can use PostToolUse and Stop hooks together. The PostToolUse hook gates individual file writes. The Stop hook gates the overall turn. The agent gets targeted file feedback during execution and a final review at the end.
 
-### Structured
+## Alternative modes
 
-Same pattern as the PostToolUse recipe — pipe `--gate --json` through a shell wrapper if you want distinct handling per decision.
+`--hook` is the recommended approach for hook integrations. Two other modes exist for different use cases:
+
+### `--gate` (plaintext)
+
+Three-button UX without hook-native JSON. Approve emits the line `The user approved.`, Close emits nothing, Send Annotations emits plaintext feedback. Useful for slash command templates where the agent reads stdout directly.
+
+### `--json` (structured decisions)
+
+Emits `{"decision":"approved|annotated|dismissed","feedback":"..."}` for every decision. Useful for wrapper scripts that want to parse the decision type for logging, telemetry, or conditional routing. Pair with `--gate` for all three decisions.
+
+See [Annotate Flags](/docs/commands/annotate/#flags) for the full stdout matrix.
 
 ## OpenCode and Pi
 
-The same `--gate` flag works in OpenCode's `/plannotator-annotate` and Pi's `/plannotator-annotate` slash commands:
+The same flags work in OpenCode's `/plannotator-annotate` and Pi's `/plannotator-annotate`:
 
 ```
 /plannotator-annotate spec.md --gate
 ```
 
-On those harnesses there is no stdout channel back to the agent — the plugin writes back via `session.prompt` (OpenCode) or `sendUserMessage` (Pi). Approve and Close both result in no session injection; Send Annotations injects the feedback. `--json` and `--hook` are accepted silently on these harnesses so recipes stay portable.
-
-Third-party Pi or OpenCode plugins that want explicit decision routing can read `approved` directly from the server's decision object:
-
-- OpenCode plugin: `server.waitForDecision()` returns `{ feedback, annotations, exit?, approved? }`.
-- Pi: `openMarkdownAnnotation()` and `openLastMessageAnnotation()` return `{ feedback, exit?, approved? }`.
+These harnesses don't use stdout for signaling -- the plugin writes directly to the session. Approve and Close skip injection; Send Annotations injects the feedback. `--hook` and `--json` are accepted silently so recipes stay portable across harnesses.
 
 ## Notes
 
-- Exit code is always `0`. Gate decisions are signaled via stdout, not exit code.
-- Folder annotation with `--gate` applies one decision to the whole session (not per-file). The user navigates the file browser inside the UI, annotates across files, and submits once.
-- The `--gate` UX is fully opt-in. Users running `/plannotator-annotate README.md` interactively without the flag still see the 2-button experience.
+- Exit code is always `0`. Decisions are signaled via stdout.
+- Folder annotation with `--hook` applies one decision to the whole session. The reviewer navigates files inside the UI and submits once.
+- `--hook` and `--gate` are opt-in. Interactive users running `/plannotator-annotate README.md` still see the default two-button experience.

--- a/packages/shared/annotate-args.test.ts
+++ b/packages/shared/annotate-args.test.ts
@@ -8,7 +8,7 @@ describe("parseAnnotateArgs", () => {
       rawFilePath: "spec.md",
       gate: false,
       json: false,
-      silentApprove: false,
+      hook: false,
     });
   });
 
@@ -18,7 +18,7 @@ describe("parseAnnotateArgs", () => {
       rawFilePath: "spec.md",
       gate: true,
       json: false,
-      silentApprove: false,
+      hook: false,
     });
   });
 
@@ -28,7 +28,7 @@ describe("parseAnnotateArgs", () => {
       rawFilePath: "spec.md",
       gate: true,
       json: false,
-      silentApprove: false,
+      hook: false,
     });
   });
 
@@ -38,7 +38,7 @@ describe("parseAnnotateArgs", () => {
       rawFilePath: "spec.md",
       gate: true,
       json: true,
-      silentApprove: false,
+      hook: false,
     });
   });
 
@@ -48,7 +48,7 @@ describe("parseAnnotateArgs", () => {
       rawFilePath: "",
       gate: true,
       json: true,
-      silentApprove: false,
+      hook: false,
     });
   });
 
@@ -58,7 +58,7 @@ describe("parseAnnotateArgs", () => {
       rawFilePath: "my file.md",
       gate: true,
       json: false,
-      silentApprove: false,
+      hook: false,
     });
   });
 
@@ -74,7 +74,7 @@ describe("parseAnnotateArgs", () => {
       rawFilePath: "@spec.md",
       gate: true,
       json: false,
-      silentApprove: false,
+      hook: false,
     });
   });
 
@@ -84,7 +84,7 @@ describe("parseAnnotateArgs", () => {
       rawFilePath: "@plannotator/ui/README.md",
       gate: false,
       json: false,
-      silentApprove: false,
+      hook: false,
     });
   });
 
@@ -94,7 +94,7 @@ describe("parseAnnotateArgs", () => {
       rawFilePath: "@docs/spec.md",
       gate: true,
       json: true,
-      silentApprove: false,
+      hook: false,
     });
   });
 
@@ -104,7 +104,7 @@ describe("parseAnnotateArgs", () => {
       rawFilePath: "https://example.com/docs",
       gate: true,
       json: false,
-      silentApprove: false,
+      hook: false,
     });
   });
 
@@ -114,7 +114,7 @@ describe("parseAnnotateArgs", () => {
       rawFilePath: "spec.md",
       gate: true,
       json: false,
-      silentApprove: false,
+      hook: false,
     });
   });
 
@@ -124,7 +124,7 @@ describe("parseAnnotateArgs", () => {
       rawFilePath: "",
       gate: false,
       json: false,
-      silentApprove: false,
+      hook: false,
     });
   });
 
@@ -134,7 +134,7 @@ describe("parseAnnotateArgs", () => {
       rawFilePath: "",
       gate: false,
       json: false,
-      silentApprove: false,
+      hook: false,
     });
   });
 
@@ -144,7 +144,7 @@ describe("parseAnnotateArgs", () => {
       rawFilePath: "./specs/",
       gate: true,
       json: true,
-      silentApprove: false,
+      hook: false,
     });
   });
 
@@ -160,7 +160,7 @@ describe("parseAnnotateArgs", () => {
       rawFilePath: "My  Notes.md",
       gate: true,
       json: false,
-      silentApprove: false,
+      hook: false,
     });
   });
 
@@ -170,7 +170,7 @@ describe("parseAnnotateArgs", () => {
       rawFilePath: "My  Notes.md",
       gate: true,
       json: false,
-      silentApprove: false,
+      hook: false,
     });
   });
 
@@ -180,7 +180,7 @@ describe("parseAnnotateArgs", () => {
       rawFilePath: "My\tNotes.md",
       gate: true,
       json: false,
-      silentApprove: false,
+      hook: false,
     });
   });
 
@@ -190,7 +190,7 @@ describe("parseAnnotateArgs", () => {
       rawFilePath: "/tmp/My  Notes.md",
       gate: false,
       json: false,
-      silentApprove: false,
+      hook: false,
     });
   });
 
@@ -205,7 +205,7 @@ describe("parseAnnotateArgs", () => {
       rawFilePath: "@foo.md",
       gate: true,
       json: false,
-      silentApprove: false,
+      hook: false,
     });
   });
 
@@ -215,7 +215,7 @@ describe("parseAnnotateArgs", () => {
       rawFilePath: "@foo.md",
       gate: true,
       json: false,
-      silentApprove: false,
+      hook: false,
     });
   });
 
@@ -225,7 +225,7 @@ describe("parseAnnotateArgs", () => {
       rawFilePath: "@My Notes.md",
       gate: true,
       json: false,
-      silentApprove: false,
+      hook: false,
     });
   });
 
@@ -235,53 +235,52 @@ describe("parseAnnotateArgs", () => {
       rawFilePath: "My Notes.md",
       gate: false,
       json: false,
-      silentApprove: false,
+      hook: false,
     });
   });
 
-  // --silent-approve (issue #570 follow-up) opts the plaintext Approve out of
-  // emitting the "The user approved." marker. It parses identically to the
-  // other flags and is recognized in any position, including without --gate
-  // (where it's a documented no-op — the parser still strips it so it doesn't
-  // leak into the path).
+  // --hook emits hook-native JSON ({"decision":"block","reason":"..."}) for
+  // annotations and empty stdout for approve/close. It implies --gate in the
+  // binary, but the parser is a pure tokenizer — it reports which flags were
+  // present without applying implication logic.
 
-  test("--silent-approve alongside --gate", () => {
-    expect(parseAnnotateArgs("spec.md --gate --silent-approve")).toEqual({
+  test("--hook alongside --gate", () => {
+    expect(parseAnnotateArgs("spec.md --gate --hook")).toEqual({
       filePath: "spec.md",
       rawFilePath: "spec.md",
       gate: true,
       json: false,
-      silentApprove: true,
+      hook: true,
     });
   });
 
-  test("--silent-approve with all three flags", () => {
-    expect(parseAnnotateArgs("spec.md --gate --json --silent-approve")).toEqual({
+  test("--hook with all three flags", () => {
+    expect(parseAnnotateArgs("spec.md --gate --json --hook")).toEqual({
       filePath: "spec.md",
       rawFilePath: "spec.md",
       gate: true,
       json: true,
-      silentApprove: true,
+      hook: true,
     });
   });
 
-  test("--silent-approve alone is stripped from path (no-op but not leaked)", () => {
-    expect(parseAnnotateArgs("spec.md --silent-approve")).toEqual({
+  test("--hook alone is stripped from path", () => {
+    expect(parseAnnotateArgs("spec.md --hook")).toEqual({
       filePath: "spec.md",
       rawFilePath: "spec.md",
       gate: false,
       json: false,
-      silentApprove: true,
+      hook: true,
     });
   });
 
-  test("--silent-approve before path", () => {
-    expect(parseAnnotateArgs("--silent-approve --gate spec.md")).toEqual({
+  test("--hook before path", () => {
+    expect(parseAnnotateArgs("--hook --gate spec.md")).toEqual({
       filePath: "spec.md",
       rawFilePath: "spec.md",
       gate: true,
       json: false,
-      silentApprove: true,
+      hook: true,
     });
   });
 });

--- a/packages/shared/annotate-args.test.ts
+++ b/packages/shared/annotate-args.test.ts
@@ -264,11 +264,11 @@ describe("parseAnnotateArgs", () => {
     });
   });
 
-  test("--hook alone is stripped from path", () => {
+  test("--hook alone implies gate", () => {
     expect(parseAnnotateArgs("spec.md --hook")).toEqual({
       filePath: "spec.md",
       rawFilePath: "spec.md",
-      gate: false,
+      gate: true,
       json: false,
       hook: true,
     });

--- a/packages/shared/annotate-args.ts
+++ b/packages/shared/annotate-args.ts
@@ -1,7 +1,7 @@
 /**
  * Parse CLI-style args arriving as a single whitespace-delimited string.
  *
- * Extracts the `--gate`, `--json`, and `--silent-approve` flags (issue #570)
+ * Extracts the `--gate`, `--json`, and `--hook` flags (issue #570)
  * from the remainder, which is treated as the target path. Leading `@` is
  * stripped via the shared at-reference helper — reference-mode is primary.
  * Scoped-package-style literal `@` paths are handled by a fallback that the
@@ -42,7 +42,7 @@ export interface ParsedAnnotateArgs {
   rawFilePath: string;
   gate: boolean;
   json: boolean;
-  silentApprove: boolean;
+  hook: boolean;
 }
 
 type Segment = { type: "ws" | "tok"; text: string };
@@ -50,12 +50,12 @@ type Segment = { type: "ws" | "tok"; text: string };
 const FLAG_MAP = {
   "--gate": "gate",
   "--json": "json",
-  "--silent-approve": "silentApprove",
+  "--hook": "hook",
 } as const satisfies Record<string, keyof Omit<ParsedAnnotateArgs, "filePath" | "rawFilePath">>;
 
 export function parseAnnotateArgs(raw: string): ParsedAnnotateArgs {
   const s = (raw ?? "").trim();
-  const flags = { gate: false, json: false, silentApprove: false };
+  const flags = { gate: false, json: false, hook: false };
 
   const segments: Segment[] = [];
   for (let i = 0; i < s.length;) {

--- a/packages/shared/annotate-args.ts
+++ b/packages/shared/annotate-args.ts
@@ -97,5 +97,7 @@ export function parseAnnotateArgs(raw: string): ParsedAnnotateArgs {
       .trim(),
   );
 
+  if (flags.hook) flags.gate = true;
+
   return { filePath: stripAtPrefix(rawFilePath), rawFilePath, ...flags };
 }


### PR DESCRIPTION
## Summary

- Replaces `--silent-approve` with `--hook`, which emits hook-native JSON that works directly with Claude Code and Codex PostToolUse/Stop hook protocols
- `--hook` implies `--gate` (always three-button UX) and supersedes `--json` if both are passed
- No wrapper script needed: `plannotator annotate "$FILE" --hook` is a drop-in hook command

## Why

After shipping #606, we discovered that `--silent-approve` solves a problem that doesn't exist:

- **Claude Code PostToolUse**: plain text stdout is added to transcript as context, it does NOT block. Only `{"decision":"block","reason":"..."}` blocks.
- **Codex PostToolUse**: plain text stdout is ignored entirely. Only JSON is processed.
- **Claude Code Stop**: plain text stdout goes to debug log, NOT added to context. Only `{"decision":"block","reason":"..."}` prevents stopping.

## Stdout matrix

| Flags | Approve | Close | Annotate |
|---|---|---|---|
| `--gate` | `The user approved.` | empty | feedback (plaintext) |
| `--json` | n/a | `{"decision":"dismissed"}` | `{"decision":"annotated","feedback":"..."}` |
| `--gate --json` | `{"decision":"approved"}` | `{"decision":"dismissed"}` | `{"decision":"annotated","feedback":"..."}` |
| **`--hook`** | **empty** | **empty** | **`{"decision":"block","reason":"..."}`** |

## Hook recipe

```json
{
  "hooks": {
    "PostToolUse": [{
      "matcher": "Write",
      "hooks": [{
        "type": "command",
        "command": "plannotator annotate \"$CLAUDE_TOOL_INPUT_file_path\" --hook",
        "timeout": 345600
      }]
    }]
  }
}
```

Follow-up to #606. Refs #570.

## Test plan

- [ ] `bun test packages/shared/ apps/opencode-plugin/ apps/hook/server/` — 205 pass
- [ ] `grep -rn "silent.approve\|silentApprove" apps/ packages/` — zero results
- [ ] Manual: `plannotator annotate README.md --hook` → 3-button UX → Approve → empty stdout → Annotate → `{"decision":"block","reason":"..."}` on stdout