### PR TITLE
Add plan context map sidebar

### DIFF
--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useLayoutEffect, useMemo, useRef, useCallback } from 'react';
 import { toast, Toaster } from 'sonner';
 import { type Origin, getAgentName } from '@plannotator/shared/agents';
+import { parseCodePath } from '@plannotator/shared/code-file';
 import { parseMarkdownToBlocks, exportAnnotations, exportLinkedDocAnnotations, exportEditorAnnotations, exportCodeFileAnnotations, extractFrontmatter, wrapFeedbackForAgent, Frontmatter, type LinkedDocAnnotationEntry } from '@plannotator/ui/utils/parser';
 import { Viewer, ViewerHandle } from '@plannotator/ui/components/Viewer';
 import { HtmlViewer } from '@plannotator/ui/components/html-viewer';
@@ -59,8 +60,10 @@ import { useExternalAnnotations } from '@plannotator/ui/hooks/useExternalAnnotat
 import { useExternalAnnotationHighlights } from '@plannotator/ui/hooks/useExternalAnnotationHighlights';
 import { buildPlanAgentInstructions } from '@plannotator/ui/utils/planAgentInstructions';
 import { useFileBrowser } from '@plannotator/ui/hooks/useFileBrowser';
+import { useValidatedCodePaths, type ValidationEntry } from '@plannotator/ui/hooks/useValidatedCodePaths';
 import { isVaultBrowserEnabled } from '@plannotator/ui/utils/obsidian';
 import { isFileBrowserEnabled, getFileBrowserSettings } from '@plannotator/ui/utils/fileBrowser';
+import { extractPlanContextFiles, type PlanContextFile } from '@plannotator/ui/utils/planContext';
 import { generateId } from '@plannotator/ui/utils/generateId';
 import { SidebarTabs } from '@plannotator/ui/components/sidebar/SidebarTabs';
 import { SidebarContainer } from '@plannotator/ui/components/sidebar/SidebarContainer';
@@ -354,6 +357,42 @@ const App: React.FC = () => {
     }, [activeDocBaseDir]),
   });
 
+  const rawPlanContextFiles = useMemo(
+    () => extractPlanContextFiles(blocks),
+    [blocks],
+  );
+  const planContextValidation = useValidatedCodePaths(markdown);
+  const planContextValidationByPath = useMemo(() => {
+    const next = new Map<string, ValidationEntry>();
+    for (const [candidate, validation] of planContextValidation.validated) {
+      const path = parseCodePath(candidate).filePath;
+      const existing = next.get(path);
+      if (!existing || validation.status === 'found') {
+        next.set(path, validation);
+      }
+    }
+    return next;
+  }, [planContextValidation.validated]);
+  const planContextFiles = useMemo<PlanContextFile[]>(
+    () => rawPlanContextFiles.map((file) => {
+      if (!planContextValidation.ready) return file;
+      const validation = planContextValidationByPath.get(file.path);
+      if (!validation) return file;
+      if (validation.status === 'found') {
+        return {
+          ...file,
+          resolvedPath: validation.resolved,
+          validationStatus: validation.status,
+        };
+      }
+      return {
+        ...file,
+        validationStatus: validation.status,
+      };
+    }),
+    [rawPlanContextFiles, planContextValidation.ready, planContextValidationByPath],
+  );
+
   // Archive browser
   const archive = useArchive({
     markdown, viewerRef, linkedDocHook,
@@ -364,6 +403,22 @@ const App: React.FC = () => {
     archiveMode: archive.archiveMode,
     isPlanDiffActive,
   }), [archive.archiveMode, isPlanDiffActive]);
+
+  const showContextTab = useMemo(
+    () => planContextFiles.length > 0
+      && !archive.archiveMode
+      && !annotateMode
+      && !linkedDocHook.isActive
+      && renderAs === 'markdown'
+      && !isPlanDiffActive,
+    [planContextFiles.length, archive.archiveMode, annotateMode, linkedDocHook.isActive, renderAs, isPlanDiffActive],
+  );
+
+  useEffect(() => {
+    if (sidebar.isOpen && sidebar.activeTab === 'context' && !showContextTab) {
+      sidebar.open('toc');
+    }
+  }, [sidebar.isOpen, sidebar.activeTab, sidebar.open, showContextTab]);
 
   const enterViewMode = useCallback((type: WideModeType) => {
     if (!canUseWideMode) return;
@@ -1280,6 +1335,22 @@ const App: React.FC = () => {
     // This is just a placeholder for future custom logic
   };
 
+  const handleContextNavigate = useCallback((blockId: string) => {
+    const target = document.querySelector(`[data-block-id="${blockId}"]`);
+    if (!target || !scrollViewport) return;
+
+    const headerOffset = 80;
+    const containerRect = scrollViewport.getBoundingClientRect();
+    const targetRect = target.getBoundingClientRect();
+    const offsetPosition =
+      scrollViewport.scrollTop + targetRect.top - containerRect.top - headerOffset;
+
+    scrollViewport.scrollTo({
+      top: offsetPosition,
+      behavior: 'smooth',
+    });
+  }, [scrollViewport]);
+
   const annotationsOutput = useMemo(() => {
     const docAnnotations = linkedDocHook.getDocAnnotations();
     const hasDocAnnotations = Array.from(docAnnotations.values()).some(
@@ -1697,6 +1768,7 @@ const App: React.FC = () => {
               onToggleTab={toggleSidebarTab}
               hasDiff={planDiff.hasPreviousVersion}
               showVersionsTab={versionInfo !== null && versionInfo.totalVersions > 1}
+              showContextTab={showContextTab}
               showFilesTab={showFilesTab && !archive.archiveMode}
               hasFileAnnotations={hasFileAnnotations}
               className="hidden lg:flex absolute left-0 top-0 z-10"
@@ -1721,6 +1793,9 @@ const App: React.FC = () => {
                 linkedDocFilepath={linkedDocHook.filepath}
                 onLinkedDocBack={linkedDocHook.isActive ? handleLinkedDocBack : undefined}
                 backLabel={backLabel}
+                showContextTab={showContextTab}
+                planContextFiles={planContextFiles}
+                onContextNavigate={handleContextNavigate}
                 showFilesTab={showFilesTab && !archive.archiveMode}
                 fileAnnotationCounts={fileAnnotationCounts}
                 highlightedFiles={highlightedFiles}

--- a/packages/shared/extract-code-paths.test.ts
+++ b/packages/shared/extract-code-paths.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { extractCandidateCodePaths } from "./extract-code-paths";
+import { extractCandidateCodePathMentions, extractCandidateCodePaths } from "./extract-code-paths";
 
 describe("extractCandidateCodePaths", () => {
 	test("extracts backtick code-file paths", () => {
@@ -17,6 +17,11 @@ describe("extractCandidateCodePaths", () => {
 	test("dedupes repeated references", () => {
 		const md = "`src/foo.ts` and src/foo.ts again";
 		expect(extractCandidateCodePaths(md)).toEqual(["src/foo.ts"]);
+	});
+
+	test("keeps repeated references for mention summaries", () => {
+		const md = "`src/foo.ts` and src/foo.ts again";
+		expect(extractCandidateCodePathMentions(md)).toEqual(["src/foo.ts", "src/foo.ts"]);
 	});
 
 	test("strips line anchors", () => {

--- a/packages/shared/extract-code-paths.ts
+++ b/packages/shared/extract-code-paths.ts
@@ -24,23 +24,37 @@ const BACKTICK_SPAN = /`([^`\n]+)`/g;
  * Hash anchors (`#L42`) are stripped from results to match the renderer's
  * `cleanPath` transform. Returns deduped candidate strings.
  */
-export function extractCandidateCodePaths(markdown: string): string[] {
+function collectCandidateCodePaths(markdown: string, dedupe: boolean): string[] {
 	const stripped = markdown
 		.replace(FENCED_CODE_BLOCK, "")
 		.replace(HTML_COMMENT, "");
 
-	const candidates = new Set<string>();
+	const seen = new Set<string>();
+	const candidates: string[] = [];
+
+	const addCandidate = (candidate: string) => {
+		const clean = candidate.replace(/#.*$/, "");
+		if (dedupe) {
+			if (seen.has(clean)) return;
+			seen.add(clean);
+		}
+		candidates.push(clean);
+	};
 
 	let m: RegExpExecArray | null;
 	const backtickRe = new RegExp(BACKTICK_SPAN.source, "g");
 	while ((m = backtickRe.exec(stripped)) !== null) {
 		const inner = m[1].trim();
 		if (isCodeFilePath(inner)) {
-			candidates.add(inner.replace(/#.*$/, ""));
+			addCandidate(inner);
 		}
 	}
 
-	for (const line of stripped.split("\n")) {
+	const strippedForBareScan = stripped.replace(BACKTICK_SPAN, (match) =>
+		" ".repeat(match.length),
+	);
+
+	for (const line of strippedForBareScan.split("\n")) {
 		const urlRanges: Array<[number, number]> = [];
 		const urlRe = new RegExp(URL_REGEX.source, "g");
 		while ((m = urlRe.exec(line)) !== null) {
@@ -58,9 +72,22 @@ export function extractCandidateCodePaths(markdown: string): string[] {
 			);
 			if (overlapsUrl) continue;
 			if (!isCodeFilePathStrict(m[0])) continue;
-			candidates.add(m[0].replace(/#.*$/, ""));
+			addCandidate(m[0]);
 		}
 	}
 
-	return Array.from(candidates);
+	return candidates;
+}
+
+export function extractCandidateCodePaths(markdown: string): string[] {
+	return collectCandidateCodePaths(markdown, true);
+}
+
+/**
+ * Extract candidate code-file path mentions without deduplication.
+ * Uses the same stripping and validation rules as `extractCandidateCodePaths`,
+ * but keeps repeated mentions so UI summaries can show frequency.
+ */
+export function extractCandidateCodePathMentions(markdown: string): string[] {
+	return collectCandidateCodePaths(markdown, false);
 }

--- a/packages/ui/components/sidebar/PlanContextBrowser.tsx
+++ b/packages/ui/components/sidebar/PlanContextBrowser.tsx
@@ -1,0 +1,256 @@
+/**
+ * PlanContextBrowser — code-file mentions extracted from the current plan.
+ *
+ * This is an orientation map, not authoritative change metadata. Status badges
+ * are best-effort hints from explicit plan headings such as "Modified files".
+ */
+
+import React, { useEffect, useMemo, useState } from "react";
+import type { PlanContextFile, PlanContextStatus } from "../../utils/planContext";
+import { CountBadge } from "./CountBadge";
+
+interface PlanContextBrowserProps {
+  files: PlanContextFile[];
+  onNavigate: (blockId: string) => void;
+}
+
+interface ContextTreeNode {
+  type: "folder" | "file";
+  name: string;
+  path: string;
+  mentionCount: number;
+  children?: ContextTreeNode[];
+  file?: PlanContextFile;
+}
+
+interface MutableContextFolder {
+  children: Map<string, MutableContextFolder | PlanContextFile>;
+}
+
+const STATUS_LABEL: Record<PlanContextStatus, string> = {
+  mentioned: "Mentioned",
+  modified: "Modified",
+  created: "Created",
+  deleted: "Deleted",
+};
+
+const STATUS_CLASS: Record<PlanContextStatus, string> = {
+  mentioned: "border-border/70 bg-muted/60 text-muted-foreground",
+  modified: "border-warning/35 bg-warning/10 text-warning",
+  created: "border-success/35 bg-success/10 text-success",
+  deleted: "border-destructive/35 bg-destructive/10 text-destructive",
+};
+
+function buildContextTree(files: PlanContextFile[]): ContextTreeNode[] {
+  const root: MutableContextFolder = { children: new Map() };
+
+  for (const file of files) {
+    const segments = file.path.split("/").filter(Boolean);
+    if (segments.length === 0) continue;
+
+    let current = root;
+    for (const segment of segments.slice(0, -1)) {
+      const existing = current.children.get(segment);
+      if (existing && !(existing as PlanContextFile).firstBlockId) {
+        current = existing as MutableContextFolder;
+      } else {
+        const next: MutableContextFolder = { children: new Map() };
+        current.children.set(segment, next);
+        current = next;
+      }
+    }
+
+    current.children.set(segments[segments.length - 1], file);
+  }
+
+  return folderToNodes(root, "");
+}
+
+function folderToNodes(folder: MutableContextFolder, parentPath: string): ContextTreeNode[] {
+  const folders: ContextTreeNode[] = [];
+  const fileNodes: ContextTreeNode[] = [];
+
+  for (const [name, value] of folder.children) {
+    const path = parentPath ? `${parentPath}/${name}` : name;
+    if ((value as PlanContextFile).firstBlockId) {
+      const file = value as PlanContextFile;
+      fileNodes.push({
+        type: "file",
+        name,
+        path: file.path,
+        mentionCount: file.mentionCount,
+        file,
+      });
+      continue;
+    }
+
+    const children = folderToNodes(value as MutableContextFolder, path);
+    folders.push({
+      type: "folder",
+      name,
+      path,
+      children,
+      mentionCount: children.reduce((sum, child) => sum + child.mentionCount, 0),
+    });
+  }
+
+  folders.sort((a, b) => a.name.localeCompare(b.name));
+  fileNodes.sort((a, b) => a.name.localeCompare(b.name));
+  return [...folders, ...fileNodes];
+}
+
+function getFolderPaths(nodes: ContextTreeNode[]): string[] {
+  const paths: string[] = [];
+  for (const node of nodes) {
+    if (node.type !== "folder") continue;
+    paths.push(node.path);
+    if (node.children) paths.push(...getFolderPaths(node.children));
+  }
+  return paths;
+}
+
+export const PlanContextBrowser: React.FC<PlanContextBrowserProps> = ({
+  files,
+  onNavigate,
+}) => {
+  const tree = useMemo(() => buildContextTree(files), [files]);
+  const folderPaths = useMemo(() => getFolderPaths(tree), [tree]);
+  const [expandedFolders, setExpandedFolders] = useState<Set<string>>(() => new Set(folderPaths));
+
+  useEffect(() => {
+    setExpandedFolders(new Set(folderPaths));
+  }, [folderPaths]);
+
+  const totalMentions = files.reduce((sum, file) => sum + file.mentionCount, 0);
+  const unresolvedCount = files.filter((file) => file.validationStatus === "missing").length;
+
+  if (files.length === 0) {
+    return (
+      <div className="p-3 text-[11px] text-muted-foreground">
+        No code-file references found in this plan.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col">
+      <div className="px-3 py-2 border-b border-border/30">
+        <div className="flex items-center justify-between gap-2">
+          <div>
+            <h2 className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Plan Context
+            </h2>
+            <p className="mt-0.5 text-[11px] text-foreground/70">
+              {files.length} file{files.length === 1 ? "" : "s"} · {totalMentions} mention{totalMentions === 1 ? "" : "s"}
+            </p>
+          </div>
+          {unresolvedCount > 0 && (
+            <span className="rounded border border-border/60 bg-muted/50 px-1.5 py-0.5 text-[10px] text-muted-foreground">
+              {unresolvedCount} unresolved
+            </span>
+          )}
+        </div>
+      </div>
+      <div className="px-1 py-1">
+        {tree.map((node) => (
+          <ContextNode
+            key={node.type === "file" ? node.path : `folder:${node.path}`}
+            node={node}
+            depth={0}
+            expandedFolders={expandedFolders}
+            onToggleFolder={(path) => {
+              setExpandedFolders((prev) => {
+                const next = new Set(prev);
+                if (next.has(path)) next.delete(path);
+                else next.add(path);
+                return next;
+              });
+            }}
+            onNavigate={onNavigate}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const ContextNode: React.FC<{
+  node: ContextTreeNode;
+  depth: number;
+  expandedFolders: Set<string>;
+  onToggleFolder: (path: string) => void;
+  onNavigate: (blockId: string) => void;
+}> = ({ node, depth, expandedFolders, onToggleFolder, onNavigate }) => {
+  const paddingLeft = 8 + depth * 12;
+
+  if (node.type === "folder") {
+    const isExpanded = expandedFolders.has(node.path);
+    return (
+      <>
+        <button
+          type="button"
+          onClick={() => onToggleFolder(node.path)}
+          className="w-full flex items-center gap-1.5 py-1 text-[11px] text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors rounded-sm"
+          style={{ paddingLeft }}
+          title={node.path}
+        >
+          <svg
+            className={`w-3 h-3 flex-shrink-0 transition-transform ${isExpanded ? "rotate-90" : ""}`}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+          </svg>
+          <svg className="w-3 h-3 flex-shrink-0 text-muted-foreground/60" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+          </svg>
+          <span className="truncate">{node.name}</span>
+          <CountBadge count={node.mentionCount} className="ml-auto" />
+        </button>
+        {isExpanded && node.children?.map((child) => (
+          <ContextNode
+            key={child.type === "file" ? child.path : `folder:${child.path}`}
+            node={child}
+            depth={depth + 1}
+            expandedFolders={expandedFolders}
+            onToggleFolder={onToggleFolder}
+            onNavigate={onNavigate}
+          />
+        ))}
+      </>
+    );
+  }
+
+  const file = node.file!;
+  const isMissing = file.validationStatus === "missing";
+  const statusTitle = `${STATUS_LABEL[file.status]}${file.sectionTitle ? ` in ${file.sectionTitle}` : ""}`;
+
+  return (
+    <button
+      type="button"
+      onClick={() => onNavigate(file.firstBlockId)}
+      className={`w-full flex items-center gap-1.5 py-1 text-[11px] transition-colors rounded-sm ${
+        isMissing
+          ? "text-muted-foreground/55 hover:text-muted-foreground hover:bg-muted/30"
+          : "text-foreground/85 hover:text-foreground hover:bg-muted/50"
+      }`}
+      style={{ paddingLeft: paddingLeft + 15 }}
+      title={`${file.path}${isMissing ? " (not found in repo)" : ""}`}
+    >
+      <svg className="w-3 h-3 flex-shrink-0 opacity-40" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+      </svg>
+      <span className="min-w-0 flex-1 truncate text-left">{node.name}</span>
+      <span
+        className={`flex-shrink-0 rounded border px-1.5 py-0.5 text-[9px] font-medium leading-none ${STATUS_CLASS[file.status]}`}
+        title={statusTitle}
+      >
+        {STATUS_LABEL[file.status]}
+      </span>
+      <CountBadge count={file.mentionCount} />
+    </button>
+  );
+};

--- a/packages/ui/components/sidebar/SidebarContainer.tsx
+++ b/packages/ui/components/sidebar/SidebarContainer.tsx
@@ -1,7 +1,8 @@
 /**
  * SidebarContainer — Shared sidebar shell
  *
- * Houses the Table of Contents, Version Browser, File Browser, and Archive Browser views.
+ * Houses the Table of Contents, Version Browser, Plan Context, File Browser,
+ * and Archive Browser views.
  * Tab bar at top switches between them.
  */
 
@@ -13,8 +14,10 @@ import type { UseFileBrowserReturn } from "../../hooks/useFileBrowser";
 import { TableOfContents } from "../TableOfContents";
 import { VersionBrowser } from "./VersionBrowser";
 import { FileBrowser } from "./FileBrowser";
+import { PlanContextBrowser } from "./PlanContextBrowser";
 import { ArchiveBrowser, type ArchivedPlan } from "./ArchiveBrowser";
 import { OverlayScrollArea } from "../OverlayScrollArea";
+import type { PlanContextFile } from "../../utils/planContext";
 
 interface SidebarContainerProps {
   activeTab: SidebarTab;
@@ -29,6 +32,10 @@ interface SidebarContainerProps {
   linkedDocFilepath?: string | null;
   onLinkedDocBack?: () => void;
   backLabel?: string;
+  // Plan Context props
+  showContextTab?: boolean;
+  planContextFiles?: PlanContextFile[];
+  onContextNavigate?: (blockId: string) => void;
   // File Browser props
   showFilesTab?: boolean;
   fileAnnotationCounts?: Map<string, number>;
@@ -72,6 +79,9 @@ export const SidebarContainer: React.FC<SidebarContainerProps> = ({
   linkedDocFilepath,
   onLinkedDocBack,
   backLabel,
+  showContextTab,
+  planContextFiles,
+  onContextNavigate,
   showFilesTab,
   fileAnnotationCounts,
   highlightedFiles,
@@ -145,6 +155,28 @@ export const SidebarContainer: React.FC<SidebarContainerProps> = ({
               </svg>
             }
             label="Versions"
+          />
+        )}
+        {showContextTab && (
+          <TabButton
+            active={activeTab === "context"}
+            onClick={() => onTabChange("context")}
+            icon={
+              <svg
+                className="w-3 h-3"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M4 7h6m4 0h6M4 12h16M4 17h8m4 0h4"
+                />
+              </svg>
+            }
+            label="Context"
           />
         )}
         {showFilesTab && (
@@ -241,6 +273,12 @@ export const SidebarContainer: React.FC<SidebarContainerProps> = ({
             isSelectingVersion={isSelectingVersion}
             fetchingVersion={fetchingVersion}
             onFetchVersions={onFetchVersions}
+          />
+        )}
+        {activeTab === "context" && showContextTab && (
+          <PlanContextBrowser
+            files={planContextFiles ?? []}
+            onNavigate={onContextNavigate ?? (() => {})}
           />
         )}
         {activeTab === "files" && showFilesTab && fileBrowser && (

--- a/packages/ui/components/sidebar/SidebarTabs.tsx
+++ b/packages/ui/components/sidebar/SidebarTabs.tsx
@@ -13,6 +13,7 @@ interface SidebarTabsProps {
   onToggleTab: (tab: SidebarTab) => void;
   hasDiff: boolean;
   showVersionsTab?: boolean;
+  showContextTab?: boolean;
   showFilesTab?: boolean;
   hasFileAnnotations?: boolean;
   className?: string;
@@ -23,6 +24,7 @@ export const SidebarTabs: React.FC<SidebarTabsProps> = ({
   onToggleTab,
   hasDiff,
   showVersionsTab,
+  showContextTab,
   showFilesTab,
   hasFileAnnotations,
   className,
@@ -77,6 +79,30 @@ export const SidebarTabs: React.FC<SidebarTabsProps> = ({
           {hasDiff && (
             <span className="absolute top-1 right-1 w-1.5 h-1.5 rounded-full bg-primary" />
           )}
+        </button>
+      )}
+
+      {/* Context tab */}
+      {showContextTab && (
+        <button
+          onClick={() => onToggleTab("context")}
+          className="sidebar-tab-flag group relative flex items-center justify-center w-7 h-9 rounded-r-md border border-l-0 border-border/50 bg-card/80 backdrop-blur-sm text-muted-foreground hover:text-foreground hover:bg-card transition-colors"
+          title="Plan Context"
+        >
+          <svg
+            className="w-3.5 h-3.5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M4 7h6m4 0h6M4 12h16M4 17h8m4 0h4"
+            />
+          </svg>
+          <span className="absolute top-1 right-1 w-1.5 h-1.5 rounded-full bg-primary" />
         </button>
       )}
 

--- a/packages/ui/hooks/useSidebar.ts
+++ b/packages/ui/hooks/useSidebar.ts
@@ -8,7 +8,7 @@
 
 import { useState, useCallback } from "react";
 
-export type SidebarTab = "toc" | "versions" | "files" | "archive";
+export type SidebarTab = "toc" | "versions" | "context" | "files" | "archive";
 
 export interface UseSidebarReturn<T extends string = SidebarTab> {
   isOpen: boolean;

--- a/packages/ui/utils/planContext.test.ts
+++ b/packages/ui/utils/planContext.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+import { parseMarkdownToBlocks } from "./parser";
+import { extractPlanContextFiles, inferPlanContextStatusFromHeading } from "./planContext";
+
+function extract(markdown: string) {
+  return extractPlanContextFiles(parseMarkdownToBlocks(markdown));
+}
+
+describe("inferPlanContextStatusFromHeading", () => {
+  test("recognizes explicit file-change headings", () => {
+    expect(inferPlanContextStatusFromHeading("Modified files")).toBe("modified");
+    expect(inferPlanContextStatusFromHeading("Files to update")).toBe("modified");
+    expect(inferPlanContextStatusFromHeading("New files")).toBe("created");
+    expect(inferPlanContextStatusFromHeading("Files to create")).toBe("created");
+    expect(inferPlanContextStatusFromHeading("Deleted files")).toBe("deleted");
+    expect(inferPlanContextStatusFromHeading("Files to remove")).toBe("deleted");
+  });
+
+  test("does not treat generic file-change headings as status", () => {
+    expect(inferPlanContextStatusFromHeading("Phase 4: File Changes")).toBeNull();
+  });
+});
+
+describe("extractPlanContextFiles", () => {
+  test("extracts backticked and bare prose code paths", () => {
+    const files = extract([
+      "# Plan",
+      "",
+      "Update `packages/editor/App.tsx`.",
+      "",
+      "Then touch packages/ui/components/Viewer.tsx.",
+    ].join("\n"));
+
+    expect(files.map((file) => file.path)).toEqual([
+      "packages/editor/App.tsx",
+      "packages/ui/components/Viewer.tsx",
+    ]);
+  });
+
+  test("ignores paths inside fenced code blocks and html comments", () => {
+    const files = extract([
+      "# Plan",
+      "",
+      "```ts",
+      "import './src/hidden.ts';",
+      "```",
+      "",
+      "<!-- packages/ui/secret.ts -->",
+    ].join("\n"));
+
+    expect(files).toEqual([]);
+  });
+
+  test("maps the first mention to the correct block id", () => {
+    const blocks = parseMarkdownToBlocks([
+      "# Plan",
+      "",
+      "Intro mentions packages/ui/first.ts.",
+      "",
+      "- Later mentions packages/ui/first.ts again.",
+    ].join("\n"));
+
+    const files = extractPlanContextFiles(blocks);
+    const firstParagraph = blocks.find((block) => block.content.includes("Intro mentions"))!;
+    expect(files[0]).toMatchObject({
+      path: "packages/ui/first.ts",
+      firstBlockId: firstParagraph.id,
+      mentionCount: 2,
+    });
+  });
+
+  test("groups line-range references by file path", () => {
+    const files = extract([
+      "# Plan",
+      "",
+      "See packages/ui/components/Viewer.tsx:140-180.",
+      "",
+      "Also revisit `packages/ui/components/Viewer.tsx#L200`.",
+    ].join("\n"));
+
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatchObject({
+      path: "packages/ui/components/Viewer.tsx",
+      mentionCount: 2,
+    });
+  });
+
+  test("uses the nearest explicit status heading", () => {
+    const files = extract([
+      "# Plan",
+      "",
+      "## Phase 1",
+      "",
+      "### Modified files",
+      "",
+      "- `packages/ui/context.ts`",
+      "",
+      "#### Client",
+      "",
+      "- packages/editor/App.tsx",
+      "",
+      "### Created files",
+      "",
+      "- packages/ui/new-widget.tsx",
+      "",
+      "### Deleted files",
+      "",
+      "- packages/ui/old-widget.tsx",
+    ].join("\n"));
+
+    expect(files.find((file) => file.path === "packages/ui/context.ts")?.status).toBe("modified");
+    expect(files.find((file) => file.path === "packages/editor/App.tsx")?.status).toBe("modified");
+    expect(files.find((file) => file.path === "packages/ui/new-widget.tsx")?.status).toBe("created");
+    expect(files.find((file) => file.path === "packages/ui/old-widget.tsx")?.status).toBe("deleted");
+  });
+
+  test("falls back to mentioned when explicit statuses conflict", () => {
+    const files = extract([
+      "# Plan",
+      "",
+      "## Modified files",
+      "",
+      "- packages/ui/conflict.ts",
+      "",
+      "## Deleted files",
+      "",
+      "- packages/ui/conflict.ts",
+    ].join("\n"));
+
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatchObject({
+      path: "packages/ui/conflict.ts",
+      status: "mentioned",
+      mentionCount: 2,
+    });
+  });
+});

--- a/packages/ui/utils/planContext.ts
+++ b/packages/ui/utils/planContext.ts
@@ -1,0 +1,131 @@
+import { extractCandidateCodePathMentions } from "@plannotator/shared/extract-code-paths";
+import { parseCodePath } from "@plannotator/shared/code-file";
+import type { Block } from "../types";
+
+export type PlanContextStatus = "mentioned" | "modified" | "created" | "deleted";
+
+export interface PlanContextFile {
+  path: string;
+  resolvedPath?: string;
+  status: PlanContextStatus;
+  mentionCount: number;
+  firstBlockId: string;
+  sectionTitle?: string;
+  validationStatus?: "found" | "ambiguous" | "missing" | "unavailable";
+}
+
+interface HeadingFrame {
+  level: number;
+  title: string;
+  status: Exclude<PlanContextStatus, "mentioned"> | null;
+}
+
+interface MutablePlanContextFile {
+  path: string;
+  explicitStatuses: Set<Exclude<PlanContextStatus, "mentioned">>;
+  mentionCount: number;
+  firstBlockId: string;
+  firstOrder: number;
+  sectionTitle?: string;
+}
+
+const BLOCK_TYPES_WITH_PATH_MENTIONS = new Set<Block["type"]>([
+  "paragraph",
+  "heading",
+  "blockquote",
+  "list-item",
+  "table",
+  "html",
+  "directive",
+]);
+
+export function inferPlanContextStatusFromHeading(
+  heading: string
+): Exclude<PlanContextStatus, "mentioned"> | null {
+  const normalized = heading
+    .toLowerCase()
+    .replace(/[`*_#[\](){}]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (/(^|\b)(modified|updated|changed)\s+files?\b/.test(normalized)) {
+    return "modified";
+  }
+  if (/\bfiles?\s+(to\s+)?(modify|update|change)\b/.test(normalized)) {
+    return "modified";
+  }
+  if (/(^|\b)(created|new|added)\s+files?\b/.test(normalized)) {
+    return "created";
+  }
+  if (/\bfiles?\s+(to\s+)?(create|add)\b/.test(normalized)) {
+    return "created";
+  }
+  if (/(^|\b)(deleted|removed)\s+files?\b/.test(normalized)) {
+    return "deleted";
+  }
+  if (/\bfiles?\s+(to\s+)?(delete|remove)\b/.test(normalized)) {
+    return "deleted";
+  }
+
+  return null;
+}
+
+export function extractPlanContextFiles(blocks: Block[]): PlanContextFile[] {
+  const byPath = new Map<string, MutablePlanContextFile>();
+  let headingStack: HeadingFrame[] = [];
+
+  for (const block of [...blocks].sort((a, b) => a.order - b.order)) {
+    if (block.type === "heading") {
+      const level = block.level ?? 1;
+      headingStack = headingStack.filter((heading) => heading.level < level);
+      headingStack.push({
+        level,
+        title: block.content,
+        status: inferPlanContextStatusFromHeading(block.content),
+      });
+    }
+
+    if (!BLOCK_TYPES_WITH_PATH_MENTIONS.has(block.type)) continue;
+
+    const mentions = extractCandidateCodePathMentions(block.content);
+    if (mentions.length === 0) continue;
+
+    const explicitStatus = [...headingStack].reverse().find((heading) => heading.status)?.status ?? null;
+    const sectionTitle = [...headingStack].reverse().find((heading) => heading.title)?.title;
+
+    for (const mention of mentions) {
+      const path = parseCodePath(mention).filePath;
+      const existing = byPath.get(path);
+      if (existing) {
+        existing.mentionCount += 1;
+        if (explicitStatus) existing.explicitStatuses.add(explicitStatus);
+        continue;
+      }
+
+      byPath.set(path, {
+        path,
+        explicitStatuses: explicitStatus ? new Set([explicitStatus]) : new Set(),
+        mentionCount: 1,
+        firstBlockId: block.id,
+        firstOrder: block.order,
+        sectionTitle,
+      });
+    }
+  }
+
+  return [...byPath.values()]
+    .sort((a, b) => a.firstOrder - b.firstOrder || a.path.localeCompare(b.path))
+    .map((entry) => {
+      const explicitStatuses = [...entry.explicitStatuses];
+      const status: PlanContextStatus =
+        explicitStatuses.length === 1 ? explicitStatuses[0] : "mentioned";
+
+      return {
+        path: entry.path,
+        status,
+        mentionCount: entry.mentionCount,
+        firstBlockId: entry.firstBlockId,
+        sectionTitle: entry.sectionTitle,
+      };
+    });
+}


### PR DESCRIPTION
## Summary
- add a Context sidebar tab for markdown plans with detected code-file mentions
- group mentions into a compact folder-style tree with mention counts and lightweight status badges
- let file rows jump back to the first plan block that mentions that file

## Details
- reuses the existing shared code-path extraction rules and adds a repeated-mention helper
- infers Modified, Created, and Deleted only from explicit nearby file-change headings, with conflicts falling back to Mentioned
- reuses /api/doc/exists validation via the existing validated-code-path hook so unresolved paths render muted
- hides the Context tab in archive, annotate, linked-doc, HTML, and active plan-diff views

## Validation
- bun test packages/shared/extract-code-paths.test.ts
- bun test packages/ui/utils/planContext.test.ts
- bun run typecheck
- bun run build:hook