### PR TITLE
fix(gitlab): handle concatenated JSON pages from glab --paginate

### DIFF
--- a/packages/shared/pr-gitlab.test.ts
+++ b/packages/shared/pr-gitlab.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { parsePaginatedArray } from "./pr-gitlab";
+
+describe("parsePaginatedArray", () => {
+  test("parses a single-page array", () => {
+    const stdout = JSON.stringify([{ a: 1 }, { a: 2 }]);
+    expect(parsePaginatedArray<{ a: number }>(stdout)).toEqual([{ a: 1 }, { a: 2 }]);
+  });
+
+  test("merges adjacent JSON arrays from --paginate output", () => {
+    const stdout = JSON.stringify([{ a: 1 }]) + JSON.stringify([{ a: 2 }, { a: 3 }]);
+    expect(parsePaginatedArray<{ a: number }>(stdout)).toEqual([
+      { a: 1 },
+      { a: 2 },
+      { a: 3 },
+    ]);
+  });
+
+  test("merges three or more pages with whitespace between them", () => {
+    const stdout = [
+      JSON.stringify([1, 2]),
+      JSON.stringify([3, 4]),
+      JSON.stringify([5]),
+    ].join("\n");
+    expect(parsePaginatedArray<number>(stdout)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  test("handles strings containing brackets without splitting prematurely", () => {
+    // Diff content frequently contains `][` inside JSON strings — must not be
+    // confused with a page boundary.
+    const page1 = [{ diff: "before][after", new_path: "a" }];
+    const page2 = [{ diff: "second", new_path: "b" }];
+    const stdout = JSON.stringify(page1) + JSON.stringify(page2);
+    expect(parsePaginatedArray(stdout)).toEqual([...page1, ...page2]);
+  });
+
+  test("handles escaped quotes inside strings", () => {
+    const page1 = [{ diff: 'has \\"quote\\" and ] bracket', new_path: "a" }];
+    const page2 = [{ diff: "second", new_path: "b" }];
+    const stdout = JSON.stringify(page1) + JSON.stringify(page2);
+    expect(parsePaginatedArray(stdout)).toEqual([...page1, ...page2]);
+  });
+
+  test("returns empty array for empty input", () => {
+    expect(parsePaginatedArray("")).toEqual([]);
+    expect(parsePaginatedArray("   \n")).toEqual([]);
+  });
+
+  test("handles empty pages mixed with non-empty ones", () => {
+    const stdout = "[]" + JSON.stringify([{ a: 1 }]) + "[]";
+    expect(parsePaginatedArray<{ a: number }>(stdout)).toEqual([{ a: 1 }]);
+  });
+});

--- a/packages/shared/pr-gitlab.ts
+++ b/packages/shared/pr-gitlab.ts
@@ -40,9 +40,61 @@ interface GitLabDiffEntry {
   renamed_file: boolean;
 }
 
-/** Parse JSON array from glab api --paginate output (already merged by glab) */
-function parsePaginatedArray<T>(stdout: string): T[] {
-  return JSON.parse(stdout) as T[];
+/**
+ * Parse output of `glab api --paginate`.
+ *
+ * glab concatenates pages as adjacent JSON arrays (`[...][...]`) which is not
+ * valid JSON. Walk the output, split it into top-level arrays, and merge them.
+ * Single-page output (the common case) round-trips through the same path.
+ */
+export function parsePaginatedArray<T>(stdout: string): T[] {
+  const trimmed = stdout.trim();
+  if (!trimmed) return [];
+
+  const slices: string[] = [];
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  let start = -1;
+
+  for (let i = 0; i < trimmed.length; i++) {
+    const c = trimmed[i];
+    if (inString) {
+      if (escape) {
+        escape = false;
+      } else if (c === "\\") {
+        escape = true;
+      } else if (c === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (c === '"') {
+      inString = true;
+      continue;
+    }
+    if (c === "[" || c === "{") {
+      if (depth === 0 && c === "[") start = i;
+      depth++;
+    } else if (c === "]" || c === "}") {
+      depth--;
+      if (depth === 0 && c === "]" && start !== -1) {
+        slices.push(trimmed.slice(start, i + 1));
+        start = -1;
+      }
+    }
+  }
+
+  if (slices.length === 0) {
+    return JSON.parse(trimmed) as T[];
+  }
+
+  const merged: T[] = [];
+  for (const slice of slices) {
+    const page = JSON.parse(slice) as T[];
+    if (Array.isArray(page)) merged.push(...page);
+  }
+  return merged;
 }
 
 /**


### PR DESCRIPTION
## Summary

- `glab api --paginate` concatenates page responses as adjacent JSON arrays (`[...][...]`), which `JSON.parse` rejects. MR reviews failed with "JSON Parse error" on any MR with more than 100 changed files.
- Replace the bare `JSON.parse` in `parsePaginatedArray` with a walker that splits the output into top-level arrays and merges them. The walker tracks string state and escape sequences so a literal `][` inside diff content is not mistaken for a page boundary.
- Add focused unit tests covering single-page, multi-page merge, brackets inside strings, escaped quotes, empty input, and empty pages.

Fixes #714

## Test plan

- [x] `bun test packages/shared/pr-gitlab.test.ts` — 7/7 pass
- [x] `bun test packages/shared/pr-provider.test.ts packages/shared/pr-gitlab.test.ts` — 25/25 pass, no regressions
- [ ] Manual: open a GitLab MR with >100 changed files and verify the diff loads