### PR TITLE
feat(ui): detect code file paths in backtick spans and bare prose

### DIFF
--- a/packages/editor/demoPlan.ts
+++ b/packages/editor/demoPlan.ts
@@ -28,10 +28,10 @@ export const COLLAB_CONFIG = {
 
 | File | Role |
 | --- | --- |
-| [App.tsx](packages/editor/App.tsx) | Editor entry point |
-| [resolve-file.ts](packages/shared/resolve-file.ts) | Path resolution |
-| [nonexistent.ts](packages/fake/nope.ts) | Should fail silently |
-| [package.json](package.json) | Root config |
+| \`packages/editor/App.tsx\` | Editor entry point |
+| \`packages/shared/resolve-file.ts\` | Path resolution |
+| \`packages/fake/nope.ts\` | Should fail silently |
+| \`package.json\` | Root config |
 
 ## Overview
 Add real-time collaboration features to the editor using _**[WebSocket API](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API)**_ and *[operational transforms](https://en.wikipedia.org/wiki/Operational_transformation)*.
@@ -366,6 +366,21 @@ digraph CollaborationStack {
 \`\`\`
 
 ---
+
+## Phase 4: File Changes
+
+### Modified files
+
+The core connection logic lives in \`packages/ui/components/InlineMarkdown.tsx\` which handles rendering inline tokens. The detection utility is in \`packages/shared/code-file.ts\` and the popout viewer is wired through \`packages/ui/hooks/useCodeFilePopout.ts\`.
+
+On the server side, update packages/server/index.ts to register the new WebSocket routes and packages/server/reference-handlers.ts for the file resolution endpoint. The editor entry point \`packages/editor/App.tsx\` needs the collaboration provider wrapper.
+
+### Build and deploy
+
+- Update the \`Dockerfile\` to expose the new WebSocket port
+- Run \`package.json\` scripts for the build pipeline
+- Config files like \`.env\` and \`README.md\` do not need changes
+- Commands like \`npm install\` and \`bun run build\` remain unchanged
 
 **Target:** Ship MVP in next sprint
 `;

--- a/packages/shared/code-file.test.ts
+++ b/packages/shared/code-file.test.ts
@@ -1,0 +1,64 @@
+import { describe, test, expect } from 'bun:test';
+import { isCodeFilePath, isCodeFilePathStrict } from './code-file';
+
+describe('isCodeFilePath', () => {
+  test('matches common extensions', () => {
+    expect(isCodeFilePath('button.tsx')).toBe(true);
+    expect(isCodeFilePath('utils.ts')).toBe(true);
+    expect(isCodeFilePath('main.py')).toBe(true);
+    expect(isCodeFilePath('lib.rs')).toBe(true);
+    expect(isCodeFilePath('config.json')).toBe(true);
+    expect(isCodeFilePath('styles.css')).toBe(true);
+  });
+
+  test('matches paths with directories', () => {
+    expect(isCodeFilePath('src/components/Button.tsx')).toBe(true);
+    expect(isCodeFilePath('./utils/helpers.ts')).toBe(true);
+    expect(isCodeFilePath('../lib/main.py')).toBe(true);
+  });
+
+  test('matches special filenames', () => {
+    expect(isCodeFilePath('Dockerfile')).toBe(true);
+    expect(isCodeFilePath('Makefile')).toBe(true);
+    expect(isCodeFilePath('path/to/Dockerfile')).toBe(true);
+  });
+
+  test('strips hash fragments', () => {
+    expect(isCodeFilePath('src/foo.ts#L42')).toBe(true);
+  });
+
+  test('rejects URLs', () => {
+    expect(isCodeFilePath('https://github.com/foo.ts')).toBe(false);
+    expect(isCodeFilePath('http://example.com/main.py')).toBe(false);
+  });
+
+  test('rejects non-code files', () => {
+    expect(isCodeFilePath('.env')).toBe(false);
+    expect(isCodeFilePath('readme.txt')).toBe(false);
+    expect(isCodeFilePath('npm install')).toBe(false);
+  });
+});
+
+describe('isCodeFilePathStrict', () => {
+  test('requires a / separator', () => {
+    expect(isCodeFilePathStrict('button.tsx')).toBe(false);
+    expect(isCodeFilePathStrict('Dockerfile')).toBe(false);
+    expect(isCodeFilePathStrict('package.json')).toBe(false);
+  });
+
+  test('matches paths with directories', () => {
+    expect(isCodeFilePathStrict('src/components/Button.tsx')).toBe(true);
+    expect(isCodeFilePathStrict('./utils/helpers.ts')).toBe(true);
+    expect(isCodeFilePathStrict('../lib/main.py')).toBe(true);
+    expect(isCodeFilePathStrict('path/to/Makefile')).toBe(true);
+  });
+
+  test('rejects URLs even with /', () => {
+    expect(isCodeFilePathStrict('https://github.com/foo.ts')).toBe(false);
+  });
+
+  test('rejects non-code paths with /', () => {
+    expect(isCodeFilePathStrict('path/to/readme.txt')).toBe(false);
+    expect(isCodeFilePathStrict('some/dir/.env')).toBe(false);
+  });
+});

--- a/packages/shared/code-file.ts
+++ b/packages/shared/code-file.ts
@@ -4,3 +4,7 @@ export function isCodeFilePath(input: string): boolean {
 	return CODE_FILE_REGEX.test(input.replace(/#.*$/, ''))
 		&& !input.startsWith('http://') && !input.startsWith('https://');
 }
+
+export function isCodeFilePathStrict(input: string): boolean {
+	return input.includes('/') && isCodeFilePath(input);
+}

--- a/packages/ui/components/InlineMarkdown.tsx
+++ b/packages/ui/components/InlineMarkdown.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { isCodeFilePath } from "@plannotator/shared/code-file";
+import { isCodeFilePath, isCodeFilePathStrict } from "@plannotator/shared/code-file";
 import { transformPlainText } from "../utils/inlineTransforms";
 import { getImageSrc } from "./ImageThumbnail";
 
@@ -8,6 +8,19 @@ function sanitizeLinkUrl(url: string): string | null {
   if (DANGEROUS_PROTOCOL.test(url)) return null;
   return url;
 }
+
+const CodeFileIcon = () => (
+  <svg
+    className="w-3 h-3 opacity-50 flex-shrink-0"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    strokeWidth={2}
+    aria-hidden="true"
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
+  </svg>
+);
 
 // Trim trailing sentence punctuation from a bare URL, but keep closing
 // brackets when they balance an opener inside the URL (Wikipedia-style
@@ -32,43 +45,91 @@ export function trimUrlTail(url: string): string {
   return url;
 }
 
-// Scan a plain-text chunk for bare https?:// URLs at word boundaries and
-// emit them as anchor nodes, passing surrounding text through
-// transformPlainText so emoji shortcodes and smart punctuation still apply
-// to the non-URL slices.
+// Scan a plain-text chunk for bare https?:// URLs and bare code file paths
+// at word boundaries, emitting them as interactive nodes. Surrounding text
+// passes through transformPlainText for emoji shortcodes + smart punctuation.
 function emitPlainTextWithBareUrls(
   text: string,
   previousChar: string,
   parts: React.ReactNode[],
   nextKey: () => number,
+  onOpenCodeFile?: (path: string) => void,
 ): void {
   if (text.length === 0) return;
-  const re = /https?:\/\/[^\s<>"']+/g;
-  let last = 0;
+
+  type Span = { start: number; end: number; kind: 'url'; value: string }
+    | { start: number; end: number; kind: 'path'; value: string };
+  const spans: Span[] = [];
+
+  // Collect bare URLs
+  const urlRe = /https?:\/\/[^\s<>"']+/g;
   let m: RegExpExecArray | null;
-  while ((m = re.exec(text)) !== null) {
+  while ((m = urlRe.exec(text)) !== null) {
     const before = m.index === 0 ? previousChar : text[m.index - 1];
     if (/\w/.test(before)) continue;
-    const raw = m[0];
-    const url = trimUrlTail(raw);
+    const url = trimUrlTail(m[0]);
     const safe = url.length > 0 ? sanitizeLinkUrl(url) : null;
     if (!safe) continue;
-    if (m.index > last) {
-      parts.push(transformPlainText(text.slice(last, m.index)));
+    spans.push({ start: m.index, end: m.index + url.length, kind: 'url', value: url });
+    urlRe.lastIndex = m.index + url.length;
+  }
+
+  // Collect bare code file paths (require /)
+  if (onOpenCodeFile) {
+    const pathRe = /(?:\.{0,2}\/)?(?:[a-zA-Z0-9_@.\-]+\/)+[a-zA-Z0-9_.\-]+\.[a-zA-Z0-9]+/g;
+    while ((m = pathRe.exec(text)) !== null) {
+      const before = m.index === 0 ? previousChar : text[m.index - 1];
+      if (/\w/.test(before)) continue;
+      const candidate = m[0];
+      if (!isCodeFilePathStrict(candidate)) continue;
+      const overlaps = spans.some(s => m!.index < s.end && m!.index + candidate.length > s.start);
+      if (overlaps) continue;
+      spans.push({ start: m.index, end: m.index + candidate.length, kind: 'path', value: candidate });
     }
-    parts.push(
-      <a
-        key={nextKey()}
-        href={safe}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-primary underline underline-offset-2 hover:text-primary/80"
-      >
-        {url}
-      </a>,
-    );
-    last = m.index + url.length;
-    re.lastIndex = last;
+  }
+
+  if (spans.length === 0) {
+    parts.push(transformPlainText(text));
+    return;
+  }
+
+  spans.sort((a, b) => a.start - b.start);
+
+  let last = 0;
+  for (const span of spans) {
+    if (span.start > last) {
+      parts.push(transformPlainText(text.slice(last, span.start)));
+    }
+    if (span.kind === 'url') {
+      parts.push(
+        <a
+          key={nextKey()}
+          href={span.value}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary underline underline-offset-2 hover:text-primary/80"
+        >
+          {span.value}
+        </a>,
+      );
+    } else {
+      const cleanPath = span.value.replace(/#.*$/, '');
+      parts.push(
+        <code
+          key={nextKey()}
+          role="button"
+          tabIndex={0}
+          onClick={() => onOpenCodeFile!(cleanPath)}
+          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onOpenCodeFile!(cleanPath); } }}
+          className="code-file-link px-1.5 py-0.5 rounded bg-muted text-sm font-mono cursor-pointer hover:text-primary inline-flex items-center gap-1 transition-colors"
+          title={`View: ${span.value}`}
+        >
+          {span.value}
+          <CodeFileIcon />
+        </code>,
+      );
+    }
+    last = span.end;
   }
   if (last < text.length) {
     parts.push(transformPlainText(text.slice(last)));
@@ -280,17 +341,36 @@ export const InlineMarkdown: React.FC<{
       continue;
     }
 
-    // Inline code: `code`
+    // Inline code: `code` — when the content is a code file path, render as clickable
     match = remaining.match(/^`([^`]+)`/);
     if (match) {
-      parts.push(
-        <code
-          key={key++}
-          className="px-1.5 py-0.5 rounded bg-muted text-sm font-mono"
-        >
-          {match[1]}
-        </code>,
-      );
+      const codeContent = match[1];
+      if (isCodeFilePath(codeContent) && onOpenCodeFile) {
+        const cleanPath = codeContent.replace(/#.*$/, '');
+        parts.push(
+          <code
+            key={key++}
+            role="button"
+            tabIndex={0}
+            onClick={() => onOpenCodeFile(cleanPath)}
+            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onOpenCodeFile(cleanPath); } }}
+            className="code-file-link px-1.5 py-0.5 rounded bg-muted text-sm font-mono cursor-pointer hover:text-primary inline-flex items-center gap-1 transition-colors"
+            title={`View: ${codeContent}`}
+          >
+            {codeContent}
+            <CodeFileIcon />
+          </code>,
+        );
+      } else {
+        parts.push(
+          <code
+            key={key++}
+            className="px-1.5 py-0.5 rounded bg-muted text-sm font-mono"
+          >
+            {codeContent}
+          </code>,
+        );
+      }
       remaining = remaining.slice(match[0].length);
       previousChar = match[0][match[0].length - 1] || previousChar;
       continue;
@@ -573,16 +653,7 @@ export const InlineMarkdown: React.FC<{
             title={`View: ${linkUrl}`}
           >
             {linkText}
-            <svg
-              className="w-3 h-3 opacity-50 flex-shrink-0"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-              aria-hidden="true"
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
-            </svg>
+            <CodeFileIcon />
           </a>,
         );
       } else if (isLocalDoc) {
@@ -645,7 +716,7 @@ export const InlineMarkdown: React.FC<{
     // detected inline via emitPlainTextWithBareUrls() below.
     const nextSpecial = remaining.slice(1).search(/[\*_`\[!~\\<#@]/);
     const plainText = nextSpecial === -1 ? remaining : remaining.slice(0, nextSpecial + 1);
-    emitPlainTextWithBareUrls(plainText, previousChar, parts, () => key++);
+    emitPlainTextWithBareUrls(plainText, previousChar, parts, () => key++, onOpenCodeFile);
     previousChar = plainText[plainText.length - 1] || previousChar;
     if (nextSpecial === -1) {
       break;

--- a/packages/ui/theme.css
+++ b/packages/ui/theme.css
@@ -195,6 +195,42 @@ body {
   100% { background: transparent; }
 }
 
+/* Clickable code file paths — subtle ambient shimmer so users discover they
+   are interactive without disrupting the familiar inline-code look. */
+.code-file-link {
+  position: relative;
+  overflow: hidden;
+}
+.code-file-link::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  width: 60%;
+  background: linear-gradient(
+    120deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.06) 35%,
+    rgba(255, 255, 255, 0.14) 50%,
+    rgba(255, 255, 255, 0.06) 65%,
+    transparent 100%
+  );
+  transform: translateX(-100%);
+  animation: code-file-shimmer 6s ease-in-out infinite;
+  pointer-events: none;
+  border-radius: inherit;
+}
+@keyframes code-file-shimmer {
+  0%  { transform: translateX(-100%); }
+  35% { transform: translateX(calc(100% / 0.6 + 100%)); }
+  100%{ transform: translateX(calc(100% / 0.6 + 100%)); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .code-file-link::after {
+    animation: none;
+    display: none;
+  }
+}
+
 /* Word-level diff markers inside modified plan-diff blocks. Emitted as
    <ins>/<del> by PlanCleanDiffView's inline renderer; keep the decoration
    compact across line wraps via box-decoration-break: clone. */


### PR DESCRIPTION
## Summary

- Inline code spans like `src/utils/foo.ts` and bare prose paths like `packages/server/index.ts` are now detected as code file paths and rendered as clickable elements that open the code file popout viewer
- Backtick paths use `isCodeFilePath()` directly (high confidence — user marked it as code), while bare prose paths require a `/` separator via new `isCodeFilePathStrict()` to avoid false positives
- Adds a subtle CSS shimmer animation and `hover:text-primary` transition so users discover the interactivity without disrupting the familiar inline-code look

### Changes

- **`packages/shared/code-file.ts`** — Add `isCodeFilePathStrict()` (requires `/` in path)
- **`packages/ui/components/InlineMarkdown.tsx`** — Branch backtick handler to detect code files, extend `emitPlainTextWithBareUrls()` for bare prose detection, extract `CodeFileIcon` component
- **`packages/ui/theme.css`** — Add `code-file-link` shimmer keyframe with `prefers-reduced-motion` support
- **`packages/shared/code-file.test.ts`** — 10 tests for both detection functions
- **`packages/editor/demoPlan.ts`** — Update demo plan with natural file path examples

## Test plan

- [ ] `bun test packages/shared/code-file.test.ts` passes (10 tests)
- [ ] `bun run dev:hook` — open plan review UI in browser
- [ ] Backtick code file paths (e.g. `` `packages/editor/App.tsx` ``) render with shimmer + code icon and are clickable
- [ ] Bare prose paths (e.g. `packages/server/index.ts`) render as clickable code elements
- [ ] Non-code backtick content (`` `npm install` ``, `` `.env` ``, `` `README.md` ``) renders as plain inline code
- [ ] Hovering a detected path transitions text to primary/link color
- [ ] Clicking a detected path opens the CodeFilePopout
- [ ] Existing markdown link code files in the Key Files table still work
- [ ] Shimmer is disabled when `prefers-reduced-motion: reduce` is set