### PR TITLE
Localize Plannotator status summary labels

### DIFF
--- a/apps/pi-extension/i18n.ts
+++ b/apps/pi-extension/i18n.ts
@@ -1,0 +1,48 @@
+type Locale = "en" | "es" | "fr" | "pt-BR";
+type Params = Record<string, string | number>;
+
+const translations: Record<Exclude<Locale, "en">, Record<string, string>> = {
+	es: {
+		"status.phase": "Fase: {phase}",
+		"status.planFile": "Archivo del plan: {path}",
+		"status.progress": "Progreso: {done}/{total}",
+	},
+	fr: {
+		"status.phase": "Phase : {phase}",
+		"status.planFile": "Fichier du plan : {path}",
+		"status.progress": "Progression : {done}/{total}",
+	},
+	"pt-BR": {
+		"status.phase": "Fase: {phase}",
+		"status.planFile": "Arquivo do plano: {path}",
+		"status.progress": "Progresso: {done}/{total}",
+	},
+};
+
+let currentLocale: Locale = "en";
+
+export function initI18n(pi: { events?: { emit?: (event: string, payload: unknown) => void } }): void {
+	pi.events?.emit?.("pi-core/i18n/registerBundle", {
+		namespace: "plannotator",
+		defaultLocale: "en",
+		locales: translations,
+	});
+	pi.events?.emit?.("pi-core/i18n/requestApi", {
+		onReady: (api: { getLocale?: () => string; onLocaleChange?: (cb: (locale: string) => void) => void }) => {
+			const locale = api.getLocale?.();
+			if (isLocale(locale)) currentLocale = locale;
+			api.onLocaleChange?.((next) => {
+				if (isLocale(next)) currentLocale = next;
+			});
+		},
+	});
+}
+
+export function t(key: string, fallback: string, params: Params = {}): string {
+	const template = currentLocale === "en" ? fallback : translations[currentLocale]?.[key] ?? fallback;
+	return template.replace(/\{(\w+)\}/g, (_, name) => String(params[name] ?? `{${name}}`));
+}
+
+function isLocale(locale: string | undefined): locale is Locale {
+	return locale === "en" || locale === "es" || locale === "fr" || locale === "pt-BR";
+}

--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -26,6 +26,7 @@ import type {
 } from "@mariozechner/pi-coding-agent";
 import { Key } from "@mariozechner/pi-tui";
 import { buildPromptVariables, formatTodoList, loadPlannotatorConfig, renderTemplate, resolvePhaseProfile } from "./config.js";
+import { initI18n, t } from "./i18n.js";
 import {
 	type ChecklistItem,
 	markCompletedSteps,
@@ -116,6 +117,8 @@ function getPlanReviewAvailabilityWarning(options: { hasUI: boolean; hasPlanHtml
 }
 
 export default function plannotator(pi: ExtensionAPI): void {
+	initI18n(pi);
+
 	let phase: Phase = "idle";
 	void registerPlannotatorEventListeners(pi);
 	let lastSubmittedPath: string | null = null;
@@ -292,13 +295,13 @@ export default function plannotator(pi: ExtensionAPI): void {
 	pi.registerCommand("plannotator-status", {
 		description: "Show plannotator status",
 		handler: async (_args, ctx) => {
-			const parts = [`Phase: ${phase}`];
+			const parts = [t("status.phase", "Phase: {phase}", { phase })];
 			if (lastSubmittedPath) {
-				parts.push(`Plan file: ${lastSubmittedPath}`);
+				parts.push(t("status.planFile", "Plan file: {path}", { path: lastSubmittedPath }));
 			}
 			if (checklistItems.length > 0) {
-				const done = checklistItems.filter((t) => t.completed).length;
-				parts.push(`Progress: ${done}/${checklistItems.length}`);
+				const done = checklistItems.filter((item) => item.completed).length;
+				parts.push(t("status.progress", "Progress: {done}/{total}", { done, total: checklistItems.length }));
 			}
 			ctx.ui.notify(parts.join("\n"), "info");
 		},

--- a/apps/pi-extension/package.json
+++ b/apps/pi-extension/package.json
@@ -21,6 +21,7 @@
   },
   "files": [
     "index.ts",
+    "i18n.ts",
     "plannotator-browser.ts",
     "plannotator-events.ts",
     "server.ts",


### PR DESCRIPTION
This is a smaller follow-up after I retracted the earlier over-broad localization PR. I kept this one limited to the /plannotator-status summary labels only.\n\nWhat changed:\n- adds a tiny local i18n helper with English fallback\n- localizes only phase, plan-file, and checklist-progress labels in /plannotator-status\n- registers an optional pi-core i18n bundle when available\n- includes es, fr, and pt-BR strings\n\nWhat did not change:\n- no required dependency\n- English remains the default/fallback\n- plan review, approval/denial behavior, annotations, file paths, and checklist state stay untouched\n\nValidation:\n- passed: npm pack --dry-run in apps/pi-extension\n- blocked: esbuild bundle check could not resolve generated files in this checkout before reaching this change path\n\nIf useful later, I’m happy to handle broader localization in small follow-up PRs using whatever locale set you prefer.