### PR TITLE
fix(session-log): detect ghost sessions from /clear to resolve correct log

### DIFF
--- a/apps/hook/server/session-log.test.ts
+++ b/apps/hook/server/session-log.test.ts
@@ -822,6 +822,87 @@ describe("resolveSessionLogByAncestorPids", () => {
       cleanup();
     }
   });
+
+  test("prefers newer ghost session over stale metadata match (after /clear)", () => {
+    const { sessionsDir, projectsDir, cleanup } = makeTempDirs("ghost-clear");
+    try {
+      const cwd = "/tmp/fake-project-ghost";
+      const oldSessionId = "old-session-before-clear";
+      const newSessionId = "new-session-after-clear";
+
+      // Metadata still points to old session (stale after /clear)
+      writeSessionMeta(sessionsDir, 400, { sessionId: oldSessionId, cwd });
+
+      // Both logs exist; new one is more recently modified
+      writeSessionLog(projectsDir, cwd, oldSessionId, buildLog(
+        userPrompt("hello"),
+        assistantText("msg_old", "Doing well, thanks!")
+      ));
+
+      // Small delay to ensure mtime ordering
+      const newLog = writeSessionLog(projectsDir, cwd, newSessionId, buildLog(
+        userPrompt("Why is the sky blue?"),
+        assistantText("msg_new", "Rayleigh scattering")
+      ));
+
+      // Touch the new file to guarantee it's newer
+      const { utimesSync } = require("node:fs");
+      utimesSync(newLog, new Date(), new Date());
+
+      const result = resolveSessionLogByAncestorPids({
+        startPid: 400,
+        getParentPid: () => null,
+        sessionsDir,
+        projectsDir,
+      });
+
+      // Should prefer the ghost session (newer, unregistered)
+      expect(result).toBe(newLog);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("keeps PID-based result when newer log belongs to a concurrent session", () => {
+    const { sessionsDir, projectsDir, cleanup } = makeTempDirs("concurrent");
+    try {
+      const cwd = "/tmp/fake-project-concurrent";
+      const sessionA = "session-terminal-1";
+      const sessionB = "session-terminal-2";
+
+      // Both sessions have their own metadata (different PIDs)
+      writeSessionMeta(sessionsDir, 400, { sessionId: sessionA, cwd });
+      writeSessionMeta(sessionsDir, 500, { sessionId: sessionB, cwd });
+
+      // Terminal 1's log
+      const logA = writeSessionLog(projectsDir, cwd, sessionA, buildLog(
+        userPrompt("hello from terminal 1"),
+        assistantText("msg_a", "Response in terminal 1")
+      ));
+
+      // Terminal 2's log (more recently modified)
+      const logB = writeSessionLog(projectsDir, cwd, sessionB, buildLog(
+        userPrompt("hello from terminal 2"),
+        assistantText("msg_b", "Response in terminal 2")
+      ));
+
+      const { utimesSync } = require("node:fs");
+      utimesSync(logB, new Date(), new Date());
+
+      // From terminal 1's process tree, should get terminal 1's log
+      const result = resolveSessionLogByAncestorPids({
+        startPid: 400,
+        getParentPid: () => null,
+        sessionsDir,
+        projectsDir,
+      });
+
+      // Should keep the PID-based result (session B is registered, not a ghost)
+      expect(result).toBe(logA);
+    } finally {
+      cleanup();
+    }
+  });
 });
 
 describe("resolveSessionLogByCwdScan", () => {

--- a/apps/hook/server/session-log.test.ts
+++ b/apps/hook/server/session-log.test.ts
@@ -833,21 +833,19 @@ describe("resolveSessionLogByAncestorPids", () => {
       // Metadata still points to old session (stale after /clear)
       writeSessionMeta(sessionsDir, 400, { sessionId: oldSessionId, cwd });
 
-      // Both logs exist; new one is more recently modified
-      writeSessionLog(projectsDir, cwd, oldSessionId, buildLog(
+      // Both logs exist; force mtime ordering via utimes
+      const { utimesSync } = require("node:fs");
+      const oldLog = writeSessionLog(projectsDir, cwd, oldSessionId, buildLog(
         userPrompt("hello"),
         assistantText("msg_old", "Doing well, thanks!")
       ));
+      const past = new Date(Date.now() - 5000);
+      utimesSync(oldLog, past, past);
 
-      // Small delay to ensure mtime ordering
       const newLog = writeSessionLog(projectsDir, cwd, newSessionId, buildLog(
         userPrompt("Why is the sky blue?"),
         assistantText("msg_new", "Rayleigh scattering")
       ));
-
-      // Touch the new file to guarantee it's newer
-      const { utimesSync } = require("node:fs");
-      utimesSync(newLog, new Date(), new Date());
 
       const result = resolveSessionLogByAncestorPids({
         startPid: 400,
@@ -874,20 +872,20 @@ describe("resolveSessionLogByAncestorPids", () => {
       writeSessionMeta(sessionsDir, 400, { sessionId: sessionA, cwd });
       writeSessionMeta(sessionsDir, 500, { sessionId: sessionB, cwd });
 
-      // Terminal 1's log
+      // Terminal 1's log (older)
+      const { utimesSync } = require("node:fs");
       const logA = writeSessionLog(projectsDir, cwd, sessionA, buildLog(
         userPrompt("hello from terminal 1"),
         assistantText("msg_a", "Response in terminal 1")
       ));
+      const past = new Date(Date.now() - 5000);
+      utimesSync(logA, past, past);
 
       // Terminal 2's log (more recently modified)
       const logB = writeSessionLog(projectsDir, cwd, sessionB, buildLog(
         userPrompt("hello from terminal 2"),
         assistantText("msg_b", "Response in terminal 2")
       ));
-
-      const { utimesSync } = require("node:fs");
-      utimesSync(logB, new Date(), new Date());
 
       // From terminal 1's process tree, should get terminal 1's log
       const result = resolveSessionLogByAncestorPids({

--- a/apps/hook/server/session-log.ts
+++ b/apps/hook/server/session-log.ts
@@ -16,7 +16,7 @@
 
 import { readdirSync, statSync, readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
-import { join, dirname } from "node:path";
+import { join, dirname, basename } from "node:path";
 import { homedir } from "node:os";
 
 const DEFAULT_SESSIONS_DIR = join(homedir(), ".claude", "sessions");
@@ -293,9 +293,42 @@ export function getAncestorPids(
 }
 
 /**
+ * Check if a sessionId is referenced by any metadata file in the sessions dir.
+ * Used to distinguish "ghost" sessions (created by /clear but never registered
+ * in metadata) from legitimate concurrent sessions (which have their own PID's
+ * metadata file).
+ */
+export function isSessionRegistered(
+  sessionId: string,
+  sessionsDir: string
+): boolean {
+  try {
+    const files = readdirSync(sessionsDir).filter((f) => f.endsWith(".json"));
+    for (const f of files) {
+      try {
+        const meta: SessionMetadata = JSON.parse(
+          readFileSync(join(sessionsDir, f), "utf-8")
+        );
+        if (meta?.sessionId === sessionId) return true;
+      } catch {
+        // Malformed file — skip
+      }
+    }
+  } catch {
+    // sessionsDir unreadable
+  }
+  return false;
+}
+
+/**
  * Resolve a session log path by walking up the PID chain, checking
  * `~/.claude/sessions/<pid>.json` at each hop for a session metadata match.
- * Deterministic — no mtime guessing, no cwd matching.
+ *
+ * When the matched log is not the most recently modified file in the project
+ * directory, checks whether the newer file is a "ghost" session — one created
+ * by /clear that was never registered in any metadata file. If so, prefers the
+ * ghost (it's the current session). If the newer file belongs to a registered
+ * concurrent session, keeps the PID-based result.
  */
 export function resolveSessionLogByAncestorPids(
   opts: {
@@ -321,7 +354,17 @@ export function resolveSessionLogByAncestorPids(
 
     const candidates = findSessionLogsForCwd(meta.cwd, opts.projectsDir);
     const match = candidates.find((p) => p.includes(meta.sessionId));
-    if (match) return match;
+    if (match) {
+      // Check for stale metadata: if a newer log exists that has no
+      // registered metadata, it's a ghost session from /clear — prefer it.
+      if (candidates[0] !== match) {
+        const newestSessionId = basename(candidates[0], ".jsonl");
+        if (!isSessionRegistered(newestSessionId, sessionsDir)) {
+          return candidates[0];
+        }
+      }
+      return match;
+    }
   }
   return null;
 }


### PR DESCRIPTION
## Summary

- After `/clear`, Claude Code creates a new session `.jsonl` but never updates `~/.claude/sessions/<pid>.json` — the metadata retains the old sessionId
- The ancestor-PID resolver (tier 1) confidently returns the stale log file, preventing fallthrough to mtime-based tiers that would pick the correct one
- Fix: after tier 1 matches a log that isn't the newest by mtime, check whether the newer file's sessionId exists in any metadata file. If not registered → ghost from `/clear` → prefer it. If registered → concurrent session → keep PID result

## Test plan

- [x] Existing 65 tests pass unchanged
- [x] New test: ghost session after `/clear` — prefers newer unregistered log
- [x] New test: concurrent sessions — keeps PID-based result when newer log is registered
- [ ] Manual verification: `/clear` then `/plannotator-last` shows the post-clear message

Fixes #643