### PR TITLE
feat(ui): add Hooks visibility tab to Settings dialog

### DIFF
--- a/apps/hook/dev-mock-api.ts
+++ b/apps/hook/dev-mock-api.ts
@@ -574,6 +574,56 @@ export function devMockApi(): Plugin {
     name: 'plannotator-dev-mock-api',
     configureServer(server) {
       server.middlewares.use(async (req, res, next) => {
+        if (req.url === '/api/hooks/status') {
+          res.setHeader('Content-Type', 'application/json');
+          try {
+            const { readImprovementHook } = await import('@plannotator/shared/improvement-hooks');
+            const { loadConfig } = await import('@plannotator/shared/config');
+            const { composeImproveContext } = await import('@plannotator/shared/pfm-reminder');
+            const config = loadConfig();
+            const hook = readImprovementHook('enterplanmode-improve');
+            const pfmEnabled = config.pfmReminder === true;
+            const composed = composeImproveContext({ pfmEnabled, improvementHookContent: hook?.content ?? null });
+            res.end(JSON.stringify({
+              pfmReminder: { enabled: pfmEnabled },
+              improvementHook: {
+                present: !!hook,
+                filePath: hook?.filePath ?? null,
+                fileSize: hook?.content?.length ?? null,
+                content: hook?.content ?? null,
+              },
+              composedLength: composed?.length ?? null,
+            }));
+          } catch {
+            res.end(JSON.stringify({
+              pfmReminder: { enabled: false },
+              improvementHook: { present: false, filePath: null, fileSize: null, content: null },
+              composedLength: null,
+            }));
+          }
+          return;
+        }
+
+        if (req.url === '/api/config' && req.method === 'POST') {
+          let body = '';
+          req.on('data', (chunk: Buffer) => { body += chunk.toString(); });
+          req.on('end', async () => {
+            try {
+              const { saveConfig } = await import('@plannotator/shared/config');
+              const parsed = JSON.parse(body);
+              const toSave: Record<string, unknown> = {};
+              if (parsed.pfmReminder !== undefined) toSave.pfmReminder = parsed.pfmReminder;
+              if (Object.keys(toSave).length > 0) saveConfig(toSave as any);
+              res.setHeader('Content-Type', 'application/json');
+              res.end(JSON.stringify({ ok: true }));
+            } catch {
+              res.statusCode = 400;
+              res.end(JSON.stringify({ error: 'Invalid request' }));
+            }
+          });
+          return;
+        }
+
         if (req.url === '/api/plan') {
           res.setHeader('Content-Type', 'application/json');
           res.end(JSON.stringify({

--- a/apps/pi-extension/server/serverPlan.ts
+++ b/apps/pi-extension/server/serverPlan.ts
@@ -36,7 +36,9 @@ import {
 } from "./integrations.js";
 import { listenOnPort } from "./network.js";
 
-import { saveConfig, detectGitUser, getServerConfig } from "../generated/config.js";
+import { loadConfig, saveConfig, detectGitUser, getServerConfig } from "../generated/config.js";
+import { readImprovementHook } from "../generated/improvement-hooks.js";
+import { composeImproveContext } from "../generated/pfm-reminder.js";
 import { detectProjectName, getRepoInfo } from "./project.js";
 import {
 	handleDocRequest,
@@ -227,13 +229,29 @@ export async function startPlanReviewServer(options: {
 					serverConfig: getServerConfig(gitUser),
 				});
 			}
+		} else if (url.pathname === "/api/hooks/status" && req.method === "GET") {
+			const config = loadConfig();
+			const hook = readImprovementHook("enterplanmode-improve");
+			const pfmEnabled = config.pfmReminder === true;
+			const composed = composeImproveContext({ pfmEnabled, improvementHookContent: hook?.content ?? null });
+			json(res, {
+				pfmReminder: { enabled: pfmEnabled },
+				improvementHook: {
+					present: !!hook,
+					filePath: hook?.filePath ?? null,
+					fileSize: hook?.content?.length ?? null,
+					content: hook?.content ?? null,
+				},
+				composedLength: composed?.length ?? null,
+			});
 		} else if (url.pathname === "/api/config" && req.method === "POST") {
 			try {
-				const body = (await parseBody(req)) as { displayName?: string; diffOptions?: Record<string, unknown>; conventionalComments?: boolean };
+				const body = (await parseBody(req)) as { displayName?: string; diffOptions?: Record<string, unknown>; conventionalComments?: boolean; pfmReminder?: boolean };
 				const toSave: Record<string, unknown> = {};
 				if (body.displayName !== undefined) toSave.displayName = body.displayName;
 				if (body.diffOptions !== undefined) toSave.diffOptions = body.diffOptions;
 				if (body.conventionalComments !== undefined) toSave.conventionalComments = body.conventionalComments;
+				if (body.pfmReminder !== undefined) toSave.pfmReminder = body.pfmReminder;
 				if (Object.keys(toSave).length > 0) saveConfig(toSave as Parameters<typeof saveConfig>[0]);
 				json(res, { ok: true });
 			} catch {

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -41,7 +41,9 @@ import {
 } from "./storage";
 import { getRepoInfo } from "./repo";
 import { detectProjectName } from "./project";
-import { saveConfig, detectGitUser, getServerConfig } from "./config";
+import { loadConfig, saveConfig, detectGitUser, getServerConfig } from "./config";
+import { readImprovementHook } from "@plannotator/shared/improvement-hooks";
+import { composeImproveContext } from "@plannotator/shared/pfm-reminder";
 import { handleImage, handleUpload, handleAgents, handleServerReady, handleDraftSave, handleDraftLoad, handleDraftDelete, handleFavicon, type OpencodeClient } from "./shared-handlers";
 import { contentHash, deleteDraft } from "./draft";
 import { handleDoc, handleDocExists, handleObsidianVaults, handleObsidianFiles, handleObsidianDoc, handleFileBrowserFiles } from "./reference-handlers";
@@ -295,15 +297,37 @@ export async function startPlannotatorServer(
             return handleDocExists(req);
           }
 
+          // API: Hook status for the Settings Hooks tab
+          if (url.pathname === "/api/hooks/status" && req.method === "GET") {
+            const config = loadConfig();
+            const hook = readImprovementHook("enterplanmode-improve");
+            const pfmEnabled = config.pfmReminder === true;
+            const composed = composeImproveContext({
+              pfmEnabled,
+              improvementHookContent: hook?.content ?? null,
+            });
+            return Response.json({
+              pfmReminder: { enabled: pfmEnabled },
+              improvementHook: {
+                present: !!hook,
+                filePath: hook?.filePath ?? null,
+                fileSize: hook?.content?.length ?? null,
+                content: hook?.content ?? null,
+              },
+              composedLength: composed?.length ?? null,
+            });
+          }
+
           // API: Update user config (write-back to ~/.plannotator/config.json)
           if (url.pathname === "/api/config" && req.method === "POST") {
             try {
-              const body = (await req.json()) as { displayName?: string; diffOptions?: Record<string, unknown>; conventionalComments?: boolean; conventionalLabels?: unknown[] | null };
+              const body = (await req.json()) as { displayName?: string; diffOptions?: Record<string, unknown>; conventionalComments?: boolean; conventionalLabels?: unknown[] | null; pfmReminder?: boolean };
               const toSave: Record<string, unknown> = {};
               if (body.displayName !== undefined) toSave.displayName = body.displayName;
               if (body.diffOptions !== undefined) toSave.diffOptions = body.diffOptions;
               if (body.conventionalComments !== undefined) toSave.conventionalComments = body.conventionalComments;
               if (body.conventionalLabels !== undefined) toSave.conventionalLabels = body.conventionalLabels;
+              if (body.pfmReminder !== undefined) toSave.pfmReminder = body.pfmReminder;
               if (Object.keys(toSave).length > 0) saveConfig(toSave as Parameters<typeof saveConfig>[0]);
               return Response.json({ ok: true });
             } catch {

--- a/packages/ui/components/Settings.tsx
+++ b/packages/ui/components/Settings.tsx
@@ -62,6 +62,7 @@ import { ThemeTab } from './ThemeTab';
 import { isMac, modKey, altKey } from '../utils/platform';
 import { getAIProviderSettings } from '../utils/aiProvider';
 import { AISettingsTab } from './AISettingsTab';
+import { HooksTab } from './settings/HooksTab';
 import { OverlayScrollArea } from './OverlayScrollArea';
 import {
   getFileBrowserSettings,
@@ -69,7 +70,7 @@ import {
   type FileBrowserSettings,
 } from '../utils/fileBrowser';
 
-type SettingsTab = 'general' | 'theme' | 'git' | 'display' | 'saving' | 'labels' | 'shortcuts' | 'ai' | 'files' | 'obsidian' | 'bear' | 'octarine' | 'comments';
+type SettingsTab = 'general' | 'theme' | 'git' | 'display' | 'saving' | 'labels' | 'shortcuts' | 'ai' | 'files' | 'obsidian' | 'bear' | 'octarine' | 'comments' | 'hooks';
 
 interface SettingsProps {
   taterMode: boolean;
@@ -640,6 +641,9 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
       }
     }
     t.push({ id: 'shortcuts', label: 'Shortcuts' });
+    if (mode === 'plan') {
+      t.push({ id: 'hooks', label: 'Hooks' });
+    }
     return t;
   }, [mode, aiProviders.length]);
 
@@ -1707,6 +1711,9 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
                     )}
                   </>
                 )}
+
+                {/* === HOOKS TAB === */}
+                {activeTab === 'hooks' && <HooksTab />}
 
                 {/* === OBSIDIAN TAB === */}
                 {activeTab === 'obsidian' && (

--- a/packages/ui/components/settings/HooksTab.tsx
+++ b/packages/ui/components/settings/HooksTab.tsx
@@ -1,0 +1,156 @@
+import React, { useEffect, useState } from 'react';
+import { FAVICON_SVG } from '@plannotator/shared/favicon';
+
+interface HooksStatus {
+  pfmReminder: { enabled: boolean };
+  improvementHook: {
+    present: boolean;
+    filePath: string | null;
+    fileSize: number | null;
+    content: string | null;
+  };
+  composedLength: number | null;
+}
+
+export const HooksTab: React.FC = () => {
+  const [status, setStatus] = useState<HooksStatus | null>(null);
+  const [pfmEnabled, setPfmEnabled] = useState(false);
+  const [hookExpanded, setHookExpanded] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/hooks/status')
+      .then(r => r.json())
+      .then((data: HooksStatus) => {
+        setStatus(data);
+        setPfmEnabled(data.pfmReminder.enabled);
+      })
+      .catch(() => {});
+  }, []);
+
+  const togglePfm = async () => {
+    const next = !pfmEnabled;
+    setPfmEnabled(next);
+    await fetch('/api/config', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pfmReminder: next }),
+    }).catch(() => setPfmEnabled(!next));
+  };
+
+  if (!status) {
+    return <div className="text-sm text-muted-foreground py-4">Loading hook status…</div>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-xs text-muted-foreground">
+        These hooks inject context into your planning agent before it writes a plan.
+      </p>
+
+      {/* PFM Reminder Card */}
+      <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+        <div className="flex items-start gap-3">
+          <div
+            className="w-8 h-8 flex-shrink-0 rounded-md overflow-hidden"
+            dangerouslySetInnerHTML={{ __html: FAVICON_SVG }}
+          />
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center justify-between gap-2">
+              <h3 className="text-sm font-semibold text-foreground">Plannotator Flavored Markdown</h3>
+              <button
+                onClick={togglePfm}
+                className={`relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${
+                  pfmEnabled ? 'bg-primary' : 'bg-muted'
+                }`}
+              >
+                <span
+                  className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition-transform ${
+                    pfmEnabled ? 'translate-x-4' : 'translate-x-0'
+                  }`}
+                />
+              </button>
+            </div>
+            <p className="text-xs text-muted-foreground mt-1 leading-relaxed">
+              Inspired by GitHub Flavored Markdown, PFM extends it with interactive tables, SVG diagrams
+              (custom, Mermaid &amp; Graphviz), code-file links that open in your editor, callouts, task lists, and more.
+              This reminder tells the planning agent what the renderer supports so it can use these features
+              naturally. <strong>No extra tokens</strong> — the agent still writes markdown as it normally would,
+              just with enhanced syntax that Plannotator renders richer.
+            </p>
+            <div className="mt-2">
+              <span className={`inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded-full ${
+                pfmEnabled
+                  ? 'bg-primary/15 text-primary'
+                  : 'bg-muted text-muted-foreground'
+              }`}>
+                <span className={`w-1.5 h-1.5 rounded-full ${pfmEnabled ? 'bg-primary' : 'bg-muted-foreground/50'}`} />
+                {pfmEnabled ? 'Enabled' : 'Disabled'}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Compound Improvement Hook Card */}
+      <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+        <div className="flex items-start gap-3">
+          <div
+            className="w-8 h-8 flex-shrink-0 rounded-md overflow-hidden"
+            dangerouslySetInnerHTML={{ __html: FAVICON_SVG }}
+          />
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center justify-between gap-2">
+              <h3 className="text-sm font-semibold text-foreground">Improvement Hook</h3>
+              <span className={`inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded-full ${
+                status.improvementHook.present
+                  ? 'bg-primary/15 text-primary'
+                  : 'bg-muted text-muted-foreground'
+              }`}>
+                <span className={`w-1.5 h-1.5 rounded-full ${status.improvementHook.present ? 'bg-primary' : 'bg-muted-foreground/50'}`} />
+                {status.improvementHook.present ? 'Active' : 'Not found'}
+              </span>
+            </div>
+
+            {status.improvementHook.present ? (
+              <>
+                <p className="text-xs text-muted-foreground mt-1 leading-relaxed">
+                  Corrective planning instructions generated from your plan denial history.
+                  {status.improvementHook.fileSize != null && (
+                    <span className="text-muted-foreground/70"> · {(status.improvementHook.fileSize / 1024).toFixed(1)}KB</span>
+                  )}
+                </p>
+                <button
+                  onClick={() => setHookExpanded(!hookExpanded)}
+                  className="text-xs text-primary hover:text-primary/80 mt-1.5 transition-colors"
+                >
+                  {hookExpanded ? '▾ Hide content' : '▸ Show content'}
+                </button>
+                {hookExpanded && status.improvementHook.content && (
+                  <pre className="mt-2 p-3 rounded-md bg-muted/50 border border-border text-[11px] text-foreground/80 overflow-auto max-h-64 whitespace-pre-wrap font-mono leading-relaxed">
+                    {status.improvementHook.content}
+                  </pre>
+                )}
+              </>
+            ) : (
+              <p className="text-xs text-muted-foreground mt-1 leading-relaxed">
+                No improvement hook file found. This file contains corrective planning instructions
+                generated from analysis of your plan denial patterns — the more you review, the better
+                your agent plans.{' '}
+                <a
+                  href="https://plannotator.ai/blog/continuously-improve-claude-code-plans/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:text-primary/80 underline underline-offset-2"
+                >
+                  Learn more
+                </a>{' '}
+                or run <code className="text-[10px] bg-muted px-1 py-0.5 rounded">/plannotator-compound</code> to generate one.
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary

Stacked on #689. Adds a **Hooks** tab to the plan review Settings dialog that gives users visibility into the improve-context system.

- **PFM Reminder card** — toggle to enable/disable, explains Plannotator Flavored Markdown extensions (interactive tables, custom SVG diagrams, code-file links, callouts, etc.). No extra tokens — the agent writes standard markdown with enhanced syntax.
- **Improvement Hook card** — shows whether the compound hook file exists with a collapsible content preview, links to the [blog post](https://plannotator.ai/blog/continuously-improve-claude-code-plans/) and `/plannotator-compound` skill for generating one.
- **New `GET /api/hooks/status` endpoint** — returns PFM and improvement hook state
- **`POST /api/config`** — now accepts `pfmReminder` for the toggle
- **Dev mock API** — wired up for local development

## Test plan

- [ ] `bun run dev:hook` — open Settings, verify Hooks tab appears below Shortcuts in plan mode
- [ ] Toggle PFM reminder — verify it persists to `~/.plannotator/config.json`
- [ ] With hook file present — verify content preview renders correctly
- [ ] Without hook file — verify "not found" state with blog link and skill mention
- [ ] Verify Hooks tab does NOT appear in review mode (code review settings)