### PR TITLE
Make Pi browser review and annotation sessions async

### DIFF
--- a/apps/pi-extension/assistant-message.ts
+++ b/apps/pi-extension/assistant-message.ts
@@ -46,6 +46,8 @@ function getCurrentBranch(ctx: ExtensionContext): SessionEntryLike[] {
 }
 
 export function getLastAssistantMessageSnapshot(ctx: ExtensionContext): LastAssistantMessageSnapshot | null {
+	// "Last" means the active conversation branch, not the newest message anywhere
+	// in the append-only session file.
 	const branch = getCurrentBranch(ctx);
 	for (let i = branch.length - 1; i >= 0; i--) {
 		const entry = branch[i];

--- a/apps/pi-extension/assistant-message.ts
+++ b/apps/pi-extension/assistant-message.ts
@@ -1,0 +1,72 @@
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+
+type AssistantTextBlock = { type?: string; text?: string };
+
+type AssistantMessageLike = {
+	role?: unknown;
+	content?: unknown;
+};
+
+type SessionEntryLike = {
+	id: string;
+	type: string;
+	message?: AssistantMessageLike;
+};
+
+export type LastAssistantMessageSnapshot = {
+	entryId: string;
+	text: string;
+};
+
+function isAssistantMessage(message: AssistantMessageLike): message is { role: "assistant"; content: AssistantTextBlock[] } {
+	return message.role === "assistant" && Array.isArray(message.content);
+}
+
+function getTextContent(message: { content: AssistantTextBlock[] }): string {
+	return message.content
+		.filter((block): block is { type: "text"; text: string } => block.type === "text")
+		.map((block) => block.text)
+		.join("\n");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+export function getAssistantMessageText(message: unknown): string | null {
+	if (!isRecord(message)) return null;
+	const candidate = { role: message.role, content: message.content };
+	if (!isAssistantMessage(candidate)) return null;
+	const text = getTextContent(candidate);
+	return text.trim() ? text : null;
+}
+
+function getCurrentBranch(ctx: ExtensionContext): SessionEntryLike[] {
+	return ctx.sessionManager.getBranch() as SessionEntryLike[];
+}
+
+export function getLastAssistantMessageSnapshot(ctx: ExtensionContext): LastAssistantMessageSnapshot | null {
+	const branch = getCurrentBranch(ctx);
+	for (let i = branch.length - 1; i >= 0; i--) {
+		const entry = branch[i];
+		if (entry.type === "message" && entry.message) {
+			const text = getAssistantMessageText(entry.message);
+			if (text) return { entryId: entry.id, text };
+		}
+	}
+	return null;
+}
+
+export function getLastAssistantMessageText(ctx: ExtensionContext): string | null {
+	return getLastAssistantMessageSnapshot(ctx)?.text ?? null;
+}
+
+export function hasSessionMovedPastEntry(ctx: ExtensionContext, entryId: string): boolean {
+	if (!ctx.isIdle()) return true;
+
+	const branch = getCurrentBranch(ctx);
+	const index = branch.findIndex((entry) => entry.id === entryId);
+	if (index === -1) return true;
+
+	return branch.slice(index + 1).some((entry) => entry.type === "message");
+}

--- a/apps/pi-extension/current-pi-session.ts
+++ b/apps/pi-extension/current-pi-session.ts
@@ -8,10 +8,7 @@ type CurrentPiSession = {
 	token: symbol;
 	sendUserMessage: (content: SendUserMessageContent, options?: SendUserMessageOptions) => void;
 	notify?: (message: string, type?: NotificationType) => void;
-	sessionId?: string;
-	sessionFile?: string;
-	sessionName?: string;
-	cwd?: string;
+	identity?: PiSessionIdentity;
 };
 
 type CurrentPiSessionStore = {
@@ -28,6 +25,13 @@ export type CurrentPiSessionRegistration = {
 	clear: () => void;
 };
 
+export type PiSessionIdentity = {
+	sessionId?: string;
+	sessionFile?: string;
+	sessionName?: string;
+	cwd?: string;
+};
+
 const globalStore = globalThis as PlannotatorGlobal;
 
 function getStore(): CurrentPiSessionStore {
@@ -39,8 +43,20 @@ function getErrorMessage(err: unknown): string {
 	return err instanceof Error ? err.message : String(err);
 }
 
-export function isStalePiContextError(err: unknown): boolean {
-	return getErrorMessage(err).includes("This extension ctx is stale after session replacement or reload");
+export function getPiSessionIdentity(ctx: ExtensionContext): PiSessionIdentity {
+	return {
+		sessionId: ctx.sessionManager.getSessionId(),
+		sessionFile: ctx.sessionManager.getSessionFile(),
+		sessionName: ctx.sessionManager.getSessionName(),
+		cwd: ctx.cwd,
+	};
+}
+
+function isDifferentSession(origin: PiSessionIdentity, current: PiSessionIdentity | undefined): boolean {
+	if (!current) return false;
+	if (origin.sessionId && current.sessionId) return origin.sessionId !== current.sessionId;
+	if (origin.sessionFile && current.sessionFile) return origin.sessionFile !== current.sessionFile;
+	return false;
 }
 
 function setCurrentPiSession(token: symbol, pi: ExtensionAPI, ctx?: ExtensionContext): void {
@@ -54,10 +70,7 @@ function setCurrentPiSession(token: symbol, pi: ExtensionAPI, ctx?: ExtensionCon
 		current.notify = (message, type = "info") => {
 			ctx.ui.notify(message, type);
 		};
-		current.sessionId = ctx.sessionManager.getSessionId();
-		current.sessionFile = ctx.sessionManager.getSessionFile();
-		current.sessionName = ctx.sessionManager.getSessionName();
-		current.cwd = ctx.cwd;
+		current.identity = getPiSessionIdentity(ctx);
 	}
 	getStore().current = current;
 }
@@ -79,9 +92,14 @@ export function registerCurrentPiSession(pi: ExtensionAPI): CurrentPiSessionRegi
 	};
 }
 
-export function notifyCurrentPiSession(message: string, type: NotificationType = "info"): boolean {
+export function notifyCurrentPiSession(
+	message: string,
+	type: NotificationType = "info",
+	origin?: PiSessionIdentity,
+): boolean {
 	const current = getStore().current;
 	if (!current?.notify) return false;
+	if (origin && !isDifferentSession(origin, current.identity)) return false;
 	try {
 		current.notify(message, type);
 		return true;
@@ -91,10 +109,14 @@ export function notifyCurrentPiSession(message: string, type: NotificationType =
 	}
 }
 
+export function isCurrentPiSessionDifferentFrom(origin: PiSessionIdentity): boolean {
+	return isDifferentSession(origin, getStore().current?.identity);
+}
+
 function getCurrentPiSessionLabel(): string {
-	const current = getStore().current;
-	if (!current) return "unknown";
-	return current.sessionName || current.sessionFile || current.sessionId || "current active Pi session";
+	const identity = getStore().current?.identity;
+	if (!identity) return "unknown";
+	return identity.sessionName || identity.sessionFile || identity.sessionId || "current active Pi session";
 }
 
 export function withCurrentPiSessionFallbackHeader(content: SendUserMessageContent): SendUserMessageContent {
@@ -107,15 +129,19 @@ ${content}`;
 export function sendUserMessageToCurrentPiSession(
 	content: SendUserMessageContent,
 	options?: SendUserMessageOptions,
-): { ok: true } | { ok: false; error: unknown } {
+	origin?: PiSessionIdentity,
+): { ok: true } | { ok: false; reason: "no-current" | "same-session" | "send-failed"; error: unknown } {
 	const current = getStore().current;
 	if (!current) {
-		return { ok: false, error: new Error("No active Pi session is available.") };
+		return { ok: false, reason: "no-current", error: new Error("No active Pi session is available.") };
+	}
+	if (origin && !isDifferentSession(origin, current.identity)) {
+		return { ok: false, reason: "same-session", error: new Error("No different active Pi session is available.") };
 	}
 	try {
 		current.sendUserMessage(content, options);
 		return { ok: true };
 	} catch (err) {
-		return { ok: false, error: err };
+		return { ok: false, reason: "send-failed", error: err };
 	}
 }

--- a/apps/pi-extension/current-pi-session.ts
+++ b/apps/pi-extension/current-pi-session.ts
@@ -1,0 +1,121 @@
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+
+type SendUserMessageContent = Parameters<ExtensionAPI["sendUserMessage"]>[0];
+type SendUserMessageOptions = Parameters<ExtensionAPI["sendUserMessage"]>[1];
+type NotificationType = "info" | "warning" | "error";
+
+type CurrentPiSession = {
+	token: symbol;
+	sendUserMessage: (content: SendUserMessageContent, options?: SendUserMessageOptions) => void;
+	notify?: (message: string, type?: NotificationType) => void;
+	sessionId?: string;
+	sessionFile?: string;
+	sessionName?: string;
+	cwd?: string;
+};
+
+type CurrentPiSessionStore = {
+	current?: CurrentPiSession;
+};
+
+type PlannotatorGlobal = typeof globalThis & {
+	__plannotatorCurrentPiSession?: CurrentPiSessionStore;
+};
+
+export type CurrentPiSessionRegistration = {
+	token: symbol;
+	update: (ctx: ExtensionContext) => void;
+	clear: () => void;
+};
+
+const globalStore = globalThis as PlannotatorGlobal;
+
+function getStore(): CurrentPiSessionStore {
+	globalStore.__plannotatorCurrentPiSession ??= {};
+	return globalStore.__plannotatorCurrentPiSession;
+}
+
+function getErrorMessage(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}
+
+export function isStalePiContextError(err: unknown): boolean {
+	return getErrorMessage(err).includes("This extension ctx is stale after session replacement or reload");
+}
+
+function setCurrentPiSession(token: symbol, pi: ExtensionAPI, ctx?: ExtensionContext): void {
+	const current: CurrentPiSession = {
+		token,
+		sendUserMessage: (content, options) => {
+			pi.sendUserMessage(content, options);
+		},
+	};
+	if (ctx) {
+		current.notify = (message, type = "info") => {
+			ctx.ui.notify(message, type);
+		};
+		current.sessionId = ctx.sessionManager.getSessionId();
+		current.sessionFile = ctx.sessionManager.getSessionFile();
+		current.sessionName = ctx.sessionManager.getSessionName();
+		current.cwd = ctx.cwd;
+	}
+	getStore().current = current;
+}
+
+export function registerCurrentPiSession(pi: ExtensionAPI): CurrentPiSessionRegistration {
+	const token = Symbol("plannotator-current-pi-session");
+	setCurrentPiSession(token, pi);
+	return {
+		token,
+		update: (ctx) => {
+			setCurrentPiSession(token, pi, ctx);
+		},
+		clear: () => {
+			const store = getStore();
+			if (store.current?.token === token) {
+				store.current = undefined;
+			}
+		},
+	};
+}
+
+export function notifyCurrentPiSession(message: string, type: NotificationType = "info"): boolean {
+	const current = getStore().current;
+	if (!current?.notify) return false;
+	try {
+		current.notify(message, type);
+		return true;
+	} catch (err) {
+		console.error(`Plannotator current-session notification failed: ${getErrorMessage(err)}`);
+		return false;
+	}
+}
+
+function getCurrentPiSessionLabel(): string {
+	const current = getStore().current;
+	if (!current) return "unknown";
+	return current.sessionName || current.sessionFile || current.sessionId || "current active Pi session";
+}
+
+export function withCurrentPiSessionFallbackHeader(content: SendUserMessageContent): SendUserMessageContent {
+	if (typeof content !== "string") return content;
+	return `This Plannotator feedback was submitted from a browser tab opened before Pi switched sessions. It is being delivered to ${getCurrentPiSessionLabel()} because the original Pi session is no longer active.
+
+${content}`;
+}
+
+export function sendUserMessageToCurrentPiSession(
+	content: SendUserMessageContent,
+	options?: SendUserMessageOptions,
+): { ok: true } | { ok: false; error: unknown } {
+	const current = getStore().current;
+	if (!current) {
+		return { ok: false, error: new Error("No active Pi session is available.") };
+	}
+	try {
+		current.sendUserMessage(content, options);
+		return { ok: true };
+	} catch (err) {
+		return { ok: false, error: err };
+	}
+}

--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -67,6 +67,13 @@ import {
 	hasSessionMovedPastEntry,
 } from "./assistant-message.js";
 import {
+	isStalePiContextError,
+	notifyCurrentPiSession,
+	registerCurrentPiSession,
+	sendUserMessageToCurrentPiSession,
+	withCurrentPiSessionFallbackHeader,
+} from "./current-pi-session.js";
+import {
 	getToolsForPhase,
 	isPlanWritePathAllowed,
 	PLAN_SUBMIT_TOOL,
@@ -109,6 +116,7 @@ function safeNotify(
 	try {
 		ctx.ui.notify(message, type);
 	} catch (err) {
+		if (isStalePiContextError(err) && notifyCurrentPiSession(message, type)) return;
 		console.error(`Plannotator notification failed: ${err instanceof Error ? err.message : String(err)}`);
 	}
 }
@@ -141,13 +149,55 @@ User feedback:
 ${feedback}`;
 }
 
+function shouldAnchorLastMessageFeedback(ctx: ExtensionContext, entryId: string): boolean {
+	try {
+		return hasSessionMovedPastEntry(ctx, entryId);
+	} catch (err) {
+		if (isStalePiContextError(err)) return true;
+		throw err;
+	}
+}
+
+function sendUserMessageWithCurrentSessionFallback(
+	pi: ExtensionAPI,
+	content: Parameters<ExtensionAPI["sendUserMessage"]>[0],
+	options: Parameters<ExtensionAPI["sendUserMessage"]>[1],
+	errorMessage: string,
+): void {
+	try {
+		pi.sendUserMessage(content, options);
+		return;
+	} catch (err) {
+		if (!isStalePiContextError(err)) throw err;
+
+		const result = sendUserMessageToCurrentPiSession(
+			withCurrentPiSessionFallbackHeader(content),
+			options,
+		);
+		if (result.ok) return;
+
+		const detail = getStartupErrorMessage(result.error);
+		console.error(`${errorMessage}: ${detail}`);
+		notifyCurrentPiSession(`${errorMessage}: ${detail}`, "error");
+	}
+}
+
 export default function plannotator(pi: ExtensionAPI): void {
+	const currentPiSession = registerCurrentPiSession(pi);
 	let phase: Phase = "idle";
 	void registerPlannotatorEventListeners(pi);
 	let lastSubmittedPath: string | null = null;
 	let checklistItems: ChecklistItem[] = [];
 	let savedState: SavedPhaseState | null = null;
 	let plannotatorConfig = {};
+
+	pi.on("session_start", (_event, ctx) => {
+		currentPiSession.update(ctx);
+	});
+
+	pi.on("session_shutdown", () => {
+		currentPiSession.clear();
+	});
 
 	// ── Flags ────────────────────────────────────────────────────────────
 
@@ -355,7 +405,12 @@ export default function plannotator(pi: ExtensionAPI): void {
 								return;
 							}
 							if (result.approved) {
-								pi.sendUserMessage(getReviewApprovedPrompt("pi", loadConfig()), { deliverAs: "followUp" });
+								sendUserMessageWithCurrentSessionFallback(
+									pi,
+									getReviewApprovedPrompt("pi", loadConfig()),
+									{ deliverAs: "followUp" },
+									"Plannotator code review feedback could not be sent",
+								);
 								return;
 							}
 							if (!result.feedback) {
@@ -365,12 +420,20 @@ export default function plannotator(pi: ExtensionAPI): void {
 							if (isPRReview) {
 								// Platform PR actions (approve/comment) return approved:false with a
 								// status message — don't tell the agent to "address" a platform action.
-								pi.sendUserMessage(result.feedback, { deliverAs: "followUp" });
+								sendUserMessageWithCurrentSessionFallback(
+									pi,
+									result.feedback,
+									{ deliverAs: "followUp" },
+									"Plannotator code review feedback could not be sent",
+								);
 								return;
 							}
-							pi.sendUserMessage(`${result.feedback}${getReviewDeniedSuffix("pi", loadConfig())}`, {
-								deliverAs: "followUp",
-							});
+							sendUserMessageWithCurrentSessionFallback(
+								pi,
+								`${result.feedback}${getReviewDeniedSuffix("pi", loadConfig())}`,
+								{ deliverAs: "followUp" },
+								"Plannotator code review feedback could not be sent",
+							);
 						} catch (err) {
 							reportBackgroundError(ctx, "Plannotator code review feedback could not be sent", err);
 						}
@@ -509,13 +572,15 @@ export default function plannotator(pi: ExtensionAPI): void {
 								safeNotify(ctx, "Annotation closed (no feedback).", "info");
 								return;
 							}
-							pi.sendUserMessage(
+							sendUserMessageWithCurrentSessionFallback(
+								pi,
 								getAnnotateFileFeedbackPrompt("pi", loadConfig(), {
 									fileHeader: isFolder ? "Folder" : "File",
 									filePath: absolutePath,
 									feedback: result.feedback,
 								}),
 								{ deliverAs: "followUp" },
+								"Plannotator annotation feedback could not be sent",
 							);
 						} catch (err) {
 							reportBackgroundError(ctx, "Plannotator annotation feedback could not be sent", err);
@@ -574,14 +639,16 @@ export default function plannotator(pi: ExtensionAPI): void {
 								safeNotify(ctx, "Annotation closed (no feedback).", "info");
 								return;
 							}
-							const feedback = hasSessionMovedPastEntry(ctx, snapshot.entryId)
+							const feedback = shouldAnchorLastMessageFeedback(ctx, snapshot.entryId)
 								? anchorMessageFeedback(result.feedback, snapshot.text)
 								: result.feedback;
-							pi.sendUserMessage(
+							sendUserMessageWithCurrentSessionFallback(
+								pi,
 								getAnnotateMessageFeedbackPrompt("pi", loadConfig(), {
 									feedback,
 								}),
 								{ deliverAs: "followUp" },
+								"Plannotator message annotation feedback could not be sent",
 							);
 						} catch (err) {
 							reportBackgroundError(ctx, "Plannotator message annotation feedback could not be sent", err);

--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -62,6 +62,11 @@ import {
 	registerPlannotatorEventListeners,
 } from "./plannotator-events.js";
 import {
+	getAssistantMessageText,
+	getLastAssistantMessageSnapshot,
+	hasSessionMovedPastEntry,
+} from "./assistant-message.js";
+import {
 	getToolsForPhase,
 	isPlanWritePathAllowed,
 	PLAN_SUBMIT_TOOL,
@@ -83,35 +88,6 @@ type PersistedPlannotatorState = {
 	lastSubmittedPath?: string;
 	savedState?: SavedPhaseState;
 };
-
-type AssistantTextBlock = { type?: string; text?: string };
-
-type AssistantMessageLike = {
-	role?: unknown;
-	content?: unknown;
-};
-
-type SessionEntryLike = {
-	id: string;
-	type: string;
-	message?: AssistantMessageLike;
-};
-
-type LastAssistantMessageSnapshot = {
-	entryId: string;
-	text: string;
-};
-
-function isAssistantMessage(m: AssistantMessageLike): m is { role: "assistant"; content: AssistantTextBlock[] } {
-	return m.role === "assistant" && Array.isArray(m.content);
-}
-
-function getTextContent(message: { content: AssistantTextBlock[] }): string {
-	return message.content
-		.filter((block): block is { type: "text"; text: string } => block.type === "text")
-		.map((block) => block.text)
-		.join("\n");
-}
 
 function getPlanReviewAvailabilityWarning(options: { hasUI: boolean; hasPlanHtml: boolean }): string | null {
 	const { hasUI, hasPlanHtml } = options;
@@ -141,28 +117,6 @@ function reportBackgroundError(ctx: ExtensionContext, message: string, err: unkn
 	const detail = getStartupErrorMessage(err);
 	console.error(`${message}: ${detail}`);
 	safeNotify(ctx, `${message}: ${detail}`, "error");
-}
-
-function getLastAssistantMessageSnapshot(ctx: ExtensionContext): LastAssistantMessageSnapshot | null {
-	const branch = ctx.sessionManager.getBranch() as SessionEntryLike[];
-	for (let i = branch.length - 1; i >= 0; i--) {
-		const entry = branch[i];
-		if (entry.type === "message" && entry.message && isAssistantMessage(entry.message)) {
-			const text = getTextContent(entry.message);
-			if (text.trim()) return { entryId: entry.id, text };
-		}
-	}
-	return null;
-}
-
-function hasSessionMovedPastEntry(ctx: ExtensionContext, entryId: string): boolean {
-	if (!ctx.isIdle()) return true;
-
-	const branch = ctx.sessionManager.getBranch() as SessionEntryLike[];
-	const index = branch.findIndex((entry) => entry.id === entryId);
-	if (index === -1) return true;
-
-	return branch.slice(index + 1).some((entry) => entry.type === "message");
 }
 
 function excerptText(text: string, maxChars = 1000): string {
@@ -1062,9 +1016,9 @@ Execute each step in order. After completing a step, include [DONE:n] in your re
 	// Track execution progress
 	pi.on("turn_end", async (event, ctx) => {
 		if (phase !== "executing" || checklistItems.length === 0) return;
-		if (!isAssistantMessage(event.message as AssistantMessageLike)) return;
 
-		const text = getTextContent(event.message as { content: AssistantTextBlock[] });
+		const text = getAssistantMessageText(event.message);
+		if (!text) return;
 		if (markCompletedSteps(text, checklistItems) > 0) {
 			updateStatus(ctx);
 			updateWidget(ctx);
@@ -1148,13 +1102,9 @@ Execute each step in order. After completing a step, include [DONE:n] in your re
 
 					for (let i = executeIndex + 1; i < entries.length; i++) {
 						const entry = entries[i];
-						if (
-							entry.type === "message" &&
-							"message" in entry &&
-							isAssistantMessage(entry.message as AssistantMessageLike)
-						) {
-							const text = getTextContent(entry.message as { content: AssistantTextBlock[] });
-							markCompletedSteps(text, checklistItems);
+						if (entry.type === "message" && "message" in entry) {
+							const text = getAssistantMessageText(entry.message);
+							if (text) markCompletedSteps(text, checklistItems);
 						}
 					}
 				} else {

--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -67,8 +67,10 @@ import {
 	hasSessionMovedPastEntry,
 } from "./assistant-message.js";
 import {
-	isStalePiContextError,
+	getPiSessionIdentity,
+	isCurrentPiSessionDifferentFrom,
 	notifyCurrentPiSession,
+	type PiSessionIdentity,
 	registerCurrentPiSession,
 	sendUserMessageToCurrentPiSession,
 	withCurrentPiSessionFallbackHeader,
@@ -112,19 +114,20 @@ function safeNotify(
 	ctx: ExtensionContext,
 	message: string,
 	type: "info" | "warning" | "error" = "info",
+	origin?: PiSessionIdentity,
 ): void {
 	try {
 		ctx.ui.notify(message, type);
 	} catch (err) {
-		if (isStalePiContextError(err) && notifyCurrentPiSession(message, type)) return;
+		if (notifyCurrentPiSession(message, type, origin)) return;
 		console.error(`Plannotator notification failed: ${err instanceof Error ? err.message : String(err)}`);
 	}
 }
 
-function reportBackgroundError(ctx: ExtensionContext, message: string, err: unknown): void {
+function reportBackgroundError(ctx: ExtensionContext, message: string, err: unknown, origin?: PiSessionIdentity): void {
 	const detail = getStartupErrorMessage(err);
 	console.error(`${message}: ${detail}`);
-	safeNotify(ctx, `${message}: ${detail}`, "error");
+	safeNotify(ctx, `${message}: ${detail}`, "error", origin);
 }
 
 function excerptText(text: string, maxChars = 1000): string {
@@ -149,13 +152,38 @@ User feedback:
 ${feedback}`;
 }
 
-function shouldAnchorLastMessageFeedback(ctx: ExtensionContext, entryId: string): boolean {
+function shouldAnchorLastMessageFeedback(ctx: ExtensionContext, entryId: string, origin: PiSessionIdentity): boolean {
+	if (isCurrentPiSessionDifferentFrom(origin)) return true;
 	try {
 		return hasSessionMovedPastEntry(ctx, entryId);
-	} catch (err) {
-		if (isStalePiContextError(err)) return true;
-		throw err;
+	} catch {
+		return true;
 	}
+}
+
+function reportCurrentSessionSendFailure(errorMessage: string, err: unknown, origin: PiSessionIdentity): void {
+	const detail = getStartupErrorMessage(err);
+	console.error(`${errorMessage}: ${detail}`);
+	notifyCurrentPiSession(`${errorMessage}: ${detail}`, "error", origin);
+}
+
+function trySendUserMessageToDifferentCurrentSession(
+	content: Parameters<ExtensionAPI["sendUserMessage"]>[0],
+	options: Parameters<ExtensionAPI["sendUserMessage"]>[1],
+	errorMessage: string,
+	origin: PiSessionIdentity,
+): boolean {
+	const result = sendUserMessageToCurrentPiSession(
+		withCurrentPiSessionFallbackHeader(content),
+		options,
+		origin,
+	);
+	if (result.ok) return true;
+	if (result.reason === "send-failed") {
+		reportCurrentSessionSendFailure(errorMessage, result.error, origin);
+		return true;
+	}
+	return false;
 }
 
 function sendUserMessageWithCurrentSessionFallback(
@@ -163,22 +191,16 @@ function sendUserMessageWithCurrentSessionFallback(
 	content: Parameters<ExtensionAPI["sendUserMessage"]>[0],
 	options: Parameters<ExtensionAPI["sendUserMessage"]>[1],
 	errorMessage: string,
+	origin: PiSessionIdentity,
 ): void {
+	if (trySendUserMessageToDifferentCurrentSession(content, options, errorMessage, origin)) return;
+
 	try {
 		pi.sendUserMessage(content, options);
 		return;
 	} catch (err) {
-		if (!isStalePiContextError(err)) throw err;
-
-		const result = sendUserMessageToCurrentPiSession(
-			withCurrentPiSessionFallbackHeader(content),
-			options,
-		);
-		if (result.ok) return;
-
-		const detail = getStartupErrorMessage(result.error);
-		console.error(`${errorMessage}: ${detail}`);
-		notifyCurrentPiSession(`${errorMessage}: ${detail}`, "error");
+		if (trySendUserMessageToDifferentCurrentSession(content, options, errorMessage, origin)) return;
+		throw err;
 	}
 }
 
@@ -391,6 +413,9 @@ export default function plannotator(pi: ExtensionAPI): void {
 				return;
 			}
 
+			currentPiSession.update(ctx);
+			const origin = getPiSessionIdentity(ctx);
+
 			try {
 				const prUrl = args?.trim() || undefined;
 				const isPRReview = prUrl?.startsWith("http://") || prUrl?.startsWith("https://");
@@ -401,7 +426,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 					.then((result) => {
 						try {
 							if (result.exit) {
-								safeNotify(ctx, "Code review session closed.", "info");
+								safeNotify(ctx, "Code review session closed.", "info", origin);
 								return;
 							}
 							if (result.approved) {
@@ -410,11 +435,12 @@ export default function plannotator(pi: ExtensionAPI): void {
 									getReviewApprovedPrompt("pi", loadConfig()),
 									{ deliverAs: "followUp" },
 									"Plannotator code review feedback could not be sent",
+									origin,
 								);
 								return;
 							}
 							if (!result.feedback) {
-								safeNotify(ctx, "Code review closed (no feedback).", "info");
+								safeNotify(ctx, "Code review closed (no feedback).", "info", origin);
 								return;
 							}
 							if (isPRReview) {
@@ -425,6 +451,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 									result.feedback,
 									{ deliverAs: "followUp" },
 									"Plannotator code review feedback could not be sent",
+									origin,
 								);
 								return;
 							}
@@ -433,13 +460,14 @@ export default function plannotator(pi: ExtensionAPI): void {
 								`${result.feedback}${getReviewDeniedSuffix("pi", loadConfig())}`,
 								{ deliverAs: "followUp" },
 								"Plannotator code review feedback could not be sent",
+								origin,
 							);
 						} catch (err) {
-							reportBackgroundError(ctx, "Plannotator code review feedback could not be sent", err);
+							reportBackgroundError(ctx, "Plannotator code review feedback could not be sent", err, origin);
 						}
 					})
 					.catch((err) => {
-						reportBackgroundError(ctx, "Plannotator code review session failed", err);
+						reportBackgroundError(ctx, "Plannotator code review session failed", err, origin);
 					});
 			} catch (err) {
 				ctx.ui.notify(
@@ -544,6 +572,9 @@ export default function plannotator(pi: ExtensionAPI): void {
 				}
 			}
 
+			currentPiSession.update(ctx);
+			const origin = getPiSessionIdentity(ctx);
+
 			try {
 				const session = await startMarkdownAnnotationSession(
 					ctx,
@@ -561,15 +592,15 @@ export default function plannotator(pi: ExtensionAPI): void {
 					.then((result) => {
 						try {
 							if (result.exit) {
-								safeNotify(ctx, "Annotation session closed.", "info");
+								safeNotify(ctx, "Annotation session closed.", "info", origin);
 								return;
 							}
 							if (result.approved) {
-								safeNotify(ctx, "Annotation approved.", "info");
+								safeNotify(ctx, "Annotation approved.", "info", origin);
 								return;
 							}
 							if (!result.feedback) {
-								safeNotify(ctx, "Annotation closed (no feedback).", "info");
+								safeNotify(ctx, "Annotation closed (no feedback).", "info", origin);
 								return;
 							}
 							sendUserMessageWithCurrentSessionFallback(
@@ -581,13 +612,14 @@ export default function plannotator(pi: ExtensionAPI): void {
 								}),
 								{ deliverAs: "followUp" },
 								"Plannotator annotation feedback could not be sent",
+								origin,
 							);
 						} catch (err) {
-							reportBackgroundError(ctx, "Plannotator annotation feedback could not be sent", err);
+							reportBackgroundError(ctx, "Plannotator annotation feedback could not be sent", err, origin);
 						}
 					})
 					.catch((err) => {
-						reportBackgroundError(ctx, "Plannotator annotation session failed", err);
+						reportBackgroundError(ctx, "Plannotator annotation session failed", err, origin);
 					});
 			} catch (err) {
 				ctx.ui.notify(
@@ -612,6 +644,9 @@ export default function plannotator(pi: ExtensionAPI): void {
 				return;
 			}
 
+			currentPiSession.update(ctx);
+			const origin = getPiSessionIdentity(ctx);
+
 			const snapshot = getLastAssistantMessageSnapshot(ctx);
 			if (!snapshot) {
 				ctx.ui.notify("No assistant message found in session.", "error");
@@ -628,18 +663,18 @@ export default function plannotator(pi: ExtensionAPI): void {
 					.then((result) => {
 						try {
 							if (result.exit) {
-								safeNotify(ctx, "Annotation session closed.", "info");
+								safeNotify(ctx, "Annotation session closed.", "info", origin);
 								return;
 							}
 							if (result.approved) {
-								safeNotify(ctx, "Message approved.", "info");
+								safeNotify(ctx, "Message approved.", "info", origin);
 								return;
 							}
 							if (!result.feedback) {
-								safeNotify(ctx, "Annotation closed (no feedback).", "info");
+								safeNotify(ctx, "Annotation closed (no feedback).", "info", origin);
 								return;
 							}
-							const feedback = shouldAnchorLastMessageFeedback(ctx, snapshot.entryId)
+							const feedback = shouldAnchorLastMessageFeedback(ctx, snapshot.entryId, origin)
 								? anchorMessageFeedback(result.feedback, snapshot.text)
 								: result.feedback;
 							sendUserMessageWithCurrentSessionFallback(
@@ -649,13 +684,14 @@ export default function plannotator(pi: ExtensionAPI): void {
 								}),
 								{ deliverAs: "followUp" },
 								"Plannotator message annotation feedback could not be sent",
+								origin,
 							);
 						} catch (err) {
-							reportBackgroundError(ctx, "Plannotator message annotation feedback could not be sent", err);
+							reportBackgroundError(ctx, "Plannotator message annotation feedback could not be sent", err, origin);
 						}
 					})
 					.catch((err) => {
-						reportBackgroundError(ctx, "Plannotator message annotation session failed", err);
+						reportBackgroundError(ctx, "Plannotator message annotation session failed", err, origin);
 					});
 			} catch (err) {
 				ctx.ui.notify(

--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -56,9 +56,9 @@ import {
 	hasReviewBrowserHtml,
 	getStartupErrorMessage,
 	openArchiveBrowserAction,
-	openCodeReview,
-	openLastMessageAnnotation,
-	openMarkdownAnnotation,
+	startCodeReviewBrowserSession,
+	startLastMessageAnnotationSession,
+	startMarkdownAnnotationSession,
 	openPlanReviewBrowser,
 	registerPlannotatorEventListeners,
 } from "./plannotator-events.js";
@@ -318,26 +318,32 @@ export default function plannotator(pi: ExtensionAPI): void {
 			try {
 				const prUrl = args?.trim() || undefined;
 				const isPRReview = prUrl?.startsWith("http://") || prUrl?.startsWith("https://");
-				const result = await openCodeReview(ctx, { prUrl });
-				if (result.exit) {
-					ctx.ui.notify("Code review session closed.", "info");
-				} else if (result.feedback) {
-					if (result.approved) {
-						pi.sendUserMessage(
-							getReviewApprovedPrompt("pi", loadConfig()),
-						);
-					} else if (isPRReview) {
-						// Platform PR actions (approve/comment) return approved:false with a
-						// status message — don't tell the agent to "address" a platform action.
-						pi.sendUserMessage(result.feedback);
-					} else {
-						pi.sendUserMessage(
-							`${result.feedback}${getReviewDeniedSuffix("pi", loadConfig())}`,
-						);
-					}
-				} else {
-					ctx.ui.notify("Code review closed (no feedback).", "info");
-				}
+				const session = await startCodeReviewBrowserSession(ctx, { prUrl });
+				ctx.ui.notify("Code review opened. You can keep chatting while it runs.", "info");
+				void session
+					.waitForDecision()
+					.then((result) => {
+						if (result.exit) {
+							return;
+						}
+						if (!result.feedback) {
+							return;
+						}
+						if (result.approved) {
+							pi.sendUserMessage(getReviewApprovedPrompt("pi", loadConfig()));
+							return;
+						}
+						if (isPRReview) {
+							// Platform PR actions (approve/comment) return approved:false with a
+							// status message — don't tell the agent to "address" a platform action.
+							pi.sendUserMessage(result.feedback);
+							return;
+						}
+						pi.sendUserMessage(`${result.feedback}${getReviewDeniedSuffix("pi", loadConfig())}`);
+					})
+					.catch(() => {
+						// Browser/session startup already reported a visible error.
+					});
 			} catch (err) {
 				ctx.ui.notify(
 					`Failed to start code review UI: ${getStartupErrorMessage(err)}`,
@@ -442,20 +448,34 @@ export default function plannotator(pi: ExtensionAPI): void {
 			}
 
 			try {
-				const result = await openMarkdownAnnotation(ctx, absolutePath, markdown, mode ?? "annotate", folderPath, sourceInfo, sourceConverted, gate);
-				if (result.approved) {
-					ctx.ui.notify("Annotation approved.", "info");
-				} else if (result.exit) {
-					ctx.ui.notify("Annotation session closed.", "info");
-				} else if (result.feedback) {
-					pi.sendUserMessage(getAnnotateFileFeedbackPrompt("pi", loadConfig(), {
-						fileHeader: isFolder ? "Folder" : "File",
-						filePath: absolutePath,
-						feedback: result.feedback,
-					}));
-				} else {
-					ctx.ui.notify("Annotation closed (no feedback).", "info");
-				}
+				const session = await startMarkdownAnnotationSession(
+					ctx,
+					absolutePath,
+					markdown,
+					mode ?? "annotate",
+					folderPath,
+					sourceInfo,
+					sourceConverted,
+					gate,
+				);
+				ctx.ui.notify("Annotation opened. You can keep chatting while it runs.", "info");
+				void session
+					.waitForDecision()
+					.then((result) => {
+						if (result.exit || result.approved || !result.feedback) {
+							return;
+						}
+						pi.sendUserMessage(
+							getAnnotateFileFeedbackPrompt("pi", loadConfig(), {
+								fileHeader: isFolder ? "Folder" : "File",
+								filePath: absolutePath,
+								feedback: result.feedback,
+							}),
+						);
+					})
+					.catch(() => {
+						// Browser/session startup already reported a visible error.
+					});
 			} catch (err) {
 				ctx.ui.notify(
 					`Failed to start annotation UI: ${getStartupErrorMessage(err)}`,
@@ -488,18 +508,23 @@ export default function plannotator(pi: ExtensionAPI): void {
 			ctx.ui.notify("Opening annotation UI for last message...", "info");
 
 			try {
-				const result = await openLastMessageAnnotation(ctx, lastText, gate);
-				if (result.approved) {
-					ctx.ui.notify("Message approved.", "info");
-				} else if (result.exit) {
-					ctx.ui.notify("Annotation session closed.", "info");
-				} else if (result.feedback) {
-					pi.sendUserMessage(getAnnotateMessageFeedbackPrompt("pi", loadConfig(), {
-						feedback: result.feedback,
-					}));
-				} else {
-					ctx.ui.notify("Annotation closed (no feedback).", "info");
-				}
+				const session = await startLastMessageAnnotationSession(ctx, lastText, gate);
+				ctx.ui.notify("Last-message annotation opened. You can keep chatting while it runs.", "info");
+				void session
+					.waitForDecision()
+					.then((result) => {
+						if (result.exit || result.approved || !result.feedback) {
+							return;
+						}
+						pi.sendUserMessage(
+							getAnnotateMessageFeedbackPrompt("pi", loadConfig(), {
+								feedback: result.feedback,
+							}),
+						);
+					})
+					.catch(() => {
+						// Browser/session startup already reported a visible error.
+					});
 			} catch (err) {
 				ctx.ui.notify(
 					`Failed to start annotation UI: ${getStartupErrorMessage(err)}`,

--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -51,7 +51,6 @@ import {
 import { parseAnnotateArgs } from "./generated/annotate-args.js";
 import { resolveAtReference } from "./generated/at-reference.js";
 import {
-	getLastAssistantMessageText,
 	hasPlanBrowserHtml,
 	hasReviewBrowserHtml,
 	getStartupErrorMessage,
@@ -92,6 +91,17 @@ type AssistantMessageLike = {
 	content?: unknown;
 };
 
+type SessionEntryLike = {
+	id: string;
+	type: string;
+	message?: AssistantMessageLike;
+};
+
+type LastAssistantMessageSnapshot = {
+	entryId: string;
+	text: string;
+};
+
 function isAssistantMessage(m: AssistantMessageLike): m is { role: "assistant"; content: AssistantTextBlock[] } {
 	return m.role === "assistant" && Array.isArray(m.content);
 }
@@ -113,6 +123,68 @@ function getPlanReviewAvailabilityWarning(options: { hasUI: boolean; hasPlanHtml
 		return "Plannotator: interactive plan review is unavailable in this session (no UI support). Plans will auto-approve on exit_plan_mode.";
 	}
 	return "Plannotator: interactive plan review assets are missing. Rebuild the extension to restore the browser UI. Plans will auto-approve on exit_plan_mode.";
+}
+
+function safeNotify(
+	ctx: ExtensionContext,
+	message: string,
+	type: "info" | "warning" | "error" = "info",
+): void {
+	try {
+		ctx.ui.notify(message, type);
+	} catch (err) {
+		console.error(`Plannotator notification failed: ${err instanceof Error ? err.message : String(err)}`);
+	}
+}
+
+function reportBackgroundError(ctx: ExtensionContext, message: string, err: unknown): void {
+	const detail = getStartupErrorMessage(err);
+	console.error(`${message}: ${detail}`);
+	safeNotify(ctx, `${message}: ${detail}`, "error");
+}
+
+function getLastAssistantMessageSnapshot(ctx: ExtensionContext): LastAssistantMessageSnapshot | null {
+	const branch = ctx.sessionManager.getBranch() as SessionEntryLike[];
+	for (let i = branch.length - 1; i >= 0; i--) {
+		const entry = branch[i];
+		if (entry.type === "message" && entry.message && isAssistantMessage(entry.message)) {
+			const text = getTextContent(entry.message);
+			if (text.trim()) return { entryId: entry.id, text };
+		}
+	}
+	return null;
+}
+
+function hasSessionMovedPastEntry(ctx: ExtensionContext, entryId: string): boolean {
+	if (!ctx.isIdle()) return true;
+
+	const branch = ctx.sessionManager.getBranch() as SessionEntryLike[];
+	const index = branch.findIndex((entry) => entry.id === entryId);
+	if (index === -1) return true;
+
+	return branch.slice(index + 1).some((entry) => entry.type === "message");
+}
+
+function excerptText(text: string, maxChars = 1000): string {
+	const trimmed = text.trim();
+	if (trimmed.length <= maxChars) return trimmed;
+	return `${trimmed.slice(0, maxChars).trimEnd()}...`;
+}
+
+function blockquote(text: string): string {
+	return text
+		.split("\n")
+		.map((line) => `> ${line}`)
+		.join("\n");
+}
+
+function anchorMessageFeedback(feedback: string, originalMessage: string): string {
+	return `This feedback applies to the earlier assistant response excerpted below:
+
+${blockquote(excerptText(originalMessage))}
+
+User feedback:
+${feedback}`;
 }
 
 export default function plannotator(pi: ExtensionAPI): void {
@@ -323,26 +395,34 @@ export default function plannotator(pi: ExtensionAPI): void {
 				void session
 					.waitForDecision()
 					.then((result) => {
-						if (result.exit) {
-							return;
+						try {
+							if (result.exit) {
+								safeNotify(ctx, "Code review session closed.", "info");
+								return;
+							}
+							if (result.approved) {
+								pi.sendUserMessage(getReviewApprovedPrompt("pi", loadConfig()), { deliverAs: "followUp" });
+								return;
+							}
+							if (!result.feedback) {
+								safeNotify(ctx, "Code review closed (no feedback).", "info");
+								return;
+							}
+							if (isPRReview) {
+								// Platform PR actions (approve/comment) return approved:false with a
+								// status message — don't tell the agent to "address" a platform action.
+								pi.sendUserMessage(result.feedback, { deliverAs: "followUp" });
+								return;
+							}
+							pi.sendUserMessage(`${result.feedback}${getReviewDeniedSuffix("pi", loadConfig())}`, {
+								deliverAs: "followUp",
+							});
+						} catch (err) {
+							reportBackgroundError(ctx, "Plannotator code review feedback could not be sent", err);
 						}
-						if (!result.feedback) {
-							return;
-						}
-						if (result.approved) {
-							pi.sendUserMessage(getReviewApprovedPrompt("pi", loadConfig()));
-							return;
-						}
-						if (isPRReview) {
-							// Platform PR actions (approve/comment) return approved:false with a
-							// status message — don't tell the agent to "address" a platform action.
-							pi.sendUserMessage(result.feedback);
-							return;
-						}
-						pi.sendUserMessage(`${result.feedback}${getReviewDeniedSuffix("pi", loadConfig())}`);
 					})
-					.catch(() => {
-						// Browser/session startup already reported a visible error.
+					.catch((err) => {
+						reportBackgroundError(ctx, "Plannotator code review session failed", err);
 					});
 			} catch (err) {
 				ctx.ui.notify(
@@ -462,19 +542,33 @@ export default function plannotator(pi: ExtensionAPI): void {
 				void session
 					.waitForDecision()
 					.then((result) => {
-						if (result.exit || result.approved || !result.feedback) {
-							return;
+						try {
+							if (result.exit) {
+								safeNotify(ctx, "Annotation session closed.", "info");
+								return;
+							}
+							if (result.approved) {
+								safeNotify(ctx, "Annotation approved.", "info");
+								return;
+							}
+							if (!result.feedback) {
+								safeNotify(ctx, "Annotation closed (no feedback).", "info");
+								return;
+							}
+							pi.sendUserMessage(
+								getAnnotateFileFeedbackPrompt("pi", loadConfig(), {
+									fileHeader: isFolder ? "Folder" : "File",
+									filePath: absolutePath,
+									feedback: result.feedback,
+								}),
+								{ deliverAs: "followUp" },
+							);
+						} catch (err) {
+							reportBackgroundError(ctx, "Plannotator annotation feedback could not be sent", err);
 						}
-						pi.sendUserMessage(
-							getAnnotateFileFeedbackPrompt("pi", loadConfig(), {
-								fileHeader: isFolder ? "Folder" : "File",
-								filePath: absolutePath,
-								feedback: result.feedback,
-							}),
-						);
 					})
-					.catch(() => {
-						// Browser/session startup already reported a visible error.
+					.catch((err) => {
+						reportBackgroundError(ctx, "Plannotator annotation session failed", err);
 					});
 			} catch (err) {
 				ctx.ui.notify(
@@ -499,8 +593,8 @@ export default function plannotator(pi: ExtensionAPI): void {
 				return;
 			}
 
-			const lastText = await getLastAssistantMessageText(ctx);
-			if (!lastText) {
+			const snapshot = getLastAssistantMessageSnapshot(ctx);
+			if (!snapshot) {
 				ctx.ui.notify("No assistant message found in session.", "error");
 				return;
 			}
@@ -508,22 +602,39 @@ export default function plannotator(pi: ExtensionAPI): void {
 			ctx.ui.notify("Opening annotation UI for last message...", "info");
 
 			try {
-				const session = await startLastMessageAnnotationSession(ctx, lastText, gate);
+				const session = await startLastMessageAnnotationSession(ctx, snapshot.text, gate);
 				ctx.ui.notify("Last-message annotation opened. You can keep chatting while it runs.", "info");
 				void session
 					.waitForDecision()
 					.then((result) => {
-						if (result.exit || result.approved || !result.feedback) {
-							return;
+						try {
+							if (result.exit) {
+								safeNotify(ctx, "Annotation session closed.", "info");
+								return;
+							}
+							if (result.approved) {
+								safeNotify(ctx, "Message approved.", "info");
+								return;
+							}
+							if (!result.feedback) {
+								safeNotify(ctx, "Annotation closed (no feedback).", "info");
+								return;
+							}
+							const feedback = hasSessionMovedPastEntry(ctx, snapshot.entryId)
+								? anchorMessageFeedback(result.feedback, snapshot.text)
+								: result.feedback;
+							pi.sendUserMessage(
+								getAnnotateMessageFeedbackPrompt("pi", loadConfig(), {
+									feedback,
+								}),
+								{ deliverAs: "followUp" },
+							);
+						} catch (err) {
+							reportBackgroundError(ctx, "Plannotator message annotation feedback could not be sent", err);
 						}
-						pi.sendUserMessage(
-							getAnnotateMessageFeedbackPrompt("pi", loadConfig(), {
-								feedback: result.feedback,
-							}),
-						);
 					})
-					.catch(() => {
-						// Browser/session startup already reported a visible error.
+					.catch((err) => {
+						reportBackgroundError(ctx, "Plannotator message annotation session failed", err);
 					});
 			} catch (err) {
 				ctx.ui.notify(

--- a/apps/pi-extension/package.json
+++ b/apps/pi-extension/package.json
@@ -21,6 +21,8 @@
   },
   "files": [
     "index.ts",
+    "assistant-message.ts",
+    "current-pi-session.ts",
     "plannotator-browser.ts",
     "plannotator-events.ts",
     "server.ts",

--- a/apps/pi-extension/plannotator-browser.ts
+++ b/apps/pi-extension/plannotator-browser.ts
@@ -36,18 +36,15 @@ export interface PlanReviewDecision {
 	permissionMode?: string;
 }
 
-export interface PlanReviewBrowserSession {
-	reviewId: string;
-	url: string;
-	waitForDecision: () => Promise<PlanReviewDecision>;
-	onDecision: (listener: (result: PlanReviewDecision) => void | Promise<void>) => () => void;
-	stop: () => void;
-}
-
 export interface BrowserDecisionSession<T> {
 	url: string;
 	waitForDecision: () => Promise<T>;
 	stop: () => void;
+}
+
+export interface PlanReviewBrowserSession extends BrowserDecisionSession<PlanReviewDecision> {
+	reviewId: string;
+	onDecision: (listener: (result: PlanReviewDecision) => void | Promise<void>) => () => void;
 }
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -129,6 +126,24 @@ async function openBrowserAndWait<T>(
 	await delay(1500);
 	server.stop();
 	return result;
+}
+
+function startBrowserDecisionSession<T>(
+	server: { url: string; stop: () => void },
+	ctx: ExtensionContext,
+	waitForResult: () => Promise<T>,
+): BrowserDecisionSession<T> {
+	openBrowserForServer(server.url, ctx);
+	return {
+		url: server.url,
+		waitForDecision: async () => {
+			const result = await waitForResult();
+			await delay(1500);
+			server.stop();
+			return result;
+		},
+		stop: server.stop,
+	};
 }
 
 export async function startPlanReviewBrowserSession(
@@ -406,18 +421,7 @@ export async function startCodeReviewBrowserSession(
 		onCleanup: worktreeCleanup,
 	});
 
-	openBrowserForServer(server.url, ctx);
-	const waitForDecision = async () => {
-		const result = await server.waitForDecision();
-		await delay(1500);
-		server.stop();
-		return result;
-	};
-	return {
-		url: server.url,
-		waitForDecision,
-		stop: server.stop,
-	};
+	return startBrowserDecisionSession(server, ctx, server.waitForDecision);
 }
 
 export async function openMarkdownAnnotation(
@@ -484,18 +488,7 @@ export async function startMarkdownAnnotationSession(
 		pasteApiUrl: process.env.PLANNOTATOR_PASTE_URL || undefined,
 	});
 
-	openBrowserForServer(server.url, ctx);
-	const waitForDecision = async () => {
-		const result = await server.waitForDecision();
-		await delay(1500);
-		server.stop();
-		return result;
-	};
-	return {
-		url: server.url,
-		waitForDecision,
-		stop: server.stop,
-	};
+	return startBrowserDecisionSession(server, ctx, server.waitForDecision);
 }
 
 export async function openLastMessageAnnotation(

--- a/apps/pi-extension/plannotator-browser.ts
+++ b/apps/pi-extension/plannotator-browser.ts
@@ -121,11 +121,20 @@ async function openBrowserAndWait<T>(
 	waitForResult: () => Promise<T>,
 ): Promise<T> {
 	openBrowserForServer(server.url, ctx);
+	return waitForDecisionWithCleanup(server, waitForResult);
+}
 
-	const result = await waitForResult();
-	await delay(1500);
-	server.stop();
-	return result;
+async function waitForDecisionWithCleanup<T>(
+	server: { url: string; stop: () => void },
+	waitForResult: () => Promise<T>,
+): Promise<T> {
+	try {
+		const result = await waitForResult();
+		await delay(1500);
+		return result;
+	} finally {
+		server.stop();
+	}
 }
 
 function startBrowserDecisionSession<T>(
@@ -136,12 +145,7 @@ function startBrowserDecisionSession<T>(
 	openBrowserForServer(server.url, ctx);
 	return {
 		url: server.url,
-		waitForDecision: async () => {
-			const result = await waitForResult();
-			await delay(1500);
-			server.stop();
-			return result;
-		},
+		waitForDecision: () => waitForDecisionWithCleanup(server, waitForResult),
 		stop: server.stop,
 	};
 }

--- a/apps/pi-extension/plannotator-browser.ts
+++ b/apps/pi-extension/plannotator-browser.ts
@@ -44,6 +44,12 @@ export interface PlanReviewBrowserSession {
 	stop: () => void;
 }
 
+export interface BrowserDecisionSession<T> {
+	url: string;
+	waitForDecision: () => Promise<T>;
+	stop: () => void;
+}
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 let planHtmlContent = "";
 let reviewHtmlContent = "";
@@ -168,6 +174,22 @@ export async function openCodeReview(
 	ctx: ExtensionContext,
 	options: { cwd?: string; defaultBranch?: string; diffType?: DiffType; prUrl?: string } = {},
 ): Promise<{ approved: boolean; feedback?: string; annotations?: unknown[]; agentSwitch?: string; exit?: boolean }> {
+	const session = await startCodeReviewBrowserSession(ctx, options);
+	return session.waitForDecision();
+}
+
+export async function startCodeReviewBrowserSession(
+	ctx: ExtensionContext,
+	options: { cwd?: string; defaultBranch?: string; diffType?: DiffType; prUrl?: string } = {},
+): Promise<
+	BrowserDecisionSession<{
+		approved: boolean;
+		feedback?: string;
+		annotations?: unknown[];
+		agentSwitch?: string;
+		exit?: boolean;
+	}>
+> {
 	if (!ctx.hasUI || !reviewHtmlContent) {
 		throw new Error("Plannotator code review browser is unavailable in this session.");
 	}
@@ -384,7 +406,18 @@ export async function openCodeReview(
 		onCleanup: worktreeCleanup,
 	});
 
-	return openBrowserAndWait(server, ctx, server.waitForDecision);
+	openBrowserForServer(server.url, ctx);
+	const waitForDecision = async () => {
+		const result = await server.waitForDecision();
+		await delay(1500);
+		server.stop();
+		return result;
+	};
+	return {
+		url: server.url,
+		waitForDecision,
+		stop: server.stop,
+	};
 }
 
 export async function openMarkdownAnnotation(
@@ -397,6 +430,29 @@ export async function openMarkdownAnnotation(
 	sourceConverted?: boolean,
 	gate?: boolean,
 ): Promise<{ feedback: string; exit?: boolean; approved?: boolean }> {
+	const session = await startMarkdownAnnotationSession(
+		ctx,
+		filePath,
+		markdown,
+		mode,
+		folderPath,
+		sourceInfo,
+		sourceConverted,
+		gate,
+	);
+	return session.waitForDecision();
+}
+
+export async function startMarkdownAnnotationSession(
+	ctx: ExtensionContext,
+	filePath: string,
+	markdown: string,
+	mode: AnnotateMode,
+	folderPath?: string,
+	sourceInfo?: string,
+	sourceConverted?: boolean,
+	gate?: boolean,
+): Promise<BrowserDecisionSession<{ feedback: string; exit?: boolean; approved?: boolean }>> {
 	if (!ctx.hasUI || !planHtmlContent) {
 		throw new Error("Plannotator annotation browser is unavailable in this session.");
 	}
@@ -428,7 +484,18 @@ export async function openMarkdownAnnotation(
 		pasteApiUrl: process.env.PLANNOTATOR_PASTE_URL || undefined,
 	});
 
-	return openBrowserAndWait(server, ctx, server.waitForDecision);
+	openBrowserForServer(server.url, ctx);
+	const waitForDecision = async () => {
+		const result = await server.waitForDecision();
+		await delay(1500);
+		server.stop();
+		return result;
+	};
+	return {
+		url: server.url,
+		waitForDecision,
+		stop: server.stop,
+	};
 }
 
 export async function openLastMessageAnnotation(
@@ -437,6 +504,23 @@ export async function openLastMessageAnnotation(
 	gate?: boolean,
 ): Promise<{ feedback: string; exit?: boolean; approved?: boolean }> {
 	return openMarkdownAnnotation(ctx, "last-message", lastText, "annotate-last", undefined, undefined, undefined, gate);
+}
+
+export async function startLastMessageAnnotationSession(
+	ctx: ExtensionContext,
+	lastText: string,
+	gate?: boolean,
+): Promise<BrowserDecisionSession<{ feedback: string; exit?: boolean; approved?: boolean }>> {
+	return startMarkdownAnnotationSession(
+		ctx,
+		"last-message",
+		lastText,
+		"annotate-last",
+		undefined,
+		undefined,
+		undefined,
+		gate,
+	);
 }
 
 export async function openArchiveBrowserAction(

--- a/apps/pi-extension/plannotator-browser.ts
+++ b/apps/pi-extension/plannotator-browser.ts
@@ -26,6 +26,7 @@ import {
 import { parseRemoteUrl } from "./generated/repo.js";
 import { fetchRef, createWorktree, removeWorktree, ensureObjectAvailable } from "./generated/worktree.js";
 import { loadConfig, resolveDefaultDiffType } from "./generated/config.js";
+export { getLastAssistantMessageText } from "./assistant-message.js";
 
 export type AnnotateMode = "annotate" | "annotate-folder" | "annotate-last";
 export interface PlanReviewDecision {
@@ -79,33 +80,6 @@ export function getStartupErrorMessage(err: unknown): string {
 	return err instanceof Error ? err.message : "Unknown error";
 }
 
-type AssistantTextBlock = { type?: string; text?: string };
-
-type AssistantMessageLike = { role?: unknown; content?: unknown };
-
-function isAssistantMessage(message: AssistantMessageLike): message is { role: "assistant"; content: AssistantTextBlock[] } {
-	return message.role === "assistant" && Array.isArray(message.content);
-}
-
-function getTextContent(message: { content: AssistantTextBlock[] }): string {
-	return message.content
-		.filter((block): block is { type: "text"; text: string } => block.type === "text")
-		.map((block) => block.text)
-		.join("\n");
-}
-
-export async function getLastAssistantMessageText(ctx: ExtensionContext): Promise<string | null> {
-	const entries = ctx.sessionManager.getEntries();
-	for (let i = entries.length - 1; i >= 0; i--) {
-		const entry = entries[i] as { type: string; message?: AssistantMessageLike };
-		if (entry.type === "message" && entry.message && isAssistantMessage(entry.message)) {
-			const text = getTextContent(entry.message);
-			if (text.trim()) return text;
-		}
-	}
-	return null;
-}
-
 function openBrowserForServer(serverUrl: string, ctx: ExtensionContext): void {
 	const browserResult = openBrowser(serverUrl);
 	if (browserResult.isRemote) {
@@ -143,10 +117,39 @@ function startBrowserDecisionSession<T>(
 	waitForResult: () => Promise<T>,
 ): BrowserDecisionSession<T> {
 	openBrowserForServer(server.url, ctx);
+	let stopped = false;
+	let stopReject: ((err: Error) => void) | undefined;
+	let decisionPromise: Promise<T> | undefined;
+	const createStoppedError = () => new Error("Plannotator browser session was stopped.");
+	const stop = () => {
+		if (stopped) return;
+		stopped = true;
+		server.stop();
+		stopReject?.(createStoppedError());
+		stopReject = undefined;
+	};
+
 	return {
 		url: server.url,
-		waitForDecision: () => waitForDecisionWithCleanup(server, waitForResult),
-		stop: server.stop,
+		waitForDecision: () => {
+			if (decisionPromise) return decisionPromise;
+			if (stopped) return Promise.reject(createStoppedError());
+			decisionPromise ??= (async () => {
+				const stoppedPromise = new Promise<never>((_, reject) => {
+					stopReject = reject;
+				});
+				try {
+					const result = await Promise.race([waitForResult(), stoppedPromise]);
+					stopReject = undefined;
+					await delay(1500);
+					return result;
+				} finally {
+					stop();
+				}
+			})();
+			return decisionPromise;
+		},
+		stop,
 	};
 }
 
@@ -167,17 +170,15 @@ export async function startPlanReviewBrowserSession(
 		pasteApiUrl: process.env.PLANNOTATOR_PASTE_URL || undefined,
 	});
 
-	openBrowserForServer(server.url, ctx);
+	const session = startBrowserDecisionSession(server, ctx, server.waitForDecision);
 	server.onDecision(() => {
-		setTimeout(() => server.stop(), 1500);
+		setTimeout(() => session.stop(), 1500);
 	});
 
 	return {
+		...session,
 		reviewId: server.reviewId,
-		url: server.url,
-		waitForDecision: server.waitForDecision,
 		onDecision: server.onDecision,
-		stop: server.stop,
 	};
 }
 

--- a/apps/pi-extension/plannotator-browser.ts
+++ b/apps/pi-extension/plannotator-browser.ts
@@ -134,7 +134,7 @@ function startBrowserDecisionSession<T>(
 		waitForDecision: () => {
 			if (decisionPromise) return decisionPromise;
 			if (stopped) return Promise.reject(createStoppedError());
-			decisionPromise ??= (async () => {
+			decisionPromise = (async () => {
 				const stoppedPromise = new Promise<never>((_, reject) => {
 					stopReject = reject;
 				});

--- a/apps/pi-extension/plannotator-events.ts
+++ b/apps/pi-extension/plannotator-events.ts
@@ -10,6 +10,9 @@ import {
 	openCodeReview,
 	openLastMessageAnnotation,
 	openMarkdownAnnotation,
+	startCodeReviewBrowserSession,
+	startLastMessageAnnotationSession,
+	startMarkdownAnnotationSession,
 	startPlanReviewBrowserSession,
 } from "./plannotator-browser.js";
 
@@ -318,6 +321,9 @@ export {
 	getLastAssistantMessageText,
 	hasPlanBrowserHtml,
 	hasReviewBrowserHtml,
+	startCodeReviewBrowserSession,
+	startLastMessageAnnotationSession,
+	startMarkdownAnnotationSession,
 	getStartupErrorMessage,
 	openArchiveBrowserAction,
 	openCodeReview,

--- a/apps/pi-extension/plannotator-events.ts
+++ b/apps/pi-extension/plannotator-events.ts
@@ -291,7 +291,7 @@ export function registerPlannotatorEventListeners(pi: ExtensionAPI): void {
 				}
 				case "annotate-last": {
 					const payload = request.payload;
-					const lastText = payload?.markdown?.trim() ? payload.markdown : await getLastAssistantMessageText(ctx);
+					const lastText = payload?.markdown?.trim() ? payload.markdown : getLastAssistantMessageText(ctx);
 					if (!lastText) {
 						request.respond({ status: "unavailable", error: "No assistant message found in session." });
 						return;


### PR DESCRIPTION
## Summary
- add async browser decision session helpers for Pi review and annotation flows
- let Pi commands return immediately after opening the browser so chat can continue while the UI stays open
- preserve existing feedback/approval behavior by forwarding the eventual browser decision back into Pi when the session completes

## Testing
- bun run build:pi