### PR TITLE
Add bun link support for local CLI development

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,22 +64,6 @@ Plannotator lets you privately share plans, annotations, and feedback with colle
 - [OpenCode](#install-for-opencode)
 - [Pi](#install-for-pi)
 - [Codex](#install-for-codex)
-- [Local Development](#local-development)
-
-## Local Development
-
-To make the global `plannotator` command run from this checkout:
-
-```bash
-bun install
-bun link
-```
-
-After linking, commands like `plannotator review` use `apps/hook/server/index.ts` from your local repo. Rebuild the bundled HTML when changing UI code:
-
-```bash
-bun run --cwd apps/review build && bun run build:hook
-```
 
 ## Install for Claude Code
 
@@ -294,3 +278,18 @@ at your option.
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in this project by you, as defined in the Apache-2.0 license,
 shall be dual licensed as above, without any additional terms or conditions.
+
+## Development
+
+To make the global `plannotator` command run from this checkout:
+
+```bash
+bun install
+bun link
+```
+
+After linking, commands like `plannotator review` use `apps/hook/server/index.ts` from your local repo. Rebuild the bundled HTML when changing UI code:
+
+```bash
+bun run --cwd apps/review build && bun run build:hook
+```

--- a/README.md
+++ b/README.md
@@ -64,6 +64,22 @@ Plannotator lets you privately share plans, annotations, and feedback with colle
 - [OpenCode](#install-for-opencode)
 - [Pi](#install-for-pi)
 - [Codex](#install-for-codex)
+- [Local Development](#local-development)
+
+## Local Development
+
+To make the global `plannotator` command run from this checkout:
+
+```bash
+bun install
+bun link
+```
+
+After linking, commands like `plannotator review` use `apps/hook/server/index.ts` from your local repo. Rebuild the bundled HTML when changing UI code:
+
+```bash
+bun run --cwd apps/review build && bun run build:hook
+```
 
 ## Install for Claude Code
 

--- a/bin/plannotator.js
+++ b/bin/plannotator.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+const childProcess = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const repoRoot = path.resolve(path.dirname(__filename), "..");
+const sourceEntry = path.join(repoRoot, "apps", "hook", "server", "index.ts");
+
+if (!fs.existsSync(sourceEntry)) {
+  console.error(`Could not find Plannotator source entry at ${sourceEntry}`);
+  process.exit(1);
+}
+
+const result = childProcess.spawnSync("bun", [sourceEntry, ...process.argv.slice(2)], {
+  cwd: process.cwd(),
+  stdio: "inherit",
+});
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+process.exit(typeof result.status === "number" ? result.status : 0);

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "description": "Interactive Plan Review for Claude Code - annotate plans visually, share with team, automatically send feedback",
   "author": "backnotprop",
   "license": "MIT OR Apache-2.0",
+  "bin": {
+    "plannotator": "bin/plannotator.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/backnotprop/plannotator.git"


### PR DESCRIPTION
Hey! No pressure to merge this. This is just a change I made to allow local development easier for me on my fork, and thought I would share incase this might be valuable.

This approach inspired from `ghui` doing the same thing: https://github.com/kitlangton/ghui

Local development/personal forks made super easy by just running `bun link` in a clone. 

## Summary
- Added a `plannotator` bin entry so the CLI can be linked from this checkout with `bun link`.
- Introduced a small Node wrapper that resolves the local `apps/hook/server/index.ts` entrypoint and forwards CLI args to Bun.
- Documented the local development workflow in the README, including when to rebuild bundled HTML after UI changes.