### PR TITLE
fix(browser): treat no-op BROWSER values as unset so headless sessions can fall back

### DIFF
--- a/packages/server/browser.test.ts
+++ b/packages/server/browser.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { shouldTryRemoteBrowserFallback } from "./browser";
+import { isNoOpBrowserSentinel, shouldTryRemoteBrowserFallback } from "./browser";
 
 const savedEnv: Record<string, string | undefined> = {};
 const envKeys = ["PLANNOTATOR_BROWSER", "BROWSER"];
@@ -42,5 +42,36 @@ describe("shouldTryRemoteBrowserFallback", () => {
     clearEnv();
     process.env.PLANNOTATOR_BROWSER = "/usr/bin/browser";
     expect(shouldTryRemoteBrowserFallback(true)).toBe(false);
+  });
+
+  test("true for remote sessions when BROWSER is a no-op sentinel (e.g. agent view)", () => {
+    clearEnv();
+    process.env.BROWSER = "true";
+    expect(shouldTryRemoteBrowserFallback(true)).toBe(true);
+  });
+
+  test("true for remote sessions when PLANNOTATOR_BROWSER is a no-op sentinel", () => {
+    clearEnv();
+    process.env.PLANNOTATOR_BROWSER = "none";
+    expect(shouldTryRemoteBrowserFallback(true)).toBe(true);
+  });
+});
+
+describe("isNoOpBrowserSentinel", () => {
+  test("returns false for undefined / empty", () => {
+    expect(isNoOpBrowserSentinel(undefined)).toBe(false);
+    expect(isNoOpBrowserSentinel("")).toBe(false);
+  });
+
+  test("recognises the documented no-op values, case- and whitespace-insensitive", () => {
+    for (const v of ["true", "false", "none", ":", "0", "1", "TRUE", "  none  "]) {
+      expect(isNoOpBrowserSentinel(v)).toBe(true);
+    }
+  });
+
+  test("does not flag real browser handlers", () => {
+    expect(isNoOpBrowserSentinel("/usr/bin/firefox")).toBe(false);
+    expect(isNoOpBrowserSentinel("Google Chrome")).toBe(false);
+    expect(isNoOpBrowserSentinel("open")).toBe(false);
   });
 });

--- a/packages/server/browser.ts
+++ b/packages/server/browser.ts
@@ -10,6 +10,20 @@ import fs from "node:fs";
 const IPC_REGISTRY = path.join(os.homedir(), ".plannotator", "vscode-ipc.json");
 
 /**
+ * Common "no-op" values for $BROWSER used by headless/background environments
+ * (e.g. Claude Code's agent view sets BROWSER=true) to signal "do not actually
+ * launch a browser". Treating these as if the variable were unset prevents
+ * silently shelling out to e.g. `true <url>`, which exits 0 without opening
+ * anything and leaves the Plannotator server hanging on waitForDecision().
+ */
+const NOOP_BROWSER_VALUES = new Set(["true", "false", "none", ":", "0", "1"]);
+
+export function isNoOpBrowserSentinel(value: string | undefined): boolean {
+  if (!value) return false;
+  return NOOP_BROWSER_VALUES.has(value.trim().toLowerCase());
+}
+
+/**
  * Try opening URL via VS Code extension IPC registry.
  * Falls back when env vars (PLANNOTATOR_BROWSER) aren't available to the process.
  */
@@ -76,7 +90,15 @@ export async function isWSL(): Promise<boolean> {
  * Fails silently if browser can't be opened
  */
 export function shouldTryRemoteBrowserFallback(isRemote: boolean): boolean {
-  return isRemote && !process.env.PLANNOTATOR_BROWSER && !process.env.BROWSER;
+  if (!isRemote) return false;
+  const plannotatorBrowser = process.env.PLANNOTATOR_BROWSER;
+  const browser = process.env.BROWSER;
+  // Treat headless sentinels (e.g. BROWSER=true from Claude Code's agent view)
+  // as if no real browser handler were configured, so the IPC fallback still runs.
+  const hasRealHandler =
+    (plannotatorBrowser && !isNoOpBrowserSentinel(plannotatorBrowser)) ||
+    (browser && !isNoOpBrowserSentinel(browser));
+  return !hasRealHandler;
 }
 
 export async function openBrowser(
@@ -84,7 +106,13 @@ export async function openBrowser(
   options?: { isRemote?: boolean }
 ): Promise<boolean> {
   try {
-    const browser = process.env.PLANNOTATOR_BROWSER || process.env.BROWSER;
+    const rawPlannotatorBrowser = process.env.PLANNOTATOR_BROWSER;
+    const rawBrowser = process.env.BROWSER;
+    const plannotatorBrowser = isNoOpBrowserSentinel(rawPlannotatorBrowser)
+      ? undefined
+      : rawPlannotatorBrowser;
+    const envBrowser = isNoOpBrowserSentinel(rawBrowser) ? undefined : rawBrowser;
+    const browser = plannotatorBrowser || envBrowser;
     if (shouldTryRemoteBrowserFallback(options?.isRemote ?? false)) {
       const openedViaIpc = await tryVscodeIpc(url);
       if (openedViaIpc) {
@@ -96,7 +124,6 @@ export async function openBrowser(
     const wsl = await isWSL();
 
     if (browser) {
-      const plannotatorBrowser = process.env.PLANNOTATOR_BROWSER;
       if (plannotatorBrowser && platform === "darwin") {
         if (plannotatorBrowser.includes("/") && !plannotatorBrowser.endsWith(".app")) {
           await $`${plannotatorBrowser} ${url}`.quiet();


### PR DESCRIPTION
## Summary

When `$BROWSER` (or `$PLANNOTATOR_BROWSER`) is set to a no-op sentinel like `true`, `false`, `none`, `:`, `0`, or `1` — as Claude Code's agent view does (`BROWSER=true`) — `openBrowser()` shells out via `Bun.$` and runs something equivalent to `true http://localhost:NNNN`. `true(1)` exits 0 without doing anything, the function returns success, and the server then sits in `waitForDecision()` forever. No browser appears, the URL isn't recoverable, and the session looks hung.

This is the BROWSER-sentinel branch of the same family as #163 (which fixed `BROWSER=open` / VS Code devcontainer scripts). The remaining sentinel case still affects every headless / background runner that conventionally sets `BROWSER=true` to disable browser launching.

## Fix

`packages/server/browser.ts`:

- Add `isNoOpBrowserSentinel()` recognising the documented no-op values (case- and whitespace-insensitive).
- In `openBrowser()`, treat a sentinel-valued `PLANNOTATOR_BROWSER` / `BROWSER` as if the variable were unset, so we fall through to the platform default (`open` / `xdg-open` / `cmd.exe /c start`) instead of shelling out to the sentinel.
- In `shouldTryRemoteBrowserFallback()`, treat the same sentinels as "no real handler configured" so the VS Code IPC fallback still fires in remote sessions where it would otherwise be skipped.

Net behaviour:

| Env                              | Before                              | After                                 |
| -------------------------------- | ----------------------------------- | ------------------------------------- |
| `BROWSER=true` (agent view)      | runs `true http://...` → no-op      | IPC fallback → platform default       |
| `BROWSER=/usr/bin/firefox`       | spawns firefox                      | spawns firefox (unchanged)            |
| `PLANNOTATOR_BROWSER='Google Chrome'` (macOS) | `open -a` chrome           | `open -a` chrome (unchanged)          |
| unset                            | platform default                    | platform default (unchanged)          |

No protocol or stdout changes, no new dependencies, no surface-area additions.

## Tests

Adds `packages/server/browser.test.ts` coverage:

- `shouldTryRemoteBrowserFallback` now returns `true` when `BROWSER` / `PLANNOTATOR_BROWSER` are sentinels.
- `isNoOpBrowserSentinel` recognises the documented values (incl. `TRUE`, `  none  `) and rejects real handlers (`/usr/bin/firefox`, `Google Chrome`, `open`).

`bun test` is green (1167 pass / 0 fail). `bun run typecheck` is clean.

Refs #154 (BROWSER-sentinel cause; other code paths in that issue may still apply).

Fixes #724 