### PR TITLE
fix(review): gutter hover button + bump @pierre/diffs to 1.1.20

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@anthropic-ai/claude-agent-sdk": "^0.2.92",
         "@openai/codex-sdk": "^0.118.0",
         "@opencode-ai/sdk": "^1.3.0",
-        "@pierre/diffs": "^1.1.12",
+        "@pierre/diffs": "^1.1.20",
         "diff": "^8.0.4",
         "dockview-react": "^5.2.0",
         "dompurify": "^3.3.3",
@@ -64,7 +64,7 @@
     },
     "apps/opencode-plugin": {
       "name": "@plannotator/opencode",
-      "version": "0.19.1",
+      "version": "0.19.3",
       "dependencies": {
         "@opencode-ai/plugin": "^1.1.10",
       },
@@ -86,7 +86,7 @@
     },
     "apps/pi-extension": {
       "name": "@plannotator/pi-extension",
-      "version": "0.19.1",
+      "version": "0.19.3",
       "dependencies": {
         "@joplin/turndown-plugin-gfm": "^1.0.64",
         "turndown": "^7.2.4",
@@ -189,7 +189,7 @@
     },
     "packages/server": {
       "name": "@plannotator/server",
-      "version": "0.19.1",
+      "version": "0.19.3",
       "dependencies": {
         "@plannotator/ai": "workspace:*",
         "@plannotator/shared": "workspace:*",
@@ -664,7 +664,7 @@
 
     "@oven/bun-windows-x64-baseline": ["@oven/bun-windows-x64-baseline@1.3.5", "", { "os": "win32", "cpu": "x64" }, "sha512-rtVQB9/1XK8FWJgFtsOthbPifRMYypgJwxu+pK3NHx8WvFKmq7HcPDqNr8xLzGULjQEO7eAo2aOZfONOwYz+5g=="],
 
-    "@pierre/diffs": ["@pierre/diffs@1.1.12", "", { "dependencies": { "@pierre/theme": "0.0.28", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-InssHHM7f0nkazIRkuaiNCy6GkBLfwJlqc7LtTkMD/KSqsuc6bnL2V9sIQoG5PZu9jwinQiXUb/gT7itFa6U9A=="],
+    "@pierre/diffs": ["@pierre/diffs@1.1.20", "", { "dependencies": { "@pierre/theme": "0.0.28", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-lLi+3sLCm3QDd5/aLO9pw+WbF6UzhrkWm2oTZ5WZJTGemOyUNRJ4DDhcEKmVusu4C4bXx9Nssh6fF+wQcapb5w=="],
 
     "@pierre/theme": ["@pierre/theme@0.0.28", "", {}, "sha512-1j/H/fECBuc9dEvntdWI+l435HZapw+RCJTlqCA6BboQ5TjlnE005j/ROWutXIs8aq5OAc82JI2Kwk4A1WWBgw=="],
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.2.92",
     "@openai/codex-sdk": "^0.118.0",
     "@opencode-ai/sdk": "^1.3.0",
-    "@pierre/diffs": "^1.1.12",
+    "@pierre/diffs": "^1.1.20",
     "diff": "^8.0.4",
     "dockview-react": "^5.2.0",
     "dompurify": "^3.3.3",

--- a/packages/review-editor/components/DiffViewer.tsx
+++ b/packages/review-editor/components/DiffViewer.tsx
@@ -497,16 +497,19 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
     );
   }, [filePath, onSelectAnnotation, handleEdit, onDeleteAnnotation, onClickAIMarker]);
 
-  // Render hover utility (+ button)
+  // Render hover utility (+ button).
+  // Pierre manages visibility imperatively — it inserts/removes the slot
+  // container on line hover. We must always return a button; calling
+  // getHoveredLine() to gate rendering would return stale data because
+  // Pierre's hover state changes don't trigger React re-renders.
   const renderHoverUtility = useCallback((getHoveredLine: () => { lineNumber: number; side: 'deletions' | 'additions' } | undefined) => {
-    const line = getHoveredLine();
-    if (!line) return null;
-
     return (
       <button
         className="hover-add-comment"
         onClick={(e) => {
           e.stopPropagation();
+          const line = getHoveredLine();
+          if (!line) return;
           toolbar.handleLineSelectionEnd({
             start: line.lineNumber,
             end: line.lineNumber,

--- a/packages/review-editor/index.css
+++ b/packages/review-editor/index.css
@@ -241,26 +241,30 @@ diffs-container {
   background: oklch(from var(--primary) l c h / 0.3) !important;
 }
 
-/* Hover utility button (GitHub-style +) */
+/* Hover utility button — matches Pierre's [data-utility-button] sizing */
 .hover-add-comment {
+  appearance: none;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 1.25rem;
-  height: 1.25rem;
-  border-radius: 0.25rem;
-  background: var(--primary);
-  color: var(--primary-foreground);
-  font-size: 0.75rem;
-  font-weight: 600;
+  width: 1lh;
+  height: 1lh;
+  font-size: var(--diffs-font-size, 13px);
+  line-height: var(--diffs-line-height, 20px);
+  border: none;
+  border-radius: 4px;
+  background-color: var(--diffs-modified-base);
+  color: var(--diffs-bg);
+  fill: currentColor;
   cursor: pointer;
-  opacity: 0;
-  transition: opacity 150ms;
+  position: relative;
+  z-index: 4;
+  padding: 0;
+  margin-right: calc(1ch - 1lh);
 }
 
 .hover-add-comment:hover {
-  opacity: 1;
-  background: oklch(0.70 0.20 280);
+  filter: brightness(1.2);
 }
 
 /* File tree styling */


### PR DESCRIPTION
## Summary

- **Fix gutter hover button not rendering** — `renderHoverUtility` was calling `getHoveredLine()` during React render to decide whether to show the button. But Pierre updates hover state imperatively via pointer events (no React re-render), so the button was permanently null. Now the button always renders; `getHoveredLine()` is only called at click time.
- **Fix button styling** — matched Pierre's own `[data-utility-button]` spec: `1lh` sizing, `--diffs-modified-base` background, correct margin/padding. Previously used hardcoded `1.25rem` and `oklch()` purple that didn't match Pierre's theme.
- **Bump `@pierre/diffs` from 1.1.12 → 1.1.20** — picks up split-view scroll fix, WorkerPool race condition fix, hydration fixes, CSS refactoring, and empty-file-as-deleted fix.

## Test plan

- [ ] Hover over line numbers in split and unified diff — the `+` button should appear on every line hover
- [ ] Click the `+` button — comment toolbar should open for that line
- [ ] Button color should match Pierre's blue theme, not purple
- [ ] Button should not clip or overflow the line number cell
- [ ] Verify no regressions with hunk expansion, line selection, annotations