### PR TITLE
fix(ui): code file and linked doc resolution in annotate-last mode

### DIFF
--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -318,11 +318,11 @@ const App: React.FC = () => {
     buildUrl: useCallback((codePath: string) => {
       const baseDir = linkedDocHook.filepath
         ? linkedDocHook.filepath.replace(/\/[^/]+$/, '')
-        : imageBaseDir;
+        : imageBaseDir?.includes('/') ? imageBaseDir : projectRoot;
       return baseDir
         ? `/api/doc?path=${encodeURIComponent(codePath)}&base=${encodeURIComponent(baseDir)}`
         : `/api/doc?path=${encodeURIComponent(codePath)}`;
-    }, [linkedDocHook.filepath, imageBaseDir]),
+    }, [linkedDocHook.filepath, imageBaseDir, projectRoot]),
   });
 
   // Archive browser
@@ -437,7 +437,7 @@ const App: React.FC = () => {
       // Pass the current file's directory as base for relative path resolution
       const baseDir = linkedDocHook.filepath
         ? linkedDocHook.filepath.replace(/\/[^/]+$/, '')
-        : imageBaseDir;
+        : imageBaseDir?.includes('/') ? imageBaseDir : projectRoot;
       if (baseDir) {
         linkedDocHook.open(docPath, (path) =>
           `/api/doc?path=${encodeURIComponent(path)}&base=${encodeURIComponent(baseDir)}`
@@ -446,7 +446,7 @@ const App: React.FC = () => {
         linkedDocHook.open(docPath);
       }
     }
-  }, [fileBrowser.dirs, fileBrowser.activeDirPath, fileBrowser.activeFile, linkedDocHook, imageBaseDir]);
+  }, [fileBrowser.dirs, fileBrowser.activeDirPath, fileBrowser.activeFile, linkedDocHook, imageBaseDir, projectRoot]);
 
   // Wrap linked doc back to also clear file browser active file
   const handleLinkedDocBack = React.useCallback(() => {

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -318,11 +318,11 @@ const App: React.FC = () => {
     buildUrl: useCallback((codePath: string) => {
       const baseDir = linkedDocHook.filepath
         ? linkedDocHook.filepath.replace(/\/[^/]+$/, '')
-        : imageBaseDir?.includes('/') ? imageBaseDir : projectRoot;
+        : imageBaseDir?.includes('/') ? imageBaseDir : undefined;
       return baseDir
         ? `/api/doc?path=${encodeURIComponent(codePath)}&base=${encodeURIComponent(baseDir)}`
         : `/api/doc?path=${encodeURIComponent(codePath)}`;
-    }, [linkedDocHook.filepath, imageBaseDir, projectRoot]),
+    }, [linkedDocHook.filepath, imageBaseDir]),
   });
 
   // Archive browser
@@ -437,7 +437,7 @@ const App: React.FC = () => {
       // Pass the current file's directory as base for relative path resolution
       const baseDir = linkedDocHook.filepath
         ? linkedDocHook.filepath.replace(/\/[^/]+$/, '')
-        : imageBaseDir?.includes('/') ? imageBaseDir : projectRoot;
+        : imageBaseDir?.includes('/') ? imageBaseDir : undefined;
       if (baseDir) {
         linkedDocHook.open(docPath, (path) =>
           `/api/doc?path=${encodeURIComponent(path)}&base=${encodeURIComponent(baseDir)}`
@@ -446,7 +446,7 @@ const App: React.FC = () => {
         linkedDocHook.open(docPath);
       }
     }
-  }, [fileBrowser.dirs, fileBrowser.activeDirPath, fileBrowser.activeFile, linkedDocHook, imageBaseDir, projectRoot]);
+  }, [fileBrowser.dirs, fileBrowser.activeDirPath, fileBrowser.activeFile, linkedDocHook, imageBaseDir]);
 
   // Wrap linked doc back to also clear file browser active file
   const handleLinkedDocBack = React.useCallback(() => {


### PR DESCRIPTION
## Summary
- In annotate-last mode, `imageBaseDir` is set to `"last-message"` — a truthy non-path string that gets sent as the `base` query param to `/api/doc`, causing a 404
- Guard both the code file popout and linked doc URL builders to skip non-path `imageBaseDir` values and fall back to `projectRoot`

## Test plan
- [ ] Open annotate-last view on a message containing code file paths (e.g. `apps/pi-extension/plannotator-events.ts`)
- [ ] Click a code file path — should open the code file popout without 404
- [ ] Click a linked markdown doc — should navigate without 404
- [ ] Verify plan mode still works (imageBaseDir is undefined, falls through to projectRoot)
- [ ] Verify annotate mode with a real file still resolves relative paths correctly