### PR TITLE
Install Plannotator command skills under Codex home

### DIFF
--- a/scripts/install.cmd
+++ b/scripts/install.cmd
@@ -486,6 +486,17 @@ for %%S in (plannotator-review plannotator-annotate plannotator-last) do (
 )
 if "!LEGACY_SKILLS_REMOVED!"=="1" echo Removed legacy Plannotator skills from !LEGACY_AGENTS_SKILLS_DIR!
 
+REM Remove Plannotator skills that belong in the shared agent scope from Codex.
+set "STALE_CODEX_SKILLS_DIR=%USERPROFILE%\.codex\skills"
+set "STALE_CODEX_SKILLS_REMOVED=0"
+for %%S in (plannotator-compound plannotator-setup-goal) do (
+    if exist "!STALE_CODEX_SKILLS_DIR!\%%S" (
+        rmdir /s /q "!STALE_CODEX_SKILLS_DIR!\%%S" >nul 2>&1
+        set "STALE_CODEX_SKILLS_REMOVED=1"
+    )
+)
+if "!STALE_CODEX_SKILLS_REMOVED!"=="1" echo Removed shared-agent Plannotator skills from !STALE_CODEX_SKILLS_DIR!
+
 where git >nul 2>&1
 if !ERRORLEVEL! equ 0 (
     if defined CLAUDE_CONFIG_DIR (
@@ -494,6 +505,7 @@ if !ERRORLEVEL! equ 0 (
         set "CLAUDE_SKILLS_DIR=%USERPROFILE%\.claude\skills"
     )
     set "CODEX_SKILLS_DIR=%USERPROFILE%\.codex\skills"
+    set "AGENTS_SKILLS_DIR=%USERPROFILE%\.agents\skills"
     set "SKILLS_TMP=%TEMP%\plannotator-skills-%RANDOM%"
     mkdir "!SKILLS_TMP!" >nul 2>&1
 
@@ -505,9 +517,14 @@ if !ERRORLEVEL! equ 0 (
         if exist "apps\skills" (
             if not exist "!CLAUDE_SKILLS_DIR!" mkdir "!CLAUDE_SKILLS_DIR!"
             if not exist "!CODEX_SKILLS_DIR!" mkdir "!CODEX_SKILLS_DIR!"
+            if not exist "!AGENTS_SKILLS_DIR!" mkdir "!AGENTS_SKILLS_DIR!"
             xcopy /s /y /q "apps\skills\*" "!CLAUDE_SKILLS_DIR!\" >nul 2>&1
-            xcopy /s /y /q "apps\skills\*" "!CODEX_SKILLS_DIR!\" >nul 2>&1
-            echo Installed skills to !CLAUDE_SKILLS_DIR!\ and !CODEX_SKILLS_DIR!\
+            xcopy /s /i /y /q "apps\skills\plannotator-review" "!CODEX_SKILLS_DIR!\plannotator-review\" >nul 2>&1
+            xcopy /s /i /y /q "apps\skills\plannotator-annotate" "!CODEX_SKILLS_DIR!\plannotator-annotate\" >nul 2>&1
+            xcopy /s /i /y /q "apps\skills\plannotator-last" "!CODEX_SKILLS_DIR!\plannotator-last\" >nul 2>&1
+            xcopy /s /i /y /q "apps\skills\plannotator-compound" "!AGENTS_SKILLS_DIR!\plannotator-compound\" >nul 2>&1
+            xcopy /s /i /y /q "apps\skills\plannotator-setup-goal" "!AGENTS_SKILLS_DIR!\plannotator-setup-goal\" >nul 2>&1
+            echo Installed skills to !CLAUDE_SKILLS_DIR!\, Codex command skills to !CODEX_SKILLS_DIR!\, and shared agent skills to !AGENTS_SKILLS_DIR!\
         )
 
         popd

--- a/scripts/install.cmd
+++ b/scripts/install.cmd
@@ -475,6 +475,17 @@ echo Address the annotation feedback above. The user has reviewed your last mess
 echo Installed /plannotator-last command to !CLAUDE_COMMANDS_DIR!\plannotator-last.md
 
 REM Install skills (requires git)
+REM Remove legacy Codex-oriented skills from the older shared agent scope.
+set "LEGACY_AGENTS_SKILLS_DIR=%USERPROFILE%\.agents\skills"
+set "LEGACY_SKILLS_REMOVED=0"
+for %%S in (plannotator-review plannotator-annotate plannotator-last) do (
+    if exist "!LEGACY_AGENTS_SKILLS_DIR!\%%S" (
+        rmdir /s /q "!LEGACY_AGENTS_SKILLS_DIR!\%%S" >nul 2>&1
+        set "LEGACY_SKILLS_REMOVED=1"
+    )
+)
+if "!LEGACY_SKILLS_REMOVED!"=="1" echo Removed legacy Plannotator skills from !LEGACY_AGENTS_SKILLS_DIR!
+
 where git >nul 2>&1
 if !ERRORLEVEL! equ 0 (
     if defined CLAUDE_CONFIG_DIR (
@@ -482,7 +493,7 @@ if !ERRORLEVEL! equ 0 (
     ) else (
         set "CLAUDE_SKILLS_DIR=%USERPROFILE%\.claude\skills"
     )
-    set "AGENTS_SKILLS_DIR=%USERPROFILE%\.agents\skills"
+    set "CODEX_SKILLS_DIR=%USERPROFILE%\.codex\skills"
     set "SKILLS_TMP=%TEMP%\plannotator-skills-%RANDOM%"
     mkdir "!SKILLS_TMP!" >nul 2>&1
 
@@ -493,10 +504,10 @@ if !ERRORLEVEL! equ 0 (
 
         if exist "apps\skills" (
             if not exist "!CLAUDE_SKILLS_DIR!" mkdir "!CLAUDE_SKILLS_DIR!"
-            if not exist "!AGENTS_SKILLS_DIR!" mkdir "!AGENTS_SKILLS_DIR!"
+            if not exist "!CODEX_SKILLS_DIR!" mkdir "!CODEX_SKILLS_DIR!"
             xcopy /s /y /q "apps\skills\*" "!CLAUDE_SKILLS_DIR!\" >nul 2>&1
-            xcopy /s /y /q "apps\skills\*" "!AGENTS_SKILLS_DIR!\" >nul 2>&1
-            echo Installed skills to !CLAUDE_SKILLS_DIR!\ and !AGENTS_SKILLS_DIR!\
+            xcopy /s /y /q "apps\skills\*" "!CODEX_SKILLS_DIR!\" >nul 2>&1
+            echo Installed skills to !CLAUDE_SKILLS_DIR!\ and !CODEX_SKILLS_DIR!\
         )
 
         popd

--- a/scripts/install.cmd
+++ b/scripts/install.cmd
@@ -385,8 +385,15 @@ echo }
 REM Codex hooks on Windows are still experimental upstream. Do not mutate
 REM %%USERPROFILE%%\.codex automatically from the cmd installer until that path
 REM is verified end-to-end.
+set "CODEX_AVAILABLE=0"
 where codex >nul 2>&1
-if !ERRORLEVEL! equ 0 (
+if !ERRORLEVEL! equ 0 set "CODEX_AVAILABLE=1"
+if exist "%USERPROFILE%\.codex" (
+    for /f "delims=" %%C in ('dir /b /a "%USERPROFILE%\.codex" 2^>nul') do (
+        if /i not "%%C"=="skills" if /i not "%%C"==".DS_Store" set "CODEX_AVAILABLE=1"
+    )
+)
+if "!CODEX_AVAILABLE!"=="1" (
     echo.
     echo Codex detected.
     echo Codex plan review hooks are experimental on Windows. To try them manually:
@@ -516,15 +523,19 @@ if !ERRORLEVEL! equ 0 (
 
         if exist "apps\skills" (
             if not exist "!CLAUDE_SKILLS_DIR!" mkdir "!CLAUDE_SKILLS_DIR!"
-            if not exist "!CODEX_SKILLS_DIR!" mkdir "!CODEX_SKILLS_DIR!"
             if not exist "!AGENTS_SKILLS_DIR!" mkdir "!AGENTS_SKILLS_DIR!"
             xcopy /s /y /q "apps\skills\*" "!CLAUDE_SKILLS_DIR!\" >nul 2>&1
-            xcopy /s /i /y /q "apps\skills\plannotator-review" "!CODEX_SKILLS_DIR!\plannotator-review\" >nul 2>&1
-            xcopy /s /i /y /q "apps\skills\plannotator-annotate" "!CODEX_SKILLS_DIR!\plannotator-annotate\" >nul 2>&1
-            xcopy /s /i /y /q "apps\skills\plannotator-last" "!CODEX_SKILLS_DIR!\plannotator-last\" >nul 2>&1
-            xcopy /s /i /y /q "apps\skills\plannotator-compound" "!AGENTS_SKILLS_DIR!\plannotator-compound\" >nul 2>&1
-            xcopy /s /i /y /q "apps\skills\plannotator-setup-goal" "!AGENTS_SKILLS_DIR!\plannotator-setup-goal\" >nul 2>&1
-            echo Installed skills to !CLAUDE_SKILLS_DIR!\, Codex command skills to !CODEX_SKILLS_DIR!\, and shared agent skills to !AGENTS_SKILLS_DIR!\
+            if exist "apps\skills\plannotator-compound" xcopy /s /i /y /q "apps\skills\plannotator-compound" "!AGENTS_SKILLS_DIR!\plannotator-compound\" >nul 2>&1
+            if exist "apps\skills\plannotator-setup-goal" xcopy /s /i /y /q "apps\skills\plannotator-setup-goal" "!AGENTS_SKILLS_DIR!\plannotator-setup-goal\" >nul 2>&1
+            if "!CODEX_AVAILABLE!"=="1" (
+                if not exist "!CODEX_SKILLS_DIR!" mkdir "!CODEX_SKILLS_DIR!"
+                if exist "apps\skills\plannotator-review" xcopy /s /i /y /q "apps\skills\plannotator-review" "!CODEX_SKILLS_DIR!\plannotator-review\" >nul 2>&1
+                if exist "apps\skills\plannotator-annotate" xcopy /s /i /y /q "apps\skills\plannotator-annotate" "!CODEX_SKILLS_DIR!\plannotator-annotate\" >nul 2>&1
+                if exist "apps\skills\plannotator-last" xcopy /s /i /y /q "apps\skills\plannotator-last" "!CODEX_SKILLS_DIR!\plannotator-last\" >nul 2>&1
+                echo Installed skills to !CLAUDE_SKILLS_DIR!\, Codex command skills to !CODEX_SKILLS_DIR!\, and shared agent skills to !AGENTS_SKILLS_DIR!\
+            ) else (
+                echo Installed skills to !CLAUDE_SKILLS_DIR!\ and shared agent skills to !AGENTS_SKILLS_DIR!\
+            )
         )
 
         popd

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -408,10 +408,25 @@ if ($legacySkillsRemoved) {
     Write-Host "Removed legacy Plannotator skills from $legacyAgentsSkillsDir"
 }
 
+# Remove Plannotator skills that belong in the shared agent scope from Codex.
+$staleCodexSkillsDir = "$env:USERPROFILE\.codex\skills"
+$staleCodexSkillsRemoved = $false
+foreach ($skill in @("plannotator-compound", "plannotator-setup-goal")) {
+    $staleSkillPath = Join-Path $staleCodexSkillsDir $skill
+    if (Test-Path $staleSkillPath) {
+        Remove-Item -Recurse -Force $staleSkillPath -ErrorAction SilentlyContinue
+        $staleCodexSkillsRemoved = $true
+    }
+}
+if ($staleCodexSkillsRemoved) {
+    Write-Host "Removed shared-agent Plannotator skills from $staleCodexSkillsDir"
+}
+
 # Install skills (requires git)
 if (Get-Command git -ErrorAction SilentlyContinue) {
     $claudeSkillsDir = if ($env:CLAUDE_CONFIG_DIR) { "$env:CLAUDE_CONFIG_DIR\skills" } else { "$env:USERPROFILE\.claude\skills" }
     $codexSkillsDir = "$env:USERPROFILE\.codex\skills"
+    $agentsSkillsDir = "$env:USERPROFILE\.agents\skills"
     $skillsTmp = Join-Path ([System.IO.Path]::GetTempPath()) "plannotator-skills-$(Get-Random)"
     New-Item -ItemType Directory -Force -Path $skillsTmp | Out-Null
 
@@ -436,9 +451,14 @@ if (Get-Command git -ErrorAction SilentlyContinue) {
                     if ($items) {
                         New-Item -ItemType Directory -Force -Path $claudeSkillsDir | Out-Null
                         New-Item -ItemType Directory -Force -Path $codexSkillsDir | Out-Null
+                        New-Item -ItemType Directory -Force -Path $agentsSkillsDir | Out-Null
                         Copy-Item -Recurse -Force "apps\skills\*" $claudeSkillsDir
-                        Copy-Item -Recurse -Force "apps\skills\*" $codexSkillsDir
-                        Write-Host "Installed skills to $claudeSkillsDir\ and $codexSkillsDir\"
+                        Copy-Item -Recurse -Force "apps\skills\plannotator-review" $codexSkillsDir
+                        Copy-Item -Recurse -Force "apps\skills\plannotator-annotate" $codexSkillsDir
+                        Copy-Item -Recurse -Force "apps\skills\plannotator-last" $codexSkillsDir
+                        Copy-Item -Recurse -Force "apps\skills\plannotator-compound" $agentsSkillsDir
+                        Copy-Item -Recurse -Force "apps\skills\plannotator-setup-goal" $agentsSkillsDir
+                        Write-Host "Installed skills to $claudeSkillsDir\, Codex command skills to $codexSkillsDir\, and shared agent skills to $agentsSkillsDir\"
                     }
                 }
             } finally {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -270,7 +270,15 @@ if (Test-Path $pluginHooks) {
 # $env:USERPROFILE\.codex automatically from the Windows installer until that
 # path is verified end-to-end.
 $codexDir = "$env:USERPROFILE\.codex"
-if ((Get-Command codex -ErrorAction SilentlyContinue) -or (Test-Path $codexDir)) {
+$codexHomeHasUserConfig = $false
+if (Test-Path $codexDir) {
+    $codexHomeHasUserConfig = [bool](Get-ChildItem -Force $codexDir -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -ne "skills" -and $_.Name -ne ".DS_Store" } |
+        Select-Object -First 1)
+}
+$codexAvailable = [bool](Get-Command codex -ErrorAction SilentlyContinue) -or $codexHomeHasUserConfig
+
+if ($codexAvailable) {
     $codexExePath = "$installDir\plannotator.exe"
     Write-Host ""
     Write-Host "Codex detected."
@@ -430,6 +438,17 @@ if (Get-Command git -ErrorAction SilentlyContinue) {
     $skillsTmp = Join-Path ([System.IO.Path]::GetTempPath()) "plannotator-skills-$(Get-Random)"
     New-Item -ItemType Directory -Force -Path $skillsTmp | Out-Null
 
+    function Copy-SkillIfPresent {
+        param(
+            [string]$SourceDir,
+            [string]$TargetDir
+        )
+
+        if (Test-Path $SourceDir) {
+            Copy-Item -Recurse -Force $SourceDir $TargetDir
+        }
+    }
+
     try {
         git clone --depth 1 --filter=blob:none --sparse "https://github.com/$repo.git" --branch $latestTag "$skillsTmp\repo" 2>$null
         # git is a native executable — it does not throw under
@@ -450,15 +469,19 @@ if (Get-Command git -ErrorAction SilentlyContinue) {
                     $items = Get-ChildItem "apps\skills" -ErrorAction SilentlyContinue
                     if ($items) {
                         New-Item -ItemType Directory -Force -Path $claudeSkillsDir | Out-Null
-                        New-Item -ItemType Directory -Force -Path $codexSkillsDir | Out-Null
                         New-Item -ItemType Directory -Force -Path $agentsSkillsDir | Out-Null
                         Copy-Item -Recurse -Force "apps\skills\*" $claudeSkillsDir
-                        Copy-Item -Recurse -Force "apps\skills\plannotator-review" $codexSkillsDir
-                        Copy-Item -Recurse -Force "apps\skills\plannotator-annotate" $codexSkillsDir
-                        Copy-Item -Recurse -Force "apps\skills\plannotator-last" $codexSkillsDir
-                        Copy-Item -Recurse -Force "apps\skills\plannotator-compound" $agentsSkillsDir
-                        Copy-Item -Recurse -Force "apps\skills\plannotator-setup-goal" $agentsSkillsDir
-                        Write-Host "Installed skills to $claudeSkillsDir\, Codex command skills to $codexSkillsDir\, and shared agent skills to $agentsSkillsDir\"
+                        Copy-SkillIfPresent "apps\skills\plannotator-compound" $agentsSkillsDir
+                        Copy-SkillIfPresent "apps\skills\plannotator-setup-goal" $agentsSkillsDir
+                        if ($codexAvailable) {
+                            New-Item -ItemType Directory -Force -Path $codexSkillsDir | Out-Null
+                            Copy-SkillIfPresent "apps\skills\plannotator-review" $codexSkillsDir
+                            Copy-SkillIfPresent "apps\skills\plannotator-annotate" $codexSkillsDir
+                            Copy-SkillIfPresent "apps\skills\plannotator-last" $codexSkillsDir
+                            Write-Host "Installed skills to $claudeSkillsDir\, Codex command skills to $codexSkillsDir\, and shared agent skills to $agentsSkillsDir\"
+                        } else {
+                            Write-Host "Installed skills to $claudeSkillsDir\ and shared agent skills to $agentsSkillsDir\"
+                        }
                     }
                 }
             } finally {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -394,10 +394,24 @@ description: Annotate the last assistant message
 
 Write-Host "Installed /plannotator-last command to $opencodeCommandsDir\plannotator-last.md"
 
+# Remove legacy Codex-oriented skills from the older shared agent scope.
+$legacyAgentsSkillsDir = "$env:USERPROFILE\.agents\skills"
+$legacySkillsRemoved = $false
+foreach ($skill in @("plannotator-review", "plannotator-annotate", "plannotator-last")) {
+    $legacySkillPath = Join-Path $legacyAgentsSkillsDir $skill
+    if (Test-Path $legacySkillPath) {
+        Remove-Item -Recurse -Force $legacySkillPath -ErrorAction SilentlyContinue
+        $legacySkillsRemoved = $true
+    }
+}
+if ($legacySkillsRemoved) {
+    Write-Host "Removed legacy Plannotator skills from $legacyAgentsSkillsDir"
+}
+
 # Install skills (requires git)
 if (Get-Command git -ErrorAction SilentlyContinue) {
     $claudeSkillsDir = if ($env:CLAUDE_CONFIG_DIR) { "$env:CLAUDE_CONFIG_DIR\skills" } else { "$env:USERPROFILE\.claude\skills" }
-    $agentsSkillsDir = "$env:USERPROFILE\.agents\skills"
+    $codexSkillsDir = "$env:USERPROFILE\.codex\skills"
     $skillsTmp = Join-Path ([System.IO.Path]::GetTempPath()) "plannotator-skills-$(Get-Random)"
     New-Item -ItemType Directory -Force -Path $skillsTmp | Out-Null
 
@@ -421,10 +435,10 @@ if (Get-Command git -ErrorAction SilentlyContinue) {
                     $items = Get-ChildItem "apps\skills" -ErrorAction SilentlyContinue
                     if ($items) {
                         New-Item -ItemType Directory -Force -Path $claudeSkillsDir | Out-Null
-                        New-Item -ItemType Directory -Force -Path $agentsSkillsDir | Out-Null
+                        New-Item -ItemType Directory -Force -Path $codexSkillsDir | Out-Null
                         Copy-Item -Recurse -Force "apps\skills\*" $claudeSkillsDir
-                        Copy-Item -Recurse -Force "apps\skills\*" $agentsSkillsDir
-                        Write-Host "Installed skills to $claudeSkillsDir\ and $agentsSkillsDir\"
+                        Copy-Item -Recurse -Force "apps\skills\*" $codexSkillsDir
+                        Write-Host "Installed skills to $claudeSkillsDir\ and $codexSkillsDir\"
                     }
                 }
             } finally {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -639,10 +639,26 @@ if [ "$legacy_skills_removed" -eq 1 ]; then
     echo "Removed legacy Plannotator skills from ${LEGACY_AGENTS_SKILLS_DIR}"
 fi
 
+# Remove Plannotator skills that belong in the shared agent scope from Codex.
+STALE_CODEX_SKILLS_DIR="$HOME/.codex/skills"
+stale_codex_skills_removed=0
+if [ -d "$STALE_CODEX_SKILLS_DIR" ]; then
+    for skill in plannotator-compound plannotator-setup-goal; do
+        if [ -d "$STALE_CODEX_SKILLS_DIR/$skill" ]; then
+            rm -rf "$STALE_CODEX_SKILLS_DIR/$skill"
+            stale_codex_skills_removed=1
+        fi
+    done
+fi
+if [ "$stale_codex_skills_removed" -eq 1 ]; then
+    echo "Removed shared-agent Plannotator skills from ${STALE_CODEX_SKILLS_DIR}"
+fi
+
 # Install skills (requires git)
 if command -v git &>/dev/null; then
     CLAUDE_SKILLS_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills"
     CODEX_SKILLS_DIR="$HOME/.codex/skills"
+    AGENTS_SKILLS_DIR="$HOME/.agents/skills"
     skills_tmp=$(mktemp -d)
 
     # Wrap the cd-bearing block in a subshell so any `cd` is scoped to
@@ -664,11 +680,15 @@ if command -v git &>/dev/null; then
         git sparse-checkout set apps/skills 2>/dev/null &&
         [ -d "apps/skills" ] &&
         [ "$(ls -A apps/skills 2>/dev/null)" ] &&
-        mkdir -p "$CLAUDE_SKILLS_DIR" "$CODEX_SKILLS_DIR" &&
+        mkdir -p "$CLAUDE_SKILLS_DIR" "$CODEX_SKILLS_DIR" "$AGENTS_SKILLS_DIR" &&
         cp -r apps/skills/* "$CLAUDE_SKILLS_DIR/" &&
-        cp -r apps/skills/* "$CODEX_SKILLS_DIR/"
+        cp -r apps/skills/plannotator-review "$CODEX_SKILLS_DIR/" &&
+        cp -r apps/skills/plannotator-annotate "$CODEX_SKILLS_DIR/" &&
+        cp -r apps/skills/plannotator-last "$CODEX_SKILLS_DIR/" &&
+        cp -r apps/skills/plannotator-compound "$AGENTS_SKILLS_DIR/" &&
+        cp -r apps/skills/plannotator-setup-goal "$AGENTS_SKILLS_DIR/"
     ); then
-        echo "Installed skills to ${CLAUDE_SKILLS_DIR}/ and ${CODEX_SKILLS_DIR}/"
+        echo "Installed skills to ${CLAUDE_SKILLS_DIR}/, Codex command skills to ${CODEX_SKILLS_DIR}/, and shared agent skills to ${AGENTS_SKILLS_DIR}/"
     else
         echo "Skipping skills install (git sparse-checkout failed or apps/skills empty)"
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -314,7 +314,17 @@ if ! echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
 fi
 
 # --- Codex CLI / Desktop app support (only if Codex is installed or configured) ---
-if command -v codex >/dev/null 2>&1 || [ -d "$HOME/.codex" ]; then
+codex_home_has_user_config() {
+    [ -d "$HOME/.codex" ] || return 1
+    [ -n "$(find "$HOME/.codex" -mindepth 1 -maxdepth 1 ! -name skills ! -name .DS_Store -print -quit 2>/dev/null)" ]
+}
+
+codex_available=0
+if command -v codex >/dev/null 2>&1 || codex_home_has_user_config; then
+    codex_available=1
+fi
+
+if [ "$codex_available" -eq 1 ]; then
     CODEX_DIR="$HOME/.codex"
     CODEX_CONFIG="$CODEX_DIR/config.toml"
     CODEX_HOOKS="$CODEX_DIR/hooks.json"
@@ -661,6 +671,15 @@ if command -v git &>/dev/null; then
     AGENTS_SKILLS_DIR="$HOME/.agents/skills"
     skills_tmp=$(mktemp -d)
 
+    copy_skill_if_present() {
+        local source_dir="$1"
+        local target_dir="$2"
+
+        if [ -d "$source_dir" ]; then
+            cp -r "$source_dir" "$target_dir/"
+        fi
+    }
+
     # Wrap the cd-bearing block in a subshell so any `cd` is scoped to
     # the subshell and can't leave the parent script with a dangling CWD.
     # Previous version chained `cd` inside an `&&` condition, and if
@@ -673,22 +692,30 @@ if command -v git &>/dev/null; then
     # equivalent — the parent shell's CWD is inherited in, and any
     # cd inside the subshell disappears when the subshell exits.
     if (
-        cd "$skills_tmp" &&
+        set -e
+        cd "$skills_tmp"
         git clone --depth 1 --filter=blob:none --sparse \
-            "https://github.com/${REPO}.git" --branch "$latest_tag" repo 2>/dev/null &&
-        cd repo &&
-        git sparse-checkout set apps/skills 2>/dev/null &&
-        [ -d "apps/skills" ] &&
-        [ "$(ls -A apps/skills 2>/dev/null)" ] &&
-        mkdir -p "$CLAUDE_SKILLS_DIR" "$CODEX_SKILLS_DIR" "$AGENTS_SKILLS_DIR" &&
-        cp -r apps/skills/* "$CLAUDE_SKILLS_DIR/" &&
-        cp -r apps/skills/plannotator-review "$CODEX_SKILLS_DIR/" &&
-        cp -r apps/skills/plannotator-annotate "$CODEX_SKILLS_DIR/" &&
-        cp -r apps/skills/plannotator-last "$CODEX_SKILLS_DIR/" &&
-        cp -r apps/skills/plannotator-compound "$AGENTS_SKILLS_DIR/" &&
-        cp -r apps/skills/plannotator-setup-goal "$AGENTS_SKILLS_DIR/"
+            "https://github.com/${REPO}.git" --branch "$latest_tag" repo 2>/dev/null
+        cd repo
+        git sparse-checkout set apps/skills 2>/dev/null
+        [ -d "apps/skills" ]
+        [ "$(ls -A apps/skills 2>/dev/null)" ]
+        mkdir -p "$CLAUDE_SKILLS_DIR" "$AGENTS_SKILLS_DIR"
+        cp -r apps/skills/* "$CLAUDE_SKILLS_DIR/"
+        copy_skill_if_present apps/skills/plannotator-compound "$AGENTS_SKILLS_DIR"
+        copy_skill_if_present apps/skills/plannotator-setup-goal "$AGENTS_SKILLS_DIR"
+        if [ "$codex_available" -eq 1 ]; then
+            mkdir -p "$CODEX_SKILLS_DIR"
+            copy_skill_if_present apps/skills/plannotator-review "$CODEX_SKILLS_DIR"
+            copy_skill_if_present apps/skills/plannotator-annotate "$CODEX_SKILLS_DIR"
+            copy_skill_if_present apps/skills/plannotator-last "$CODEX_SKILLS_DIR"
+        fi
     ); then
-        echo "Installed skills to ${CLAUDE_SKILLS_DIR}/, Codex command skills to ${CODEX_SKILLS_DIR}/, and shared agent skills to ${AGENTS_SKILLS_DIR}/"
+        if [ "$codex_available" -eq 1 ]; then
+            echo "Installed skills to ${CLAUDE_SKILLS_DIR}/, Codex command skills to ${CODEX_SKILLS_DIR}/, and shared agent skills to ${AGENTS_SKILLS_DIR}/"
+        else
+            echo "Installed skills to ${CLAUDE_SKILLS_DIR}/ and shared agent skills to ${AGENTS_SKILLS_DIR}/"
+        fi
     else
         echo "Skipping skills install (git sparse-checkout failed or apps/skills empty)"
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -624,10 +624,25 @@ COMMAND_EOF
 
 echo "Installed /plannotator-last command to ${OPENCODE_COMMANDS_DIR}/plannotator-last.md"
 
+# Remove legacy Codex-oriented skills from the older shared agent scope.
+LEGACY_AGENTS_SKILLS_DIR="$HOME/.agents/skills"
+legacy_skills_removed=0
+if [ -d "$LEGACY_AGENTS_SKILLS_DIR" ]; then
+    for skill in plannotator-review plannotator-annotate plannotator-last; do
+        if [ -d "$LEGACY_AGENTS_SKILLS_DIR/$skill" ]; then
+            rm -rf "$LEGACY_AGENTS_SKILLS_DIR/$skill"
+            legacy_skills_removed=1
+        fi
+    done
+fi
+if [ "$legacy_skills_removed" -eq 1 ]; then
+    echo "Removed legacy Plannotator skills from ${LEGACY_AGENTS_SKILLS_DIR}"
+fi
+
 # Install skills (requires git)
 if command -v git &>/dev/null; then
     CLAUDE_SKILLS_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills"
-    AGENTS_SKILLS_DIR="$HOME/.agents/skills"
+    CODEX_SKILLS_DIR="$HOME/.codex/skills"
     skills_tmp=$(mktemp -d)
 
     # Wrap the cd-bearing block in a subshell so any `cd` is scoped to
@@ -649,11 +664,11 @@ if command -v git &>/dev/null; then
         git sparse-checkout set apps/skills 2>/dev/null &&
         [ -d "apps/skills" ] &&
         [ "$(ls -A apps/skills 2>/dev/null)" ] &&
-        mkdir -p "$CLAUDE_SKILLS_DIR" "$AGENTS_SKILLS_DIR" &&
+        mkdir -p "$CLAUDE_SKILLS_DIR" "$CODEX_SKILLS_DIR" &&
         cp -r apps/skills/* "$CLAUDE_SKILLS_DIR/" &&
-        cp -r apps/skills/* "$AGENTS_SKILLS_DIR/"
+        cp -r apps/skills/* "$CODEX_SKILLS_DIR/"
     ); then
-        echo "Installed skills to ${CLAUDE_SKILLS_DIR}/ and ${AGENTS_SKILLS_DIR}/"
+        echo "Installed skills to ${CLAUDE_SKILLS_DIR}/ and ${CODEX_SKILLS_DIR}/"
     else
         echo "Skipping skills install (git sparse-checkout failed or apps/skills empty)"
     fi

--- a/scripts/install.test.ts
+++ b/scripts/install.test.ts
@@ -57,8 +57,15 @@ describe("install.sh", () => {
     expect(script).toContain("git sparse-checkout set apps/skills");
     expect(script).toContain("CLAUDE_SKILLS_DIR");
     expect(script).toContain("CODEX_SKILLS_DIR");
+    expect(script).toContain("AGENTS_SKILLS_DIR");
     expect(script).toContain("$HOME/.codex/skills");
-    expect(script).not.toContain('mkdir -p "$CLAUDE_SKILLS_DIR" "$AGENTS_SKILLS_DIR"');
+    expect(script).toContain("$HOME/.agents/skills");
+    expect(script).toContain('cp -r apps/skills/plannotator-review "$CODEX_SKILLS_DIR/"');
+    expect(script).toContain('cp -r apps/skills/plannotator-annotate "$CODEX_SKILLS_DIR/"');
+    expect(script).toContain('cp -r apps/skills/plannotator-last "$CODEX_SKILLS_DIR/"');
+    expect(script).toContain('cp -r apps/skills/plannotator-compound "$AGENTS_SKILLS_DIR/"');
+    expect(script).toContain('cp -r apps/skills/plannotator-setup-goal "$AGENTS_SKILLS_DIR/"');
+    expect(script).not.toContain('cp -r apps/skills/* "$CODEX_SKILLS_DIR/"');
     expect(script).not.toContain('cp -r apps/skills/* "$AGENTS_SKILLS_DIR/"');
     expect(script).toContain('Skipping skills install (git not found)');
   });
@@ -68,6 +75,11 @@ describe("install.sh", () => {
     expect(script).toContain("plannotator-review plannotator-annotate plannotator-last");
     expect(script).not.toContain("plannotator-review plannotator-annotate plannotator-last plannotator-compound");
     expect(script).not.toContain("plannotator-review plannotator-annotate plannotator-last plannotator-setup-goal");
+  });
+
+  test("removes shared-agent Plannotator skills from Codex scope", () => {
+    expect(script).toContain("STALE_CODEX_SKILLS_DIR");
+    expect(script).toContain("plannotator-compound plannotator-setup-goal");
   });
 
   test("installs slash commands for Claude Code and OpenCode", () => {
@@ -158,8 +170,16 @@ describe("install.ps1", () => {
     expect(script).toContain("git sparse-checkout set apps/skills");
     expect(script).toContain("claudeSkillsDir");
     expect(script).toContain("codexSkillsDir");
+    expect(script).toContain("agentsSkillsDir");
     expect(script).toContain("$env:USERPROFILE\\.codex\\skills");
-    expect(script).not.toContain('$agentsSkillsDir = "$env:USERPROFILE\\.agents\\skills"');
+    expect(script).toContain("$env:USERPROFILE\\.agents\\skills");
+    expect(script).toContain('Copy-Item -Recurse -Force "apps\\skills\\plannotator-review" $codexSkillsDir');
+    expect(script).toContain('Copy-Item -Recurse -Force "apps\\skills\\plannotator-annotate" $codexSkillsDir');
+    expect(script).toContain('Copy-Item -Recurse -Force "apps\\skills\\plannotator-last" $codexSkillsDir');
+    expect(script).toContain('Copy-Item -Recurse -Force "apps\\skills\\plannotator-compound" $agentsSkillsDir');
+    expect(script).toContain('Copy-Item -Recurse -Force "apps\\skills\\plannotator-setup-goal" $agentsSkillsDir');
+    expect(script).not.toContain('Copy-Item -Recurse -Force "apps\\skills\\*" $codexSkillsDir');
+    expect(script).not.toContain('Copy-Item -Recurse -Force "apps\\skills\\*" $agentsSkillsDir');
     expect(script).toContain('Skipping skills install (git not found)');
   });
 
@@ -168,6 +188,11 @@ describe("install.ps1", () => {
     expect(script).toContain('"plannotator-review", "plannotator-annotate", "plannotator-last"');
     expect(script).not.toContain('"plannotator-review", "plannotator-annotate", "plannotator-last", "plannotator-compound"');
     expect(script).not.toContain('"plannotator-review", "plannotator-annotate", "plannotator-last", "plannotator-setup-goal"');
+  });
+
+  test("removes shared-agent Plannotator skills from Codex scope", () => {
+    expect(script).toContain("staleCodexSkillsDir");
+    expect(script).toContain('"plannotator-compound", "plannotator-setup-goal"');
   });
 
   test("installs slash commands", () => {
@@ -228,8 +253,16 @@ describe("install.cmd", () => {
     expect(script).toContain("git sparse-checkout set apps/skills");
     expect(script).toContain("CLAUDE_SKILLS_DIR");
     expect(script).toContain("CODEX_SKILLS_DIR");
+    expect(script).toContain("AGENTS_SKILLS_DIR");
     expect(script).toContain("%USERPROFILE%\\.codex\\skills");
-    expect(script).not.toContain('set "AGENTS_SKILLS_DIR=%USERPROFILE%\\.agents\\skills"');
+    expect(script).toContain("%USERPROFILE%\\.agents\\skills");
+    expect(script).toContain('xcopy /s /i /y /q "apps\\skills\\plannotator-review" "!CODEX_SKILLS_DIR!\\plannotator-review\\"');
+    expect(script).toContain('xcopy /s /i /y /q "apps\\skills\\plannotator-annotate" "!CODEX_SKILLS_DIR!\\plannotator-annotate\\"');
+    expect(script).toContain('xcopy /s /i /y /q "apps\\skills\\plannotator-last" "!CODEX_SKILLS_DIR!\\plannotator-last\\"');
+    expect(script).toContain('xcopy /s /i /y /q "apps\\skills\\plannotator-compound" "!AGENTS_SKILLS_DIR!\\plannotator-compound\\"');
+    expect(script).toContain('xcopy /s /i /y /q "apps\\skills\\plannotator-setup-goal" "!AGENTS_SKILLS_DIR!\\plannotator-setup-goal\\"');
+    expect(script).not.toContain('xcopy /s /y /q "apps\\skills\\*" "!CODEX_SKILLS_DIR!\\"');
+    expect(script).not.toContain('xcopy /s /y /q "apps\\skills\\*" "!AGENTS_SKILLS_DIR!\\"');
     expect(script).toContain("Skipping skills install");
   });
 
@@ -238,6 +271,11 @@ describe("install.cmd", () => {
     expect(script).toContain("plannotator-review plannotator-annotate plannotator-last");
     expect(script).not.toContain("plannotator-review plannotator-annotate plannotator-last plannotator-compound");
     expect(script).not.toContain("plannotator-review plannotator-annotate plannotator-last plannotator-setup-goal");
+  });
+
+  test("removes shared-agent Plannotator skills from Codex scope", () => {
+    expect(script).toContain("STALE_CODEX_SKILLS_DIR");
+    expect(script).toContain("plannotator-compound plannotator-setup-goal");
   });
 
   test("installs slash commands", () => {

--- a/scripts/install.test.ts
+++ b/scripts/install.test.ts
@@ -60,13 +60,16 @@ describe("install.sh", () => {
     expect(script).toContain("AGENTS_SKILLS_DIR");
     expect(script).toContain("$HOME/.codex/skills");
     expect(script).toContain("$HOME/.agents/skills");
-    expect(script).toContain('cp -r apps/skills/plannotator-review "$CODEX_SKILLS_DIR/"');
-    expect(script).toContain('cp -r apps/skills/plannotator-annotate "$CODEX_SKILLS_DIR/"');
-    expect(script).toContain('cp -r apps/skills/plannotator-last "$CODEX_SKILLS_DIR/"');
-    expect(script).toContain('cp -r apps/skills/plannotator-compound "$AGENTS_SKILLS_DIR/"');
-    expect(script).toContain('cp -r apps/skills/plannotator-setup-goal "$AGENTS_SKILLS_DIR/"');
+    expect(script).toContain("copy_skill_if_present");
+    expect(script).toContain('copy_skill_if_present apps/skills/plannotator-review "$CODEX_SKILLS_DIR"');
+    expect(script).toContain('copy_skill_if_present apps/skills/plannotator-annotate "$CODEX_SKILLS_DIR"');
+    expect(script).toContain('copy_skill_if_present apps/skills/plannotator-last "$CODEX_SKILLS_DIR"');
+    expect(script).toContain('copy_skill_if_present apps/skills/plannotator-compound "$AGENTS_SKILLS_DIR"');
+    expect(script).toContain('copy_skill_if_present apps/skills/plannotator-setup-goal "$AGENTS_SKILLS_DIR"');
+    expect(script).toContain('if [ "$codex_available" -eq 1 ]; then');
     expect(script).not.toContain('cp -r apps/skills/* "$CODEX_SKILLS_DIR/"');
     expect(script).not.toContain('cp -r apps/skills/* "$AGENTS_SKILLS_DIR/"');
+    expect(script).not.toContain('cp -r apps/skills/plannotator-review "$CODEX_SKILLS_DIR/"');
     expect(script).toContain('Skipping skills install (git not found)');
   });
 
@@ -98,6 +101,13 @@ describe("install.sh", () => {
     expect(script).toContain('codex_hook_configured=1');
     expect(script).toContain('if [ "$codex_hook_configured" -eq 1 ]; then');
     expect(script).toContain("Leaving Codex hook support unchanged");
+  });
+
+  test("does not treat a skills-only Codex home as configured", () => {
+    expect(script).toContain("codex_home_has_user_config");
+    expect(script).toContain("! -name skills");
+    expect(script).toContain("codex_available=1");
+    expect(script).not.toContain('if command -v codex >/dev/null 2>&1 || [ -d "$HOME/.codex" ]; then');
   });
 
   test("does not rewrite inline Codex features config", () => {
@@ -173,13 +183,16 @@ describe("install.ps1", () => {
     expect(script).toContain("agentsSkillsDir");
     expect(script).toContain("$env:USERPROFILE\\.codex\\skills");
     expect(script).toContain("$env:USERPROFILE\\.agents\\skills");
-    expect(script).toContain('Copy-Item -Recurse -Force "apps\\skills\\plannotator-review" $codexSkillsDir');
-    expect(script).toContain('Copy-Item -Recurse -Force "apps\\skills\\plannotator-annotate" $codexSkillsDir');
-    expect(script).toContain('Copy-Item -Recurse -Force "apps\\skills\\plannotator-last" $codexSkillsDir');
-    expect(script).toContain('Copy-Item -Recurse -Force "apps\\skills\\plannotator-compound" $agentsSkillsDir');
-    expect(script).toContain('Copy-Item -Recurse -Force "apps\\skills\\plannotator-setup-goal" $agentsSkillsDir');
+    expect(script).toContain("Copy-SkillIfPresent");
+    expect(script).toContain('Copy-SkillIfPresent "apps\\skills\\plannotator-review" $codexSkillsDir');
+    expect(script).toContain('Copy-SkillIfPresent "apps\\skills\\plannotator-annotate" $codexSkillsDir');
+    expect(script).toContain('Copy-SkillIfPresent "apps\\skills\\plannotator-last" $codexSkillsDir');
+    expect(script).toContain('Copy-SkillIfPresent "apps\\skills\\plannotator-compound" $agentsSkillsDir');
+    expect(script).toContain('Copy-SkillIfPresent "apps\\skills\\plannotator-setup-goal" $agentsSkillsDir');
+    expect(script).toContain("if ($codexAvailable)");
     expect(script).not.toContain('Copy-Item -Recurse -Force "apps\\skills\\*" $codexSkillsDir');
     expect(script).not.toContain('Copy-Item -Recurse -Force "apps\\skills\\*" $agentsSkillsDir');
+    expect(script).not.toContain('Copy-Item -Recurse -Force "apps\\skills\\plannotator-review" $codexSkillsDir');
     expect(script).toContain('Skipping skills install (git not found)');
   });
 
@@ -193,6 +206,12 @@ describe("install.ps1", () => {
   test("removes shared-agent Plannotator skills from Codex scope", () => {
     expect(script).toContain("staleCodexSkillsDir");
     expect(script).toContain('"plannotator-compound", "plannotator-setup-goal"');
+  });
+
+  test("does not treat a skills-only Codex home as configured", () => {
+    expect(script).toContain("codexHomeHasUserConfig");
+    expect(script).toContain('$_.Name -ne "skills"');
+    expect(script).toContain("$codexAvailable");
   });
 
   test("installs slash commands", () => {
@@ -256,11 +275,12 @@ describe("install.cmd", () => {
     expect(script).toContain("AGENTS_SKILLS_DIR");
     expect(script).toContain("%USERPROFILE%\\.codex\\skills");
     expect(script).toContain("%USERPROFILE%\\.agents\\skills");
-    expect(script).toContain('xcopy /s /i /y /q "apps\\skills\\plannotator-review" "!CODEX_SKILLS_DIR!\\plannotator-review\\"');
-    expect(script).toContain('xcopy /s /i /y /q "apps\\skills\\plannotator-annotate" "!CODEX_SKILLS_DIR!\\plannotator-annotate\\"');
-    expect(script).toContain('xcopy /s /i /y /q "apps\\skills\\plannotator-last" "!CODEX_SKILLS_DIR!\\plannotator-last\\"');
-    expect(script).toContain('xcopy /s /i /y /q "apps\\skills\\plannotator-compound" "!AGENTS_SKILLS_DIR!\\plannotator-compound\\"');
-    expect(script).toContain('xcopy /s /i /y /q "apps\\skills\\plannotator-setup-goal" "!AGENTS_SKILLS_DIR!\\plannotator-setup-goal\\"');
+    expect(script).toContain('if "!CODEX_AVAILABLE!"=="1"');
+    expect(script).toContain('if exist "apps\\skills\\plannotator-review" xcopy /s /i /y /q "apps\\skills\\plannotator-review" "!CODEX_SKILLS_DIR!\\plannotator-review\\"');
+    expect(script).toContain('if exist "apps\\skills\\plannotator-annotate" xcopy /s /i /y /q "apps\\skills\\plannotator-annotate" "!CODEX_SKILLS_DIR!\\plannotator-annotate\\"');
+    expect(script).toContain('if exist "apps\\skills\\plannotator-last" xcopy /s /i /y /q "apps\\skills\\plannotator-last" "!CODEX_SKILLS_DIR!\\plannotator-last\\"');
+    expect(script).toContain('if exist "apps\\skills\\plannotator-compound" xcopy /s /i /y /q "apps\\skills\\plannotator-compound" "!AGENTS_SKILLS_DIR!\\plannotator-compound\\"');
+    expect(script).toContain('if exist "apps\\skills\\plannotator-setup-goal" xcopy /s /i /y /q "apps\\skills\\plannotator-setup-goal" "!AGENTS_SKILLS_DIR!\\plannotator-setup-goal\\"');
     expect(script).not.toContain('xcopy /s /y /q "apps\\skills\\*" "!CODEX_SKILLS_DIR!\\"');
     expect(script).not.toContain('xcopy /s /y /q "apps\\skills\\*" "!AGENTS_SKILLS_DIR!\\"');
     expect(script).toContain("Skipping skills install");
@@ -276,6 +296,11 @@ describe("install.cmd", () => {
   test("removes shared-agent Plannotator skills from Codex scope", () => {
     expect(script).toContain("STALE_CODEX_SKILLS_DIR");
     expect(script).toContain("plannotator-compound plannotator-setup-goal");
+  });
+
+  test("does not treat a skills-only Codex home as configured", () => {
+    expect(script).toContain("CODEX_AVAILABLE");
+    expect(script).toContain('if /i not "%%C"=="skills"');
   });
 
   test("installs slash commands", () => {

--- a/scripts/install.test.ts
+++ b/scripts/install.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 const scriptsDir = import.meta.dir;
@@ -56,8 +56,18 @@ describe("install.sh", () => {
     expect(script).toContain("git clone --depth 1 --filter=blob:none --sparse");
     expect(script).toContain("git sparse-checkout set apps/skills");
     expect(script).toContain("CLAUDE_SKILLS_DIR");
-    expect(script).toContain("AGENTS_SKILLS_DIR");
+    expect(script).toContain("CODEX_SKILLS_DIR");
+    expect(script).toContain("$HOME/.codex/skills");
+    expect(script).not.toContain('mkdir -p "$CLAUDE_SKILLS_DIR" "$AGENTS_SKILLS_DIR"');
+    expect(script).not.toContain('cp -r apps/skills/* "$AGENTS_SKILLS_DIR/"');
     expect(script).toContain('Skipping skills install (git not found)');
+  });
+
+  test("cleans only legacy command-overlap agent skills", () => {
+    expect(script).toContain("LEGACY_AGENTS_SKILLS_DIR");
+    expect(script).toContain("plannotator-review plannotator-annotate plannotator-last");
+    expect(script).not.toContain("plannotator-review plannotator-annotate plannotator-last plannotator-compound");
+    expect(script).not.toContain("plannotator-review plannotator-annotate plannotator-last plannotator-setup-goal");
   });
 
   test("installs slash commands for Claude Code and OpenCode", () => {
@@ -147,8 +157,17 @@ describe("install.ps1", () => {
     expect(script).toContain("git clone --depth 1 --filter=blob:none --sparse");
     expect(script).toContain("git sparse-checkout set apps/skills");
     expect(script).toContain("claudeSkillsDir");
-    expect(script).toContain("agentsSkillsDir");
+    expect(script).toContain("codexSkillsDir");
+    expect(script).toContain("$env:USERPROFILE\\.codex\\skills");
+    expect(script).not.toContain('$agentsSkillsDir = "$env:USERPROFILE\\.agents\\skills"');
     expect(script).toContain('Skipping skills install (git not found)');
+  });
+
+  test("cleans only legacy command-overlap agent skills", () => {
+    expect(script).toContain("legacyAgentsSkillsDir");
+    expect(script).toContain('"plannotator-review", "plannotator-annotate", "plannotator-last"');
+    expect(script).not.toContain('"plannotator-review", "plannotator-annotate", "plannotator-last", "plannotator-compound"');
+    expect(script).not.toContain('"plannotator-review", "plannotator-annotate", "plannotator-last", "plannotator-setup-goal"');
   });
 
   test("installs slash commands", () => {
@@ -208,8 +227,17 @@ describe("install.cmd", () => {
     expect(script).toContain("git clone --depth 1 --filter=blob:none --sparse");
     expect(script).toContain("git sparse-checkout set apps/skills");
     expect(script).toContain("CLAUDE_SKILLS_DIR");
-    expect(script).toContain("AGENTS_SKILLS_DIR");
+    expect(script).toContain("CODEX_SKILLS_DIR");
+    expect(script).toContain("%USERPROFILE%\\.codex\\skills");
+    expect(script).not.toContain('set "AGENTS_SKILLS_DIR=%USERPROFILE%\\.agents\\skills"');
     expect(script).toContain("Skipping skills install");
+  });
+
+  test("cleans only legacy command-overlap agent skills", () => {
+    expect(script).toContain("LEGACY_AGENTS_SKILLS_DIR");
+    expect(script).toContain("plannotator-review plannotator-annotate plannotator-last");
+    expect(script).not.toContain("plannotator-review plannotator-annotate plannotator-last plannotator-compound");
+    expect(script).not.toContain("plannotator-review plannotator-annotate plannotator-last plannotator-setup-goal");
   });
 
   test("installs slash commands", () => {
@@ -243,6 +271,15 @@ describe("install.cmd", () => {
     expect(script).toContain("--skip-attestation");
     // Enforcement: hard-fail when opted in but gh missing
     expect(script).toContain("gh CLI was not found");
+  });
+});
+
+describe("Codex Plannotator skills", () => {
+  test("command-overlap skills include OpenAI agent config", () => {
+    for (const skill of ["plannotator-review", "plannotator-annotate", "plannotator-last"]) {
+      const configPath = join(scriptsDir, "..", "apps", "skills", skill, "agents", "openai.yaml");
+      expect(existsSync(configPath)).toBe(true);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- install only the command-overlap Plannotator skills into `~/.codex/skills`: `plannotator-review`, `plannotator-annotate`, and `plannotator-last`
- remove those command-overlap skills from the legacy shared `~/.agents/skills` scope so they no longer collide with slash commands
- keep shared-agent Plannotator skills, including `plannotator-setup-goal`, in `~/.agents/skills` and remove stale Codex copies of those shared-agent skills
- avoid treating an installer-created `~/.codex/skills` directory as proof that Codex hooks should be configured
- copy skill directories only when present so version-pinned installs against older tags do not fail on missing newer skills
- keep Claude skill install behavior unchanged and assert command-overlap skills include OpenAI config

## Tests
- `bash -n scripts/install.sh`
- `git diff --check`
- `bun test scripts/install.test.ts`
- temp-dir copy simulation against `v0.17.10`, `v0.19.7`, and `HEAD`