### PR TITLE
fix(opencode): intercept annotate/review/archive commands before LLM

### DIFF
--- a/apps/opencode-plugin/commands/plannotator-annotate.md
+++ b/apps/opencode-plugin/commands/plannotator-annotate.md
@@ -1,6 +1,3 @@
 ---
 description: Open interactive annotation UI for a markdown file, HTML file, or URL
 ---
-
-The Plannotator Annotate UI has been triggered. Opening the annotation UI...
-Acknowledge "Opening annotation UI..." and wait for the user's feedback.

--- a/apps/opencode-plugin/commands/plannotator-archive.md
+++ b/apps/opencode-plugin/commands/plannotator-archive.md
@@ -1,6 +1,3 @@
 ---
 description: Browse saved plan decisions in the archive
 ---
-
-The Plannotator Archive has been triggered. Opening the archive browser...
-Acknowledge "Opening plan archive..." and wait for the user to finish browsing.

--- a/apps/opencode-plugin/commands/plannotator-review.md
+++ b/apps/opencode-plugin/commands/plannotator-review.md
@@ -1,6 +1,3 @@
 ---
 description: Open interactive code review for current changes or a PR URL; pass --git to force Git in JJ workspaces
 ---
-
-The Plannotator Code Review has been triggered. Opening the review UI...
-Acknowledge "Opening code review..." and wait for the user's feedback.

--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -383,11 +383,26 @@ The user will review your plan in a visual UI where they can annotate, approve, 
 Do NOT proceed with implementation until your plan is approved.`);
     },
 
-    // Intercept plannotator-last before the agent sees the command
+    // Intercept plannotator commands before the agent sees them.
+    // Clearing output.parts in place suppresses the .md body + appended
+    // args so the agent never receives the command — without this, OpenCode
+    // calls resolvePromptParts() on "<body> <arguments>", which auto-attaches
+    // any file path it finds as a FilePart. On a large file that blows the
+    // context before the annotation UI even opens (#713).
+    //
+    // Must mutate in place (length = 0), not reassign (= []). The caller
+    // holds a reference to the parts array directly and ignores any new
+    // array assigned to output.parts.
     "command.execute.before": async (input, output) => {
-      if (input.command !== "plannotator-last") return;
+      const cmd = input.command;
+      if (
+        cmd !== "plannotator-last" &&
+        cmd !== "plannotator-annotate" &&
+        cmd !== "plannotator-review" &&
+        cmd !== "plannotator-archive"
+      ) return;
 
-      output.parts = [];
+      output.parts.length = 0;
 
       const deps: CommandDeps = {
         client: ctx.client,
@@ -398,58 +413,35 @@ Do NOT proceed with implementation until your plan is approved.`);
         getPasteApiUrl,
         directory: ctx.directory,
       };
+      // input.arguments is the raw tail string from OpenCode's command dispatcher —
+      // needed so --gate / --json reach the handlers' parseAnnotateArgs (#570).
+      const event = {
+        properties: { sessionID: input.sessionID, arguments: input.arguments },
+      };
 
-      const feedback = await handleAnnotateLastCommand(
-        // input.arguments is the raw tail string from OpenCode's command dispatcher —
-        // needed so --gate / --json reach handleAnnotateLastCommand's parseAnnotateArgs (#570).
-        { properties: { sessionID: input.sessionID, arguments: input.arguments } },
-        deps
-      );
-
-      if (feedback) {
-        try {
-          await ctx.client.session.prompt({
-            path: { id: input.sessionID },
-            body: {
-              parts: [{
-                type: "text",
-                text: getAnnotateMessageFeedbackPrompt("opencode", undefined, { feedback }),
-              }],
-            },
-          });
-        } catch {
-          // Session may not be available
+      if (cmd === "plannotator-last") {
+        const feedback = await handleAnnotateLastCommand(event, deps);
+        if (feedback) {
+          try {
+            await ctx.client.session.prompt({
+              path: { id: input.sessionID },
+              body: {
+                parts: [{
+                  type: "text",
+                  text: getAnnotateMessageFeedbackPrompt("opencode", undefined, { feedback }),
+                }],
+              },
+            });
+          } catch {
+            // Session may not be available
+          }
         }
+        return;
       }
-    },
 
-    // Listen for slash commands (review + annotate)
-    event: async ({ event }) => {
-      const isCommandEvent =
-        event.type === "command.executed" ||
-        event.type === "tui.command.execute";
-
-      if (!isCommandEvent) return;
-
-      // @ts-ignore - Event structure varies
-      const commandName = event.properties?.name || event.command || event.payload?.name;
-
-      const deps: CommandDeps = {
-        client: ctx.client,
-        htmlContent: getPlanHtml(),
-        reviewHtmlContent: getReviewHtml(),
-        getSharingEnabled,
-        getShareBaseUrl,
-        getPasteApiUrl,
-        directory: ctx.directory,
-      };
-
-      if (commandName === "plannotator-review")
-        return handleReviewCommand(event, deps);
-      if (commandName === "plannotator-annotate")
-        return handleAnnotateCommand(event, deps);
-      if (commandName === "plannotator-archive")
-        return handleArchiveCommand(event, deps);
+      if (cmd === "plannotator-annotate") return handleAnnotateCommand(event, deps);
+      if (cmd === "plannotator-review") return handleReviewCommand(event, deps);
+      if (cmd === "plannotator-archive") return handleArchiveCommand(event, deps);
     },
   };
 


### PR DESCRIPTION
## Summary

- Move `/plannotator-annotate`, `/plannotator-review`, `/plannotator-archive` from the post-hoc `event` handler into `command.execute.before` — same pattern `plannotator-last` already used — so the agent never sees the command body or appended args.
- Empty the bodies of the three `.md` files; only the frontmatter is needed for OpenCode to register the slash command.
- Fix `output.parts = []` → `output.parts.length = 0`: OpenCode's caller (`prompt.ts:1944-1979`) holds a direct reference to the parts array and ignores any new array assigned to the hook's `output.parts`, so the previous reassignment was a no-op.

## Root cause

When the user runs `/plannotator-annotate /path/to/huge.md`, OpenCode appends the args to the `.md` body and runs `resolvePromptParts()` on the combined string. That function (`prompt.ts`) walks file references and pushes `{ type: "file", url, filename, mime }` parts. The agent then receives the file as a `FilePart` in a user message — before the annotation UI even exists. With a large file plus GLM-5, that blows the context and triggers auto-compact.

`plannotator-last` already used `command.execute.before` to intercept the prompt before it reached the LLM. The other three commands relied on the `event` handler, which fires *after* `command.executed` is published — i.e. after the agent has already processed the turn.

## Test plan

- [x] `bun test apps/opencode-plugin/` — 37 pass
- [x] `bun build apps/opencode-plugin/index.ts` — clean
- [ ] Manual: `/plannotator-annotate <large markdown file>` in OpenCode no longer triggers auto-compact; annotation UI opens immediately; feedback is delivered after submit.
- [ ] Manual: `/plannotator-review`, `/plannotator-archive`, `/plannotator-last` still behave as before.

Fixes #713