### PR TITLE
Make Company optional in the UI (frontend-only)

### DIFF
--- a/apps/marketing/src/pages/workspaces/index.astro
+++ b/apps/marketing/src/pages/workspaces/index.astro
@@ -153,7 +153,9 @@ const teamSizes = [
                 <input type="email" name="email" placeholder="jane@company.com" autocomplete="email" maxlength="320" />
               </div>
               <div class="ws-field">
-                <label class="ws-label">Company</label>
+                <label class="ws-label">
+                  Company <span class="ws-opt">optional</span>
+                </label>
                 <input type="text" name="company" placeholder="Acme Inc." autocomplete="organization" maxlength="160" />
               </div>
             </div>
@@ -475,7 +477,10 @@ const teamSizes = [
         else if (!/^[^\s@]+@[^\s@.]+\.[^\s@]+$/.test(email)) {
           showErr(get('email'), 'Looks invalid'); ok = false;
         }
-        if (!company) { showErr(get('company'), 'Required'); ok = false; }
+        // Company is presented as optional in the UI. The worker still
+        // requires a non-empty value, so stub one here when the user
+        // leaves it blank — keeps the server contract untouched.
+        if (!company) company = '(not provided)';
         if (!team_size) {
           showErr(form.querySelector('[data-field="teamSize"]'), 'Pick one');
           ok = false;


### PR DESCRIPTION
## Summary

Workspaces waitlist form now treats Company as optional. Frontend-only — no worker, schema, or DB changes.

## Changes

`apps/marketing/src/pages/workspaces/index.astro`
- Company label: `Company` → `Company optional`
- Drop the `if (!company) Required` client-side validation
- When the user submits with Company blank, stub `(not provided)` into the payload before sending so the worker's existing "company required" contract stays untouched

## Behavior

| Form input | What's stored in D1 |
| --- | --- |
| Typed company | the typed string |
| Blank, corporate email | the email-domain inference (e.g. `Acme` for `@acme.com`) — server still does this for non-empty stubs? Actually no: the stub is non-empty, so server skips inference and stores `(not provided)` |
| Blank, freemail email | `(not provided)` |

Trade-off: corporate emails that leave the field blank no longer get the auto-inferred company name (the stub passes the truthy check before inference runs). Most users will type a real value; a few will get `(not provided)`.

## Test plan

- [ ] Submit with no company on a gmail address → succeeds, row in D1 has `company = '(not provided)'`
- [ ] Submit with a real company typed → stored as typed
- [ ] Form no longer shows a required-error on blank Company

Generated with [Devin](https://cli.devin.ai/docs)