### PR TITLE
fix(review): stop diff list re-rendering on every comment keystroke

### DIFF
--- a/packages/review-editor/components/AllFilesDiffView.tsx
+++ b/packages/review-editor/components/AllFilesDiffView.tsx
@@ -4,12 +4,8 @@ import { getSingularPatch } from '@pierre/diffs';
 import { CodeAnnotation, CodeAnnotationType, SelectedLineRange, DiffAnnotationMetadata, TokenAnnotationMeta, ConventionalLabel, ConventionalDecoration } from '@plannotator/ui/types';
 import { usePierreTheme } from '../hooks/usePierreTheme';
 import { LazyFileDiff } from './LazyFileDiff';
-import { useAnnotationToolbar } from '../hooks/useAnnotationToolbar';
-import { useConfigValue } from '@plannotator/ui/config';
-import { getEnabledLabels } from './ConventionalLabelPicker';
+import { ToolbarHost, type ToolbarHostHandle } from './ToolbarHost';
 import { InlineAnnotation } from './InlineAnnotation';
-import { AnnotationToolbar } from './AnnotationToolbar';
-import { SuggestionModal } from './SuggestionModal';
 import { FileHeader } from './FileHeader';
 import { CommentPopover } from '@plannotator/ui/components/CommentPopover';
 import { detectLanguage } from '../utils/detectLanguage';
@@ -97,9 +93,6 @@ export const AllFilesDiffView: React.FC<AllFilesDiffViewProps> = ({
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const headerRefs = useRef<Map<string, HTMLDivElement>>(new Map());
-  const conventionalCommentsEnabled = useConfigValue('conventionalComments');
-  const conventionalLabelsJson = useConfigValue('conventionalLabels');
-  const enabledLabels = useMemo(() => getEnabledLabels(conventionalLabelsJson), [conventionalLabelsJson]);
 
   const activePatch = useMemo(
     () => files.find(f => f.path === activeFilePath)?.patch ?? '',
@@ -119,27 +112,20 @@ export const AllFilesDiffView: React.FC<AllFilesDiffViewProps> = ({
     onAddAnnotation(activeFilePath, type, text, suggestedCode, originalCode, conventionalLabel, decorations, tokenMeta);
   }, [activeFilePath, onAddAnnotation]);
 
-  const toolbar = useAnnotationToolbar({
-    patch: activePatch,
-    filePath: activeFilePath ?? '',
-    isFocused: true,
-    onLineSelection,
-    onAddAnnotation: handleAddAnnotation,
-    onEditAnnotation,
-  });
+  const toolbarHostRef = useRef<ToolbarHostHandle>(null);
 
   useEffect(() => {
     if (pendingToolbarRange.current && activePatch) {
-      toolbar.handleLineSelectionEnd(pendingToolbarRange.current);
+      toolbarHostRef.current?.handleLineSelectionEnd(pendingToolbarRange.current);
       pendingToolbarRange.current = null;
     }
-  }, [activePatch, toolbar.handleLineSelectionEnd]);
+  }, [activePatch]);
 
   const handleEdit = useCallback((id: string) => {
     const ann = annotations.find(a => a.id === id);
     if (!ann) return;
-    toolbar.startEdit(ann);
-  }, [annotations, toolbar.startEdit]);
+    toolbarHostRef.current?.startEdit(ann);
+  }, [annotations]);
 
   const visualOrder = useMemo(() => {
     const tree = buildFileTree(files);
@@ -338,7 +324,7 @@ export const AllFilesDiffView: React.FC<AllFilesDiffViewProps> = ({
           }
           setActiveFilePath(closestFile);
         }
-        toolbar.handleLineSelectionEnd({
+        toolbarHostRef.current?.handleLineSelectionEnd({
           start: Math.min(anchorLine, focusLine),
           end: Math.max(anchorLine, focusLine),
           side,
@@ -348,7 +334,7 @@ export const AllFilesDiffView: React.FC<AllFilesDiffViewProps> = ({
     };
     root.addEventListener('mouseup', handler, true);
     return () => root.removeEventListener('mouseup', handler, true);
-  }, [toolbar.handleLineSelectionEnd, sortedFiles, activeFilePath]);
+  }, [sortedFiles, activeFilePath]);
 
   // Scroll to selected annotation — auto-expand collapsed file
   useEffect(() => {
@@ -368,7 +354,7 @@ export const AllFilesDiffView: React.FC<AllFilesDiffViewProps> = ({
   }, [selectedAnnotationId, annotations]);
 
   return (
-    <div className="h-full overflow-auto" ref={scrollRef} onMouseMove={toolbar.handleMouseMove}>
+    <div className="h-full overflow-auto" ref={scrollRef}>
       {sortedFiles.map(file => {
         const isCollapsed = collapsedFiles.has(file.path);
         const fileAnnotations = annotations
@@ -454,7 +440,7 @@ export const AllFilesDiffView: React.FC<AllFilesDiffViewProps> = ({
                   onLineSelectionEnd: (range: SelectedLineRange | null) => {
                     if (range) {
                       if (activeFilePath === file.path) {
-                        toolbar.handleLineSelectionEnd(range);
+                        toolbarHostRef.current?.handleLineSelectionEnd(range);
                       } else {
                         pendingToolbarRange.current = range;
                         setActiveFilePath(file.path);
@@ -486,7 +472,7 @@ export const AllFilesDiffView: React.FC<AllFilesDiffViewProps> = ({
                       if (!line) return;
                       const range = { start: line.lineNumber, end: line.lineNumber, side: line.side };
                       if (activeFilePath === file.path) {
-                        toolbar.handleLineSelectionEnd(range);
+                        toolbarHostRef.current?.handleLineSelectionEnd(range);
                       } else {
                         pendingToolbarRange.current = range;
                         setActiveFilePath(file.path);
@@ -502,43 +488,15 @@ export const AllFilesDiffView: React.FC<AllFilesDiffViewProps> = ({
         );
       })}
 
-      {toolbar.toolbarState && !toolbar.showCodeModal && (
-        <AnnotationToolbar
-          toolbarState={toolbar.toolbarState}
-          toolbarRef={toolbar.toolbarRef}
-          commentText={toolbar.commentText}
-          setCommentText={toolbar.setCommentText}
-          suggestedCode={toolbar.suggestedCode}
-          setSuggestedCode={toolbar.setSuggestedCode}
-          showSuggestedCode={toolbar.showSuggestedCode}
-          setShowSuggestedCode={toolbar.setShowSuggestedCode}
-          selectedOriginalCode={toolbar.selectedOriginalCode}
-          setShowCodeModal={toolbar.setShowCodeModal}
-          isEditing={!!toolbar.editingAnnotationId}
-          onSubmit={toolbar.handleSubmitAnnotation}
-          onDismiss={toolbar.handleDismiss}
-          onCancel={toolbar.handleCancel}
-          conventionalCommentsEnabled={conventionalCommentsEnabled}
-          conventionalLabel={toolbar.conventionalLabel}
-          onConventionalLabelChange={toolbar.setConventionalLabel}
-          decorations={toolbar.decorations}
-          onDecorationsChange={toolbar.setDecorations}
-          enabledLabels={enabledLabels}
-        />
-      )}
-
-      {toolbar.showCodeModal && (
-        <SuggestionModal
-          filePath={activeFilePath ?? ''}
-          toolbarState={toolbar.toolbarState}
-          selectedOriginalCode={toolbar.selectedOriginalCode}
-          suggestedCode={toolbar.suggestedCode}
-          setSuggestedCode={toolbar.setSuggestedCode}
-          modalLayout={toolbar.modalLayout}
-          setModalLayout={toolbar.setModalLayout}
-          onClose={() => toolbar.setShowCodeModal(false)}
-        />
-      )}
+      <ToolbarHost
+        ref={toolbarHostRef}
+        patch={activePatch}
+        filePath={activeFilePath ?? ''}
+        isFocused={true}
+        onLineSelection={onLineSelection}
+        onAddAnnotation={handleAddAnnotation}
+        onEditAnnotation={onEditAnnotation}
+      />
 
       {fileCommentAnchor && onAddFileComment && (
         <CommentPopover

--- a/packages/review-editor/components/DiffViewer.tsx
+++ b/packages/review-editor/components/DiffViewer.tsx
@@ -7,18 +7,14 @@ import { usePierreTheme } from '../hooks/usePierreTheme';
 import { CommentPopover } from '@plannotator/ui/components/CommentPopover';
 import { storage } from '@plannotator/ui/utils/storage';
 import { detectLanguage } from '../utils/detectLanguage';
-import { useAnnotationToolbar } from '../hooks/useAnnotationToolbar';
-import { useConfigValue } from '@plannotator/ui/config';
+import { ToolbarHost, type ToolbarHostHandle } from './ToolbarHost';
 import { OverlayScrollArea } from '@plannotator/ui/components/OverlayScrollArea';
 import { useOverlayViewport } from '@plannotator/ui/hooks/useOverlayViewport';
-import { getEnabledLabels } from './ConventionalLabelPicker';
 import { FileHeader } from './FileHeader';
 import { getLineNumberFromNode, getSideFromNode, getDiffSelection } from '../utils/diffSelection';
 import { InlineAnnotation } from './InlineAnnotation';
 import { InlineAIMarker } from './InlineAIMarker';
-import { AnnotationToolbar } from './AnnotationToolbar';
 import type { AIChatEntry } from '../hooks/useAIChat';
-import { SuggestionModal } from './SuggestionModal';
 import { type ReviewSearchMatch } from '../utils/reviewSearch';
 import {
   applySearchHighlights,
@@ -264,10 +260,7 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
     storage.setItem('review-split-ratio', '0.5');
   }, []);
 
-  const toolbar = useAnnotationToolbar({ patch, filePath, isFocused, onLineSelection, onAddAnnotation, onEditAnnotation });
-  const conventionalCommentsEnabled = useConfigValue('conventionalComments');
-  const conventionalLabelsJson = useConfigValue('conventionalLabels');
-  const enabledLabels = useMemo(() => getEnabledLabels(conventionalLabelsJson), [conventionalLabelsJson]);
+  const toolbarHostRef = useRef<ToolbarHostHandle>(null);
 
   // Parse patch into FileDiffMetadata for @pierre/diffs FileDiff component
   const fileDiff = useMemo(() => getSingularPatch(patch), [patch]);
@@ -468,8 +461,8 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
   // Handle edit: find annotation and start editing in toolbar
   const handleEdit = useCallback((id: string) => {
     const ann = annotations.find(a => a.id === id);
-    if (ann) toolbar.startEdit(ann);
-  }, [annotations, toolbar.startEdit]);
+    if (ann) toolbarHostRef.current?.startEdit(ann);
+  }, [annotations]);
 
   // Render annotation or AI marker in diff
   const renderAnnotation = useCallback((annotation: { side: string; lineNumber: number; metadata?: DiffAnnotationMetadata }) => {
@@ -511,7 +504,7 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
           e.stopPropagation();
           const line = getHoveredLine();
           if (!line) return;
-          toolbar.handleLineSelectionEnd({
+          toolbarHostRef.current?.handleLineSelectionEnd({
             start: line.lineNumber,
             end: line.lineNumber,
             side: line.side,
@@ -521,7 +514,7 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
         +
       </button>
     );
-  }, [toolbar.handleLineSelectionEnd]);
+  }, []);
 
   useEffect(() => {
     const root = diffContentRef.current;
@@ -535,7 +528,7 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
         if (anchorLine == null || focusLine == null) return;
         if (anchorLine === focusLine) return;
         const side = getSideFromNode(selection.anchorNode);
-        toolbar.handleLineSelectionEnd({
+        toolbarHostRef.current?.handleLineSelectionEnd({
           start: Math.min(anchorLine, focusLine),
           end: Math.max(anchorLine, focusLine),
           side,
@@ -545,12 +538,16 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
     };
     root.addEventListener('mouseup', handler, true);
     return () => root.removeEventListener('mouseup', handler, true);
-  }, [toolbar.handleLineSelectionEnd]);
+  }, []);
+
+  const handlePierreLineSelectionEnd = useCallback((range: SelectedLineRange | null) => {
+    toolbarHostRef.current?.handleLineSelectionEnd(range);
+  }, []);
 
   // Token interaction handlers (code area clicks)
   const handleTokenClick = useCallback((props: DiffTokenEventBaseProps, event: MouseEvent) => {
-    toolbar.handleTokenClick(props, event);
-  }, [toolbar.handleTokenClick]);
+    toolbarHostRef.current?.handleTokenClick(props, event);
+  }, []);
 
   const handleTokenEnter = useCallback((props: DiffTokenEventBaseProps) => {
     props.tokenElement.classList.add('pn-token-hover');
@@ -587,7 +584,6 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
         className={`flex-1 min-h-0 relative ${isDraggingSplit ? 'select-none' : ''}`}
         overflowX="scroll"
         onViewportReady={onViewportReady}
-        onMouseMove={toolbar.handleMouseMove}
       >
         <div className="p-4" ref={diffContentRef}>
           <div ref={splitSurfaceRef} className="relative min-w-0" style={splitGridStyle}>
@@ -613,7 +609,7 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
               disableBackground={disableBackground}
               mergedAnnotations={mergedAnnotations}
               pendingSelection={pendingSelection}
-              onLineSelectionEnd={toolbar.handleLineSelectionEnd}
+              onLineSelectionEnd={handlePierreLineSelectionEnd}
               renderAnnotation={renderAnnotation}
               renderHoverUtility={renderHoverUtility}
               onTokenClick={handleTokenClick}
@@ -623,48 +619,20 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
           </div>
         </div>
 
-      {toolbar.toolbarState && !toolbar.showCodeModal && (
-        <AnnotationToolbar
-          toolbarState={toolbar.toolbarState}
-          toolbarRef={toolbar.toolbarRef}
-          commentText={toolbar.commentText}
-          setCommentText={toolbar.setCommentText}
-          suggestedCode={toolbar.suggestedCode}
-          setSuggestedCode={toolbar.setSuggestedCode}
-          showSuggestedCode={toolbar.showSuggestedCode}
-          setShowSuggestedCode={toolbar.setShowSuggestedCode}
-          selectedOriginalCode={toolbar.selectedOriginalCode}
-          setShowCodeModal={toolbar.setShowCodeModal}
-          isEditing={!!toolbar.editingAnnotationId}
-          onSubmit={toolbar.handleSubmitAnnotation}
-          onDismiss={toolbar.handleDismiss}
-          onCancel={toolbar.handleCancel}
-          conventionalCommentsEnabled={conventionalCommentsEnabled}
-          conventionalLabel={toolbar.conventionalLabel}
-          onConventionalLabelChange={toolbar.setConventionalLabel}
-          decorations={toolbar.decorations}
-          onDecorationsChange={toolbar.setDecorations}
-          enabledLabels={enabledLabels}
-          aiAvailable={aiAvailable}
-          onAskAI={onAskAI}
-          isAILoading={isAILoading}
-          onViewAIResponse={onViewAIResponse}
-          aiHistoryMessages={aiHistoryMessages}
-        />
-      )}
-
-      {toolbar.showCodeModal && (
-        <SuggestionModal
-          filePath={filePath}
-          toolbarState={toolbar.toolbarState}
-          selectedOriginalCode={toolbar.selectedOriginalCode}
-          suggestedCode={toolbar.suggestedCode}
-          setSuggestedCode={toolbar.setSuggestedCode}
-          modalLayout={toolbar.modalLayout}
-          setModalLayout={toolbar.setModalLayout}
-          onClose={() => toolbar.setShowCodeModal(false)}
-        />
-      )}
+      <ToolbarHost
+        ref={toolbarHostRef}
+        patch={patch}
+        filePath={filePath}
+        isFocused={isFocused}
+        onLineSelection={onLineSelection}
+        onAddAnnotation={onAddAnnotation}
+        onEditAnnotation={onEditAnnotation}
+        aiAvailable={aiAvailable}
+        onAskAI={onAskAI}
+        isAILoading={isAILoading}
+        onViewAIResponse={onViewAIResponse}
+        aiHistoryMessages={aiHistoryMessages}
+      />
 
       {fileCommentAnchor && (
         <CommentPopover

--- a/packages/review-editor/components/ToolbarHost.tsx
+++ b/packages/review-editor/components/ToolbarHost.tsx
@@ -1,0 +1,157 @@
+import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo } from 'react';
+import type {
+  CodeAnnotation,
+  CodeAnnotationType,
+  ConventionalDecoration,
+  ConventionalLabel,
+  SelectedLineRange,
+  TokenAnnotationMeta,
+} from '@plannotator/ui/types';
+import type { DiffTokenEventBaseProps } from '@pierre/diffs';
+import { useConfigValue } from '@plannotator/ui/config';
+import { useAnnotationToolbar } from '../hooks/useAnnotationToolbar';
+import { AnnotationToolbar } from './AnnotationToolbar';
+import { SuggestionModal } from './SuggestionModal';
+import { getEnabledLabels } from './ConventionalLabelPicker';
+import type { AIChatEntry } from '../hooks/useAIChat';
+
+export interface ToolbarHostHandle {
+  handleLineSelectionEnd: (range: SelectedLineRange | null) => void;
+  handleTokenClick: (props: DiffTokenEventBaseProps, event: MouseEvent) => void;
+  startEdit: (annotation: CodeAnnotation) => void;
+}
+
+interface ToolbarHostProps {
+  patch: string;
+  filePath: string;
+  isFocused: boolean;
+  onLineSelection: (range: SelectedLineRange | null) => void;
+  onAddAnnotation: (
+    type: CodeAnnotationType,
+    text?: string,
+    suggestedCode?: string,
+    originalCode?: string,
+    conventionalLabel?: ConventionalLabel,
+    decorations?: ConventionalDecoration[],
+    tokenMeta?: TokenAnnotationMeta,
+  ) => void;
+  onEditAnnotation: (
+    id: string,
+    text?: string,
+    suggestedCode?: string,
+    originalCode?: string,
+    conventionalLabel?: ConventionalLabel | null,
+    decorations?: ConventionalDecoration[],
+  ) => void;
+  // AI props (optional — only DiffViewer wires these today)
+  aiAvailable?: boolean;
+  onAskAI?: (question: string) => void;
+  isAILoading?: boolean;
+  onViewAIResponse?: (questionId?: string) => void;
+  aiHistoryMessages?: AIChatEntry[];
+}
+
+/**
+ * Owns `useAnnotationToolbar` so per-keystroke state changes don't re-render
+ * the parent diff list. Parents talk to it through the imperative handle.
+ */
+export const ToolbarHost = forwardRef<ToolbarHostHandle, ToolbarHostProps>(function ToolbarHost(
+  {
+    patch,
+    filePath,
+    isFocused,
+    onLineSelection,
+    onAddAnnotation,
+    onEditAnnotation,
+    aiAvailable,
+    onAskAI,
+    isAILoading,
+    onViewAIResponse,
+    aiHistoryMessages,
+  },
+  ref,
+) {
+  const toolbar = useAnnotationToolbar({
+    patch,
+    filePath,
+    isFocused,
+    onLineSelection,
+    onAddAnnotation,
+    onEditAnnotation,
+  });
+
+  const conventionalCommentsEnabled = useConfigValue('conventionalComments');
+  const conventionalLabelsJson = useConfigValue('conventionalLabels');
+  const enabledLabels = useMemo(() => getEnabledLabels(conventionalLabelsJson), [conventionalLabelsJson]);
+
+  // Replaces the parent's `onMouseMove={toolbar.handleMouseMove}` on its scroll
+  // container — the hook only stashes clientX/Y for toolbar placement, so a
+  // window-level listener is functionally equivalent for that purpose.
+  const handleMouseMove = toolbar.handleMouseMove;
+  useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      handleMouseMove({ clientX: e.clientX, clientY: e.clientY } as unknown as React.MouseEvent);
+    };
+    window.addEventListener('mousemove', onMove);
+    return () => window.removeEventListener('mousemove', onMove);
+  }, [handleMouseMove]);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      handleLineSelectionEnd: toolbar.handleLineSelectionEnd,
+      handleTokenClick: toolbar.handleTokenClick,
+      startEdit: toolbar.startEdit,
+    }),
+    [toolbar.handleLineSelectionEnd, toolbar.handleTokenClick, toolbar.startEdit],
+  );
+
+  const handleCloseCodeModal = useCallback(() => toolbar.setShowCodeModal(false), [toolbar.setShowCodeModal]);
+
+  return (
+    <>
+      {toolbar.toolbarState && !toolbar.showCodeModal && (
+        <AnnotationToolbar
+          toolbarState={toolbar.toolbarState}
+          toolbarRef={toolbar.toolbarRef}
+          commentText={toolbar.commentText}
+          setCommentText={toolbar.setCommentText}
+          suggestedCode={toolbar.suggestedCode}
+          setSuggestedCode={toolbar.setSuggestedCode}
+          showSuggestedCode={toolbar.showSuggestedCode}
+          setShowSuggestedCode={toolbar.setShowSuggestedCode}
+          selectedOriginalCode={toolbar.selectedOriginalCode}
+          setShowCodeModal={toolbar.setShowCodeModal}
+          isEditing={!!toolbar.editingAnnotationId}
+          onSubmit={toolbar.handleSubmitAnnotation}
+          onDismiss={toolbar.handleDismiss}
+          onCancel={toolbar.handleCancel}
+          conventionalCommentsEnabled={conventionalCommentsEnabled}
+          conventionalLabel={toolbar.conventionalLabel}
+          onConventionalLabelChange={toolbar.setConventionalLabel}
+          decorations={toolbar.decorations}
+          onDecorationsChange={toolbar.setDecorations}
+          enabledLabels={enabledLabels}
+          aiAvailable={aiAvailable}
+          onAskAI={onAskAI}
+          isAILoading={isAILoading}
+          onViewAIResponse={onViewAIResponse}
+          aiHistoryMessages={aiHistoryMessages}
+        />
+      )}
+
+      {toolbar.showCodeModal && (
+        <SuggestionModal
+          filePath={filePath}
+          toolbarState={toolbar.toolbarState}
+          selectedOriginalCode={toolbar.selectedOriginalCode}
+          suggestedCode={toolbar.suggestedCode}
+          setSuggestedCode={toolbar.setSuggestedCode}
+          modalLayout={toolbar.modalLayout}
+          setModalLayout={toolbar.setModalLayout}
+          onClose={handleCloseCodeModal}
+        />
+      )}
+    </>
+  );
+});

--- a/packages/review-editor/components/ToolbarHost.tsx
+++ b/packages/review-editor/components/ToolbarHost.tsx
@@ -89,11 +89,8 @@ export const ToolbarHost = forwardRef<ToolbarHostHandle, ToolbarHostProps>(funct
   // window-level listener is functionally equivalent for that purpose.
   const handleMouseMove = toolbar.handleMouseMove;
   useEffect(() => {
-    const onMove = (e: MouseEvent) => {
-      handleMouseMove({ clientX: e.clientX, clientY: e.clientY } as unknown as React.MouseEvent);
-    };
-    window.addEventListener('mousemove', onMove);
-    return () => window.removeEventListener('mousemove', onMove);
+    window.addEventListener('mousemove', handleMouseMove);
+    return () => window.removeEventListener('mousemove', handleMouseMove);
   }, [handleMouseMove]);
 
   useImperativeHandle(

--- a/packages/review-editor/hooks/useAnnotationToolbar.ts
+++ b/packages/review-editor/hooks/useAnnotationToolbar.ts
@@ -133,8 +133,10 @@ export function useAnnotationToolbar({ patch, filePath, isFocused, onLineSelecti
     setDecorations([]);
   }, []);
 
-  // Track mouse position continuously for toolbar placement
-  const handleMouseMove = useCallback((e: React.MouseEvent) => {
+  // Track mouse position continuously for toolbar placement.
+  // Structural type so the same handler accepts both React synthetic events
+  // (parent JSX onMouseMove) and native MouseEvents (ToolbarHost window listener).
+  const handleMouseMove = useCallback((e: { clientX: number; clientY: number }) => {
     lastMousePosition.current = { x: e.clientX, y: e.clientY };
   }, []);
 


### PR DESCRIPTION
Closes part of #659 (fix #1: move toolbar form state out of the parent).

## Summary

- Move `useAnnotationToolbar` + the `AnnotationToolbar` / `SuggestionModal` JSX out of `AllFilesDiffView` and `DiffViewer` into a new `ToolbarHost` wrapper component.
- Parents talk to the host through an imperative handle (`forwardRef` + `useImperativeHandle`) for `handleLineSelectionEnd`, `handleTokenClick`, and `startEdit`.
- The parent's `onMouseMove={toolbar.handleMouseMove}` on the scroll container becomes a window-level `mousemove` listener inside the host (functionally equivalent — handler only stashes `clientX/Y`).

## Why

Users reported the review UI getting laggy when typing in a comment on moderately-sized diffs. We proved with a temporary `console.count` probe at the top of `AllFilesDiffView` that the counter ticked up on every single keystroke. Cause: `commentText` state lived in `useAnnotationToolbar` which was called *from* `AllFilesDiffView`, so every keystroke re-rendered the entire all-files view → every `LazyFileDiff` → every Pierre `<FileDiff>`.

After this change, keystrokes only re-render the host. The diff list is unaffected.

## Test plan

Manual verification in the dev review UI (`bun run dev:review`):

- [x] Counter probe stays flat while typing (validated locally before removing the probe).
- [x] Click line numbers → toolbar opens at mouse position.
- [x] Cmd/Ctrl+Enter submits the comment.
- [x] Type, click outside, reopen same range → draft restored.
- [x] Type, switch files → draft saved; switch back → restored.
- [x] "Add suggested code" → expand to modal → type → close → submit.
- [x] Edit existing annotation → toolbar reopens prefilled.
- [x] Token click → toolbar opens for single-token annotation (DiffViewer path).

## Out of scope (tracked in #659)

- Wrapping `LazyFileDiff` / Pierre's `FileDiff` in `React.memo` and stabilizing the inline `options` / `renderAnnotation` / `renderHoverUtility` props in `AllFilesDiffView`. Evaluated as a moderate refactor (per-file closures need a `FileRow` extraction); deferred since the user-reported lag is gone.
- Adding React Compiler.
- Server-side prerendering the review diff via `preloadPatchFile` (already wired up for `CodeFilePopout` but not the main review path).
- Throttling capture-phase scroll listeners in `AnnotationToolbar` / `CommentPopover` / `FloatingQuickLabelPicker`.