### PR TITLE
docs: scrub Insert/Replace from docs to match shipped UI

### DIFF
--- a/apps/marketing/src/content/blog/plannotator-meets-pi.md
+++ b/apps/marketing/src/content/blog/plannotator-meets-pi.md
@@ -49,7 +49,7 @@ Because the plan lives on disk as a regular file, you can open it in your editor
 
 ### Review phase
 
-When the agent calls `plannotator_submit_plan`, the extension reads `PLAN.md` from disk, starts a local HTTP server, and opens the Plannotator browser UI. You see the rendered plan with all the annotation tools — comments, deletions, global comments, and quick labels.
+When the agent calls `plannotator_submit_plan`, the extension reads `PLAN.md` from disk, starts a local HTTP server, and opens the Plannotator browser UI. You see the rendered plan with all the annotation tools — comments, deletions, global comments, quick labels, and "looks good" approvals.
 
 Three outcomes:
 

--- a/apps/marketing/src/content/blog/plannotator-meets-pi.md
+++ b/apps/marketing/src/content/blog/plannotator-meets-pi.md
@@ -49,7 +49,7 @@ Because the plan lives on disk as a regular file, you can open it in your editor
 
 ### Review phase
 
-When the agent calls `plannotator_submit_plan`, the extension reads `PLAN.md` from disk, starts a local HTTP server, and opens the Plannotator browser UI. You see the rendered plan with all the annotation tools — comments, deletions, replacements, insertions.
+When the agent calls `plannotator_submit_plan`, the extension reads `PLAN.md` from disk, starts a local HTTP server, and opens the Plannotator browser UI. You see the rendered plan with all the annotation tools — comments, deletions, global comments, and quick labels.
 
 Three outcomes:
 

--- a/apps/marketing/src/content/blog/sharing-plans-with-your-team.md
+++ b/apps/marketing/src/content/blog/sharing-plans-with-your-team.md
@@ -49,7 +49,7 @@ Your senior clicks **Export → Copy Link** to share their annotated version bac
 
 ### 5. You send combined feedback to Claude
 
-With the merged annotations in front of you, you click **Request Changes**. Plannotator formats the combined feedback — deletions, comments, global comments, and quick labels — into structured markdown and sends it back to Claude Code through the hook system. Claude receives specific, actionable feedback and revises the plan.
+With the merged annotations in front of you, you click **Request Changes**. Plannotator formats the combined feedback — deletions, comments, global comments, quick labels, and "looks good" approvals — into structured markdown and sends it back to Claude Code through the hook system. Claude receives specific, actionable feedback and revises the plan.
 
 ## How the hook integration works
 

--- a/apps/marketing/src/content/blog/sharing-plans-with-your-team.md
+++ b/apps/marketing/src/content/blog/sharing-plans-with-your-team.md
@@ -37,9 +37,9 @@ You paste this in Slack and send it to your senior teammate.
 Your senior clicks the link. The share portal — a static page with no backend — decompresses the URL hash and renders the plan with your annotations. They can now add their own feedback:
 
 - **Comment** on the migration script section: "Add a rollback step"
-- **Replace** the session handling approach: swap JWT for HTTP-only cookies
+- **Comment** on the session handling approach: "Swap JWT for HTTP-only cookies"
 - **Delete** the unnecessary logging middleware
-- **Insert** a note about rate limiting on the new auth endpoints
+- **Quick label** the auth endpoints with "Needs tests" and add a comment: "Document rate limiting here"
 
 Each annotation is tied to the specific text it references.
 
@@ -49,7 +49,7 @@ Your senior clicks **Export → Copy Link** to share their annotated version bac
 
 ### 5. You send combined feedback to Claude
 
-With the merged annotations in front of you, you click **Request Changes**. Plannotator formats the combined feedback — deletions, replacements, comments, insertions — into structured markdown and sends it back to Claude Code through the hook system. Claude receives specific, actionable feedback and revises the plan.
+With the merged annotations in front of you, you click **Request Changes**. Plannotator formats the combined feedback — deletions, comments, global comments, and quick labels — into structured markdown and sends it back to Claude Code through the hook system. Claude receives specific, actionable feedback and revises the plan.
 
 ## How the hook integration works
 

--- a/apps/marketing/src/content/blog/welcome.md
+++ b/apps/marketing/src/content/blog/welcome.md
@@ -14,7 +14,7 @@ Plannotator is a plan review UI for Claude Code that intercepts `ExitPlanMode` v
 
 ## What is Plannotator?
 
-When Claude Code generates a plan, Plannotator opens an interactive review UI in your browser. You can read through the plan, select text to annotate, and provide structured feedback — deletions, replacements, comments, and insertions — before approving or requesting changes.
+When Claude Code generates a plan, Plannotator opens an interactive review UI in your browser. You can read through the plan, select text to annotate, and provide structured feedback — deletions, comments, global comments, and quick labels — before approving or requesting changes.
 
 ## Key Features
 

--- a/apps/marketing/src/content/blog/welcome.md
+++ b/apps/marketing/src/content/blog/welcome.md
@@ -14,7 +14,7 @@ Plannotator is a plan review UI for Claude Code that intercepts `ExitPlanMode` v
 
 ## What is Plannotator?
 
-When Claude Code generates a plan, Plannotator opens an interactive review UI in your browser. You can read through the plan, select text to annotate, and provide structured feedback — deletions, comments, global comments, and quick labels — before approving or requesting changes.
+When Claude Code generates a plan, Plannotator opens an interactive review UI in your browser. You can read through the plan, select text to annotate, and provide structured feedback — deletions, comments, global comments, quick labels, and "looks good" approvals — before approving or requesting changes.
 
 ## Key Features
 

--- a/apps/marketing/src/content/docs/commands/annotate.md
+++ b/apps/marketing/src/content/docs/commands/annotate.md
@@ -99,7 +99,7 @@ The annotation UI in annotate mode works the same as plan review, with a few cha
 - `Cmd/Ctrl+Enter` sends annotations instead of approving
 - The completion screen says "Annotations Sent" instead of "Plan Approved"
 
-All annotation types work identically: deletions, comments, global comments, quick labels, and image attachments.
+All annotation types work identically: deletions, comments, global comments, quick labels, "looks good" approvals, and image attachments.
 
 ## Flags
 

--- a/apps/marketing/src/content/docs/commands/annotate.md
+++ b/apps/marketing/src/content/docs/commands/annotate.md
@@ -99,7 +99,7 @@ The annotation UI in annotate mode works the same as plan review, with a few cha
 - `Cmd/Ctrl+Enter` sends annotations instead of approving
 - The completion screen says "Annotations Sent" instead of "Plan Approved"
 
-All annotation types work identically: deletions, replacements, comments, insertions, global comments, and image attachments.
+All annotation types work identically: deletions, comments, global comments, quick labels, and image attachments.
 
 ## Flags
 

--- a/apps/marketing/src/content/docs/commands/code-review.md
+++ b/apps/marketing/src/content/docs/commands/code-review.md
@@ -79,7 +79,7 @@ The review UI shows your changes in a familiar diff format:
 - **File tree sidebar** for navigating between changed files
 - **Viewed tracking** to mark files as reviewed and track your progress
 - **Unified diff** showing additions and deletions in context
-- **Annotation tools** with the same annotation types as plan review (delete, comment, quick label)
+- **Annotation tools** with the same annotation types as plan review (delete, comment, quick label, "looks good")
 
 ## Annotating code
 

--- a/apps/marketing/src/content/docs/commands/code-review.md
+++ b/apps/marketing/src/content/docs/commands/code-review.md
@@ -79,7 +79,7 @@ The review UI shows your changes in a familiar diff format:
 - **File tree sidebar** for navigating between changed files
 - **Viewed tracking** to mark files as reviewed and track your progress
 - **Unified diff** showing additions and deletions in context
-- **Annotation tools** with the same annotation types as plan review (delete, replace, comment, insert)
+- **Annotation tools** with the same annotation types as plan review (delete, comment, quick label)
 
 ## Annotating code
 

--- a/apps/marketing/src/content/docs/commands/plan-review.md
+++ b/apps/marketing/src/content/docs/commands/plan-review.md
@@ -36,10 +36,12 @@ When you select text in the plan, the annotation toolbar appears with these opti
 | Type | What it does | Example |
 |------|-------------|---------|
 | **Deletion** | Marks text for removal | "Remove this section" |
-| **Replacement** | Suggests alternative text | "Change `WebSocket` to `SSE`" |
 | **Comment** | Adds feedback on a section | "This needs error handling" |
-| **Insertion** | Adds content after the selection | "Add a retry mechanism here" |
+| **Quick label** | Applies a preset label (⚡) | "Clarify this", "Needs tests", "Out of scope" |
+| **Looks good** | Marks a section as approved (👍) | — |
 | **Global comment** | General feedback (not tied to text) | "The plan looks good overall but needs tests" |
+
+If you want a replacement or an insertion, ask for it in a comment ("Change `WebSocket` to `SSE`" or "Add a retry mechanism here") — the agent will incorporate it during the revision.
 
 ## Image attachments
 

--- a/apps/marketing/src/content/docs/getting-started/quickstart.md
+++ b/apps/marketing/src/content/docs/getting-started/quickstart.md
@@ -31,11 +31,14 @@ The plan renders as formatted markdown with syntax-highlighted code blocks. Read
 Select any text in the plan to open the annotation toolbar. Choose an action:
 
 - **Delete** — Mark text for removal ("Remove this")
-- **Replace** — Suggest replacement text ("Change this to...")
 - **Comment** — Add feedback on a section ("This needs more detail")
-- **Insert** — Add new content after the selection ("Add error handling here")
+- **Quick label** (⚡) — Apply a preset label like "Clarify this", "Needs tests", or "Out of scope"
+- **Looks good** (👍) — Mark a section as approved
+- **Copy** — Copy the selected text to your clipboard
 
 You can also add **global comments** — general feedback that isn't tied to specific text.
+
+Need a replacement or an insertion? Just say so in a comment — the agent will handle it.
 
 Switch between annotation modes using the mode switcher at the top of the document:
 

--- a/apps/marketing/src/content/docs/getting-started/ui-settings.md
+++ b/apps/marketing/src/content/docs/getting-started/ui-settings.md
@@ -116,7 +116,7 @@ The mode switcher below the header in the plan review UI controls how text selec
 
 | Mode | Behavior |
 |------|----------|
-| **Selection** (default) | Select text, then choose an annotation type from the toolbar (comment, deletion, replacement, insertion) |
+| **Selection** (default) | Select text, then choose an annotation type from the toolbar (comment, deletion, quick label, "looks good") |
 | **Comment** | Select text to immediately create a comment annotation |
 | **Redline** | Select text to immediately create a deletion annotation |
 

--- a/apps/portal/ANNOTATE.md
+++ b/apps/portal/ANNOTATE.md
@@ -74,10 +74,10 @@ The annotation tools are identical to plan review:
 Annotation types:
 
 - **Deletion** — "Remove this"
-- **Replacement** — "Change this to..."
 - **Comment** — "Feedback on this..."
-- **Insertion** — "Add this after..."
 - **Global comment** — General feedback not tied to specific text
+- **Quick label** — Apply a preset label like "Clarify this" or "Needs tests"
+- **Looks good** — Mark a section as approved (👍)
 
 Users can also paste or upload images and attach them to annotations.
 


### PR DESCRIPTION
Closes #617.

Since the removal of `INSERTION` and `REPLACEMENT` was intentional. This PR scrubs both from the docs and brings the toolbar inventory in line with the shipped UI: **Delete, Comment, Quick Label (⚡), Looks good (👍), Global Comment, Copy**.

Updates the 7 files from the issue, plus 2 more I noticed had the same drift while sweeping:
- `apps/marketing/src/content/docs/commands/code-review.md` — toolbar inventory listed `(delete, replace, comment, insert)`
- `apps/marketing/src/content/blog/sharing-plans-with-your-team.md` — example bullets and closing paragraph used Replace/Insert

Where the original passage was instructional, I added a short note that users can ask for a replacement or insertion inside a Comment — preserves the capability without misrepresenting the UI.
