### PR TITLE
Tighten Nav for mobile

### DIFF
--- a/apps/marketing/src/components/Nav.astro
+++ b/apps/marketing/src/components/Nav.astro
@@ -6,14 +6,14 @@ const isDocsActive = currentPath.startsWith('/docs/');
 const isBlogActive = currentPath.startsWith('/blog/');
 const isWorkspacesActive = currentPath.startsWith('/workspaces/');
 ---
-<nav class="fixed top-0 left-0 right-0 h-12 flex items-center justify-between px-6 bg-background/80 backdrop-blur-sm border-b border-border/30 z-50">
+<nav class="fixed top-0 left-0 right-0 h-12 flex items-center justify-between px-4 sm:px-6 bg-background/80 backdrop-blur-sm border-b border-border/30 z-50">
   <div class="flex items-center gap-2">
     <a href="/" class="text-sm font-semibold tracking-tight hover:text-primary transition-colors">
       Plannotator
     </a>
   </div>
   <div class="flex items-center gap-3">
-    <div class="flex items-center gap-2 text-xs">
+    <div class="flex items-center gap-1.5 sm:gap-2 text-xs">
       <a
         href="/docs/getting-started/installation/"
         class:list={[
@@ -54,6 +54,8 @@ const isWorkspacesActive = currentPath.startsWith('/workspaces/');
         GitHub
       </a>
     </div>
-    <ModeToggleIsland client:only="react" />
+    <div class="hidden sm:flex">
+      <ModeToggleIsland client:only="react" />
+    </div>
   </div>
 </nav>


### PR DESCRIPTION
Follow-up to #781. Three additional tweaks that shrink the right-side cluster on mobile so the Docs link stops nudging the Plannotator logo:

- `px-6` → `px-4 sm:px-6` on the nav (24px → 16px side padding on mobile)
- `gap-2` → `gap-1.5 sm:gap-2` on the link group (8px → 6px between links on mobile)
- Theme toggle wrapped in `hidden sm:flex` so it disappears on mobile entirely. Mode is still applied from the cookie pre-paint script in Base.astro; users just lose the visible toggle on phones (still there on tablets+).

Generated with [Devin](https://cli.devin.ai/docs)