### PR TITLE
fix(remote): notify URL in remote mode for OpenCode and Pi

### DIFF
--- a/apps/opencode-plugin/commands.ts
+++ b/apps/opencode-plugin/commands.ts
@@ -114,7 +114,12 @@ export async function handleReviewCommand(
     shareBaseUrl: getShareBaseUrl(),
     htmlContent: reviewHtmlContent,
     opencodeClient: client,
-    onReady: handleReviewServerReady,
+    onReady: (url, isRemote, port) => {
+      handleReviewServerReady(url, isRemote, port);
+      if (isRemote) {
+        client.app.log({ level: "info", message: `[Plannotator] Open in browser: ${url}` });
+      }
+    },
   });
 
   const result = await server.waitForDecision();
@@ -275,7 +280,12 @@ export async function handleAnnotateCommand(
     pasteApiUrl: getPasteApiUrl(),
     gate,
     htmlContent,
-    onReady: handleAnnotateServerReady,
+    onReady: (url, isRemote, port) => {
+      handleAnnotateServerReady(url, isRemote, port);
+      if (isRemote) {
+        client.app.log({ level: "info", message: `[Plannotator] Open in browser: ${url}` });
+      }
+    },
   });
 
   const result = await server.waitForDecision();
@@ -376,7 +386,12 @@ export async function handleAnnotateLastCommand(
     pasteApiUrl: getPasteApiUrl(),
     gate,
     htmlContent,
-    onReady: handleAnnotateServerReady,
+    onReady: (url, isRemote, port) => {
+      handleAnnotateServerReady(url, isRemote, port);
+      if (isRemote) {
+        client.app.log({ level: "info", message: `[Plannotator] Open in browser: ${url}` });
+      }
+    },
   });
 
   const result = await server.waitForDecision();
@@ -407,7 +422,12 @@ export async function handleArchiveCommand(
     shareBaseUrl: getShareBaseUrl(),
     pasteApiUrl: getPasteApiUrl(),
     htmlContent,
-    onReady: handleServerReady,
+    onReady: (url, isRemote, port) => {
+      handleServerReady(url, isRemote, port);
+      if (isRemote) {
+        client.app.log({ level: "info", message: `[Plannotator] Open in browser: ${url}` });
+      }
+    },
   });
 
   if (server.waitForDone) {

--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -481,6 +481,9 @@ Use /plannotator-last or /plannotator-annotate for manual review, or set workflo
             opencodeClient: ctx.client,
             onReady: async (url, isRemote, port) => {
               handleServerReady(url, isRemote, port);
+              if (isRemote) {
+                ctx.client.app.log({ level: "info", message: `[Plannotator] Open in browser: ${url}` });
+              }
             },
           });
 

--- a/apps/pi-extension/plannotator-browser.ts
+++ b/apps/pi-extension/plannotator-browser.ts
@@ -83,7 +83,7 @@ export function getStartupErrorMessage(err: unknown): string {
 function openBrowserForServer(serverUrl: string, ctx: ExtensionContext): void {
 	const browserResult = openBrowser(serverUrl);
 	if (isRemoteSession()) {
-		ctx.ui.notify(`Remote session. Open manually: ${serverUrl}`, "info");
+		ctx.ui.notify(`[Plannotator] ${serverUrl}`, "info");
 	} else if (!browserResult.opened) {
 		ctx.ui.notify(`Open this URL to review: ${serverUrl}`, "info");
 	}

--- a/apps/pi-extension/plannotator-browser.ts
+++ b/apps/pi-extension/plannotator-browser.ts
@@ -14,7 +14,7 @@ import {
 	startReviewServer,
 	type DiffType,
 } from "./server.js";
-import { openBrowser } from "./server/network.js";
+import { openBrowser, isRemoteSession } from "./server/network.js";
 import { parsePRUrl, checkPRAuth, fetchPR } from "./server/pr.js";
 import {
 	getMRLabel,
@@ -82,8 +82,8 @@ export function getStartupErrorMessage(err: unknown): string {
 
 function openBrowserForServer(serverUrl: string, ctx: ExtensionContext): void {
 	const browserResult = openBrowser(serverUrl);
-	if (browserResult.isRemote) {
-		ctx.ui.notify(`Remote session. Open manually: ${browserResult.url}`, "info");
+	if (isRemoteSession()) {
+		ctx.ui.notify(`Remote session. Open manually: ${serverUrl}`, "info");
 	} else if (!browserResult.opened) {
 		ctx.ui.notify(`Open this URL to review: ${serverUrl}`, "info");
 	}


### PR DESCRIPTION
## Summary

- **OpenCode regression fix**: PR #440 removed `writeRemoteShareLink` because the base64 share URL flooded the TUI, but no replacement was added. Remote users got zero feedback. Now logs the short localhost URL via `client.app.log()` in all `onReady` callbacks (submit_plan, review, annotate, annotate-last, archive).
- **Pi bug fix**: `openBrowserForServer` relied on the `openBrowser` return value to detect remote mode, but `isRemote` was only set when `BROWSER` env was unset. Users running via Cursor (which sets `BROWSER`) never got the URL notification. Now checks `isRemoteSession()` directly.

Closes #551
Closes #574
Related: #601, #192, #435

## Test plan

- [ ] OpenCode remote: set `PLANNOTATOR_REMOTE=1`, call `submit_plan` → confirm `[Plannotator] Open in browser: http://...` appears in TUI log
- [ ] OpenCode remote review: set `PLANNOTATOR_REMOTE=1`, run `/plannotator-review` → same
- [ ] Pi remote with `BROWSER` set: set `PLANNOTATOR_REMOTE=1` and `BROWSER=some-browser`, trigger plan review → confirm `ctx.ui.notify` fires with URL
- [ ] Local mode: confirm no extra output when running locally (browser opens normally)