### PR TITLE
Fix directory name for OpenCode commands

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -470,7 +470,7 @@ Address the annotation feedback above. The user has reviewed your last message a
 Write-Host "Installed /plannotator-last command to $claudeCommandsDir\plannotator-last.md"
 
 # Install OpenCode slash command
-$opencodeCommandsDir = "$env:USERPROFILE\.config\opencode\command"
+$opencodeCommandsDir = "$env:USERPROFILE\.config\opencode\commands"
 New-Item -ItemType Directory -Force -Path $opencodeCommandsDir | Out-Null
 
 @"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -694,7 +694,7 @@ COMMAND_EOF
 echo "Installed /plannotator-last command to ${CLAUDE_COMMANDS_DIR}/plannotator-last.md"
 
 # Install OpenCode slash command
-OPENCODE_COMMANDS_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/opencode/command"
+OPENCODE_COMMANDS_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/opencode/commands"
 mkdir -p "$OPENCODE_COMMANDS_DIR"
 
 cat > "$OPENCODE_COMMANDS_DIR/plannotator-review.md" << 'COMMAND_EOF'


### PR DESCRIPTION
Bug: The path used for opencode's commands dir in the install.sh script doesn't match the [opencode docs](https://opencode.ai/docs/commands/#:~:text=Create%20markdown%20files%20in%20the%20commands/%20directory%20to%20define%20custom%20commands)

Proposed Fix:
I believe an s is missing from the OPENCODE_COMMANDS_DIR path
/command -> /commands