### PR TITLE
fix: scope id-token:write to only AWS OIDC deploy jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,6 @@ on:
           - paste
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:
@@ -86,6 +85,9 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.marketing == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     environment: production
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -121,6 +123,9 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.portal == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     environment: production
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -154,6 +159,8 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.paste == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     environment: production
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

- Removes `id-token: write` from the workflow-level `permissions` block in `deploy.yml`
- Adds job-level `permissions` with `id-token: write` only to `deploy-marketing` and `deploy-portal` (the two jobs that use `aws-actions/configure-aws-credentials` with OIDC)
- `deploy-paste` gets only `contents: read` since it authenticates via `CLOUDFLARE_API_TOKEN`
- `detect-changes` inherits only `contents: read` — it just reads git diffs and has no need for OIDC minting

Motivated by the TanStack supply chain attack (https://github.com/TanStack/router/issues/7383) which used GitHub Actions cache poisoning + OIDC trusted publishing. Our pipelines don't use `actions/cache` and aren't vulnerable, but least-privilege on OIDC is good hygiene.

## Test plan

- [ ] Trigger deploy workflow via `workflow_dispatch` targeting marketing — confirm AWS OIDC auth succeeds
- [ ] Confirm `detect-changes` job still works without `id-token: write`