### PR TITLE
feat(feedback): configurable plan, annotation, and review feedback

### DIFF
--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -82,7 +82,6 @@ import {
   getPlanDeniedPrompt,
   getPlanToolName,
   buildPlanFileRule,
-  getAnnotateApprovedPrompt,
 } from "@plannotator/shared/prompts";
 import { registerSession, unregisterSession, listSessions } from "@plannotator/server/sessions";
 import { openBrowser } from "@plannotator/server/browser";
@@ -159,7 +158,14 @@ if (hookFlag) gateFlag = true;
 //   Emits {"decision":"approved|dismissed|annotated","feedback":"..."}.
 //
 // Plaintext (default):
-//   Close → empty. Approve → configurable via getAnnotateApprovedPrompt(). Annotate → feedback.
+//   Close → empty. Approve → "The user approved." Annotate → feedback.
+//
+// TODO: The plaintext --gate approval sentinel must stay as the exact string
+// "The user approved." because slash command templates (plannotator-annotate.md,
+// plannotator-last.md) instruct the agent to match it literally. Making this
+// configurable requires updating those templates to accept dynamic values or
+// switching gate mode to structured output only.
+const APPROVED_PLAINTEXT_MARKER = "The user approved.";
 
 function emitAnnotateOutcome(result: {
   feedback: string;
@@ -185,7 +191,7 @@ function emitAnnotateOutcome(result: {
   }
   if (result.exit) return;
   if (result.approved) {
-    console.log(getAnnotateApprovedPrompt(detectedOrigin));
+    console.log(APPROVED_PLAINTEXT_MARKER);
     return;
   }
   if (result.feedback) console.log(result.feedback);

--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -76,12 +76,18 @@ import { resolveMarkdownFile, resolveUserPath, hasMarkdownFiles } from "@plannot
 import { FILE_BROWSER_EXCLUDED } from "@plannotator/shared/reference-common";
 import { statSync, rmSync, realpathSync, existsSync } from "fs";
 import { parseRemoteUrl } from "@plannotator/shared/repo";
-import { getReviewApprovedPrompt } from "@plannotator/shared/prompts";
+import {
+  getReviewApprovedPrompt,
+  getReviewDeniedSuffix,
+  getPlanDeniedPrompt,
+  getPlanToolName,
+  buildPlanFileRule,
+  getAnnotateApprovedPrompt,
+} from "@plannotator/shared/prompts";
 import { registerSession, unregisterSession, listSessions } from "@plannotator/server/sessions";
 import { openBrowser } from "@plannotator/server/browser";
 import { detectProjectName } from "@plannotator/server/project";
 import { hostnameOrFallback } from "@plannotator/shared/project";
-import { planDenyFeedback } from "@plannotator/shared/feedback-templates";
 import { readImprovementHook } from "@plannotator/shared/improvement-hooks";
 import { AGENT_CONFIG, type Origin } from "@plannotator/shared/agents";
 import {
@@ -153,8 +159,7 @@ if (hookFlag) gateFlag = true;
 //   Emits {"decision":"approved|dismissed|annotated","feedback":"..."}.
 //
 // Plaintext (default):
-//   Close → empty. Approve → "The user approved." Annotate → feedback.
-export const APPROVED_PLAINTEXT_MARKER = "The user approved.";
+//   Close → empty. Approve → configurable via getAnnotateApprovedPrompt(). Annotate → feedback.
 
 function emitAnnotateOutcome(result: {
   feedback: string;
@@ -180,7 +185,7 @@ function emitAnnotateOutcome(result: {
   }
   if (result.exit) return;
   if (result.approved) {
-    console.log(APPROVED_PLAINTEXT_MARKER);
+    console.log(getAnnotateApprovedPrompt(detectedOrigin));
     return;
   }
   if (result.feedback) console.log(result.feedback);
@@ -549,7 +554,7 @@ if (args[0] === "sessions") {
   } else {
     console.log(result.feedback);
     if (!isPRMode) {
-      console.log("\nThe reviewer has identified issues above. You must address all of them.");
+      console.log(getReviewDeniedSuffix(detectedOrigin));
     }
   }
   process.exit(0);
@@ -950,10 +955,11 @@ if (args[0] === "sessions") {
       permissionDecision: "allow",
     }));
   } else {
-    const feedback = planDenyFeedback(
-      result.feedback || "",
-      "exit_plan_mode",
-    );
+    const feedback = getPlanDeniedPrompt("copilot-cli", undefined, {
+      toolName: getPlanToolName("copilot-cli"),
+      planFileRule: "",
+      feedback: result.feedback || "Plan changes requested",
+    });
     console.log(JSON.stringify({
       permissionDecision: "deny",
       permissionDecisionReason: feedback,
@@ -1151,8 +1157,10 @@ if (args[0] === "sessions") {
       console.log(
         JSON.stringify({
           decision: "deny",
-          reason: planDenyFeedback(result.feedback || "", "exit_plan_mode", {
-            planFilePath: planFilename,
+          reason: getPlanDeniedPrompt("gemini-cli", undefined, {
+            toolName: getPlanToolName("gemini-cli"),
+            planFileRule: buildPlanFileRule(getPlanToolName("gemini-cli"), planFilename),
+            feedback: result.feedback || "Plan changes requested",
           }),
         })
       );
@@ -1187,7 +1195,11 @@ if (args[0] === "sessions") {
             hookEventName: "PermissionRequest",
             decision: {
               behavior: "deny",
-              message: planDenyFeedback(result.feedback || "", "ExitPlanMode"),
+              message: getPlanDeniedPrompt(detectedOrigin, undefined, {
+                toolName: getPlanToolName(detectedOrigin),
+                planFileRule: "",
+                feedback: result.feedback || "Plan changes requested",
+              }),
             },
           },
         })

--- a/apps/marketing/src/content/docs/getting-started/configuration.md
+++ b/apps/marketing/src/content/docs/getting-started/configuration.md
@@ -99,9 +99,9 @@ Approved and denied plans are saved to `~/.plannotator/plans/` by default. You c
 
 ## Config file
 
-Plannotator also reads `~/.plannotator/config.json` for persistent settings and feature-specific overrides.
+Plannotator reads `~/.plannotator/config.json` for persistent settings. This includes display name, diff options, conventional comment labels, and feedback message customization.
 
-For example, code review approval prompts can be customized there. See the code review docs for the prompt shape and supported runtime keys.
+You can customize the messages Plannotator sends to the agent when you approve, deny, or annotate plans and documents. See the [custom feedback guide](/docs/guides/custom-feedback/) for the full config shape, template variables, and runtime-specific overrides.
 
 ## Remote mode
 

--- a/apps/marketing/src/content/docs/guides/custom-feedback.md
+++ b/apps/marketing/src/content/docs/guides/custom-feedback.md
@@ -49,7 +49,6 @@ These are sent when you annotate a file (`/plannotator-annotate`) or the last as
 |-----|---------------|-------------------|
 | `fileFeedback` | You annotate a file or folder | `{{fileHeader}}`, `{{filePath}}`, `{{feedback}}` |
 | `messageFeedback` | You annotate the last assistant message | `{{feedback}}` |
-| `approved` | You approve in gate mode (plaintext output) | none |
 
 ### Review feedback
 

--- a/apps/marketing/src/content/docs/guides/custom-feedback.md
+++ b/apps/marketing/src/content/docs/guides/custom-feedback.md
@@ -1,0 +1,199 @@
+---
+title: Custom Feedback Messages
+description: "How to customize the messages Plannotator sends to your agent when you approve, deny, or annotate plans and documents."
+sidebar:
+  order: 29
+section: "Guides"
+---
+
+Every time you approve a plan, deny it with feedback, annotate a file, or finish a code review, Plannotator sends a message to the agent. These messages are what the agent actually sees and acts on. By default they work well, but you can change any of them to match how you want your agent to behave.
+
+All customization happens in `~/.plannotator/config.json` under the `prompts` key. No restart needed. Changes take effect the next time a feedback message is generated. You can set overrides that apply globally, or target a specific agent runtime (Claude Code, OpenCode, Pi, etc.) with [runtime-specific overrides](#runtime-specific-overrides).
+
+## Quick example
+
+Say you want a shorter, more direct plan denial message. Add a `prompts.plan.denied` override to your config file (`~/.plannotator/config.json`):
+
+```json
+{
+  "prompts": {
+    "plan": {
+      "denied": "PLAN REJECTED.\n\nFix these issues and resubmit via {{toolName}}:\n\n{{feedback}}"
+    }
+  }
+}
+```
+
+Next time you deny a plan, the agent will see your custom message instead of the default. The `{{toolName}}` and `{{feedback}}` placeholders get filled in automatically.
+
+## What you can customize
+
+There are three sections: `plan`, `annotate`, and `review`. Each has its own set of message types.
+
+### Plan feedback
+
+These are sent when you approve or deny a plan in the review UI.
+
+| Key | When it's used | Available variables |
+|-----|---------------|-------------------|
+| `denied` | You deny a plan (with or without annotations) | `{{toolName}}`, `{{feedback}}`, `{{planFileRule}}` |
+| `approved` | You approve a plan without notes | `{{planFilePath}}`, `{{doneMsg}}` |
+| `approvedWithNotes` | You approve but include annotation notes | `{{planFilePath}}`, `{{doneMsg}}`, `{{feedback}}` |
+| `autoApproved` | Plan is auto-approved in non-interactive mode | none |
+
+### Annotation feedback
+
+These are sent when you annotate a file (`/plannotator-annotate`) or the last assistant message (`/plannotator-last`).
+
+| Key | When it's used | Available variables |
+|-----|---------------|-------------------|
+| `fileFeedback` | You annotate a file or folder | `{{fileHeader}}`, `{{filePath}}`, `{{feedback}}` |
+| `messageFeedback` | You annotate the last assistant message | `{{feedback}}` |
+| `approved` | You approve in gate mode (plaintext output) | none |
+
+### Review feedback
+
+These are sent during code review (`/plannotator-review`).
+
+| Key | When it's used | Available variables |
+|-----|---------------|-------------------|
+| `approved` | You approve a code review with no feedback | none |
+| `denied` | Appended after your review feedback | none |
+
+## Template variables
+
+Templates use `{{variable}}` placeholders. Here's what each one contains:
+
+| Variable | Description |
+|----------|-------------|
+| `{{feedback}}` | Your annotations, exported as structured text. This is the main content. |
+| `{{toolName}}` | The tool the agent needs to call to resubmit (`ExitPlanMode`, `submit_plan`, etc.). Varies by runtime. |
+| `{{planFileRule}}` | A conditional line telling the agent where the plan file is saved and how to edit it. Empty string when there's no file path. |
+| `{{planFilePath}}` | Path to the plan file being reviewed. |
+| `{{doneMsg}}` | Optional checklist instruction or save-path info, depending on the runtime. |
+| `{{fileHeader}}` | Either `"File"` or `"Folder"`, depending on what was annotated. |
+| `{{filePath}}` | Path to the annotated file or folder. |
+
+If you use a `{{variable}}` that doesn't exist for that message type, it stays in the output as-is. This means you can include literal `{{text}}` in your templates without worrying about it being stripped.
+
+## Runtime-specific overrides
+
+Different agent runtimes (Claude Code, OpenCode, Pi, Gemini CLI, etc.) sometimes need different messages. For example, OpenCode's plan approval is shorter because the agent already knows it has tool access.
+
+You can override a message for a specific runtime using the `runtimes` key:
+
+```json
+{
+  "prompts": {
+    "plan": {
+      "denied": "PLAN REJECTED.\n\n{{feedback}}",
+      "runtimes": {
+        "claude-code": {
+          "denied": "Your plan was not approved. Address ALL feedback below, then call {{toolName}} again.\n\n{{feedback}}"
+        },
+        "opencode": {
+          "denied": "Plan rejected. Fix the following and call {{toolName}}:\n\n{{feedback}}"
+        }
+      }
+    }
+  }
+}
+```
+
+The resolution order is:
+
+1. Runtime-specific config override (e.g., `prompts.plan.runtimes.opencode.denied`)
+2. Generic config override (e.g., `prompts.plan.denied`)
+3. Built-in default (some prompts have runtime-specific built-in defaults, like OpenCode's shorter plan approval)
+
+Blank or whitespace-only values are treated as "not set" and fall through to the next level. This means you can clear a runtime override by setting it to `""` without affecting others.
+
+Valid runtime keys: `claude-code`, `opencode`, `copilot-cli`, `pi`, `codex`, `gemini-cli`.
+
+## Full config example
+
+Here's a config that customizes several messages at once:
+
+```json
+{
+  "prompts": {
+    "plan": {
+      "denied": "PLAN NOT APPROVED.\n\nRevise your plan based on this feedback, then resubmit via {{toolName}}.\n\n{{feedback}}",
+      "approved": "Plan approved. Begin implementation.",
+      "approvedWithNotes": "Plan approved with the following notes:\n\n{{feedback}}\n\nKeep these in mind as you implement."
+    },
+    "annotate": {
+      "fileFeedback": "# Annotations for {{filePath}}\n\n{{feedback}}\n\nPlease address these.",
+      "messageFeedback": "{{feedback}}\n\nRevise your response based on these notes."
+    },
+    "review": {
+      "approved": "Code review passed. No changes needed."
+    }
+  }
+}
+```
+
+## Defaults
+
+If you don't set any `prompts` config, everything works the same as it always has. The built-in defaults are the exact messages Plannotator has always sent. Here are the key ones for reference:
+
+**Plan denied (default):**
+```
+YOUR PLAN WAS NOT APPROVED.
+
+You MUST revise the plan to address ALL of the feedback below
+before calling {{toolName}} again.
+
+Rules:
+{{planFileRule}}- Do not resubmit the same plan unchanged.
+- Do NOT change the plan title (first # heading) unless the
+  user explicitly asks you to.
+
+{{feedback}}
+```
+
+**Plan approved (default, Pi runtime):**
+```
+Plan approved. You now have full tool access (read, bash, edit,
+write). Execute the plan in {{planFilePath}}. {{doneMsg}}
+```
+
+**Annotate file feedback (default):**
+```
+# Markdown Annotations
+
+{{fileHeader}}: {{filePath}}
+
+{{feedback}}
+
+Please address the annotation feedback above.
+```
+
+## Example: context anchoring with a Decisions Log
+
+When you deny a plan multiple times, the agent only sees the current round's feedback. It can re-propose the same rejected approach without realizing it was already rejected. Martin Fowler's [context anchoring](https://martinfowler.com/articles/reduce-friction-ai/context-anchoring.html) pattern solves this by having the agent maintain a running log of rejected decisions directly in the plan document.
+
+You can implement this entirely through feedback customization. Add a `## Context Anchoring` section to your denial template that instructs the agent to keep a `## Decisions Log` in the plan itself:
+
+```json
+{
+  "prompts": {
+    "plan": {
+      "denied": "YOUR PLAN WAS NOT APPROVED.\n\nYou MUST revise the plan to address ALL of the feedback below before calling {{toolName}} again.\n\nRules:\n{{planFileRule}}- Do not resubmit the same plan unchanged.\n- Do NOT change the plan title (first # heading) unless the user explicitly asks you to.\n\n## Context Anchoring\n\nBefore revising your plan:\n1. Add (or update) a `## Decisions Log` section at the bottom of the plan.\n2. For each rejected approach from this feedback, add an entry:\n   - **Rejected:** [brief description]  **Why:** [reason from this feedback]\n3. Do NOT re-propose approaches already in the Decisions Log.\n\n{{feedback}}",
+      "approved": "Plan approved. Begin implementation.\n\nIf your plan contains a `## Decisions Log`, keep it as a reference during implementation. It documents the rejected alternatives that shaped this design.",
+      "approvedWithNotes": "Plan approved with the following notes:\n\n{{feedback}}\n\nKeep these in mind as you implement.\n\nIf your plan contains a `## Decisions Log`, keep it as a reference during implementation. It documents the rejected alternatives that shaped this design."
+    }
+  }
+}
+```
+
+This works because the plan is already a persistent artifact (saved to version history on every submission). The Decisions Log travels with every revision, is visible in the plan diff view, and survives context window resets since it lives in the document, not just the conversation.
+
+*This example is based on a contribution by [Aviad Shiber](https://github.com/aviadshiber).*
+
+## Tips
+
+- Start by customizing `plan.denied` since that's the message agents see most often during iterative planning.
+- Keep the `{{feedback}}` variable in your templates. Without it, the agent won't see your annotations.
+- The denial message framing matters. Claude was tested to respond better to strong, directive language ("You MUST revise") than softer phrasing. If you soften the tone too much, you may notice the agent ignoring feedback or resubmitting unchanged plans.
+- You can test your templates by denying a plan and checking what the agent receives. The full message shows up in the agent's conversation.

--- a/apps/marketing/src/styles/global.css
+++ b/apps/marketing/src/styles/global.css
@@ -89,10 +89,16 @@
   opacity: 0.8;
 }
 
-.prose ul,
+.prose ul {
+  padding-left: 1.5rem;
+  margin-bottom: 0.75rem;
+  list-style-type: disc;
+}
+
 .prose ol {
   padding-left: 1.5rem;
   margin-bottom: 0.75rem;
+  list-style-type: decimal;
 }
 
 .prose li {

--- a/apps/opencode-plugin/commands.ts
+++ b/apps/opencode-plugin/commands.ts
@@ -296,7 +296,7 @@ export async function handleAnnotateCommand(
             parts: [{
               type: "text",
               text: getAnnotateFileFeedbackPrompt("opencode", undefined, {
-                fileHeader: "File",
+                fileHeader: isFolder ? "Folder" : "File",
                 filePath: absolutePath,
                 feedback: result.feedback,
               }),

--- a/apps/opencode-plugin/commands.ts
+++ b/apps/opencode-plugin/commands.ts
@@ -174,6 +174,7 @@ export async function handleAnnotateCommand(
   let absolutePath: string;
   let folderPath: string | undefined;
   let annotateMode: "annotate" | "annotate-folder" = "annotate";
+  let isFolder = false;
   let sourceInfo: string | undefined;
   let sourceConverted = false;
 
@@ -197,7 +198,6 @@ export async function handleAnnotateCommand(
     const projectRoot = directory || process.cwd();
     const resolvedArg = resolveUserPath(filePath, projectRoot);
 
-    let isFolder = false;
     try {
       isFolder = statSync(resolvedArg).isDirectory();
     } catch {

--- a/apps/opencode-plugin/commands.ts
+++ b/apps/opencode-plugin/commands.ts
@@ -21,7 +21,11 @@ import {
 import { getGitContext, runGitDiffWithContext } from "@plannotator/server/git";
 import { parsePRUrl, checkPRAuth, fetchPR, getCliName, getMRLabel, getMRNumberLabel, getDisplayRepo } from "@plannotator/server/pr";
 import { loadConfig, resolveDefaultDiffType, resolveUseJina } from "@plannotator/shared/config";
-import { getReviewApprovedPrompt } from "@plannotator/shared/prompts";
+import {
+  getReviewApprovedPrompt,
+  getReviewDeniedSuffix,
+  getAnnotateFileFeedbackPrompt,
+} from "@plannotator/shared/prompts";
 import { resolveMarkdownFile, resolveUserPath, hasMarkdownFiles } from "@plannotator/shared/resolve-file";
 import { FILE_BROWSER_EXCLUDED } from "@plannotator/shared/reference-common";
 import { htmlToMarkdown } from "@plannotator/shared/html-to-markdown";
@@ -130,7 +134,7 @@ export async function handleReviewCommand(
         ? getReviewApprovedPrompt("opencode")
         : isPRMode
           ? result.feedback
-          : `${result.feedback}\n\nPlease address this feedback.`;
+          : `${result.feedback}${getReviewDeniedSuffix("opencode")}`;
 
       try {
         await client.session.prompt({
@@ -291,7 +295,11 @@ export async function handleAnnotateCommand(
           body: {
             parts: [{
               type: "text",
-              text: `# Markdown Annotations\n\nFile: ${absolutePath}\n\n${result.feedback}\n\nPlease address the annotation feedback above.`,
+              text: getAnnotateFileFeedbackPrompt("opencode", undefined, {
+                fileHeader: "File",
+                filePath: absolutePath,
+                feedback: result.feedback,
+              }),
             }],
           },
         });

--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -528,14 +528,14 @@ Use /plannotator-last or /plannotator-annotate for manual review, or set workflo
 
             if (result.feedback) {
               return getPlanApprovedWithNotesPrompt("opencode", undefined, {
-                planFilePath: "",
+                planFilePath: sourceFilePath,
                 doneMsg: result.savedPath ? `Saved to: ${result.savedPath}` : "",
                 feedback: result.feedback,
               });
             }
 
             return getPlanApprovedPrompt("opencode", undefined, {
-              planFilePath: "",
+              planFilePath: sourceFilePath,
               doneMsg: result.savedPath ? ` Saved to: ${result.savedPath}` : "",
             });
           } else {

--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -56,7 +56,14 @@ import {
   handleArchiveCommand,
   type CommandDeps,
 } from "./commands";
-import { planDenyFeedback } from "@plannotator/shared/feedback-templates";
+import {
+  getPlanDeniedPrompt,
+  getPlanApprovedPrompt,
+  getPlanApprovedWithNotesPrompt,
+  getPlanToolName,
+  buildPlanFileRule,
+  getAnnotateMessageFeedbackPrompt,
+} from "@plannotator/shared/prompts";
 import {
   stripConflictingPlanModeRules,
 } from "./plan-mode";
@@ -389,7 +396,7 @@ Do NOT proceed with implementation until your plan is approved.`);
             body: {
               parts: [{
                 type: "text",
-                text: `# Message Annotations\n\n${feedback}\n\nPlease address the annotation feedback above.`,
+                text: getAnnotateMessageFeedbackPrompt("opencode", undefined, { feedback }),
               }],
             },
           });
@@ -520,22 +527,22 @@ Use /plannotator-last or /plannotator-annotate for manual review, or set workflo
             }
 
             if (result.feedback) {
-              return `Plan approved with notes!
-${result.savedPath ? `Saved to: ${result.savedPath}` : ""}
-
-## Implementation Notes
-
-The user approved your plan but added the following notes to consider during implementation:
-
-${result.feedback}
-
-Proceed with implementation, incorporating these notes where applicable.`;
+              return getPlanApprovedWithNotesPrompt("opencode", undefined, {
+                planFilePath: "",
+                doneMsg: result.savedPath ? `Saved to: ${result.savedPath}` : "",
+                feedback: result.feedback,
+              });
             }
 
-            return `Plan approved!${result.savedPath ? ` Saved to: ${result.savedPath}` : ""}`;
+            return getPlanApprovedPrompt("opencode", undefined, {
+              planFilePath: "",
+              doneMsg: result.savedPath ? ` Saved to: ${result.savedPath}` : "",
+            });
           } else {
-            return planDenyFeedback(result.feedback || "", "submit_plan", {
-              planFilePath: sourceFilePath,
+            return getPlanDeniedPrompt("opencode", undefined, {
+              toolName: getPlanToolName("opencode"),
+              planFileRule: buildPlanFileRule(getPlanToolName("opencode"), sourceFilePath),
+              feedback: result.feedback || "Plan changes requested",
             }) + "\n\nAfter making your revisions, call `submit_plan` again to resubmit for review.";
           }
         },

--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -31,13 +31,23 @@ import {
 	markCompletedSteps,
 	parseChecklist,
 } from "./generated/checklist.js";
-import { planDenyFeedback } from "./generated/feedback-templates.js";
 import { hasMarkdownFiles, resolveUserPath } from "./generated/resolve-file.js";
 import { FILE_BROWSER_EXCLUDED } from "./generated/reference-common.js";
 import { htmlToMarkdown } from "./generated/html-to-markdown.js";
 import { urlToMarkdown, isConvertedSource } from "./generated/url-to-markdown.js";
 import { loadConfig, resolveUseJina } from "./generated/config.js";
-import { getReviewApprovedPrompt } from "./generated/prompts.js";
+import {
+	getReviewApprovedPrompt,
+	getReviewDeniedSuffix,
+	getPlanDeniedPrompt,
+	getPlanApprovedPrompt,
+	getPlanApprovedWithNotesPrompt,
+	getPlanAutoApprovedPrompt,
+	getPlanToolName,
+	buildPlanFileRule,
+	getAnnotateFileFeedbackPrompt,
+	getAnnotateMessageFeedbackPrompt,
+} from "./generated/prompts.js";
 import { parseAnnotateArgs } from "./generated/annotate-args.js";
 import { resolveAtReference } from "./generated/at-reference.js";
 import {
@@ -322,7 +332,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 						pi.sendUserMessage(result.feedback);
 					} else {
 						pi.sendUserMessage(
-							`${result.feedback}\n\nPlease address this feedback.`,
+							`${result.feedback}${getReviewDeniedSuffix("pi", loadConfig())}`,
 						);
 					}
 				} else {
@@ -438,12 +448,11 @@ export default function plannotator(pi: ExtensionAPI): void {
 				} else if (result.exit) {
 					ctx.ui.notify("Annotation session closed.", "info");
 				} else if (result.feedback) {
-					const header = isFolder
-						? `# Markdown Annotations\n\nFolder: ${absolutePath}\n\n`
-						: `# Markdown Annotations\n\nFile: ${absolutePath}\n\n`;
-					pi.sendUserMessage(
-						`${header}${result.feedback}\n\nPlease address the annotation feedback above.`,
-					);
+					pi.sendUserMessage(getAnnotateFileFeedbackPrompt("pi", loadConfig(), {
+						fileHeader: isFolder ? "Folder" : "File",
+						filePath: absolutePath,
+						feedback: result.feedback,
+					}));
 				} else {
 					ctx.ui.notify("Annotation closed (no feedback).", "info");
 				}
@@ -485,9 +494,9 @@ export default function plannotator(pi: ExtensionAPI): void {
 				} else if (result.exit) {
 					ctx.ui.notify("Annotation session closed.", "info");
 				} else if (result.feedback) {
-					pi.sendUserMessage(
-						`# Message Annotations\n\n${result.feedback}\n\nPlease address the annotation feedback above.`,
-					);
+					pi.sendUserMessage(getAnnotateMessageFeedbackPrompt("pi", loadConfig(), {
+						feedback: result.feedback,
+					}));
 				} else {
 					ctx.ui.notify("Annotation closed (no feedback).", "info");
 				}
@@ -655,7 +664,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 					content: [
 						{
 							type: "text",
-							text: "Plan auto-approved (non-interactive mode). Execute the plan now.",
+							text: getPlanAutoApprovedPrompt("pi", loadConfig()),
 						},
 					],
 					details: { approved: true },
@@ -690,7 +699,11 @@ export default function plannotator(pi: ExtensionAPI): void {
 						content: [
 							{
 								type: "text",
-								text: `Plan approved with notes! You now have full tool access (read, bash, edit, write). Execute the plan in ${inputPath}. ${doneMsg}\n\n## Implementation Notes\n\nThe user approved your plan but added the following notes to consider during implementation:\n\n${result.feedback}\n\nProceed with implementation, incorporating these notes where applicable.`,
+								text: getPlanApprovedWithNotesPrompt("pi", loadConfig(), {
+									planFilePath: inputPath,
+									doneMsg,
+									feedback: result.feedback,
+								}),
 							},
 						],
 						details: { approved: true, feedback: result.feedback },
@@ -701,7 +714,10 @@ export default function plannotator(pi: ExtensionAPI): void {
 					content: [
 						{
 							type: "text",
-							text: `Plan approved. You now have full tool access (read, bash, edit, write). Execute the plan in ${inputPath}. ${doneMsg}`,
+							text: getPlanApprovedPrompt("pi", loadConfig(), {
+								planFilePath: inputPath,
+								doneMsg,
+							}),
 						},
 					],
 					details: { approved: true },
@@ -715,8 +731,10 @@ export default function plannotator(pi: ExtensionAPI): void {
 				content: [
 					{
 						type: "text",
-						text: planDenyFeedback(feedbackText, PLAN_SUBMIT_TOOL, {
-							planFilePath: inputPath,
+						text: getPlanDeniedPrompt("pi", loadConfig(), {
+							toolName: getPlanToolName("pi"),
+							planFileRule: buildPlanFileRule(getPlanToolName("pi"), inputPath),
+							feedback: feedbackText,
 						}),
 					},
 				],

--- a/packages/shared/config.ts
+++ b/packages/shared/config.ts
@@ -31,9 +31,7 @@ export interface CCLabelConfig {
   blocking: boolean;
 }
 
-export interface ReviewPromptOverrides {
-  approved?: string;
-}
+export type PromptSectionOverrides = Record<string, string | undefined>;
 
 export type PromptRuntime =
   | "claude-code"
@@ -43,12 +41,30 @@ export type PromptRuntime =
   | "codex"
   | "gemini-cli";
 
+interface PromptSectionConfig {
+  [key: string]: string | Partial<Record<PromptRuntime, PromptSectionOverrides>> | undefined;
+  runtimes?: Partial<Record<PromptRuntime, PromptSectionOverrides>>;
+}
+
 export interface PromptConfig {
-  review?: {
+  review?: PromptSectionConfig & {
     approved?: string;
-    runtimes?: Partial<Record<PromptRuntime, ReviewPromptOverrides>>;
+    denied?: string;
+  };
+  plan?: PromptSectionConfig & {
+    approved?: string;
+    approvedWithNotes?: string;
+    autoApproved?: string;
+    denied?: string;
+  };
+  annotate?: PromptSectionConfig & {
+    fileFeedback?: string;
+    messageFeedback?: string;
+    approved?: string;
   };
 }
+
+const PROMPT_SECTIONS = ["review", "plan", "annotate"] as const;
 
 export function mergePromptConfig(
   current?: PromptConfig,
@@ -56,24 +72,23 @@ export function mergePromptConfig(
 ): PromptConfig | undefined {
   if (!current && !partial) return undefined;
 
-  const currentReview = current?.review;
-  const partialReview = partial?.review;
+  const result: Record<string, any> = { ...current, ...partial };
 
-  const mergedReview = (currentReview || partialReview)
-    ? {
-        ...currentReview,
-        ...partialReview,
-        runtimes: (currentReview?.runtimes || partialReview?.runtimes)
-          ? { ...currentReview?.runtimes, ...partialReview?.runtimes }
+  for (const section of PROMPT_SECTIONS) {
+    const cur = current?.[section];
+    const par = partial?.[section];
+    if (cur || par) {
+      result[section] = {
+        ...cur,
+        ...par,
+        runtimes: (cur?.runtimes || par?.runtimes)
+          ? { ...cur?.runtimes, ...par?.runtimes }
           : undefined,
-      }
-    : undefined;
+      };
+    }
+  }
 
-  return {
-    ...current,
-    ...partial,
-    review: mergedReview,
-  };
+  return result as PromptConfig;
 }
 
 export interface PlannotatorConfig {

--- a/packages/shared/feedback-templates.ts
+++ b/packages/shared/feedback-templates.ts
@@ -4,11 +4,13 @@
  * The plan deny template was tuned in #224 / commit 3dca977 to use strong
  * directive framing — Claude was ignoring softer phrasing.
  *
- * This module now routes through the configurable prompt pipeline in prompts.ts.
- * The function signature is preserved for backward compatibility.
+ * IMPORTANT: This module is imported by packages/ui/utils/parser.ts which is
+ * bundled into the browser SPA. It must NOT import from ./prompts or ./config
+ * (which depend on node:fs, node:os, node:child_process). Keep it self-contained.
+ *
+ * Server-side call sites use getPlanDeniedPrompt() from ./prompts directly.
+ * This module is only kept for the browser's wrapFeedbackForAgent clipboard feature.
  */
-
-import { getPlanDeniedPrompt, buildPlanFileRule } from "./prompts";
 
 export interface PlanDenyFeedbackOptions {
   planFilePath?: string;
@@ -19,9 +21,9 @@ export const planDenyFeedback = (
   toolName: string = "ExitPlanMode",
   options?: PlanDenyFeedbackOptions,
 ): string => {
-  return getPlanDeniedPrompt(null, undefined, {
-    toolName,
-    planFileRule: buildPlanFileRule(toolName, options?.planFilePath),
-    feedback: feedback || "Plan changes requested",
-  });
+  const planFileRule = options?.planFilePath
+    ? `- Your plan is saved at: ${options.planFilePath}\n  You can edit this file to make targeted changes, then pass its path to ${toolName}.\n`
+    : "";
+
+  return `YOUR PLAN WAS NOT APPROVED.\n\nYou MUST revise the plan to address ALL of the feedback below before calling ${toolName} again.\n\nRules:\n${planFileRule}- Do not resubmit the same plan unchanged.\n- Do NOT change the plan title (first # heading) unless the user explicitly asks you to.\n\n${feedback || "Plan changes requested"}`;
 };

--- a/packages/shared/feedback-templates.ts
+++ b/packages/shared/feedback-templates.ts
@@ -3,7 +3,12 @@
  *
  * The plan deny template was tuned in #224 / commit 3dca977 to use strong
  * directive framing — Claude was ignoring softer phrasing.
+ *
+ * This module now routes through the configurable prompt pipeline in prompts.ts.
+ * The function signature is preserved for backward compatibility.
  */
+
+import { getPlanDeniedPrompt, buildPlanFileRule } from "./prompts";
 
 export interface PlanDenyFeedbackOptions {
   planFilePath?: string;
@@ -14,9 +19,9 @@ export const planDenyFeedback = (
   toolName: string = "ExitPlanMode",
   options?: PlanDenyFeedbackOptions,
 ): string => {
-  const planFileRule = options?.planFilePath
-    ? `- Your plan is saved at: ${options.planFilePath}\n  You can edit this file to make targeted changes, then pass its path to ${toolName}.\n`
-    : "";
-
-  return `YOUR PLAN WAS NOT APPROVED.\n\nYou MUST revise the plan to address ALL of the feedback below before calling ${toolName} again.\n\nRules:\n${planFileRule}- Do not resubmit the same plan unchanged.\n- Do NOT change the plan title (first # heading) unless the user explicitly asks you to.\n\n${feedback || "Plan changes requested"}`;
+  return getPlanDeniedPrompt(null, undefined, {
+    toolName,
+    planFileRule: buildPlanFileRule(toolName, options?.planFilePath),
+    feedback: feedback || "Plan changes requested",
+  });
 };

--- a/packages/shared/prompts-integration.test.ts
+++ b/packages/shared/prompts-integration.test.ts
@@ -398,12 +398,12 @@ describe("prompts integration (config from disk)", () => {
     expect(result).toContain("YOUR PLAN WAS NOT APPROVED");
   });
 
-  // ── planDenyFeedback backward compat through disk ────────────────────
+  // ── planDenyFeedback is browser-safe (no Node imports) ────────────────
 
-  test("planDenyFeedback() picks up config from disk", async () => {
+  test("planDenyFeedback() always uses hardcoded default (not config)", async () => {
     writeConfig({
       prompts: {
-        plan: { denied: "BLOCKED.\n\n{{feedback}}" },
+        plan: { denied: "CUSTOM.\n\n{{feedback}}" },
       },
     });
 
@@ -412,9 +412,10 @@ describe("prompts integration (config from disk)", () => {
       console.log(planDenyFeedback("Fix auth", "ExitPlanMode"));
     `);
 
-    // planDenyFeedback passes config=undefined → loadConfig() reads disk
-    // BUT: planDenyFeedback calls getPlanDeniedPrompt(null, undefined, ...)
-    // which means config=undefined → loadConfig() → should read our custom config
-    expect(result).toBe("BLOCKED.\n\nFix auth");
+    // planDenyFeedback is self-contained — it does NOT read config.json.
+    // This is intentional: it's imported by the browser SPA bundle, which
+    // cannot access Node APIs. Config-aware denials use getPlanDeniedPrompt().
+    expect(result).toContain("YOUR PLAN WAS NOT APPROVED");
+    expect(result).toContain("Fix auth");
   });
 });

--- a/packages/shared/prompts-integration.test.ts
+++ b/packages/shared/prompts-integration.test.ts
@@ -1,0 +1,420 @@
+/**
+ * Integration tests for the prompt pipeline.
+ *
+ * Each test writes a real ~/.plannotator/config.json (in a temp HOME),
+ * then calls prompt functions WITHOUT passing a config parameter —
+ * forcing loadConfig() to read from disk. This proves the full path:
+ *   config.json on disk → loadConfig() → getConfiguredPrompt() → output
+ *
+ * Uses the same subprocess isolation pattern as improvement-hooks.test.ts.
+ *
+ * Run: bun test packages/shared/prompts-integration.test.ts
+ */
+
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+const TEST_HOME = join(tmpdir(), `prompts-integration-test-${Date.now()}`);
+const CONFIG_DIR = join(TEST_HOME, ".plannotator");
+const CONFIG_PATH = join(CONFIG_DIR, "config.json");
+const PROJECT_ROOT = join(import.meta.dir, "../..");
+
+function writeConfig(config: Record<string, unknown>) {
+  mkdirSync(CONFIG_DIR, { recursive: true });
+  writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2));
+}
+
+function cleanTestHome() {
+  if (existsSync(TEST_HOME)) {
+    rmSync(TEST_HOME, { recursive: true, force: true });
+  }
+}
+
+async function runScript(script: string): Promise<string> {
+  const proc = Bun.spawn(["bun", "-e", script], {
+    env: { ...process.env, HOME: TEST_HOME },
+    cwd: PROJECT_ROOT,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const stdout = await new Response(proc.stdout).text();
+  const exitCode = await proc.exited;
+
+  if (exitCode !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+    throw new Error(`Subprocess failed (exit ${exitCode}): ${stderr}`);
+  }
+
+  return stdout.trim();
+}
+
+describe("prompts integration (config from disk)", () => {
+  beforeEach(() => {
+    cleanTestHome();
+    mkdirSync(CONFIG_DIR, { recursive: true });
+  });
+  afterEach(cleanTestHome);
+
+  // ── Plan denied ──────────────────────────────────────────────────────
+
+  test("plan denied reads generic override from config.json", async () => {
+    writeConfig({
+      prompts: {
+        plan: {
+          denied: "NOPE.\n\n{{feedback}}",
+        },
+      },
+    });
+
+    const result = await runScript(`
+      import { getPlanDeniedPrompt } from "./packages/shared/prompts";
+      console.log(getPlanDeniedPrompt("claude-code", undefined, {
+        toolName: "ExitPlanMode",
+        planFileRule: "",
+        feedback: "Fix the auth",
+      }));
+    `);
+
+    expect(result).toBe("NOPE.\n\nFix the auth");
+    expect(result).not.toContain("YOUR PLAN WAS NOT APPROVED");
+  });
+
+  test("plan denied reads runtime-specific override from config.json", async () => {
+    writeConfig({
+      prompts: {
+        plan: {
+          denied: "Generic: {{feedback}}",
+          runtimes: {
+            opencode: { denied: "OpenCode: {{feedback}}" },
+          },
+        },
+      },
+    });
+
+    const oc = await runScript(`
+      import { getPlanDeniedPrompt, getPlanToolName } from "./packages/shared/prompts";
+      console.log(getPlanDeniedPrompt("opencode", undefined, {
+        toolName: getPlanToolName("opencode"),
+        planFileRule: "",
+        feedback: "Fix it",
+      }));
+    `);
+    expect(oc).toBe("OpenCode: Fix it");
+
+    const cc = await runScript(`
+      import { getPlanDeniedPrompt, getPlanToolName } from "./packages/shared/prompts";
+      console.log(getPlanDeniedPrompt("claude-code", undefined, {
+        toolName: getPlanToolName("claude-code"),
+        planFileRule: "",
+        feedback: "Fix it",
+      }));
+    `);
+    expect(cc).toBe("Generic: Fix it");
+  });
+
+  test("plan denied falls back to hardcoded default when config.json missing", async () => {
+    // No config file written — CONFIG_DIR exists but no config.json
+    rmSync(CONFIG_PATH, { force: true });
+
+    const result = await runScript(`
+      import { getPlanDeniedPrompt } from "./packages/shared/prompts";
+      console.log(getPlanDeniedPrompt("claude-code", undefined, {
+        toolName: "ExitPlanMode",
+        planFileRule: "",
+        feedback: "Some feedback",
+      }));
+    `);
+
+    expect(result).toContain("YOUR PLAN WAS NOT APPROVED");
+    expect(result).toContain("Some feedback");
+  });
+
+  test("plan denied falls through blank config values to default", async () => {
+    writeConfig({
+      prompts: {
+        plan: {
+          denied: "   ",
+          runtimes: { "claude-code": { denied: "" } },
+        },
+      },
+    });
+
+    const result = await runScript(`
+      import { getPlanDeniedPrompt } from "./packages/shared/prompts";
+      console.log(getPlanDeniedPrompt("claude-code", undefined, {
+        toolName: "ExitPlanMode",
+        planFileRule: "",
+        feedback: "fb",
+      }));
+    `);
+
+    expect(result).toContain("YOUR PLAN WAS NOT APPROVED");
+  });
+
+  // ── Plan approved ────────────────────────────────────────────────────
+
+  test("plan approved reads override from config.json", async () => {
+    writeConfig({
+      prompts: {
+        plan: {
+          approved: "Go build it.",
+        },
+      },
+    });
+
+    const result = await runScript(`
+      import { getPlanApprovedPrompt } from "./packages/shared/prompts";
+      console.log(getPlanApprovedPrompt("pi"));
+    `);
+
+    expect(result).toBe("Go build it.");
+    expect(result).not.toContain("full tool access");
+  });
+
+  test("plan approved uses runtime built-in default when no config", async () => {
+    // No config — opencode should get its built-in "Plan approved!{{doneMsg}}"
+    const oc = await runScript(`
+      import { getPlanApprovedPrompt } from "./packages/shared/prompts";
+      console.log(getPlanApprovedPrompt("opencode", undefined, { doneMsg: " Done." }));
+    `);
+    expect(oc).toBe("Plan approved! Done.");
+
+    // Pi should get the verbose default
+    const pi = await runScript(`
+      import { getPlanApprovedPrompt } from "./packages/shared/prompts";
+      console.log(getPlanApprovedPrompt("pi", undefined, {
+        planFilePath: "plan.md", doneMsg: "",
+      }));
+    `);
+    expect(pi).toContain("full tool access");
+    expect(pi).toContain("plan.md");
+  });
+
+  // ── Plan approved with notes ─────────────────────────────────────────
+
+  test("plan approved with notes reads override from config.json", async () => {
+    writeConfig({
+      prompts: {
+        plan: {
+          approvedWithNotes: "Approved. User says: {{feedback}}",
+        },
+      },
+    });
+
+    const result = await runScript(`
+      import { getPlanApprovedWithNotesPrompt } from "./packages/shared/prompts";
+      console.log(getPlanApprovedWithNotesPrompt("pi", undefined, {
+        feedback: "Watch the edge case",
+      }));
+    `);
+
+    expect(result).toBe("Approved. User says: Watch the edge case");
+  });
+
+  test("plan approved with notes uses opencode runtime default when no config", async () => {
+    const result = await runScript(`
+      import { getPlanApprovedWithNotesPrompt } from "./packages/shared/prompts";
+      console.log(getPlanApprovedWithNotesPrompt("opencode", undefined, {
+        doneMsg: "",
+        feedback: "Be careful",
+      }));
+    `);
+
+    expect(result).toContain("Plan approved with notes!");
+    expect(result).toContain("Be careful");
+    expect(result).not.toContain("full tool access");
+    expect(result).not.toContain("Execute the plan in");
+  });
+
+  // ── Plan auto-approved ───────────────────────────────────────────────
+
+  test("plan auto-approved reads override from config.json", async () => {
+    writeConfig({
+      prompts: { plan: { autoApproved: "Auto-OK. Proceed." } },
+    });
+
+    const result = await runScript(`
+      import { getPlanAutoApprovedPrompt } from "./packages/shared/prompts";
+      console.log(getPlanAutoApprovedPrompt("pi"));
+    `);
+
+    expect(result).toBe("Auto-OK. Proceed.");
+  });
+
+  // ── Annotate file feedback ───────────────────────────────────────────
+
+  test("annotate file feedback reads override from config.json", async () => {
+    writeConfig({
+      prompts: {
+        annotate: {
+          fileFeedback: "# Notes\n\n{{filePath}}: {{feedback}}",
+        },
+      },
+    });
+
+    const result = await runScript(`
+      import { getAnnotateFileFeedbackPrompt } from "./packages/shared/prompts";
+      console.log(getAnnotateFileFeedbackPrompt("opencode", undefined, {
+        fileHeader: "File",
+        filePath: "src/app.ts",
+        feedback: "Fix line 10",
+      }));
+    `);
+
+    expect(result).toBe("# Notes\n\nsrc/app.ts: Fix line 10");
+  });
+
+  test("annotate file feedback reads runtime-specific override", async () => {
+    writeConfig({
+      prompts: {
+        annotate: {
+          fileFeedback: "Generic: {{feedback}}",
+          runtimes: {
+            pi: { fileFeedback: "Pi: {{filePath}} — {{feedback}}" },
+          },
+        },
+      },
+    });
+
+    const pi = await runScript(`
+      import { getAnnotateFileFeedbackPrompt } from "./packages/shared/prompts";
+      console.log(getAnnotateFileFeedbackPrompt("pi", undefined, {
+        fileHeader: "File", filePath: "x.ts", feedback: "fix",
+      }));
+    `);
+    expect(pi).toBe("Pi: x.ts — fix");
+
+    const oc = await runScript(`
+      import { getAnnotateFileFeedbackPrompt } from "./packages/shared/prompts";
+      console.log(getAnnotateFileFeedbackPrompt("opencode", undefined, {
+        fileHeader: "File", filePath: "x.ts", feedback: "fix",
+      }));
+    `);
+    expect(oc).toBe("Generic: fix");
+  });
+
+  // ── Annotate message feedback ────────────────────────────────────────
+
+  test("annotate message feedback reads override from config.json", async () => {
+    writeConfig({
+      prompts: {
+        annotate: {
+          messageFeedback: "Message review:\n\n{{feedback}}",
+        },
+      },
+    });
+
+    const result = await runScript(`
+      import { getAnnotateMessageFeedbackPrompt } from "./packages/shared/prompts";
+      console.log(getAnnotateMessageFeedbackPrompt("pi", undefined, {
+        feedback: "Wrong output",
+      }));
+    `);
+
+    expect(result).toBe("Message review:\n\nWrong output");
+  });
+
+  // ── Annotate approved ────────────────────────────────────────────────
+
+  test("annotate approved reads override from config.json", async () => {
+    writeConfig({
+      prompts: { annotate: { approved: "LGTM" } },
+    });
+
+    const result = await runScript(`
+      import { getAnnotateApprovedPrompt } from "./packages/shared/prompts";
+      console.log(getAnnotateApprovedPrompt("claude-code"));
+    `);
+
+    expect(result).toBe("LGTM");
+  });
+
+  // ── Review denied suffix ─────────────────────────────────────────────
+
+  test("review denied suffix reads override from config.json", async () => {
+    writeConfig({
+      prompts: { review: { denied: "\n\nFix everything now." } },
+    });
+
+    const result = await runScript(`
+      import { getReviewDeniedSuffix } from "./packages/shared/prompts";
+      console.log(JSON.stringify(getReviewDeniedSuffix("claude-code")));
+    `);
+
+    expect(JSON.parse(result)).toBe("\n\nFix everything now.");
+  });
+
+  // ── Cross-section isolation ──────────────────────────────────────────
+
+  test("config sections don't bleed into each other", async () => {
+    writeConfig({
+      prompts: {
+        plan: { denied: "Custom plan denial: {{feedback}}" },
+        annotate: { approved: "Custom annotate approved" },
+      },
+    });
+
+    // Plan denied should use custom
+    const planDenied = await runScript(`
+      import { getPlanDeniedPrompt } from "./packages/shared/prompts";
+      console.log(getPlanDeniedPrompt("claude-code", undefined, {
+        toolName: "ExitPlanMode", planFileRule: "", feedback: "fb",
+      }));
+    `);
+    expect(planDenied).toBe("Custom plan denial: fb");
+
+    // Annotate approved should use custom
+    const annotateApproved = await runScript(`
+      import { getAnnotateApprovedPrompt } from "./packages/shared/prompts";
+      console.log(getAnnotateApprovedPrompt("claude-code"));
+    `);
+    expect(annotateApproved).toBe("Custom annotate approved");
+
+    // Plan approved should still be the default (not set in config)
+    const planApproved = await runScript(`
+      import { getPlanApprovedPrompt } from "./packages/shared/prompts";
+      console.log(getPlanApprovedPrompt("pi", undefined, {
+        planFilePath: "p.md", doneMsg: "",
+      }));
+    `);
+    expect(planApproved).toContain("full tool access");
+  });
+
+  // ── Malformed config resilience ──────────────────────────────────────
+
+  test("malformed config.json falls back to defaults gracefully", async () => {
+    writeFileSync(CONFIG_PATH, "not valid json {{{");
+
+    const result = await runScript(`
+      import { getPlanDeniedPrompt } from "./packages/shared/prompts";
+      console.log(getPlanDeniedPrompt("claude-code", undefined, {
+        toolName: "ExitPlanMode", planFileRule: "", feedback: "fb",
+      }));
+    `);
+
+    expect(result).toContain("YOUR PLAN WAS NOT APPROVED");
+  });
+
+  // ── planDenyFeedback backward compat through disk ────────────────────
+
+  test("planDenyFeedback() picks up config from disk", async () => {
+    writeConfig({
+      prompts: {
+        plan: { denied: "BLOCKED.\n\n{{feedback}}" },
+      },
+    });
+
+    const result = await runScript(`
+      import { planDenyFeedback } from "./packages/shared/feedback-templates";
+      console.log(planDenyFeedback("Fix auth", "ExitPlanMode"));
+    `);
+
+    // planDenyFeedback passes config=undefined → loadConfig() reads disk
+    // BUT: planDenyFeedback calls getPlanDeniedPrompt(null, undefined, ...)
+    // which means config=undefined → loadConfig() → should read our custom config
+    expect(result).toBe("BLOCKED.\n\nFix auth");
+  });
+});

--- a/packages/shared/prompts.test.ts
+++ b/packages/shared/prompts.test.ts
@@ -1,6 +1,388 @@
 import { describe, expect, test } from "bun:test";
-import { mergePromptConfig } from "./config";
-import { DEFAULT_REVIEW_APPROVED_PROMPT, getConfiguredPrompt, getReviewApprovedPrompt } from "./prompts";
+import { mergePromptConfig, type PromptRuntime } from "./config";
+import {
+  DEFAULT_REVIEW_APPROVED_PROMPT,
+  DEFAULT_PLAN_DENIED_PROMPT,
+  DEFAULT_PLAN_APPROVED_PROMPT,
+  DEFAULT_PLAN_APPROVED_WITH_NOTES_PROMPT,
+  DEFAULT_PLAN_AUTO_APPROVED_PROMPT,
+  DEFAULT_ANNOTATE_FILE_FEEDBACK_PROMPT,
+  DEFAULT_ANNOTATE_MESSAGE_FEEDBACK_PROMPT,
+  DEFAULT_ANNOTATE_APPROVED_PROMPT,
+  DEFAULT_REVIEW_DENIED_SUFFIX,
+  getConfiguredPrompt,
+  getReviewApprovedPrompt,
+  getPlanDeniedPrompt,
+  getPlanApprovedPrompt,
+  getPlanApprovedWithNotesPrompt,
+  getPlanAutoApprovedPrompt,
+  getAnnotateFileFeedbackPrompt,
+  getAnnotateMessageFeedbackPrompt,
+  getAnnotateApprovedPrompt,
+  getReviewDeniedSuffix,
+  resolveTemplate,
+  getPlanToolName,
+  buildPlanFileRule,
+} from "./prompts";
+import { planDenyFeedback } from "./feedback-templates";
+
+// ─── A1. Template engine ─────────────────────────────────────────────────────
+
+describe("resolveTemplate", () => {
+  test("replaces known variables", () => {
+    expect(resolveTemplate("Hello {{name}}", { name: "world" }))
+      .toBe("Hello world");
+  });
+
+  test("leaves unknown {{variables}} as-is", () => {
+    expect(resolveTemplate("Hello {{unknown}}", {}))
+      .toBe("Hello {{unknown}}");
+  });
+
+  test("handles empty vars object", () => {
+    expect(resolveTemplate("no vars here", {}))
+      .toBe("no vars here");
+  });
+
+  test("handles undefined values in vars (leaves placeholder)", () => {
+    expect(resolveTemplate("Hello {{name}}", { name: undefined }))
+      .toBe("Hello {{name}}");
+  });
+
+  test("handles template with no variables", () => {
+    expect(resolveTemplate("static text", { name: "ignored" }))
+      .toBe("static text");
+  });
+
+  test("handles adjacent and repeated variables", () => {
+    expect(resolveTemplate("{{a}}{{b}} and {{a}}", { a: "X", b: "Y" }))
+      .toBe("XY and X");
+  });
+});
+
+// ─── A2. Plan denied ─────────────────────────────────────────────────────────
+
+describe("getPlanDeniedPrompt", () => {
+  test("falls back to built-in default when no config", () => {
+    const result = getPlanDeniedPrompt("claude-code", {}, {
+      toolName: "ExitPlanMode",
+      planFileRule: "",
+      feedback: "Fix the auth section",
+    });
+    expect(result).toContain("YOUR PLAN WAS NOT APPROVED");
+    expect(result).toContain("Fix the auth section");
+    expect(result).toContain("ExitPlanMode");
+  });
+
+  test("uses generic plan.denied config override", () => {
+    const result = getPlanDeniedPrompt("claude-code", {
+      prompts: { plan: { denied: "REJECTED.\n\n{{feedback}}" } },
+    }, { feedback: "Fix it" });
+    expect(result).toBe("REJECTED.\n\nFix it");
+    expect(result).not.toContain("YOUR PLAN WAS NOT APPROVED");
+  });
+
+  test("runtime-specific override wins over generic", () => {
+    const result = getPlanDeniedPrompt("opencode", {
+      prompts: {
+        plan: {
+          denied: "Generic denial: {{feedback}}",
+          runtimes: { opencode: { denied: "OC denial: {{feedback}}" } },
+        },
+      },
+    }, { feedback: "nope" });
+    expect(result).toBe("OC denial: nope");
+  });
+
+  test("interpolates {{toolName}}, {{feedback}}, {{planFileRule}}", () => {
+    const result = getPlanDeniedPrompt(null, {}, {
+      toolName: "submit_plan",
+      feedback: "user feedback here",
+      planFileRule: "- Saved at: plan.md\n",
+    });
+    expect(result).toContain("submit_plan");
+    expect(result).toContain("user feedback here");
+    expect(result).toContain("Saved at: plan.md");
+  });
+
+  test("blank config falls through to default", () => {
+    const result = getPlanDeniedPrompt("opencode", {
+      prompts: { plan: { denied: "   ", runtimes: { opencode: { denied: "" } } } },
+    }, { toolName: "submit_plan", planFileRule: "", feedback: "fb" });
+    expect(result).toContain("YOUR PLAN WAS NOT APPROVED");
+  });
+
+  test("default template preserves plan title instruction (regression #296)", () => {
+    const result = getPlanDeniedPrompt(null, {}, {
+      toolName: "ExitPlanMode", planFileRule: "", feedback: "fb",
+    });
+    expect(result.toLowerCase()).toContain("title");
+    expect(result.toLowerCase()).toContain("heading");
+  });
+
+  test("includes plan file rule when planFileRule var is populated", () => {
+    const result = getPlanDeniedPrompt(null, {}, {
+      toolName: "ExitPlanMode",
+      planFileRule: buildPlanFileRule("ExitPlanMode", "plans/auth.md"),
+      feedback: "fb",
+    });
+    expect(result).toContain("plans/auth.md");
+    expect(result).toContain("edit this file");
+  });
+
+  test("omits plan file rule when planFileRule is empty", () => {
+    const result = getPlanDeniedPrompt(null, {}, {
+      toolName: "ExitPlanMode", planFileRule: "", feedback: "fb",
+    });
+    expect(result).not.toContain("saved at");
+  });
+
+  test("output is identical across runtimes modulo toolName (parity)", () => {
+    const normalize = (s: string) =>
+      s.replace(/ExitPlanMode|submit_plan|exit_plan_mode|plannotator_submit_plan/g, "TOOL");
+
+    const make = (rt: PromptRuntime) => normalize(getPlanDeniedPrompt(rt, {}, {
+      toolName: getPlanToolName(rt),
+      planFileRule: "",
+      feedback: "## Fix auth",
+    }));
+
+    const cc = make("claude-code");
+    expect(make("opencode")).toBe(cc);
+    expect(make("pi")).toBe(cc);
+    expect(make("copilot-cli")).toBe(cc);
+    expect(make("gemini-cli")).toBe(cc);
+  });
+});
+
+// ─── A3. Plan approved ───────────────────────────────────────────────────────
+
+describe("getPlanApprovedPrompt", () => {
+  test("falls back to runtime built-in default (pi vs opencode differ)", () => {
+    const pi = getPlanApprovedPrompt("pi", {}, { planFilePath: "plan.md", doneMsg: "" });
+    const oc = getPlanApprovedPrompt("opencode", {}, { doneMsg: "" });
+    expect(pi).toContain("full tool access");
+    expect(oc).not.toContain("full tool access");
+    expect(oc).toContain("Plan approved!");
+  });
+
+  test("uses configured prompt with variable interpolation", () => {
+    const result = getPlanApprovedPrompt("pi", {
+      prompts: { plan: { approved: "Go ahead with {{planFilePath}}." } },
+    }, { planFilePath: "my-plan.md" });
+    expect(result).toBe("Go ahead with my-plan.md.");
+  });
+
+  test("runtime config wins over generic config wins over runtime default", () => {
+    const result = getPlanApprovedPrompt("opencode", {
+      prompts: {
+        plan: {
+          approved: "Generic approved",
+          runtimes: { opencode: { approved: "OC approved" } },
+        },
+      },
+    });
+    expect(result).toBe("OC approved");
+  });
+
+  test("interpolates {{planFilePath}} and {{doneMsg}}", () => {
+    const result = getPlanApprovedPrompt("pi", {}, {
+      planFilePath: "plans/auth.md",
+      doneMsg: "Check each step.",
+    });
+    expect(result).toContain("plans/auth.md");
+    expect(result).toContain("Check each step.");
+  });
+});
+
+describe("getPlanApprovedWithNotesPrompt", () => {
+  test("includes Implementation Notes section in default", () => {
+    const result = getPlanApprovedWithNotesPrompt("pi", {}, {
+      planFilePath: "p.md", doneMsg: "", feedback: "Watch the edge case",
+    });
+    expect(result).toContain("## Implementation Notes");
+    expect(result).toContain("Watch the edge case");
+  });
+
+  test("opencode runtime default omits planFilePath and tool access language", () => {
+    const result = getPlanApprovedWithNotesPrompt("opencode", {}, {
+      doneMsg: "Saved to: /tmp/plan.md",
+      feedback: "Watch the edge case",
+    });
+    expect(result).toContain("Plan approved with notes!");
+    expect(result).toContain("Watch the edge case");
+    expect(result).toContain("Saved to: /tmp/plan.md");
+    expect(result).not.toContain("full tool access");
+    expect(result).not.toContain("Execute the plan in");
+    // doneMsg is on its own line after the header (matching old behavior)
+    expect(result).toContain("notes!\nSaved to:");
+  });
+
+  test("uses configured override when present", () => {
+    const result = getPlanApprovedWithNotesPrompt("pi", {
+      prompts: { plan: { approvedWithNotes: "Approved. Notes: {{feedback}}" } },
+    }, { feedback: "be careful" });
+    expect(result).toBe("Approved. Notes: be careful");
+  });
+});
+
+describe("getPlanAutoApprovedPrompt", () => {
+  test("returns default auto-approved message", () => {
+    expect(getPlanAutoApprovedPrompt("pi", {})).toContain("auto-approved");
+  });
+
+  test("uses configured override", () => {
+    expect(getPlanAutoApprovedPrompt("pi", {
+      prompts: { plan: { autoApproved: "Auto OK" } },
+    })).toBe("Auto OK");
+  });
+});
+
+// ─── A4. Annotation feedback ─────────────────────────────────────────────────
+
+describe("getAnnotateFileFeedbackPrompt", () => {
+  test("includes file header and path in default", () => {
+    const result = getAnnotateFileFeedbackPrompt("opencode", {}, {
+      fileHeader: "File", filePath: "/src/app.ts", feedback: "Fix line 5",
+    });
+    expect(result).toContain("File: /src/app.ts");
+    expect(result).toContain("Fix line 5");
+    expect(result).toContain("Please address");
+  });
+
+  test("handles folder header variant", () => {
+    const result = getAnnotateFileFeedbackPrompt("pi", {}, {
+      fileHeader: "Folder", filePath: "/src/", feedback: "Check all files",
+    });
+    expect(result).toContain("Folder: /src/");
+  });
+
+  test("uses configured override", () => {
+    const result = getAnnotateFileFeedbackPrompt("opencode", {
+      prompts: { annotate: { fileFeedback: "Review {{filePath}}: {{feedback}}" } },
+    }, { filePath: "x.ts", feedback: "fix it" });
+    expect(result).toBe("Review x.ts: fix it");
+  });
+
+  test("runtime-specific override wins over generic", () => {
+    const result = getAnnotateFileFeedbackPrompt("pi", {
+      prompts: {
+        annotate: {
+          fileFeedback: "Generic: {{feedback}}",
+          runtimes: { pi: { fileFeedback: "Pi: {{feedback}}" } },
+        },
+      },
+    }, { feedback: "note" });
+    expect(result).toBe("Pi: note");
+  });
+});
+
+describe("getAnnotateMessageFeedbackPrompt", () => {
+  test("includes feedback in default template", () => {
+    const result = getAnnotateMessageFeedbackPrompt("pi", {}, { feedback: "Wrong output" });
+    expect(result).toContain("Message Annotations");
+    expect(result).toContain("Wrong output");
+  });
+
+  test("uses configured override", () => {
+    const result = getAnnotateMessageFeedbackPrompt("pi", {
+      prompts: { annotate: { messageFeedback: "Notes: {{feedback}}" } },
+    }, { feedback: "fix" });
+    expect(result).toBe("Notes: fix");
+  });
+});
+
+describe("getAnnotateApprovedPrompt", () => {
+  test("returns default approved message", () => {
+    expect(getAnnotateApprovedPrompt("claude-code", {})).toBe("The user approved.");
+  });
+
+  test("uses configured override", () => {
+    expect(getAnnotateApprovedPrompt("claude-code", {
+      prompts: { annotate: { approved: "Approved!" } },
+    })).toBe("Approved!");
+  });
+});
+
+// ─── A4b. Review denied suffix ───────────────────────────────────────────────
+
+describe("getReviewDeniedSuffix", () => {
+  test("returns default suffix for claude-code", () => {
+    const result = getReviewDeniedSuffix("claude-code", {});
+    expect(result).toContain("identified issues");
+  });
+
+  test("opencode and pi use softer runtime default", () => {
+    const oc = getReviewDeniedSuffix("opencode", {});
+    const pi = getReviewDeniedSuffix("pi", {});
+    expect(oc).toBe("\n\nPlease address this feedback.");
+    expect(pi).toBe("\n\nPlease address this feedback.");
+  });
+
+  test("uses configured override", () => {
+    expect(getReviewDeniedSuffix("claude-code", {
+      prompts: { review: { denied: "\nFix everything." } },
+    })).toBe("\nFix everything.");
+  });
+});
+
+// ─── A5. Backward compatibility ──────────────────────────────────────────────
+
+describe("backward compatibility", () => {
+  test("planDenyFeedback() produces same output via pipeline as before", () => {
+    const feedback = "## Fix auth\n> Remove the old token.";
+    const direct = getPlanDeniedPrompt(null, undefined, {
+      toolName: "ExitPlanMode",
+      planFileRule: "",
+      feedback,
+    });
+    expect(planDenyFeedback(feedback, "ExitPlanMode")).toBe(direct);
+  });
+
+  test("planDenyFeedback() with planFilePath produces same output", () => {
+    const direct = getPlanDeniedPrompt(null, undefined, {
+      toolName: "plannotator_submit_plan",
+      planFileRule: buildPlanFileRule("plannotator_submit_plan", "plans/auth.md"),
+      feedback: "Fix it",
+    });
+    expect(planDenyFeedback("Fix it", "plannotator_submit_plan", {
+      planFilePath: "plans/auth.md",
+    })).toBe(direct);
+  });
+});
+
+// ─── A6. Config merge (expanded) ─────────────────────────────────────────────
+
+describe("mergePromptConfig (expanded)", () => {
+  test("merges plan section alongside existing review section", () => {
+    const merged = mergePromptConfig(
+      { review: { approved: "R" } },
+      { plan: { denied: "D" } },
+    );
+    expect(merged?.review?.approved).toBe("R");
+    expect(merged?.plan?.denied).toBe("D");
+  });
+
+  test("merges annotate section", () => {
+    const merged = mergePromptConfig(
+      { annotate: { approved: "A" } },
+      { annotate: { fileFeedback: "F" } },
+    );
+    expect(merged?.annotate?.approved).toBe("A");
+    expect(merged?.annotate?.fileFeedback).toBe("F");
+  });
+
+  test("deep merges runtimes within plan section", () => {
+    const merged = mergePromptConfig(
+      { plan: { runtimes: { pi: { denied: "Pi deny" } } } },
+      { plan: { runtimes: { opencode: { denied: "OC deny" } } } },
+    );
+    expect(merged?.plan?.runtimes?.pi?.denied).toBe("Pi deny");
+    expect(merged?.plan?.runtimes?.opencode?.denied).toBe("OC deny");
+  });
+});
+
+// ─── Existing review prompt tests (preserved from PR #561) ───────────────────
 
 describe("prompts", () => {
   test("falls back to built-in default when no config is present", () => {
@@ -87,5 +469,36 @@ describe("prompts", () => {
     expect(merged?.review?.approved).toBe("Generic approval.");
     expect(merged?.review?.runtimes?.opencode?.approved).toBe("OpenCode approval.");
     expect(merged?.review?.runtimes?.["claude-code"]?.approved).toBe("Claude approval.");
+  });
+});
+
+// ─── Helper tests ────────────────────────────────────────────────────────────
+
+describe("getPlanToolName", () => {
+  test("returns correct tool name per runtime", () => {
+    expect(getPlanToolName("claude-code")).toBe("ExitPlanMode");
+    expect(getPlanToolName("opencode")).toBe("submit_plan");
+    expect(getPlanToolName("copilot-cli")).toBe("exit_plan_mode");
+    expect(getPlanToolName("pi")).toBe("plannotator_submit_plan");
+    expect(getPlanToolName("gemini-cli")).toBe("exit_plan_mode");
+  });
+
+  test("defaults to ExitPlanMode for null/undefined", () => {
+    expect(getPlanToolName(null)).toBe("ExitPlanMode");
+    expect(getPlanToolName(undefined)).toBe("ExitPlanMode");
+  });
+});
+
+describe("buildPlanFileRule", () => {
+  test("returns empty string when no planFilePath", () => {
+    expect(buildPlanFileRule("ExitPlanMode")).toBe("");
+    expect(buildPlanFileRule("ExitPlanMode", undefined)).toBe("");
+  });
+
+  test("includes path and tool name when planFilePath provided", () => {
+    const result = buildPlanFileRule("submit_plan", "plans/auth.md");
+    expect(result).toContain("plans/auth.md");
+    expect(result).toContain("submit_plan");
+    expect(result).toContain("edit this file");
   });
 });

--- a/packages/shared/prompts.ts
+++ b/packages/shared/prompts.ts
@@ -73,9 +73,9 @@ interface PromptLookupOptions {
   runtimeFallbacks?: Partial<Record<PromptRuntime, string>>;
 }
 
-function normalizePrompt(prompt: string | undefined): string | undefined {
-  const trimmed = prompt?.trim();
-  return trimmed ? prompt : undefined;
+function normalizePrompt(prompt: unknown): string | undefined {
+  if (typeof prompt !== "string") return undefined;
+  return prompt.trim() ? prompt : undefined;
 }
 
 export function getConfiguredPrompt(options: PromptLookupOptions): string {

--- a/packages/shared/prompts.ts
+++ b/packages/shared/prompts.ts
@@ -1,9 +1,68 @@
 import { loadConfig, type PlannotatorConfig, type PromptRuntime } from "./config";
 
+// ─── Template engine ─────────────────────────────────────────────────────────
+
+export function resolveTemplate(
+  template: string,
+  vars: Record<string, string | undefined>,
+): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (match, key) => {
+    const val = vars[key];
+    return val !== undefined ? val : match;
+  });
+}
+
+// ─── Tool name map ───────────────────────────────────────────────────────────
+
+export const PLAN_TOOL_NAMES: Record<PromptRuntime, string> = {
+  "claude-code": "ExitPlanMode",
+  opencode: "submit_plan",
+  "copilot-cli": "exit_plan_mode",
+  pi: "plannotator_submit_plan",
+  codex: "ExitPlanMode",
+  "gemini-cli": "exit_plan_mode",
+};
+
+export function getPlanToolName(runtime?: PromptRuntime | null): string {
+  return (runtime && PLAN_TOOL_NAMES[runtime]) || "ExitPlanMode";
+}
+
+export function buildPlanFileRule(toolName: string, planFilePath?: string): string {
+  if (!planFilePath) return "";
+  return `- Your plan is saved at: ${planFilePath}\n  You can edit this file to make targeted changes, then pass its path to ${toolName}.\n`;
+}
+
+// ─── Default constants ───────────────────────────────────────────────────────
+
 export const DEFAULT_REVIEW_APPROVED_PROMPT = "# Code Review\n\nCode review completed — no changes requested.";
 
-type PromptSection = "review";
-type PromptKey = "approved";
+export const DEFAULT_REVIEW_DENIED_SUFFIX = "\nThe reviewer has identified issues above. You must address all of them.";
+
+export const DEFAULT_PLAN_DENIED_PROMPT =
+  "YOUR PLAN WAS NOT APPROVED.\n\nYou MUST revise the plan to address ALL of the feedback below before calling {{toolName}} again.\n\nRules:\n{{planFileRule}}- Do not resubmit the same plan unchanged.\n- Do NOT change the plan title (first # heading) unless the user explicitly asks you to.\n\n{{feedback}}";
+
+export const DEFAULT_PLAN_APPROVED_PROMPT =
+  "Plan approved. You now have full tool access (read, bash, edit, write). Execute the plan in {{planFilePath}}. {{doneMsg}}";
+
+export const DEFAULT_PLAN_APPROVED_WITH_NOTES_PROMPT =
+  "Plan approved with notes! You now have full tool access (read, bash, edit, write). Execute the plan in {{planFilePath}}. {{doneMsg}}\n\n## Implementation Notes\n\nThe user approved your plan but added the following notes to consider during implementation:\n\n{{feedback}}\n\nProceed with implementation, incorporating these notes where applicable.";
+
+export const DEFAULT_PLAN_AUTO_APPROVED_PROMPT =
+  "Plan auto-approved (non-interactive mode). Execute the plan now.";
+
+export const DEFAULT_ANNOTATE_FILE_FEEDBACK_PROMPT =
+  "# Markdown Annotations\n\n{{fileHeader}}: {{filePath}}\n\n{{feedback}}\n\nPlease address the annotation feedback above.";
+
+export const DEFAULT_ANNOTATE_MESSAGE_FEEDBACK_PROMPT =
+  "# Message Annotations\n\n{{feedback}}\n\nPlease address the annotation feedback above.";
+
+export const DEFAULT_ANNOTATE_APPROVED_PROMPT = "The user approved.";
+
+// ─── Core resolver ───────────────────────────────────────────────────────────
+
+type PromptSection = "review" | "plan" | "annotate";
+type PromptKey = "approved" | "approvedWithNotes" | "autoApproved" | "denied"
+  | "fileFeedback" | "messageFeedback";
 
 interface PromptLookupOptions {
   section: PromptSection;
@@ -11,6 +70,7 @@ interface PromptLookupOptions {
   runtime?: PromptRuntime | null;
   config?: PlannotatorConfig;
   fallback: string;
+  runtimeFallbacks?: Partial<Record<PromptRuntime, string>>;
 }
 
 function normalizePrompt(prompt: string | undefined): string | undefined {
@@ -25,9 +85,16 @@ export function getConfiguredPrompt(options: PromptLookupOptions): string {
     ? normalizePrompt(section?.runtimes?.[options.runtime]?.[options.key])
     : undefined;
   const genericPrompt = normalizePrompt(section?.[options.key]);
+  const runtimeFallback = options.runtime
+    ? options.runtimeFallbacks?.[options.runtime]
+    : undefined;
 
-  return runtimePrompt ?? genericPrompt ?? options.fallback;
+  return runtimePrompt ?? genericPrompt ?? runtimeFallback ?? options.fallback;
 }
+
+type FeedbackVars = Record<string, string | undefined>;
+
+// ─── Review wrappers ─────────────────────────────────────────────────────────
 
 export function getReviewApprovedPrompt(
   runtime?: PromptRuntime | null,
@@ -39,5 +106,139 @@ export function getReviewApprovedPrompt(
     runtime,
     config,
     fallback: DEFAULT_REVIEW_APPROVED_PROMPT,
+  });
+}
+
+const REVIEW_DENIED_RUNTIME_DEFAULTS: Partial<Record<PromptRuntime, string>> = {
+  opencode: "\n\nPlease address this feedback.",
+  pi: "\n\nPlease address this feedback.",
+};
+
+export function getReviewDeniedSuffix(
+  runtime?: PromptRuntime | null,
+  config?: PlannotatorConfig,
+): string {
+  return getConfiguredPrompt({
+    section: "review",
+    key: "denied",
+    runtime,
+    config,
+    fallback: DEFAULT_REVIEW_DENIED_SUFFIX,
+    runtimeFallbacks: REVIEW_DENIED_RUNTIME_DEFAULTS,
+  });
+}
+
+// ─── Plan wrappers ───────────────────────────────────────────────────────────
+
+export function getPlanDeniedPrompt(
+  runtime?: PromptRuntime | null,
+  config?: PlannotatorConfig,
+  vars?: FeedbackVars,
+): string {
+  const template = getConfiguredPrompt({
+    section: "plan",
+    key: "denied",
+    runtime,
+    config,
+    fallback: DEFAULT_PLAN_DENIED_PROMPT,
+  });
+  return resolveTemplate(template, vars ?? {});
+}
+
+const PLAN_APPROVED_RUNTIME_DEFAULTS: Partial<Record<PromptRuntime, string>> = {
+  opencode: "Plan approved!{{doneMsg}}",
+};
+
+export function getPlanApprovedPrompt(
+  runtime?: PromptRuntime | null,
+  config?: PlannotatorConfig,
+  vars?: FeedbackVars,
+): string {
+  const template = getConfiguredPrompt({
+    section: "plan",
+    key: "approved",
+    runtime,
+    config,
+    fallback: DEFAULT_PLAN_APPROVED_PROMPT,
+    runtimeFallbacks: PLAN_APPROVED_RUNTIME_DEFAULTS,
+  });
+  return resolveTemplate(template, vars ?? {});
+}
+
+const PLAN_APPROVED_WITH_NOTES_RUNTIME_DEFAULTS: Partial<Record<PromptRuntime, string>> = {
+  opencode: "Plan approved with notes!\n{{doneMsg}}\n\n## Implementation Notes\n\nThe user approved your plan but added the following notes to consider during implementation:\n\n{{feedback}}\n\nProceed with implementation, incorporating these notes where applicable.",
+};
+
+export function getPlanApprovedWithNotesPrompt(
+  runtime?: PromptRuntime | null,
+  config?: PlannotatorConfig,
+  vars?: FeedbackVars,
+): string {
+  const template = getConfiguredPrompt({
+    section: "plan",
+    key: "approvedWithNotes",
+    runtime,
+    config,
+    fallback: DEFAULT_PLAN_APPROVED_WITH_NOTES_PROMPT,
+    runtimeFallbacks: PLAN_APPROVED_WITH_NOTES_RUNTIME_DEFAULTS,
+  });
+  return resolveTemplate(template, vars ?? {});
+}
+
+export function getPlanAutoApprovedPrompt(
+  runtime?: PromptRuntime | null,
+  config?: PlannotatorConfig,
+): string {
+  return getConfiguredPrompt({
+    section: "plan",
+    key: "autoApproved",
+    runtime,
+    config,
+    fallback: DEFAULT_PLAN_AUTO_APPROVED_PROMPT,
+  });
+}
+
+// ─── Annotate wrappers ──────────────────────────────────────────────────────
+
+export function getAnnotateFileFeedbackPrompt(
+  runtime?: PromptRuntime | null,
+  config?: PlannotatorConfig,
+  vars?: FeedbackVars,
+): string {
+  const template = getConfiguredPrompt({
+    section: "annotate",
+    key: "fileFeedback",
+    runtime,
+    config,
+    fallback: DEFAULT_ANNOTATE_FILE_FEEDBACK_PROMPT,
+  });
+  return resolveTemplate(template, vars ?? {});
+}
+
+export function getAnnotateMessageFeedbackPrompt(
+  runtime?: PromptRuntime | null,
+  config?: PlannotatorConfig,
+  vars?: FeedbackVars,
+): string {
+  const template = getConfiguredPrompt({
+    section: "annotate",
+    key: "messageFeedback",
+    runtime,
+    config,
+    fallback: DEFAULT_ANNOTATE_MESSAGE_FEEDBACK_PROMPT,
+  });
+  return resolveTemplate(template, vars ?? {});
+}
+
+export function getAnnotateApprovedPrompt(
+  runtime?: PromptRuntime | null,
+  config?: PlannotatorConfig,
+): string {
+  return getConfiguredPrompt({
+    section: "annotate",
+    key: "approved",
+    runtime,
+    config,
+    fallback: DEFAULT_ANNOTATE_APPROVED_PROMPT,
   });
 }


### PR DESCRIPTION
## Summary

- Unified feedback pipeline that all plan approvals, plan denials, annotation feedback, and review suffixes flow through
- Users customize any message via `~/.plannotator/config.json` with `{{variable}}` template interpolation and per-runtime overrides
- 17 hardcoded strings replaced across hook, opencode, and pi with shared pipeline calls
- 72 tests (55 unit + 17 integration) covering template engine, every prompt type, config resolution, backward compatibility, and disk-to-output flow
- New docs page at `/docs/guides/custom-feedback/` with examples including a context anchoring pattern (credited to @aviadshiber)
- Fix missing list bullets site-wide on docs site

Closes #624

## Test plan

- [ ] `bun test packages/shared/prompts.test.ts` — 55 unit tests pass
- [ ] `bun test packages/shared/prompts-integration.test.ts` — 17 integration tests pass (subprocess with HOME override, real config.json on disk)
- [ ] `bun test packages/shared/feedback-templates.test.ts` — 5 existing backward compat tests pass
- [ ] Set custom `prompts.plan.denied` in `~/.plannotator/config.json`, deny a plan, verify custom message in agent output
- [ ] Set `prompts.plan.runtimes.claude-code.denied`, verify runtime-specific override wins
- [ ] Verify no config = identical behavior to before (defaults match old hardcoded strings)
- [ ] `bash apps/pi-extension/vendor.sh` regenerates cleanly
- [ ] Docs page renders at `/docs/guides/custom-feedback/`