### PR TITLE
Reword Compound phase on /workspaces/

### DIFF
--- a/apps/marketing/src/pages/workspaces/index.astro
+++ b/apps/marketing/src/pages/workspaces/index.astro
@@ -91,7 +91,7 @@ const teamSizes = [
           </div>
           <div class="ws-phase">
             <span class="ws-when">Compound</span>
-            <span class="ws-what">Those standards get checked during generation, in review, and after code lands. Workspaces will offer enhanced gating for PRs and releases.</span>
+            <span class="ws-what">Those standards get checked before and after code lands. Additionally, Workspaces will offer enhanced gating for PRs and releases; achieving higher quality and faster product verification.</span>
           </div>
         </div>
 


### PR DESCRIPTION
## Change

Compound phase description on `/workspaces/`:

**Before**
> Those standards get checked during generation, in review, and after code lands. Workspaces will offer enhanced gating for PRs and releases.

**After**
> Those standards get checked before and after code lands. Additionally, Workspaces will offer enhanced gating for PRs and releases; achieving higher quality and faster product verification.

Generated with [Devin](https://cli.devin.ai/docs)