### PR TITLE
Avoid Pi bundled skill conflicts

### DIFF
--- a/scripts/install.cmd
+++ b/scripts/install.cmd
@@ -414,14 +414,6 @@ if exist "%USERPROFILE%\.cache\opencode\node_modules\@plannotator" rmdir /s /q "
 if exist "%USERPROFILE%\.cache\opencode\packages\@plannotator" rmdir /s /q "%USERPROFILE%\.cache\opencode\packages\@plannotator" >nul 2>&1
 if exist "%USERPROFILE%\.bun\install\cache\@plannotator" rmdir /s /q "%USERPROFILE%\.bun\install\cache\@plannotator" >nul 2>&1
 
-REM Update Pi extension if pi is installed
-where pi >nul 2>&1
-if !ERRORLEVEL! equ 0 (
-    echo Updating Pi extension...
-    pi install npm:@plannotator/pi-extension
-    echo Pi extension updated.
-)
-
 REM Install /review slash command
 if defined CLAUDE_CONFIG_DIR (
     set "CLAUDE_COMMANDS_DIR=%CLAUDE_CONFIG_DIR%\commands"
@@ -546,6 +538,40 @@ if !ERRORLEVEL! equ 0 (
     rmdir /s /q "!SKILLS_TMP!" >nul 2>&1
 ) else (
     echo Skipping skills install ^(git not found^)
+)
+
+REM Update Pi extension if pi is installed. When global shared skills are
+REM available, keep the extension commands but disable its bundled skill copy to
+REM avoid duplicate Pi skill warnings.
+where pi >nul 2>&1
+if !ERRORLEVEL! equ 0 (
+    echo Updating Pi extension...
+    pi install npm:@plannotator/pi-extension
+    if !ERRORLEVEL! equ 0 (
+        set "PI_SHARED_SKILLS_DIR=%USERPROFILE%\.agents\skills"
+        set "PI_SHARED_SKILLS_AVAILABLE=0"
+        if exist "!PI_SHARED_SKILLS_DIR!\plannotator-compound\SKILL.md" if exist "!PI_SHARED_SKILLS_DIR!\plannotator-setup-goal\SKILL.md" set "PI_SHARED_SKILLS_AVAILABLE=1"
+        if "!PI_SHARED_SKILLS_AVAILABLE!"=="1" (
+            if defined PI_CODING_AGENT_DIR (
+                set "PI_SETTINGS_PATH=!PI_CODING_AGENT_DIR!\settings.json"
+            ) else (
+                set "PI_SETTINGS_PATH=%USERPROFILE%\.pi\agent\settings.json"
+            )
+            if exist "!PI_SETTINGS_PATH!" (
+                where powershell >nul 2>&1
+                if !ERRORLEVEL! equ 0 (
+                    powershell -NoProfile -ExecutionPolicy Bypass -Command "$p=$env:PI_SETTINGS_PATH; if ((Test-Path $p) -eq $false) { exit 0 }; try { $s=Get-Content -Path $p -Raw -ErrorAction Stop | ConvertFrom-Json } catch { Write-Host 'Skipping Pi settings update (could not parse settings.json)'; exit 0 }; if (($null -eq $s) -or ($null -eq $s.packages)) { exit 0 }; $pattern='^(?:npm:)?@plannotator/pi-extension(?:@.+)?$'; $changed=$false; $packages=@(); foreach ($entry in @($s.packages)) { if (($entry -is [string]) -and ($entry -match $pattern)) { $packages += [pscustomobject]@{ source=$entry; skills=@() }; $changed=$true; continue }; $sourceProperty=$null; if (($null -ne $entry) -and ($null -ne $entry.PSObject)) { $sourceProperty=$entry.PSObject.Properties['source'] }; if (($null -ne $sourceProperty) -and ($sourceProperty.Value -is [string]) -and ($sourceProperty.Value -match $pattern)) { $skillsProperty=$entry.PSObject.Properties['skills']; if (($null -eq $skillsProperty) -or (@($skillsProperty.Value).Count -ne 0)) { if ($null -ne $skillsProperty) { $entry.skills=@() } else { $entry | Add-Member -NotePropertyName 'skills' -NotePropertyValue @() }; $changed=$true } }; $packages += $entry }; if ($changed) { $s.packages=@($packages); $tmp=[System.IO.Path]::GetTempFileName(); try { $json=($s | ConvertTo-Json -Depth 20)+[Environment]::NewLine; $utf8NoBom=New-Object System.Text.UTF8Encoding -ArgumentList $false; [System.IO.File]::WriteAllText($tmp,$json,$utf8NoBom); Move-Item -Force $tmp $p; Write-Host 'Configured Pi to use global Plannotator skills and skip bundled package skills.' } catch { Write-Host 'Skipping Pi settings update (could not rewrite settings.json)'; Remove-Item -Force $tmp -ErrorAction SilentlyContinue } }"
+                ) else (
+                    echo Skipping Pi settings update ^(PowerShell not found^)
+                )
+            )
+        ) else (
+            echo Leaving Pi bundled skills enabled ^(global Plannotator agent skills not found^).
+        )
+        echo Pi extension updated.
+    ) else (
+        echo Skipping Pi settings update ^(pi install failed^)
+    )
 )
 
 REM --- Gemini CLI support (only if Gemini is installed) ---

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -302,11 +302,101 @@ Remove-Item -Recurse -Force "$env:USERPROFILE\.bun\install\cache\@plannotator" -
 # Clear Pi jiti cache to force fresh download on next run
 Remove-Item -Recurse -Force "$env:TEMP\jiti" -ErrorAction SilentlyContinue
 
-# Update Pi extension if pi is installed
-if (Get-Command pi -ErrorAction SilentlyContinue) {
+function Test-PlannotatorSharedAgentSkillsAvailable {
+    $agentsSkillsDir = "$env:USERPROFILE\.agents\skills"
+    return (Test-Path (Join-Path $agentsSkillsDir "plannotator-compound\SKILL.md")) -and
+        (Test-Path (Join-Path $agentsSkillsDir "plannotator-setup-goal\SKILL.md"))
+}
+
+function Configure-PiPlannotatorPackageFilter {
+    $piAgentDir = if ($env:PI_CODING_AGENT_DIR) { $env:PI_CODING_AGENT_DIR } else { "$env:USERPROFILE\.pi\agent" }
+    $piSettings = Join-Path $piAgentDir "settings.json"
+
+    if (-not (Test-Path $piSettings)) {
+        return
+    }
+
+    try {
+        $settings = Get-Content -Path $piSettings -Raw -ErrorAction Stop | ConvertFrom-Json
+    } catch {
+        Write-Host "Skipping Pi settings update (could not parse settings.json)"
+        return
+    }
+
+    if ($null -eq $settings -or $null -eq $settings.packages) {
+        return
+    }
+
+    $packagePattern = "^(?:npm:)?@plannotator/pi-extension(?:@.+)?$"
+    $changed = $false
+    $packages = @()
+
+    foreach ($entry in @($settings.packages)) {
+        if ($entry -is [string] -and $entry -match $packagePattern) {
+            $packages += [pscustomobject]@{
+                source = $entry
+                skills = @()
+            }
+            $changed = $true
+            continue
+        }
+
+        $sourceProperty = $null
+        if ($entry -and $entry.PSObject) {
+            $sourceProperty = $entry.PSObject.Properties["source"]
+        }
+
+        if ($sourceProperty -and $sourceProperty.Value -is [string] -and $sourceProperty.Value -match $packagePattern) {
+            $skillsProperty = $entry.PSObject.Properties["skills"]
+            if (-not $skillsProperty -or @($skillsProperty.Value).Count -ne 0) {
+                if ($skillsProperty) {
+                    $entry.skills = @()
+                } else {
+                    $entry | Add-Member -NotePropertyName "skills" -NotePropertyValue @()
+                }
+                $changed = $true
+            }
+        }
+
+        $packages += $entry
+    }
+
+    if (-not $changed) {
+        return
+    }
+
+    $settings.packages = @($packages)
+    $tmpPath = [System.IO.Path]::GetTempFileName()
+
+    try {
+        $json = ($settings | ConvertTo-Json -Depth 20) + "`n"
+        $utf8NoBom = New-Object System.Text.UTF8Encoding -ArgumentList $false
+        [System.IO.File]::WriteAllText($tmpPath, $json, $utf8NoBom)
+        Move-Item -Force $tmpPath $piSettings
+        Write-Host "Configured Pi to use global Plannotator skills and skip bundled package skills."
+    } catch {
+        Write-Host "Skipping Pi settings update (could not rewrite settings.json)"
+        Remove-Item -Force $tmpPath -ErrorAction SilentlyContinue
+    }
+}
+
+function Update-PiExtensionIfPresent {
+    if (-not (Get-Command pi -ErrorAction SilentlyContinue)) {
+        return
+    }
+
     Write-Host "Updating Pi extension..."
     pi install npm:@plannotator/pi-extension
-    Write-Host "Pi extension updated."
+    if ($LASTEXITCODE -eq 0) {
+        if (Test-PlannotatorSharedAgentSkillsAvailable) {
+            Configure-PiPlannotatorPackageFilter
+        } else {
+            Write-Host "Leaving Pi bundled skills enabled (global Plannotator agent skills not found)."
+        }
+        Write-Host "Pi extension updated."
+    } else {
+        Write-Host "Skipping Pi settings update (pi install failed)"
+    }
 }
 
 # Install Claude Code slash command
@@ -496,6 +586,11 @@ if (Get-Command git -ErrorAction SilentlyContinue) {
 } else {
     Write-Host "Skipping skills install (git not found)"
 }
+
+# Update Pi extension if pi is installed. When global shared skills are
+# available, keep the extension commands but disable its bundled skill copy to
+# avoid duplicate Pi skill warnings.
+Update-PiExtensionIfPresent
 
 # --- Gemini CLI support (only if Gemini is installed) ---
 $geminiDir = "$env:USERPROFILE\.gemini"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -534,12 +534,94 @@ rm -rf "$HOME/.cache/opencode/node_modules/@plannotator" "$HOME/.cache/opencode/
 # Clear Pi jiti cache to force fresh download on next run
 rm -rf /tmp/jiti 2>/dev/null || true
 
-# Update Pi extension if pi is installed
-if command -v pi &>/dev/null; then
+plannotator_shared_agent_skills_available() {
+    local agents_skills_dir="$HOME/.agents/skills"
+
+    [ -f "$agents_skills_dir/plannotator-compound/SKILL.md" ] &&
+        [ -f "$agents_skills_dir/plannotator-setup-goal/SKILL.md" ]
+}
+
+configure_pi_plannotator_package_filter() {
+    local pi_agent_dir="${PI_CODING_AGENT_DIR:-$HOME/.pi/agent}"
+    local pi_settings="$pi_agent_dir/settings.json"
+
+    if [ ! -f "$pi_settings" ]; then
+        return 0
+    fi
+
+    if ! command -v node &>/dev/null; then
+        echo "Skipping Pi settings update (node not found)"
+        return 0
+    fi
+
+    node - "$pi_settings" <<'NODE' || echo "Skipping Pi settings update (could not rewrite settings.json)"
+const fs = require("fs");
+
+const settingsPath = process.argv[2];
+const packagePattern = /^(?:npm:)?@plannotator\/pi-extension(?:@.+)?$/;
+
+let settings;
+try {
+  settings = JSON.parse(fs.readFileSync(settingsPath, "utf8"));
+} catch {
+  console.log("Skipping Pi settings update (could not parse settings.json)");
+  process.exit(0);
+}
+
+if (!settings || !Array.isArray(settings.packages)) {
+  process.exit(0);
+}
+
+let changed = false;
+settings.packages = settings.packages.map((entry) => {
+  if (typeof entry === "string" && packagePattern.test(entry)) {
+    changed = true;
+    return { source: entry, skills: [] };
+  }
+
+  if (
+    entry &&
+    typeof entry === "object" &&
+    typeof entry.source === "string" &&
+    packagePattern.test(entry.source)
+  ) {
+    if (!Array.isArray(entry.skills) || entry.skills.length !== 0) {
+      changed = true;
+      return { ...entry, skills: [] };
+    }
+  }
+
+  return entry;
+});
+
+if (!changed) {
+  process.exit(0);
+}
+
+const tmpPath = `${settingsPath}.${process.pid}.tmp`;
+fs.writeFileSync(tmpPath, `${JSON.stringify(settings, null, 2)}\n`);
+fs.renameSync(tmpPath, settingsPath);
+console.log("Configured Pi to use global Plannotator skills and skip bundled package skills.");
+NODE
+}
+
+update_pi_extension_if_present() {
+    if ! command -v pi &>/dev/null; then
+        return 0
+    fi
+
     echo "Updating Pi extension..."
-    pi install npm:@plannotator/pi-extension
-    echo "Pi extension updated."
-fi
+    if pi install npm:@plannotator/pi-extension; then
+        if plannotator_shared_agent_skills_available; then
+            configure_pi_plannotator_package_filter
+        else
+            echo "Leaving Pi bundled skills enabled (global Plannotator agent skills not found)."
+        fi
+        echo "Pi extension updated."
+    else
+        echo "Skipping Pi settings update (pi install failed)"
+    fi
+}
 
 # Install /review slash command
 CLAUDE_COMMANDS_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/commands"
@@ -724,6 +806,11 @@ if command -v git &>/dev/null; then
 else
     echo "Skipping skills install (git not found)"
 fi
+
+# Update Pi extension if pi is installed. When global shared skills are
+# available, keep the extension commands but disable its bundled skill copy to
+# avoid duplicate Pi skill warnings.
+update_pi_extension_if_present
 
 # --- Gemini CLI support (only if Gemini is installed) ---
 if [ -d "$HOME/.gemini" ]; then

--- a/scripts/install.test.ts
+++ b/scripts/install.test.ts
@@ -121,6 +121,22 @@ describe("install.sh", () => {
     expect(script).toContain("Existing custom Codex Plannotator hook found");
     expect(script).not.toContain('hook.command.includes("plannotator")) {\n      hook.command = command;');
   });
+
+  test("configures Pi to skip bundled skills only after shared skills exist", () => {
+    expect(script).toContain("configure_pi_plannotator_package_filter");
+    expect(script).toContain("plannotator_shared_agent_skills_available");
+    expect(script).toContain("PI_CODING_AGENT_DIR");
+    expect(script).toContain("npm:@plannotator/pi-extension");
+    expect(script).toContain("return { source: entry, skills: [] };");
+    expect(script).toContain("Leaving Pi bundled skills enabled (global Plannotator agent skills not found).");
+    expect(script).toContain("Configured Pi to use global Plannotator skills and skip bundled package skills.");
+    expect(script).toContain("if plannotator_shared_agent_skills_available; then\n            configure_pi_plannotator_package_filter");
+
+    const skillsInstallIndex = script.indexOf("# Install skills (requires git)");
+    const piUpdateCallIndex = script.lastIndexOf("update_pi_extension_if_present");
+    expect(skillsInstallIndex).toBeGreaterThan(0);
+    expect(piUpdateCallIndex).toBeGreaterThan(skillsInstallIndex);
+  });
 });
 
 describe("install.ps1", () => {
@@ -218,6 +234,25 @@ describe("install.ps1", () => {
     expect(script).toContain("plannotator-review.md");
     expect(script).toContain("plannotator-annotate.md");
     expect(script).toContain("plannotator-last.md");
+  });
+
+  test("configures Pi to skip bundled skills only after shared skills exist", () => {
+    expect(script).toContain("Configure-PiPlannotatorPackageFilter");
+    expect(script).toContain("Test-PlannotatorSharedAgentSkillsAvailable");
+    expect(script).toContain("PI_CODING_AGENT_DIR");
+    expect(script).toContain("npm:@plannotator/pi-extension");
+    expect(script).toContain("skills = @()");
+    expect(script).toContain("New-Object System.Text.UTF8Encoding -ArgumentList $false");
+    expect(script).toContain("[System.IO.File]::WriteAllText($tmpPath, $json, $utf8NoBom)");
+    expect(script).not.toContain("$settings | ConvertTo-Json -Depth 20 | Set-Content -Path $tmpPath -Encoding UTF8");
+    expect(script).toContain("Leaving Pi bundled skills enabled (global Plannotator agent skills not found).");
+    expect(script).toContain("Configured Pi to use global Plannotator skills and skip bundled package skills.");
+    expect(script).toContain("if (Test-PlannotatorSharedAgentSkillsAvailable) {\n            Configure-PiPlannotatorPackageFilter");
+
+    const skillsInstallIndex = script.indexOf("# Install skills (requires git)");
+    const piUpdateCallIndex = script.lastIndexOf("Update-PiExtensionIfPresent");
+    expect(skillsInstallIndex).toBeGreaterThan(0);
+    expect(piUpdateCallIndex).toBeGreaterThan(skillsInstallIndex);
   });
 });
 
@@ -318,6 +353,27 @@ describe("install.cmd", () => {
     expect(script).toContain("s.hooks.BeforeTool=s.hooks.BeforeTool||[]");
     expect(script).not.toContain("if(!s.hooks)");
     expect(script).not.toContain("if(!s.hooks.BeforeTool)");
+  });
+
+  test("configures Pi to skip bundled skills only after shared skills exist", () => {
+    expect(script).toContain("PI_CODING_AGENT_DIR");
+    expect(script).toContain("PI_SETTINGS_PATH");
+    expect(script).toContain("$env:PI_SETTINGS_PATH");
+    expect(script).toContain("npm:@plannotator/pi-extension");
+    expect(script).toContain("skills=@()");
+    expect(script).toContain("New-Object System.Text.UTF8Encoding -ArgumentList $false");
+    expect(script).toContain("[System.IO.File]::WriteAllText($tmp,$json,$utf8NoBom)");
+    expect(script).not.toContain("Set-Content -Path $tmp -Encoding UTF8");
+    expect(script).toContain("Leaving Pi bundled skills enabled ^(global Plannotator agent skills not found^).");
+    expect(script).toContain("Configured Pi to use global Plannotator skills and skip bundled package skills.");
+    expect(script).toContain('set "PI_SHARED_SKILLS_AVAILABLE=0"');
+    expect(script).toContain('if exist "!PI_SHARED_SKILLS_DIR!\\plannotator-compound\\SKILL.md" if exist "!PI_SHARED_SKILLS_DIR!\\plannotator-setup-goal\\SKILL.md" set "PI_SHARED_SKILLS_AVAILABLE=1"');
+    expect(script).toContain('if "!PI_SHARED_SKILLS_AVAILABLE!"=="1"');
+
+    const skillsInstallIndex = script.indexOf("REM Install skills (requires git)");
+    const piUpdateIndex = script.lastIndexOf("REM Update Pi extension if pi is installed.");
+    expect(skillsInstallIndex).toBeGreaterThan(0);
+    expect(piUpdateIndex).toBeGreaterThan(skillsInstallIndex);
   });
 
   test("attestation verification is off by default with three-layer opt-in", () => {


### PR DESCRIPTION
## Summary
- update Pi extension after shared skill install so global skills are available first
- rewrite the Pi package entry to keep commands enabled while setting bundled package skills to []
- leave Pi bundled skills enabled when global shared skills are unavailable

## Tests
- bash -n scripts/install.sh
- bun test scripts/install.test.ts
- git diff --check

Note: PowerShell parse check was skipped locally because pwsh/powershell is not installed.