### PR TITLE
Add source line numbers to exported feedback annotations

### DIFF
--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -559,6 +559,7 @@ if (args[0] === "sessions") {
   let folderPath: string | undefined;
   let annotateMode: "annotate" | "annotate-folder" = "annotate";
   let sourceInfo: string | undefined;
+  let sourceConverted = false;
 
   // --- URL annotation ---
   const isUrl = /^https?:\/\//i.test(filePath);
@@ -578,6 +579,7 @@ if (args[0] === "sessions") {
     }
     absolutePath = filePath; // Use URL as the "path" for display
     sourceInfo = filePath;   // Full URL for source attribution
+    sourceConverted = true;  // Markdown produced by Jina/Turndown — line numbers caveated
   } else {
     // Folder check with literal-@ fallback for scoped-package-style names.
     const folderCandidate = resolveAtReference(rawFilePath, (c) => {
@@ -615,6 +617,7 @@ if (args[0] === "sessions") {
         markdown = htmlToMarkdown(html);
         absolutePath = resolvedArg;
         sourceInfo = path.basename(resolvedArg);
+        sourceConverted = true; // Turndown conversion — line numbers caveated
         console.error(`Converted: ${absolutePath}`);
       } else {
         // Single markdown file annotation mode
@@ -653,6 +656,7 @@ if (args[0] === "sessions") {
     mode: annotateMode,
     folderPath,
     sourceInfo,
+    sourceConverted,
     sharingEnabled,
     shareBaseUrl,
     pasteApiUrl,

--- a/apps/opencode-plugin/commands.ts
+++ b/apps/opencode-plugin/commands.ts
@@ -170,6 +170,7 @@ export async function handleAnnotateCommand(
   let folderPath: string | undefined;
   let annotateMode: "annotate" | "annotate-folder" = "annotate";
   let sourceInfo: string | undefined;
+  let sourceConverted = false;
 
   // --- URL annotation ---
   const isUrl = /^https?:\/\//i.test(filePath);
@@ -186,6 +187,7 @@ export async function handleAnnotateCommand(
     }
     absolutePath = filePath;
     sourceInfo = filePath;
+    sourceConverted = true;
   } else {
     const projectRoot = directory || process.cwd();
     const resolvedArg = resolveUserPath(filePath, projectRoot);
@@ -223,6 +225,7 @@ export async function handleAnnotateCommand(
       markdown = htmlToMarkdown(html);
       absolutePath = resolvedArg;
       sourceInfo = path.basename(resolvedArg);
+      sourceConverted = true;
       client.app.log({ level: "info", message: `Converted: ${absolutePath}` });
     } else {
       // Markdown file annotation
@@ -258,6 +261,7 @@ export async function handleAnnotateCommand(
     mode: annotateMode,
     folderPath,
     sourceInfo,
+    sourceConverted,
     sharingEnabled: await getSharingEnabled(),
     shareBaseUrl: getShareBaseUrl(),
     pasteApiUrl: getPasteApiUrl(),

--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -361,6 +361,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 			let folderPath: string | undefined;
 			let mode: "annotate" | "annotate-folder" | undefined;
 			let sourceInfo: string | undefined;
+			let sourceConverted = false;
 			let isFolder = false;
 
 			// --- URL annotation ---
@@ -378,6 +379,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 				}
 				absolutePath = filePath;
 				sourceInfo = filePath;
+				sourceConverted = true;
 			} else {
 				// Pick the interpretation of the user input that actually exists:
 				// stripped form first (reference-mode primary), literal as fallback
@@ -420,6 +422,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 					const html = readFileSync(absolutePath, "utf-8");
 					markdown = htmlToMarkdown(html);
 					sourceInfo = basename(absolutePath);
+					sourceConverted = true;
 					ctx.ui.notify(`Opening annotation UI for ${filePath}...`, "info");
 				} else {
 					markdown = readFileSync(absolutePath, "utf-8");
@@ -428,7 +431,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 			}
 
 			try {
-				const result = await openMarkdownAnnotation(ctx, absolutePath, markdown, mode ?? "annotate", folderPath, sourceInfo, gate);
+				const result = await openMarkdownAnnotation(ctx, absolutePath, markdown, mode ?? "annotate", folderPath, sourceInfo, gate, sourceConverted);
 				if (result.approved) {
 					ctx.ui.notify("Annotation approved.", "info");
 				} else if (result.exit) {

--- a/apps/pi-extension/plannotator-browser.ts
+++ b/apps/pi-extension/plannotator-browser.ts
@@ -377,6 +377,7 @@ export async function openMarkdownAnnotation(
 	folderPath?: string,
 	sourceInfo?: string,
 	gate?: boolean,
+	sourceConverted?: boolean,
 ): Promise<{ feedback: string; exit?: boolean; approved?: boolean }> {
 	if (!ctx.hasUI || !planHtmlContent) {
 		throw new Error("Plannotator annotation browser is unavailable in this session.");
@@ -401,6 +402,7 @@ export async function openMarkdownAnnotation(
 		mode,
 		folderPath,
 		sourceInfo,
+		sourceConverted,
 		gate,
 		htmlContent: planHtmlContent,
 		sharingEnabled: process.env.PLANNOTATOR_SHARE !== "disabled",

--- a/apps/pi-extension/server/reference.ts
+++ b/apps/pi-extension/server/reference.ts
@@ -77,8 +77,9 @@ export function handleDocRequest(res: Res, url: URL): void {
 		try {
 			if (existsSync(fromBase)) {
 				const raw = readFileSync(fromBase, "utf-8");
-				const markdown = /\.html?$/i.test(requestedPath) ? htmlToMarkdown(raw) : raw;
-				json(res, { markdown, filepath: fromBase });
+				const isHtml = /\.html?$/i.test(requestedPath);
+				const markdown = isHtml ? htmlToMarkdown(raw) : raw;
+				json(res, { markdown, filepath: fromBase, isConverted: isHtml });
 				return;
 			}
 		} catch {
@@ -97,7 +98,7 @@ export function handleDocRequest(res: Res, url: URL): void {
 		try {
 			if (existsSync(resolvedHtml)) {
 				const html = readFileSync(resolvedHtml, "utf-8");
-				json(res, { markdown: htmlToMarkdown(html), filepath: resolvedHtml });
+				json(res, { markdown: htmlToMarkdown(html), filepath: resolvedHtml, isConverted: true });
 				return;
 			}
 		} catch { /* fall through to 404 */ }

--- a/apps/pi-extension/server/serverAnnotate.ts
+++ b/apps/pi-extension/server/serverAnnotate.ts
@@ -43,6 +43,9 @@ export async function startAnnotateServer(options: {
 	shareBaseUrl?: string;
 	pasteApiUrl?: string;
 	sourceInfo?: string;
+	/** True when `markdown` was converted from HTML/URL via Turndown/Jina —
+	 *  feedback line numbers won't match the original source. */
+	sourceConverted?: boolean;
 	gate?: boolean;
 }): Promise<AnnotateServerResult> {
 	const gitUser = detectGitUser();
@@ -92,6 +95,7 @@ export async function startAnnotateServer(options: {
 				mode: options.mode || "annotate",
 				filePath: options.filePath,
 				sourceInfo: options.sourceInfo,
+				sourceConverted: options.sourceConverted ?? false,
 				gate: options.gate ?? false,
 				sharingEnabled,
 				shareBaseUrl,

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -152,6 +152,9 @@ const App: React.FC = () => {
   const [gate, setGate] = useState(false);
   const [annotateSource, setAnnotateSource] = useState<'file' | 'message' | 'folder' | null>(null);
   const [sourceInfo, setSourceInfo] = useState<string | undefined>();
+  /** True when the active document was converted from HTML/URL via Turndown/Jina —
+   *  used to caveat line numbers in exported feedback. */
+  const [sourceConverted, setSourceConverted] = useState(false);
   const [sourceFilePath, setSourceFilePath] = useState<string | undefined>();
   const [imageBaseDir, setImageBaseDir] = useState<string | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(true);
@@ -306,7 +309,7 @@ const App: React.FC = () => {
   const linkedDocHook = useLinkedDoc({
     markdown, annotations, selectedAnnotationId, globalAttachments,
     setMarkdown, setAnnotations, setSelectedAnnotationId, setGlobalAttachments,
-    viewerRef, sidebar: linkedDocSidebar, sourceFilePath,
+    viewerRef, sidebar: linkedDocSidebar, sourceFilePath, sourceConverted,
   });
 
   // Archive browser
@@ -654,7 +657,7 @@ const App: React.FC = () => {
         if (!res.ok) throw new Error('Not in API mode');
         return res.json();
       })
-      .then((data: { plan: string; origin?: Origin; mode?: 'annotate' | 'annotate-last' | 'annotate-folder' | 'archive'; filePath?: string; sourceInfo?: string; gate?: boolean; sharingEnabled?: boolean; shareBaseUrl?: string; pasteApiUrl?: string; repoInfo?: { display: string; branch?: string; host?: string }; previousPlan?: string | null; versionInfo?: { version: number; totalVersions: number; project: string }; archivePlans?: ArchivedPlan[]; projectRoot?: string; isWSL?: boolean; serverConfig?: { displayName?: string; gitUser?: string } }) => {
+      .then((data: { plan: string; origin?: Origin; mode?: 'annotate' | 'annotate-last' | 'annotate-folder' | 'archive'; filePath?: string; sourceInfo?: string; sourceConverted?: boolean; gate?: boolean; sharingEnabled?: boolean; shareBaseUrl?: string; pasteApiUrl?: string; repoInfo?: { display: string; branch?: string; host?: string }; previousPlan?: string | null; versionInfo?: { version: number; totalVersions: number; project: string }; archivePlans?: ArchivedPlan[]; projectRoot?: string; isWSL?: boolean; serverConfig?: { displayName?: string; gitUser?: string } }) => {
         // Initialize config store with server-provided values (config file > cookie > default)
         configStore.init(data.serverConfig);
         // gitUser drives the "Use git name" button in Settings; stays undefined (button hidden) when unavailable
@@ -684,6 +687,7 @@ const App: React.FC = () => {
           setAnnotateSource(data.mode === 'annotate-last' ? 'message' : data.mode === 'annotate-folder' ? 'folder' : 'file');
         }
         setSourceInfo(data.sourceInfo ?? undefined);
+        setSourceConverted(!!data.sourceConverted);
         if (data.filePath) {
           setImageBaseDir(data.mode === 'annotate-folder' ? data.filePath : data.filePath.replace(/\/[^/]+$/, ''));
           if (data.mode === 'annotate') {
@@ -1187,11 +1191,27 @@ const App: React.FC = () => {
     }
 
     let output = hasPlanAnnotations
-      ? exportAnnotations(blocks, allAnnotations, globalAttachments, annotateSource === 'message' ? 'Message Feedback' : annotateSource === 'folder' ? 'Folder Feedback' : annotateSource === 'file' ? 'File Feedback' : 'Plan Feedback', annotateSource ?? 'plan')
+      ? exportAnnotations(
+          blocks,
+          allAnnotations,
+          globalAttachments,
+          annotateSource === 'message' ? 'Message Feedback' : annotateSource === 'folder' ? 'Folder Feedback' : annotateSource === 'file' ? 'File Feedback' : 'Plan Feedback',
+          annotateSource ?? 'plan',
+          { sourceConverted }
+        )
       : '';
 
     if (hasDocAnnotations) {
-      output += exportLinkedDocAnnotations(docAnnotations);
+      // Parse blocks for each linked doc's cached markdown so the exporter can
+      // attach source line numbers per annotation. Skip docs without cached
+      // markdown (defensive — older entries pre-dating the markdown field).
+      const enriched = new Map(docAnnotations);
+      for (const [filepath, entry] of enriched) {
+        if (entry.markdown) {
+          enriched.set(filepath, { ...entry, blocks: parseMarkdownToBlocks(entry.markdown) });
+        }
+      }
+      output += exportLinkedDocAnnotations(enriched);
     }
 
     if (hasEditorAnnotations) {
@@ -1199,7 +1219,7 @@ const App: React.FC = () => {
     }
 
     return output;
-  }, [blocks, allAnnotations, globalAttachments, linkedDocHook.getDocAnnotations, editorAnnotations]);
+  }, [blocks, allAnnotations, globalAttachments, linkedDocHook.getDocAnnotations, editorAnnotations, sourceConverted, annotateSource]);
 
   // Bot callback config — read once from URL search params (?cb=&ct=)
   const callbackConfig = React.useMemo(() => getCallbackConfig(), []);

--- a/packages/server/annotate.ts
+++ b/packages/server/annotate.ts
@@ -50,6 +50,10 @@ export interface AnnotateServerOptions {
   pasteApiUrl?: string;
   /** Source attribution: original URL or filename (e.g. "https://..." or "index.html") */
   sourceInfo?: string;
+  /** True when `markdown` was converted from HTML/URL via Turndown/Jina —
+   *  feedback line numbers won't match the original source, so the export
+   *  caveats them. */
+  sourceConverted?: boolean;
   /** Enable review-gate UX: adds an Approve button alongside Close/Send Annotations (#570) */
   gate?: boolean;
   /** Called when server starts with the URL, remote status, and port */
@@ -98,6 +102,7 @@ export async function startAnnotateServer(
     mode = "annotate",
     folderPath,
     sourceInfo,
+    sourceConverted,
     sharingEnabled = true,
     shareBaseUrl,
     pasteApiUrl,
@@ -155,6 +160,7 @@ export async function startAnnotateServer(
               mode,
               filePath,
               sourceInfo,
+              sourceConverted,
               gate,
               sharingEnabled,
               shareBaseUrl,

--- a/packages/server/reference-handlers.ts
+++ b/packages/server/reference-handlers.ts
@@ -45,8 +45,9 @@ export async function handleDoc(req: Request): Promise<Response> {
 			const file = Bun.file(fromBase);
 			if (await file.exists()) {
 				const raw = await file.text();
-				const markdown = /\.html?$/i.test(requestedPath) ? htmlToMarkdown(raw) : raw;
-				return Response.json({ markdown, filepath: fromBase });
+				const isHtml = /\.html?$/i.test(requestedPath);
+				const markdown = isHtml ? htmlToMarkdown(raw) : raw;
+				return Response.json({ markdown, filepath: fromBase, isConverted: isHtml });
 			}
 		} catch {
 			/* fall through to standard resolution */
@@ -65,7 +66,7 @@ export async function handleDoc(req: Request): Promise<Response> {
 			if (await file.exists()) {
 				const html = await file.text();
 				const markdown = htmlToMarkdown(html);
-				return Response.json({ markdown, filepath: resolvedHtml });
+				return Response.json({ markdown, filepath: resolvedHtml, isConverted: true });
 			}
 		} catch { /* fall through */ }
 		return Response.json({ error: `File not found: ${requestedPath}` }, { status: 404 });

--- a/packages/ui/hooks/useLinkedDoc.ts
+++ b/packages/ui/hooks/useLinkedDoc.ts
@@ -25,6 +25,10 @@ export interface UseLinkedDocOptions {
   /** Absolute path of the primary document — enables getDocAnnotations() to include
    *  stashed original-file annotations when viewing a linked doc. */
   sourceFilePath?: string;
+  /** Whether the primary document was converted from HTML/URL — propagated to the
+   *  stashed entry in getDocAnnotations() so feedback caveats survive cross-doc
+   *  navigation. */
+  sourceConverted?: boolean;
 }
 
 interface SavedPlanState {
@@ -37,6 +41,11 @@ interface SavedPlanState {
 export interface CachedDocState {
   annotations: Annotation[];
   globalAttachments: ImageAttachment[];
+  /** Source markdown (raw, as served by the doc API) — needed to compute
+   *  per-block source line numbers when exporting feedback. */
+  markdown?: string;
+  /** True when the doc was converted from HTML to markdown for display. */
+  isConverted?: boolean;
 }
 
 export interface UseLinkedDocReturn {
@@ -75,9 +84,10 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
     viewerRef,
     sidebar,
     sourceFilePath,
+    sourceConverted,
   } = options;
 
-  const [linkedDoc, setLinkedDoc] = useState<{ filepath: string } | null>(null);
+  const [linkedDoc, setLinkedDoc] = useState<{ filepath: string; isConverted?: boolean; markdown?: string } | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [docAnnotationCount, setDocAnnotationCount] = useState(0);
@@ -104,6 +114,7 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
         const data = (await res.json()) as {
           markdown?: string;
           filepath?: string;
+          isConverted?: boolean;
           error?: string;
           matches?: string[];
         };
@@ -147,6 +158,8 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
           docCache.current.set(linkedDoc.filepath, {
             annotations: [...annotations],
             globalAttachments: [...globalAttachments],
+            markdown: linkedDoc.markdown,
+            isConverted: linkedDoc.isConverted,
           });
           let total = 0;
           for (const [fp, cached] of docCache.current.entries()) {
@@ -167,7 +180,11 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
         setAnnotations(cached?.annotations ?? []);
         setGlobalAttachments(cached?.globalAttachments ?? []);
         setSelectedAnnotationId(null);
-        setLinkedDoc({ filepath: data.filepath! });
+        setLinkedDoc({
+          filepath: data.filepath!,
+          isConverted: !!data.isConverted,
+          markdown: data.markdown,
+        });
         sidebar.open(targetTab ?? "toc");
 
         // Re-apply cached annotations after DOM settles
@@ -209,6 +226,8 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
       docCache.current.set(linkedDoc.filepath, {
         annotations: [...annotations],
         globalAttachments: [...globalAttachments],
+        markdown: linkedDoc.markdown,
+        isConverted: linkedDoc.isConverted,
       });
       // Update reactive count so button labels can respond
       let total = 0;
@@ -255,16 +274,20 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
       result.set(sourceFilePath, {
         annotations: [...savedPlanState.current.annotations],
         globalAttachments: [...savedPlanState.current.globalAttachments],
+        markdown: savedPlanState.current.markdown,
+        isConverted: !!sourceConverted,
       });
     }
     if (linkedDoc) {
       result.set(linkedDoc.filepath, {
         annotations: [...annotations],
         globalAttachments: [...globalAttachments],
+        markdown: linkedDoc.markdown,
+        isConverted: linkedDoc.isConverted,
       });
     }
     return result;
-  }, [linkedDoc, annotations, globalAttachments, sourceFilePath]);
+  }, [linkedDoc, annotations, globalAttachments, sourceFilePath, sourceConverted]);
 
   return {
     isActive: linkedDoc !== null,

--- a/packages/ui/utils/parser.ts
+++ b/packages/ui/utils/parser.ts
@@ -447,7 +447,30 @@ export const computeListIndices = (blocks: Block[]): (number | null)[] => {
 export const wrapFeedbackForAgent = (feedback: string): string =>
   planDenyFeedback(feedback);
 
-export const exportAnnotations = (blocks: Block[], annotations: any[], globalAttachments: ImageAttachment[] = [], title: string = 'Plan Feedback', subject: string = 'plan'): string => {
+export interface ExportAnnotationsOptions {
+  /** True when the source markdown was converted from HTML/URL via Turndown/Jina.
+   *  When set, line numbers refer to the converted markdown — a caveat is added. */
+  sourceConverted?: boolean;
+}
+
+/** Resolve the source-line label for a single annotation. Returns null when no
+ *  meaningful line exists (global comment, diff-view annotation, missing block). */
+const lineLabelForAnnotation = (blocks: Block[], ann: any): string | null => {
+  if (!ann.blockId) return null;
+  if (typeof ann.blockId === 'string' && ann.blockId.startsWith('diff-block-')) return null;
+  const block = blocks.find(b => b.id === ann.blockId);
+  if (!block || typeof block.startLine !== 'number') return null;
+  return `line ${block.startLine}`;
+};
+
+export const exportAnnotations = (
+  blocks: Block[],
+  annotations: any[],
+  globalAttachments: ImageAttachment[] = [],
+  title: string = 'Plan Feedback',
+  subject: string = 'plan',
+  opts: ExportAnnotationsOptions = {}
+): string => {
   if (annotations.length === 0 && globalAttachments.length === 0) {
     return 'No changes detected.';
   }
@@ -461,6 +484,10 @@ export const exportAnnotations = (blocks: Block[], annotations: any[], globalAtt
   });
 
   let output = `# ${title}\n\n`;
+
+  if (opts.sourceConverted) {
+    output += `> Note: Line numbers below refer to the converted markdown, not the original HTML/URL source.\n\n`;
+  }
 
   // Add global reference images section if any
   if (globalAttachments.length > 0) {
@@ -477,13 +504,14 @@ export const exportAnnotations = (blocks: Block[], annotations: any[], globalAtt
   }
 
   sortedAnns.forEach((ann, index) => {
-    const block = blocks.find(b => b.id === ann.blockId);
-
     output += `## ${index + 1}. `;
 
     // Add diff context label if annotation was created in diff view
     if (ann.diffContext) {
       output += `[In diff content] `;
+    } else {
+      const lineLabel = lineLabelForAnnotation(blocks, ann);
+      if (lineLabel) output += `(${lineLabel}) `;
     }
 
     switch (ann.type) {
@@ -542,15 +570,24 @@ export const exportAnnotations = (blocks: Block[], annotations: any[], globalAtt
   return output;
 };
 
+export interface LinkedDocAnnotationEntry {
+  annotations: Annotation[];
+  globalAttachments: ImageAttachment[];
+  /** Parsed blocks for the doc — needed to map blockId → source line number. */
+  blocks?: Block[];
+  /** True when the doc was converted from HTML to markdown for display. */
+  isConverted?: boolean;
+}
+
 export const exportLinkedDocAnnotations = (
-  docAnnotations: Map<string, { annotations: Annotation[]; globalAttachments: ImageAttachment[] }>
+  docAnnotations: Map<string, LinkedDocAnnotationEntry>
 ): string => {
   let output = `\n# Linked Document Feedback\n\nThe following feedback is on documents referenced in the plan.\n\n`;
 
-  for (const [filepath, { annotations, globalAttachments }] of docAnnotations) {
+  for (const [filepath, { annotations, globalAttachments, blocks: docBlocks, isConverted }] of docAnnotations) {
     if (annotations.length === 0 && globalAttachments.length === 0) continue;
 
-    output += `## ${filepath}\n\n`;
+    output += `## ${filepath}${isConverted ? ' (converted from HTML — line numbers refer to converted markdown)' : ''}\n\n`;
 
     if (globalAttachments.length > 0) {
       output += `### Reference Images\n`;
@@ -571,6 +608,9 @@ export const exportLinkedDocAnnotations = (
 
     sortedAnns.forEach((ann, index) => {
       output += `### ${index + 1}. `;
+
+      const lineLabel = docBlocks ? lineLabelForAnnotation(docBlocks, ann) : null;
+      if (lineLabel) output += `(${lineLabel}) `;
 
       switch (ann.type) {
         case 'DELETION':


### PR DESCRIPTION
## Summary
This PR enhances the feedback export functionality to include source line numbers for annotations, with special handling for documents converted from HTML/URL sources where line numbers are caveated.

## Key Changes

- **Line number extraction**: Added `lineLabelForAnnotation()` helper to resolve source line numbers from block metadata, filtering out global comments and diff-view annotations
- **Export options interface**: Created `ExportAnnotationsOptions` to support the `sourceConverted` flag, which adds a caveat note when markdown was converted from HTML/URL via Turndown/Jina
- **Main document feedback**: Updated `exportAnnotations()` to include line labels in annotation headers and display a caveat when `sourceConverted` is true
- **Linked document feedback**: Enhanced `exportLinkedDocAnnotations()` to:
  - Accept `LinkedDocAnnotationEntry` with optional `blocks` and `isConverted` fields
  - Include line numbers for linked doc annotations
  - Display conversion caveat in section headers
- **Document caching**: Modified `useLinkedDoc` hook to cache markdown and conversion status alongside annotations, enabling line number computation during export
- **Server-side tracking**: Updated all annotation entry points (extension, hook, OpenCode plugin) to detect and propagate the `sourceConverted` flag when:
  - Loading from URLs (Jina conversion)
  - Loading from `.html` files (Turndown conversion)
- **API responses**: Modified document handlers in both extension and Bun servers to include `isConverted` flag in responses
- **State management**: Added `sourceConverted` state to App component and threaded it through to export functions and linked doc hook

## Implementation Details

- Line labels are only shown for annotations with valid block references (excludes diff-view and global annotations)
- Conversion detection is automatic based on file extension (`.html`/`.htm`) or URL source
- Caveats are added at both the document level (linked docs) and globally (main feedback) to ensure users understand line number limitations
- The markdown content is cached per linked document to enable block parsing during export without re-fetching

