### PR TITLE
fix(ui): smart resolution + existence-validation for code-file paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,6 +220,7 @@ During normal plan review, an Archive sidebar tab provides the same browsing via
 | `/api/reference/obsidian/doc`   | GET | Read a vault markdown file (`?vaultPath=<path>&path=<file>`) |
 | `/api/plan/vscode-diff` | POST   | Open diff in VS Code (body: baseVersion)   |
 | `/api/doc`              | GET    | Serve linked .md/.mdx file (`?path=<path>`) |
+| `/api/doc/exists`       | POST   | Batch-validate code-file paths (body: `{ paths: string[], base?: string }`) returns `{ results: { [path]: { status: "found"\|"ambiguous"\|"missing"\|"unavailable", … } } }` |
 | `/api/draft`          | GET/POST/DELETE | Auto-save annotation drafts to survive server crashes |
 | `/api/editor-annotations` | GET | List editor annotations (VS Code only) |
 | `/api/editor-annotation` | POST/DELETE | Add or remove an editor annotation (VS Code only) |
@@ -276,6 +277,8 @@ During normal plan review, an Archive sidebar tab provides the same browsing via
 | `/api/exit`           | POST   | Close session without feedback |
 | `/api/image`          | GET    | Serve image by path query param            |
 | `/api/upload`         | POST   | Upload image, returns `{ path, originalName }` |
+| `/api/doc`            | GET    | Serve linked .md/.mdx/.html file or code file (`?path=<path>&base=<dir>`) |
+| `/api/doc/exists`     | POST   | Batch-validate code-file paths (body: `{ paths: string[], base?: string }`) |
 | `/api/draft`          | GET/POST/DELETE | Auto-save annotation drafts to survive server crashes |
 | `/api/external-annotations/stream` | GET | SSE stream for real-time external annotations |
 | `/api/external-annotations` | GET | Snapshot of external annotations (polling fallback, `?since=N` for version gating) |

--- a/apps/pi-extension/server/reference.ts
+++ b/apps/pi-extension/server/reference.ts
@@ -201,6 +201,11 @@ export async function handleDocRequest(res: Res, url: URL): Promise<void> {
 /**
  * Batch existence check for code-file paths the renderer wants to linkify.
  * POST /api/doc/exists with { paths: string[] }.
+ *
+ * TODO(security): see packages/server/reference-handlers.ts handleDocExists —
+ * absolute paths are probed verbatim with no project-root containment check,
+ * leaking file existence back to the caller. Fix in lockstep with the Bun
+ * handler (reject absolute inputs or filter results via isWithinProjectRoot).
  */
 export async function handleDocExistsRequest(res: Res, req: IncomingMessage): Promise<void> {
 	const body = await parseBody(req);
@@ -213,6 +218,10 @@ export async function handleDocExistsRequest(res: Res, req: IncomingMessage): Pr
 		json(res, { error: "Too many paths (max 500)" }, 400);
 		return;
 	}
+	const baseRaw = (body as { base?: unknown }).base;
+	const baseDir = typeof baseRaw === "string" && baseRaw.length > 0
+		? resolveUserPath(baseRaw)
+		: undefined;
 
 	const projectRoot = process.cwd();
 	const results: Record<
@@ -225,7 +234,7 @@ export async function handleDocExistsRequest(res: Res, req: IncomingMessage): Pr
 
 	await Promise.all(
 		(paths as string[]).map(async (p) => {
-			const r = await resolveCodeFile(p, projectRoot);
+			const r = await resolveCodeFile(p, projectRoot, baseDir);
 			if (r.kind === "found") {
 				results[p] = { status: "found", resolved: r.path };
 			} else if (r.kind === "ambiguous") {

--- a/apps/pi-extension/server/reference.ts
+++ b/apps/pi-extension/server/reference.ts
@@ -14,7 +14,8 @@ import {
 import type { ServerResponse } from "node:http";
 import { join, resolve as resolvePath } from "node:path";
 
-import { json } from "./helpers";
+import { json, parseBody } from "./helpers";
+import type { IncomingMessage } from "node:http";
 
 import {
 	type VaultNode,
@@ -25,9 +26,11 @@ import { detectObsidianVaults } from "../generated/integrations-common.js";
 import {
 	isAbsoluteUserPath,
 	isCodeFilePath,
+	resolveCodeFile,
 	resolveMarkdownFile,
 	resolveUserPath,
 	isWithinProjectRoot,
+	warmFileListCache,
 } from "../generated/resolve-file.js";
 import { htmlToMarkdown } from "../generated/html-to-markdown.js";
 import { preloadFile } from "@pierre/diffs/ssr";
@@ -62,6 +65,9 @@ export async function handleDocRequest(res: Res, url: URL): Promise<void> {
 		json(res, { error: "Missing path parameter" }, 400);
 		return;
 	}
+
+	// Side-channel: warm the code-file walk so /api/doc/exists POSTs land warm.
+	void warmFileListCache(process.cwd(), "code");
 
 	// Try resolving relative to base directory first (used by annotate mode).
 	// No isWithinProjectRoot check here — intentional, matches pre-existing
@@ -108,38 +114,61 @@ export async function handleDocRequest(res: Res, url: URL): Promise<void> {
 		return;
 	}
 
-	// Code files: resolve directly, return raw contents (no markdown conversion)
+	// Code files: try literal resolve first; on miss, fall back to smart resolver.
 	if (isCodeFilePath(requestedPath)) {
-		const resolvedCode = resolveUserPath(requestedPath, resolvedBase || projectRoot);
-		if (!resolvedBase && !isWithinProjectRoot(resolvedCode, projectRoot)) {
-			json(res, { error: "Access denied: path is outside project root" }, 403);
-			return;
+		const literalPath = resolveUserPath(requestedPath, resolvedBase || projectRoot);
+		const literalAllowed = resolvedBase || isWithinProjectRoot(literalPath, projectRoot);
+
+		let resolvedCode: string | null = null;
+		if (literalAllowed && existsSync(literalPath)) {
+			resolvedCode = literalPath;
 		}
-		try {
-			if (existsSync(resolvedCode)) {
-				const stat = statSync(resolvedCode);
-				if (stat.size > 2 * 1024 * 1024) {
-					json(res, { error: "File too large (max 2MB)" }, 413);
-					return;
-				}
-				const contents = readFileSync(resolvedCode, "utf-8");
-				const displayName = resolvedCode.split("/").pop() || resolvedCode;
-				let prerenderedHTML: string | undefined;
-				try {
-					const result = await preloadFile({
-						file: { name: displayName, contents },
-						options: { disableFileHeader: true },
-					});
-					prerenderedHTML = result.prerenderedHTML;
-				} catch {
-					// Fall back to client-side rendering
-				}
-				json(res, { codeFile: true, contents, filepath: resolvedCode, prerenderedHTML });
+
+		if (!resolvedCode) {
+			const result = await resolveCodeFile(requestedPath, projectRoot);
+			if (result.kind === "found") {
+				resolvedCode = result.path;
+			} else if (result.kind === "ambiguous") {
+				const prefix = `${projectRoot}/`;
+				const relative = result.matches.map((m: string) =>
+					m.startsWith(prefix) ? m.slice(prefix.length) : m,
+				);
+				json(res, { error: `Ambiguous path '${requestedPath}'`, matches: relative }, 400);
+				return;
+			} else {
+				json(res, { error: `File not found: ${requestedPath}` }, 404);
 				return;
 			}
-		} catch { /* fall through */ }
-		json(res, { error: `File not found: ${requestedPath}` }, 404);
-		return;
+			if (!isWithinProjectRoot(resolvedCode, projectRoot)) {
+				json(res, { error: "Access denied: path is outside project root" }, 403);
+				return;
+			}
+		}
+
+		try {
+			const stat = statSync(resolvedCode);
+			if (stat.size > 2 * 1024 * 1024) {
+				json(res, { error: "File too large (max 2MB)" }, 413);
+				return;
+			}
+			const contents = readFileSync(resolvedCode, "utf-8");
+			const displayName = resolvedCode.split("/").pop() || resolvedCode;
+			let prerenderedHTML: string | undefined;
+			try {
+				const result = await preloadFile({
+					file: { name: displayName, contents },
+					options: { disableFileHeader: true },
+				});
+				prerenderedHTML = result.prerenderedHTML;
+			} catch {
+				// Fall back to client-side rendering
+			}
+			json(res, { codeFile: true, contents, filepath: resolvedCode, prerenderedHTML });
+			return;
+		} catch {
+			json(res, { error: `File not found: ${requestedPath}` }, 404);
+			return;
+		}
 	}
 
 	const result = resolveMarkdownFile(requestedPath, projectRoot);
@@ -167,6 +196,53 @@ export async function handleDocRequest(res: Res, url: URL): Promise<void> {
 	} catch {
 		json(res, { error: "Failed to read file" }, 500);
 	}
+}
+
+/**
+ * Batch existence check for code-file paths the renderer wants to linkify.
+ * POST /api/doc/exists with { paths: string[] }.
+ */
+export async function handleDocExistsRequest(res: Res, req: IncomingMessage): Promise<void> {
+	const body = await parseBody(req);
+	const paths = (body as { paths?: unknown }).paths;
+	if (!Array.isArray(paths) || !paths.every((p) => typeof p === "string")) {
+		json(res, { error: "Expected { paths: string[] }" }, 400);
+		return;
+	}
+	if (paths.length > 500) {
+		json(res, { error: "Too many paths (max 500)" }, 400);
+		return;
+	}
+
+	const projectRoot = process.cwd();
+	const results: Record<
+		string,
+		| { status: "found"; resolved: string }
+		| { status: "ambiguous"; matches: string[] }
+		| { status: "missing" }
+		| { status: "unavailable" }
+	> = {};
+
+	await Promise.all(
+		(paths as string[]).map(async (p) => {
+			const r = await resolveCodeFile(p, projectRoot);
+			if (r.kind === "found") {
+				results[p] = { status: "found", resolved: r.path };
+			} else if (r.kind === "ambiguous") {
+				const prefix = `${projectRoot}/`;
+				results[p] = {
+					status: "ambiguous",
+					matches: r.matches.map((m: string) => (m.startsWith(prefix) ? m.slice(prefix.length) : m)),
+				};
+			} else if (r.kind === "unavailable") {
+				results[p] = { status: "unavailable" };
+			} else {
+				results[p] = { status: "missing" };
+			}
+		}),
+	);
+
+	json(res, { results });
 }
 
 export function handleObsidianVaultsRequest(res: Res): void {

--- a/apps/pi-extension/server/reference.ts
+++ b/apps/pi-extension/server/reference.ts
@@ -203,9 +203,9 @@ export async function handleDocRequest(res: Res, url: URL): Promise<void> {
  * POST /api/doc/exists with { paths: string[] }.
  *
  * TODO(security): see packages/server/reference-handlers.ts handleDocExists —
- * absolute paths are probed verbatim with no project-root containment check,
- * leaking file existence back to the caller. Fix in lockstep with the Bun
- * handler (reject absolute inputs or filter results via isWithinProjectRoot).
+ * both absolute paths in `paths[]` AND the `base` field are honored verbatim
+ * with no project-root containment check, leaking file existence back to the
+ * caller. Fix in lockstep with the Bun handler.
  */
 export async function handleDocExistsRequest(res: Res, req: IncomingMessage): Promise<void> {
 	const body = await parseBody(req);

--- a/apps/pi-extension/server/reference.ts
+++ b/apps/pi-extension/server/reference.ts
@@ -185,7 +185,7 @@ export async function handleDocRequest(res: Res, url: URL): Promise<void> {
 		return;
 	}
 
-	if (result.kind === "not_found") {
+	if (result.kind === "not_found" || result.kind === "unavailable") {
 		json(res, { error: `File not found: ${result.input}` }, 404);
 		return;
 	}

--- a/apps/pi-extension/server/serverAnnotate.ts
+++ b/apps/pi-extension/server/serverAnnotate.ts
@@ -17,11 +17,13 @@ import { listenOnPort } from "./network.js";
 import { getRepoInfo } from "./project.js";
 import {
 	handleDocRequest,
+	handleDocExistsRequest,
 	handleFileBrowserRequest,
 	handleObsidianVaultsRequest,
 	handleObsidianFilesRequest,
 	handleObsidianDocRequest,
 } from "./reference.js";
+import { warmFileListCache } from "../generated/resolve-file.js";
 import { createExternalAnnotationHandler } from "./external-annotations.js";
 
 export interface AnnotateServerResult {
@@ -46,6 +48,8 @@ export async function startAnnotateServer(options: {
 	sourceConverted?: boolean;
 	gate?: boolean;
 }): Promise<AnnotateServerResult> {
+	// Side-channel pre-warm so /api/doc/exists POSTs land on warm cache.
+	void warmFileListCache(process.cwd(), "code");
 	const gitUser = detectGitUser();
 	const sharingEnabled =
 		options.sharingEnabled ?? process.env.PLANNOTATOR_SHARE !== "disabled";
@@ -127,6 +131,8 @@ export async function startAnnotateServer(options: {
 				url.searchParams.set("base", dirname(resolvePath(options.filePath)));
 			}
 			await handleDocRequest(res, url);
+		} else if (url.pathname === "/api/doc/exists" && req.method === "POST") {
+			await handleDocExistsRequest(res, req);
 		} else if (url.pathname === "/api/obsidian/vaults") {
 			handleObsidianVaultsRequest(res);
 		} else if (url.pathname === "/api/reference/obsidian/files" && req.method === "GET") {

--- a/apps/pi-extension/server/serverPlan.ts
+++ b/apps/pi-extension/server/serverPlan.ts
@@ -40,11 +40,13 @@ import { saveConfig, detectGitUser, getServerConfig } from "../generated/config.
 import { detectProjectName, getRepoInfo } from "./project.js";
 import {
 	handleDocRequest,
+	handleDocExistsRequest,
 	handleFileBrowserRequest,
 	handleObsidianDocRequest,
 	handleObsidianFilesRequest,
 	handleObsidianVaultsRequest,
 } from "./reference.js";
+import { warmFileListCache } from "../generated/resolve-file.js";
 
 export interface PlanReviewDecision {
 	approved: boolean;
@@ -76,6 +78,8 @@ export async function startPlanReviewServer(options: {
 	mode?: "archive";
 	customPlanPath?: string | null;
 }): Promise<PlanServerResult> {
+	// Side-channel pre-warm so /api/doc/exists POSTs land on warm cache.
+	void warmFileListCache(process.cwd(), "code");
 	const gitUser = detectGitUser();
 	const sharingEnabled =
 		options.sharingEnabled ?? process.env.PLANNOTATOR_SHARE !== "disabled";
@@ -247,6 +251,8 @@ export async function startPlanReviewServer(options: {
 			return;
 		} else if (url.pathname === "/api/doc" && req.method === "GET") {
 			await handleDocRequest(res, url);
+		} else if (url.pathname === "/api/doc/exists" && req.method === "POST") {
+			await handleDocExistsRequest(res, req);
 		} else if (url.pathname === "/api/obsidian/vaults") {
 			handleObsidianVaultsRequest(res);
 		} else if (url.pathname === "/api/reference/obsidian/files" && req.method === "GET") {

--- a/bun.lock
+++ b/bun.lock
@@ -64,7 +64,7 @@
     },
     "apps/opencode-plugin": {
       "name": "@plannotator/opencode",
-      "version": "0.19.5",
+      "version": "0.19.7",
       "dependencies": {
         "@opencode-ai/plugin": "^1.1.10",
       },
@@ -86,7 +86,7 @@
     },
     "apps/pi-extension": {
       "name": "@plannotator/pi-extension",
-      "version": "0.19.5",
+      "version": "0.19.7",
       "dependencies": {
         "@joplin/turndown-plugin-gfm": "^1.0.64",
         "@pierre/diffs": "^1.1.12",
@@ -191,7 +191,7 @@
     },
     "packages/server": {
       "name": "@plannotator/server",
-      "version": "0.19.5",
+      "version": "0.19.7",
       "dependencies": {
         "@pierre/diffs": "^1.1.12",
         "@plannotator/ai": "workspace:*",

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -335,16 +335,23 @@ const App: React.FC = () => {
     viewerRef, sidebar: linkedDocSidebar, sourceFilePath, sourceConverted,
   });
 
+  // Active document's directory — feeds both click-time popout fetches and
+  // the validator hook so they resolve against the same base. Drifting
+  // these would silently re-introduce the demote-correct-link bug.
+  const activeDocBaseDir = useMemo(
+    () => linkedDocHook.filepath
+      ? linkedDocHook.filepath.replace(/\/[^/]+$/, '')
+      : imageBaseDir?.includes('/') ? imageBaseDir : undefined,
+    [linkedDocHook.filepath, imageBaseDir],
+  );
+
   // Code file popout (read-only syntax-highlighted overlay)
   const codeFilePopout = useCodeFilePopout({
     buildUrl: useCallback((codePath: string) => {
-      const baseDir = linkedDocHook.filepath
-        ? linkedDocHook.filepath.replace(/\/[^/]+$/, '')
-        : imageBaseDir?.includes('/') ? imageBaseDir : undefined;
-      return baseDir
-        ? `/api/doc?path=${encodeURIComponent(codePath)}&base=${encodeURIComponent(baseDir)}`
+      return activeDocBaseDir
+        ? `/api/doc?path=${encodeURIComponent(codePath)}&base=${encodeURIComponent(activeDocBaseDir)}`
         : `/api/doc?path=${encodeURIComponent(codePath)}`;
-    }, [linkedDocHook.filepath, imageBaseDir]),
+    }, [activeDocBaseDir]),
   });
 
   // Archive browser
@@ -1969,9 +1976,7 @@ const App: React.FC = () => {
                   onOpenCodeFile={codeFilePopout.open}
                   linkedDocInfo={linkedDocHook.isActive ? { filepath: linkedDocHook.filepath!, onBack: handleLinkedDocBack, label: fileBrowser.dirs.find(d => d.path === fileBrowser.activeDirPath)?.isVault ? 'Vault File' : fileBrowser.activeFile ? 'File' : undefined, backLabel } : null}
                   imageBaseDir={imageBaseDir}
-                  codePathBaseDir={linkedDocHook.filepath
-                    ? linkedDocHook.filepath.replace(/\/[^/]+$/, '')
-                    : imageBaseDir}
+                  codePathBaseDir={activeDocBaseDir}
                   copyLabel={annotateSource === 'message' ? 'Copy message' : annotateSource === 'file' || annotateSource === 'folder' ? 'Copy file' : undefined}
                   archiveInfo={archive.currentInfo}
                   sourceInfo={sourceInfo}

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -1969,6 +1969,9 @@ const App: React.FC = () => {
                   onOpenCodeFile={codeFilePopout.open}
                   linkedDocInfo={linkedDocHook.isActive ? { filepath: linkedDocHook.filepath!, onBack: handleLinkedDocBack, label: fileBrowser.dirs.find(d => d.path === fileBrowser.activeDirPath)?.isVault ? 'Vault File' : fileBrowser.activeFile ? 'File' : undefined, backLabel } : null}
                   imageBaseDir={imageBaseDir}
+                  codePathBaseDir={linkedDocHook.filepath
+                    ? linkedDocHook.filepath.replace(/\/[^/]+$/, '')
+                    : imageBaseDir}
                   copyLabel={annotateSource === 'message' ? 'Copy message' : annotateSource === 'file' || annotateSource === 'folder' ? 'Copy file' : undefined}
                   archiveInfo={archive.currentInfo}
                   sourceInfo={sourceInfo}

--- a/packages/server/annotate.ts
+++ b/packages/server/annotate.ts
@@ -15,7 +15,8 @@ import { isRemoteSession, getServerHostname, getServerPort } from "./remote";
 import { getRepoInfo } from "./repo";
 import type { Origin } from "@plannotator/shared/agents";
 import { handleImage, handleUpload, handleServerReady, handleDraftSave, handleDraftLoad, handleDraftDelete, handleFavicon } from "./shared-handlers";
-import { handleDoc, handleFileBrowserFiles, handleObsidianVaults, handleObsidianFiles, handleObsidianDoc } from "./reference-handlers";
+import { handleDoc, handleDocExists, handleFileBrowserFiles, handleObsidianVaults, handleObsidianFiles, handleObsidianDoc } from "./reference-handlers";
+import { warmFileListCache } from "@plannotator/shared/resolve-file";
 import { contentHash, deleteDraft } from "./draft";
 import { createExternalAnnotationHandler } from "./external-annotations";
 import { saveConfig, detectGitUser, getServerConfig } from "./config";
@@ -93,6 +94,9 @@ const RETRY_DELAY_MS = 500;
 export async function startAnnotateServer(
   options: AnnotateServerOptions
 ): Promise<AnnotateServerResult> {
+  // Side-channel pre-warm so /api/doc/exists POSTs land on warm cache.
+  void warmFileListCache(process.cwd(), "code");
+
   const {
     markdown,
     filePath,
@@ -202,6 +206,11 @@ export async function startAnnotateServer(
               return handleDoc(new Request(docUrl.toString()));
             }
             return handleDoc(req);
+          }
+
+          // API: Batch existence check for code-file paths the renderer detected
+          if (url.pathname === "/api/doc/exists" && req.method === "POST") {
+            return handleDocExists(req);
           }
 
           // API: Detect Obsidian vaults

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -44,7 +44,8 @@ import { detectProjectName } from "./project";
 import { saveConfig, detectGitUser, getServerConfig } from "./config";
 import { handleImage, handleUpload, handleAgents, handleServerReady, handleDraftSave, handleDraftLoad, handleDraftDelete, handleFavicon, type OpencodeClient } from "./shared-handlers";
 import { contentHash, deleteDraft } from "./draft";
-import { handleDoc, handleObsidianVaults, handleObsidianFiles, handleObsidianDoc, handleFileBrowserFiles } from "./reference-handlers";
+import { handleDoc, handleDocExists, handleObsidianVaults, handleObsidianFiles, handleObsidianDoc, handleFileBrowserFiles } from "./reference-handlers";
+import { warmFileListCache } from "@plannotator/shared/resolve-file";
 import { createEditorAnnotationHandler } from "./editor-annotations";
 import { createExternalAnnotationHandler } from "./external-annotations";
 import { isWSL } from "./browser";
@@ -128,6 +129,10 @@ export async function startPlannotatorServer(
   const configuredPort = getServerPort();
   const wslFlag = await isWSL();
   const gitUser = detectGitUser();
+
+  // Side-channel pre-warm: kick off the code-file walk now so the
+  // renderer's POST /api/doc/exists lands on warm cache.
+  void warmFileListCache(process.cwd(), "code");
 
   // --- Archive mode setup ---
   let archivePlans: ArchivedPlan[] = [];
@@ -283,6 +288,11 @@ export async function startPlannotatorServer(
           // API: Serve a linked markdown document
           if (url.pathname === "/api/doc" && req.method === "GET") {
             return handleDoc(req);
+          }
+
+          // API: Batch existence check for code-file paths the renderer detected
+          if (url.pathname === "/api/doc/exists" && req.method === "POST") {
+            return handleDocExists(req);
           }
 
           // API: Update user config (write-back to ~/.plannotator/config.json)

--- a/packages/server/reference-handlers.ts
+++ b/packages/server/reference-handlers.ts
@@ -152,7 +152,7 @@ export async function handleDoc(req: Request): Promise<Response> {
 		);
 	}
 
-	if (result.kind === "not_found") {
+	if (result.kind === "not_found" || result.kind === "unavailable") {
 		return Response.json(
 			{ error: `File not found: ${result.input}` },
 			{ status: 404 },

--- a/packages/server/reference-handlers.ts
+++ b/packages/server/reference-handlers.ts
@@ -172,13 +172,18 @@ export async function handleDoc(req: Request): Promise<Response> {
  * POST /api/doc/exists with { paths: string[] } returns { results: { [path]: ValidationEntry } }.
  * Reads from the warm file-list cache populated at plan/annotate load.
  *
- * TODO(security): absolute paths sent here are probed verbatim against the
- * filesystem — `resolveCodeFile` returns `{ kind: 'found', path: abs }` for any
- * existing absolute file with no project-root containment check. A malicious
- * shared plan with backtick-wrapped absolute paths (e.g. `/Users/x/.aws/…`)
- * leaks file existence + canonical path back to the caller. Mitigation:
- * reject absolute inputs (or `isWithinProjectRoot`-filter `r.path`) before
- * recording a found result. Mirror in apps/pi-extension/server/reference.ts.
+ * TODO(security): two related leaks of arbitrary file existence:
+ *   1. Absolute paths in `paths[]` are probed verbatim — `resolveCodeFile`
+ *      returns `{ kind: 'found', path: abs }` for any existing absolute file
+ *      with no project-root containment check. A malicious shared plan with
+ *      backtick-wrapped absolute paths (e.g. `/Users/x/.aws/…`) leaks file
+ *      existence + canonical path back to the caller.
+ *   2. The `base` field is honored verbatim — a hostile sender can supply
+ *      `base=/Users/x/.aws` + `paths=["credentials.json"]` and the resolver
+ *      will check `<base>/<path>` existence with no containment check.
+ * Mitigation: reject absolute inputs and `isWithinProjectRoot`-filter the
+ * resolved base before passing it to `resolveCodeFile` (or filter `r.path`
+ * before recording a found result). Mirror in apps/pi-extension/server/reference.ts.
  */
 export async function handleDocExists(req: Request): Promise<Response> {
 	let body: unknown;

--- a/packages/server/reference-handlers.ts
+++ b/packages/server/reference-handlers.ts
@@ -12,10 +12,13 @@ import { detectObsidianVaults } from "./integrations";
 import {
 	isAbsoluteUserPath,
 	isCodeFilePath,
+	resolveCodeFile,
 	resolveMarkdownFile,
 	resolveUserPath,
 	isWithinProjectRoot,
+	warmFileListCache,
 } from "@plannotator/shared/resolve-file";
+import { extractCandidateCodePaths } from "@plannotator/shared/extract-code-paths";
 import { htmlToMarkdown } from "@plannotator/shared/html-to-markdown";
 import { preloadFile } from "@pierre/diffs/ssr";
 
@@ -28,6 +31,10 @@ export async function handleDoc(req: Request): Promise<Response> {
 	if (!requestedPath) {
 		return Response.json({ error: "Missing path parameter" }, { status: 400 });
 	}
+
+	// Side-channel: kick off a code-file walk for the project root so that any
+	// /api/doc/exists POST issued by the rendered linked-doc lands on warm cache.
+	void warmFileListCache(process.cwd(), "code");
 
 	// If a base directory is provided, try resolving relative to it first
 	// (used by annotate mode to resolve paths relative to the source file).
@@ -74,34 +81,64 @@ export async function handleDoc(req: Request): Promise<Response> {
 		return Response.json({ error: `File not found: ${requestedPath}` }, { status: 404 });
 	}
 
-	// Code files: resolve directly, return raw contents (no markdown conversion)
+	// Code files: try literal resolve first; on miss, fall back to the smart
+	// resolver which walks the project for case-insensitive / suffix matches.
 	if (isCodeFilePath(requestedPath)) {
-		const resolvedCode = resolveUserPath(requestedPath, resolvedBase || projectRoot);
-		if (!resolvedBase && !isWithinProjectRoot(resolvedCode, projectRoot)) {
-			return Response.json({ error: "Access denied: path is outside project root" }, { status: 403 });
+		const literalPath = resolveUserPath(requestedPath, resolvedBase || projectRoot);
+		const literalAllowed = resolvedBase || isWithinProjectRoot(literalPath, projectRoot);
+
+		let resolvedCode: string | null = null;
+		if (literalAllowed) {
+			try {
+				const file = Bun.file(literalPath);
+				if (await file.exists()) resolvedCode = literalPath;
+			} catch { /* fall through */ }
 		}
+
+		if (!resolvedCode) {
+			const result = await resolveCodeFile(requestedPath, projectRoot);
+			if (result.kind === "found") {
+				resolvedCode = result.path;
+			} else if (result.kind === "ambiguous") {
+				const prefix = `${projectRoot}/`;
+				const relative = result.matches.map((m) =>
+					m.startsWith(prefix) ? m.slice(prefix.length) : m,
+				);
+				return Response.json(
+					{ error: `Ambiguous path '${requestedPath}'`, matches: relative },
+					{ status: 400 },
+				);
+			} else if (result.kind === "unavailable") {
+				return Response.json({ error: `Cannot scan project: ${requestedPath}` }, { status: 404 });
+			} else {
+				return Response.json({ error: `File not found: ${requestedPath}` }, { status: 404 });
+			}
+			if (!isWithinProjectRoot(resolvedCode, projectRoot)) {
+				return Response.json({ error: "Access denied: path is outside project root" }, { status: 403 });
+			}
+		}
+
 		try {
 			const file = Bun.file(resolvedCode);
-			if (await file.exists()) {
-				if (file.size > 2 * 1024 * 1024) {
-					return Response.json({ error: "File too large (max 2MB)" }, { status: 413 });
-				}
-				const contents = await file.text();
-				const displayName = resolvedCode.split("/").pop() || resolvedCode;
-				let prerenderedHTML: string | undefined;
-				try {
-					const result = await preloadFile({
-						file: { name: displayName, contents },
-						options: { disableFileHeader: true },
-					});
-					prerenderedHTML = result.prerenderedHTML;
-				} catch {
-					// Fall back to client-side rendering
-				}
-				return Response.json({ codeFile: true, contents, filepath: resolvedCode, prerenderedHTML });
+			if (file.size > 2 * 1024 * 1024) {
+				return Response.json({ error: "File too large (max 2MB)" }, { status: 413 });
 			}
-		} catch { /* fall through */ }
-		return Response.json({ error: `File not found: ${requestedPath}` }, { status: 404 });
+			const contents = await file.text();
+			const displayName = resolvedCode.split("/").pop() || resolvedCode;
+			let prerenderedHTML: string | undefined;
+			try {
+				const result = await preloadFile({
+					file: { name: displayName, contents },
+					options: { disableFileHeader: true },
+				});
+				prerenderedHTML = result.prerenderedHTML;
+			} catch {
+				// Fall back to client-side rendering
+			}
+			return Response.json({ codeFile: true, contents, filepath: resolvedCode, prerenderedHTML });
+		} catch {
+			return Response.json({ error: `File not found: ${requestedPath}` }, { status: 404 });
+		}
 	}
 
 	const result = resolveMarkdownFile(requestedPath, projectRoot);
@@ -129,6 +166,57 @@ export async function handleDoc(req: Request): Promise<Response> {
 	} catch {
 		return Response.json({ error: "Failed to read file" }, { status: 500 });
 	}
+}
+
+/**
+ * Batch existence check for code-file paths the renderer wants to linkify.
+ * POST /api/doc/exists with { paths: string[] } returns { results: { [path]: ValidationEntry } }.
+ * Reads from the warm file-list cache populated at plan/annotate load.
+ */
+export async function handleDocExists(req: Request): Promise<Response> {
+	let body: unknown;
+	try {
+		body = await req.json();
+	} catch {
+		return Response.json({ error: "Invalid JSON" }, { status: 400 });
+	}
+	const paths = (body as { paths?: unknown })?.paths;
+	if (!Array.isArray(paths) || !paths.every((p) => typeof p === "string")) {
+		return Response.json({ error: "Expected { paths: string[] }" }, { status: 400 });
+	}
+	if (paths.length > 500) {
+		return Response.json({ error: "Too many paths (max 500)" }, { status: 400 });
+	}
+
+	const projectRoot = process.cwd();
+	const results: Record<
+		string,
+		| { status: "found"; resolved: string }
+		| { status: "ambiguous"; matches: string[] }
+		| { status: "missing" }
+		| { status: "unavailable" }
+	> = {};
+
+	await Promise.all(
+		(paths as string[]).map(async (p) => {
+			const r = await resolveCodeFile(p, projectRoot);
+			if (r.kind === "found") {
+				results[p] = { status: "found", resolved: r.path };
+			} else if (r.kind === "ambiguous") {
+				const prefix = `${projectRoot}/`;
+				results[p] = {
+					status: "ambiguous",
+					matches: r.matches.map((m) => (m.startsWith(prefix) ? m.slice(prefix.length) : m)),
+				};
+			} else if (r.kind === "unavailable") {
+				results[p] = { status: "unavailable" };
+			} else {
+				results[p] = { status: "missing" };
+			}
+		}),
+	);
+
+	return Response.json({ results });
 }
 
 /** Detect available Obsidian vaults. */

--- a/packages/server/reference-handlers.ts
+++ b/packages/server/reference-handlers.ts
@@ -18,7 +18,6 @@ import {
 	isWithinProjectRoot,
 	warmFileListCache,
 } from "@plannotator/shared/resolve-file";
-import { extractCandidateCodePaths } from "@plannotator/shared/extract-code-paths";
 import { htmlToMarkdown } from "@plannotator/shared/html-to-markdown";
 import { preloadFile } from "@pierre/diffs/ssr";
 
@@ -172,6 +171,14 @@ export async function handleDoc(req: Request): Promise<Response> {
  * Batch existence check for code-file paths the renderer wants to linkify.
  * POST /api/doc/exists with { paths: string[] } returns { results: { [path]: ValidationEntry } }.
  * Reads from the warm file-list cache populated at plan/annotate load.
+ *
+ * TODO(security): absolute paths sent here are probed verbatim against the
+ * filesystem — `resolveCodeFile` returns `{ kind: 'found', path: abs }` for any
+ * existing absolute file with no project-root containment check. A malicious
+ * shared plan with backtick-wrapped absolute paths (e.g. `/Users/x/.aws/…`)
+ * leaks file existence + canonical path back to the caller. Mitigation:
+ * reject absolute inputs (or `isWithinProjectRoot`-filter `r.path`) before
+ * recording a found result. Mirror in apps/pi-extension/server/reference.ts.
  */
 export async function handleDocExists(req: Request): Promise<Response> {
 	let body: unknown;
@@ -187,6 +194,10 @@ export async function handleDocExists(req: Request): Promise<Response> {
 	if (paths.length > 500) {
 		return Response.json({ error: "Too many paths (max 500)" }, { status: 400 });
 	}
+	const baseRaw = (body as { base?: unknown })?.base;
+	const baseDir = typeof baseRaw === "string" && baseRaw.length > 0
+		? resolveUserPath(baseRaw)
+		: undefined;
 
 	const projectRoot = process.cwd();
 	const results: Record<
@@ -199,7 +210,7 @@ export async function handleDocExists(req: Request): Promise<Response> {
 
 	await Promise.all(
 		(paths as string[]).map(async (p) => {
-			const r = await resolveCodeFile(p, projectRoot);
+			const r = await resolveCodeFile(p, projectRoot, baseDir);
 			if (r.kind === "found") {
 				results[p] = { status: "found", resolved: r.path };
 			} else if (r.kind === "ambiguous") {

--- a/packages/shared/code-file.test.ts
+++ b/packages/shared/code-file.test.ts
@@ -1,5 +1,10 @@
 import { describe, test, expect } from 'bun:test';
-import { isCodeFilePath, isCodeFilePathStrict } from './code-file';
+import {
+  isCodeFilePath,
+  isCodeFilePathStrict,
+  isPlausibleCodeFilePath,
+  CODE_PATH_BARE_REGEX,
+} from './code-file';
 
 describe('isCodeFilePath', () => {
   test('matches common extensions', () => {
@@ -60,5 +65,48 @@ describe('isCodeFilePathStrict', () => {
   test('rejects non-code paths with /', () => {
     expect(isCodeFilePathStrict('path/to/readme.txt')).toBe(false);
     expect(isCodeFilePathStrict('some/dir/.env')).toBe(false);
+  });
+
+  test('rejects shape-implausible bare prose', () => {
+    expect(isCodeFilePathStrict('packages/ui/{a,b}.ts')).toBe(false);
+  });
+});
+
+describe('isPlausibleCodeFilePath', () => {
+  test('accepts plain code paths', () => {
+    expect(isPlausibleCodeFilePath('packages/editor/App.tsx')).toBe(true);
+    expect(isPlausibleCodeFilePath('foo.ts')).toBe(true);
+  });
+
+  test('accepts Next.js dynamic routes', () => {
+    expect(isPlausibleCodeFilePath('app/[slug]/page.tsx')).toBe(true);
+    expect(isPlausibleCodeFilePath('app/[...rest]/page.tsx')).toBe(true);
+  });
+
+  test('rejects shell brace expansion', () => {
+    expect(isPlausibleCodeFilePath('packages/ui/{a,b,c}.ts')).toBe(false);
+  });
+
+  test('rejects glob wildcards', () => {
+    expect(isPlausibleCodeFilePath('src/*.ts')).toBe(false);
+    expect(isPlausibleCodeFilePath('src/foo?.ts')).toBe(false);
+  });
+
+  test('rejects whitespace', () => {
+    expect(isPlausibleCodeFilePath('path with space.ts')).toBe(false);
+  });
+});
+
+describe('CODE_PATH_BARE_REGEX', () => {
+  test('matches abbreviated paths', () => {
+    const re = new RegExp(CODE_PATH_BARE_REGEX.source, 'g');
+    const m = 'see editor/App.tsx for details'.match(re);
+    expect(m).toContain('editor/App.tsx');
+  });
+
+  test('matches Next.js dynamic-route paths', () => {
+    const re = new RegExp(CODE_PATH_BARE_REGEX.source, 'g');
+    const m = 'visit app/[slug]/page.tsx'.match(re);
+    expect(m).toContain('app/[slug]/page.tsx');
   });
 });

--- a/packages/shared/code-file.ts
+++ b/packages/shared/code-file.ts
@@ -1,6 +1,15 @@
 export const CODE_FILE_REGEX = /(?:\.(tsx?|jsx?|py|rb|go|rs|java|c|cpp|h|hpp|cs|swift|kt|scala|sh|bash|zsh|sql|graphql|json|ya?ml|toml|ini|css|scss|less|xml|tf|lua|r|dart|ex|exs|vue|svelte|astro|zig|proto)|(?:^|\/)(Dockerfile|Makefile|Rakefile|Gemfile|Procfile|Vagrantfile|Brewfile|Justfile))$/i;
 
+export const CODE_PATH_BARE_REGEX = /(?:\.{0,2}\/)?(?:[a-zA-Z0-9_@.\-\[\]]+\/)+[a-zA-Z0-9_.\-\[\]]+\.[a-zA-Z0-9]+/g;
+
+const IMPLAUSIBLE_CHARS = /[{},*?\s]/;
+
+export function isPlausibleCodeFilePath(input: string): boolean {
+	return !IMPLAUSIBLE_CHARS.test(input);
+}
+
 export function isCodeFilePath(input: string): boolean {
+	if (!isPlausibleCodeFilePath(input)) return false;
 	return CODE_FILE_REGEX.test(input.replace(/#.*$/, ''))
 		&& !input.startsWith('http://') && !input.startsWith('https://');
 }

--- a/packages/shared/extract-code-paths.test.ts
+++ b/packages/shared/extract-code-paths.test.ts
@@ -1,0 +1,59 @@
+import { describe, test, expect } from "bun:test";
+import { extractCandidateCodePaths } from "./extract-code-paths";
+
+describe("extractCandidateCodePaths", () => {
+	test("extracts backtick code-file paths", () => {
+		const md = "Open `packages/editor/App.tsx` to see the code.";
+		expect(extractCandidateCodePaths(md)).toEqual(["packages/editor/App.tsx"]);
+	});
+
+	test("extracts bare-prose paths", () => {
+		const md = "see editor/App.tsx and review-editor/App.tsx";
+		const out = extractCandidateCodePaths(md);
+		expect(out).toContain("editor/App.tsx");
+		expect(out).toContain("review-editor/App.tsx");
+	});
+
+	test("dedupes repeated references", () => {
+		const md = "`src/foo.ts` and src/foo.ts again";
+		expect(extractCandidateCodePaths(md)).toEqual(["src/foo.ts"]);
+	});
+
+	test("strips line anchors", () => {
+		const md = "see `src/foo.ts#L42`";
+		expect(extractCandidateCodePaths(md)).toEqual(["src/foo.ts"]);
+	});
+
+	test("rejects shell brace expansion", () => {
+		const md = "files in packages/ui/{a,b}.ts";
+		expect(extractCandidateCodePaths(md)).toEqual([]);
+	});
+
+	test("ignores fenced code blocks", () => {
+		const md = "```ts\nimport foo from 'src/foo.ts';\n```";
+		expect(extractCandidateCodePaths(md)).toEqual([]);
+	});
+
+	test("ignores HTML comments", () => {
+		const md = "<!-- src/foo.ts is a placeholder -->";
+		expect(extractCandidateCodePaths(md)).toEqual([]);
+	});
+
+	test("URLs do not produce path-shaped substrings", () => {
+		const md = "see https://github.com/foo/bar.ts in the docs";
+		expect(extractCandidateCodePaths(md)).toEqual([]);
+	});
+
+	test("URL on same line as a real path keeps the path", () => {
+		const md = "https://github.com/example.com docs and editor/App.tsx";
+		const out = extractCandidateCodePaths(md);
+		expect(out).toContain("editor/App.tsx");
+	});
+
+	test("URLs containing parens or brackets do not leak path-shaped substrings", () => {
+		// Wikipedia-style URL ends in `).ts` — earlier extractor erroneously
+		// stopped its URL match at `(`, leaving `bar).ts` as a path candidate.
+		const md = "see https://en.wikipedia.org/wiki/Foo_(bar).ts in the docs";
+		expect(extractCandidateCodePaths(md)).toEqual([]);
+	});
+});

--- a/packages/shared/extract-code-paths.ts
+++ b/packages/shared/extract-code-paths.ts
@@ -1,0 +1,66 @@
+import {
+	CODE_PATH_BARE_REGEX,
+	isCodeFilePath,
+	isCodeFilePathStrict,
+} from "./code-file";
+
+const FENCED_CODE_BLOCK = /(^|\n)([ \t]*)(```|~~~)[\s\S]*?\n\2\3/g;
+const HTML_COMMENT = /<!--[\s\S]*?-->/g;
+// Match InlineMarkdown.tsx's bare-URL regex exactly so URL ranges excised
+// here mirror the ranges the renderer would consume.
+const URL_REGEX = /https?:\/\/[^\s<>"']+/g;
+const BACKTICK_SPAN = /`([^`\n]+)`/g;
+
+/**
+ * Extract candidate code-file paths from markdown text. Mirrors the renderer's
+ * detection precedence so the validator only sees paths the renderer would
+ * actually linkify:
+ *   1. fenced code blocks and HTML comments are stripped first;
+ *   2. URL ranges are excised before the bare-prose scan (URLs win);
+ *   3. backtick spans matching `isCodeFilePath` are collected;
+ *   4. bare-prose paths matching `CODE_PATH_BARE_REGEX` and
+ *      `isCodeFilePathStrict` are collected.
+ *
+ * Hash anchors (`#L42`) are stripped from results to match the renderer's
+ * `cleanPath` transform. Returns deduped candidate strings.
+ */
+export function extractCandidateCodePaths(markdown: string): string[] {
+	const stripped = markdown
+		.replace(FENCED_CODE_BLOCK, "")
+		.replace(HTML_COMMENT, "");
+
+	const candidates = new Set<string>();
+
+	let m: RegExpExecArray | null;
+	const backtickRe = new RegExp(BACKTICK_SPAN.source, "g");
+	while ((m = backtickRe.exec(stripped)) !== null) {
+		const inner = m[1].trim();
+		if (isCodeFilePath(inner)) {
+			candidates.add(inner.replace(/#.*$/, ""));
+		}
+	}
+
+	for (const line of stripped.split("\n")) {
+		const urlRanges: Array<[number, number]> = [];
+		const urlRe = new RegExp(URL_REGEX.source, "g");
+		while ((m = urlRe.exec(line)) !== null) {
+			urlRanges.push([m.index, m.index + m[0].length]);
+		}
+
+		const pathRe = new RegExp(CODE_PATH_BARE_REGEX.source, "g");
+		while ((m = pathRe.exec(line)) !== null) {
+			const start = m.index;
+			const end = start + m[0].length;
+			const prev = start === 0 ? "" : line[start - 1];
+			if (/\w/.test(prev)) continue;
+			const overlapsUrl = urlRanges.some(
+				([s, e]) => start < e && end > s,
+			);
+			if (overlapsUrl) continue;
+			if (!isCodeFilePathStrict(m[0])) continue;
+			candidates.add(m[0].replace(/#.*$/, ""));
+		}
+	}
+
+	return Array.from(candidates);
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -21,6 +21,7 @@
     "./favicon": "./favicon.ts",
     "./code-file": "./code-file.ts",
     "./resolve-file": "./resolve-file.ts",
+    "./extract-code-paths": "./extract-code-paths.ts",
     "./external-annotation": "./external-annotation.ts",
     "./agent-jobs": "./agent-jobs.ts",
     "./config": "./config.ts",

--- a/packages/shared/resolve-file.test.ts
+++ b/packages/shared/resolve-file.test.ts
@@ -82,4 +82,32 @@ describe("resolveCodeFile", () => {
 			expect(r.path).toBe(join(root, "packages/editor/App.tsx"));
 		}
 	});
+
+	test("does NOT strip leading ../ — without baseDir, refuses to fabricate", async () => {
+		// `../foo.tsx` is meaningful (escape parent). With no baseDir context,
+		// we can't honor it, so we must fail rather than silently returning
+		// an unrelated file with the same basename from inside cwd.
+		const r = await resolveCodeFile("../editor/App.tsx", root);
+		expect(r.kind).toBe("not_found");
+	});
+
+	test("resolves via baseDir when input is relative to active doc", async () => {
+		// Linked doc at `<root>/packages/review-editor/...` references `../editor/App.tsx`
+		const baseDir = join(root, "packages/review-editor");
+		const r = await resolveCodeFile("../editor/App.tsx", root, baseDir);
+		expect(r.kind).toBe("found");
+		if (r.kind === "found") {
+			expect(r.path).toBe(join(root, "packages/editor/App.tsx"));
+		}
+	});
+
+	test("baseDir miss falls through to suffix walk", async () => {
+		// baseDir doesn't have the file, but cwd tree does — walk catches it.
+		const baseDir = join(root, "packages/review-editor");
+		const r = await resolveCodeFile("ui/components/Button.tsx", root, baseDir);
+		expect(r.kind).toBe("found");
+		if (r.kind === "found") {
+			expect(r.path).toBe(join(root, "packages/ui/components/Button.tsx"));
+		}
+	});
 });

--- a/packages/shared/resolve-file.test.ts
+++ b/packages/shared/resolve-file.test.ts
@@ -1,0 +1,85 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { resolveCodeFile } from "./resolve-file";
+
+let root: string;
+
+beforeAll(() => {
+	root = mkdtempSync(join(tmpdir(), "plannotator-resolve-"));
+	mkdirSync(join(root, "packages/editor"), { recursive: true });
+	mkdirSync(join(root, "packages/review-editor"), { recursive: true });
+	mkdirSync(join(root, "packages/ui/components"), { recursive: true });
+	mkdirSync(join(root, "node_modules/junk"), { recursive: true });
+	writeFileSync(join(root, "packages/editor/App.tsx"), "// editor");
+	writeFileSync(join(root, "packages/review-editor/App.tsx"), "// review");
+	writeFileSync(join(root, "packages/ui/components/Button.tsx"), "// btn");
+	writeFileSync(join(root, "packages/ui/index.ts"), "// idx");
+	writeFileSync(join(root, "node_modules/junk/App.tsx"), "// junk");
+});
+
+afterAll(() => {
+	rmSync(root, { recursive: true, force: true });
+});
+
+describe("resolveCodeFile", () => {
+	test("resolves an exact relative path", async () => {
+		const r = await resolveCodeFile("packages/editor/App.tsx", root);
+		expect(r.kind).toBe("found");
+		if (r.kind === "found") {
+			expect(r.path).toBe(join(root, "packages/editor/App.tsx"));
+		}
+	});
+
+	test("resolves an abbreviated path via suffix match", async () => {
+		const r = await resolveCodeFile("editor/App.tsx", root);
+		expect(r.kind).toBe("found");
+		if (r.kind === "found") {
+			expect(r.path).toBe(join(root, "packages/editor/App.tsx"));
+		}
+	});
+
+	test("returns ambiguous when basename matches multiple files", async () => {
+		const r = await resolveCodeFile("App.tsx", root);
+		expect(r.kind).toBe("ambiguous");
+		if (r.kind === "ambiguous") {
+			expect(r.matches).toHaveLength(2);
+		}
+	});
+
+	test("returns not_found for a non-existent path", async () => {
+		const r = await resolveCodeFile("packages/ui/shortcuts/core.ts", root);
+		expect(r.kind).toBe("not_found");
+	});
+
+	test("ignores node_modules", async () => {
+		const r = await resolveCodeFile("junk/App.tsx", root);
+		expect(r.kind).toBe("not_found");
+	});
+
+	test("does not match similarly-named directories", async () => {
+		// myeditor/App.tsx must NOT match packages/editor/App.tsx — segment boundary required.
+		const r = await resolveCodeFile("myeditor/App.tsx", root);
+		expect(r.kind).toBe("not_found");
+	});
+
+	test("returns found for a single-segment input that uniquely exists", async () => {
+		// `index.ts` is bare basename; only one in tree.
+		const r = await resolveCodeFile("index.ts", root);
+		expect(r.kind).toBe("found");
+		if (r.kind === "found") {
+			expect(r.path).toBe(join(root, "packages/ui/index.ts"));
+		}
+	});
+
+	test("strips leading ./ before suffix matching", async () => {
+		// Earlier this fell through to step 3 with target='./editor/app.tsx'
+		// and never matched any real file. The cleanup makes it work.
+		const r = await resolveCodeFile("./editor/App.tsx", root);
+		expect(r.kind).toBe("found");
+		if (r.kind === "found") {
+			expect(r.path).toBe(join(root, "packages/editor/App.tsx"));
+		}
+	});
+});

--- a/packages/shared/resolve-file.ts
+++ b/packages/shared/resolve-file.ts
@@ -15,6 +15,7 @@ import { existsSync, readdirSync, type Dirent } from "fs";
 
 const MARKDOWN_PATH_REGEX = /\.mdx?$/i;
 
+import { CODE_FILE_REGEX as CODE_FILE_BASENAME_REGEX } from "./code-file";
 export { CODE_FILE_REGEX, isCodeFilePath } from "./code-file";
 
 const WINDOWS_DRIVE_PATH_PATTERNS = [
@@ -33,10 +34,22 @@ const IGNORED_DIRS = [
 	".trash/",
 ];
 
+const CODE_IGNORED_DIRS = [
+	...IGNORED_DIRS,
+	".turbo/",
+	".cache/",
+	"target/",
+	"vendor/",
+	"coverage/",
+	".venv/",
+	".pytest_cache/",
+];
+
 export type ResolveResult =
 	| { kind: "found"; path: string }
 	| { kind: "not_found"; input: string }
-	| { kind: "ambiguous"; input: string; matches: string[] };
+	| { kind: "ambiguous"; input: string; matches: string[] }
+	| { kind: "unavailable"; input: string };
 
 function normalizeSeparators(input: string): string {
 	return input.replace(/\\/g, "/");
@@ -181,25 +194,159 @@ function fileExists(filePath: string): boolean {
 	}
 }
 
-/** Recursively walk a directory collecting markdown files, skipping ignored dirs. */
-function walkMarkdownFiles(dir: string, root: string, results: string[], ignoredDirs: string[]): void {
-	let entries: Dirent[];
-	try {
-		entries = readdirSync(dir, { withFileTypes: true }) as Dirent[];
-	} catch {
-		return;
-	}
+/** Recursively walk a directory collecting files matching `fileMatcher`, skipping ignored dirs. */
+function walkFiles(
+	dir: string,
+	root: string,
+	results: string[],
+	ignoredDirs: string[],
+	fileMatcher: (name: string) => boolean,
+): void {
+	const entries = readdirSync(dir, { withFileTypes: true }) as Dirent[];
 	for (const entry of entries) {
 		if (entry.isDirectory()) {
 			if (ignoredDirs.some((d) => d === entry.name + "/")) continue;
-			walkMarkdownFiles(join(dir, entry.name), root, results, ignoredDirs);
-		} else if (entry.isFile() && /\.mdx?$/i.test(entry.name)) {
+			try {
+				walkFiles(join(dir, entry.name), root, results, ignoredDirs, fileMatcher);
+			} catch {
+				/* skip dirs we can't read */
+			}
+		} else if (entry.isFile() && fileMatcher(entry.name)) {
 			const relative = join(dir, entry.name)
 				.slice(root.length + 1)
 				.replace(/\\/g, "/");
 			results.push(relative);
 		}
 	}
+}
+
+function walkMarkdownFiles(dir: string, root: string, results: string[], ignoredDirs: string[]): void {
+	try {
+		walkFiles(dir, root, results, ignoredDirs, (name) => /\.mdx?$/i.test(name));
+	} catch {
+		/* fail soft for markdown — preserves existing behavior */
+	}
+}
+
+// --- Code-file resolution (async, cached) ---
+
+const FILE_LIST_CACHE_TTL_MS = 30_000;
+const fileListCache = new Map<
+	string,
+	{ promise: Promise<string[] | null>; startedAt: number }
+>();
+
+function fileListCacheKey(projectRoot: string, kind: string): string {
+	return `${projectRoot}|${kind}`;
+}
+
+function startCodeWalk(projectRoot: string): Promise<string[] | null> {
+	return Promise.resolve().then(() => {
+		try {
+			const results: string[] = [];
+			walkFiles(projectRoot, projectRoot, results, CODE_IGNORED_DIRS, (name) =>
+				CODE_FILE_BASENAME_REGEX.test(name),
+			);
+			return results;
+		} catch {
+			return null;
+		}
+	});
+}
+
+/**
+ * Trigger (or return the in-flight) walk of `projectRoot` for code files.
+ * Cached for `FILE_LIST_CACHE_TTL_MS`. Storing a Promise (not a value) makes
+ * concurrent callers piggyback on the same walk — first arrival wins.
+ *
+ * Returns `null` (wrapped in Promise) when the walk fails (perms, etc).
+ */
+export function warmFileListCache(
+	projectRoot: string,
+	kind: "code",
+): Promise<string[] | null> {
+	const key = fileListCacheKey(projectRoot, kind);
+	const entry = fileListCache.get(key);
+	if (entry && Date.now() - entry.startedAt < FILE_LIST_CACHE_TTL_MS) {
+		return entry.promise;
+	}
+	const promise = startCodeWalk(projectRoot);
+	fileListCache.set(key, { promise, startedAt: Date.now() });
+	return promise;
+}
+
+/**
+ * Resolve a code-file path within a project root.
+ *
+ * Strategies:
+ *   1. Absolute path → use as-is.
+ *   2. Exact relative from project root.
+ *   3. Case-insensitive suffix match against the cached file list:
+ *      - bare basename input → match any file with that basename;
+ *      - input with `/` → match files whose path equals or ends with `/<input>`
+ *        on a segment boundary (so `editor/App.tsx` matches `packages/editor/App.tsx`
+ *        but not `myeditor/App.tsx`).
+ */
+export async function resolveCodeFile(
+	input: string,
+	projectRoot: string,
+): Promise<ResolveResult> {
+	const originalInput = input.trim();
+	const unquotedInput = stripWrappingQuotes(originalInput);
+	const normalizedInput = normalizeUserPathInput(unquotedInput);
+	const searchInput = normalizeSeparators(normalizedInput);
+
+	if (!searchInput) {
+		return { kind: "not_found", input: originalInput };
+	}
+
+	if (isAbsoluteNormalizedUserPath(normalizedInput)) {
+		const absolutePath = resolveAbsolutePath(normalizedInput);
+		if (fileExists(absolutePath)) {
+			return { kind: "found", path: absolutePath };
+		}
+		return { kind: "not_found", input: originalInput };
+	}
+
+	const fromRoot = resolve(projectRoot, searchInput);
+	if (isWithinProjectRoot(fromRoot, projectRoot) && fileExists(fromRoot)) {
+		return { kind: "found", path: fromRoot };
+	}
+
+	const fileList = await warmFileListCache(projectRoot, "code");
+	if (fileList === null) {
+		return { kind: "unavailable", input: originalInput };
+	}
+
+	// Strip leading `./` or `../` so suffix matching works on inputs like
+	// `./editor/App.tsx` — file list entries never carry those segments.
+	const cleanedInput = searchInput.replace(/^(?:\.\.?\/)+/, "");
+	if (!cleanedInput) {
+		return { kind: "not_found", input: originalInput };
+	}
+	const target = cleanedInput.toLowerCase();
+	const isBareFilename = !cleanedInput.includes("/");
+	const matches: string[] = [];
+
+	for (const f of fileList) {
+		const fl = f.toLowerCase();
+		if (isBareFilename) {
+			const base = fl.split("/").pop();
+			if (base === target) matches.push(resolve(projectRoot, f));
+		} else {
+			if (fl === target || fl.endsWith("/" + target)) {
+				matches.push(resolve(projectRoot, f));
+			}
+		}
+	}
+
+	if (matches.length === 1) {
+		return { kind: "found", path: matches[0] };
+	}
+	if (matches.length > 1) {
+		return { kind: "ambiguous", input: originalInput, matches };
+	}
+	return { kind: "not_found", input: originalInput };
 }
 
 /**

--- a/packages/shared/resolve-file.ts
+++ b/packages/shared/resolve-file.ts
@@ -281,15 +281,23 @@ export function warmFileListCache(
  * Strategies:
  *   1. Absolute path → use as-is.
  *   2. Exact relative from project root.
- *   3. Case-insensitive suffix match against the cached file list:
+ *   3. If `baseDir` provided, literal `<baseDir>/<input>` existence check —
+ *      lets out-of-tree linked docs resolve their own relative references
+ *      (e.g. `../script.ts` in `~/notes/foo.md` finds `~/script.ts`).
+ *   4. Case-insensitive suffix match against the cached file list:
  *      - bare basename input → match any file with that basename;
  *      - input with `/` → match files whose path equals or ends with `/<input>`
  *        on a segment boundary (so `editor/App.tsx` matches `packages/editor/App.tsx`
  *        but not `myeditor/App.tsx`).
+ *
+ * `..` segments in the input are honored: only `./` is stripped before suffix
+ * matching. `../foo.ts` without a `baseDir` correctly falls through to
+ * not_found rather than fabricating a match against `foo.ts` somewhere in cwd.
  */
 export async function resolveCodeFile(
 	input: string,
 	projectRoot: string,
+	baseDir?: string,
 ): Promise<ResolveResult> {
 	const originalInput = input.trim();
 	const unquotedInput = stripWrappingQuotes(originalInput);
@@ -313,15 +321,25 @@ export async function resolveCodeFile(
 		return { kind: "found", path: fromRoot };
 	}
 
+	if (baseDir) {
+		const fromBase = resolve(baseDir, searchInput);
+		if (fileExists(fromBase)) {
+			return { kind: "found", path: fromBase };
+		}
+	}
+
 	const fileList = await warmFileListCache(projectRoot, "code");
 	if (fileList === null) {
 		return { kind: "unavailable", input: originalInput };
 	}
 
-	// Strip leading `./` or `../` so suffix matching works on inputs like
-	// `./editor/App.tsx` — file list entries never carry those segments.
-	const cleanedInput = searchInput.replace(/^(?:\.\.?\/)+/, "");
-	if (!cleanedInput) {
+	// Strip leading `./` so suffix matching works on inputs like
+	// `./editor/App.tsx` — file list entries never carry that segment.
+	// `../` is intentionally NOT stripped: `..` is meaningful (escape parent),
+	// not noise. If we can't honor it via baseDir, the input has no
+	// suffix-match equivalent in the in-tree file list.
+	const cleanedInput = searchInput.replace(/^(?:\.\/)+/, "");
+	if (!cleanedInput || cleanedInput.startsWith("../")) {
 		return { kind: "not_found", input: originalInput };
 	}
 	const target = cleanedInput.toLowerCase();

--- a/packages/ui/components/CodeFilePicker.tsx
+++ b/packages/ui/components/CodeFilePicker.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useDismissOnOutsideAndEscape } from "../hooks/useDismissOnOutsideAndEscape";
+
+/**
+ * Floating popover anchored to a code-file link with multiple repo matches.
+ * Selecting an entry calls `onPick(path)`. Esc / outside-click dismisses.
+ */
+export const CodeFilePicker: React.FC<{
+	anchorEl: HTMLElement | null;
+	matches: string[];
+	onPick: (path: string) => void;
+	onDismiss: () => void;
+}> = ({ anchorEl, matches, onPick, onDismiss }) => {
+	const popoverRef = useRef<HTMLDivElement>(null);
+	const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+
+	useEffect(() => {
+		if (!anchorEl) return;
+		const rect = anchorEl.getBoundingClientRect();
+		setPos({
+			top: rect.bottom + 4,
+			left: rect.left,
+		});
+	}, [anchorEl]);
+
+	useDismissOnOutsideAndEscape({
+		enabled: true,
+		ref: popoverRef as React.RefObject<HTMLElement>,
+		onDismiss,
+	});
+
+	if (!pos) return null;
+
+	return createPortal(
+		<div
+			ref={popoverRef}
+			role="menu"
+			aria-label="Choose file"
+			className="fixed z-[100] min-w-[240px] max-w-[480px] bg-popover text-popover-foreground border border-border/70 rounded-lg shadow-xl py-1"
+			style={{ top: pos.top, left: pos.left }}
+		>
+			<div className="px-3 py-1.5 text-xs uppercase tracking-wide opacity-60 border-b border-border/40">
+				{matches.length} matches
+			</div>
+			<ul className="max-h-72 overflow-y-auto">
+				{matches.map((m) => (
+					<li key={m}>
+						<button
+							type="button"
+							role="menuitem"
+							onClick={() => onPick(m)}
+							className="w-full text-left px-3 py-1.5 text-sm font-mono hover:bg-muted hover:text-primary transition-colors truncate"
+							title={m}
+						>
+							{m}
+						</button>
+					</li>
+				))}
+			</ul>
+		</div>,
+		document.body,
+	);
+};

--- a/packages/ui/components/CodeFilePopout.tsx
+++ b/packages/ui/components/CodeFilePopout.tsx
@@ -468,6 +468,12 @@ export const CodeFilePopout: React.FC<CodeFilePopoutProps> = ({
   };
 
   if (error) {
+    // The server's error string distinguishes "File not found", "Ambiguous
+    // path '…'", and other failures (e.g. permission). Earlier this dialog
+    // hardcoded "File not found in repo" regardless of cause, which was
+    // misleading when an optimistic-link click hit an ambiguous response
+    // before validation completed.
+    const isNotFound = /^file not found/i.test(error);
     return (
       <PopoutDialog
         open={open}
@@ -477,14 +483,16 @@ export const CodeFilePopout: React.FC<CodeFilePopoutProps> = ({
         className="w-[min(520px,calc(100vw-4rem))]"
       >
         <div className="flex flex-col gap-2 px-5 py-6 text-sm">
-          <div className="font-medium text-foreground">File not found in repo</div>
+          <div className="font-medium text-foreground">{error}</div>
           <code className="text-xs font-mono text-muted-foreground break-all">
             {requestedPath ?? filepath}
           </code>
-          <p className="text-xs text-muted-foreground mt-1">
-            The path was referenced in the document but no matching file was found
-            in this project. It may describe a planned/future file.
-          </p>
+          {isNotFound && (
+            <p className="text-xs text-muted-foreground mt-1">
+              The path was referenced in the document but no matching file was found
+              in this project. It may describe a planned/future file.
+            </p>
+          )}
         </div>
       </PopoutDialog>
     );

--- a/packages/ui/components/CodeFilePopout.tsx
+++ b/packages/ui/components/CodeFilePopout.tsx
@@ -22,6 +22,8 @@ interface CodeFilePopoutProps {
   filepath: string;
   contents: string;
   prerenderedHTML?: string;
+  error?: string;
+  requestedPath?: string;
   annotations?: CodeAnnotation[];
   selectedAnnotationId?: string | null;
   onAddAnnotation?: (annotation: CodeFileAnnotationInput) => void;
@@ -286,6 +288,8 @@ export const CodeFilePopout: React.FC<CodeFilePopoutProps> = ({
   filepath,
   contents,
   prerenderedHTML,
+  error,
+  requestedPath,
   annotations = [],
   selectedAnnotationId,
   onAddAnnotation,
@@ -462,6 +466,29 @@ export const CodeFilePopout: React.FC<CodeFilePopoutProps> = ({
       console.error('Failed to copy:', err);
     }
   };
+
+  if (error) {
+    return (
+      <PopoutDialog
+        open={open}
+        onClose={onClose}
+        title={requestedPath ?? displayName}
+        container={container}
+        className="w-[min(520px,calc(100vw-4rem))]"
+      >
+        <div className="flex flex-col gap-2 px-5 py-6 text-sm">
+          <div className="font-medium text-foreground">File not found in repo</div>
+          <code className="text-xs font-mono text-muted-foreground break-all">
+            {requestedPath ?? filepath}
+          </code>
+          <p className="text-xs text-muted-foreground mt-1">
+            The path was referenced in the document but no matching file was found
+            in this project. It may describe a planned/future file.
+          </p>
+        </div>
+      </PopoutDialog>
+    );
+  }
 
   return (
     <PopoutDialog

--- a/packages/ui/components/CodePathValidationContext.tsx
+++ b/packages/ui/components/CodePathValidationContext.tsx
@@ -1,0 +1,14 @@
+import { createContext, useContext } from "react";
+import type { ValidatedMap } from "../hooks/useValidatedCodePaths";
+
+export interface CodePathValidationContextValue {
+	validated: ValidatedMap;
+	ready: boolean;
+}
+
+export const CodePathValidationContext =
+	createContext<CodePathValidationContextValue | null>(null);
+
+export function useCodePathValidation(): CodePathValidationContextValue | null {
+	return useContext(CodePathValidationContext);
+}

--- a/packages/ui/components/InlineMarkdown.tsx
+++ b/packages/ui/components/InlineMarkdown.tsx
@@ -1,7 +1,91 @@
 import React from "react";
-import { isCodeFilePath, isCodeFilePathStrict } from "@plannotator/shared/code-file";
+import { isCodeFilePath, isCodeFilePathStrict, CODE_PATH_BARE_REGEX } from "@plannotator/shared/code-file";
 import { transformPlainText } from "../utils/inlineTransforms";
 import { getImageSrc } from "./ImageThumbnail";
+import { useCodePathValidation, type CodePathValidationContextValue } from "./CodePathValidationContext";
+import type { ValidationEntry } from "../hooks/useValidatedCodePaths";
+import { CodeFilePicker } from "./CodeFilePicker";
+
+/**
+ * Decide how a candidate code-file path should render based on validation state:
+ *   - 'link'           → clickable, opens directly via onOpenCodeFile(resolvedOrInput)
+ *   - 'ambiguous-link' → clickable, opens a picker over `matches`
+ *   - 'plain'          → not a link (file does not exist anywhere in the repo)
+ *
+ * No provider or `ready: false` falls back to optimistic 'link' behavior.
+ */
+function gateCodePath(
+  candidate: string,
+  validation: CodePathValidationContextValue | null,
+): { render: 'link'; resolved?: string } | { render: 'ambiguous-link'; matches: string[] } | { render: 'plain' } {
+  if (!validation || !validation.ready) return { render: 'link' };
+  const entry = validation.validated.get(candidate);
+  if (!entry) return { render: 'link' };
+  switch ((entry as ValidationEntry).status) {
+    case 'found':       return { render: 'link', resolved: (entry as Extract<ValidationEntry, { status: 'found' }>).resolved };
+    case 'ambiguous':   return { render: 'ambiguous-link', matches: (entry as Extract<ValidationEntry, { status: 'ambiguous' }>).matches };
+    case 'unavailable': return { render: 'link' };
+    case 'missing':     return { render: 'plain' };
+    default:            return { render: 'link' }; // unknown status — degrade to optimistic
+  }
+}
+
+const CodeFileLink: React.FC<{
+  candidate: string;
+  display: string;
+  onOpenCodeFile: (path: string) => void;
+}> = ({ candidate, display, onOpenCodeFile }) => {
+  const validation = useCodePathValidation();
+  const gate = gateCodePath(candidate, validation);
+  const [pickerOpen, setPickerOpen] = React.useState(false);
+  const anchorRef = React.useRef<HTMLElement | null>(null);
+
+  if (gate.render === 'plain') {
+    return (
+      <code className="px-1.5 py-0.5 rounded bg-muted text-sm font-mono">
+        {display}
+      </code>
+    );
+  }
+
+  const isAmbiguous = gate.render === 'ambiguous-link';
+  const handleClick = () => {
+    if (isAmbiguous) {
+      setPickerOpen(true);
+      return;
+    }
+    onOpenCodeFile(gate.render === 'link' && gate.resolved ? gate.resolved : candidate);
+  };
+
+  return (
+    <>
+      <code
+        ref={(el) => { anchorRef.current = el; }}
+        role="button"
+        tabIndex={0}
+        data-ambiguous={isAmbiguous ? "true" : undefined}
+        onClick={handleClick}
+        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleClick(); } }}
+        className="code-file-link px-1.5 py-0.5 rounded bg-muted text-sm font-mono cursor-pointer hover:text-primary inline-flex items-center gap-1 transition-colors"
+        title={isAmbiguous ? `${display} — multiple matches` : `View: ${display}`}
+      >
+        {display}
+        <CodeFileIcon />
+        {isAmbiguous && (
+          <sup className="text-[0.6rem] opacity-70 -ml-0.5">{(gate as { matches: string[] }).matches.length}</sup>
+        )}
+      </code>
+      {pickerOpen && isAmbiguous && (
+        <CodeFilePicker
+          anchorEl={anchorRef.current}
+          matches={(gate as { matches: string[] }).matches}
+          onPick={(path) => { setPickerOpen(false); onOpenCodeFile(path); }}
+          onDismiss={() => setPickerOpen(false)}
+        />
+      )}
+    </>
+  );
+};
 
 const DANGEROUS_PROTOCOL = /^\s*(javascript|data|vbscript|file)\s*:/i;
 function sanitizeLinkUrl(url: string): string | null {
@@ -54,6 +138,7 @@ function emitPlainTextWithBareUrls(
   parts: React.ReactNode[],
   nextKey: () => number,
   onOpenCodeFile?: (path: string) => void,
+  validation?: CodePathValidationContextValue | null,
 ): void {
   if (text.length === 0) return;
 
@@ -76,7 +161,7 @@ function emitPlainTextWithBareUrls(
 
   // Collect bare code file paths (require /)
   if (onOpenCodeFile) {
-    const pathRe = /(?:\.{0,2}\/)?(?:[a-zA-Z0-9_@.\-]+\/)+[a-zA-Z0-9_.\-]+\.[a-zA-Z0-9]+/g;
+    const pathRe = new RegExp(CODE_PATH_BARE_REGEX.source, 'g');
     while ((m = pathRe.exec(text)) !== null) {
       const before = m.index === 0 ? previousChar : text[m.index - 1];
       if (/\w/.test(before)) continue;
@@ -114,20 +199,20 @@ function emitPlainTextWithBareUrls(
       );
     } else {
       const cleanPath = span.value.replace(/#.*$/, '');
-      parts.push(
-        <code
-          key={nextKey()}
-          role="button"
-          tabIndex={0}
-          onClick={() => onOpenCodeFile!(cleanPath)}
-          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onOpenCodeFile!(cleanPath); } }}
-          className="code-file-link px-1.5 py-0.5 rounded bg-muted text-sm font-mono cursor-pointer hover:text-primary inline-flex items-center gap-1 transition-colors"
-          title={`View: ${span.value}`}
-        >
-          {span.value}
-          <CodeFileIcon />
-        </code>,
-      );
+      const gate = gateCodePath(cleanPath, validation ?? null);
+      if (gate.render === 'plain') {
+        // Bare prose, file doesn't exist — emit as plain text, no link styling.
+        parts.push(span.value);
+      } else {
+        parts.push(
+          <CodeFileLink
+            key={nextKey()}
+            candidate={cleanPath}
+            display={span.value}
+            onOpenCodeFile={onOpenCodeFile!}
+          />,
+        );
+      }
     }
     last = span.end;
   }
@@ -153,6 +238,7 @@ export const InlineMarkdown: React.FC<{
   onImageClick?: (src: string, alt: string) => void;
   githubRepo?: string;
 }> = ({ text, onOpenLinkedDoc, onOpenCodeFile, onNavigateAnchor, imageBaseDir, onImageClick, githubRepo }) => {
+  const validation = useCodePathValidation();
   const parts: React.ReactNode[] = [];
   let remaining = text;
   let key = 0;
@@ -348,18 +434,12 @@ export const InlineMarkdown: React.FC<{
       if (isCodeFilePath(codeContent) && onOpenCodeFile) {
         const cleanPath = codeContent.replace(/#.*$/, '');
         parts.push(
-          <code
+          <CodeFileLink
             key={key++}
-            role="button"
-            tabIndex={0}
-            onClick={() => onOpenCodeFile(cleanPath)}
-            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onOpenCodeFile(cleanPath); } }}
-            className="code-file-link px-1.5 py-0.5 rounded bg-muted text-sm font-mono cursor-pointer hover:text-primary inline-flex items-center gap-1 transition-colors"
-            title={`View: ${codeContent}`}
-          >
-            {codeContent}
-            <CodeFileIcon />
-          </code>,
+            candidate={cleanPath}
+            display={codeContent}
+            onOpenCodeFile={onOpenCodeFile}
+          />,
         );
       } else {
         parts.push(
@@ -716,7 +796,7 @@ export const InlineMarkdown: React.FC<{
     // detected inline via emitPlainTextWithBareUrls() below.
     const nextSpecial = remaining.slice(1).search(/[\*_`\[!~\\<#@]/);
     const plainText = nextSpecial === -1 ? remaining : remaining.slice(0, nextSpecial + 1);
-    emitPlainTextWithBareUrls(plainText, previousChar, parts, () => key++, onOpenCodeFile);
+    emitPlainTextWithBareUrls(plainText, previousChar, parts, () => key++, onOpenCodeFile, validation);
     previousChar = plainText[plainText.length - 1] || previousChar;
     if (nextSpecial === -1) {
       break;

--- a/packages/ui/components/InlineMarkdown.tsx
+++ b/packages/ui/components/InlineMarkdown.tsx
@@ -202,7 +202,7 @@ function emitPlainTextWithBareUrls(
       const gate = gateCodePath(cleanPath, validation ?? null);
       if (gate.render === 'plain') {
         // Bare prose, file doesn't exist — emit as plain text, no link styling.
-        parts.push(span.value);
+        parts.push(transformPlainText(span.value));
       } else {
         parts.push(
           <CodeFileLink

--- a/packages/ui/components/InlineMarkdown.tsx
+++ b/packages/ui/components/InlineMarkdown.tsx
@@ -20,7 +20,10 @@ function gateCodePath(
 ): { render: 'link'; resolved?: string } | { render: 'ambiguous-link'; matches: string[] } | { render: 'plain' } {
   if (!validation || !validation.ready) return { render: 'link' };
   const entry = validation.validated.get(candidate);
-  if (!entry) return { render: 'link' };
+  // If the validator is ready but has no entry for this candidate, the
+  // extractor intentionally excluded it (e.g., inside an HTML comment or
+  // fenced code block). Demote rather than optimistically linking.
+  if (!entry) return { render: 'plain' };
   switch ((entry as ValidationEntry).status) {
     case 'found':       return { render: 'link', resolved: (entry as Extract<ValidationEntry, { status: 'found' }>).resolved };
     case 'ambiguous':   return { render: 'ambiguous-link', matches: (entry as Extract<ValidationEntry, { status: 'ambiguous' }>).matches };

--- a/packages/ui/components/InlineMarkdown.tsx
+++ b/packages/ui/components/InlineMarkdown.tsx
@@ -248,8 +248,19 @@ export const InlineMarkdown: React.FC<{
   let previousChar = "";
 
   while (remaining.length > 0) {
+    // HTML comments: skip entirely — they should be invisible per CommonMark.
+    // The parser doesn't recognize <!-- --> as a block-level construct, so
+    // comments inside paragraphs land here. Without this, path detection
+    // would linkify paths inside comments.
+    let match = remaining.match(/^<!--[\s\S]*?-->/);
+    if (match) {
+      remaining = remaining.slice(match[0].length);
+      previousChar = ">";
+      continue;
+    }
+
     // Backslash escaping: \. \* \_ \` \[ \~ etc. — emit literal char, hide backslash
-    let match = remaining.match(/^\\([\\*_`\[\]~!.()\-#>+|{}&])/);
+    match = remaining.match(/^\\([\\*_`\[\]~!.()\-#>+|{}&])/);
     if (match) {
       parts.push(match[1]);
       remaining = remaining.slice(2);

--- a/packages/ui/components/Viewer.tsx
+++ b/packages/ui/components/Viewer.tsx
@@ -9,6 +9,8 @@ import { CodeBlock } from './blocks/CodeBlock';
 import { TableBlock } from './blocks/TableBlock';
 import { TableToolbar } from './blocks/TableToolbar';
 import { TablePopout } from './blocks/TablePopout';
+import { CodePathValidationContext } from './CodePathValidationContext';
+import { useValidatedCodePaths } from '../hooks/useValidatedCodePaths';
 import { ListMarker } from './ListMarker';
 import { AnnotationToolbar } from './AnnotationToolbar';
 import { FloatingQuickLabelPicker } from './FloatingQuickLabelPicker';
@@ -510,7 +512,10 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
     setViewerCommentPopover(null);
   }, []);
 
+  const codePathValidation = useValidatedCodePaths(markdown);
+
   return (
+    <CodePathValidationContext.Provider value={codePathValidation}>
     <div className="relative z-50 w-full" style={maxWidth === null ? undefined : { maxWidth: maxWidth ?? 832 }}>
       {taterMode && <TaterSpriteSitting />}
       <article
@@ -855,6 +860,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
         document.body
       )}
     </div>
+    </CodePathValidationContext.Provider>
   );
 });
 

--- a/packages/ui/components/Viewer.tsx
+++ b/packages/ui/components/Viewer.tsx
@@ -68,6 +68,10 @@ interface ViewerProps {
   onOpenLinkedDoc?: (path: string) => void;
   onOpenCodeFile?: (path: string) => void;
   imageBaseDir?: string;
+  /** Directory the active document lives in — used by the code-path validator
+   *  so out-of-tree relative references (e.g. `../foo.ts` in a linked doc)
+   *  resolve against the doc's own directory rather than only cwd. */
+  codePathBaseDir?: string;
   linkedDocInfo?: { filepath: string; onBack: () => void; label?: string; backLabel?: string } | null;
   // Plan diff props
   planDiffStats?: { additions: number; deletions: number; modifications: number } | null;
@@ -159,6 +163,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
   onOpenCodeFile,
   linkedDocInfo,
   imageBaseDir,
+  codePathBaseDir,
   copyLabel,
   actionsLabelMode = 'full',
   archiveInfo,
@@ -512,7 +517,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
     setViewerCommentPopover(null);
   }, []);
 
-  const codePathValidation = useValidatedCodePaths(markdown);
+  const codePathValidation = useValidatedCodePaths(markdown, codePathBaseDir);
 
   return (
     <CodePathValidationContext.Provider value={codePathValidation}>

--- a/packages/ui/hooks/useCodeFilePopout.ts
+++ b/packages/ui/hooks/useCodeFilePopout.ts
@@ -4,6 +4,8 @@ interface CodeFileState {
   filepath: string;
   contents: string;
   prerenderedHTML?: string;
+  error?: string;
+  requestedPath?: string;
 }
 
 interface UseCodeFilePopoutOptions {
@@ -20,6 +22,8 @@ export interface UseCodeFilePopoutReturn {
     filepath: string;
     contents: string;
     prerenderedHTML?: string;
+    error?: string;
+    requestedPath?: string;
   } | null;
 }
 
@@ -48,12 +52,26 @@ export function useCodeFilePopout(
           error?: string;
         };
         if (!res.ok || data.error || !data.codeFile || typeof data.contents !== 'string' || !data.filepath) {
+          // Surface the not-found state so the popout can show a clear message
+          // instead of silently doing nothing.
+          setState({
+            filepath: codePath,
+            contents: "",
+            error: data.error ?? `File not found in repo: ${codePath}`,
+            requestedPath: codePath,
+          });
           setIsLoading(false);
           return;
         }
         setState({ filepath: data.filepath, contents: data.contents, prerenderedHTML: data.prerenderedHTML });
         setIsLoading(false);
       } catch {
+        setState({
+          filepath: codePath,
+          contents: "",
+          error: `Failed to load: ${codePath}`,
+          requestedPath: codePath,
+        });
         setIsLoading(false);
       }
     },
@@ -65,7 +83,15 @@ export function useCodeFilePopout(
     close,
     isLoading,
     popoutProps: state
-      ? { open: true, onClose: close, filepath: state.filepath, contents: state.contents, prerenderedHTML: state.prerenderedHTML }
+      ? {
+          open: true,
+          onClose: close,
+          filepath: state.filepath,
+          contents: state.contents,
+          prerenderedHTML: state.prerenderedHTML,
+          error: state.error,
+          requestedPath: state.requestedPath,
+        }
       : null,
   };
 }

--- a/packages/ui/hooks/useValidatedCodePaths.ts
+++ b/packages/ui/hooks/useValidatedCodePaths.ts
@@ -1,0 +1,76 @@
+import { useEffect, useMemo, useState } from "react";
+import { extractCandidateCodePaths } from "@plannotator/shared/extract-code-paths";
+
+export type ValidationEntry =
+	| { status: "found"; resolved: string }
+	| { status: "ambiguous"; matches: string[] }
+	| { status: "missing" }
+	| { status: "unavailable" };
+
+export type ValidatedMap = Map<string, ValidationEntry>;
+
+/**
+ * Extracts code-file path candidates from `markdown` and posts them to
+ * `/api/doc/exists` once per markdown change. The server has typically
+ * pre-warmed the file walk at plan/annotate load, so the response is fast.
+ *
+ * `validated` is empty until `ready` flips to true, at which point it holds
+ * an entry for every candidate (including missing/unavailable ones). The
+ * renderer dispatches on status — see InlineMarkdown.
+ *
+ * Empty candidate set short-circuits — no fetch, ready: true immediately.
+ */
+export function useValidatedCodePaths(
+	markdown: string,
+): { validated: ValidatedMap; ready: boolean } {
+	const [validated, setValidated] = useState<ValidatedMap>(new Map());
+	const [ready, setReady] = useState<boolean>(false);
+
+	useEffect(() => {
+		setValidated(new Map());
+		setReady(false);
+
+		const candidates = extractCandidateCodePaths(markdown);
+		if (candidates.length === 0) {
+			setReady(true);
+			return;
+		}
+
+		let cancelled = false;
+		(async () => {
+			try {
+				const res = await fetch("/api/doc/exists", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ paths: candidates }),
+				});
+				if (cancelled) return;
+				if (!res.ok) {
+					setReady(true);
+					return;
+				}
+				const data = (await res.json()) as {
+					results: Record<string, ValidationEntry>;
+				};
+				if (cancelled) return;
+				const next: ValidatedMap = new Map();
+				for (const [k, v] of Object.entries(data.results ?? {})) {
+					next.set(k, v);
+				}
+				setValidated(next);
+				setReady(true);
+			} catch {
+				if (!cancelled) setReady(true);
+			}
+		})();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [markdown]);
+
+	// Stable reference: only changes when validated/ready actually change.
+	// Without memoization, the parent provider's value is a fresh object every
+	// render, forcing all context consumers (every InlineMarkdown) to re-render.
+	return useMemo(() => ({ validated, ready }), [validated, ready]);
+}

--- a/packages/ui/hooks/useValidatedCodePaths.ts
+++ b/packages/ui/hooks/useValidatedCodePaths.ts
@@ -19,9 +19,16 @@ export type ValidatedMap = Map<string, ValidationEntry>;
  * renderer dispatches on status — see InlineMarkdown.
  *
  * Empty candidate set short-circuits — no fetch, ready: true immediately.
+ *
+ * `baseDir` is the directory the active document lives in (linked-doc parent
+ * or the annotate source file's parent). When set, the server tries
+ * `<baseDir>/<input>` literal-resolve before its cwd walk so out-of-tree
+ * relative references (e.g. `../script.ts` in `~/notes/foo.md`) don't get
+ * demoted to plain text.
  */
 export function useValidatedCodePaths(
 	markdown: string,
+	baseDir?: string,
 ): { validated: ValidatedMap; ready: boolean } {
 	const [validated, setValidated] = useState<ValidatedMap>(new Map());
 	const [ready, setReady] = useState<boolean>(false);
@@ -42,7 +49,9 @@ export function useValidatedCodePaths(
 				const res = await fetch("/api/doc/exists", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ paths: candidates }),
+					body: JSON.stringify(
+						baseDir ? { paths: candidates, base: baseDir } : { paths: candidates },
+					),
 				});
 				if (cancelled) return;
 				if (!res.ok) {
@@ -67,7 +76,7 @@ export function useValidatedCodePaths(
 		return () => {
 			cancelled = true;
 		};
-	}, [markdown]);
+	}, [markdown, baseDir]);
 
 	// Stable reference: only changes when validated/ready actually change.
 	// Without memoization, the parent provider's value is a fresh object every

--- a/packages/ui/theme.css
+++ b/packages/ui/theme.css
@@ -230,6 +230,18 @@ body {
     display: none;
   }
 }
+/* Ambiguous matches — paint a softer shimmer in a different hue so users
+   notice that clicking will surface a picker rather than open one file. */
+.code-file-link[data-ambiguous="true"]::after {
+  background: linear-gradient(
+    120deg,
+    transparent 0%,
+    rgba(168, 85, 247, 0.08) 35%,
+    rgba(168, 85, 247, 0.18) 50%,
+    rgba(168, 85, 247, 0.08) 65%,
+    transparent 100%
+  );
+}
 
 /* Word-level diff markers inside modified plan-diff blocks. Emitted as
    <ins>/<del> by PlanCleanDiffView's inline renderer; keep the decoration

--- a/tests/manual/path-detection/README.md
+++ b/tests/manual/path-detection/README.md
@@ -1,0 +1,99 @@
+# Path Detection Manual Test
+
+Tests code-file path detection, smart resolution, existence validation,
+baseDir threading, and the ambiguous-match picker.
+
+## Quick start
+
+```bash
+cd tests/manual/path-detection
+chmod +x *.sh
+
+# Plan mode (primary in-repo)
+./run-plan.sh --keep
+
+# Annotate mode (primary in-repo)
+./run-annotate-in-tree.sh --keep
+
+# Annotate mode (primary outside repo — key baseDir test)
+./run-annotate-out-of-tree.sh --keep
+```
+
+`--keep` prevents sandbox cleanup on exit so you can inspect files.
+Without it, the temp directory is removed when the script exits.
+
+Each script: builds hook, creates a temp sandbox with a fake repo +
+external fixtures, launches the appropriate server, opens the browser.
+
+## What the sandbox contains
+
+```
+$SANDBOX/
+├── repo/                               ← fake project root (git init'd)
+│   ├── packages/editor/App.tsx         ← ambiguous basename (1/2)
+│   ├── packages/review-editor/App.tsx  ← ambiguous basename (2/2)
+│   ├── packages/ui/components/Button.tsx ← unique basename
+│   ├── packages/ui/index.ts
+│   ├── src/utils/helper.ts             ← abbreviated path target
+│   ├── src/config.json                 ← non-.ts code file
+│   ├── app/[slug]/page.tsx             ← Next.js bracket-route
+│   ├── node_modules/junk/App.tsx       ← must be ignored
+│   └── test-plan.md                    ← fixture plan
+└── external/                           ← outside the repo
+    ├── notes.md                        ← annotate-out-of-tree primary
+    ├── script.ts, config.yaml, bar.ts, parent.ts
+    ├── design.md                       ← linked doc target
+    └── sub/subdoc.md, sub/nested.ts    ← nested linked doc
+```
+
+## Checklist
+
+### Plan mode (`run-plan.sh`)
+
+| § | Case | Expected |
+|---|------|----------|
+| 1A | `packages/editor/App.tsx` (backtick, full) | Link → opens file |
+| 1B | `packages/ui/components/Button.tsx` (prose, full) | Link → opens file |
+| 1C | `src/config.json` (backtick, JSON ext) | Link → opens file |
+| 2A | `editor/App.tsx` (abbreviated) | Link → opens packages/editor/App.tsx |
+| 2B | `utils/helper.ts` (abbreviated, prose) | Link → opens src/utils/helper.ts |
+| 2C | `./editor/App.tsx` (leading ./) | Link → opens packages/editor/App.tsx |
+| 3A | `Button.tsx` (unique basename) | Link → opens packages/ui/components/Button.tsx |
+| 3B | `App.tsx` (ambiguous basename) | Link with badge → picker → two entries |
+| 3C | `helper.ts` (unique basename) | Link → opens src/utils/helper.ts |
+| 4A | `packages/ui/shortcuts/core.ts` (missing, backtick) | Plain `<code>`, not clickable |
+| 4B | `packages/ui/shortcuts/runtime.ts` (missing, prose) | Plain text, not a link |
+| 5A | `packages/ui/{core,runtime}.ts` (braces) | Plain `<code>`, not a link |
+| 5B | `packages/ui/*.tsx` (glob) | Plain `<code>`, not a link |
+| 5C | `some path/with spaces/file.ts` (spaces) | Plain `<code>`, not a link |
+| 6A | `app/[slug]/page.tsx` (bracket route) | Link → opens file |
+| 6B | `[slug]/page.tsx` (abbreviated bracket) | Link → opens app/[slug]/page.tsx |
+| 7A | `junk/App.tsx` (node_modules) | Plain text or only real App.tsx matches |
+| 8A | URL with .ts extension | URL link only, no path leak |
+| 8B | URL + real path on same line | Two separate links |
+| 8C | Wikipedia-style parens URL | Single URL link |
+| 9 | Paths inside fenced code block | No links inside the block |
+| 10 | Paths inside HTML comment | Invisible, no links |
+| 11A | `../script.ts` (no baseDir in plan) | Plain text (demoted) |
+| 12 | Click linked doc → external/notes.md | Overlay opens; verify paths inside |
+
+### Annotate out-of-tree (`run-annotate-out-of-tree.sh`)
+
+| Case | Expected |
+|------|----------|
+| notes.md `script.ts` | Link → opens external/script.ts |
+| notes.md `config.yaml` | Link → opens external/config.yaml |
+| notes.md `editor/App.tsx` (cross-context) | Link → opens repo's packages/editor/App.tsx via cwd walk |
+| notes.md `packages/ui/shortcuts/core.ts` | Plain text (missing everywhere) |
+| Click [Open design doc] | Overlay; `bar.ts` → external/bar.ts |
+| Click [Open subdoc] → subdoc.md | Overlay; `../parent.ts` → external/parent.ts |
+| subdoc.md `nested.ts` | Link → opens external/sub/nested.ts |
+| subdoc.md `../missing.ts` | Plain text (doesn't exist) |
+
+### Network tab checks
+
+- On plan/annotate load: exactly **one** `POST /api/doc/exists`
+- When a linked doc overlay opens: **one** additional POST
+- Plan mode POST body: `{ paths: [...] }` (no `base` field)
+- Annotate out-of-tree POST body: `{ paths: [...], base: "<external dir>" }`
+- Linked doc POST body: `{ paths: [...], base: "<linked doc's parent>" }`

--- a/tests/manual/path-detection/run-annotate-in-tree.sh
+++ b/tests/manual/path-detection/run-annotate-in-tree.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Launch annotate mode with the test plan inside the sandbox repo.
+#
+# Usage:
+#   ./run-annotate-in-tree.sh [--keep]
+#
+# Test focus: annotate mode where the primary file is inside the
+# project root. baseDir = repo/test-plan.md's parent = repo root.
+# All in-repo paths should resolve normally. §12 linked-doc overlay
+# transitions baseDir to the external directory.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+KEEP_FLAG=""
+for arg in "$@"; do
+  case $arg in
+    --keep) KEEP_FLAG="--keep" ;;
+  esac
+done
+
+echo "=== Path Detection: Annotate In-Tree ==="
+echo ""
+
+# Build
+echo "Building review + hook..."
+cd "$PROJECT_ROOT"
+bun run build:review > /dev/null 2>&1
+bun run build:hook > /dev/null 2>&1
+echo "Build complete."
+echo ""
+
+# Setup sandbox
+source "$SCRIPT_DIR/setup.sh" $KEEP_FLAG
+
+# Run annotate from the sandbox repo directory
+echo "Launching annotate server from $SANDBOX/repo ..."
+echo ""
+cd "$SANDBOX/repo"
+bun run "$PROJECT_ROOT/apps/hook/server/index.ts" annotate test-plan.md
+
+echo ""
+echo "=== Done ==="

--- a/tests/manual/path-detection/run-annotate-out-of-tree.sh
+++ b/tests/manual/path-detection/run-annotate-out-of-tree.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Launch annotate mode with the external notes.md (outside the repo).
+#
+# Usage:
+#   ./run-annotate-out-of-tree.sh [--keep]
+#
+# Test focus: annotate mode where the primary file is OUTSIDE cwd.
+# baseDir = external/, cwd = repo/. This is the key scenario for
+# baseDir threading — sibling references like `script.ts` should
+# resolve against external/, not the repo.
+#
+# Also tests: linked-doc overlay from notes.md → design.md and
+# notes.md → sub/subdoc.md (nested baseDir transitions).
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+KEEP_FLAG=""
+for arg in "$@"; do
+  case $arg in
+    --keep) KEEP_FLAG="--keep" ;;
+  esac
+done
+
+echo "=== Path Detection: Annotate Out-of-Tree ==="
+echo ""
+
+# Build
+echo "Building review + hook..."
+cd "$PROJECT_ROOT"
+bun run build:review > /dev/null 2>&1
+bun run build:hook > /dev/null 2>&1
+echo "Build complete."
+echo ""
+
+# Setup sandbox
+source "$SCRIPT_DIR/setup.sh" $KEEP_FLAG
+
+# Run annotate from the sandbox repo (cwd = repo), pointing at external file
+echo "Launching annotate server..."
+echo "  cwd:  $SANDBOX/repo"
+echo "  file: $SANDBOX/external/notes.md"
+echo ""
+cd "$SANDBOX/repo"
+bun run "$PROJECT_ROOT/apps/hook/server/index.ts" annotate "$SANDBOX/external/notes.md"
+
+echo ""
+echo "=== Done ==="

--- a/tests/manual/path-detection/run-plan.sh
+++ b/tests/manual/path-detection/run-plan.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Launch plan mode with the path-detection test plan.
+#
+# Usage:
+#   ./run-plan.sh [--keep]
+#
+# Runs setup.sh to create a temp sandbox, builds the hook, then pipes
+# test-plan.md as a plan JSON to the hook server. Browser opens with
+# the rendered plan. Sandbox is cleaned up on exit unless --keep.
+#
+# Test focus: in-repo path detection. baseDir is undefined for the
+# primary plan; becomes set when you click linked-doc overlays (§12).
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+# Forward --keep
+KEEP_FLAG=""
+for arg in "$@"; do
+  case $arg in
+    --keep) KEEP_FLAG="--keep" ;;
+  esac
+done
+
+echo "=== Path Detection: Plan Mode ==="
+echo ""
+
+# Build
+echo "Building review + hook..."
+cd "$PROJECT_ROOT"
+bun run build:review > /dev/null 2>&1
+bun run build:hook > /dev/null 2>&1
+echo "Build complete."
+echo ""
+
+# Setup sandbox
+source "$SCRIPT_DIR/setup.sh" $KEEP_FLAG
+
+# Read the test plan
+PLAN_MD=$(cat "$SANDBOX/repo/test-plan.md")
+
+# Escape for JSON embedding (newlines, quotes, backslashes)
+PLAN_ESCAPED=$(printf '%s' "$PLAN_MD" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))')
+
+# Pipe as hook JSON to the server, running from the sandbox repo dir
+echo "Launching plan server from $SANDBOX/repo ..."
+echo ""
+cd "$SANDBOX/repo"
+echo "{\"tool_input\":{\"plan\":$PLAN_ESCAPED}}" | bun run "$PROJECT_ROOT/apps/hook/server/index.ts"
+
+echo ""
+echo "=== Done ==="

--- a/tests/manual/path-detection/setup.sh
+++ b/tests/manual/path-detection/setup.sh
@@ -1,0 +1,365 @@
+#!/bin/bash
+# Build a self-contained temp sandbox for testing code-file path detection.
+#
+# Usage:
+#   source ./setup.sh          # sets $SANDBOX in your shell
+#   source ./setup.sh --keep   # don't auto-clean on shell exit
+#
+# What it creates (everything under a single mktemp -d):
+#
+#   $SANDBOX/
+#   ├── repo/                           ← fake project root (git init'd)
+#   │   ├── packages/
+#   │   │   ├── editor/App.tsx          ← ambiguous basename (1 of 2)
+#   │   │   ├── review-editor/App.tsx   ← ambiguous basename (2 of 2)
+#   │   │   └── ui/
+#   │   │       ├── components/Button.tsx  ← unique basename
+#   │   │       └── index.ts
+#   │   ├── src/
+#   │   │   ├── utils/helper.ts         ← abbreviated path target
+#   │   │   └── config.json             ← non-.ts code file
+#   │   ├── app/
+#   │   │   └── [slug]/page.tsx         ← Next.js bracket-route
+#   │   ├── node_modules/
+#   │   │   └── junk/App.tsx            ← should be ignored by walker
+#   │   └── test-plan.md                ← the primary fixture plan
+#   │
+#   └── external/                       ← out-of-tree (simulates ~/notes/)
+#       ├── notes.md                    ← annotate primary (out-of-tree)
+#       ├── script.ts                   ← sibling reference from notes.md
+#       ├── config.yaml                 ← sibling, different extension
+#       ├── design.md                   ← linked doc opened from notes.md
+#       ├── bar.ts                      ← sibling reference from design.md
+#       ├── parent.ts                   ← target for ../parent.ts from sub/
+#       └── sub/
+#           ├── subdoc.md              ← references ../parent.ts
+#           └── nested.ts             ← local sibling of subdoc.md
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+KEEP=false
+for arg in "$@"; do
+  case $arg in
+    --keep) KEEP=true ;;
+  esac
+done
+
+SANDBOX=$(mktemp -d "${TMPDIR:-/tmp}/plannotator-pathtest-XXXXXX")
+echo "Sandbox: $SANDBOX"
+
+if [ "$KEEP" = false ]; then
+  trap 'echo "Cleaning up $SANDBOX"; rm -rf "$SANDBOX"' EXIT
+else
+  echo "(--keep: won't auto-clean)"
+fi
+
+# ───────────────────────────────────────────────────
+# 1. Fake repo with known file tree
+# ───────────────────────────────────────────────────
+REPO="$SANDBOX/repo"
+mkdir -p "$REPO"
+cd "$REPO"
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+
+# Ambiguous pair (both named App.tsx)
+mkdir -p packages/editor
+mkdir -p packages/review-editor
+cat > packages/editor/App.tsx << 'TSEOF'
+export default function EditorApp() { return <div>Editor</div>; }
+TSEOF
+cat > packages/review-editor/App.tsx << 'TSEOF'
+export default function ReviewApp() { return <div>Review</div>; }
+TSEOF
+
+# Unique basenames
+mkdir -p packages/ui/components
+cat > packages/ui/components/Button.tsx << 'TSEOF'
+export const Button = () => <button>Click</button>;
+TSEOF
+cat > packages/ui/index.ts << 'TSEOF'
+export * from './components/Button';
+TSEOF
+
+# Abbreviated path targets (src/utils/helper.ts → match "utils/helper.ts")
+mkdir -p src/utils
+cat > src/utils/helper.ts << 'TSEOF'
+export function helper() { return 42; }
+TSEOF
+
+# Non-.ts code file to verify resolver handles other extensions
+cat > src/config.json << 'JSONEOF'
+{ "key": "value" }
+JSONEOF
+
+# Next.js bracket-route (shape filter must allow [ and ])
+mkdir -p "app/[slug]"
+cat > "app/[slug]/page.tsx" << 'TSEOF'
+export default function SlugPage() { return <div>Slug</div>; }
+TSEOF
+
+# node_modules — walker must skip this
+mkdir -p node_modules/junk
+cat > node_modules/junk/App.tsx << 'TSEOF'
+// should never resolve
+TSEOF
+
+# Commit so git is happy
+git add -A
+git commit -q -m "initial"
+
+# ───────────────────────────────────────────────────
+# 2. Out-of-tree fixtures (simulates external docs)
+# ───────────────────────────────────────────────────
+EXT="$SANDBOX/external"
+mkdir -p "$EXT/sub"
+
+cat > "$EXT/script.ts" << 'TSEOF'
+export function externalScript() { return "external"; }
+TSEOF
+
+cat > "$EXT/config.yaml" << 'YAMLEOF'
+key: value
+YAMLEOF
+
+cat > "$EXT/bar.ts" << 'TSEOF'
+export function bar() { return "bar"; }
+TSEOF
+
+cat > "$EXT/parent.ts" << 'TSEOF'
+export function parent() { return "parent"; }
+TSEOF
+
+cat > "$EXT/sub/nested.ts" << 'TSEOF'
+export function nested() { return "nested"; }
+TSEOF
+
+# ───────────────────────────────────────────────────
+# 3. Test markdown: plan-fixture.md (used by run-plan.sh)
+# ───────────────────────────────────────────────────
+cat > "$REPO/test-plan.md" << 'MDEOF'
+# Path Detection Test Plan
+
+Use this plan to manually verify code-file path detection, smart
+resolution, and existence validation. Each section tests a different
+scenario. The line below each path says what should happen.
+
+---
+
+## §1 — Full repo paths (should all be clickable links)
+
+A. Backtick, full path: `packages/editor/App.tsx`
+   → clickable, opens packages/editor/App.tsx
+
+B. Bare prose, full path: see packages/ui/components/Button.tsx for the button
+   → clickable, opens Button.tsx
+
+C. JSON extension: `src/config.json`
+   → clickable, opens config.json
+
+## §2 — Abbreviated paths (suffix-walk resolution)
+
+A. Backtick abbreviated: `editor/App.tsx`
+   → clickable, opens packages/editor/App.tsx
+
+B. Bare prose abbreviated: see utils/helper.ts for the implementation
+   → clickable, opens src/utils/helper.ts
+
+C. Backtick with leading dot-slash: `./editor/App.tsx`
+   → clickable, opens packages/editor/App.tsx
+
+## §3 — Bare basename (single match → link, multiple → picker)
+
+A. Unique basename: `Button.tsx`
+   → clickable, opens packages/ui/components/Button.tsx
+
+B. Ambiguous basename: `App.tsx`
+   → clickable with superscript count badge, click opens picker
+     listing packages/editor/App.tsx and packages/review-editor/App.tsx
+
+C. Unique non-component: `helper.ts`
+   → clickable, opens src/utils/helper.ts
+
+## §4 — Non-existent paths (should demote to plain text)
+
+A. Backtick, missing file: `packages/ui/shortcuts/core.ts`
+   → rendered as plain code (not clickable), no shimmer
+
+B. Bare prose, missing file: see packages/ui/shortcuts/runtime.ts for details
+   → rendered as plain text (not a link at all)
+
+## §5 — Shape filter (should never be detected as paths)
+
+A. Brace expansion: `packages/ui/{core,runtime}.ts`
+   → rendered as plain code, NOT a link
+
+B. Glob wildcard: `packages/ui/*.tsx`
+   → rendered as plain code, NOT a link
+
+C. Path with spaces: `some path/with spaces/file.ts`
+   → rendered as plain code, NOT a link
+
+## §6 — Bracket routes (shape filter must allow [ and ])
+
+A. Next.js dynamic route: `app/[slug]/page.tsx`
+   → clickable, opens app/[slug]/page.tsx
+
+B. Abbreviated bracket route: `[slug]/page.tsx`
+   → clickable via suffix walk
+
+## §7 — node_modules exclusion
+
+A. Path inside node_modules: `junk/App.tsx`
+   → should be not_found (walker skips node_modules), demoted to plain text
+     or rendered as ambiguous with only the two real App.tsx files
+
+## §8 — URLs (should not produce path-shaped leaks)
+
+A. URL with .ts extension: see https://github.com/example/bar.ts in the docs
+   → URL is a link, no stray "bar.ts" path link appears
+
+B. URL on same line as real path: https://github.com/example.com and editor/App.tsx
+   → URL is a URL link, editor/App.tsx is a separate code-file link
+
+C. Wikipedia-style parens: see https://en.wikipedia.org/wiki/Foo_(bar).ts
+   → entire URL is one link, no path extracted
+
+## §9 — Fenced code blocks (should NOT detect paths inside)
+
+```ts
+import { helper } from 'src/utils/helper.ts';
+const x = require('packages/editor/App.tsx');
+```
+
+→ No clickable links inside the fenced block above
+
+## §10 — HTML comments (should not detect)
+
+<!-- packages/editor/App.tsx is a placeholder -->
+
+→ Comment content is invisible; no links generated
+
+## §11 — Leading ../ paths
+
+A. Without baseDir context (plan mode, no linked doc):
+   `../script.ts`
+   → demoted to plain text (no baseDir to resolve against)
+
+B. This scenario is tested by opening an out-of-tree linked doc (see §12).
+
+## §12 — Linked doc overlay (baseDir transition)
+
+Click this link to open the external notes. Once inside the overlay,
+verify the paths listed in notes.md resolve correctly against their
+own directory, not against this repo's cwd.
+
+[Open external notes](EXTERNAL_NOTES_PLACEHOLDER)
+
+After opening, check:
+- `script.ts` in the notes should be clickable (resolves to external/script.ts)
+- `../parent.ts` referenced from sub/subdoc.md should resolve
+- `editor/App.tsx` in the notes should still resolve via cwd suffix-walk
+MDEOF
+
+# ───────────────────────────────────────────────────
+# 4. Out-of-tree markdown fixtures
+# ───────────────────────────────────────────────────
+cat > "$EXT/notes.md" << 'MDEOF'
+# External Notes
+
+This file lives outside the project repo. References below should
+resolve against THIS directory when opened in annotate mode or as
+a linked-doc overlay.
+
+## Sibling references (baseDir-literal should hit)
+
+A. Backtick sibling: `script.ts`
+   → clickable, opens external/script.ts
+
+B. Bare prose sibling: see config.yaml for the config
+   → clickable, opens external/config.yaml
+
+## Relative escape (../ with baseDir)
+
+These only work when baseDir is set (annotate or linked-doc mode):
+
+A. From sub/subdoc.md: [Open subdoc](sub/subdoc.md)
+   After opening, `../parent.ts` should resolve to external/parent.ts
+
+## Cross-context fallback (baseDir miss → cwd suffix walk)
+
+A. Repo path from outside: `editor/App.tsx`
+   → IF opened as linked doc from the repo plan: clickable, resolves
+     to repo's packages/editor/App.tsx via cwd suffix-walk fallback
+   → IF opened standalone via annotate: may not find it (no cwd walk
+     if repo is not cwd)
+
+## Linked doc from out-of-tree
+
+A. [Open design doc](design.md)
+   After opening, `bar.ts` should resolve to external/bar.ts
+
+## Missing from here
+
+A. `packages/ui/shortcuts/core.ts`
+   → demoted to plain text (doesn't exist anywhere near this file)
+MDEOF
+
+cat > "$EXT/design.md" << 'MDEOF'
+# Design Doc
+
+Opened as a linked doc from notes.md. baseDir should be external/.
+
+## References
+
+A. Sibling code file: `bar.ts`
+   → clickable, opens external/bar.ts
+
+B. Non-existent here: `baz.ts`
+   → demoted to plain text
+
+C. Repo file via suffix-walk: `Button.tsx`
+   → If opened from repo plan → cwd walk finds packages/ui/components/Button.tsx
+   → If opened standalone → demoted (no cwd context)
+MDEOF
+
+cat > "$EXT/sub/subdoc.md" << 'MDEOF'
+# Sub-document
+
+Opened from notes.md. baseDir should be external/sub/.
+
+## Parent escape
+
+A. `../parent.ts`
+   → clickable, opens external/parent.ts (baseDir literal: external/sub/../parent.ts)
+
+## Local sibling
+
+A. `nested.ts`
+   → clickable, opens external/sub/nested.ts
+
+## Non-existent
+
+A. `../missing.ts`
+   → demoted to plain text (external/missing.ts doesn't exist)
+MDEOF
+
+# ───────────────────────────────────────────────────
+# 5. Patch the placeholder link in plan-fixture.md
+#    to point to the actual external notes path
+# ───────────────────────────────────────────────────
+sed -i '' "s|EXTERNAL_NOTES_PLACEHOLDER|$EXT/notes.md|" "$REPO/test-plan.md"
+
+echo ""
+echo "Sandbox ready."
+echo "  Repo:     $REPO"
+echo "  External: $EXT"
+echo ""
+echo "Export for launcher scripts:"
+echo "  export SANDBOX=$SANDBOX"
+
+export SANDBOX


### PR DESCRIPTION
## Summary

- **Smart resolution for code-file paths** in `/api/doc`: a literal miss now falls back to a case-insensitive suffix match against a cached project walk, mirroring what already works for markdown. Abbreviated paths from prose (`editor/App.tsx` → `packages/editor/App.tsx`) resolve correctly.
- **Existence pre-validation** via a new `POST /api/doc/exists` endpoint + frontend `useValidatedCodePaths` hook. The renderer demotes paths the project doesn't contain (e.g. files the plan proposes creating) to plain code instead of leaving broken-link buttons that 404 on click.
- **Picker popover for ambiguous matches**: when a name like `App.tsx` exists in multiple packages, clicking opens a small dropdown of all matches; selecting one opens that file in the popout.

The server walk is pre-warmed at plan/annotate load and on every `/api/doc` request, stored as a Promise (race-safe), with a 30s TTL so newly-created files resolve mid-review. The frontend renders optimistically (every detected path is a link on first paint) and demotes missing ones once the POST returns — first paint is unchanged.

A shape filter (`isPlausibleCodeFilePath`) hard-rejects shell brace expansion (`{a,b}.ts`), glob wildcards, and whitespace, while still allowing `[` / `]` so Next.js dynamic routes survive. Pi extension mirrors all server changes. The popout now surfaces "File not found in repo: \<path\>" instead of silently swallowing 404s.

Original failure case: `~/.plannotator/plans/salvage-pr-380-shortcut-regist-2026-05-03-approved.md` produced 404s for `editor/App.tsx`, `review-editor/App.tsx`, and `packages/ui/shortcuts/{core,runtime,index}.ts`. After: the first two resolve to their `packages/...` real paths; the shortcuts files render as plain code (they don't exist yet — the plan proposes creating them).

## Test plan

- [x] `bun test packages/shared/` — 218 pass
- [x] New unit tests pin the two regressions caught in self-review (URL-with-parens leaking path-shaped substrings; leading `./` breaking suffix match)
- [x] `bun run --cwd apps/review build` and `bun run build:hook` both succeed
- [ ] Open `~/.plannotator/plans/salvage-pr-380-shortcut-regist-2026-05-03-approved.md` in `dev:hook` and verify:
  - `editor/App.tsx` (line 7) is clickable, opens `packages/editor/App.tsx`
  - `review-editor/App.tsx` (line 7) is clickable, opens `packages/review-editor/App.tsx`
  - `packages/ui/shortcuts/core.ts` etc. render as plain `<code>`, no shimmer, no click handler
  - `packages/editor/App.tsx` (full path, lines 81/82/109/110) still clickable — regression check
  - Network tab shows exactly one `POST /api/doc/exists` after the initial render
- [ ] Verify Next.js-style `app/[slug]/page.tsx` paths still linkify in a test plan
- [ ] Verify a backtick `App.tsx` in a test plan opens the picker showing both `packages/editor/App.tsx` and `packages/review-editor/App.tsx`