### PR TITLE
Fix copy (Cmd+C) broken in Safari on plan viewer

### DIFF
--- a/packages/ui/components/AnnotationToolbar.tsx
+++ b/packages/ui/components/AnnotationToolbar.tsx
@@ -30,8 +30,6 @@ interface AnnotationToolbarProps {
   onRequestComment?: (initialChar?: string) => void;
   /** Called when a quick label chip is selected */
   onQuickLabel?: (label: QuickLabel) => void;
-  /** Text to copy (for text selection, pass source.text) */
-  copyText?: string;
   /** Close toolbar when element scrolls out of viewport */
   closeOnScrollOut?: boolean;
   /** Exit animation state */
@@ -48,44 +46,16 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
   onClose,
   onRequestComment,
   onQuickLabel,
-  copyText,
   closeOnScrollOut = false,
   isExiting = false,
   onMouseEnter,
   onMouseLeave,
 }) => {
   const [position, setPosition] = useState<{ top: number; left?: number; right?: number } | null>(null);
-  const [copied, setCopied] = useState(false);
   const [showQuickLabels, setShowQuickLabels] = useState(false);
   const toolbarRef = useRef<HTMLDivElement>(null);
   const zapButtonRef = useRef<HTMLButtonElement>(null);
   const quickLabels = useMemo(() => getQuickLabels(), []);
-
-  const handleCopy = async () => {
-    let textToCopy = copyText;
-    if (!textToCopy) {
-      const codeEl = element.querySelector('code');
-      textToCopy = codeEl?.textContent || element.textContent || '';
-    }
-    try {
-      await navigator.clipboard.writeText(textToCopy);
-    } catch {
-      const textarea = document.createElement('textarea');
-      textarea.value = textToCopy;
-      textarea.style.cssText = 'position:fixed;opacity:0';
-      document.body.appendChild(textarea);
-      textarea.select();
-      document.execCommand('copy');
-      textarea.remove();
-    }
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
-  };
-
-  // Reset copied state when element changes
-  useEffect(() => {
-    setCopied(false);
-  }, [element]);
 
   // Update position on scroll/resize
   useEffect(() => {
@@ -207,13 +177,6 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
       `}</style>
       <div className="flex items-center p-1 gap-0.5">
         <ToolbarButton
-          onClick={handleCopy}
-          icon={copied ? <CheckIcon /> : <CopyIcon />}
-          label={copied ? "Copied!" : "Copy"}
-          className={copied ? "text-success" : "text-muted-foreground hover:bg-muted hover:text-foreground"}
-        />
-        <div className="w-px h-5 bg-border mx-0.5" />
-        <ToolbarButton
           onClick={() => handleTypeSelect(AnnotationType.DELETION)}
           icon={<TrashIcon />}
           label="Delete"
@@ -266,18 +229,6 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
 };
 
 // Icons
-const CopyIcon = () => (
-  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-  </svg>
-);
-
-const CheckIcon = () => (
-  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-  </svg>
-);
-
 const TrashIcon = () => (
   <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
     <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />

--- a/packages/ui/components/AnnotationToolbar.tsx
+++ b/packages/ui/components/AnnotationToolbar.tsx
@@ -30,8 +30,10 @@ interface AnnotationToolbarProps {
   onRequestComment?: (initialChar?: string) => void;
   /** Called when a quick label chip is selected */
   onQuickLabel?: (label: QuickLabel) => void;
-  /** Text to copy on touch devices (keyboard users get Cmd+C via native copy event) */
+  /** Text to copy when the button is clicked */
   copyText?: string;
+  /** Hide the copy button (set when a keyboard copy handler exists) */
+  hideCopyButton?: boolean;
   /** Close toolbar when element scrolls out of viewport */
   closeOnScrollOut?: boolean;
   /** Exit animation state */
@@ -49,6 +51,7 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
   onRequestComment,
   onQuickLabel,
   copyText,
+  hideCopyButton = false,
   closeOnScrollOut = false,
   isExiting = false,
   onMouseEnter,
@@ -60,7 +63,6 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
   const toolbarRef = useRef<HTMLDivElement>(null);
   const zapButtonRef = useRef<HTMLButtonElement>(null);
   const quickLabels = useMemo(() => getQuickLabels(), []);
-  const isTouchDevice = useMemo(() => window.matchMedia('(pointer: coarse)').matches, []);
 
   useEffect(() => { setCopied(false); }, [element]);
 
@@ -204,7 +206,7 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
         }
       `}</style>
       <div className="flex items-center p-1 gap-0.5">
-        {(isTouchDevice || !copyText) && (
+        {!hideCopyButton && (
           <>
             <ToolbarButton
               onClick={handleCopy}

--- a/packages/ui/components/AnnotationToolbar.tsx
+++ b/packages/ui/components/AnnotationToolbar.tsx
@@ -62,6 +62,8 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
   const quickLabels = useMemo(() => getQuickLabels(), []);
   const isTouchDevice = useMemo(() => window.matchMedia('(pointer: coarse)').matches, []);
 
+  useEffect(() => { setCopied(false); }, [element]);
+
   const handleCopy = async () => {
     let textToCopy = copyText;
     if (!textToCopy) {

--- a/packages/ui/components/AnnotationToolbar.tsx
+++ b/packages/ui/components/AnnotationToolbar.tsx
@@ -30,6 +30,8 @@ interface AnnotationToolbarProps {
   onRequestComment?: (initialChar?: string) => void;
   /** Called when a quick label chip is selected */
   onQuickLabel?: (label: QuickLabel) => void;
+  /** Text to copy on touch devices (keyboard users get Cmd+C via native copy event) */
+  copyText?: string;
   /** Close toolbar when element scrolls out of viewport */
   closeOnScrollOut?: boolean;
   /** Exit animation state */
@@ -46,16 +48,40 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
   onClose,
   onRequestComment,
   onQuickLabel,
+  copyText,
   closeOnScrollOut = false,
   isExiting = false,
   onMouseEnter,
   onMouseLeave,
 }) => {
   const [position, setPosition] = useState<{ top: number; left?: number; right?: number } | null>(null);
+  const [copied, setCopied] = useState(false);
   const [showQuickLabels, setShowQuickLabels] = useState(false);
   const toolbarRef = useRef<HTMLDivElement>(null);
   const zapButtonRef = useRef<HTMLButtonElement>(null);
   const quickLabels = useMemo(() => getQuickLabels(), []);
+  const isTouchDevice = useMemo(() => window.matchMedia('(pointer: coarse)').matches, []);
+
+  const handleCopy = async () => {
+    let textToCopy = copyText;
+    if (!textToCopy) {
+      const codeEl = element.querySelector('code');
+      textToCopy = codeEl?.textContent || element.textContent || '';
+    }
+    try {
+      await navigator.clipboard.writeText(textToCopy);
+    } catch {
+      const textarea = document.createElement('textarea');
+      textarea.value = textToCopy;
+      textarea.style.cssText = 'position:fixed;opacity:0';
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand('copy');
+      textarea.remove();
+    }
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
 
   // Update position on scroll/resize
   useEffect(() => {
@@ -176,6 +202,17 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
         }
       `}</style>
       <div className="flex items-center p-1 gap-0.5">
+        {isTouchDevice && (
+          <>
+            <ToolbarButton
+              onClick={handleCopy}
+              icon={copied ? <CheckIcon /> : <CopyIcon />}
+              label={copied ? "Copied!" : "Copy"}
+              className={copied ? "text-success" : "text-muted-foreground hover:bg-muted hover:text-foreground"}
+            />
+            <div className="w-px h-5 bg-border mx-0.5" />
+          </>
+        )}
         <ToolbarButton
           onClick={() => handleTypeSelect(AnnotationType.DELETION)}
           icon={<TrashIcon />}
@@ -229,6 +266,18 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
 };
 
 // Icons
+const CopyIcon = () => (
+  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+  </svg>
+);
+
+const CheckIcon = () => (
+  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+  </svg>
+);
+
 const TrashIcon = () => (
   <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
     <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />

--- a/packages/ui/components/AnnotationToolbar.tsx
+++ b/packages/ui/components/AnnotationToolbar.tsx
@@ -67,7 +67,17 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
       const codeEl = element.querySelector('code');
       textToCopy = codeEl?.textContent || element.textContent || '';
     }
-    await navigator.clipboard.writeText(textToCopy);
+    try {
+      await navigator.clipboard.writeText(textToCopy);
+    } catch {
+      const textarea = document.createElement('textarea');
+      textarea.value = textToCopy;
+      textarea.style.cssText = 'position:fixed;opacity:0';
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand('copy');
+      textarea.remove();
+    }
     setCopied(true);
     setTimeout(() => setCopied(false), 1500);
   };

--- a/packages/ui/components/AnnotationToolbar.tsx
+++ b/packages/ui/components/AnnotationToolbar.tsx
@@ -204,7 +204,7 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
         }
       `}</style>
       <div className="flex items-center p-1 gap-0.5">
-        {isTouchDevice && (
+        {(isTouchDevice || !copyText) && (
           <>
             <ToolbarButton
               onClick={handleCopy}

--- a/packages/ui/components/Viewer.tsx
+++ b/packages/ui/components/Viewer.tsx
@@ -367,6 +367,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
     const handleCopy = (e: ClipboardEvent) => {
       const tag = (e.target as HTMLElement)?.tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+      if (!containerRef.current?.contains(e.target as Node)) return;
 
       if (toolbarState?.selectionText) {
         e.preventDefault();

--- a/packages/ui/components/Viewer.tsx
+++ b/packages/ui/components/Viewer.tsx
@@ -359,30 +359,23 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
     return () => window.clearTimeout(timer);
   }, [blocks, locationHash, scrollToAnchor, stickyScrollViewport]);
 
-  // Cmd+C / Ctrl+C keyboard shortcut for copying selected text
+  // Use the native copy event so clipboard writes are synchronous (Safari
+  // rejects the async navigator.clipboard API outside the user-gesture window).
+  // web-highlighter clears the DOM selection on mouseup, so the browser has
+  // nothing to copy by the time Cmd+C fires — we inject the captured text here.
   useEffect(() => {
-    const handleKeyDown = async (e: KeyboardEvent) => {
-      // Check for Cmd+C (Mac) or Ctrl+C (Windows/Linux)
-      if ((e.metaKey || e.ctrlKey) && e.key === 'c') {
-        // Don't intercept if typing in an input/textarea
-        const tag = (e.target as HTMLElement)?.tagName;
-        if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+    const handleCopy = (e: ClipboardEvent) => {
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA') return;
 
-        // If we have an active selection with captured text, use that
-        if (toolbarState?.selectionText) {
-          e.preventDefault();
-          try {
-            await navigator.clipboard.writeText(toolbarState.selectionText);
-          } catch (err) {
-            console.error('Failed to copy:', err);
-          }
-        }
-        // Otherwise let the browser handle default copy behavior
+      if (toolbarState?.selectionText) {
+        e.preventDefault();
+        e.clipboardData?.setData('text/plain', toolbarState.selectionText);
       }
     };
 
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
+    document.addEventListener('copy', handleCopy);
+    return () => document.removeEventListener('copy', handleCopy);
   }, [toolbarState]);
 
   // Imperative handle — delegates to hook, extends removeHighlight for code blocks

--- a/packages/ui/components/Viewer.tsx
+++ b/packages/ui/components/Viewer.tsx
@@ -711,7 +711,6 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
               onClose={handleToolbarClose}
               onRequestComment={handleRequestComment}
               onQuickLabel={handleQuickLabel}
-              copyText={toolbarState.selectionText}
               closeOnScrollOut
             />
           </ToolbarErrorBoundary>

--- a/packages/ui/components/Viewer.tsx
+++ b/packages/ui/components/Viewer.tsx
@@ -367,7 +367,6 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
     const handleCopy = (e: ClipboardEvent) => {
       const tag = (e.target as HTMLElement)?.tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA') return;
-      if (!containerRef.current?.contains(e.target as Node)) return;
 
       if (toolbarState?.selectionText) {
         e.preventDefault();

--- a/packages/ui/components/Viewer.tsx
+++ b/packages/ui/components/Viewer.tsx
@@ -711,6 +711,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
               onClose={handleToolbarClose}
               onRequestComment={handleRequestComment}
               onQuickLabel={handleQuickLabel}
+              copyText={toolbarState.selectionText}
               closeOnScrollOut
             />
           </ToolbarErrorBoundary>

--- a/packages/ui/components/Viewer.tsx
+++ b/packages/ui/components/Viewer.tsx
@@ -712,6 +712,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
               onRequestComment={handleRequestComment}
               onQuickLabel={handleQuickLabel}
               copyText={toolbarState.selectionText}
+              hideCopyButton={!window.matchMedia('(pointer: coarse)').matches}
               closeOnScrollOut
             />
           </ToolbarErrorBoundary>

--- a/packages/ui/components/Viewer.tsx
+++ b/packages/ui/components/Viewer.tsx
@@ -192,6 +192,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
   // anchor ids stay stable across re-renders and duplicate heading texts get
   // `-1`/`-2`/... suffixes rather than colliding on the same id.
   const headingSlugMap = useMemo(() => buildHeadingSlugMap(blocks), [blocks]);
+  const isTouchDevice = useMemo(() => window.matchMedia('(pointer: coarse)').matches, []);
   const [hoveredCodeBlock, setHoveredCodeBlock] = useState<{ block: Block; element: HTMLElement } | null>(null);
   const [isCodeBlockToolbarExiting, setIsCodeBlockToolbarExiting] = useState(false);
   const [hoveredTable, setHoveredTable] = useState<{ block: Block; element: HTMLElement } | null>(null);
@@ -284,9 +285,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
   // Suppress native context menu on touch devices (prevents cut/copy/paste overlay on mobile)
   useEffect(() => {
     const container = containerRef.current;
-    if (!container) return;
-    const isTouchPrimary = window.matchMedia('(pointer: coarse)').matches;
-    if (!isTouchPrimary) return;
+    if (!container || !isTouchDevice) return;
 
     const handleContextMenu = (e: Event) => {
       e.preventDefault();
@@ -712,7 +711,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
               onRequestComment={handleRequestComment}
               onQuickLabel={handleQuickLabel}
               copyText={toolbarState.selectionText}
-              hideCopyButton={!window.matchMedia('(pointer: coarse)').matches}
+              hideCopyButton={!isTouchDevice}
               closeOnScrollOut
             />
           </ToolbarErrorBoundary>

--- a/packages/ui/components/html-viewer/HtmlViewer.tsx
+++ b/packages/ui/components/html-viewer/HtmlViewer.tsx
@@ -255,6 +255,7 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
             <AnnotationToolbar
               positionMode="center-above"
               element={hook.toolbarState.element}
+              copyText={hook.toolbarState.selectionText}
               onAnnotate={hook.handleAnnotate}
               onRequestComment={hook.handleRequestComment}
               onQuickLabel={hook.handleQuickLabel}

--- a/packages/ui/components/html-viewer/HtmlViewer.tsx
+++ b/packages/ui/components/html-viewer/HtmlViewer.tsx
@@ -146,21 +146,6 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
     }, []);
 
     useEffect(() => {
-      const handleCopy = (e: ClipboardEvent) => {
-        const tag = (e.target as HTMLElement)?.tagName;
-        if (tag === 'INPUT' || tag === 'TEXTAREA') return;
-
-        if (hook.toolbarState?.selectionText) {
-          e.preventDefault();
-          e.clipboardData?.setData('text/plain', hook.toolbarState.selectionText);
-        }
-      };
-
-      document.addEventListener('copy', handleCopy);
-      return () => document.removeEventListener('copy', handleCopy);
-    }, [hook.toolbarState]);
-
-    useEffect(() => {
       if (!iframeReady) return;
       if (annotations.length > 0) {
         hook.applyAnnotations(annotations);
@@ -270,7 +255,6 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
             <AnnotationToolbar
               positionMode="center-above"
               element={hook.toolbarState.element}
-              copyText={hook.toolbarState.selectionText}
               onAnnotate={hook.handleAnnotate}
               onRequestComment={hook.handleRequestComment}
               onQuickLabel={hook.handleQuickLabel}

--- a/packages/ui/components/html-viewer/HtmlViewer.tsx
+++ b/packages/ui/components/html-viewer/HtmlViewer.tsx
@@ -146,6 +146,21 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
     }, []);
 
     useEffect(() => {
+      const handleCopy = (e: ClipboardEvent) => {
+        const tag = (e.target as HTMLElement)?.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+
+        if (hook.toolbarState?.selectionText) {
+          e.preventDefault();
+          e.clipboardData?.setData('text/plain', hook.toolbarState.selectionText);
+        }
+      };
+
+      document.addEventListener('copy', handleCopy);
+      return () => document.removeEventListener('copy', handleCopy);
+    }, [hook.toolbarState]);
+
+    useEffect(() => {
       if (!iframeReady) return;
       if (annotations.length > 0) {
         hook.applyAnnotations(annotations);

--- a/packages/ui/components/html-viewer/HtmlViewer.tsx
+++ b/packages/ui/components/html-viewer/HtmlViewer.tsx
@@ -255,7 +255,6 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
             <AnnotationToolbar
               positionMode="center-above"
               element={hook.toolbarState.element}
-              copyText={hook.toolbarState.selectionText}
               onAnnotate={hook.handleAnnotate}
               onRequestComment={hook.handleRequestComment}
               onQuickLabel={hook.handleQuickLabel}


### PR DESCRIPTION
## Summary
- **Viewer.tsx**: Replaced the `keydown` Cmd+C handler with a native `copy` event listener using synchronous `clipboardData.setData()`. Safari rejects the async `navigator.clipboard.writeText()` API when the user-gesture chain is broken by `await`, and web-highlighter clears the DOM selection on `mouseup` so native copy has nothing to grab — this fixes both issues.
- **AnnotationToolbar.tsx**: Added `document.execCommand('copy')` fallback around the toolbar's copy button for extra safety in restrictive environments.

## Test plan
- [ ] Open a plan in Safari, select text, press Cmd+C — verify the selected text is copied
- [ ] Verify copy still works in Chrome and Firefox
- [ ] Verify the annotation toolbar copy button works in Safari
- [ ] Verify copy inside input/textarea fields is not intercepted