### PR TITLE
feat(ui): copyable hook path + guidance in Settings Hooks tab

### DIFF
--- a/apps/hook/dev-mock-api.ts
+++ b/apps/hook/dev-mock-api.ts
@@ -577,7 +577,7 @@ export function devMockApi(): Plugin {
         if (req.url === '/api/hooks/status') {
           res.setHeader('Content-Type', 'application/json');
           try {
-            const { readImprovementHook } = await import('@plannotator/shared/improvement-hooks');
+            const { readImprovementHook, getImprovementHookExpectedPath } = await import('@plannotator/shared/improvement-hooks');
             const { loadConfig } = await import('@plannotator/shared/config');
             const { composeImproveContext } = await import('@plannotator/shared/pfm-reminder');
             const config = loadConfig();
@@ -588,7 +588,7 @@ export function devMockApi(): Plugin {
               pfmReminder: { enabled: pfmEnabled },
               improvementHook: {
                 present: !!hook,
-                filePath: hook?.filePath ?? null,
+                filePath: hook?.filePath ?? getImprovementHookExpectedPath('enterplanmode-improve'),
                 fileSize: hook?.content?.length ?? null,
                 content: hook?.content ?? null,
               },
@@ -597,7 +597,7 @@ export function devMockApi(): Plugin {
           } catch {
             res.end(JSON.stringify({
               pfmReminder: { enabled: false },
-              improvementHook: { present: false, filePath: null, fileSize: null, content: null },
+              improvementHook: { present: false, filePath: '~/.plannotator/hooks/compound/enterplanmode-improve-hook.txt', fileSize: null, content: null },
               composedLength: null,
             }));
           }

--- a/apps/pi-extension/server/serverPlan.ts
+++ b/apps/pi-extension/server/serverPlan.ts
@@ -37,7 +37,7 @@ import {
 import { listenOnPort } from "./network.js";
 
 import { loadConfig, saveConfig, detectGitUser, getServerConfig } from "../generated/config.js";
-import { readImprovementHook } from "../generated/improvement-hooks.js";
+import { readImprovementHook, getImprovementHookExpectedPath } from "../generated/improvement-hooks.js";
 import { composeImproveContext } from "../generated/pfm-reminder.js";
 import { detectProjectName, getRepoInfo } from "./project.js";
 import {
@@ -238,7 +238,7 @@ export async function startPlanReviewServer(options: {
 				pfmReminder: { enabled: pfmEnabled },
 				improvementHook: {
 					present: !!hook,
-					filePath: hook?.filePath ?? null,
+					filePath: hook?.filePath ?? getImprovementHookExpectedPath("enterplanmode-improve"),
 					fileSize: hook?.content?.length ?? null,
 					content: hook?.content ?? null,
 				},

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -42,7 +42,7 @@ import {
 import { getRepoInfo } from "./repo";
 import { detectProjectName } from "./project";
 import { loadConfig, saveConfig, detectGitUser, getServerConfig } from "./config";
-import { readImprovementHook } from "@plannotator/shared/improvement-hooks";
+import { readImprovementHook, getImprovementHookExpectedPath } from "@plannotator/shared/improvement-hooks";
 import { composeImproveContext } from "@plannotator/shared/pfm-reminder";
 import { handleImage, handleUpload, handleAgents, handleServerReady, handleDraftSave, handleDraftLoad, handleDraftDelete, handleFavicon, type OpencodeClient } from "./shared-handlers";
 import { contentHash, deleteDraft } from "./draft";
@@ -310,7 +310,7 @@ export async function startPlannotatorServer(
               pfmReminder: { enabled: pfmEnabled },
               improvementHook: {
                 present: !!hook,
-                filePath: hook?.filePath ?? null,
+                filePath: hook?.filePath ?? getImprovementHookExpectedPath("enterplanmode-improve"),
                 fileSize: hook?.content?.length ?? null,
                 content: hook?.content ?? null,
               },

--- a/packages/shared/improvement-hooks.ts
+++ b/packages/shared/improvement-hooks.ts
@@ -44,6 +44,14 @@ const KNOWN_HOOKS = {
 
 export type ImprovementHookName = keyof typeof KNOWN_HOOKS;
 
+export function getImprovementHookExpectedPath(
+  hookName: ImprovementHookName,
+): string | null {
+  const entry = KNOWN_HOOKS[hookName];
+  if (!entry) return null;
+  return join(HOOKS_BASE_DIR, entry.path);
+}
+
 export interface ImprovementHookResult {
   content: string;
   hookName: ImprovementHookName;

--- a/packages/ui/components/settings/HooksTab.tsx
+++ b/packages/ui/components/settings/HooksTab.tsx
@@ -12,6 +12,42 @@ interface HooksStatus {
   composedLength: number | null;
 }
 
+function displayPath(filePath: string): string {
+  const home = filePath.match(/^(\/[^/]+\/[^/]+)\//)?.[1];
+  if (home && filePath.startsWith(home)) return '~' + filePath.slice(home.length);
+  return filePath;
+}
+
+const CopyPathButton: React.FC<{ filePath: string }> = ({ filePath }) => {
+  const [copied, setCopied] = useState(false);
+
+  const copy = () => {
+    navigator.clipboard.writeText(filePath).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
+  return (
+    <button
+      onClick={copy}
+      title="Copy path"
+      className="inline-flex items-center gap-1.5 mt-1.5 px-2 py-1 rounded bg-muted/60 hover:bg-muted border border-border/50 transition-colors group max-w-full"
+    >
+      <code className="text-[10px] text-muted-foreground font-mono truncate">
+        {displayPath(filePath)}
+      </code>
+      <span className="flex-shrink-0 text-muted-foreground/60 group-hover:text-muted-foreground transition-colors">
+        {copied ? (
+          <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M13.25 4.75 6 12 2.75 8.75" /></svg>
+        ) : (
+          <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><rect x="5.5" y="5.5" width="8" height="8" rx="1.5" /><path d="M10.5 5.5V3a1.5 1.5 0 0 0-1.5-1.5H3A1.5 1.5 0 0 0 1.5 3v6A1.5 1.5 0 0 0 3 10.5h2.5" /></svg>
+        )}
+      </span>
+    </button>
+  );
+};
+
 export const HooksTab: React.FC = () => {
   const [status, setStatus] = useState<HooksStatus | null>(null);
   const [pfmEnabled, setPfmEnabled] = useState(false);
@@ -119,6 +155,14 @@ export const HooksTab: React.FC = () => {
                     <span className="text-muted-foreground/70"> · {(status.improvementHook.fileSize / 1024).toFixed(1)}KB</span>
                   )}
                 </p>
+                {status.improvementHook.filePath && (
+                  <CopyPathButton filePath={status.improvementHook.filePath} />
+                )}
+                <p className="text-[11px] text-muted-foreground/70 mt-2 leading-relaxed">
+                  Edit this file directly to customize, or
+                  run <code className="text-[10px] bg-muted px-1 py-0.5 rounded">/plannotator-compound</code> to
+                  regenerate from recent denial history.
+                </p>
                 <button
                   onClick={() => setHookExpanded(!hookExpanded)}
                   className="text-xs text-primary hover:text-primary/80 mt-1.5 transition-colors"
@@ -132,20 +176,28 @@ export const HooksTab: React.FC = () => {
                 )}
               </>
             ) : (
-              <p className="text-xs text-muted-foreground mt-1 leading-relaxed">
-                No improvement hook file found. This file contains corrective planning instructions
-                generated from analysis of your plan denial patterns — the more you review, the better
-                your agent plans.{' '}
-                <a
-                  href="https://plannotator.ai/blog/continuously-improve-claude-code-plans/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-primary hover:text-primary/80 underline underline-offset-2"
-                >
-                  Learn more
-                </a>{' '}
-                or run <code className="text-[10px] bg-muted px-1 py-0.5 rounded">/plannotator-compound</code> to generate one.
-              </p>
+              <>
+                <p className="text-xs text-muted-foreground mt-1 leading-relaxed">
+                  No improvement hook found. This file injects corrective planning instructions
+                  before your agent writes a plan — the more you review, the better your agent plans.
+                </p>
+                {status.improvementHook.filePath && (
+                  <CopyPathButton filePath={status.improvementHook.filePath} />
+                )}
+                <p className="text-[11px] text-muted-foreground/70 mt-2 leading-relaxed">
+                  Run <code className="text-[10px] bg-muted px-1 py-0.5 rounded">/plannotator-compound</code> to
+                  auto-generate from your denial history, or create a plain text file at the path above with
+                  your own instructions.{' '}
+                  <a
+                    href="https://plannotator.ai/blog/continuously-improve-claude-code-plans/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary hover:text-primary/80 underline underline-offset-2"
+                  >
+                    Learn more
+                  </a>
+                </p>
+              </>
             )}
           </div>
         </div>

--- a/packages/ui/components/settings/HooksTab.tsx
+++ b/packages/ui/components/settings/HooksTab.tsx
@@ -13,8 +13,8 @@ interface HooksStatus {
 }
 
 function displayPath(filePath: string): string {
-  const home = filePath.match(/^(\/[^/]+\/[^/]+)\//)?.[1];
-  if (home && filePath.startsWith(home)) return '~' + filePath.slice(home.length);
+  const idx = filePath.indexOf('/.plannotator/');
+  if (idx >= 0) return '~' + filePath.slice(idx);
   return filePath;
 }
 


### PR DESCRIPTION
## Summary
- Always return the improvement hook file path from `GET /api/hooks/status` — actual path when the file exists, expected path when it doesn't — across all three servers (Bun, Pi, dev mock)
- Add `CopyPathButton` component: tilde-shortened display (`~/.plannotator/...`), copies full absolute path to clipboard with checkmark feedback
- **Active state:** shows copyable path + guidance to edit directly or regenerate via `/plannotator-compound`
- **Not found state:** shows expected path + guidance for both auto-generation and manual file creation, with blog link

## Test plan
- [ ] `bun run dev:hook` → Settings → Hooks tab with no hook file present — verify "Not found" state shows expected path, copy works, guidance text is correct
- [ ] Create `~/.plannotator/hooks/compound/enterplanmode-improve-hook.txt` with test content → reopen Settings → verify "Active" state shows actual path, file size, copy works, "Show content" expander works
- [ ] Remove the file → verify "Not found" returns with expected path
- [ ] Click copy button → paste in terminal → verify full absolute path (not tilde-shortened)