### PR TITLE
fix: pin @pierre/diffs to exact version 1.1.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.2.92",
     "@openai/codex-sdk": "^0.118.0",
     "@opencode-ai/sdk": "^1.3.0",
-    "@pierre/diffs": "^1.1.12",
+    "@pierre/diffs": "1.1.12",
     "diff": "^8.0.4",
     "dockview-react": "^5.2.0",
     "dompurify": "^3.3.3",


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Issue

`@pierre/diffs` is currently declared with a caret range (`^1.1.12`) in `package.json`, which permits automatic minor and patch version upgrades without explicit review.

This package is particularly sensitive: the [pierre-guard skill](apps/skills/plannotator-compound/SKILL.md) in this repo explicitly documents that `@pierre/diffs` uses shadow DOM selectors and grid layout assumptions that can break silently on minor version bumps. An unreviewed upgrade could cause subtle rendering regressions that bypass automated testing.

## Fix

Pin `@pierre/diffs` to the exact version `1.1.12`. Future upgrades should be run through the pierre-guard verification checklist before the pin is advanced.

The other three SDK dependencies (`@anthropic-ai/claude-agent-sdk`, `@openai/codex-sdk`, `@opencode-ai/sdk`) are externally versioned and benefit from caret ranges for security patches; this change deliberately targets only `@pierre/diffs` which carries unique internal breakage risk per the guard skill.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"SEC-unpinned-semver","fingerprint":"sha256:2f3b13d852f10c41afa303ee4fd0a03d1aa46f469b608ab56f3e299abf6ec89b"}]}
nlpm-metadata-end -->