### PR TITLE
fix: honor CLAUDE_CONFIG_DIR in session log discovery

### DIFF
--- a/apps/hook/server/session-log.test.ts
+++ b/apps/hook/server/session-log.test.ts
@@ -26,7 +26,6 @@ import {
 } from "./session-log";
 import { mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { homedir } from "node:os";
 import { tmpdir } from "node:os";
 
 // --- Fixture Helpers ---
@@ -578,66 +577,47 @@ describe("parseSessionLog", () => {
 });
 
 describe("findSessionLogsByAncestorWalk", () => {
-  // These tests use the real ~/.claude/projects/ directory structure.
-  // They verify the ancestor walk logic without needing mocks.
-
   test("returns empty array for root directory (no parents to walk)", () => {
     const result = findSessionLogsByAncestorWalk("/");
     expect(result).toEqual([]);
   });
 
   test("walks up to find parent directory session logs", () => {
-    // Create a temporary project slug structure
-    const testId = `plannotator-test-${Date.now()}`;
-    const testDir = join(tmpdir(), testId, "sub", "deep");
-    const slugDir = join(
-      homedir(),
-      ".claude",
-      "projects",
-      // Slug for the parent (tmpdir/testId)
-      `${join(tmpdir(), testId)}`.replace(/[^a-zA-Z0-9-]/g, "-")
-    );
-
+    const { projectsDir, cleanup } = makeTempDirs("ancestor-walk");
     try {
-      // Set up: create a fake session log at the parent slug
+      const testId = `plannotator-test-${Date.now()}`;
+      const testDir = join(tmpdir(), testId, "sub", "deep");
+      const parentSlug = join(tmpdir(), testId).replace(/[^a-zA-Z0-9-]/g, "-");
+      const slugDir = join(projectsDir, parentSlug);
       mkdirSync(slugDir, { recursive: true });
       const fakeLog = join(slugDir, "fake-session.jsonl");
       writeFileSync(fakeLog, '{"type":"assistant","message":{"id":"m1","content":[{"type":"text","text":"hello"}]}}\n');
 
-      // Walk from the deep subdirectory — should find the parent's logs
-      const result = findSessionLogsByAncestorWalk(testDir);
+      const result = findSessionLogsByAncestorWalk(testDir, projectsDir);
       expect(result.length).toBeGreaterThan(0);
       expect(result[0]).toBe(fakeLog);
     } finally {
-      // Cleanup
-      rmSync(slugDir, { recursive: true, force: true });
+      cleanup();
     }
   });
 
   test("does not return results for the exact CWD (caller already tried it)", () => {
-    // Create a temp slug for the exact CWD
-    const testId = `plannotator-test-exact-${Date.now()}`;
-    const testDir = join(tmpdir(), testId);
-    const slugDir = join(
-      homedir(),
-      ".claude",
-      "projects",
-      testDir.replace(/[^a-zA-Z0-9-]/g, "-")
-    );
-
+    const { projectsDir, cleanup } = makeTempDirs("ancestor-exact");
     try {
+      const testId = `plannotator-test-exact-${Date.now()}`;
+      const testDir = join(tmpdir(), testId);
+      const cwdSlug = testDir.replace(/[^a-zA-Z0-9-]/g, "-");
+      const slugDir = join(projectsDir, cwdSlug);
       mkdirSync(slugDir, { recursive: true });
       writeFileSync(
         join(slugDir, "fake.jsonl"),
         '{"type":"assistant","message":{"id":"m1","content":[{"type":"text","text":"hi"}]}}\n'
       );
 
-      // Ancestor walk skips the exact CWD — the caller already tried it
-      const result = findSessionLogsByAncestorWalk(testDir);
-      // Should not find the CWD's own slug; only parents
+      const result = findSessionLogsByAncestorWalk(testDir, projectsDir);
       expect(result.every((p) => !p.includes(slugDir))).toBe(true);
     } finally {
-      rmSync(slugDir, { recursive: true, force: true });
+      cleanup();
     }
   });
 });

--- a/apps/hook/server/session-log.ts
+++ b/apps/hook/server/session-log.ts
@@ -19,8 +19,10 @@ import { spawnSync } from "node:child_process";
 import { join, dirname, basename } from "node:path";
 import { homedir } from "node:os";
 
-const DEFAULT_SESSIONS_DIR = join(homedir(), ".claude", "sessions");
-const DEFAULT_PROJECTS_DIR = join(homedir(), ".claude", "projects");
+const claudeConfigDir =
+  process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
+const DEFAULT_SESSIONS_DIR = join(claudeConfigDir, "sessions");
+const DEFAULT_PROJECTS_DIR = join(claudeConfigDir, "projects");
 
 /**
  * Normalize a cwd for comparison. On Windows, filesystems are case-insensitive
@@ -432,12 +434,15 @@ export function resolveSessionLogByCwdScan(
  * Used as a fallback when session metadata resolution (PPID) is unavailable.
  * Stops at the filesystem root to avoid infinite loops.
  */
-export function findSessionLogsByAncestorWalk(cwd: string): string[] {
+export function findSessionLogsByAncestorWalk(
+  cwd: string,
+  projectsDirOverride?: string
+): string[] {
   let dir = dirname(cwd);
   if (dir === cwd) return [];
 
   while (true) {
-    const logs = findSessionLogsForCwd(dir);
+    const logs = findSessionLogsForCwd(dir, projectsDirOverride);
     if (logs.length > 0) return logs;
 
     const parent = dirname(dir);


### PR DESCRIPTION
## Summary
- Session log discovery now reads `CLAUDE_CONFIG_DIR` when resolving `sessions/` and `projects/` paths, falling back to `~/.claude/`
- Added `projectsDirOverride` param to `findSessionLogsByAncestorWalk` so all four resolution tiers respect custom config paths
- Moved `findSessionLogsByAncestorWalk` tests from writing to real `~/.claude/projects/` to isolated temp dirs

Closes #783

## Test plan
- [x] All 67 existing session-log tests pass
- [x] Built and installed binary locally, verified `plannotator last` works