### PR TITLE
feat(marketing): include co-authors in contributors strip

### DIFF
--- a/apps/marketing/src/components/Footer.astro
+++ b/apps/marketing/src/components/Footer.astro
@@ -2,7 +2,7 @@
 import { getContributors } from '../lib/contributors';
 
 const year = new Date().getFullYear();
-const contributors = await getContributors();
+const { authors, community } = await getContributors();
 ---
 <footer class="py-10 px-8 border-t border-border/30">
   <div class="grid grid-cols-2 sm:grid-cols-3 gap-6 mb-6 text-sm">
@@ -50,11 +50,11 @@ const contributors = await getContributors();
   </p>
 </footer>
 
-{contributors.length > 0 && (
-  <div class="pt-6 pb-12 px-8 border-t border-border/20">
+{authors.length > 0 && (
+  <div class="pt-6 pb-8 px-8 border-t border-border/20">
     <p class="text-[0.6875rem] text-muted-foreground/40 text-center mb-4">Built by</p>
     <div class="flex flex-wrap items-center justify-center gap-2">
-      {contributors.map((c) => (
+      {authors.map((c) => (
         <a
           href={c.url}
           target="_blank"
@@ -67,6 +67,32 @@ const contributors = await getContributors();
             alt={c.login}
             width="36"
             height="36"
+            loading="lazy"
+            class="rounded-full"
+          />
+        </a>
+      ))}
+    </div>
+  </div>
+)}
+
+{community.length > 0 && (
+  <div class="pt-4 pb-12 px-8">
+    <p class="text-[0.6875rem] text-muted-foreground/40 text-center mb-4">With contributions from</p>
+    <div class="flex flex-wrap items-center justify-center gap-1.5">
+      {community.map((c) => (
+        <a
+          href={c.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          title={`@${c.login}`}
+          class="contributor-avatar"
+        >
+          <img
+            src={`${c.avatarUrl}&s=56`}
+            alt={c.login}
+            width="28"
+            height="28"
             loading="lazy"
             class="rounded-full"
           />

--- a/apps/marketing/src/lib/contributors.ts
+++ b/apps/marketing/src/lib/contributors.ts
@@ -3,18 +3,49 @@
 
 type Person = { login: string; avatarUrl: string; url: string };
 
-let cached: Person[] | null = null;
+export interface Contributors {
+  authors: Person[];
+  community: Person[];
+}
+
+let cached: Contributors | null = null;
 
 const COAUTHOR_RE = /^Co-authored-by:\s*.+?\s*<([^>]+)>\s*$/gim;
+const NOREPLY_RE = /^(\d+)\+([^@]+)@users\.noreply\.github\.com$/;
 
-export async function getContributors(): Promise<Person[]> {
+async function fetchJSON(url: string, headers: Record<string, string>) {
+  const res = await fetch(url, { headers });
+  return res.ok ? res.json() : null;
+}
+
+export async function getContributors(): Promise<Contributors> {
   if (cached) return cached;
 
-  const people = new Map<string, Person>();
+  const authors = new Map<string, Person>();
+  const headers: Record<string, string> = { 'Accept': 'application/vnd.github.v3+json' };
   const token = import.meta.env.GITHUB_TOKEN || process.env.GITHUB_TOKEN;
+  if (token) headers['Authorization'] = `bearer ${token}`;
+
+  // REST /contributors covers the full commit history (not just last 100).
+  try {
+    const data = await fetchJSON(
+      'https://api.github.com/repos/backnotprop/plannotator/contributors?per_page=100',
+      headers,
+    );
+    if (data) {
+      for (const c of data) {
+        if (c.type === 'User' && c.login) {
+          authors.set(c.login, { login: c.login, avatarUrl: c.avatar_url, url: c.html_url });
+        }
+      }
+    }
+  } catch {}
+
+  const community = new Map<string, Person>();
 
   if (token) {
-    const coAuthorEmails = new Set<string>();
+    // GraphQL adds issue authors, discussion participants, and commit messages
+    // for Co-authored-by parsing — none of which REST /contributors provides.
     try {
       const query = `{
         repository(owner: "backnotprop", name: "plannotator") {
@@ -22,10 +53,7 @@ export async function getContributors(): Promise<Person[]> {
             target {
               ... on Commit {
                 history(first: 100) {
-                  nodes {
-                    author { user { login avatarUrl url } }
-                    message
-                  }
+                  nodes { message }
                 }
               }
             }
@@ -46,73 +74,54 @@ export async function getContributors(): Promise<Person[]> {
       if (res.ok) {
         const json = await res.json();
         const repo = json.data?.repository;
+
+        // Parse co-author emails from commit messages
+        const coAuthorEmails = new Set<string>();
         for (const node of repo?.defaultBranchRef?.target?.history?.nodes || []) {
-          const u = node?.author?.user;
-          if (u?.login) people.set(u.login, u);
           const message: string = node?.message || '';
           for (const match of message.matchAll(COAUTHOR_RE)) {
             coAuthorEmails.add(match[1].toLowerCase());
           }
         }
 
-        // Resolve co-author emails before processing issues/discussions so
-        // they appear alongside commit authors in the natural recency order.
+        // Resolve co-author emails — these are code authors too
         for (const email of coAuthorEmails) {
-          try {
-            const r = await fetch(
-              `https://api.github.com/search/users?q=${encodeURIComponent(email)}+in:email`,
-              {
-                headers: {
-                  'Authorization': `bearer ${token}`,
-                  'Accept': 'application/vnd.github.v3+json',
-                },
-              },
-            );
-            if (r.ok) {
-              const j = await r.json();
-              const item = j?.items?.[0];
-              if (item?.login && item?.type === 'User' && !people.has(item.login)) {
-                people.set(item.login, {
-                  login: item.login,
-                  avatarUrl: item.avatar_url,
-                  url: item.html_url,
-                });
+          if (email.includes('noreply.github.com')) {
+            const m = NOREPLY_RE.exec(email);
+            if (m && !authors.has(m[2])) {
+              const user = await fetchJSON(`https://api.github.com/users/${m[2]}`, headers);
+              if (user?.login && user?.type === 'User') {
+                authors.set(user.login, { login: user.login, avatarUrl: user.avatar_url, url: user.html_url });
               }
             }
-          } catch {}
+          } else {
+            const data = await fetchJSON(
+              `https://api.github.com/search/users?q=${encodeURIComponent(email)}+in:email`,
+              headers,
+            );
+            const item = data?.items?.[0];
+            if (item?.login && item?.type === 'User' && !authors.has(item.login)) {
+              authors.set(item.login, { login: item.login, avatarUrl: item.avatar_url, url: item.html_url });
+            }
+          }
         }
 
+        // Issue and discussion authors who aren't code contributors
         for (const node of repo?.issues?.nodes || []) {
           const u = node?.author;
-          if (u?.login) people.set(u.login, u);
+          if (u?.login && !authors.has(u.login)) community.set(u.login, u);
         }
         for (const node of repo?.discussions?.nodes || []) {
           const u = node?.author;
-          if (u?.login) people.set(u.login, u);
-        }
-      }
-    } catch {}
-  } else {
-    try {
-      const res = await fetch(
-        'https://api.github.com/repos/backnotprop/plannotator/contributors?per_page=100',
-        { headers: { 'Accept': 'application/vnd.github.v3+json' } },
-      );
-      if (res.ok) {
-        const data = await res.json();
-        for (const c of data) {
-          if (c.type === 'User' && c.login) {
-            people.set(c.login, {
-              login: c.login,
-              avatarUrl: c.avatar_url,
-              url: c.html_url,
-            });
-          }
+          if (u?.login && !authors.has(u.login)) community.set(u.login, u);
         }
       }
     } catch {}
   }
 
-  cached = [...people.values()];
+  cached = {
+    authors: [...authors.values()],
+    community: [...community.values()],
+  };
   return cached;
 }

--- a/apps/marketing/src/lib/contributors.ts
+++ b/apps/marketing/src/lib/contributors.ts
@@ -11,10 +11,20 @@ export interface Contributors {
 let cached: Contributors | null = null;
 
 const COAUTHOR_RE = /^Co-authored-by:\s*.+?\s*<([^>]+)>\s*$/gim;
-const NOREPLY_RE = /^(\d+)\+([^@]+)@users\.noreply\.github\.com$/;
+const NOREPLY_ID_RE = /^(\d+)\+([^@]+)@users\.noreply\.github\.com$/;
+const NOREPLY_LOGIN_RE = /^([^@]+)@users\.noreply\.github\.com$/;
 
 async function fetchJSON(url: string, headers: Record<string, string>) {
   const res = await fetch(url, { headers });
+  return res.ok ? res.json() : null;
+}
+
+async function fetchGraphQL(token: string, query: string) {
+  const res = await fetch('https://api.github.com/graphql', {
+    method: 'POST',
+    headers: { 'Authorization': `bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query }),
+  });
   return res.ok ? res.json() : null;
 }
 
@@ -26,7 +36,7 @@ export async function getContributors(): Promise<Contributors> {
   const token = import.meta.env.GITHUB_TOKEN || process.env.GITHUB_TOKEN;
   if (token) headers['Authorization'] = `bearer ${token}`;
 
-  // REST /contributors covers the full commit history (not just last 100).
+  // REST /contributors covers the full commit history.
   try {
     const data = await fetchJSON(
       'https://api.github.com/repos/backnotprop/plannotator/contributors?per_page=100',
@@ -44,20 +54,64 @@ export async function getContributors(): Promise<Contributors> {
   const community = new Map<string, Person>();
 
   if (token) {
-    // GraphQL adds issue authors, discussion participants, and commit messages
-    // for Co-authored-by parsing — none of which REST /contributors provides.
     try {
-      const query = `{
-        repository(owner: "backnotprop", name: "plannotator") {
-          defaultBranchRef {
-            target {
-              ... on Commit {
-                history(first: 100) {
-                  nodes { message }
+      // Paginate through all commits to collect every Co-authored-by trailer
+      const coAuthorEmails = new Set<string>();
+      let cursor: string | null = null;
+      let hasNextPage = true;
+      while (hasNextPage) {
+        const afterClause = cursor ? `, after: "${cursor}"` : '';
+        const json = await fetchGraphQL(token, `{
+          repository(owner: "backnotprop", name: "plannotator") {
+            defaultBranchRef {
+              target {
+                ... on Commit {
+                  history(first: 100${afterClause}) {
+                    pageInfo { hasNextPage endCursor }
+                    nodes { message }
+                  }
                 }
               }
             }
           }
+        }`);
+        const history = json?.data?.repository?.defaultBranchRef?.target?.history;
+        if (!history) break;
+        for (const node of history.nodes || []) {
+          const message: string = node?.message || '';
+          for (const match of message.matchAll(COAUTHOR_RE)) {
+            coAuthorEmails.add(match[1].toLowerCase());
+          }
+        }
+        hasNextPage = history.pageInfo.hasNextPage;
+        cursor = history.pageInfo.endCursor;
+      }
+
+      // Resolve co-author emails — these are code authors too
+      for (const email of coAuthorEmails) {
+        if (email.includes('noreply.github.com')) {
+          const login = NOREPLY_ID_RE.exec(email)?.[2] ?? NOREPLY_LOGIN_RE.exec(email)?.[1];
+          if (login && !authors.has(login)) {
+            const user = await fetchJSON(`https://api.github.com/users/${login}`, headers);
+            if (user?.login && user?.type === 'User') {
+              authors.set(user.login, { login: user.login, avatarUrl: user.avatar_url, url: user.html_url });
+            }
+          }
+        } else {
+          const data = await fetchJSON(
+            `https://api.github.com/search/users?q=${encodeURIComponent(email)}+in:email`,
+            headers,
+          );
+          const item = data?.items?.[0];
+          if (item?.login && item?.type === 'User' && !authors.has(item.login)) {
+            authors.set(item.login, { login: item.login, avatarUrl: item.avatar_url, url: item.html_url });
+          }
+        }
+      }
+
+      // Issue and discussion authors who aren't code contributors
+      const json = await fetchGraphQL(token, `{
+        repository(owner: "backnotprop", name: "plannotator") {
           issues(first: 100, orderBy: { field: CREATED_AT, direction: DESC }) {
             nodes { author { login avatarUrl url } }
           }
@@ -65,56 +119,15 @@ export async function getContributors(): Promise<Contributors> {
             nodes { author { login avatarUrl url } }
           }
         }
-      }`;
-      const res = await fetch('https://api.github.com/graphql', {
-        method: 'POST',
-        headers: { 'Authorization': `bearer ${token}`, 'Content-Type': 'application/json' },
-        body: JSON.stringify({ query }),
-      });
-      if (res.ok) {
-        const json = await res.json();
-        const repo = json.data?.repository;
-
-        // Parse co-author emails from commit messages
-        const coAuthorEmails = new Set<string>();
-        for (const node of repo?.defaultBranchRef?.target?.history?.nodes || []) {
-          const message: string = node?.message || '';
-          for (const match of message.matchAll(COAUTHOR_RE)) {
-            coAuthorEmails.add(match[1].toLowerCase());
-          }
-        }
-
-        // Resolve co-author emails — these are code authors too
-        for (const email of coAuthorEmails) {
-          if (email.includes('noreply.github.com')) {
-            const m = NOREPLY_RE.exec(email);
-            if (m && !authors.has(m[2])) {
-              const user = await fetchJSON(`https://api.github.com/users/${m[2]}`, headers);
-              if (user?.login && user?.type === 'User') {
-                authors.set(user.login, { login: user.login, avatarUrl: user.avatar_url, url: user.html_url });
-              }
-            }
-          } else {
-            const data = await fetchJSON(
-              `https://api.github.com/search/users?q=${encodeURIComponent(email)}+in:email`,
-              headers,
-            );
-            const item = data?.items?.[0];
-            if (item?.login && item?.type === 'User' && !authors.has(item.login)) {
-              authors.set(item.login, { login: item.login, avatarUrl: item.avatar_url, url: item.html_url });
-            }
-          }
-        }
-
-        // Issue and discussion authors who aren't code contributors
-        for (const node of repo?.issues?.nodes || []) {
-          const u = node?.author;
-          if (u?.login && !authors.has(u.login)) community.set(u.login, u);
-        }
-        for (const node of repo?.discussions?.nodes || []) {
-          const u = node?.author;
-          if (u?.login && !authors.has(u.login)) community.set(u.login, u);
-        }
+      }`);
+      const repo = json?.data?.repository;
+      for (const node of repo?.issues?.nodes || []) {
+        const u = node?.author;
+        if (u?.login && !authors.has(u.login)) community.set(u.login, u);
+      }
+      for (const node of repo?.discussions?.nodes || []) {
+        const u = node?.author;
+        if (u?.login && !authors.has(u.login)) community.set(u.login, u);
       }
     } catch {}
   }

--- a/apps/marketing/src/lib/contributors.ts
+++ b/apps/marketing/src/lib/contributors.ts
@@ -5,21 +5,27 @@ type Person = { login: string; avatarUrl: string; url: string };
 
 let cached: Person[] | null = null;
 
+const COAUTHOR_RE = /^Co-authored-by:\s*.+?\s*<([^>]+)>\s*$/gim;
+
 export async function getContributors(): Promise<Person[]> {
   if (cached) return cached;
 
   const people = new Map<string, Person>();
   const token = import.meta.env.GITHUB_TOKEN || process.env.GITHUB_TOKEN;
 
-  try {
-    if (token) {
+  if (token) {
+    const coAuthorEmails = new Set<string>();
+    try {
       const query = `{
         repository(owner: "backnotprop", name: "plannotator") {
-          contributors: defaultBranchRef {
+          defaultBranchRef {
             target {
               ... on Commit {
                 history(first: 100) {
-                  nodes { author { user { login avatarUrl url } } }
+                  nodes {
+                    author { user { login avatarUrl url } }
+                    message
+                  }
                 }
               }
             }
@@ -40,10 +46,42 @@ export async function getContributors(): Promise<Person[]> {
       if (res.ok) {
         const json = await res.json();
         const repo = json.data?.repository;
-        for (const node of repo?.contributors?.target?.history?.nodes || []) {
+        for (const node of repo?.defaultBranchRef?.target?.history?.nodes || []) {
           const u = node?.author?.user;
           if (u?.login) people.set(u.login, u);
+          const message: string = node?.message || '';
+          for (const match of message.matchAll(COAUTHOR_RE)) {
+            coAuthorEmails.add(match[1].toLowerCase());
+          }
         }
+
+        // Resolve co-author emails before processing issues/discussions so
+        // they appear alongside commit authors in the natural recency order.
+        for (const email of coAuthorEmails) {
+          try {
+            const r = await fetch(
+              `https://api.github.com/search/users?q=${encodeURIComponent(email)}+in:email`,
+              {
+                headers: {
+                  'Authorization': `bearer ${token}`,
+                  'Accept': 'application/vnd.github.v3+json',
+                },
+              },
+            );
+            if (r.ok) {
+              const j = await r.json();
+              const item = j?.items?.[0];
+              if (item?.login && item?.type === 'User' && !people.has(item.login)) {
+                people.set(item.login, {
+                  login: item.login,
+                  avatarUrl: item.avatar_url,
+                  url: item.html_url,
+                });
+              }
+            }
+          } catch {}
+        }
+
         for (const node of repo?.issues?.nodes || []) {
           const u = node?.author;
           if (u?.login) people.set(u.login, u);
@@ -53,20 +91,27 @@ export async function getContributors(): Promise<Person[]> {
           if (u?.login) people.set(u.login, u);
         }
       }
-    } else {
-      const res = await fetch('https://api.github.com/repos/backnotprop/plannotator/contributors?per_page=50', {
-        headers: { 'Accept': 'application/vnd.github.v3+json' },
-      });
+    } catch {}
+  } else {
+    try {
+      const res = await fetch(
+        'https://api.github.com/repos/backnotprop/plannotator/contributors?per_page=100',
+        { headers: { 'Accept': 'application/vnd.github.v3+json' } },
+      );
       if (res.ok) {
         const data = await res.json();
         for (const c of data) {
-          if (c.type === 'User') {
-            people.set(c.login, { login: c.login, avatarUrl: c.avatar_url, url: c.html_url });
+          if (c.type === 'User' && c.login) {
+            people.set(c.login, {
+              login: c.login,
+              avatarUrl: c.avatar_url,
+              url: c.html_url,
+            });
           }
         }
       }
-    }
-  } catch {}
+    } catch {}
+  }
 
   cached = [...people.values()];
   return cached;


### PR DESCRIPTION
## Summary

- Parses `Co-authored-by:` trailers from commit messages (already fetched via GraphQL) to extract co-author emails
- Resolves emails to GitHub profiles via `/search/users` so co-authors of squash-merged PRs appear on the homepage
- Preserves the existing recency-based ordering (Map insertion order from most-recent commits first)

Fixes the case where contributors like @gjermundgaraba (co-author on #652) were invisible because GitHub's GraphQL `Commit.author` only returns the primary author.

## Test plan

- [ ] Run `GITHUB_TOKEN=$(gh auth token) bun run dev:marketing` and verify co-authors appear in the contributors strip at the bottom of the homepage
- [ ] Verify ordering matches the previous most-recent-first behavior
- [ ] Verify the unauthenticated fallback (no token) still works