### PR TITLE
Drop redundant 'engineering knowledge base' tagline

### DIFF
--- a/apps/marketing/src/pages/workspaces/index.astro
+++ b/apps/marketing/src/pages/workspaces/index.astro
@@ -102,7 +102,7 @@ const teamSizes = [
             <strong>Collaborative knowledge base for agent artifacts.</strong>
             Share plans, specs, explainers, and reviews with your team
             (and agents) in markdown or HTML, before and after agents
-            code. Craft your shared engineering knowledge base.
+            code.
           </li>
           <li>
             <strong>Artifacts and annotations become standards.</strong>


### PR DESCRIPTION
Trailing sentence "Craft your shared engineering knowledge base." duplicates the bullet's strong heading. Removing.

Generated with [Devin](https://cli.devin.ai/docs)