### PR TITLE
feat(editor): auto-close left sidebar when TOC is empty

### DIFF
--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -268,9 +268,22 @@ const App: React.FC = () => {
     if (wideModeType !== null) return;
     if (lastAppliedTocEnabledRef.current === uiPrefs.tocEnabled) return;
     lastAppliedTocEnabledRef.current = uiPrefs.tocEnabled;
-    if (uiPrefs.tocEnabled) sidebar.open('toc');
-    else sidebar.close();
-  }, [wideModeType, sidebar.close, sidebar.open, uiPrefs.tocEnabled]);
+    if (uiPrefs.tocEnabled && hasTocEntries) sidebar.open('toc');
+    else if (!uiPrefs.tocEnabled) sidebar.close();
+  }, [wideModeType, sidebar.close, sidebar.open, uiPrefs.tocEnabled, hasTocEntries]);
+
+  // Auto-close the sidebar when blocks parse with no TOC entries. Fires
+  // only on blocks/hasTocEntries change (not on sidebar state) so a user
+  // who manually re-opens the empty sidebar is left alone — until the
+  // document changes again (e.g. picking a new file in annotate-folder).
+  useEffect(() => {
+    if (blocks.length === 0) return;
+    if (hasTocEntries) return;
+    if (sidebar.activeTab === 'toc' && sidebar.isOpen) {
+      sidebar.close();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [blocks, hasTocEntries]);
 
   // Clear diff view when switching away from versions tab
   useEffect(() => {
@@ -522,6 +535,10 @@ const App: React.FC = () => {
 
   // Track active section for TOC highlighting
   const headingCount = useMemo(() => blocks.filter(b => b.type === 'heading').length, [blocks]);
+  const hasTocEntries = useMemo(
+    () => blocks.some(b => b.type === 'heading' && (b.level ?? 0) <= 3),
+    [blocks]
+  );
   const activeSection = useActiveSection(containerRef, headingCount, scrollViewport);
 
   const { editorAnnotations, deleteEditorAnnotation } = useEditorAnnotations();

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -210,6 +210,14 @@ const App: React.FC = () => {
   // Sidebar (shared TOC + Version Browser)
   const sidebar = useSidebar(getUIPreferences().tocEnabled);
 
+  // Whether the document has any TOC-eligible headings (level <= 3, matching
+  // buildTocHierarchy). Drives the empty-doc auto-close behavior below — must
+  // be declared before the effects that reference it (TDZ in dep arrays).
+  const hasTocEntries = useMemo(
+    () => blocks.some(b => b.type === 'heading' && (b.level ?? 0) <= 3),
+    [blocks]
+  );
+
   const exitWideMode = useCallback((options?: {
     restore?: boolean;
     sidebarTab?: SidebarTab;
@@ -535,10 +543,6 @@ const App: React.FC = () => {
 
   // Track active section for TOC highlighting
   const headingCount = useMemo(() => blocks.filter(b => b.type === 'heading').length, [blocks]);
-  const hasTocEntries = useMemo(
-    () => blocks.some(b => b.type === 'heading' && (b.level ?? 0) <= 3),
-    [blocks]
-  );
   const activeSection = useActiveSection(containerRef, headingCount, scrollViewport);
 
   const { editorAnnotations, deleteEditorAnnotation } = useEditorAnnotations();


### PR DESCRIPTION
## Summary
- When a document has no level 1-3 headings (common in `annotate` / `annotate-last` sessions and structureless plans), keep the left sidebar closed regardless of the "Auto-open Sidebar" preference.
- The collapsed flag strip remains available so users can still open it manually; manual re-open isn't overridden until the document changes again (e.g. picking a new file in `annotate-folder`).
- Mode overrides untouched: `archive` still forces the Archive tab open, `annotate-folder` still forces Files.

## Implementation
In `packages/editor/App.tsx`:
- Derive `hasTocEntries` from `blocks` using the same `level <= 3` rule as `buildTocHierarchy`.
- Gate the existing `tocEnabled` sync effect: only `sidebar.open('toc')` when `hasTocEntries` is true. Closing on toggle-off is preserved.
- Add a one-shot effect keyed on `[blocks, hasTocEntries]` that closes the sidebar when blocks parse with no TOC entries and the active tab is TOC. Intentionally does not depend on sidebar state, so a manual re-open sticks until the document changes.

## Test plan
- [ ] Plan with headings: sidebar opens to TOC per `tocEnabled` (unchanged).
- [ ] Plan with no headings: sidebar stays closed; clicking the TOC flag still opens it.
- [ ] `annotate` / `annotate-last` on a heading-less doc: sidebar stays closed.
- [ ] `annotate-folder`: switching between files with/without headings keeps Files tab open; switching to TOC tab on a heading-less file closes the sidebar.
- [ ] `archive` mode: Archive tab still force-opens.
- [ ] Toggle "Auto-open Sidebar" in Settings on a heading-less doc: no flicker, sidebar stays closed.