### PR TITLE
fix(pi): model switch takes effect on plan approval

### DIFF
--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -212,6 +212,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 	let checklistItems: ChecklistItem[] = [];
 	let savedState: SavedPhaseState | null = null;
 	let plannotatorConfig = {};
+	let justApprovedPlan = false;
 
 	pi.on("session_start", (_event, ctx) => {
 		currentPiSession.update(ctx);
@@ -349,7 +350,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 		await applyPhaseConfig(ctx, { restoreSavedState: false });
 		persistState();
 		ctx.ui.notify(
-			"Plannotator: planning mode enabled. Write a markdown plan, then submit it for review.",
+			"Plannotator: planning mode enabled.",
 		);
 		const warning = getPlanReviewAvailabilityWarning({ hasUI: ctx.hasUI, hasPlanHtml: hasPlanBrowserHtml() });
 		if (warning) {
@@ -853,6 +854,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 				await applyPhaseConfig(ctx, { restoreSavedState: true });
 				pi.appendEntry("plannotator-execute", { lastSubmittedPath });
 				persistState();
+				justApprovedPlan = true;
 				return {
 					content: [
 						{
@@ -861,6 +863,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 						},
 					],
 					details: { approved: true },
+					terminate: true,
 				};
 			}
 
@@ -881,6 +884,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 				await applyPhaseConfig(ctx, { restoreSavedState: true });
 				pi.appendEntry("plannotator-execute", { lastSubmittedPath });
 				persistState();
+				justApprovedPlan = true;
 
 				const doneMsg =
 					checklistItems.length > 0
@@ -900,6 +904,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 							},
 						],
 						details: { approved: true, feedback: result.feedback },
+						terminate: true,
 					};
 				}
 
@@ -914,6 +919,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 						},
 					],
 					details: { approved: true },
+					terminate: true,
 				};
 			}
 
@@ -1131,6 +1137,14 @@ Execute each step in order. After completing a step, include [DONE:n] in your re
 
 	// Detect execution completion
 	pi.on("agent_end", async (_event, ctx) => {
+		if (phase === "executing" && justApprovedPlan) {
+			justApprovedPlan = false;
+			setTimeout(() => {
+				pi.sendUserMessage("Continue with the approved plan.");
+			}, 0);
+			return;
+		}
+
 		if (phase !== "executing" || checklistItems.length === 0) return;
 
 		if (checklistItems.every((t) => t.completed)) {

--- a/bun.lock
+++ b/bun.lock
@@ -64,7 +64,7 @@
     },
     "apps/opencode-plugin": {
       "name": "@plannotator/opencode",
-      "version": "0.19.7",
+      "version": "0.19.8",
       "dependencies": {
         "@opencode-ai/plugin": "^1.1.10",
       },
@@ -86,7 +86,7 @@
     },
     "apps/pi-extension": {
       "name": "@plannotator/pi-extension",
-      "version": "0.19.7",
+      "version": "0.19.8",
       "dependencies": {
         "@joplin/turndown-plugin-gfm": "^1.0.64",
         "@pierre/diffs": "^1.1.12",
@@ -191,7 +191,7 @@
     },
     "packages/server": {
       "name": "@plannotator/server",
-      "version": "0.19.7",
+      "version": "0.19.8",
       "dependencies": {
         "@pierre/diffs": "^1.1.12",
         "@plannotator/ai": "workspace:*",


### PR DESCRIPTION
## Summary

- Pi snapshots `config.model` at the start of each `agent.prompt()` call, so `pi.setModel()` mid-loop has no effect until the next user-initiated turn
- Return `terminate: true` from the plan approval tool result to cleanly end the current agent loop
- Use a deferred `sendUserMessage` in the `agent_end` handler (`setTimeout(0)`) to start a fresh turn that picks up the executing model
- Also cleans up the planning mode notification message

## Details

The `setTimeout(0)` is necessary because Pi's `agent_end` event fires while the `_agentEventQueue` is still draining. Calling `sendUserMessage` synchronously throws "Agent is already processing". The deferral ensures the agent is fully idle before retriggering.

Closes #674

## Test plan

- [ ] Configure `~/.pi/agent/plannotator.json` with different planning/executing models
- [ ] Start a planning session, submit and approve a plan
- [ ] Verify execution auto-continues on the executing model (no manual intervention needed)
- [ ] Verify denied plans continue on the planning model
- [ ] Verify auto-approve path (no UI) also switches correctly
- [ ] `pi --no-extensions -e ./apps/pi-extension/index.ts` loads without errors