### PR TITLE
fix(review): hide-whitespace matches GitHub's git diff -w

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,6 @@
       "version": "0.0.1",
       "dependencies": {
         "@plannotator/editor": "workspace:*",
-        "@plannotator/review-editor": "workspace:*",
         "@plannotator/server": "workspace:*",
         "@plannotator/shared": "workspace:*",
         "@plannotator/ui": "workspace:*",
@@ -214,7 +213,6 @@
       "version": "0.0.1",
       "dependencies": {
         "@pierre/diffs": "^1.1.12",
-        "@plannotator/review-editor": "workspace:*",
         "@plannotator/shared": "workspace:*",
         "@plannotator/web-highlighter": "^0.8.1",
         "@radix-ui/react-dialog": "^1.1.15",

--- a/packages/review-editor/components/DiffViewer.tsx
+++ b/packages/review-editor/components/DiffViewer.tsx
@@ -300,10 +300,10 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
     if (!fileContents || fileContents.forPath !== filePath || (fileContents.old == null && fileContents.new == null)) return fileDiff;
     try {
       if (hideWhitespace && fileContents.old != null && fileContents.new != null) {
+        const normalize = (s: string) => s.split('\n').map(l => l.replace(/\s+/g, ' ').trim()).join('\n');
         return parseDiffFromFile(
-          { name: oldPath || filePath, contents: fileContents.old },
-          { name: filePath, contents: fileContents.new },
-          { ignoreWhitespace: true },
+          { name: oldPath || filePath, contents: normalize(fileContents.old) },
+          { name: filePath, contents: normalize(fileContents.new) },
         );
       }
       const result = processFile(patch, {

--- a/packages/review-editor/demoData.ts
+++ b/packages/review-editor/demoData.ts
@@ -73,7 +73,7 @@ export function getDatabaseConfig() {
         connectionString: config.DATABASE_URL,
         pool: {
             min: 2,
-            max: config.NODE_ENV === 'production' ? 20 : 5,
+            max: config.NODE_ENV === 'production' ? 20 : 10,
         },
         ssl: config.NODE_ENV === 'production',
     };
@@ -335,7 +335,7 @@ index 5678901..efghijk 100644
 +        connectionString: config.DATABASE_URL,
 +        pool: {
 +            min: 2,
-+            max: config.NODE_ENV === 'production' ? 20 : 5,
++            max: config.NODE_ENV === 'production' ? 20 : 10,
 +        },
 +        ssl: config.NODE_ENV === 'production',
 +    };


### PR DESCRIPTION
## Summary
- **Fix**: Hide-whitespace was only trimming leading/trailing whitespace per line (via the `diff` library's `ignoreWhitespace`), so interior whitespace changes like alignment padding (`NODE_ENV: z.enum(...)` → `NODE_ENV:     z.enum(...)`) and extra spaces between tokens (`from 'zod'` → `from  'zod'`) were still showing as diffs. Now normalizes all whitespace runs to a single space before diffing, matching GitHub's `?w=1` / `git diff -w` behavior.
- **Demo**: Adds a real code change (`pool.max: 5 → 10`) to the `settings.ts` demo file so it's not fully collapsed when hide-whitespace is on — demonstrates the feature clearly.

## Test plan
- [ ] Open review dev server (`bun run dev:review`)
- [ ] Select `src/config/settings.ts` in the file tree
- [ ] Verify without hide-whitespace: all alignment, indentation, and pool max changes visible
- [ ] Toggle hide-whitespace on: only the `max: ... ? 20 : 5` → `10` change should remain
- [ ] Verify other demo files (Button.tsx, api.ts, Modal.tsx) render correctly with hide-whitespace on/off