### PR TITLE
Add Pi annotation tools

### DIFF
--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -82,6 +82,7 @@ import {
 	type Phase,
 	stripPlanningOnlyTools,
 } from "./tool-scope.ts";
+import { registerPlannotatorAgentTools } from "./plannotator-agent-tools.js";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -208,6 +209,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 	const currentPiSession = registerCurrentPiSession(pi);
 	let phase: Phase = "idle";
 	void registerPlannotatorEventListeners(pi);
+	registerPlannotatorAgentTools(pi);
 	let lastSubmittedPath: string | null = null;
 	let checklistItems: ChecklistItem[] = [];
 	let savedState: SavedPhaseState | null = null;

--- a/apps/pi-extension/plannotator-agent-tools.test.ts
+++ b/apps/pi-extension/plannotator-agent-tools.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { registerPlannotatorAgentTools } from "./plannotator-agent-tools";
+
+type RegisteredTool = {
+	name: string;
+	description: string;
+	execute: (id: string, params: unknown, signal: AbortSignal | undefined, onUpdate: unknown, ctx: unknown) => Promise<{ content: Array<{ type: string; text: string }>; details?: unknown }>;
+};
+
+function createPiMock(handler: (channel: string, request: any) => void) {
+	const tools = new Map<string, RegisteredTool>();
+	return {
+		tools,
+		pi: {
+			registerTool(tool: RegisteredTool) {
+				tools.set(tool.name, tool);
+			},
+			events: {
+				emit: handler,
+			},
+		},
+	};
+}
+
+describe("Plannotator agent tools", () => {
+	test("registers annotate and annotate-last tools", () => {
+		const mock = createPiMock(() => undefined);
+
+		registerPlannotatorAgentTools(mock.pi as never);
+
+		expect([...mock.tools.keys()].sort()).toEqual(["plannotator_annotate", "plannotator_annotate_last"]);
+	});
+
+	test("plannotator_annotate emits annotate request and returns feedback", async () => {
+		const mock = createPiMock((_channel, request) => {
+			expect(_channel).toBe("plannotator:request");
+			expect(request.action).toBe("annotate");
+			expect(request.payload).toEqual({ filePath: "/tmp/spec.md", gate: true });
+			request.respond({ status: "handled", result: { feedback: "Clarify scope." } });
+		});
+		registerPlannotatorAgentTools(mock.pi as never);
+
+		const result = await mock.tools.get("plannotator_annotate")!.execute("call-1", { filePath: "/tmp/spec.md", gate: true }, undefined, undefined, {});
+
+		expect(result.content[0].text).toBe("Clarify scope.");
+		expect(result.details).toEqual({ feedback: "Clarify scope." });
+	});
+
+	test("plannotator_annotate_last emits annotate-last request and reports approval", async () => {
+		const mock = createPiMock((_channel, request) => {
+			expect(_channel).toBe("plannotator:request");
+			expect(request.action).toBe("annotate-last");
+			expect(request.payload).toEqual({ filePath: "", gate: true });
+			request.respond({ status: "handled", result: { feedback: "", approved: true } });
+		});
+		registerPlannotatorAgentTools(mock.pi as never);
+
+		const result = await mock.tools.get("plannotator_annotate_last")!.execute("call-2", { gate: true }, undefined, undefined, {});
+
+		expect(result.content[0].text).toBe("Approved.");
+		expect(result.details).toEqual({ feedback: "", approved: true });
+	});
+
+	test("returns error text when Plannotator is unavailable", async () => {
+		const mock = createPiMock((_channel, request) => {
+			request.respond({ status: "unavailable", error: "No active session" });
+		});
+		registerPlannotatorAgentTools(mock.pi as never);
+
+		const result = await mock.tools.get("plannotator_annotate")!.execute("call-3", { filePath: "/tmp/spec.md" }, undefined, undefined, {});
+
+		expect(result.content[0].text).toBe("Plannotator unavailable: No active session");
+	});
+});

--- a/apps/pi-extension/plannotator-agent-tools.ts
+++ b/apps/pi-extension/plannotator-agent-tools.ts
@@ -1,0 +1,125 @@
+import { Type } from "@mariozechner/pi-ai";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+const PLANNOTATOR_REQUEST_CHANNEL = "plannotator:request";
+
+type PlannotatorAnnotationResult = {
+	feedback: string;
+	exit?: boolean;
+	approved?: boolean;
+};
+
+type PlannotatorResponse<T> =
+	| { status: "handled"; result: T }
+	| { status: "unavailable"; error?: string }
+	| { status: "error"; error: string };
+
+type ToolResult = {
+	content: Array<{ type: "text"; text: string }>;
+	details: unknown;
+};
+
+type AnnotateParams = {
+	filePath?: string;
+	gate?: boolean;
+};
+
+type AnnotateLastParams = {
+	gate?: boolean;
+};
+
+const RESPONSE_TIMEOUT_MS = 10 * 60 * 1_000;
+
+function textResult(text: string, details?: unknown): ToolResult {
+	return {
+		content: [{ type: "text", text }],
+		details: details ?? {},
+	};
+}
+
+function formatAnnotationResult(result: PlannotatorAnnotationResult): string {
+	if (result.feedback?.trim()) return result.feedback.trim();
+	if (result.approved) return "Approved.";
+	if (result.exit) return "Annotation session closed.";
+	return "Annotation closed without feedback.";
+}
+
+function formatUnavailable(response: PlannotatorResponse<PlannotatorAnnotationResult>): string {
+	if (response.status === "unavailable") return `Plannotator unavailable: ${response.error || "unknown reason"}`;
+	if (response.status === "error") return `Plannotator error: ${response.error}`;
+	return "Plannotator unavailable: unknown reason";
+}
+
+function requestAnnotation(
+	pi: ExtensionAPI,
+	action: "annotate" | "annotate-last",
+	payload: { filePath: string; gate?: boolean },
+): Promise<ToolResult> {
+	return new Promise((resolve) => {
+		let settled = false;
+		const timer = setTimeout(() => {
+			if (settled) return;
+			settled = true;
+			resolve(textResult("Plannotator unavailable: request timed out."));
+		}, RESPONSE_TIMEOUT_MS);
+
+		function finish(result: ToolResult): void {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			resolve(result);
+		}
+
+		try {
+			pi.events.emit(PLANNOTATOR_REQUEST_CHANNEL, {
+				requestId: `agent-tool-${action}-${Date.now()}`,
+				action,
+				payload,
+				respond(response: PlannotatorResponse<PlannotatorAnnotationResult>) {
+					if (response.status !== "handled") {
+						finish(textResult(formatUnavailable(response)));
+						return;
+					}
+					finish(textResult(formatAnnotationResult(response.result), response.result));
+				},
+			});
+		} catch (error) {
+			finish(textResult(`Plannotator error: ${error instanceof Error ? error.message : String(error)}`));
+		}
+	});
+}
+
+export function registerPlannotatorAgentTools(pi: ExtensionAPI): void {
+	pi.registerTool({
+		name: "plannotator_annotate",
+		label: "Plannotator Annotate",
+		description: "Open a file, folder, HTML file, or URL in Plannotator annotation UI and return reviewer feedback.",
+		parameters: Type.Object({
+			filePath: Type.String({ description: "File, folder, HTML file, or URL to annotate." }),
+			gate: Type.Optional(Type.Boolean({ description: "Show approve/annotate/close review-gate controls." })),
+		}) as any,
+		async execute(_toolCallId, params) {
+			const filePath = (params as AnnotateParams).filePath?.trim();
+			if (!filePath) return textResult("Error: plannotator_annotate requires a filePath.");
+			return requestAnnotation(pi, "annotate", {
+				filePath,
+				...((params as AnnotateParams).gate !== undefined ? { gate: (params as AnnotateParams).gate } : {}),
+			});
+		},
+	});
+
+	pi.registerTool({
+		name: "plannotator_annotate_last",
+		label: "Plannotator Annotate Last",
+		description: "Open the latest assistant message in Plannotator annotation UI and return reviewer feedback.",
+		parameters: Type.Object({
+			gate: Type.Optional(Type.Boolean({ description: "Show approve/annotate/close review-gate controls." })),
+		}) as any,
+		async execute(_toolCallId, params) {
+			return requestAnnotation(pi, "annotate-last", {
+				filePath: "",
+				...((params as AnnotateLastParams).gate !== undefined ? { gate: (params as AnnotateLastParams).gate } : {}),
+			});
+		},
+	});
+}


### PR DESCRIPTION
## Summary
- Add `plannotator_annotate` Pi tool for opening file/folder/HTML/URL annotation UI and returning reviewer feedback.
- Add `plannotator_annotate_last` Pi tool for opening the latest assistant message in annotation UI.
- Reuse the existing `plannotator:request` bridge so behavior stays aligned with current annotation handlers.

## Verification
- `bun test ./apps/pi-extension/plannotator-agent-tools.test.ts`
- `bunx tsc --noEmit -p apps/pi-extension/tsconfig.json`
- `bun run build:pi`

## Note
- A broader existing server test suite was also run; `apps/pi-extension/server.test.ts` had an unrelated pre-existing/flaky failure around diff parity content and timeout. The new focused tests passed.