### PR TITLE
Reword /workspaces/ page title

### DIFF
--- a/apps/marketing/src/pages/workspaces/index.astro
+++ b/apps/marketing/src/pages/workspaces/index.astro
@@ -76,7 +76,7 @@ const teamSizes = [
       <div class="ws-col-left">
         <header class="ws-hero">
           <p class="ws-eyebrow">Plannotator Workspaces · Waitlist</p>
-          <h1 class="ws-page-title">From review surfaces to integrated verification systems.</h1>
+          <h1 class="ws-page-title">From review surfaces to standards your agents learn from.</h1>
         </header>
 
         <section class="ws-info">


### PR DESCRIPTION
## Change

`From review surfaces to integrated verification systems.`

→ `From review surfaces to standards your agents learn from.`

## Why

The original phrasing started reading like a slide title. The new line keeps the same arc and conveys both ideas (verification *and* agents that improve from team reviews) without the corporate phrasing. `standards` carries "verifiable + shared" implicitly; `your agents learn from` is the friendly way to say "self-updating".

Generated with [Devin](https://cli.devin.ai/docs)