### PR TITLE
Fix OpenCode planning agent resolution for display names

### DIFF
--- a/apps/opencode-plugin/workflow.test.ts
+++ b/apps/opencode-plugin/workflow.test.ts
@@ -186,6 +186,38 @@ describe("applyWorkflowConfig", () => {
     expect(config.agent.build.permission.submit_plan).toBe("deny");
   });
 
+  test("plan-agent mode resolves planningAgents to existing display-named agents", () => {
+    const prometheusKey = "\u200B\u200B\u200BPrometheus - Plan Builder";
+    const sisyphusKey = "Sisyphus (Ultraworker)";
+    const config: any = {
+      agent: {
+        [prometheusKey]: {
+          mode: "primary",
+          permission: {},
+        },
+        [sisyphusKey]: {
+          mode: "primary",
+          permission: {},
+        },
+      },
+    };
+
+    applyWorkflowConfig(
+      config,
+      normalizeWorkflowOptions({
+        workflow: "plan-agent",
+        planningAgents: ["prometheus", "sisyphus"],
+      }),
+      false,
+    );
+
+    expect(config.agent[prometheusKey].permission.submit_plan).toBe("allow");
+    expect(config.agent[sisyphusKey].permission.submit_plan).toBe("allow");
+    expect(config.agent.prometheus).toBeUndefined();
+    expect(config.agent.sisyphus).toBeUndefined();
+    expect(config.agent.build.permission.submit_plan).toBe("deny");
+  });
+
   test("plan-agent mode denies user-configured non-planning primary agents", () => {
     const config: any = {
       agent: {

--- a/apps/opencode-plugin/workflow.ts
+++ b/apps/opencode-plugin/workflow.ts
@@ -132,7 +132,9 @@ export function applyWorkflowConfig(
 
   opencodeConfig.agent ??= {};
 
+  const planningAgentConfigKeys = new Set<string>();
   for (const agentName of options.planningAgents) {
+    planningAgentConfigKeys.add(resolveAgentConfigKey(opencodeConfig, agentName));
     allowPlanningAgent(opencodeConfig, agentName);
   }
 
@@ -143,7 +145,7 @@ export function applyWorkflowConfig(
   }
 
   for (const [agentName, agentConfig] of Object.entries(opencodeConfig.agent)) {
-    if (options.planningAgentSet.has(agentName)) {
+    if (options.planningAgentSet.has(agentName) || planningAgentConfigKeys.has(agentName)) {
       allowPlanningAgent(opencodeConfig, agentName);
       continue;
     }
@@ -169,10 +171,36 @@ function denySubmitPlan(opencodeConfig: OpenCodeConfig, agentName: string): void
   ensurePermission(agent).submit_plan = "deny";
 }
 
+function normalizeAgentLookupKey(value: string): string {
+  return value.replace(/[\u200B-\u200D\uFEFF]/g, "").trim().toLowerCase();
+}
+
+function resolveAgentConfigKey(opencodeConfig: OpenCodeConfig, agentName: string): string {
+  opencodeConfig.agent ??= {};
+
+  if (Object.prototype.hasOwnProperty.call(opencodeConfig.agent, agentName)) {
+    return agentName;
+  }
+
+  const normalizedTarget = normalizeAgentLookupKey(agentName);
+  for (const existingKey of Object.keys(opencodeConfig.agent)) {
+    const normalizedExisting = normalizeAgentLookupKey(existingKey);
+    if (normalizedExisting === normalizedTarget) {
+      return existingKey;
+    }
+    if (normalizedExisting.startsWith(`${normalizedTarget} -`) || normalizedExisting.startsWith(`${normalizedTarget} (`)) {
+      return existingKey;
+    }
+  }
+
+  return agentName;
+}
+
 function ensureAgentConfig(opencodeConfig: OpenCodeConfig, agentName: string): AgentConfig {
   opencodeConfig.agent ??= {};
-  opencodeConfig.agent[agentName] ??= {};
-  return opencodeConfig.agent[agentName];
+  const resolvedAgentName = resolveAgentConfigKey(opencodeConfig, agentName);
+  opencodeConfig.agent[resolvedAgentName] ??= {};
+  return opencodeConfig.agent[resolvedAgentName];
 }
 
 function ensurePermission(agent: AgentConfig): Record<string, any> {


### PR DESCRIPTION
## Summary
- Resolve configured OpenCode `planningAgents` to existing agent config keys before mutating permissions.
- Match display-name agent keys such as `Prometheus - Plan Builder` / `Sisyphus (Ultraworker)` and keys prefixed with zero-width characters, avoiding duplicate raw `prometheus` / `sisyphus` agent entries.
- Preserve allow permissions during the later non-planning-agent deny pass by tracking resolved planning-agent config keys.

## Verification
- `bun test apps/opencode-plugin/workflow.test.ts` ✅
- LSP diagnostics clean for `apps/opencode-plugin/workflow.ts` and `apps/opencode-plugin/workflow.test.ts` ✅
- `bun test apps/opencode-plugin` was attempted, but this temp checkout lacks workspace dependency resolution for `@plannotator/server`, so unrelated command tests fail before exercising this change.

## Context
This fixes a real OpenCode config interaction where `planningAgents: ["prometheus", "sisyphus"]` created extra raw agent entries instead of reusing existing OhMyOpenCode display-keyed agent configs.