### PR TITLE
Feat: add Codex Plannotator skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,12 @@ irm https://plannotator.ai/install.ps1 | iex
 **Then in Codex — feedback flows back into the agent loop automatically:**
 
 ```
+$plannotator-review          # Code review skill for current changes
+$plannotator-annotate        # Annotate a markdown file, URL, or folder
+$plannotator-last            # Annotate the last agent message
+```
+
+```
 !plannotator review           # Code review for current changes
 !plannotator review <pr-url>  # Review a GitHub pull request
 !plannotator annotate file.md # Annotate a markdown file

--- a/apps/skills/plannotator-annotate/SKILL.md
+++ b/apps/skills/plannotator-annotate/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: plannotator-annotate
+description: Open Plannotator's annotation UI for a markdown file, converted HTML file, URL, or folder and then respond to the returned annotations.
+---
+
+# Plannotator Annotate
+
+Use this skill when the user wants to annotate a document in Plannotator instead of reviewing it inline in chat.
+
+Run:
+
+```bash
+plannotator annotate <path-or-url>
+```
+
+Behavior:
+
+1. Launch the command with Bash.
+2. Wait for the browser review to finish.
+3. If annotations are returned, address them directly.
+4. If the session closes without feedback, say so briefly and continue.
+
+Do not ask the user to paste a shell command into the chat. Run the command yourself.

--- a/apps/skills/plannotator-annotate/agents/openai.yaml
+++ b/apps/skills/plannotator-annotate/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Plannotator Annotate"
+  short_description: "Annotate a markdown file, URL, or folder in Plannotator."
+policy:
+  allow_implicit_invocation: false

--- a/apps/skills/plannotator-last/SKILL.md
+++ b/apps/skills/plannotator-last/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: plannotator-last
+description: Open Plannotator on the latest rendered assistant message and use the returned annotations to revise that message or continue.
+---
+
+# Plannotator Last
+
+Use this skill when the user wants to annotate the latest assistant response in Plannotator.
+
+Run:
+
+```bash
+plannotator last
+```
+
+Behavior:
+
+1. Launch the command with Bash.
+2. Wait for the annotation session to finish.
+3. If feedback is returned, incorporate it into the follow-up response.
+4. If the session closes without feedback, mention that briefly and continue.
+
+Run the command yourself rather than telling the user to invoke shell syntax manually.

--- a/apps/skills/plannotator-last/agents/openai.yaml
+++ b/apps/skills/plannotator-last/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Plannotator Last"
+  short_description: "Annotate the latest assistant message in Plannotator."
+policy:
+  allow_implicit_invocation: false

--- a/apps/skills/plannotator-review/SKILL.md
+++ b/apps/skills/plannotator-review/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: plannotator-review
+description: Open Plannotator's browser-based code review UI for the current worktree or a pull request URL, then act on the feedback that comes back.
+---
+
+# Plannotator Review
+
+Use this skill when the user wants to review current code changes in Plannotator instead of reading a diff inline.
+
+Run:
+
+```bash
+plannotator review [optional-pr-url]
+```
+
+Behavior:
+
+1. Launch the command with Bash.
+2. Wait for it to finish.
+3. If it returns feedback or annotations, address them in the same conversation.
+4. If it returns an approval/LGTM-style message, acknowledge that review passed and continue.
+
+Do not ask the user to copy shell commands into chat. Run the command yourself.

--- a/apps/skills/plannotator-review/agents/openai.yaml
+++ b/apps/skills/plannotator-review/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Plannotator Review"
+  short_description: "Open Plannotator code review for local changes or a PR."
+policy:
+  allow_implicit_invocation: false


### PR DESCRIPTION
## Summary
- add Codex-callable Plannotator skills for `review`, `annotate`, and `last`
- document the Codex skill entrypoints in the README
- keep plan mode out of scope; this only improves the existing manual Codex flows

## Why
Codex app does not accept `!` commands in chat, so the current direct shell-style Plannotator invocations are awkward or unavailable in the app experience.

There is also a workflow gap when Plannotator returns annotations in Codex CLI: the agent receives the feedback, but it does not proactively act on it unless the user sends another explicit follow-up message.

These skills help in both places:
- they make Plannotator callable from Codex app through `$plannotator-*` skills
- they instruct the agent to run the command itself, wait for the browser session to finish, and then act on the returned feedback without requiring an extra user prompt

## Screenshots
Codex App - Skill execution and waiting responses:
<img width="804" height="381" alt="image" src="https://github.com/user-attachments/assets/2086ec82-fe33-49ed-875b-4251283aa87f" />

Codex App - Receiving annotation and acting on it:
<img width="806" height="316" alt="image" src="https://github.com/user-attachments/assets/71ab2c16-a523-4f56-b986-01001d23e039" />


## Scope notes
This PR focuses only on the user-invoked Codex flows that already map well to Plannotator today.

## Test plan
- verify the new skill folders are present under `apps/skills/`
- verify the README documents the Codex skill entrypoints
