### PR TITLE
feat(review): hide/de-emphasize merged PRs in stacked PR selector

### DIFF
--- a/packages/review-editor/components/PRSelector.tsx
+++ b/packages/review-editor/components/PRSelector.tsx
@@ -37,11 +37,12 @@ export function PRSelector({ mrNumberLabel, prTitle, currentNumber, onSelect, di
   const selectedId = String(currentNumber);
 
   const visiblePrs = useMemo(
-    () => hideMerged ? prs.filter(pr => pr.state !== 'merged') : prs,
+    () => hideMerged ? prs.filter(pr => pr.state === 'open') : prs,
     [prs, hideMerged],
   );
 
-  const mergedCount = useMemo(() => prs.filter(pr => pr.state === 'merged').length, [prs]);
+  const openCount = useMemo(() => prs.filter(pr => pr.state === 'open').length, [prs]);
+  const mergedCount = useMemo(() => prs.filter(pr => pr.state !== 'open').length, [prs]);
 
   function toggleHideMerged() {
     const next = !hideMerged;
@@ -93,7 +94,7 @@ export function PRSelector({ mrNumberLabel, prTitle, currentNumber, onSelect, di
       headerContent={mergedCount > 0 ? (
         <div className="flex items-center justify-between px-3 py-1.5 border-b border-border/50">
           <span className="text-[10px] text-muted-foreground/60">
-            {hideMerged ? `${mergedCount} merged hidden` : `${visiblePrs.length} PRs`}
+            {hideMerged ? `${openCount} open · ${mergedCount} hidden` : `${openCount} open, ${prs.length} total`}
           </span>
           <button
             type="button"

--- a/packages/review-editor/components/PRSelector.tsx
+++ b/packages/review-editor/components/PRSelector.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import { SearchableSelect } from '@plannotator/ui/components/SearchableSelect';
 import { PullRequestIcon } from '@plannotator/ui/components/PullRequestIcon';
+import { getItem, setItem } from '@plannotator/ui/utils/storage';
 import type { PRListItem } from '@plannotator/shared/pr-provider';
 
 type PRItem = PRListItem;
@@ -25,12 +26,28 @@ interface PRSelectorProps {
   disabled?: boolean;
 }
 
+const HIDE_MERGED_PR_KEY = 'plannotator-pr-list-hide-merged';
+
 export function PRSelector({ mrNumberLabel, prTitle, currentNumber, onSelect, disabled }: PRSelectorProps) {
   const [prs, setPrs] = useState<PRItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [fetched, setFetched] = useState(false);
+  const [hideMerged, setHideMerged] = useState(() => getItem(HIDE_MERGED_PR_KEY) === 'true');
 
   const selectedId = String(currentNumber);
+
+  const visiblePrs = useMemo(
+    () => hideMerged ? prs.filter(pr => pr.state !== 'merged') : prs,
+    [prs, hideMerged],
+  );
+
+  const mergedCount = useMemo(() => prs.filter(pr => pr.state === 'merged').length, [prs]);
+
+  function toggleHideMerged() {
+    const next = !hideMerged;
+    setHideMerged(next);
+    setItem(HIDE_MERGED_PR_KEY, String(next));
+  }
 
   useEffect(() => { setPrs([]); setFetched(false); }, [currentNumber]);
 
@@ -53,7 +70,7 @@ export function PRSelector({ mrNumberLabel, prTitle, currentNumber, onSelect, di
 
   return (
     <SearchableSelect
-      items={prs}
+      items={visiblePrs}
       selectedId={selectedId}
       onSelect={(item) => {
         if (item.number !== currentNumber) {
@@ -73,6 +90,23 @@ export function PRSelector({ mrNumberLabel, prTitle, currentNumber, onSelect, di
       align="start"
       width="w-80"
       onOpenChange={handleOpen}
+      headerContent={mergedCount > 0 ? (
+        <div className="flex items-center justify-between px-3 py-1.5 border-b border-border/50">
+          <span className="text-[10px] text-muted-foreground/60">
+            {hideMerged ? `${mergedCount} merged hidden` : `${visiblePrs.length} PRs`}
+          </span>
+          <button
+            type="button"
+            onClick={toggleHideMerged}
+            title={hideMerged ? 'Show merged PRs' : 'Hide merged PRs'}
+            className={`cc-blocking-toggle ${hideMerged ? 'is-on' : ''}`}
+            style={{ borderLeft: 'none', marginLeft: 0 }}
+          >
+            <span className="cc-toggle-track"><span className="cc-toggle-thumb" /></span>
+            <span>Hide merged</span>
+          </button>
+        </div>
+      ) : undefined}
       renderTrigger={({ open }) => (
         <button
           type="button"

--- a/packages/review-editor/components/StackedPRLabel.tsx
+++ b/packages/review-editor/components/StackedPRLabel.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import * as Popover from '@radix-ui/react-popover';
 import { getPlatformLabel } from '@plannotator/shared/pr-provider';
 import { buildMinimalStackTree } from '@plannotator/shared/pr-stack';
+import { getItem, setItem } from '@plannotator/ui/utils/storage';
 import type { PRMetadata } from '@plannotator/shared/pr-provider';
 import type { PRDiffScope, PRDiffScopeOption, PRStackInfo, PRStackTree, PRStackNode } from '@plannotator/shared/pr-stack';
 
@@ -43,6 +44,8 @@ function classifyNode(
   return { kind: 'navigate', url: node.url ?? '' };
 }
 
+const HIDE_MERGED_KEY = 'plannotator-stack-hide-merged';
+
 export function StackedPRLabel({
   metadata,
   mrNumberLabel,
@@ -56,6 +59,13 @@ export function StackedPRLabel({
 }: StackedPRLabelProps) {
   const [open, setOpen] = useState(false);
 
+  const [hideMerged, setHideMerged] = useState(() => getItem(HIDE_MERGED_KEY) === 'true');
+  function toggleHideMerged() {
+    const next = !hideMerged;
+    setHideMerged(next);
+    setItem(HIDE_MERGED_KEY, String(next));
+  }
+
   const hasStack = !!(stackInfo || (stackTree && stackTree.nodes.filter(n => !n.isDefaultBranch).length > 1));
 
   if (!hasStack) return null;
@@ -65,6 +75,18 @@ export function StackedPRLabel({
   const currentIndex = tree.nodes.findIndex(n => n.isCurrent);
   const parentNode = currentIndex > 0 ? tree.nodes[currentIndex - 1] : null;
   const rootNode = tree.nodes[0];
+
+  const hasStateInfo = tree.nodes.some(n => !n.isDefaultBranch && n.state !== undefined);
+  const mergedCount = tree.nodes.filter(n => !n.isDefaultBranch && !n.isCurrent && n.state === 'merged').length;
+  const showToggle = hasStateInfo && mergedCount > 0;
+
+  const visibleNodes = hideMerged && showToggle
+    ? tree.nodes.filter(n => n.isCurrent || n.isDefaultBranch || n.state !== 'merged')
+    : tree.nodes;
+
+  function isMergedNode(node: PRStackNode): boolean {
+    return !node.isCurrent && !node.isDefaultBranch && node.state === 'merged';
+  }
 
   const layerTarget = parentNode ? shortNodeLabel(parentNode) : (stackInfo?.baseBranch ?? 'base');
   const fullStackTarget = rootNode?.isDefaultBranch ? rootNode.branch : (stackInfo?.defaultBranch ?? 'main');
@@ -84,6 +106,7 @@ export function StackedPRLabel({
   }
 
   function isNodeDisabled(node: PRStackNode): boolean {
+    if (isMergedNode(node)) return true;
     const action = classifyNode(node);
     if (action.kind === 'current') return true;
     if (action.kind === 'full-stack') return !(fullStackOption?.enabled) || isSwitchingScope;
@@ -156,14 +179,34 @@ export function StackedPRLabel({
         >
           {/* Section 1: Stack Tree */}
           <div className="px-3 pt-3 pb-2">
-            <div className="text-[11px] font-medium text-muted-foreground mb-2">
-              Stack ({prNodes.length} {prNodes.length === 1 ? 'PR' : 'PRs'})
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-[11px] font-medium text-muted-foreground">
+                Stack ({prNodes.length} {prNodes.length === 1 ? 'PR' : 'PRs'})
+                {hideMerged && showToggle && (
+                  <span className="ml-1 text-[10px] text-muted-foreground/50">
+                    · {mergedCount} merged hidden
+                  </span>
+                )}
+              </span>
+              {showToggle && (
+                <button
+                  type="button"
+                  onClick={toggleHideMerged}
+                  title={hideMerged ? 'Show merged PRs' : 'Hide merged PRs'}
+                  className={`cc-blocking-toggle ${hideMerged ? 'is-on' : ''}`}
+                  style={{ borderLeft: 'none', marginLeft: 0 }}
+                >
+                  <span className="cc-toggle-track"><span className="cc-toggle-thumb" /></span>
+                  <span>Hide merged</span>
+                </button>
+              )}
             </div>
             <div>
-              {tree.nodes.map((node, i) => {
+              {visibleNodes.map((node, i) => {
                 const depth = node.isDefaultBranch ? 0 : i;
-                const isLast = i === tree.nodes.length - 1;
+                const isLast = i === visibleNodes.length - 1;
                 const disabled = isNodeDisabled(node);
+                const merged = isMergedNode(node);
                 const action = classifyNode(node);
                 const tooltip = nodeTooltip(node);
 
@@ -171,7 +214,7 @@ export function StackedPRLabel({
                   <div
                     key={node.branch}
                     className="flex items-start"
-                    style={{ paddingLeft: `${Math.max(0, depth - 1) * 14}px` }}
+                    style={{ paddingLeft: `${depth * 2}px` }}
                   >
                     <div className="flex items-center flex-shrink-0 mt-[5px]">
                       {depth > 0 && (
@@ -180,7 +223,7 @@ export function StackedPRLabel({
                         </span>
                       )}
                       <span className={`inline-block w-1.5 h-1.5 rounded-full flex-shrink-0 ${
-                        node.isCurrent ? 'bg-accent' : node.isDefaultBranch ? 'bg-muted-foreground/30' : 'bg-muted-foreground/40'
+                        node.isCurrent ? 'bg-accent' : node.isDefaultBranch ? 'bg-muted-foreground/30' : merged ? 'bg-muted-foreground/20' : 'bg-muted-foreground/40'
                       }`} />
                     </div>
                     <button
@@ -191,16 +234,21 @@ export function StackedPRLabel({
                       className={`flex items-center gap-1.5 min-w-0 text-xs leading-6 ml-1.5 rounded px-1 -mx-0.5 transition-colors ${
                         node.isCurrent
                           ? 'text-accent font-medium cursor-default'
-                          : disabled
-                            ? 'text-muted-foreground/40 cursor-not-allowed'
-                            : action.kind === 'navigate'
-                              ? 'text-muted-foreground hover:text-foreground hover:bg-muted/30 cursor-pointer'
-                              : 'text-muted-foreground hover:text-accent hover:bg-muted/30 cursor-pointer'
+                          : merged
+                            ? 'text-muted-foreground/40 cursor-default'
+                            : disabled
+                              ? 'text-muted-foreground/40 cursor-not-allowed'
+                              : action.kind === 'navigate'
+                                ? 'text-muted-foreground hover:text-foreground hover:bg-muted/30 cursor-pointer'
+                                : 'text-muted-foreground hover:text-accent hover:bg-muted/30 cursor-pointer'
                       }`}
                     >
-                      <span className="truncate">{nodeLabel(node)}</span>
+                      <span className={`truncate ${merged ? 'line-through' : ''}`}>{nodeLabel(node)}</span>
                       {node.isCurrent && (
                         <span className="text-[9px] text-accent/60 whitespace-nowrap">reviewing</span>
+                      )}
+                      {merged && (
+                        <span className="text-[9px] text-muted-foreground/40 whitespace-nowrap border border-muted-foreground/20 rounded px-0.5 leading-tight">merged</span>
                       )}
                       {action.kind === 'navigate' && node.url && !disabled && (
                         <svg className="w-2.5 h-2.5 flex-shrink-0 opacity-40" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>

--- a/packages/review-editor/index.css
+++ b/packages/review-editor/index.css
@@ -478,6 +478,21 @@ diffs-container {
   color: var(--destructive);
 }
 
+/* Generic ON state for cc-toggle (non-destructive) */
+.cc-blocking-toggle.is-on .cc-toggle-track {
+  background: oklch(from var(--accent) l c h / 0.20);
+  border-color: oklch(from var(--accent) l c h / 0.40);
+}
+
+.cc-blocking-toggle.is-on .cc-toggle-thumb {
+  transform: translateX(0.4375rem);
+  background: var(--accent);
+}
+
+.cc-blocking-toggle.is-on {
+  color: var(--accent);
+}
+
 /* --- Inline badge on rendered annotation comments --- */
 
 .cc-inline-badge {

--- a/packages/shared/pr-github.ts
+++ b/packages/shared/pr-github.ts
@@ -505,7 +505,7 @@ export async function submitGhPRReview(
 
 // --- Stack Tree (GraphQL) ---
 
-type StackPRNode = { number: number; title: string; url: string; baseRefName: string; headRefName: string };
+type StackPRNode = { number: number; title: string; url: string; baseRefName: string; headRefName: string; state: string };
 
 function stackPRQuery(kind: "head" | "base"): string {
   const varName = kind === "head" ? "headRefName" : "baseRefName";
@@ -514,7 +514,7 @@ function stackPRQuery(kind: "head" | "base"): string {
 query($owner: String!, $repo: String!, $${varName}: String!) {
   repository(owner: $owner, name: $repo) {
     pullRequests(first: ${first}, ${varName}: $${varName}, states: [OPEN, MERGED]) {
-      nodes { number title url baseRefName headRefName }
+      nodes { number title url baseRefName headRefName state }
     }
   }
 }`;
@@ -587,6 +587,7 @@ export async function fetchGhPRStack(
       url: pr.url,
       isCurrent: false,
       isDefaultBranch: false,
+      state: (pr.state === 'MERGED' ? 'merged' : pr.state === 'CLOSED' ? 'closed' : 'open') as PRStackNode['state'],
     });
     nextHead = pr.baseRefName;
   }
@@ -607,6 +608,7 @@ export async function fetchGhPRStack(
       url: pr.url,
       isCurrent: false,
       isDefaultBranch: false,
+      state: (pr.state === 'MERGED' ? 'merged' : pr.state === 'CLOSED' ? 'closed' : 'open') as PRStackNode['state'],
     });
     nextBase = pr.headRefName;
   }

--- a/packages/shared/pr-provider.ts
+++ b/packages/shared/pr-provider.ts
@@ -200,6 +200,7 @@ export interface PRStackNode {
   url?: string;
   isCurrent: boolean;
   isDefaultBranch: boolean;
+  state?: 'open' | 'merged' | 'closed';
 }
 
 export interface PRStackTree {

--- a/packages/ui/components/SearchableSelect.tsx
+++ b/packages/ui/components/SearchableSelect.tsx
@@ -8,6 +8,7 @@ interface SearchableSelectProps<T extends { id: string }> {
   filterFn: (item: T, query: string) => boolean;
   renderItem: (item: T, state: { isSelected: boolean; isFocused: boolean }) => ReactNode;
   renderTrigger: (state: { open: boolean }) => ReactNode;
+  headerContent?: ReactNode;
   placeholder?: string;
   emptyMessage?: string;
   align?: 'start' | 'center' | 'end';
@@ -22,6 +23,7 @@ export function SearchableSelect<T extends { id: string }>({
   filterFn,
   renderItem,
   renderTrigger,
+  headerContent,
   placeholder = 'Search...',
   emptyMessage = 'No results',
   align = 'start',
@@ -119,6 +121,8 @@ export function SearchableSelect<T extends { id: string }>({
             className="w-full bg-transparent text-xs text-foreground placeholder:text-muted-foreground/50 outline-none"
           />
         </div>
+
+        {headerContent}
 
         {/* Item list */}
         <div ref={listRef} className="max-h-60 overflow-y-auto py-1">


### PR DESCRIPTION
## Summary

- Fetches PR `state` from GitHub GraphQL stack walker and adds it to `PRStackNode`
- Adds a cookie-persisted "Hide merged" toggle to the stack tree popover
- When hidden: merged nodes removed, "N merged hidden" summary shown
- When visible: merged nodes dimmed with strikethrough + "merged" badge, non-clickable
- Reduces tree indentation to 2px/level to prevent horizontal overflow on deep (10+) stacks

Closes #625

## Test plan

- [ ] `plannotator review https://github.com/backnotprop/plannotator-stack-fixture/pull/8` — verify 4 merged nodes appear dimmed with badge
- [ ] Toggle "Hide merged" on — merged nodes disappear, count shown in header
- [ ] Toggle persists across page refresh (cookie)
- [ ] Current PR node is never hidden/dimmed regardless of state
- [ ] Non-stacked PR reviews show no toggle
- [ ] Deep stacks (12 nodes) don't overflow horizontally