### PR TITLE
feat(opencode): agent picker dropdown on Approve button

### DIFF
--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -531,6 +531,9 @@ Use /plannotator-last or /plannotator-annotate for manual review, or set workflo
                 planFilePath: sourceFilePath,
                 doneMsg: result.savedPath ? `Saved to: ${result.savedPath}` : "",
                 feedback: result.feedback,
+                proceedSuffix: shouldSwitchAgent
+                  ? "\n\nProceed with implementation, incorporating these notes where applicable."
+                  : "",
               });
             }
 

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -15,6 +15,7 @@ import { TaterSpriteRunning } from '@plannotator/ui/components/TaterSpriteRunnin
 import { TaterSpritePullup } from '@plannotator/ui/components/TaterSpritePullup';
 import { Settings } from '@plannotator/ui/components/Settings';
 import { FeedbackButton, ApproveButton, ExitButton } from '@plannotator/ui/components/ToolbarButtons';
+import { ApproveDropdown } from '@plannotator/ui/components/ApproveDropdown';
 import { useSharing } from '@plannotator/ui/hooks/useSharing';
 import { getCallbackConfig, CallbackAction, executeCallback, type ToastPayload } from '@plannotator/ui/utils/callback';
 import { useAgents } from '@plannotator/ui/hooks/useAgents';
@@ -918,7 +919,6 @@ const App: React.FC = () => {
       const obsidianSettings = getObsidianSettings();
       const bearSettings = getBearSettings();
       const octarineSettings = getOctarineSettings();
-      const agentSwitchSettings = getAgentSwitchSettings();
       const planSaveSettings = getPlanSaveSettings();
       const autoSaveResults = bearSettings.autoSave && autoSavePromiseRef.current
         ? await autoSavePromiseRef.current
@@ -932,8 +932,7 @@ const App: React.FC = () => {
         body.permissionMode = permissionMode;
       }
 
-      // Include agent switch setting for OpenCode (effective name handles custom agents)
-      const effectiveAgent = getEffectiveAgentName(agentSwitchSettings);
+      const effectiveAgent = getEffectiveAgentName(getAgentSwitchSettings());
       if (effectiveAgent) {
         body.agentSwitch = effectiveAgent;
       }
@@ -1606,48 +1605,64 @@ const App: React.FC = () => {
                   />
                 )}
 
-                {(!annotateMode || gate) && <div className="relative group/approve">
-                  <ApproveButton
-                    onClick={() => {
-                      // Annotate gate mode: guard against dropping annotations via the existing
-                      // showExitWarning dialog (routed via exitWarningAction='approve').
-                      if (annotateMode) {
-                        if (hasAnyAnnotations) {
-                          setExitWarningAction('approve');
-                          setShowExitWarning(true);
-                          return;
-                        }
-                        handleAnnotateApprove();
-                        return;
-                      }
-                      // Plan mode: existing Claude-Code / OpenCode guards.
-                      if (origin === 'claude-code' && (allAnnotations.length > 0 || codeAnnotations.length > 0)) {
-                        setShowClaudeCodeWarning(true);
-                        return;
-                      }
-                      if (origin === 'opencode') {
+                {(!annotateMode || gate) && (
+                  origin === 'opencode' && !annotateMode && availableAgents.length > 0 ? (
+                    <ApproveDropdown
+                      onApprove={() => {
                         const warning = getAgentWarning();
                         if (warning) {
                           setAgentWarningMessage(warning);
                           setShowAgentWarning(true);
                           return;
                         }
-                      }
-                      handleApprove();
-                    }}
-                    disabled={isSubmitting || (annotateMode && isExiting)}
-                    isLoading={isSubmitting}
-                    dimmed={!annotateMode && (origin === 'claude-code' || origin === 'gemini-cli') && (allAnnotations.length > 0 || codeAnnotations.length > 0)}
-                    title={annotateMode ? 'Approve — no changes requested' : undefined}
-                  />
-                  {!annotateMode && (origin === 'claude-code' || origin === 'gemini-cli') && (allAnnotations.length > 0 || codeAnnotations.length > 0) && (
-                    <div className="absolute top-full right-0 mt-2 px-3 py-2 bg-popover border border-border rounded-lg shadow-xl text-xs text-foreground w-56 text-center opacity-0 invisible group-hover/approve:opacity-100 group-hover/approve:visible transition-all pointer-events-none z-50">
-                      <div className="absolute bottom-full right-4 border-4 border-transparent border-b-border" />
-                      <div className="absolute bottom-full right-4 mt-px border-4 border-transparent border-b-popover" />
-                      {agentName} doesn't support feedback on approval. Your annotations won't be seen.
+                        handleApprove();
+                      }}
+                      agents={availableAgents}
+                      disabled={isSubmitting}
+                      isLoading={isSubmitting}
+                    />
+                  ) : (
+                    <div className="relative group/approve">
+                      <ApproveButton
+                        onClick={() => {
+                          if (annotateMode) {
+                            if (hasAnyAnnotations) {
+                              setExitWarningAction('approve');
+                              setShowExitWarning(true);
+                              return;
+                            }
+                            handleAnnotateApprove();
+                            return;
+                          }
+                          if (origin === 'claude-code' && (allAnnotations.length > 0 || codeAnnotations.length > 0)) {
+                            setShowClaudeCodeWarning(true);
+                            return;
+                          }
+                          if (origin === 'opencode') {
+                            const warning = getAgentWarning();
+                            if (warning) {
+                              setAgentWarningMessage(warning);
+                              setShowAgentWarning(true);
+                              return;
+                            }
+                          }
+                          handleApprove();
+                        }}
+                        disabled={isSubmitting || (annotateMode && isExiting)}
+                        isLoading={isSubmitting}
+                        dimmed={!annotateMode && (origin === 'claude-code' || origin === 'gemini-cli') && (allAnnotations.length > 0 || codeAnnotations.length > 0)}
+                        title={annotateMode ? 'Approve — no changes requested' : undefined}
+                      />
+                      {!annotateMode && (origin === 'claude-code' || origin === 'gemini-cli') && (allAnnotations.length > 0 || codeAnnotations.length > 0) && (
+                        <div className="absolute top-full right-0 mt-2 px-3 py-2 bg-popover border border-border rounded-lg shadow-xl text-xs text-foreground w-56 text-center opacity-0 invisible group-hover/approve:opacity-100 group-hover/approve:visible transition-all pointer-events-none z-50">
+                          <div className="absolute bottom-full right-4 border-4 border-transparent border-b-border" />
+                          <div className="absolute bottom-full right-4 mt-px border-4 border-transparent border-b-popover" />
+                          {agentName} doesn't support feedback on approval. Your annotations won't be seen.
+                        </div>
+                      )}
                     </div>
-                  )}
-                </div>}
+                  )
+                )}
 
                 <div className="w-px h-5 bg-border/50 mx-1 hidden md:block" />
               </>

--- a/packages/shared/prompts.ts
+++ b/packages/shared/prompts.ts
@@ -166,7 +166,7 @@ export function getPlanApprovedPrompt(
 }
 
 const PLAN_APPROVED_WITH_NOTES_RUNTIME_DEFAULTS: Partial<Record<PromptRuntime, string>> = {
-  opencode: "Plan approved with notes!\n{{doneMsg}}\n\n## Implementation Notes\n\nThe user approved your plan but added the following notes to consider during implementation:\n\n{{feedback}}\n\nProceed with implementation, incorporating these notes where applicable.",
+  opencode: "Plan approved with notes!\n{{doneMsg}}\n\n## Implementation Notes\n\nThe user approved your plan but added the following notes to consider during implementation:\n\n{{feedback}}{{proceedSuffix}}",
 };
 
 export function getPlanApprovedWithNotesPrompt(
@@ -182,7 +182,7 @@ export function getPlanApprovedWithNotesPrompt(
     fallback: DEFAULT_PLAN_APPROVED_WITH_NOTES_PROMPT,
     runtimeFallbacks: PLAN_APPROVED_WITH_NOTES_RUNTIME_DEFAULTS,
   });
-  return resolveTemplate(template, vars ?? {});
+  return resolveTemplate(template, { proceedSuffix: "", ...vars });
 }
 
 export function getPlanAutoApprovedPrompt(

--- a/packages/ui/components/ApproveDropdown.tsx
+++ b/packages/ui/components/ApproveDropdown.tsx
@@ -1,0 +1,170 @@
+import React, { useState, useRef, useEffect } from 'react';
+import type { Agent } from '../hooks/useAgents';
+import { getAgentSwitchSettings, saveAgentSwitchSettings, type AgentSwitchSettings } from '../utils/agentSwitch';
+
+interface ApproveDropdownProps {
+  onApprove: () => void;
+  agents: Agent[];
+  disabled?: boolean;
+  isLoading?: boolean;
+}
+
+function getSelectedLabel(setting: AgentSwitchSettings, agents: Agent[]): string | null {
+  if (setting.switchTo === 'disabled') return null;
+  if (setting.switchTo === 'custom' && setting.customName) {
+    return setting.customName;
+  }
+  const match = agents.find(a => a.id.toLowerCase() === setting.switchTo.toLowerCase());
+  return match?.name ?? setting.switchTo;
+}
+
+function isSelected(agentId: string, setting: AgentSwitchSettings): boolean {
+  if (setting.switchTo === 'custom') return false;
+  if (setting.switchTo === 'disabled') return false;
+  return agentId.toLowerCase() === setting.switchTo.toLowerCase();
+}
+
+const Checkmark = () => (
+  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+  </svg>
+);
+
+export const ApproveDropdown: React.FC<ApproveDropdownProps> = ({
+  onApprove,
+  agents,
+  disabled = false,
+  isLoading = false,
+}) => {
+  const [setting, setSetting] = useState<AgentSwitchSettings>(() => getAgentSwitchSettings());
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: PointerEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setIsOpen(false);
+    };
+    document.addEventListener('pointerdown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('pointerdown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, []);
+
+  const handleSelect = (newSetting: AgentSwitchSettings) => {
+    setSetting(newSetting);
+    saveAgentSwitchSettings(newSetting);
+    setIsOpen(false);
+  };
+
+  const agentLabel = getSelectedLabel(setting, agents);
+  const isNoSwitch = setting.switchTo === 'disabled';
+  const isCustom = setting.switchTo === 'custom';
+  const notFound = agentLabel && !isNoSwitch && !isCustom
+    && !agents.some(a => a.id.toLowerCase() === setting.switchTo.toLowerCase());
+
+  const baseClasses = disabled
+    ? 'opacity-50 cursor-not-allowed bg-muted text-muted-foreground'
+    : 'bg-success text-success-foreground hover:opacity-90';
+
+  const handleApproveClick = () => {
+    setIsOpen(false);
+    onApprove();
+  };
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      {/* Mobile: simple button */}
+      <button
+        onClick={handleApproveClick}
+        disabled={disabled}
+        className={`md:hidden px-2 py-1 rounded-md text-xs font-medium transition-all ${baseClasses}`}
+      >
+        {isLoading ? '...' : 'OK'}
+      </button>
+
+      {/* Desktop: split button */}
+      <div className="hidden md:flex items-stretch">
+        <button
+          onClick={handleApproveClick}
+          disabled={disabled}
+          className={`px-2.5 py-1 rounded-l-md text-xs font-medium transition-all ${baseClasses}`}
+        >
+          {isLoading ? 'Approving...' : (
+            agentLabel ? (
+              <span className="flex items-center gap-1">
+                Approve
+                <span className="opacity-60">&rarr;</span>
+                <span className="max-w-[120px] truncate">{agentLabel}</span>
+                {notFound && <span className="opacity-60 text-[10px]">(?)</span>}
+              </span>
+            ) : 'Approve'
+          )}
+        </button>
+        <button
+          onClick={() => setIsOpen(!isOpen)}
+          disabled={disabled}
+          className={`px-1.5 py-1 rounded-r-md border-l border-success-foreground/20 text-xs transition-all ${baseClasses}`}
+        >
+          <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Dropdown */}
+      {isOpen && (
+        <div className="absolute right-0 top-full mt-1 w-52 rounded-lg border border-border bg-popover shadow-xl z-[70] overflow-hidden py-1">
+          <div className="px-3 py-1.5 text-[10px] uppercase tracking-wider text-muted-foreground/70 font-medium">
+            Switch to agent
+          </div>
+          {agents.map((agent) => {
+            const selected = isSelected(agent.id, setting);
+            return (
+              <button
+                key={agent.id}
+                onClick={() => handleSelect({ switchTo: agent.id })}
+                className={`w-full px-3 py-1.5 text-left text-xs transition-colors flex items-center gap-2 ${
+                  selected
+                    ? 'text-primary bg-primary/10 font-medium'
+                    : 'text-popover-foreground hover:bg-muted'
+                }`}
+              >
+                <span className="w-4 flex-shrink-0">{selected && <Checkmark />}</span>
+                <span className="truncate">{agent.name}</span>
+              </button>
+            );
+          })}
+          {isCustom && setting.customName && (
+            <button
+              onClick={() => setIsOpen(false)}
+              className="w-full px-3 py-1.5 text-left text-xs transition-colors flex items-center gap-2 text-primary bg-primary/10 font-medium"
+            >
+              <span className="w-4 flex-shrink-0"><Checkmark /></span>
+              <span className="truncate">{setting.customName}</span>
+              <span className="text-[10px] text-muted-foreground ml-auto">(custom)</span>
+            </button>
+          )}
+          <div className="border-t border-border my-1" />
+          <button
+            onClick={() => handleSelect({ switchTo: 'disabled' })}
+            className={`w-full px-3 py-1.5 text-left text-xs transition-colors flex items-center gap-2 ${
+              isNoSwitch
+                ? 'text-primary bg-primary/10 font-medium'
+                : 'text-popover-foreground hover:bg-muted'
+            }`}
+          >
+            <span className="w-4 flex-shrink-0">{isNoSwitch && <Checkmark />}</span>
+            No switch
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/ui/components/ToolbarButtons.tsx
+++ b/packages/ui/components/ToolbarButtons.tsx
@@ -49,7 +49,7 @@ export const FeedbackButton: React.FC<FeedbackButtonProps> = ({
   </button>
 );
 
-interface ApproveButtonProps {
+export interface ApproveButtonProps {
   onClick: () => void;
   disabled?: boolean;
   isLoading?: boolean;


### PR DESCRIPTION
## Summary

- Adds a GitHub-style split Approve button for OpenCode users with a dropdown to pick which agent to switch to after plan approval (or "No switch" to disable switching entirely)
- Fixes the "approved with notes" prompt to omit "Proceed with implementation" when agent switching is disabled
- Non-OpenCode origins are completely unaffected

## Related issues

**Closes #575** — User's CLI switched from Orchestrator to Build mode after plannotator. The agent switch setting was buried in Settings and undiscoverable. The dropdown surfaces it directly on the button, and "No switch" prevents any mode change.

**Closes #114** — Agent switched to the wrong agent on approval. The existing setting (default: "build") was the cause, but users didn't know about it. Now the button label shows exactly which agent will be activated ("Approve → Build"), and changing it is one click.

**Closes #106** — Sisyphus mode compatibility. PR #318 handled prompt stripping; the remaining issue was agent switching interfering with Sisyphus's agent topology. Users can now set "No switch" to prevent plannotator from changing agents at all.

**Closes #159** — No way to approve a plan without triggering implementation. When "No switch" is selected, the approve message no longer contains "Proceed with implementation" — it just returns "Plan approved!" (or notes without an implementation directive), letting the current agent decide what to do next.

## Changes

| File | Change |
|------|--------|
| `packages/ui/components/ApproveDropdown.tsx` | New split button component — lists agents from OpenCode API + "No switch" option |
| `packages/editor/App.tsx` | Renders `ApproveDropdown` for OpenCode, plain `ApproveButton` for all other origins |
| `packages/shared/prompts.ts` | OpenCode approved-with-notes template uses `{{proceedSuffix}}`; defaults to `""` |
| `apps/opencode-plugin/index.ts` | Passes `proceedSuffix` based on whether agent switching is active |
| `packages/ui/components/ToolbarButtons.tsx` | Exports `ApproveButtonProps` interface |

## Test plan

- [ ] OpenCode: verify split button shows with agent list from API
- [ ] Pick different agents from dropdown → label updates, cookie persists, Settings reflects change
- [ ] Select "No switch" → button shows "Approve", approved-with-notes prompt has no "Proceed with implementation"
- [ ] Approve with agent selected → agent switches correctly, prompt includes implementation directive
- [ ] Claude Code / Gemini CLI / other origins → unchanged single Approve button
- [ ] Mobile → plain "OK" button, no dropdown
- [ ] Keyboard shortcut (Cmd+Enter) → still works, reads agent from cookies