### PR TITLE
fix: accept PLANNOTATOR_PORT=0 without spurious warning

### DIFF
--- a/packages/server/remote.ts
+++ b/packages/server/remote.ts
@@ -53,7 +53,7 @@ export function getServerPort(): number {
   const envPort = process.env.PLANNOTATOR_PORT;
   if (envPort) {
     const parsed = parseInt(envPort, 10);
-    if (!isNaN(parsed) && parsed > 0 && parsed < 65536) {
+    if (!isNaN(parsed) && parsed >= 0 && parsed < 65536) {
       return parsed;
     }
     console.error(


### PR DESCRIPTION
## Summary
- `PLANNOTATOR_PORT=0` printed `[Plannotator] Warning: Invalid PLANNOTATOR_PORT "0", using default` even though port 0 is the conventional "OS picks a random port" value — and already the local-mode fallback.
- Relax the validator in `getServerPort()` from `parsed > 0` to `parsed >= 0` so `0` passes through silently.

Fixes #715

## Test plan
- [ ] `PLANNOTATOR_PORT=0 plannotator annotate README.md` — no warning printed
- [ ] `PLANNOTATOR_PORT=-1 plannotator annotate README.md` — warning still printed (negative still invalid)
- [ ] `PLANNOTATOR_PORT=8080 plannotator annotate README.md` — still binds to 8080