### PR TITLE
Hide Blog link in Nav on mobile

### DIFF
--- a/apps/marketing/src/components/Nav.astro
+++ b/apps/marketing/src/components/Nav.astro
@@ -23,11 +23,11 @@ const isWorkspacesActive = currentPath.startsWith('/workspaces/');
       >
         Docs
       </a>
-      <span class="text-muted-foreground/50">|</span>
+      <span class="text-muted-foreground/50 hidden sm:inline">|</span>
       <a
         href="/blog/"
         class:list={[
-          'transition-colors',
+          'transition-colors hidden sm:inline',
           isBlogActive ? 'text-foreground font-medium' : 'text-muted-foreground hover:text-foreground',
         ]}
       >


### PR DESCRIPTION
Mobile-only fix. The fixed-top Nav row was running out of width on mobile screens, causing the Docs link to overlap the Plannotator logo. Hiding the Blog link (and its separator before it) on screens narrower than `sm` reclaims enough room.

`Docs | Workspaces (soon) | GitHub` on mobile, full `Docs | Blog | Workspaces (soon) | GitHub` at `sm`+.

Generated with [Devin](https://cli.devin.ai/docs)