### PR TITLE
[codex] Add ASCII plan flow reminder

### DIFF
--- a/apps/hook/dev-mock-api.ts
+++ b/apps/hook/dev-mock-api.ts
@@ -583,9 +583,11 @@ export function devMockApi(): Plugin {
             const config = loadConfig();
             const hook = readImprovementHook('enterplanmode-improve');
             const pfmEnabled = config.pfmReminder === true;
-            const composed = composeImproveContext({ pfmEnabled, improvementHookContent: hook?.content ?? null });
+            const asciiFlowEnabled = config.asciiFlowReminder === true;
+            const composed = composeImproveContext({ pfmEnabled, asciiFlowEnabled, improvementHookContent: hook?.content ?? null });
             res.end(JSON.stringify({
               pfmReminder: { enabled: pfmEnabled },
+              asciiFlowReminder: { enabled: asciiFlowEnabled },
               improvementHook: {
                 present: !!hook,
                 filePath: hook?.filePath ?? getImprovementHookExpectedPath('enterplanmode-improve'),
@@ -597,6 +599,7 @@ export function devMockApi(): Plugin {
           } catch {
             res.end(JSON.stringify({
               pfmReminder: { enabled: false },
+              asciiFlowReminder: { enabled: false },
               improvementHook: { present: false, filePath: '~/.plannotator/hooks/compound/enterplanmode-improve-hook.txt', fileSize: null, content: null },
               composedLength: null,
             }));
@@ -613,6 +616,7 @@ export function devMockApi(): Plugin {
               const parsed = JSON.parse(body);
               const toSave: Record<string, unknown> = {};
               if (parsed.pfmReminder !== undefined) toSave.pfmReminder = parsed.pfmReminder;
+              if (parsed.asciiFlowReminder !== undefined) toSave.asciiFlowReminder = parsed.asciiFlowReminder;
               if (Object.keys(toSave).length > 0) saveConfig(toSave as any);
               res.setHeader('Content-Type', 'application/json');
               res.end(JSON.stringify({ ok: true }));

--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -1067,10 +1067,13 @@ if (args[0] === "sessions") {
   await Bun.stdin.text();
 
   const hook = readImprovementHook("enterplanmode-improve");
-  const pfmEnabled = loadConfig().pfmReminder === true;
+  const config = loadConfig();
+  const pfmEnabled = config.pfmReminder === true;
+  const asciiFlowEnabled = config.asciiFlowReminder === true;
 
   const context = composeImproveContext({
     pfmEnabled,
+    asciiFlowEnabled,
     improvementHookContent: hook?.content ?? null,
   });
 

--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -360,9 +360,12 @@ tools (except writing markdown files), or otherwise make changes to the system.
         output.system.push(getPlanningPrompt());
 
         const hook = readImprovementHook("enterplanmode-improve");
-        const pfmEnabled = loadConfig().pfmReminder === true;
+        const config = loadConfig();
+        const pfmEnabled = config.pfmReminder === true;
+        const asciiFlowEnabled = config.asciiFlowReminder === true;
         const improveContext = composeImproveContext({
           pfmEnabled,
+          asciiFlowEnabled,
           improvementHookContent: hook?.content ?? null,
         });
         if (improveContext) {

--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -995,9 +995,12 @@ export default function plannotator(pi: ExtensionAPI): void {
 		let improveContext: string | null = null;
 		if (phase === "planning") {
 			const hook = readImprovementHook("enterplanmode-improve");
-			const pfmEnabled = loadConfig().pfmReminder === true;
+			const config = loadConfig();
+			const pfmEnabled = config.pfmReminder === true;
+			const asciiFlowEnabled = config.asciiFlowReminder === true;
 			improveContext = composeImproveContext({
 				pfmEnabled,
+				asciiFlowEnabled,
 				improvementHookContent: hook?.content ?? null,
 			});
 		}

--- a/apps/pi-extension/server/serverPlan.ts
+++ b/apps/pi-extension/server/serverPlan.ts
@@ -233,9 +233,11 @@ export async function startPlanReviewServer(options: {
 			const config = loadConfig();
 			const hook = readImprovementHook("enterplanmode-improve");
 			const pfmEnabled = config.pfmReminder === true;
-			const composed = composeImproveContext({ pfmEnabled, improvementHookContent: hook?.content ?? null });
+			const asciiFlowEnabled = config.asciiFlowReminder === true;
+			const composed = composeImproveContext({ pfmEnabled, asciiFlowEnabled, improvementHookContent: hook?.content ?? null });
 			json(res, {
 				pfmReminder: { enabled: pfmEnabled },
+				asciiFlowReminder: { enabled: asciiFlowEnabled },
 				improvementHook: {
 					present: !!hook,
 					filePath: hook?.filePath ?? getImprovementHookExpectedPath("enterplanmode-improve"),
@@ -246,12 +248,13 @@ export async function startPlanReviewServer(options: {
 			});
 		} else if (url.pathname === "/api/config" && req.method === "POST") {
 			try {
-				const body = (await parseBody(req)) as { displayName?: string; diffOptions?: Record<string, unknown>; conventionalComments?: boolean; pfmReminder?: boolean };
+				const body = (await parseBody(req)) as { displayName?: string; diffOptions?: Record<string, unknown>; conventionalComments?: boolean; pfmReminder?: boolean; asciiFlowReminder?: boolean };
 				const toSave: Record<string, unknown> = {};
 				if (body.displayName !== undefined) toSave.displayName = body.displayName;
 				if (body.diffOptions !== undefined) toSave.diffOptions = body.diffOptions;
 				if (body.conventionalComments !== undefined) toSave.conventionalComments = body.conventionalComments;
 				if (body.pfmReminder !== undefined) toSave.pfmReminder = body.pfmReminder;
+				if (body.asciiFlowReminder !== undefined) toSave.asciiFlowReminder = body.asciiFlowReminder;
 				if (Object.keys(toSave).length > 0) saveConfig(toSave as Parameters<typeof saveConfig>[0]);
 				json(res, { ok: true });
 			} catch {

--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "@types/node": "^25.5.2",
         "@types/turndown": "^5.0.6",
         "bun-types": "^1.3.11",
+        "typescript": "~5.8.2",
       },
     },
     "apps/hook": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@types/dompurify": "^3.2.0",
     "@types/node": "^25.5.2",
     "@types/turndown": "^5.0.6",
-    "bun-types": "^1.3.11"
+    "bun-types": "^1.3.11",
+    "typescript": "~5.8.2"
   }
 }

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -302,12 +302,15 @@ export async function startPlannotatorServer(
             const config = loadConfig();
             const hook = readImprovementHook("enterplanmode-improve");
             const pfmEnabled = config.pfmReminder === true;
+            const asciiFlowEnabled = config.asciiFlowReminder === true;
             const composed = composeImproveContext({
               pfmEnabled,
+              asciiFlowEnabled,
               improvementHookContent: hook?.content ?? null,
             });
             return Response.json({
               pfmReminder: { enabled: pfmEnabled },
+              asciiFlowReminder: { enabled: asciiFlowEnabled },
               improvementHook: {
                 present: !!hook,
                 filePath: hook?.filePath ?? getImprovementHookExpectedPath("enterplanmode-improve"),
@@ -321,13 +324,14 @@ export async function startPlannotatorServer(
           // API: Update user config (write-back to ~/.plannotator/config.json)
           if (url.pathname === "/api/config" && req.method === "POST") {
             try {
-              const body = (await req.json()) as { displayName?: string; diffOptions?: Record<string, unknown>; conventionalComments?: boolean; conventionalLabels?: unknown[] | null; pfmReminder?: boolean };
+              const body = (await req.json()) as { displayName?: string; diffOptions?: Record<string, unknown>; conventionalComments?: boolean; conventionalLabels?: unknown[] | null; pfmReminder?: boolean; asciiFlowReminder?: boolean };
               const toSave: Record<string, unknown> = {};
               if (body.displayName !== undefined) toSave.displayName = body.displayName;
               if (body.diffOptions !== undefined) toSave.diffOptions = body.diffOptions;
               if (body.conventionalComments !== undefined) toSave.conventionalComments = body.conventionalComments;
               if (body.conventionalLabels !== undefined) toSave.conventionalLabels = body.conventionalLabels;
               if (body.pfmReminder !== undefined) toSave.pfmReminder = body.pfmReminder;
+              if (body.asciiFlowReminder !== undefined) toSave.asciiFlowReminder = body.asciiFlowReminder;
               if (Object.keys(toSave).length > 0) saveConfig(toSave as Parameters<typeof saveConfig>[0]);
               return Response.json({ ok: true });
             } catch {

--- a/packages/shared/config.ts
+++ b/packages/shared/config.ts
@@ -124,6 +124,13 @@ export interface PlannotatorConfig {
    * Read by the `improve-context` PreToolUse handler. Default: false.
    */
   pfmReminder?: boolean;
+  /**
+   * Inject an ASCII flow reminder into every EnterPlanMode call so the agent
+   * adds a compact `## Plan Flow` text diagram when it helps the reviewer
+   * understand plan order, branches, gates, and feedback loops.
+   * Read by the `improve-context` PreToolUse handler. Default: false.
+   */
+  asciiFlowReminder?: boolean;
 }
 
 const CONFIG_DIR = join(homedir(), ".plannotator");

--- a/packages/shared/pfm-reminder.test.ts
+++ b/packages/shared/pfm-reminder.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { PFM_REMINDER, composeImproveContext } from "./pfm-reminder";
+import { ASCII_FLOW_REMINDER, PFM_REMINDER, composeImproveContext } from "./pfm-reminder";
 
 describe("PFM_REMINDER", () => {
   test("identifies itself with a recognizable header", () => {
@@ -34,32 +34,67 @@ describe("PFM_REMINDER", () => {
   });
 });
 
+describe("ASCII_FLOW_REMINDER", () => {
+  test("identifies itself with a recognizable header", () => {
+    expect(ASCII_FLOW_REMINDER).toContain("[ASCII Plan Flow]");
+  });
+
+  test("describes the required plan flow contract", () => {
+    expect(ASCII_FLOW_REMINDER).toContain("## Plan Flow");
+    expect(ASCII_FLOW_REMINDER).toContain("```text");
+    expect(ASCII_FLOW_REMINDER).toContain("pure ASCII");
+    expect(ASCII_FLOW_REMINDER).toContain("Mermaid");
+    expect(ASCII_FLOW_REMINDER).toContain("Graphviz");
+    expect(ASCII_FLOW_REMINDER).toContain("5-12 nodes");
+  });
+
+  test("stays small enough to inject on every EnterPlanMode call", () => {
+    expect(ASCII_FLOW_REMINDER.length).toBeLessThan(1500);
+  });
+});
+
 describe("composeImproveContext", () => {
   test("returns null when nothing is enabled", () => {
     expect(
-      composeImproveContext({ pfmEnabled: false, improvementHookContent: null }),
+      composeImproveContext({ pfmEnabled: false, asciiFlowEnabled: false, improvementHookContent: null }),
     ).toBeNull();
   });
 
   test("treats empty improvement-hook content the same as null", () => {
     expect(
-      composeImproveContext({ pfmEnabled: false, improvementHookContent: "" }),
+      composeImproveContext({ pfmEnabled: false, asciiFlowEnabled: false, improvementHookContent: "" }),
     ).toBeNull();
   });
 
   test("returns just the PFM reminder when only PFM is enabled", () => {
     const ctx = composeImproveContext({
       pfmEnabled: true,
+      asciiFlowEnabled: false,
       improvementHookContent: null,
     });
     expect(ctx).not.toBeNull();
     expect(ctx).toContain("[Plannotator Flavored Markdown]");
+    expect(ctx).not.toContain("[ASCII Plan Flow]");
+    expect(ctx).not.toContain("[Plannotator Improvement Hook]");
+  });
+
+  test("returns just the ASCII flow reminder when only ASCII flow is enabled", () => {
+    const ctx = composeImproveContext({
+      pfmEnabled: false,
+      asciiFlowEnabled: true,
+      improvementHookContent: null,
+    });
+    expect(ctx).not.toBeNull();
+    expect(ctx).toContain("[ASCII Plan Flow]");
+    expect(ctx).toContain("## Plan Flow");
+    expect(ctx).not.toContain("[Plannotator Flavored Markdown]");
     expect(ctx).not.toContain("[Plannotator Improvement Hook]");
   });
 
   test("returns just the improvement-hook block when only it is set (legacy behavior)", () => {
     const ctx = composeImproveContext({
       pfmEnabled: false,
+      asciiFlowEnabled: false,
       improvementHookContent: "1. Always include a test plan section.",
     });
     expect(ctx).not.toBeNull();
@@ -67,22 +102,28 @@ describe("composeImproveContext", () => {
     expect(ctx).toContain("The following corrective instructions were generated");
     expect(ctx).toContain("1. Always include a test plan section.");
     expect(ctx).not.toContain("[Plannotator Flavored Markdown]");
+    expect(ctx).not.toContain("[ASCII Plan Flow]");
   });
 
-  test("composes both with PFM reminder first, separated by a divider", () => {
+  test("composes reminders and improvement hook in stable order", () => {
     const ctx = composeImproveContext({
       pfmEnabled: true,
+      asciiFlowEnabled: true,
       improvementHookContent: "1. Always include a test plan section.",
     })!;
 
     const pfmIdx = ctx.indexOf("[Plannotator Flavored Markdown]");
+    const asciiIdx = ctx.indexOf("[ASCII Plan Flow]");
     const improveIdx = ctx.indexOf("[Plannotator Improvement Hook]");
     expect(pfmIdx).toBeGreaterThanOrEqual(0);
-    expect(improveIdx).toBeGreaterThan(pfmIdx);
+    expect(asciiIdx).toBeGreaterThan(pfmIdx);
+    expect(improveIdx).toBeGreaterThan(asciiIdx);
 
     // A horizontal rule separates the two sections so the agent reads them
     // as distinct payloads.
-    const between = ctx.slice(pfmIdx, improveIdx);
-    expect(between).toContain("\n---\n");
+    const pfmToAscii = ctx.slice(pfmIdx, asciiIdx);
+    const asciiToImprove = ctx.slice(asciiIdx, improveIdx);
+    expect(pfmToAscii).toContain("\n---\n");
+    expect(asciiToImprove).toContain("\n---\n");
   });
 });

--- a/packages/shared/pfm-reminder.ts
+++ b/packages/shared/pfm-reminder.ts
@@ -1,10 +1,9 @@
 /**
- * Plannotator Flavored Markdown reminder.
+ * Plannotator planning reminders.
  *
  * Static prose injected into the EnterPlanMode PreToolUse hook when the user
- * has opted in via `pfmReminder: true` in ~/.plannotator/config.json. It tells
- * the planning agent which markdown extensions Plannotator's viewer renders so
- * plans can be enriched with code-file links, callouts, tables, diagrams, etc.
+ * has opted in through ~/.plannotator/config.json. These reminders tell the
+ * planning agent how to shape plans for Plannotator review.
  *
  * Keep this short. The agent reads it on every EnterPlanMode call.
  */
@@ -13,17 +12,23 @@
  * Compose the additionalContext string for the improve-context PreToolUse handler.
  * Returns null when no sources are enabled (handler should exit silently).
  *
- * Order: PFM reminder first (capabilities) then improvement hook (corrective
- * rules). Both appear separated by a horizontal rule.
+ * Order: PFM reminder first (capabilities), ASCII flow reminder second
+ * (structure), then improvement hook (corrective rules). Sections appear
+ * separated by a horizontal rule.
  */
 export function composeImproveContext(input: {
   pfmEnabled: boolean;
+  asciiFlowEnabled: boolean;
   improvementHookContent: string | null;
 }): string | null {
   const sections: string[] = [];
 
   if (input.pfmEnabled) {
     sections.push(PFM_REMINDER);
+  }
+
+  if (input.asciiFlowEnabled) {
+    sections.push(ASCII_FLOW_REMINDER);
   }
 
   if (input.improvementHookContent) {
@@ -78,3 +83,21 @@ Other extras
   - A small set of emoji shortcodes is supported (:rocket:, :warning:, :white_check_mark:, ...)
 
 Plain prose is always fine. The point is: prefer code-file links over copy-pasted snippets, and reach for callouts or tables when structure makes the plan easier to scan.`;
+
+export const ASCII_FLOW_REMINDER = `[ASCII Plan Flow]
+This plan will be reviewed by a human before implementation. Add a compact \`## Plan Flow\` section after Summary/Context and before implementation details so the reviewer can quickly judge whether the order, branches, and review gates make sense.
+
+Use a fenced \`text\` code block with pure ASCII only:
+\`\`\`text
+[Explore] -> [Draft plan] -> [Review]
+                   |             |
+                   v             v
+              [Revise] <---- [Feedback]
+\`\`\`
+
+Rules:
+- Use pure ASCII characters only. Do not use Unicode box drawing.
+- Do not use Mermaid, Graphviz, or SVG for this section.
+- Show the main execution order, important branches, review gates, rollback/feedback loops, and parallel work where relevant.
+- Keep it compact: roughly 5-12 nodes, short concrete labels, and no decorative art.
+- For very small plans, keep the flow to the minimum useful shape.`;

--- a/packages/ui/components/settings/HooksTab.tsx
+++ b/packages/ui/components/settings/HooksTab.tsx
@@ -3,6 +3,7 @@ import { FAVICON_SVG } from '@plannotator/shared/favicon';
 
 interface HooksStatus {
   pfmReminder: { enabled: boolean };
+  asciiFlowReminder: { enabled: boolean };
   improvementHook: {
     present: boolean;
     filePath: string | null;
@@ -51,6 +52,7 @@ const CopyPathButton: React.FC<{ filePath: string }> = ({ filePath }) => {
 export const HooksTab: React.FC = () => {
   const [status, setStatus] = useState<HooksStatus | null>(null);
   const [pfmEnabled, setPfmEnabled] = useState(false);
+  const [asciiFlowEnabled, setAsciiFlowEnabled] = useState(false);
   const [hookExpanded, setHookExpanded] = useState(false);
 
   useEffect(() => {
@@ -59,6 +61,7 @@ export const HooksTab: React.FC = () => {
       .then((data: HooksStatus) => {
         setStatus(data);
         setPfmEnabled(data.pfmReminder.enabled);
+        setAsciiFlowEnabled(data.asciiFlowReminder.enabled);
       })
       .catch(() => {});
   }, []);
@@ -71,6 +74,16 @@ export const HooksTab: React.FC = () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ pfmReminder: next }),
     }).catch(() => setPfmEnabled(!next));
+  };
+
+  const toggleAsciiFlow = async () => {
+    const next = !asciiFlowEnabled;
+    setAsciiFlowEnabled(next);
+    await fetch('/api/config', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ asciiFlowReminder: next }),
+    }).catch(() => setAsciiFlowEnabled(!next));
   };
 
   if (!status) {
@@ -121,6 +134,48 @@ export const HooksTab: React.FC = () => {
               }`}>
                 <span className={`w-1.5 h-1.5 rounded-full ${pfmEnabled ? 'bg-primary' : 'bg-muted-foreground/50'}`} />
                 {pfmEnabled ? 'Enabled' : 'Disabled'}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* ASCII Flow Reminder Card */}
+      <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+        <div className="flex items-start gap-3">
+          <div
+            className="w-8 h-8 flex-shrink-0 rounded-md overflow-hidden"
+            dangerouslySetInnerHTML={{ __html: FAVICON_SVG }}
+          />
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center justify-between gap-2">
+              <h3 className="text-sm font-semibold text-foreground">ASCII Plan Flow</h3>
+              <button
+                onClick={toggleAsciiFlow}
+                className={`relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${
+                  asciiFlowEnabled ? 'bg-primary' : 'bg-muted'
+                }`}
+              >
+                <span
+                  className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition-transform ${
+                    asciiFlowEnabled ? 'translate-x-4' : 'translate-x-0'
+                  }`}
+                />
+              </button>
+            </div>
+            <p className="text-xs text-muted-foreground mt-1 leading-relaxed">
+              Asks the planning agent to include a compact <code className="text-[10px] bg-muted px-1 py-0.5 rounded">## Plan Flow</code>{' '}
+              section with a fenced <code className="text-[10px] bg-muted px-1 py-0.5 rounded">text</code> ASCII flowchart.
+              This helps reviewers scan execution order, branches, review gates, rollback paths, and feedback loops before approving.
+            </p>
+            <div className="mt-2">
+              <span className={`inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded-full ${
+                asciiFlowEnabled
+                  ? 'bg-primary/15 text-primary'
+                  : 'bg-muted text-muted-foreground'
+              }`}>
+                <span className={`w-1.5 h-1.5 rounded-full ${asciiFlowEnabled ? 'bg-primary' : 'bg-muted-foreground/50'}`} />
+                {asciiFlowEnabled ? 'Enabled' : 'Disabled'}
               </span>
             </div>
           </div>


### PR DESCRIPTION
## Summary

- Adds an opt-in ASCII Plan Flow planning reminder so supported agents can include a compact `## Plan Flow` section with a fenced `text` ASCII flowchart.
- Persists the new `asciiFlowReminder` config flag and exposes it through `/api/config` and `/api/hooks/status`.
- Wires the reminder through Claude Code, OpenCode, and Pi planning-context injection paths, plus the hook dev mock API.
- Adds a separate Hooks settings card and toggle for ASCII Plan Flow.

## Why

This makes generated plans easier to review before approval by showing execution order, branches, review gates, rollback paths, feedback loops, and parallel work without adding a new renderer. The reminder is prompt-level only and defaults off.

## Notes

- `typescript` is now a root devDependency because the root `typecheck` script directly invokes `tsc`; without it, `bun run typecheck` can fail in a fresh install.
- The ASCII reminder is ordered after the PFM reminder and before the improvement hook when multiple planning reminders are enabled.

## Validation

- `git diff --check`
- `bun test packages/shared/pfm-reminder.test.ts`
- `PATH="$HOME/.bun/bin:$PATH" bun test` — 1036 pass, 1 skip, 0 fail
- `PATH="$HOME/.bun/bin:$PATH" bun run typecheck`
- Manual build completed earlier: `bun run --cwd apps/review build`, `bun run build:hook`, and compiled the local `plannotator` binary.
- Local binary smoke check confirmed the installed binary contains `ASCII Plan Flow` / `asciiFlowReminder` strings.
