### PR TITLE
feat(review): add "All files" diff type

### DIFF
--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -951,7 +951,7 @@ const ReviewApp: React.FC = () => {
       const lastColon = rest.lastIndexOf(':');
       if (lastColon !== -1) {
         const sub = rest.slice(lastColon + 1);
-        if (['uncommitted', 'staged', 'unstaged', 'last-commit', 'branch', 'merge-base'].includes(sub)) {
+        if (['uncommitted', 'staged', 'unstaged', 'last-commit', 'branch', 'merge-base', 'all'].includes(sub)) {
           return { activeWorktreePath: rest.slice(0, lastColon), activeDiffBase: sub };
         }
       }
@@ -1977,6 +1977,7 @@ const ReviewApp: React.FC = () => {
                           {activeDiffBase === 'last-commit' && `No changes in the last commit${activeWorktreePath ? ' in this worktree' : ''}.`}
                           {activeDiffBase === 'branch' && `No changes vs ${selectedBase || gitContext?.defaultBranch || 'main'}${activeWorktreePath ? ' in this worktree' : ''}.`}
                           {activeDiffBase === 'merge-base' && `No changes vs ${selectedBase || gitContext?.defaultBranch || 'main'}${activeWorktreePath ? ' in this worktree' : ''}.`}
+                          {activeDiffBase === 'all' && `No tracked files${activeWorktreePath ? ' in this worktree' : ' in this repository'}.`}
                         </p>
                       </>
                     )}

--- a/packages/review-editor/components/DiffTypePicker.tsx
+++ b/packages/review-editor/components/DiffTypePicker.tsx
@@ -22,7 +22,7 @@ const OPTION_HINTS: Record<string, string> = {
   'last-commit': "Just your most recent commit.",
   branch: "Straight compare against the base branch (picked below). Can show commits that aren't yours if the base has new commits.",
   'merge-base': "Only what you've added on top of the base branch (picked below). Same as GitHub's PR view.",
-  all: "Every tracked file in the repo, shown as additions. Useful for reviewing an entire codebase.",
+  all: "Every tracked file at HEAD, shown as additions. Unlike Committed, which shows what changed vs a base branch, this shows the entire codebase.",
 };
 
 export const DiffTypePicker: React.FC<DiffTypePickerProps> = ({

--- a/packages/review-editor/components/DiffTypePicker.tsx
+++ b/packages/review-editor/components/DiffTypePicker.tsx
@@ -22,6 +22,7 @@ const OPTION_HINTS: Record<string, string> = {
   'last-commit': "Just your most recent commit.",
   branch: "Straight compare against the base branch (picked below). Can show commits that aren't yours if the base has new commits.",
   'merge-base': "Only what you've added on top of the base branch (picked below). Same as GitHub's PR view.",
+  all: "Every tracked file in the repo, shown as additions. Useful for reviewing an entire codebase.",
 };
 
 export const DiffTypePicker: React.FC<DiffTypePickerProps> = ({

--- a/packages/review-editor/utils/exportFeedback.ts
+++ b/packages/review-editor/utils/exportFeedback.ts
@@ -38,6 +38,7 @@ function describeDiff(ctx: FeedbackDiffContext): string {
     case "last-commit":  label = "Last commit"; break;
     case "branch":       label = base ? `Branch diff vs \`${base}\`` : "Branch diff"; break;
     case "merge-base":   label = base ? `Committed changes vs \`${base}\`` : "Committed changes"; break;
+    case "all":          label = "All files"; break;
     default:             label = mode; // p4-* or anything else — show raw
   }
   return worktreePath ? `${label} _(worktree: ${worktreePath})_` : label;

--- a/packages/server/codex-review.ts
+++ b/packages/server/codex-review.ts
@@ -223,6 +223,9 @@ export function buildCodexReviewUserMessage(
       return `Review the PR-style diff against base '${base}'. First find the common ancestor with \`git merge-base ${base} HEAD\`, then run \`git diff <merge-base>..HEAD\` using that commit to inspect only the changes introduced on this branch (matches GitHub's PR view). Provide prioritized, actionable findings.`;
     }
 
+    case "all":
+      return "Review every file in the repository (all files shown as additions, diffed against an empty tree). Provide prioritized, actionable findings.";
+
     default:
       // p4 or unknown — fall back to generic with inlined diff
       return [

--- a/packages/server/tour/tour-review.ts
+++ b/packages/server/tour/tour-review.ts
@@ -338,6 +338,8 @@ function buildTourUserMessage(
       const base = options?.defaultBranch || "main";
       return `Walk the reviewer through the PR-style diff against base '${base}' as a guided tour. First find the common ancestor with \`git merge-base ${base} HEAD\`, then run \`git diff <merge-base>..HEAD\` using that commit to inspect only the changes introduced on this branch (matches GitHub's PR view).`;
     }
+    case "all":
+      return "Walk the reviewer through every file in the repository as a guided tour. All files are shown as additions (diffed against an empty tree).";
     default:
       return [
         "Walk the reviewer through the following code changes as a guided tour.",

--- a/packages/server/vcs.ts
+++ b/packages/server/vcs.ts
@@ -72,7 +72,7 @@ export interface VcsProvider {
 
 // --- Git provider ---
 
-const GIT_DIFF_TYPES = new Set(["uncommitted", "staged", "unstaged", "last-commit", "branch", "merge-base"]);
+const GIT_DIFF_TYPES = new Set(["uncommitted", "staged", "unstaged", "last-commit", "branch", "merge-base", "all"]);
 
 const gitProvider: VcsProvider = {
   id: "git",

--- a/packages/shared/config.ts
+++ b/packages/shared/config.ts
@@ -10,7 +10,7 @@ import { join } from "path";
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
 import { execSync } from "child_process";
 
-export type DefaultDiffType = 'uncommitted' | 'unstaged' | 'staged' | 'merge-base';
+export type DefaultDiffType = 'uncommitted' | 'unstaged' | 'staged' | 'merge-base' | 'all';
 
 export interface DiffOptions {
   diffStyle?: 'split' | 'unified';
@@ -198,7 +198,7 @@ export function getServerConfig(gitUser: string | null): {
 export function resolveDefaultDiffType(cfg?: PlannotatorConfig): DefaultDiffType {
   const v = cfg?.diffOptions?.defaultDiffType as string | undefined;
   if (v === 'branch') return 'merge-base';
-  return v === 'uncommitted' || v === 'unstaged' || v === 'staged' || v === 'merge-base' ? v : 'unstaged';
+  return v === 'uncommitted' || v === 'unstaged' || v === 'staged' || v === 'merge-base' || v === 'all' ? v : 'unstaged';
 }
 
 /**

--- a/packages/shared/review-core.ts
+++ b/packages/shared/review-core.ts
@@ -14,6 +14,7 @@ export type DiffType =
   | "last-commit"
   | "branch"
   | "merge-base"
+  | "all"
   | `worktree:${string}`
   | "p4-default"
   | `p4-changelist:${string}`;
@@ -275,6 +276,8 @@ export async function getGitContext(
     diffOptions.push({ id: "merge-base", label: "Committed changes" });
   }
 
+  diffOptions.push({ id: "all", label: "All files" });
+
   const [worktrees, currentTreePathResult] = await Promise.all([
     getWorktrees(runtime, cwd),
     runtime.runGit(["rev-parse", "--show-toplevel"], { cwd }),
@@ -368,6 +371,7 @@ const WORKTREE_SUB_TYPES = new Set([
   "last-commit",
   "branch",
   "merge-base",
+  "all",
 ]);
 
 export function parseWorktreeDiffType(
@@ -539,6 +543,29 @@ export async function runGitDiff(
         break;
       }
 
+      case "all": {
+        // Diff from the empty tree to HEAD — shows every tracked file as an addition.
+        const emptyTreeResult = await runtime.runGit(["hash-object", "-t", "tree", "/dev/null"], { cwd });
+        const emptyTree = emptyTreeResult.exitCode === 0
+          ? emptyTreeResult.stdout.trim()
+          : "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+        const allDiffArgs = [
+          "diff",
+          "--no-ext-diff",
+          "--src-prefix=a/",
+          "--dst-prefix=b/",
+          "--end-of-options",
+          `${emptyTree}..HEAD`,
+        ];
+        const allDiff = assertGitSuccess(
+          await runtime.runGit(allDiffArgs, { cwd }),
+          allDiffArgs,
+        );
+        patch = allDiff.stdout;
+        label = "All files";
+        break;
+      }
+
       default:
         return { patch: "", label: "Unknown diff type" };
     }
@@ -637,6 +664,11 @@ export async function getFileContentsForDiff(
         newContent: await gitShow("HEAD", filePath),
       };
     }
+    case "all":
+      return {
+        oldContent: null,
+        newContent: await gitShow("HEAD", filePath),
+      };
     default:
       return { oldContent: null, newContent: null };
   }

--- a/packages/shared/review-core.ts
+++ b/packages/shared/review-core.ts
@@ -276,7 +276,7 @@ export async function getGitContext(
     diffOptions.push({ id: "merge-base", label: "Committed changes" });
   }
 
-  diffOptions.push({ id: "all", label: "All files" });
+  diffOptions.push({ id: "all", label: "All files (HEAD)" });
 
   const [worktrees, currentTreePathResult] = await Promise.all([
     getWorktrees(runtime, cwd),

--- a/packages/ui/components/DiffTypeSetupDialog.tsx
+++ b/packages/ui/components/DiffTypeSetupDialog.tsx
@@ -28,8 +28,8 @@ const OPTIONS: { value: DefaultDiffType; label: string; description: string }[] 
   },
   {
     value: 'all',
-    label: 'All Files',
-    description: "Every tracked file in the repo, shown as additions",
+    label: 'All Files (HEAD)',
+    description: "Every tracked file at HEAD, shown as additions",
   },
 ];
 

--- a/packages/ui/components/DiffTypeSetupDialog.tsx
+++ b/packages/ui/components/DiffTypeSetupDialog.tsx
@@ -26,6 +26,11 @@ const OPTIONS: { value: DefaultDiffType; label: string; description: string }[] 
     label: 'Committed',
     description: "Everything you've committed on this branch",
   },
+  {
+    value: 'all',
+    label: 'All Files',
+    description: "Every tracked file in the repo, shown as additions",
+  },
 ];
 
 interface DiffTypeSetupDialogProps {

--- a/packages/ui/components/Settings.tsx
+++ b/packages/ui/components/Settings.tsx
@@ -126,7 +126,7 @@ const DEFAULT_DIFF_TYPE_OPTIONS = [
   { value: 'unstaged' as const, label: 'Unstaged', description: "Only changes you haven't staged yet" },
   { value: 'staged' as const, label: 'Staged', description: "Only changes you've staged for commit" },
   { value: 'merge-base' as const, label: 'Committed', description: "Everything you've committed on this branch" },
-  { value: 'all' as const, label: 'All Files', description: "Every tracked file in the repo, shown as additions" },
+  { value: 'all' as const, label: 'All Files (HEAD)', description: "Every tracked file at HEAD, shown as additions" },
 ];
 
 function SegmentedControl<T extends string>({ options, value, onChange }: {

--- a/packages/ui/components/Settings.tsx
+++ b/packages/ui/components/Settings.tsx
@@ -126,6 +126,7 @@ const DEFAULT_DIFF_TYPE_OPTIONS = [
   { value: 'unstaged' as const, label: 'Unstaged', description: "Only changes you haven't staged yet" },
   { value: 'staged' as const, label: 'Staged', description: "Only changes you've staged for commit" },
   { value: 'merge-base' as const, label: 'Committed', description: "Everything you've committed on this branch" },
+  { value: 'all' as const, label: 'All Files', description: "Every tracked file in the repo, shown as additions" },
 ];
 
 function SegmentedControl<T extends string>({ options, value, onChange }: {

--- a/packages/ui/config/settings.ts
+++ b/packages/ui/config/settings.ts
@@ -36,18 +36,18 @@ export const SETTINGS = {
   // --- Diff display options (namespaced under diffOptions in config.json) ---
 
   defaultDiffType: {
-    defaultValue: 'unstaged' as 'uncommitted' | 'unstaged' | 'staged' | 'merge-base',
+    defaultValue: 'unstaged' as 'uncommitted' | 'unstaged' | 'staged' | 'merge-base' | 'all',
     fromCookie: () => {
       const v = storage.getItem('plannotator-default-diff-type');
       if (v === 'branch') return 'merge-base' as const;
-      return v === 'uncommitted' || v === 'unstaged' || v === 'staged' || v === 'merge-base' ? v : undefined;
+      return v === 'uncommitted' || v === 'unstaged' || v === 'staged' || v === 'merge-base' || v === 'all' ? v : undefined;
     },
     toCookie: (v: string) => storage.setItem('plannotator-default-diff-type', v),
     serverKey: 'diffOptions',
     fromServer: (sc: Record<string, unknown>) => {
       const v = (sc.diffOptions as Record<string, unknown> | undefined)?.defaultDiffType;
       if (v === 'branch') return 'merge-base' as const;
-      return v === 'uncommitted' || v === 'unstaged' || v === 'staged' || v === 'merge-base' ? v : undefined;
+      return v === 'uncommitted' || v === 'unstaged' || v === 'staged' || v === 'merge-base' || v === 'all' ? v : undefined;
     },
     toServer: (v: string) => ({ diffOptions: { defaultDiffType: v } }),
   },


### PR DESCRIPTION
## Summary

- Adds an **"All files"** diff type that diffs the empty tree against HEAD, showing every tracked file as an addition
- Solves the case where a repo has only committed changes (no working tree diffs) and there's no way to launch a review
- Available in the diff type dropdown, as a default preference, and works with worktrees

## Test plan

- [ ] Open a review on a repo with no uncommitted/staged/unstaged changes — select "All files" from the dropdown
- [ ] Verify every tracked file appears as additions
- [ ] Verify file expansion (click to expand context) works correctly
- [ ] Verify "All files" works in a worktree
- [ ] Verify it can be set as the default diff type via the setup dialog or config