### PR TITLE
feat(review): right-click file tree row to copy path or filename

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -64,7 +64,7 @@
     },
     "apps/opencode-plugin": {
       "name": "@plannotator/opencode",
-      "version": "0.19.4",
+      "version": "0.19.5",
       "dependencies": {
         "@opencode-ai/plugin": "^1.1.10",
       },
@@ -86,7 +86,7 @@
     },
     "apps/pi-extension": {
       "name": "@plannotator/pi-extension",
-      "version": "0.19.4",
+      "version": "0.19.5",
       "dependencies": {
         "@joplin/turndown-plugin-gfm": "^1.0.64",
         "@pierre/diffs": "^1.1.12",
@@ -177,6 +177,7 @@
         "@plannotator/ui": "workspace:*",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-collapsible": "^1.1.12",
+        "@radix-ui/react-context-menu": "^2.2.15",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-popover": "^1.1.15",
@@ -190,7 +191,7 @@
     },
     "packages/server": {
       "name": "@plannotator/server",
-      "version": "0.19.4",
+      "version": "0.19.5",
       "dependencies": {
         "@pierre/diffs": "^1.1.12",
         "@plannotator/ai": "workspace:*",
@@ -734,6 +735,8 @@
     "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
 
     "@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+
+    "@radix-ui/react-context-menu": ["@radix-ui/react-context-menu@2.2.16", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-menu": "2.1.16", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww=="],
 
     "@radix-ui/react-dialog": ["@radix-ui/react-dialog@1.1.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw=="],
 

--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -2102,6 +2102,7 @@ const ReviewApp: React.FC = () => {
                 activeSearchMatchId={hasSearchableFiles ? activeSearchMatchId : null}
                 onSelectSearchMatch={hasSearchableFiles ? handleSelectSearchMatch : undefined}
                 onStepSearchMatch={hasSearchableFiles ? stepSearchMatch : undefined}
+                repoRoot={prMetadata ? null : (activeWorktreePath ?? agentCwd ?? gitContext?.cwd ?? null)}
               />
               <ResizeHandle {...fileTreeResize.handleProps} side="left" />
             </>

--- a/packages/review-editor/components/FileTree.tsx
+++ b/packages/review-editor/components/FileTree.tsx
@@ -55,6 +55,8 @@ interface FileTreeProps {
   onSelectAllFiles?: () => void;
   isAllFilesActive?: boolean;
   scrollHighlightIndex?: number;
+  /** Absolute repo root for the "Copy full path" context menu item. Null/undefined hides the option (e.g. PR review mode). */
+  repoRoot?: string | null;
 }
 
 export const FileTree: React.FC<FileTreeProps> = ({
@@ -101,6 +103,7 @@ export const FileTree: React.FC<FileTreeProps> = ({
   onSelectAllFiles,
   isAllFilesActive = false,
   scrollHighlightIndex,
+  repoRoot,
 }) => {
   const isSearchVisible = !!onSearchChange && (isSearchOpen || !!searchQuery.trim());
 
@@ -445,6 +448,7 @@ export const FileTree: React.FC<FileTreeProps> = ({
               hideViewedFiles={hideViewedFiles}
               getAnnotationCount={getAnnotationCount}
               stagedFiles={stagedFiles}
+              repoRoot={repoRoot}
             />
           ))}
           </>

--- a/packages/review-editor/components/FileTreeNode.tsx
+++ b/packages/review-editor/components/FileTreeNode.tsx
@@ -15,6 +15,8 @@ interface FileTreeNodeProps {
   getAnnotationCount: (filePath: string) => number;
   stagedFiles?: Set<string>;
   scrollHighlightIndex?: number;
+  /** Absolute repo root used to build the "Copy full path" menu item. Null in PR-review mode (files aren't on local disk). */
+  repoRoot?: string | null;
 }
 
 function hasVisibleChildren(
@@ -47,6 +49,7 @@ export const FileTreeNodeItem: React.FC<FileTreeNodeProps> = ({
   getAnnotationCount,
   stagedFiles,
   scrollHighlightIndex,
+  repoRoot,
 }) => {
   const paddingLeft = 4 + node.depth * 8;
 
@@ -96,6 +99,7 @@ export const FileTreeNodeItem: React.FC<FileTreeNodeProps> = ({
             getAnnotationCount={getAnnotationCount}
             stagedFiles={stagedFiles}
             scrollHighlightIndex={scrollHighlightIndex}
+            repoRoot={repoRoot}
           />
         ))}
       </>
@@ -170,6 +174,14 @@ export const FileTreeNodeItem: React.FC<FileTreeNodeProps> = ({
           >
             Copy filename
           </ContextMenu.Item>
+          {repoRoot && (
+            <ContextMenu.Item
+              onSelect={() => navigator.clipboard.writeText(`${repoRoot.replace(/\/$/, '')}/${node.path}`)}
+              className="flex items-center gap-2 mx-1 px-2 py-1.5 text-xs rounded cursor-pointer outline-none text-foreground/80 data-[highlighted]:bg-muted data-[highlighted]:text-foreground"
+            >
+              Copy full path
+            </ContextMenu.Item>
+          )}
         </ContextMenu.Content>
       </ContextMenu.Portal>
     </ContextMenu.Root>

--- a/packages/review-editor/components/FileTreeNode.tsx
+++ b/packages/review-editor/components/FileTreeNode.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import * as ContextMenu from '@radix-ui/react-context-menu';
 import type { FileTreeNode as TreeNode } from '../utils/buildFileTree';
 
 interface FileTreeNodeProps {
@@ -113,44 +114,64 @@ export const FileTreeNodeItem: React.FC<FileTreeNodeProps> = ({
   }
 
   return (
-    <button
-      onClick={() => onSelectFile(node.fileIndex!)}
-      onDoubleClick={() => onDoubleClickFile?.(node.fileIndex!)}
-      className={`file-tree-item w-full text-left group ${isActive ? 'active' : isScrollActive ? 'scroll-active' : ''} ${annotationCount > 0 ? 'has-annotations' : ''} ${isStaged ? 'staged' : ''}`}
-      style={{ paddingLeft }}
-    >
-      <div className="flex items-center gap-1.5 flex-1 min-w-0">
-        <span
-          role="checkbox"
-          aria-checked={isViewed}
-          onClick={(e) => {
-            e.stopPropagation();
-            onToggleViewed?.(node.path);
-          }}
-          className="flex-shrink-0 p-0.5 rounded hover:bg-muted/50 cursor-pointer"
+    <ContextMenu.Root>
+      <ContextMenu.Trigger asChild>
+        <button
+          onClick={() => onSelectFile(node.fileIndex!)}
+          onDoubleClick={() => onDoubleClickFile?.(node.fileIndex!)}
+          className={`file-tree-item w-full text-left group ${isActive ? 'active' : isScrollActive ? 'scroll-active' : ''} ${annotationCount > 0 ? 'has-annotations' : ''} ${isStaged ? 'staged' : ''}`}
+          style={{ paddingLeft }}
         >
-          {isViewed ? (
-            <svg className="w-3.5 h-3.5 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-          ) : (
-            <svg className="w-3.5 h-3.5 text-muted-foreground opacity-50" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <circle cx="12" cy="12" r="9" />
-            </svg>
-          )}
-        </span>
-        <span className="truncate">{node.name}</span>
-      </div>
-      <div className="flex items-center gap-1.5 flex-shrink-0 text-[10px]">
-        {isStaged && (
-          <span className="text-primary font-medium" title="Staged (git add)">+</span>
-        )}
-        {annotationCount > 0 && (
-          <span className="text-primary font-medium">{annotationCount}</span>
-        )}
-        <span className="additions">+{node.file!.additions}</span>
-        <span className="deletions">-{node.file!.deletions}</span>
-      </div>
-    </button>
+          <div className="flex items-center gap-1.5 flex-1 min-w-0">
+            <span
+              role="checkbox"
+              aria-checked={isViewed}
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggleViewed?.(node.path);
+              }}
+              className="flex-shrink-0 p-0.5 rounded hover:bg-muted/50 cursor-pointer"
+            >
+              {isViewed ? (
+                <svg className="w-3.5 h-3.5 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+              ) : (
+                <svg className="w-3.5 h-3.5 text-muted-foreground opacity-50" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <circle cx="12" cy="12" r="9" />
+                </svg>
+              )}
+            </span>
+            <span className="truncate">{node.name}</span>
+          </div>
+          <div className="flex items-center gap-1.5 flex-shrink-0 text-[10px]">
+            {isStaged && (
+              <span className="text-primary font-medium" title="Staged (git add)">+</span>
+            )}
+            {annotationCount > 0 && (
+              <span className="text-primary font-medium">{annotationCount}</span>
+            )}
+            <span className="additions">+{node.file!.additions}</span>
+            <span className="deletions">-{node.file!.deletions}</span>
+          </div>
+        </button>
+      </ContextMenu.Trigger>
+      <ContextMenu.Portal>
+        <ContextMenu.Content className="z-50 min-w-[160px] bg-popover text-popover-foreground border border-border rounded shadow-lg overflow-hidden py-1 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0">
+          <ContextMenu.Item
+            onSelect={() => navigator.clipboard.writeText(node.path)}
+            className="flex items-center gap-2 mx-1 px-2 py-1.5 text-xs rounded cursor-pointer outline-none text-foreground/80 data-[highlighted]:bg-muted data-[highlighted]:text-foreground"
+          >
+            Copy path
+          </ContextMenu.Item>
+          <ContextMenu.Item
+            onSelect={() => navigator.clipboard.writeText(node.name)}
+            className="flex items-center gap-2 mx-1 px-2 py-1.5 text-xs rounded cursor-pointer outline-none text-foreground/80 data-[highlighted]:bg-muted data-[highlighted]:text-foreground"
+          >
+            Copy filename
+          </ContextMenu.Item>
+        </ContextMenu.Content>
+      </ContextMenu.Portal>
+    </ContextMenu.Root>
   );
 };

--- a/packages/review-editor/package.json
+++ b/packages/review-editor/package.json
@@ -12,6 +12,7 @@
     "@plannotator/ui": "workspace:*",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-collapsible": "^1.1.12",
+    "@radix-ui/react-context-menu": "^2.2.15",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-popover": "^1.1.15",


### PR DESCRIPTION
## Summary
- Right-click a file row in the code review file tree to open a context menu with **Copy path** (repo-relative) and **Copy filename** options.
- Uses `@radix-ui/react-context-menu` (same family as the Radix primitives already in the review editor) wrapped via `Trigger asChild` on the existing row `<button>`, so single/double-click and the inner viewed-toggle's `stopPropagation` are preserved. Folder rows are intentionally out of scope for this pass.

## Test plan
- [ ] Right-click a file row → menu shows; Copy path writes the repo-relative path; Copy filename writes just the leaf filename.
- [ ] Left-click and double-click on the row still select / open the file as before.
- [ ] Right-click on the inner viewed-state checkbox still opens the file's context menu (does not toggle viewed).
- [ ] Escape / click-outside closes the menu without changing `activeFileIndex`.
- [ ] j/k file navigation does not fire while the menu is open (Radix popper wrapper is already excluded by the keyboard guard in `FileTree.tsx`).
- [ ] Menu renders correctly above the file tree's overflow container (portal + `z-50`).