### PR TITLE
fix(review): support non-ASCII and whitespace file paths

### DIFF
--- a/apps/pi-extension/server/serverReview.ts
+++ b/apps/pi-extension/server/serverReview.ts
@@ -126,7 +126,7 @@ export const reviewRuntime: ReviewGitRuntime = {
 		options?: { cwd?: string; timeoutMs?: number },
 	): Promise<GitCommandResult> {
 		return new Promise((resolve) => {
-			const proc = spawn("git", args, {
+			const proc = spawn("git", ["-c", "core.quotePath=false", ...args], {
 				cwd: options?.cwd,
 				stdio: ["ignore", "pipe", "pipe"],
 			});

--- a/packages/server/git.ts
+++ b/packages/server/git.ts
@@ -38,7 +38,7 @@ async function runGit(
   args: string[],
   options?: { cwd?: string; timeoutMs?: number },
 ): Promise<GitCommandResult> {
-  const proc = Bun.spawn(["git", ...args], {
+  const proc = Bun.spawn(["git", "-c", "core.quotePath=false", ...args], {
     cwd: options?.cwd,
     stdout: "pipe",
     stderr: "pipe",


### PR DESCRIPTION
## Summary
- Passes `-c core.quotePath=false` to both central `runGit` functions (Bun + Pi) so git outputs raw UTF-8 paths instead of octal escapes
- Fixes code review showing 0/0 files when repos contain non-ASCII (Korean, Chinese, accented) or whitespace file paths

## Details

Git defaults to `core.quotePath=true`, which emits paths like `\355\225\234\352\265\255\354\226\264` instead of `한국어`. The `@pierre/diffs` parser expects unquoted paths, so every affected file was silently dropped.

The fix injects `-c core.quotePath=false` as a per-invocation flag in the two central git entry points — `packages/server/git.ts` (Bun) and `apps/pi-extension/server/serverReview.ts` (Pi/Node). This flag:
- Only affects the specific git process (never written to user config)
- Has zero effect on ASCII-only paths (majority of users)
- Matches how GitHub, VS Code, and GitLab handle non-ASCII paths

Closes #628

## Test plan
- [ ] `bun test` — 892 tests pass
- [ ] Repro from #628: create repo with Korean folder name, run `plannotator review`, verify files appear
- [ ] Verify ASCII-only repos are unaffected