### PR TITLE
Localize Pi extension review flow strings

### DIFF
--- a/apps/pi-extension/i18n.ts
+++ b/apps/pi-extension/i18n.ts
@@ -1,0 +1,147 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+type Params = Record<string, string | number>;
+type Translate = (key: string, fallback: string, params?: Params) => string;
+
+let translate: Translate = (_key, fallback, params) => format(fallback, params);
+
+function format(text: string, params?: Params): string {
+	if (!params) return text;
+	return text.replace(/\{(\w+)\}/g, (_match, key: string) => String(params[key] ?? `{${key}}`));
+}
+
+export function t(key: string, fallback: string, params?: Params): string {
+	return translate(key, fallback, params);
+}
+
+const bundles = [
+	{
+		locale: "ja",
+		namespace: "plannotator",
+		messages: {
+			"flag.plan.description": "計画モードで開始（制限付きの調査と計画作成）",
+			"cmd.toggle.description": "plannotator の計画モードを切り替え",
+			"cmd.status.description": "plannotator の状態を表示",
+			"cmd.review.description": "現在の変更または PR URL のインタラクティブなコードレビューを開く",
+			"cmd.annotate.description": "Markdown ファイルまたはフォルダーを注釈 UI で開く",
+			"cmd.annotateMessage.description": "最後のアシスタントメッセージに注釈を付ける",
+			"cmd.archive.description": "保存済みの計画判断を閲覧",
+			"cmd.shortcut.description": "plannotator を切り替え",
+			"notify.planning.enabled": "Plannotator: 計画モードを有効にしました。Markdown の計画を書いてレビューに提出してください。",
+			"notify.disabled": "Plannotator: 無効にしました。全アクセスを復元しました。",
+			"notify.review.assetsMissing": "Plannotator: コードレビュー UI アセットが見つかりません。拡張機能を再ビルドしてブラウザー UI を復元してください。",
+			"notify.review.closed": "コードレビューセッションを閉じました。",
+			"notify.review.noFeedback": "コードレビューを閉じました（フィードバックなし）。",
+			"notify.review.failedStart": "コードレビュー UI の開始に失敗しました: {message}",
+			"notify.annotate.usage": "使用方法: /plannotator-annotate <file.md | file.html | https://... | folder/> [--gate] [--json]",
+			"notify.annotate.fetching": "取得中: {path}{mode}...",
+			"notify.annotate.failedFetch": "URL の取得に失敗しました: {message}",
+			"notify.annotate.fileNotFound": "ファイルが見つかりません: {path}",
+			"notify.annotate.cannotAccess": "アクセスできません: {path}",
+			"notify.annotate.noMarkdown": "{path} に Markdown または HTML ファイルが見つかりません",
+			"notify.annotate.openFolder": "フォルダー {path} の注釈 UI を開いています...",
+			"notify.annotate.tooLarge": "ファイルが大きすぎます（{mb}MB、最大 10MB）",
+			"notify.annotate.openFile": "{path} の注釈 UI を開いています...",
+			"notify.annotate.approved": "注釈が承認されました。",
+			"notify.annotate.closed": "注釈セッションを閉じました。",
+			"notify.annotate.noFeedback": "注釈を閉じました（フィードバックなし）。",
+			"notify.annotate.failedStart": "注釈 UI の開始に失敗しました: {message}",
+			"notify.message.noAssistant": "セッションにアシスタントメッセージが見つかりません。",
+			"notify.message.open": "最後のメッセージの注釈 UI を開いています...",
+			"notify.message.approved": "メッセージが承認されました。",
+			"notify.archive.open": "計画アーカイブを開いています...",
+			"notify.archive.closed": "アーカイブブラウザーを閉じました。",
+			"notify.archive.failedStart": "アーカイブの開始に失敗しました: {message}",
+		},
+	},
+	{
+		locale: "zh-CN",
+		namespace: "plannotator",
+		messages: {
+			"flag.plan.description": "以计划模式启动（受限探索和计划）",
+			"cmd.toggle.description": "切换 plannotator 计划模式",
+			"cmd.status.description": "显示 plannotator 状态",
+			"cmd.review.description": "为当前更改或 PR URL 打开交互式代码审查",
+			"cmd.annotate.description": "在批注 UI 中打开 Markdown 文件或文件夹",
+			"cmd.annotateMessage.description": "批注最后一条 assistant 消息",
+			"cmd.archive.description": "浏览已保存的计划决策",
+			"cmd.shortcut.description": "切换 plannotator",
+			"notify.planning.enabled": "Plannotator: 已启用计划模式。请编写 Markdown 计划，然后提交审查。",
+			"notify.disabled": "Plannotator: 已禁用。已恢复完整访问。",
+			"notify.review.assetsMissing": "Plannotator: 缺少代码审查 UI 资源。请重新构建扩展以恢复浏览器 UI。",
+			"notify.review.closed": "代码审查会话已关闭。",
+			"notify.review.noFeedback": "代码审查已关闭（无反馈）。",
+			"notify.review.failedStart": "启动代码审查 UI 失败: {message}",
+			"notify.annotate.usage": "用法: /plannotator-annotate <file.md | file.html | https://... | folder/> [--gate] [--json]",
+			"notify.annotate.fetching": "正在获取: {path}{mode}...",
+			"notify.annotate.failedFetch": "获取 URL 失败: {message}",
+			"notify.annotate.fileNotFound": "文件未找到: {path}",
+			"notify.annotate.cannotAccess": "无法访问: {path}",
+			"notify.annotate.noMarkdown": "在 {path} 中未找到 Markdown 或 HTML 文件",
+			"notify.annotate.openFolder": "正在为文件夹 {path} 打开批注 UI...",
+			"notify.annotate.tooLarge": "文件过大（{mb}MB，最大 10MB）",
+			"notify.annotate.openFile": "正在为 {path} 打开批注 UI...",
+			"notify.annotate.approved": "批注已批准。",
+			"notify.annotate.closed": "批注会话已关闭。",
+			"notify.annotate.noFeedback": "批注已关闭（无反馈）。",
+			"notify.annotate.failedStart": "启动批注 UI 失败: {message}",
+			"notify.message.noAssistant": "会话中未找到 assistant 消息。",
+			"notify.message.open": "正在为最后一条消息打开批注 UI...",
+			"notify.message.approved": "消息已批准。",
+			"notify.archive.open": "正在打开计划归档...",
+			"notify.archive.closed": "归档浏览器已关闭。",
+			"notify.archive.failedStart": "启动归档失败: {message}",
+		},
+	},
+	{
+		locale: "es",
+		namespace: "plannotator",
+		messages: {
+			"flag.plan.description": "Iniciar en modo plan (exploración y planificación restringidas)",
+			"cmd.toggle.description": "Alternar modo de planificación de plannotator",
+			"cmd.status.description": "Mostrar estado de plannotator",
+			"cmd.review.description": "Abrir revisión de código interactiva para cambios actuales o una URL de PR",
+			"cmd.annotate.description": "Abrir archivo o carpeta Markdown en la UI de anotación",
+			"cmd.annotateMessage.description": "Anotar el último mensaje del asistente",
+			"cmd.archive.description": "Explorar decisiones de planes guardadas",
+			"cmd.shortcut.description": "Alternar plannotator",
+			"notify.planning.enabled": "Plannotator: modo de planificación activado. Escribe un plan Markdown y envíalo a revisión.",
+			"notify.disabled": "Plannotator: desactivado. Acceso completo restaurado.",
+			"notify.review.assetsMissing": "Plannotator: faltan recursos de la UI de revisión de código. Reconstruye la extensión para restaurar la UI del navegador.",
+			"notify.review.closed": "Sesión de revisión de código cerrada.",
+			"notify.review.noFeedback": "Revisión de código cerrada (sin feedback).",
+			"notify.review.failedStart": "No se pudo iniciar la UI de revisión de código: {message}",
+			"notify.annotate.usage": "Uso: /plannotator-annotate <file.md | file.html | https://... | folder/> [--gate] [--json]",
+			"notify.annotate.fetching": "Obteniendo: {path}{mode}...",
+			"notify.annotate.failedFetch": "No se pudo obtener la URL: {message}",
+			"notify.annotate.fileNotFound": "Archivo no encontrado: {path}",
+			"notify.annotate.cannotAccess": "No se puede acceder: {path}",
+			"notify.annotate.noMarkdown": "No se encontraron archivos Markdown o HTML en {path}",
+			"notify.annotate.openFolder": "Abriendo UI de anotación para la carpeta {path}...",
+			"notify.annotate.tooLarge": "Archivo demasiado grande ({mb}MB, máximo 10MB)",
+			"notify.annotate.openFile": "Abriendo UI de anotación para {path}...",
+			"notify.annotate.approved": "Anotación aprobada.",
+			"notify.annotate.closed": "Sesión de anotación cerrada.",
+			"notify.annotate.noFeedback": "Anotación cerrada (sin feedback).",
+			"notify.annotate.failedStart": "No se pudo iniciar la UI de anotación: {message}",
+			"notify.message.noAssistant": "No se encontró ningún mensaje del asistente en la sesión.",
+			"notify.message.open": "Abriendo UI de anotación para el último mensaje...",
+			"notify.message.approved": "Mensaje aprobado.",
+			"notify.archive.open": "Abriendo archivo de planes...",
+			"notify.archive.closed": "Navegador de archivo cerrado.",
+			"notify.archive.failedStart": "No se pudo iniciar el archivo: {message}",
+		},
+	},
+];
+
+export function initI18n(pi: ExtensionAPI): void {
+	const events = pi.events;
+	if (!events) return;
+	for (const bundle of bundles) events.emit("pi-core/i18n/registerBundle", bundle);
+	events.emit("pi-core/i18n/requestApi", {
+		namespace: "plannotator",
+		callback(api: { t?: Translate } | undefined) {
+			if (typeof api?.t === "function") translate = api.t;
+		},
+	});
+}

--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -62,6 +62,7 @@ import {
 	openPlanReviewBrowser,
 	registerPlannotatorEventListeners,
 } from "./plannotator-events.js";
+import { initI18n, t } from "./i18n.js";
 import {
 	getToolsForPhase,
 	isPlanWritePathAllowed,
@@ -116,6 +117,7 @@ function getPlanReviewAvailabilityWarning(options: { hasUI: boolean; hasPlanHtml
 }
 
 export default function plannotator(pi: ExtensionAPI): void {
+	initI18n(pi);
 	let phase: Phase = "idle";
 	void registerPlannotatorEventListeners(pi);
 	let lastSubmittedPath: string | null = null;
@@ -126,7 +128,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 	// ── Flags ────────────────────────────────────────────────────────────
 
 	pi.registerFlag("plan", {
-		description: "Start in plan mode (restricted exploration and planning)",
+		description: t("flag.plan.description", "Start in plan mode (restricted exploration and planning)"),
 		type: "boolean",
 		default: false,
 	});
@@ -251,7 +253,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 		await applyPhaseConfig(ctx, { restoreSavedState: false });
 		persistState();
 		ctx.ui.notify(
-			"Plannotator: planning mode enabled. Write a markdown plan, then submit it for review.",
+			t("notify.planning.enabled", "Plannotator: planning mode enabled. Write a markdown plan, then submit it for review."),
 		);
 		const warning = getPlanReviewAvailabilityWarning({ hasUI: ctx.hasUI, hasPlanHtml: hasPlanBrowserHtml() });
 		if (warning) {
@@ -269,7 +271,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 		updateStatus(ctx);
 		updateWidget(ctx);
 		persistState();
-		ctx.ui.notify("Plannotator: disabled. Full access restored.");
+		ctx.ui.notify(t("notify.disabled", "Plannotator: disabled. Full access restored."));
 	}
 
 	async function togglePlanMode(ctx: ExtensionContext): Promise<void> {
@@ -283,14 +285,14 @@ export default function plannotator(pi: ExtensionAPI): void {
 	// ── Commands & Shortcuts ─────────────────────────────────────────────
 
 	pi.registerCommand("plannotator", {
-		description: "Toggle plannotator planning mode",
+		description: t("cmd.toggle.description", "Toggle plannotator planning mode"),
 		handler: async (_args, ctx) => {
 			await togglePlanMode(ctx);
 		},
 	});
 
 	pi.registerCommand("plannotator-status", {
-		description: "Show plannotator status",
+		description: t("cmd.status.description", "Show plannotator status"),
 		handler: async (_args, ctx) => {
 			const parts = [`Phase: ${phase}`];
 			if (lastSubmittedPath) {
@@ -305,11 +307,11 @@ export default function plannotator(pi: ExtensionAPI): void {
 	});
 
 	pi.registerCommand("plannotator-review", {
-		description: "Open interactive code review for current changes or a PR URL",
+		description: t("cmd.review.description", "Open interactive code review for current changes or a PR URL"),
 		handler: async (args, ctx) => {
 			if (!hasReviewBrowserHtml()) {
 				ctx.ui.notify(
-					"Code review UI not available. Run 'bun run build' in the pi-extension directory.",
+					t("notify.review.assetsMissing", "Code review UI not available. Run 'bun run build' in the pi-extension directory."),
 					"error",
 				);
 				return;
@@ -320,7 +322,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 				const isPRReview = prUrl?.startsWith("http://") || prUrl?.startsWith("https://");
 				const result = await openCodeReview(ctx, { prUrl });
 				if (result.exit) {
-					ctx.ui.notify("Code review session closed.", "info");
+					ctx.ui.notify(t("notify.review.closed", "Code review session closed."), "info");
 				} else if (result.feedback) {
 					if (result.approved) {
 						pi.sendUserMessage(
@@ -336,11 +338,12 @@ export default function plannotator(pi: ExtensionAPI): void {
 						);
 					}
 				} else {
-					ctx.ui.notify("Code review closed (no feedback).", "info");
+					ctx.ui.notify(t("notify.review.noFeedback", "Code review closed (no feedback)."), "info");
 				}
 			} catch (err) {
+				const message = getStartupErrorMessage(err);
 				ctx.ui.notify(
-					`Failed to start code review UI: ${getStartupErrorMessage(err)}`,
+					t("notify.review.failedStart", `Failed to start code review UI: ${message}`, { message }),
 					"error",
 				);
 			}
@@ -348,7 +351,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 	});
 
 	pi.registerCommand("plannotator-annotate", {
-		description: "Open markdown file or folder in annotation UI",
+		description: t("cmd.annotate.description", "Open markdown file or folder in annotation UI"),
 		handler: async (args, ctx) => {
 			// #570: split --gate / --json from the path. --json is silently
 			// accepted (Pi writes back via sendUserMessage, not stdout).
@@ -356,7 +359,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 			// (scoped-package-style names).
 			const { filePath, rawFilePath, gate } = parseAnnotateArgs(args ?? "");
 			if (!filePath) {
-				ctx.ui.notify("Usage: /plannotator-annotate <file.md | file.html | https://... | folder/> [--gate] [--json]", "error");
+				ctx.ui.notify(t("notify.annotate.usage", "Usage: /plannotator-annotate <file.md | file.html | https://... | folder/> [--gate] [--json]"), "error");
 				return;
 			}
 			if (!hasPlanBrowserHtml()) {
@@ -380,13 +383,15 @@ export default function plannotator(pi: ExtensionAPI): void {
 
 			if (isUrl) {
 				const useJina = resolveUseJina(false, loadConfig());
-				ctx.ui.notify(`Fetching: ${filePath}${useJina ? " (via Jina Reader)" : " (via fetch+Turndown)"}...`, "info");
+				const fetchMode = useJina ? " (via Jina Reader)" : " (via fetch+Turndown)";
+				ctx.ui.notify(t("notify.annotate.fetching", `Fetching: ${filePath}${fetchMode}...`, { path: filePath, mode: fetchMode }), "info");
 				try {
 					const result = await urlToMarkdown(filePath, { useJina });
 					markdown = result.markdown;
 					sourceConverted = isConvertedSource(result.source);
 				} catch (err) {
-					ctx.ui.notify(`Failed to fetch URL: ${err instanceof Error ? err.message : String(err)}`, "error");
+					const message = err instanceof Error ? err.message : String(err);
+					ctx.ui.notify(t("notify.annotate.failedFetch", `Failed to fetch URL: ${message}`, { message }), "error");
 					return;
 				}
 				absolutePath = filePath;
@@ -402,7 +407,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 				});
 				if (resolvedCandidate === null) {
 					absolutePath = resolveUserPath(filePath, ctx.cwd);
-					ctx.ui.notify(`File not found: ${absolutePath}`, "error");
+					ctx.ui.notify(t("notify.annotate.fileNotFound", `File not found: ${absolutePath}`, { path: absolutePath }), "error");
 					return;
 				}
 				absolutePath = resolveUserPath(resolvedCandidate, ctx.cwd);
@@ -410,43 +415,44 @@ export default function plannotator(pi: ExtensionAPI): void {
 				try {
 					isFolder = statSync(absolutePath).isDirectory();
 				} catch {
-					ctx.ui.notify(`Cannot access: ${absolutePath}`, "error");
+					ctx.ui.notify(t("notify.annotate.cannotAccess", `Cannot access: ${absolutePath}`, { path: absolutePath }), "error");
 					return;
 				}
 
 				if (isFolder) {
 					if (!hasMarkdownFiles(absolutePath, FILE_BROWSER_EXCLUDED, /\.(mdx?|html?)$/i)) {
-						ctx.ui.notify(`No markdown or HTML files found in ${absolutePath}`, "error");
+						ctx.ui.notify(t("notify.annotate.noMarkdown", `No markdown or HTML files found in ${absolutePath}`, { path: absolutePath }), "error");
 						return;
 					}
 					markdown = "";
 					folderPath = absolutePath;
 					mode = "annotate-folder";
-					ctx.ui.notify(`Opening annotation UI for folder ${filePath}...`, "info");
+					ctx.ui.notify(t("notify.annotate.openFolder", `Opening annotation UI for folder ${filePath}...`, { path: filePath }), "info");
 				} else if (/\.html?$/i.test(absolutePath)) {
 					// HTML file annotation — convert to markdown via Turndown
 					const fileSize = statSync(absolutePath).size;
 					if (fileSize > 10 * 1024 * 1024) {
-						ctx.ui.notify(`File too large (${Math.round(fileSize / 1024 / 1024)}MB, max 10MB)`, "error");
+						const mb = Math.round(fileSize / 1024 / 1024);
+						ctx.ui.notify(t("notify.annotate.tooLarge", `File too large (${mb}MB, max 10MB)`, { mb }), "error");
 						return;
 					}
 					const html = readFileSync(absolutePath, "utf-8");
 					markdown = htmlToMarkdown(html);
 					sourceInfo = basename(absolutePath);
 					sourceConverted = true;
-					ctx.ui.notify(`Opening annotation UI for ${filePath}...`, "info");
+					ctx.ui.notify(t("notify.annotate.openFile", `Opening annotation UI for ${filePath}...`, { path: filePath }), "info");
 				} else {
 					markdown = readFileSync(absolutePath, "utf-8");
-					ctx.ui.notify(`Opening annotation UI for ${filePath}...`, "info");
+					ctx.ui.notify(t("notify.annotate.openFile", `Opening annotation UI for ${filePath}...`, { path: filePath }), "info");
 				}
 			}
 
 			try {
 				const result = await openMarkdownAnnotation(ctx, absolutePath, markdown, mode ?? "annotate", folderPath, sourceInfo, sourceConverted, gate);
 				if (result.approved) {
-					ctx.ui.notify("Annotation approved.", "info");
+					ctx.ui.notify(t("notify.annotate.approved", "Annotation approved."), "info");
 				} else if (result.exit) {
-					ctx.ui.notify("Annotation session closed.", "info");
+					ctx.ui.notify(t("notify.annotate.closed", "Annotation session closed."), "info");
 				} else if (result.feedback) {
 					pi.sendUserMessage(getAnnotateFileFeedbackPrompt("pi", loadConfig(), {
 						fileHeader: isFolder ? "Folder" : "File",
@@ -454,11 +460,12 @@ export default function plannotator(pi: ExtensionAPI): void {
 						feedback: result.feedback,
 					}));
 				} else {
-					ctx.ui.notify("Annotation closed (no feedback).", "info");
+					ctx.ui.notify(t("notify.annotate.noFeedback", "Annotation closed (no feedback)."), "info");
 				}
 			} catch (err) {
+				const message = getStartupErrorMessage(err);
 				ctx.ui.notify(
-					`Failed to start annotation UI: ${getStartupErrorMessage(err)}`,
+					t("notify.annotate.failedStart", `Failed to start annotation UI: ${message}`, { message }),
 					"error",
 				);
 			}
@@ -466,7 +473,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 	});
 
 	pi.registerCommand("plannotator-last", {
-		description: "Annotate the last assistant message",
+		description: t("cmd.annotateMessage.description", "Annotate the last assistant message"),
 		handler: async (args, ctx) => {
 			// #570: support --gate on /plannotator-last for Stop-hook review gate.
 			const { gate } = parseAnnotateArgs(args ?? "");
@@ -481,28 +488,29 @@ export default function plannotator(pi: ExtensionAPI): void {
 
 			const lastText = await getLastAssistantMessageText(ctx);
 			if (!lastText) {
-				ctx.ui.notify("No assistant message found in session.", "error");
+				ctx.ui.notify(t("notify.message.noAssistant", "No assistant message found in session."), "error");
 				return;
 			}
 
-			ctx.ui.notify("Opening annotation UI for last message...", "info");
+			ctx.ui.notify(t("notify.message.open", "Opening annotation UI for last message..."), "info");
 
 			try {
 				const result = await openLastMessageAnnotation(ctx, lastText, gate);
 				if (result.approved) {
-					ctx.ui.notify("Message approved.", "info");
+					ctx.ui.notify(t("notify.message.approved", "Message approved."), "info");
 				} else if (result.exit) {
-					ctx.ui.notify("Annotation session closed.", "info");
+					ctx.ui.notify(t("notify.annotate.closed", "Annotation session closed."), "info");
 				} else if (result.feedback) {
 					pi.sendUserMessage(getAnnotateMessageFeedbackPrompt("pi", loadConfig(), {
 						feedback: result.feedback,
 					}));
 				} else {
-					ctx.ui.notify("Annotation closed (no feedback).", "info");
+					ctx.ui.notify(t("notify.annotate.noFeedback", "Annotation closed (no feedback)."), "info");
 				}
 			} catch (err) {
+				const message = getStartupErrorMessage(err);
 				ctx.ui.notify(
-					`Failed to start annotation UI: ${getStartupErrorMessage(err)}`,
+					t("notify.annotate.failedStart", `Failed to start annotation UI: ${message}`, { message }),
 					"error",
 				);
 			}
@@ -510,7 +518,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 	});
 
 	pi.registerCommand("plannotator-archive", {
-		description: "Browse saved plan decisions",
+		description: t("cmd.archive.description", "Browse saved plan decisions"),
 		handler: async (_args, ctx) => {
 			if (!hasPlanBrowserHtml()) {
 				ctx.ui.notify(
@@ -520,14 +528,15 @@ export default function plannotator(pi: ExtensionAPI): void {
 				return;
 			}
 
-			ctx.ui.notify("Opening plan archive...", "info");
+			ctx.ui.notify(t("notify.archive.open", "Opening plan archive..."), "info");
 
 			try {
 				await openArchiveBrowserAction(ctx);
-				ctx.ui.notify("Archive browser closed.", "info");
+				ctx.ui.notify(t("notify.archive.closed", "Archive browser closed."), "info");
 			} catch (err) {
+				const message = getStartupErrorMessage(err);
 				ctx.ui.notify(
-					`Failed to start archive: ${getStartupErrorMessage(err)}`,
+					t("notify.archive.failedStart", `Failed to start archive: ${message}`, { message }),
 					"error",
 				);
 			}
@@ -535,7 +544,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 	});
 
 	pi.registerShortcut(Key.ctrlAlt("p"), {
-		description: "Toggle plannotator",
+		description: t("cmd.shortcut.description", "Toggle plannotator"),
 		handler: async (ctx) => {
 			await togglePlanMode(ctx);
 		},

--- a/apps/pi-extension/package.json
+++ b/apps/pi-extension/package.json
@@ -21,6 +21,7 @@
   },
   "files": [
     "index.ts",
+    "i18n.ts",
     "plannotator-browser.ts",
     "plannotator-events.ts",
     "server.ts",


### PR DESCRIPTION
I found one focused UX issue in the Pi extension: plan/review/annotation flows have status and error text exactly where users approve plans, request changes, open code review, or annotate files. If those messages are misread, the user can miss whether a review is closed, approved, missing assets, or waiting for feedback.

This PR makes that Pi-extension path optionally localizable while preserving the current English strings as fallbacks.

- No new dependency
- No behavior change without an i18n provider
- English remains the default/fallback
- Locales: ja, zh-CN, es — common developer workflow locales for review/approval UI
- Covers Pi command descriptions and high-friction review/annotation/archive notifications
- Does not touch generated browser UI bundles

Validation:
- npm pack --dry-run from apps/pi-extension

Note: bun is not available in this environment, so I could not run the repo's bun test/typecheck scripts here.