### PR TITLE
fix: update Codex hooks feature flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -353,7 +353,7 @@ jobs:
           run_installer
 
           test -x "$tmp_home/.local/bin/plannotator"
-          grep -q 'codex_hooks = true' "$tmp_home/.codex/config.toml"
+          grep -q 'hooks = true' "$tmp_home/.codex/config.toml"
 
           HOME="$tmp_home" node <<'NODE'
           const fs = require("fs");

--- a/apps/codex/README.md
+++ b/apps/codex/README.md
@@ -33,7 +33,7 @@ Add this to `~/.codex/config.toml` or `<repo>/.codex/config.toml`:
 
 ```toml
 [features]
-codex_hooks = true
+hooks = true
 ```
 
 Then create `~/.codex/hooks.json` or `<repo>/.codex/hooks.json`:

--- a/apps/marketing/src/content/docs/getting-started/installation.md
+++ b/apps/marketing/src/content/docs/getting-started/installation.md
@@ -138,7 +138,7 @@ For manual setup, enable hooks in `~/.codex/config.toml` or `<repo>/.codex/confi
 
 ```toml
 [features]
-codex_hooks = true
+hooks = true
 ```
 
 Then add `hooks.json` next to that config layer:

--- a/apps/marketing/src/content/docs/guides/troubleshooting.md
+++ b/apps/marketing/src/content/docs/guides/troubleshooting.md
@@ -72,7 +72,7 @@ If a Codex plan turn completes without opening Plannotator:
 
 1. Rerun the installer: `curl -fsSL https://plannotator.ai/install.sh | bash`
 2. Restart Codex Desktop or CLI so hooks are reloaded
-3. Check `~/.codex/config.toml` contains `codex_hooks = true` under `[features]`
+3. Check `~/.codex/config.toml` contains `hooks = true` under `[features]`
 4. Check `~/.codex/hooks.json` has a `Stop` hook whose command points to `plannotator`
 5. Run `plannotator sessions` in case the browser failed to open but the session is running
 

--- a/scripts/install.cmd
+++ b/scripts/install.cmd
@@ -413,7 +413,7 @@ if "!CODEX_AVAILABLE!"=="1" (
     echo   1. Add this to %%USERPROFILE%%\.codex\config.toml:
     echo.
     echo      [features]
-    echo      codex_hooks = true
+    echo      hooks = true
     echo.
     echo   2. Add a Stop hook in %%USERPROFILE%%\.codex\hooks.json that runs:
     echo.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -299,7 +299,7 @@ if ($codexAvailable) {
     Write-Host "  1. Add this to $env:USERPROFILE\.codex\config.toml:"
     Write-Host ""
     Write-Host "     [features]"
-    Write-Host "     codex_hooks = true"
+    Write-Host "     hooks = true"
     Write-Host ""
     Write-Host "  2. Add a Stop hook in $env:USERPROFILE\.codex\hooks.json that runs:"
     Write-Host ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -337,7 +337,7 @@ if [ "$codex_available" -eq 1 ]; then
         if [ ! -f "$CODEX_CONFIG" ]; then
             cat > "$CODEX_CONFIG" << 'CODEX_CONFIG_EOF'
 [features]
-codex_hooks = true
+hooks = true
 CODEX_CONFIG_EOF
             echo "Created Codex config at ${CODEX_CONFIG}"
             return 0
@@ -349,7 +349,7 @@ CODEX_CONFIG_EOF
             echo "Add this manually to enable Plannotator plan review:"
             echo ""
             echo "  [features]"
-            echo "  codex_hooks = true"
+            echo "  hooks = true"
             return 1
         fi
 
@@ -366,15 +366,15 @@ CODEX_CONFIG_EOF
             {
                 if (is_table($0)) {
                     if (in_features && !saw_hook) {
-                        print "codex_hooks = true"
+                        print "hooks = true"
                         saw_hook = 1
                     }
                     in_features = ($0 ~ /^[[:space:]]*\[features\][[:space:]]*$/)
                     if (in_features) saw_features = 1
                 }
 
-                if (in_features && $0 ~ /^[[:space:]]*codex_hooks[[:space:]]*=/) {
-                    print "codex_hooks = true"
+                if (in_features && $0 ~ /^[[:space:]]*(codex_hooks|hooks)[[:space:]]*=/) {
+                    print "hooks = true"
                     saw_hook = 1
                     next
                 }
@@ -383,21 +383,21 @@ CODEX_CONFIG_EOF
             }
             END {
                 if (saw_features && in_features && !saw_hook) {
-                    print "codex_hooks = true"
+                    print "hooks = true"
                 } else if (!saw_features) {
                     print ""
                     print "[features]"
-                    print "codex_hooks = true"
+                    print "hooks = true"
                 }
             }
         ' "$CODEX_CONFIG" > "$tmp_config"; then
             mv "$tmp_config" "$CODEX_CONFIG"
-            echo "Enabled codex_hooks in ${CODEX_CONFIG}"
+            echo "Enabled Codex hooks in ${CODEX_CONFIG}"
             return 0
         fi
 
         rm -f "$tmp_config"
-        echo "Could not update ${CODEX_CONFIG}; add codex_hooks manually." >&2
+        echo "Could not update ${CODEX_CONFIG}; add hooks manually." >&2
         return 1
     }
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -66,7 +66,7 @@ Options:
 ```
 
 Builds the hook and review apps, creates a disposable `HOME` plus sample git repo, copies your Codex `auth.json`,
-enables `codex_hooks`, and runs a real `codex exec` against the sample project. The script writes logs, rollout paths,
+enables `hooks`, and runs a real `codex exec` against the sample project. The script writes logs, rollout paths,
 history indices, and session URLs into an artifact directory under the temp root.
 
 Tips:

--- a/tests/UI-TESTING.md
+++ b/tests/UI-TESTING.md
@@ -193,7 +193,7 @@ UI test scripts simulate plugin behavior locally:
 1. Builds the hook + review apps (unless `--skip-build`)
 2. Creates a disposable `HOME` and sample git repo
 3. Copies your Codex auth into the disposable config
-4. Enables `codex_hooks` and registers a `Stop` hook pointing at the local Plannotator entrypoint
+4. Enables `hooks` and registers a `Stop` hook pointing at the local Plannotator entrypoint
 5. Runs a real `codex exec` prompt that returns only a `<proposed_plan>` block
 6. Leaves behind rollout logs, Plannotator history, plan files, and session URLs in an artifact directory
 

--- a/tests/manual/local/enter-codex-plan-review-sandbox.sh
+++ b/tests/manual/local/enter-codex-plan-review-sandbox.sh
@@ -34,7 +34,7 @@ Sandbox env:
   CODEX_HOME=$CODEX_HOME
 
 Run Desktop Codex from this shell:
-  codex --enable codex_hooks -m gpt-5.4-mini -s workspace-write app
+  codex --enable hooks -m gpt-5.4-mini -s workspace-write app
 
 After a failed hook, inspect:
   cat $ROOT_DIR/artifacts/plannotator-hook-events.log

--- a/tests/manual/local/test-codex-plan-review-e2e.sh
+++ b/tests/manual/local/test-codex-plan-review-e2e.sh
@@ -205,7 +205,7 @@ fi
 
 cat > "$TEMP_HOME/.codex/config.toml" <<'EOF'
 [features]
-codex_hooks = true
+hooks = true
 EOF
 
 cat > "$TEMP_HOME/.codex/hooks.json" <<'EOF'
@@ -298,8 +298,8 @@ env HOME="$TEMP_HOME" "${CODEX_CMD[@]}" --version > "$ARTIFACTS_DIR/codex-versio
 env HOME="$TEMP_HOME" "${CODEX_CMD[@]}" features list > "$ARTIFACTS_DIR/codex-features.txt" 2>&1
 env HOME="$TEMP_HOME" "${CODEX_CMD[@]}" login status > "$ARTIFACTS_DIR/codex-login-status.txt" 2>&1 || true
 
-if ! grep -q 'codex_hooks' "$ARTIFACTS_DIR/codex-features.txt"; then
-  echo "Selected Codex CLI does not expose codex_hooks." >&2
+if ! grep -Eq '^hooks[[:space:]]' "$ARTIFACTS_DIR/codex-features.txt"; then
+  echo "Selected Codex CLI does not expose hooks." >&2
   echo "See: $ARTIFACTS_DIR/codex-features.txt" >&2
   exit 1
 fi
@@ -333,7 +333,7 @@ PROMPT_CONTENT="$(cat "$PROMPT_PATH")"
   printf 'PROMPT_CONTENT="$(cat %q)"\n' "$PROMPT_PATH"
   printf 'exec '
   printf '%q ' "${CODEX_CMD[@]}"
-  printf 'exec --enable codex_hooks -m %q -s %q -C %q "$PROMPT_CONTENT"\n' "$MODEL" "$SANDBOX_MODE" "$WORKSPACE_DIR"
+  printf 'exec --enable hooks -m %q -s %q -C %q "$PROMPT_CONTENT"\n' "$MODEL" "$SANDBOX_MODE" "$WORKSPACE_DIR"
 } > "$RUNNER_SCRIPT"
 chmod +x "$RUNNER_SCRIPT"
 


### PR DESCRIPTION
## Problem

Codex no longer wants users or installers to enable hooks with `[features].codex_hooks`. The current CLI reports that flag as deprecated and asks users to use `[features].hooks` instead.

Plannotator still wrote and documented the old flag in a few places: the Unix installer, Windows manual guidance, Codex setup docs, troubleshooting docs, local E2E harnesses, and the release smoke test. That means new installs could produce deprecation warnings, and the project documentation pointed users at a stale Codex configuration shape.

## Solution

Update Plannotator’s Codex setup path to use the current `[features].hooks = true` flag everywhere user-facing or test-facing.

The Unix installer now writes `hooks = true` for new Codex configs and also migrates an existing managed `codex_hooks = ...` entry to `hooks = true` when it updates the `[features]` table. Inline `features = ...` configs are still left untouched, with the manual guidance updated to show the new flag.

This also updates the docs, Windows installer guidance, manual Codex harness commands, and the release workflow assertion so they all agree on the same current Codex feature flag.

## Validation

- `bun test scripts/install.test.ts`
