### PR TITLE
Expose bypass clear reminder permission mode

### DIFF
--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -1261,6 +1261,10 @@ if (args[0] === "sessions") {
 
       console.log(
         JSON.stringify({
+          ...(result.clearContextNudge && {
+            systemMessage:
+              "Plannotator requested bypass mode. Hooks cannot clear context. Run /clear before continuing if you want a fresh implementation session.",
+          }),
           hookSpecificOutput: {
             hookEventName: "PermissionRequest",
             decision: {

--- a/apps/pi-extension/plannotator-browser.ts
+++ b/apps/pi-extension/plannotator-browser.ts
@@ -35,6 +35,7 @@ export interface PlanReviewDecision {
 	savedPath?: string;
 	agentSwitch?: string;
 	permissionMode?: string;
+	clearContextNudge?: boolean;
 }
 
 export interface BrowserDecisionSession<T> {

--- a/apps/pi-extension/plannotator-events.ts
+++ b/apps/pi-extension/plannotator-events.ts
@@ -73,6 +73,7 @@ export interface PlannotatorReviewResultEvent {
 	savedPath?: string;
 	agentSwitch?: string;
 	permissionMode?: string;
+	clearContextNudge?: boolean;
 }
 
 export interface PlannotatorReviewStatusPayload {
@@ -246,6 +247,7 @@ export function registerPlannotatorEventListeners(pi: ExtensionAPI): void {
 							savedPath: result.savedPath,
 							agentSwitch: result.agentSwitch,
 							permissionMode: result.permissionMode,
+							clearContextNudge: result.clearContextNudge,
 						} satisfies PlannotatorReviewResultEvent;
 						setStoredReviewStatus(session.reviewId, { status: "completed", ...reviewResult });
 						pi.events.emit(PLANNOTATOR_REVIEW_RESULT_CHANNEL, reviewResult);

--- a/apps/pi-extension/server.test.ts
+++ b/apps/pi-extension/server.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { createServer as createNetServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { getGitContext, runGitDiff, startReviewServer } from "./server";
+import { getGitContext, runGitDiff, startPlanReviewServer, startReviewServer } from "./server";
 
 const tempDirs: string[] = [];
 const originalCwd = process.cwd();
@@ -82,6 +82,45 @@ afterEach(() => {
 });
 
 describe("pi review server", () => {
+  test("plan approve preserves clear context nudge decisions", async () => {
+    const homeDir = makeTempDir("plannotator-pi-home-");
+    const repoDir = makeTempDir("plannotator-pi-plan-");
+    process.env.HOME = homeDir;
+    process.chdir(repoDir);
+    process.env.PLANNOTATOR_PORT = String(await reservePort());
+
+    const server = await startPlanReviewServer({
+      plan: "# Plan\n\nShip it.",
+      htmlContent: "<!doctype html><html><body>plan</body></html>",
+      origin: "pi",
+      permissionMode: "acceptEdits",
+    });
+
+    try {
+      const approveResponse = await fetch(`${server.url}/api/approve`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          permissionMode: "bypassPermissions",
+          clearContextNudge: true,
+          planSave: { enabled: false },
+        }),
+      });
+      expect(approveResponse.status).toBe(200);
+
+      await expect(server.waitForDecision()).resolves.toEqual({
+        approved: true,
+        feedback: undefined,
+        savedPath: undefined,
+        agentSwitch: undefined,
+        permissionMode: "bypassPermissions",
+        clearContextNudge: true,
+      });
+    } finally {
+      server.stop();
+    }
+  });
+
   test("serves review diff parity endpoints including drafts, uploads, and editor annotations", async () => {
     const homeDir = makeTempDir("plannotator-pi-home-");
     const repoDir = initRepo();

--- a/apps/pi-extension/server/serverPlan.ts
+++ b/apps/pi-extension/server/serverPlan.ts
@@ -54,6 +54,7 @@ export interface PlanReviewDecision {
 	savedPath?: string;
 	agentSwitch?: string;
 	permissionMode?: string;
+	clearContextNudge?: boolean;
 }
 
 export interface PlanServerResult {
@@ -351,6 +352,7 @@ export async function startPlanReviewServer(options: {
 			let feedback: string | undefined;
 			let agentSwitch: string | undefined;
 			let requestedPermissionMode: string | undefined;
+			let clearContextNudge: boolean | undefined;
 			let planSaveEnabled = true;
 			let planSaveCustomPath: string | undefined;
 			try {
@@ -359,6 +361,7 @@ export async function startPlanReviewServer(options: {
 				if (body.agentSwitch) agentSwitch = body.agentSwitch as string;
 				if (body.permissionMode)
 					requestedPermissionMode = body.permissionMode as string;
+				if (body.clearContextNudge === true) clearContextNudge = true;
 				if (body.planSave !== undefined) {
 					const ps = body.planSave as { enabled: boolean; customPath?: string };
 					planSaveEnabled = ps.enabled;
@@ -420,6 +423,7 @@ export async function startPlanReviewServer(options: {
 				savedPath,
 				agentSwitch,
 				permissionMode: effectivePermissionMode,
+				clearContextNudge,
 			});
 			json(res, { ok: true, savedPath });
 		} else if (url.pathname === "/api/deny" && req.method === "POST") {

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -1738,6 +1738,7 @@ const App: React.FC = () => {
                 onIdentityChange={handleIdentityChange}
                 origin={origin}
                 onUIPreferencesChange={setUiPrefs}
+                onPermissionModeChange={setPermissionMode}
                 externalOpen={mobileSettingsOpen}
                 onExternalClose={() => setMobileSettingsOpen(false)}
                 gitUser={gitUser}

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -15,7 +15,7 @@ import { TaterSpriteRunning } from '@plannotator/ui/components/TaterSpriteRunnin
 import { TaterSpritePullup } from '@plannotator/ui/components/TaterSpritePullup';
 import { Settings } from '@plannotator/ui/components/Settings';
 import { FeedbackButton, ApproveButton, ExitButton } from '@plannotator/ui/components/ToolbarButtons';
-import { ApproveDropdown } from '@plannotator/ui/components/ApproveDropdown';
+import { ApproveDropdown, type ApproveExtraEntry } from '@plannotator/ui/components/ApproveDropdown';
 import { useSharing } from '@plannotator/ui/hooks/useSharing';
 import { getCallbackConfig, CallbackAction, executeCallback, type ToastPayload } from '@plannotator/ui/utils/callback';
 import { useAgents } from '@plannotator/ui/hooks/useAgents';
@@ -91,6 +91,11 @@ type NoteAutoSaveResults = {
   octarine?: boolean;
 };
 
+type ApprovalOverride = {
+  permissionMode?: PermissionMode;
+  clearContextNudge?: boolean;
+};
+
 const App: React.FC = () => {
   const [markdown, setMarkdown] = useState(DEMO_PLAN_CONTENT);
   const [annotations, setAnnotations] = useState<Annotation[]>([]);
@@ -103,6 +108,7 @@ const App: React.FC = () => {
   const [showImport, setShowImport] = useState(false);
   const [showFeedbackPrompt, setShowFeedbackPrompt] = useState(false);
   const [showClaudeCodeWarning, setShowClaudeCodeWarning] = useState(false);
+  const [pendingApprovalOverride, setPendingApprovalOverride] = useState<ApprovalOverride | null>(null);
   const [showExitWarning, setShowExitWarning] = useState(false);
   // When the warning dialog confirms, route to the handler matching the button that opened it.
   const [exitWarningAction, setExitWarningAction] = useState<'close' | 'approve'>('close');
@@ -941,7 +947,8 @@ const App: React.FC = () => {
   };
 
   // API mode handlers
-  const handleApprove = async () => {
+  const handleApprove = async (override: ApprovalOverride = {}) => {
+    setPendingApprovalOverride(null);
     setIsSubmitting(true);
     try {
       const obsidianSettings = getObsidianSettings();
@@ -953,11 +960,14 @@ const App: React.FC = () => {
         : autoSaveResultsRef.current;
 
       // Build request body - include integrations if enabled
-      const body: { obsidian?: object; bear?: object; octarine?: object; feedback?: string; agentSwitch?: string; planSave?: { enabled: boolean; customPath?: string }; permissionMode?: string } = {};
+      const body: { obsidian?: object; bear?: object; octarine?: object; feedback?: string; agentSwitch?: string; planSave?: { enabled: boolean; customPath?: string }; permissionMode?: string; clearContextNudge?: boolean } = {};
 
       // Include permission mode for Claude Code
       if (origin === 'claude-code') {
-        body.permissionMode = permissionMode;
+        body.permissionMode = override.permissionMode ?? permissionMode;
+        if (override.clearContextNudge) {
+          body.clearContextNudge = true;
+        }
       }
 
       const effectiveAgent = getEffectiveAgentName(getAgentSwitchSettings());
@@ -1039,6 +1049,25 @@ const App: React.FC = () => {
       setIsSubmitting(false);
     }
   };
+
+  const approveWithClaudeCodeWarning = useCallback((override: ApprovalOverride = {}) => {
+    setPendingApprovalOverride(override);
+    if (origin === 'claude-code' && (allAnnotations.length > 0 || codeAnnotations.length > 0)) {
+      setShowClaudeCodeWarning(true);
+      return;
+    }
+    handleApprove(override);
+  }, [allAnnotations.length, codeAnnotations.length, origin, handleApprove]);
+
+  const claudeCodeExtraEntries = useMemo<ApproveExtraEntry[]>(() => (origin === 'claude-code' ? [{
+    id: 'approve-bypass-clear-reminder',
+    label: 'Approve + Bypass + /clear Reminder',
+    description: 'Requests bypass mode and reminds you to run /clear. Hooks cannot clear context directly.',
+    onSelect: () => approveWithClaudeCodeWarning({
+      permissionMode: 'bypassPermissions',
+      clearContextNudge: true,
+    }),
+  }] : []), [approveWithClaudeCodeWarning, origin]);
 
   // Annotate mode handler — sends feedback via /api/feedback
   const handleAnnotateFeedback = async () => {
@@ -1634,18 +1663,24 @@ const App: React.FC = () => {
                 )}
 
                 {(!annotateMode || gate) && (
-                  origin === 'opencode' && !annotateMode && availableAgents.length > 0 ? (
+                  !annotateMode && (
+                    (origin === 'opencode' && availableAgents.length > 0) ||
+                    (origin === 'claude-code' && claudeCodeExtraEntries.length > 0)
+                  ) ? (
                     <ApproveDropdown
                       onApprove={() => {
-                        const warning = getAgentWarning();
-                        if (warning) {
-                          setAgentWarningMessage(warning);
-                          setShowAgentWarning(true);
-                          return;
+                        if (origin === 'opencode') {
+                          const warning = getAgentWarning();
+                          if (warning) {
+                            setAgentWarningMessage(warning);
+                            setShowAgentWarning(true);
+                            return;
+                          }
                         }
-                        handleApprove();
+                        approveWithClaudeCodeWarning();
                       }}
-                      agents={availableAgents}
+                      agents={origin === 'opencode' ? availableAgents : []}
+                      extraEntries={claudeCodeExtraEntries}
                       disabled={isSubmitting}
                       isLoading={isSubmitting}
                     />
@@ -1663,6 +1698,7 @@ const App: React.FC = () => {
                             return;
                           }
                           if (origin === 'claude-code' && (allAnnotations.length > 0 || codeAnnotations.length > 0)) {
+                            setPendingApprovalOverride({});
                             setShowClaudeCodeWarning(true);
                             return;
                           }
@@ -2074,10 +2110,15 @@ const App: React.FC = () => {
         {/* Claude Code annotation warning dialog */}
         <ConfirmDialog
           isOpen={showClaudeCodeWarning}
-          onClose={() => setShowClaudeCodeWarning(false)}
-          onConfirm={() => {
+          onClose={() => {
             setShowClaudeCodeWarning(false);
-            handleApprove();
+            setPendingApprovalOverride(null);
+          }}
+          onConfirm={() => {
+            const override = pendingApprovalOverride ?? {};
+            setShowClaudeCodeWarning(false);
+            setPendingApprovalOverride(null);
+            handleApprove(override);
           }}
           title="Annotations Won't Be Sent"
           message={<>{agentName} doesn't yet support feedback on approval. Your {allAnnotations.length + codeAnnotations.length} annotation{(allAnnotations.length + codeAnnotations.length) !== 1 ? 's' : ''} will be lost.</>}

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -77,6 +77,7 @@ import type { PlanDiffMode } from '@plannotator/ui/components/plan-diff/PlanDiff
 import { DEMO_PLAN_CONTENT as DEFAULT_DEMO_PLAN_CONTENT } from './demoPlan';
 import { DIFF_DEMO_PLAN_CONTENT } from './demoPlanDiffDemo';
 import { canUseAnnotateWideMode, resolveWideModeExitLayout, type WideModeLayoutSnapshot, type WideModeType } from './wideMode';
+import { buildApprovalRequestBody, type ApprovalOverride } from './approvalBody';
 const USE_DIFF_DEMO =
   import.meta.env.VITE_DIFF_DEMO === '1' ||
   import.meta.env.VITE_DIFF_DEMO === 'true';
@@ -89,11 +90,6 @@ type NoteAutoSaveResults = {
   obsidian?: boolean;
   bear?: boolean;
   octarine?: boolean;
-};
-
-type ApprovalOverride = {
-  permissionMode?: PermissionMode;
-  clearContextNudge?: boolean;
 };
 
 const App: React.FC = () => {
@@ -959,27 +955,14 @@ const App: React.FC = () => {
         ? await autoSavePromiseRef.current
         : autoSaveResultsRef.current;
 
-      // Build request body - include integrations if enabled
-      const body: { obsidian?: object; bear?: object; octarine?: object; feedback?: string; agentSwitch?: string; planSave?: { enabled: boolean; customPath?: string }; permissionMode?: string; clearContextNudge?: boolean } = {};
-
-      // Include permission mode for Claude Code
-      if (origin === 'claude-code') {
-        body.permissionMode = override.permissionMode ?? permissionMode;
-        if (override.clearContextNudge) {
-          body.clearContextNudge = true;
-        }
-      }
-
       const effectiveAgent = getEffectiveAgentName(getAgentSwitchSettings());
-      if (effectiveAgent) {
-        body.agentSwitch = effectiveAgent;
-      }
-
-      // Include plan save settings
-      body.planSave = {
-        enabled: planSaveSettings.enabled,
-        ...(planSaveSettings.customPath && { customPath: planSaveSettings.customPath }),
-      };
+      const body = buildApprovalRequestBody({
+        origin,
+        permissionMode,
+        override,
+        effectiveAgent,
+        planSaveSettings,
+      });
 
       const effectiveVaultPath = getEffectiveVaultPath(obsidianSettings);
       if (obsidianSettings.enabled && effectiveVaultPath) {

--- a/packages/editor/approvalBody.test.ts
+++ b/packages/editor/approvalBody.test.ts
@@ -36,8 +36,7 @@ describe('buildApprovalRequestBody', () => {
       origin: 'claude-code',
       permissionMode: 'acceptEdits',
       override: {
-        permissionMode: 'bypassPermissions',
-        clearContextNudge: true,
+        permissionMode: 'bypassPermissionsClearReminder',
       },
       planSaveSettings: { enabled: true },
     })).toEqual({

--- a/packages/editor/approvalBody.test.ts
+++ b/packages/editor/approvalBody.test.ts
@@ -2,6 +2,18 @@ import { describe, expect, test } from 'bun:test';
 import { buildApprovalRequestBody } from './approvalBody';
 
 describe('buildApprovalRequestBody', () => {
+  test('maps bypass clear reminder mode to Claude Code wire fields', () => {
+    expect(buildApprovalRequestBody({
+      origin: 'claude-code',
+      permissionMode: 'bypassPermissionsClearReminder',
+      planSaveSettings: { enabled: true },
+    })).toEqual({
+      permissionMode: 'bypassPermissions',
+      clearContextNudge: true,
+      planSave: { enabled: true },
+    });
+  });
+
   test('omits agentSwitch for Claude Code approvals', () => {
     expect(buildApprovalRequestBody({
       origin: 'claude-code',
@@ -19,10 +31,38 @@ describe('buildApprovalRequestBody', () => {
     });
   });
 
+  test('keeps bypass clear reminder override wire fields for Claude Code approvals', () => {
+    expect(buildApprovalRequestBody({
+      origin: 'claude-code',
+      permissionMode: 'acceptEdits',
+      override: {
+        permissionMode: 'bypassPermissions',
+        clearContextNudge: true,
+      },
+      planSaveSettings: { enabled: true },
+    })).toEqual({
+      permissionMode: 'bypassPermissions',
+      clearContextNudge: true,
+      planSave: { enabled: true },
+    });
+  });
+
   test('keeps agentSwitch for OpenCode approvals', () => {
     expect(buildApprovalRequestBody({
       origin: 'opencode',
       permissionMode: 'acceptEdits',
+      effectiveAgent: 'build',
+      planSaveSettings: { enabled: true },
+    })).toEqual({
+      agentSwitch: 'build',
+      planSave: { enabled: true },
+    });
+  });
+
+  test('ignores bypass clear reminder mode for OpenCode approvals', () => {
+    expect(buildApprovalRequestBody({
+      origin: 'opencode',
+      permissionMode: 'bypassPermissionsClearReminder',
       effectiveAgent: 'build',
       planSaveSettings: { enabled: true },
     })).toEqual({

--- a/packages/editor/approvalBody.test.ts
+++ b/packages/editor/approvalBody.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test';
+import { buildApprovalRequestBody } from './approvalBody';
+
+describe('buildApprovalRequestBody', () => {
+  test('omits agentSwitch for Claude Code approvals', () => {
+    expect(buildApprovalRequestBody({
+      origin: 'claude-code',
+      permissionMode: 'acceptEdits',
+      effectiveAgent: 'build',
+      override: {
+        permissionMode: 'bypassPermissions',
+        clearContextNudge: true,
+      },
+      planSaveSettings: { enabled: true },
+    })).toEqual({
+      permissionMode: 'bypassPermissions',
+      clearContextNudge: true,
+      planSave: { enabled: true },
+    });
+  });
+
+  test('keeps agentSwitch for OpenCode approvals', () => {
+    expect(buildApprovalRequestBody({
+      origin: 'opencode',
+      permissionMode: 'acceptEdits',
+      effectiveAgent: 'build',
+      planSaveSettings: { enabled: true },
+    })).toEqual({
+      agentSwitch: 'build',
+      planSave: { enabled: true },
+    });
+  });
+});

--- a/packages/editor/approvalBody.ts
+++ b/packages/editor/approvalBody.ts
@@ -28,8 +28,11 @@ export function buildApprovalRequestBody(options: {
   const body: ApprovalRequestBody = {};
 
   if (origin === 'claude-code') {
-    body.permissionMode = override.permissionMode ?? permissionMode;
-    if (override.clearContextNudge) {
+    const effectivePermissionMode = override.permissionMode ?? permissionMode;
+    body.permissionMode = effectivePermissionMode === 'bypassPermissionsClearReminder'
+      ? 'bypassPermissions'
+      : effectivePermissionMode;
+    if (override.clearContextNudge || effectivePermissionMode === 'bypassPermissionsClearReminder') {
       body.clearContextNudge = true;
     }
   }

--- a/packages/editor/approvalBody.ts
+++ b/packages/editor/approvalBody.ts
@@ -1,0 +1,47 @@
+import type { Origin } from '@plannotator/shared/agents';
+import type { PermissionMode } from '@plannotator/ui/utils/permissionMode';
+
+export type ApprovalOverride = {
+  permissionMode?: PermissionMode;
+  clearContextNudge?: boolean;
+};
+
+export interface ApprovalRequestBody {
+  obsidian?: object;
+  bear?: object;
+  octarine?: object;
+  feedback?: string;
+  agentSwitch?: string;
+  planSave?: { enabled: boolean; customPath?: string };
+  permissionMode?: string;
+  clearContextNudge?: boolean;
+}
+
+export function buildApprovalRequestBody(options: {
+  origin: Origin | null;
+  permissionMode: PermissionMode;
+  override?: ApprovalOverride;
+  effectiveAgent?: string;
+  planSaveSettings: { enabled: boolean; customPath?: string | null };
+}): ApprovalRequestBody {
+  const { origin, permissionMode, override = {}, effectiveAgent, planSaveSettings } = options;
+  const body: ApprovalRequestBody = {};
+
+  if (origin === 'claude-code') {
+    body.permissionMode = override.permissionMode ?? permissionMode;
+    if (override.clearContextNudge) {
+      body.clearContextNudge = true;
+    }
+  }
+
+  if (origin === 'opencode' && effectiveAgent) {
+    body.agentSwitch = effectiveAgent;
+  }
+
+  body.planSave = {
+    enabled: planSaveSettings.enabled,
+    ...(planSaveSettings.customPath && { customPath: planSaveSettings.customPath }),
+  };
+
+  return body;
+}

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -99,6 +99,7 @@ export interface ServerResult {
     savedPath?: string;
     agentSwitch?: string;
     permissionMode?: string;
+    clearContextNudge?: boolean;
   }>;
   /** Wait for user to close (archive mode only) */
   waitForDone?: () => Promise<void>;
@@ -170,6 +171,7 @@ export async function startPlannotatorServer(
     savedPath?: string;
     agentSwitch?: string;
     permissionMode?: string;
+    clearContextNudge?: boolean;
   }) => void;
   let decisionPromise: Promise<{
     approved: boolean;
@@ -177,6 +179,7 @@ export async function startPlannotatorServer(
     savedPath?: string;
     agentSwitch?: string;
     permissionMode?: string;
+    clearContextNudge?: boolean;
   }>;
 
   if (mode !== "archive") {
@@ -431,6 +434,7 @@ export async function startPlannotatorServer(
             let feedback: string | undefined;
             let agentSwitch: string | undefined;
             let requestedPermissionMode: string | undefined;
+            let clearContextNudge: boolean | undefined;
             let planSaveEnabled = true; // default to enabled for backwards compat
             let planSaveCustomPath: string | undefined;
             try {
@@ -442,6 +446,7 @@ export async function startPlannotatorServer(
                 agentSwitch?: string;
                 planSave?: { enabled: boolean; customPath?: string };
                 permissionMode?: string;
+                clearContextNudge?: boolean;
               };
 
               // Capture feedback if provided (for "approve with notes")
@@ -457,6 +462,11 @@ export async function startPlannotatorServer(
               // Capture permission mode from client request (Claude Code)
               if (body.permissionMode) {
                 requestedPermissionMode = body.permissionMode;
+              }
+
+              // Capture optional /clear reminder request for Claude Code approval flow
+              if (body.clearContextNudge === true) {
+                clearContextNudge = true;
               }
 
               // Capture plan save settings
@@ -504,7 +514,7 @@ export async function startPlannotatorServer(
 
             // Use permission mode from client request if provided, otherwise fall back to hook input
             const effectivePermissionMode = requestedPermissionMode || permissionMode;
-            resolveDecision({ approved: true, feedback, savedPath, agentSwitch, permissionMode: effectivePermissionMode });
+            resolveDecision({ approved: true, feedback, savedPath, agentSwitch, permissionMode: effectivePermissionMode, clearContextNudge });
             return Response.json({ ok: true, savedPath });
           }
 

--- a/packages/ui/components/ApproveDropdown.test.tsx
+++ b/packages/ui/components/ApproveDropdown.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ApproveDropdown } from './ApproveDropdown';
+
+describe('ApproveDropdown', () => {
+  test('does not show agent-switch label when only extra approval entries are enabled', () => {
+    const html = renderToStaticMarkup(
+      <ApproveDropdown
+        onApprove={() => {}}
+        agents={[]}
+        extraEntries={[{
+          id: 'approve-bypass-clear-reminder',
+          label: 'Approve + Bypass + /clear Reminder',
+          onSelect: () => {},
+        }]}
+      />,
+    );
+
+    expect(html).toContain('Approve');
+    expect(html).not.toContain('build');
+    expect(html).not.toContain('(?)');
+  });
+});

--- a/packages/ui/components/ApproveDropdown.tsx
+++ b/packages/ui/components/ApproveDropdown.tsx
@@ -2,11 +2,21 @@ import React, { useState, useRef, useEffect } from 'react';
 import type { Agent } from '../hooks/useAgents';
 import { getAgentSwitchSettings, saveAgentSwitchSettings, type AgentSwitchSettings } from '../utils/agentSwitch';
 
+export interface ApproveExtraEntry {
+  id: string;
+  label: string;
+  description?: string;
+  onSelect: () => void;
+  disabled?: boolean;
+}
+
 interface ApproveDropdownProps {
   onApprove: () => void;
   agents: Agent[];
   disabled?: boolean;
   isLoading?: boolean;
+  extraEntries?: ApproveExtraEntry[];
+  showAgentSwitch?: boolean;
 }
 
 function getSelectedLabel(setting: AgentSwitchSettings, agents: Agent[]): string | null {
@@ -35,6 +45,8 @@ export const ApproveDropdown: React.FC<ApproveDropdownProps> = ({
   agents,
   disabled = false,
   isLoading = false,
+  extraEntries = [],
+  showAgentSwitch,
 }) => {
   const [setting, setSetting] = useState<AgentSwitchSettings>(() => getAgentSwitchSettings());
   const [isOpen, setIsOpen] = useState(false);
@@ -57,6 +69,10 @@ export const ApproveDropdown: React.FC<ApproveDropdownProps> = ({
     };
   }, []);
 
+  const hasExtraEntries = extraEntries.length > 0;
+  const shouldShowAgentSwitch = showAgentSwitch ?? agents.length > 0;
+  const hasDropdownContent = hasExtraEntries || shouldShowAgentSwitch;
+
   const handleSelect = (newSetting: AgentSwitchSettings) => {
     setSetting(newSetting);
     saveAgentSwitchSettings(newSetting);
@@ -78,16 +94,36 @@ export const ApproveDropdown: React.FC<ApproveDropdownProps> = ({
     onApprove();
   };
 
+  const handleExtraSelect = (entry: ApproveExtraEntry) => {
+    if (entry.disabled) return;
+    setIsOpen(false);
+    entry.onSelect();
+  };
+
   return (
     <div className="relative" ref={dropdownRef}>
-      {/* Mobile: simple button */}
-      <button
-        onClick={handleApproveClick}
-        disabled={disabled}
-        className={`md:hidden px-2 py-1 rounded-md text-xs font-medium transition-all ${baseClasses}`}
-      >
-        {isLoading ? '...' : 'OK'}
-      </button>
+      {/* Mobile: simple button, with menu when extra actions exist */}
+      <div className="md:hidden flex items-stretch">
+        <button
+          onClick={handleApproveClick}
+          disabled={disabled}
+          className={`px-2 py-1 ${hasDropdownContent ? 'rounded-l-md' : 'rounded-md'} text-xs font-medium transition-all ${baseClasses}`}
+        >
+          {isLoading ? '...' : 'OK'}
+        </button>
+        {hasDropdownContent && (
+          <button
+            onClick={() => setIsOpen(!isOpen)}
+            disabled={disabled}
+            className={`px-1.5 py-1 rounded-r-md border-l border-success-foreground/20 text-xs transition-all ${baseClasses}`}
+            aria-label="More approval options"
+          >
+            <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+        )}
+      </div>
 
       {/* Desktop: split button */}
       <div className="hidden md:flex items-stretch">
@@ -109,8 +145,9 @@ export const ApproveDropdown: React.FC<ApproveDropdownProps> = ({
         </button>
         <button
           onClick={() => setIsOpen(!isOpen)}
-          disabled={disabled}
+          disabled={disabled || !hasDropdownContent}
           className={`px-1.5 py-1 rounded-r-md border-l border-success-foreground/20 text-xs transition-all ${baseClasses}`}
+          aria-label="More approval options"
         >
           <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
@@ -119,50 +156,72 @@ export const ApproveDropdown: React.FC<ApproveDropdownProps> = ({
       </div>
 
       {/* Dropdown */}
-      {isOpen && (
-        <div className="absolute right-0 top-full mt-1 w-52 rounded-lg border border-border bg-popover shadow-xl z-[70] overflow-hidden py-1">
-          <div className="px-3 py-1.5 text-[10px] uppercase tracking-wider text-muted-foreground/70 font-medium">
-            Switch to agent
-          </div>
-          {agents.map((agent) => {
-            const selected = isSelected(agent.id, setting);
-            return (
+      {isOpen && hasDropdownContent && (
+        <div className="absolute right-0 top-full mt-1 w-64 rounded-lg border border-border bg-popover shadow-xl z-[70] overflow-hidden py-1">
+          {hasExtraEntries && (
+            <>
+              {extraEntries.map((entry) => (
+                <button
+                  key={entry.id}
+                  onClick={() => handleExtraSelect(entry)}
+                  disabled={entry.disabled}
+                  className="w-full px-3 py-2 text-left text-xs transition-colors text-popover-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <span className="block font-medium">{entry.label}</span>
+                  {entry.description && (
+                    <span className="block mt-0.5 text-[11px] leading-snug text-muted-foreground">{entry.description}</span>
+                  )}
+                </button>
+              ))}
+              {shouldShowAgentSwitch && <div className="border-t border-border my-1" />}
+            </>
+          )}
+          {shouldShowAgentSwitch && (
+            <>
+              <div className="px-3 py-1.5 text-[10px] uppercase tracking-wider text-muted-foreground/70 font-medium">
+                Switch to agent
+              </div>
+              {agents.map((agent) => {
+                const selected = isSelected(agent.id, setting);
+                return (
+                  <button
+                    key={agent.id}
+                    onClick={() => handleSelect({ switchTo: agent.id })}
+                    className={`w-full px-3 py-1.5 text-left text-xs transition-colors flex items-center gap-2 ${
+                      selected
+                        ? 'text-primary bg-primary/10 font-medium'
+                        : 'text-popover-foreground hover:bg-muted'
+                    }`}
+                  >
+                    <span className="w-4 flex-shrink-0">{selected && <Checkmark />}</span>
+                    <span className="truncate">{agent.name}</span>
+                  </button>
+                );
+              })}
+              {isCustom && setting.customName && (
+                <button
+                  onClick={() => setIsOpen(false)}
+                  className="w-full px-3 py-1.5 text-left text-xs transition-colors flex items-center gap-2 text-primary bg-primary/10 font-medium"
+                >
+                  <span className="w-4 flex-shrink-0"><Checkmark /></span>
+                  <span className="truncate">{setting.customName}</span>
+                  <span className="text-[10px] text-muted-foreground ml-auto">(custom)</span>
+                </button>
+              )}
+              <div className="border-t border-border my-1" />
               <button
-                key={agent.id}
-                onClick={() => handleSelect({ switchTo: agent.id })}
+                onClick={() => handleSelect({ switchTo: 'disabled' })}
                 className={`w-full px-3 py-1.5 text-left text-xs transition-colors flex items-center gap-2 ${
-                  selected
+                  isNoSwitch
                     ? 'text-primary bg-primary/10 font-medium'
                     : 'text-popover-foreground hover:bg-muted'
                 }`}
               >
-                <span className="w-4 flex-shrink-0">{selected && <Checkmark />}</span>
-                <span className="truncate">{agent.name}</span>
+                <span className="w-4 flex-shrink-0">{isNoSwitch && <Checkmark />}</span>
+                No switch
               </button>
-            );
-          })}
-          {isCustom && setting.customName && (
-            <button
-              onClick={() => setIsOpen(false)}
-              className="w-full px-3 py-1.5 text-left text-xs transition-colors flex items-center gap-2 text-primary bg-primary/10 font-medium"
-            >
-              <span className="w-4 flex-shrink-0"><Checkmark /></span>
-              <span className="truncate">{setting.customName}</span>
-              <span className="text-[10px] text-muted-foreground ml-auto">(custom)</span>
-            </button>
+            </>
           )}
-          <div className="border-t border-border my-1" />
-          <button
-            onClick={() => handleSelect({ switchTo: 'disabled' })}
-            className={`w-full px-3 py-1.5 text-left text-xs transition-colors flex items-center gap-2 ${
-              isNoSwitch
-                ? 'text-primary bg-primary/10 font-medium'
-                : 'text-popover-foreground hover:bg-muted'
-            }`}
-          >
-            <span className="w-4 flex-shrink-0">{isNoSwitch && <Checkmark />}</span>
-            No switch
-          </button>
         </div>
       )}
     </div>

--- a/packages/ui/components/ApproveDropdown.tsx
+++ b/packages/ui/components/ApproveDropdown.tsx
@@ -79,10 +79,10 @@ export const ApproveDropdown: React.FC<ApproveDropdownProps> = ({
     setIsOpen(false);
   };
 
-  const agentLabel = getSelectedLabel(setting, agents);
-  const isNoSwitch = setting.switchTo === 'disabled';
-  const isCustom = setting.switchTo === 'custom';
-  const notFound = agentLabel && !isNoSwitch && !isCustom
+  const agentLabel = shouldShowAgentSwitch ? getSelectedLabel(setting, agents) : null;
+  const isNoSwitch = shouldShowAgentSwitch && setting.switchTo === 'disabled';
+  const isCustom = shouldShowAgentSwitch && setting.switchTo === 'custom';
+  const notFound = shouldShowAgentSwitch && agentLabel && !isNoSwitch && !isCustom
     && !agents.some(a => a.id.toLowerCase() === setting.switchTo.toLowerCase());
 
   const baseClasses = disabled

--- a/packages/ui/components/Settings.tsx
+++ b/packages/ui/components/Settings.tsx
@@ -78,6 +78,7 @@ interface SettingsProps {
   origin?: Origin | null;
   mode?: 'plan' | 'review';
   onUIPreferencesChange?: (prefs: UIPreferences) => void;
+  onPermissionModeChange?: (mode: PermissionMode) => void;
   /** Externally controlled open state (for mobile menu integration) */
   externalOpen?: boolean;
   onExternalClose?: () => void;
@@ -580,7 +581,7 @@ const CommentsTab: React.FC = () => {
   );
 };
 
-export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange, onIdentityChange, origin, mode = 'plan', onUIPreferencesChange, externalOpen, onExternalClose, aiProviders = [], gitUser }) => {
+export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange, onIdentityChange, origin, mode = 'plan', onUIPreferencesChange, onPermissionModeChange, externalOpen, onExternalClose, aiProviders = [], gitUser }) => {
   const [showDialog, setShowDialog] = useState(false);
   const [themePreview, setThemePreview] = useState(false);
 
@@ -781,6 +782,7 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
   const handlePermissionModeChange = (mode: PermissionMode) => {
     setPermissionMode(mode);
     savePermissionModeSettings(mode);
+    onPermissionModeChange?.(mode);
   };
 
   const handleDefaultNotesAppChange = (app: DefaultNotesApp) => {

--- a/packages/ui/utils/permissionMode.ts
+++ b/packages/ui/utils/permissionMode.ts
@@ -6,6 +6,7 @@
  *
  * Available modes:
  * - bypassPermissions: Auto-approve all tool calls
+ * - bypassPermissionsClearReminder: Persisted UI mode that sends bypassPermissions plus a /clear reminder nudge
  * - acceptEdits: Auto-approve file edits only
  * - default: Manually approve each tool call
  */
@@ -15,7 +16,7 @@ import { storage } from './storage';
 const STORAGE_KEY_MODE = 'plannotator-permission-mode';
 const STORAGE_KEY_CONFIGURED = 'plannotator-permission-mode-configured';
 
-export type PermissionMode = 'bypassPermissions' | 'acceptEdits' | 'default';
+export type PermissionMode = 'bypassPermissions' | 'bypassPermissionsClearReminder' | 'acceptEdits' | 'default';
 
 export interface PermissionModeSettings {
   mode: PermissionMode;
@@ -32,6 +33,11 @@ export const PERMISSION_MODE_OPTIONS: { value: PermissionMode; label: string; de
     value: 'bypassPermissions',
     label: 'Bypass Permissions',
     description: 'Auto-approve all tool calls (equivalent to --dangerously-skip-permissions)',
+  },
+  {
+    value: 'bypassPermissionsClearReminder',
+    label: 'Bypass + /clear Reminder',
+    description: 'Auto-approve all tool calls and emit a system message reminding you to run /clear (hooks cannot clear context directly).',
   },
   {
     value: 'default',

--- a/packages/ui/utils/permissionMode.ts
+++ b/packages/ui/utils/permissionMode.ts
@@ -48,15 +48,19 @@ export const PERMISSION_MODE_OPTIONS: { value: PermissionMode; label: string; de
 
 const DEFAULT_MODE: PermissionMode = 'acceptEdits';
 
+function isPermissionMode(value: string | null): value is PermissionMode {
+  return PERMISSION_MODE_OPTIONS.some((option) => option.value === value);
+}
+
 /**
  * Get current permission mode settings from storage
  */
 export function getPermissionModeSettings(): PermissionModeSettings {
-  const mode = storage.getItem(STORAGE_KEY_MODE) as PermissionMode | null;
+  const mode = storage.getItem(STORAGE_KEY_MODE);
   const configured = storage.getItem(STORAGE_KEY_CONFIGURED) === 'true';
 
   return {
-    mode: mode || DEFAULT_MODE,
+    mode: isPermissionMode(mode) ? mode : DEFAULT_MODE,
     configured,
   };
 }


### PR DESCRIPTION
## Summary
- Adds a synthetic persisted `bypassPermissionsClearReminder` permission mode for Settings and first-run setup.
- Decomposes that UI mode to Claude Code wire fields: `permissionMode: 'bypassPermissions'` plus `clearContextNudge: true`.
- Validates stored permission-mode cookie values before reusing them.

## Test Plan
- `bun test packages/editor/approvalBody.test.ts`
- `bun run --cwd apps/review build && bun run build:hook`
- `bun run --cwd packages/ui typecheck`
- `PATH="$PWD/packages/ui/node_modules/.bin:$PATH" bun run typecheck`
- `bun test`
- `git diff --check c7727b9..HEAD`

## Notes
- Direct push to `backnotprop/plannotator` was denied for the authenticated accounts, so this PR is opened from the `AgileInnov8tor/plannotator` fork.