### PR TITLE
fix(review): persist file comment drafts across close/reopen

### DIFF
--- a/packages/review-editor/components/AllFilesDiffView.tsx
+++ b/packages/review-editor/components/AllFilesDiffView.tsx
@@ -101,6 +101,7 @@ export const AllFilesDiffView: React.FC<AllFilesDiffViewProps> = ({
     setActiveFilePath(null);
     setCollapsedFiles(new Set());
     collapseHistory.current = [];
+    setFileCommentAnchor(null);
   }, [files]);
 
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -515,6 +516,7 @@ export const AllFilesDiffView: React.FC<AllFilesDiffViewProps> = ({
 
       {fileCommentAnchor && onAddFileComment && (
         <CommentPopover
+          key={`file:${prUrl ?? ''}:${prDiffScope ?? ''}:${fileCommentAnchor.filePath}`}
           anchorEl={fileCommentAnchor.el}
           contextText={fileCommentAnchor.filePath.split('/').pop() || fileCommentAnchor.filePath}
           isGlobal={false}

--- a/packages/review-editor/components/AllFilesDiffView.tsx
+++ b/packages/review-editor/components/AllFilesDiffView.tsx
@@ -501,6 +501,7 @@ export const AllFilesDiffView: React.FC<AllFilesDiffViewProps> = ({
           anchorEl={fileCommentAnchor.el}
           contextText={fileCommentAnchor.filePath.split('/').pop() || fileCommentAnchor.filePath}
           isGlobal={false}
+          draftKey={`file:${fileCommentAnchor.filePath}`}
           onSubmit={(text) => {
             onAddFileComment(fileCommentAnchor.filePath, text);
             setFileCommentAnchor(null);

--- a/packages/review-editor/components/AllFilesDiffView.tsx
+++ b/packages/review-editor/components/AllFilesDiffView.tsx
@@ -518,7 +518,7 @@ export const AllFilesDiffView: React.FC<AllFilesDiffViewProps> = ({
           anchorEl={fileCommentAnchor.el}
           contextText={fileCommentAnchor.filePath.split('/').pop() || fileCommentAnchor.filePath}
           isGlobal={false}
-          draftKey={`file:${fileCommentAnchor.filePath}`}
+          draftKey={`file:${prUrl ?? ''}:${prDiffScope ?? ''}:${fileCommentAnchor.filePath}`}
           onSubmit={(text) => {
             onAddFileComment(fileCommentAnchor.filePath, text);
             setFileCommentAnchor(null);

--- a/packages/review-editor/components/DiffViewer.tsx
+++ b/packages/review-editor/components/DiffViewer.tsx
@@ -621,6 +621,7 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
           anchorEl={fileCommentAnchor}
           contextText={filePath.split('/').pop() || filePath}
           isGlobal={false}
+          draftKey={`file:${filePath}`}
           onSubmit={(text) => {
             onAddFileComment(text);
             setFileCommentAnchor(null);

--- a/packages/review-editor/components/DiffViewer.tsx
+++ b/packages/review-editor/components/DiffViewer.tsx
@@ -120,6 +120,9 @@ interface DiffViewerProps {
   oldPath?: string;
   /** Base branch override used for file-content lookups (branch / merge-base modes only). */
   reviewBase?: string;
+  /** Current PR url + diff scope — used to namespace file-comment drafts so they don't leak across in-place PR switches. */
+  prUrl?: string;
+  prDiffScope?: string;
   isFocused?: boolean;
   diffStyle: 'split' | 'unified';
   diffOverflow?: 'scroll' | 'wrap';
@@ -165,6 +168,8 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
   filePath,
   oldPath,
   reviewBase,
+  prUrl,
+  prDiffScope,
   isFocused = false,
   diffStyle,
   diffOverflow,
@@ -621,7 +626,7 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
           anchorEl={fileCommentAnchor}
           contextText={filePath.split('/').pop() || filePath}
           isGlobal={false}
-          draftKey={`file:${filePath}`}
+          draftKey={`file:${prUrl ?? ''}:${prDiffScope ?? ''}:${filePath}`}
           onSubmit={(text) => {
             onAddFileComment(text);
             setFileCommentAnchor(null);

--- a/packages/review-editor/dock/panels/ReviewDiffPanel.tsx
+++ b/packages/review-editor/dock/panels/ReviewDiffPanel.tsx
@@ -71,6 +71,8 @@ export const ReviewDiffPanel: React.FC<IDockviewPanelProps> = (props) => {
         filePath={file.path}
         oldPath={file.oldPath}
         reviewBase={state.reviewBase}
+        prUrl={state.prMetadata?.url}
+        prDiffScope={state.prDiffScope}
         isFocused={isFocusedFile}
         diffStyle={state.diffStyle}
         diffOverflow={state.diffOverflow}

--- a/packages/ui/components/CommentPopover.tsx
+++ b/packages/ui/components/CommentPopover.tsx
@@ -20,10 +20,27 @@ interface CommentPopoverProps {
   onSubmit: (text: string, images?: ImageAttachment[]) => void;
   /** Called when popover is closed/cancelled */
   onClose: () => void;
+  /** Opt-in: persist text + images across close/reopen, keyed by this string. Cleared on submit. */
+  draftKey?: string;
 }
 
 const MAX_POPOVER_WIDTH = 384;
 const GAP = 8;
+
+// Module-level draft store: survives popover unmount so reopening the same key restores in-progress text.
+const draftStore = new Map<string, { text: string; images: ImageAttachment[] }>();
+
+/** Mirrors the latest text + images into `draftStore[draftKey]` so they outlive popover unmount. No-op without a key. */
+function useCommentDraftSync(draftKey: string | undefined, text: string, images: ImageAttachment[]) {
+  useEffect(() => {
+    if (!draftKey) return;
+    if (text.trim() || images.length > 0) {
+      draftStore.set(draftKey, { text, images });
+    } else {
+      draftStore.delete(draftKey);
+    }
+  }, [draftKey, text, images]);
+}
 
 function computePosition(anchorRect: DOMRect): { top: number; left: number; flipAbove: boolean; width: number } {
   const spaceBelow = window.innerHeight - anchorRect.bottom;
@@ -48,14 +65,18 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
   initialText = '',
   onSubmit,
   onClose,
+  draftKey,
 }) => {
   const [mode, setMode] = useState<'popover' | 'dialog'>('popover');
-  const [text, setText] = useState(initialText);
-  const [images, setImages] = useState<ImageAttachment[]>([]);
+  const initialDraft = draftKey ? draftStore.get(draftKey) : undefined;
+  const [text, setText] = useState(initialDraft?.text ?? initialText);
+  const [images, setImages] = useState<ImageAttachment[]>(initialDraft?.images ?? []);
   const [position, setPosition] = useState<{ top: number; left: number; flipAbove: boolean; width: number } | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
   const { dragPosition, dragHandleProps, wasDragged, reset: resetDrag } = useDraggable(popoverRef);
+
+  useCommentDraftSync(draftKey, text, images);
 
   // Reset drag when anchor changes (new annotation) or mode switches
   useEffect(() => { resetDrag(); }, [anchorEl, anchorRect, resetDrag]);
@@ -111,9 +132,10 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
 
   const handleSubmit = useCallback(() => {
     if (text.trim() || images.length > 0) {
+      if (draftKey) draftStore.delete(draftKey);
       onSubmit(text, images.length > 0 ? images : undefined);
     }
-  }, [text, images, onSubmit]);
+  }, [text, images, onSubmit, draftKey]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Escape') {


### PR DESCRIPTION
## Summary

- File comment popovers in the code review UI dropped in-progress text whenever the popover was dismissed (click-outside / `Escape` / close button) — `text` and `images` lived in `CommentPopover`'s local `useState`, so unmount erased them. Reopening on the same file started from a blank textarea.
- The line-comment toolbar already solves this with a module-level draft map. This PR mirrors that pattern in `CommentPopover` behind an opt-in `draftKey` prop so existing call sites that don't want draft persistence are unaffected.
- Wire both file-comment call sites — `AllFilesDiffView` and `DiffViewer` — with `draftKey={`file:${filePath}`}`. Drafts are cleared on submit.

## Recording


https://github.com/user-attachments/assets/bb0758df-94b9-41a4-acf1-3b96aadb9bf9

## Test plan

- [x] `bun run --cwd apps/review build && bun run build:hook` — clean build
- [x] Open a file-level comment popover, type some text, click outside — reopen the same file's popover, draft is restored
- [x] Same flow with `Escape` and the X close button — draft restored in both cases
- [x] Attach an image, dismiss, reopen — image attachment is restored alongside text
- [x] Submit the comment — reopen the same file's popover, textarea is empty (draft cleared on submit)
- [x] Open file A's popover, type, dismiss; open file B's popover — file B is blank (drafts keyed per file, no cross-talk)
- [x] Line-comment toolbar still behaves as before (regression check on the existing line-comment draft path)