### PR TITLE
Pin light theme on /workspaces/ at wrapper scope

### DIFF
--- a/apps/marketing/src/pages/workspaces/index.astro
+++ b/apps/marketing/src/pages/workspaces/index.astro
@@ -26,15 +26,43 @@ const teamSizes = [
   description="Plannotator Workspaces is the hosted team layer for collaborating on agent plans, specs, code reviews, and verification standards. Plannotator core stays free and open source."
 >
   <Fragment slot="head">
-    <!-- Force light mode on this page only. The Base.astro cookie-reader
-         only ADDS the `.light` class (never removes), so this `add` runs
-         before paint and any saved-dark setting won't undo it. -->
-    <script is:inline>
-      document.documentElement.classList.add('light');
-    </script>
+    <!-- Force light mode on this page only. We pin the light-theme tokens
+         directly inside `.ws-force-light` rather than relying on the
+         global `.light` class — the Nav's ModeToggleIsland hydrates a
+         React effect that calls `classList.remove('light')` on mount,
+         which would otherwise undo any earlier force-light attempt. */ -->
+    <style>
+      .ws-force-light {
+        --background: oklch(0.97 0.005 260);
+        --foreground: oklch(0.18 0.02 260);
+        --card: oklch(1 0 0);
+        --card-foreground: oklch(0.18 0.02 260);
+        --popover: oklch(1 0 0);
+        --popover-foreground: oklch(0.18 0.02 260);
+        --primary: oklch(0.50 0.25 280);
+        --primary-foreground: oklch(1 0 0);
+        --secondary: oklch(0.50 0.18 180);
+        --secondary-foreground: oklch(1 0 0);
+        --muted: oklch(0.92 0.01 260);
+        --muted-foreground: oklch(0.40 0.02 260);
+        --accent: oklch(0.60 0.22 50);
+        --accent-foreground: oklch(0.18 0.02 260);
+        --destructive: oklch(0.50 0.25 25);
+        --destructive-foreground: oklch(1 0 0);
+        --border: oklch(0.88 0.01 260);
+        --input: oklch(0.92 0.01 260);
+        --ring: oklch(0.50 0.25 280);
+        --success: oklch(0.45 0.20 150);
+        --success-foreground: oklch(1 0 0);
+        --warning: oklch(0.55 0.18 85);
+        --warning-foreground: oklch(0.18 0.02 260);
+        --code-bg: oklch(0.92 0.01 260);
+        color-scheme: light;
+      }
+    </style>
   </Fragment>
 
-  <div class="min-h-screen bg-background text-foreground">
+  <div class="ws-force-light min-h-screen bg-background text-foreground">
     <Nav />
 
     <!-- Two independent flex columns so the hero (top of left column) and


### PR DESCRIPTION
## Summary

Follow-up to #771. The earlier "force light mode on `/workspaces/`" change added the `.light` class to `<html>` via a head-slot inline script. That works for the first paint, but then gets undone:

The `ModeToggleIsland` React component in `Nav.astro` hydrates on mount and runs `applyTheme(theme)`, which always calls `classList.remove('light')` first before re-applying based on the saved theme cookie. So if a visitor's saved theme is dark, the page flashes light then flips to dark a few hundred ms later — which is what was happening in production after #771 merged.

## Fix

Pin the light-theme CSS variables inside a `.ws-force-light` wrapper scope on the workspaces page. The toggle component can still flip the global `.light` class on/off, but the workspaces page's tokens are locked in at the wrapper level and aren't affected.

Net effect: `/workspaces/` is deterministically light regardless of the visitor's saved theme preference, and the rest of the site continues to honor the toggle as before.

## Test plan

- [ ] Hard-refresh `https://plannotator.ai/workspaces/` with `plannotator-theme=dark` cookie set → page renders light, doesn't flash
- [ ] Set `plannotator-theme=light` → still light (unchanged)
- [ ] Navigate to `/docs/` after merging → renders dark (or whatever the saved theme is), confirming the override is page-scoped
- [ ] Click the dark/light toggle in the nav while on `/workspaces/` → toggle still works on the rest of the site if you navigate away; `/workspaces/` itself stays light

Generated with [Devin](https://cli.devin.ai/docs)
