### PR TITLE
Fix Windows Pi shim spawning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,6 +267,37 @@ jobs:
           # 3. annotate: exercises annotate server startup with a real file.
           Test-PlannotatorServer "plannotator annotate" "19501" "/api/plan" @("annotate", "README.md")
 
+  pi-extension-ai-runtime-windows:
+    needs: test
+    # Exercises the Pi extension's Node/jiti server mirror on Windows with an
+    # npm-style `pi` shim pair. The binary smoke above covers the compiled Bun
+    # CLI, but the published Pi extension uses this separate Node path.
+    name: Pi extension AI runtime (Windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.11
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Generate Pi extension shared copies
+        shell: bash
+        run: bash apps/pi-extension/vendor.sh
+
+      - name: Build Pi AI runtime smoke
+        run: bun build scripts/smoke-pi-extension-ai-runtime.ts --target=node --outfile "$env:RUNNER_TEMP/pi-ai-runtime-smoke.mjs"
+
+      - name: Run Pi AI runtime smoke
+        run: node "$env:RUNNER_TEMP/pi-ai-runtime-smoke.mjs"
+
   install-script-smoke:
     needs: build
     runs-on: ${{ matrix.os }}
@@ -423,6 +454,7 @@ jobs:
     needs:
       - build
       - smoke-binaries
+      - pi-extension-ai-runtime-windows
       - install-script-smoke
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
@@ -489,6 +521,7 @@ jobs:
     needs:
       - build
       - smoke-binaries
+      - pi-extension-ai-runtime-windows
       - install-script-smoke
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,37 @@ jobs:
       - name: Run tests
         run: bun test
 
+  pi-extension-ai-runtime-windows:
+    # Exercises the Pi extension's Node/jiti server mirror on Windows with an
+    # npm-style `pi` shim pair. This catches regressions where `where pi`
+    # resolves the extensionless shim before pi.cmd and the Ask AI provider
+    # crashes before the plan review UI opens.
+    name: Pi extension AI runtime (Windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Generate Pi extension shared copies
+        shell: bash
+        run: bash apps/pi-extension/vendor.sh
+
+      - name: Build Pi AI runtime smoke
+        run: bun build scripts/smoke-pi-extension-ai-runtime.ts --target=node --outfile "$env:RUNNER_TEMP/pi-ai-runtime-smoke.mjs"
+
+      - name: Run Pi AI runtime smoke
+        run: node "$env:RUNNER_TEMP/pi-ai-runtime-smoke.mjs"
+
   install-cmd-windows:
     # End-to-end integration test for scripts/install.cmd on real cmd.exe.
     # The unit tests in scripts/install.test.ts are file-content string checks

--- a/apps/pi-extension/server/ai-runtime.ts
+++ b/apps/pi-extension/server/ai-runtime.ts
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { Readable } from "node:stream";
 
+import { resolveCommandFromWhichOutput } from "../generated/ai/providers/command-path.js";
 import { json, toWebRequest } from "./helpers.js";
 
 export interface PiAIRuntime {
@@ -21,10 +22,7 @@ function whichCmd(cmd: string): string | null {
 			encoding: "utf-8",
 			stdio: ["pipe", "pipe", "pipe"],
 		});
-		return output
-			.split(/\r?\n/)
-			.map((line) => line.trim())
-			.find(Boolean) ?? null;
+		return resolveCommandFromWhichOutput(output);
 	} catch {
 		return null;
 	}

--- a/apps/pi-extension/vendor.sh
+++ b/apps/pi-extension/vendor.sh
@@ -39,7 +39,7 @@ for f in index types provider session-manager endpoints context base-session; do
   printf '// @generated — DO NOT EDIT. Source: packages/ai/%s.ts\n' "$f" | cat - "$src" > "generated/ai/$f.ts"
 done
 
-for f in claude-agent-sdk codex-sdk opencode-sdk pi-sdk pi-sdk-node pi-events; do
+for f in claude-agent-sdk codex-sdk opencode-sdk command-path pi-sdk pi-sdk-node pi-events; do
   src="../../packages/ai/providers/$f.ts"
   printf '// @generated — DO NOT EDIT. Source: packages/ai/providers/%s.ts\n' "$f" | cat - "$src" > "generated/ai/providers/$f.ts"
 done

--- a/packages/ai/ai.test.ts
+++ b/packages/ai/ai.test.ts
@@ -13,6 +13,12 @@ import type {
   AIMessage,
   AIContext,
 } from "./types.ts";
+import {
+  buildWindowsCommandScriptSpawnCommand,
+  resolveCommandFromWhichOutput,
+  resolveWindowsCommandShim,
+  shouldSpawnViaShell,
+} from "./providers/command-path.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers — mock provider/session for testing
@@ -70,6 +76,78 @@ function mockProvider(name = "mock"): AIProvider {
     dispose() {},
   };
 }
+
+// ---------------------------------------------------------------------------
+// Command path helpers
+// ---------------------------------------------------------------------------
+
+describe("command path helpers", () => {
+  test("resolveWindowsCommandShim prefers a sibling .cmd for npm shims", () => {
+    const raw = String.raw`C:\Users\Andrew\AppData\Roaming\npm\pi`;
+    const resolved = resolveWindowsCommandShim(
+      raw,
+      "win32",
+      (path) => path === `${raw}.cmd`,
+    );
+
+    expect(resolved).toBe(`${raw}.cmd`);
+  });
+
+  test("resolveCommandFromWhichOutput skips extensionless Windows shims", () => {
+    const raw = String.raw`C:\Users\Andrew\AppData\Roaming\npm\pi`;
+    const resolved = resolveCommandFromWhichOutput(
+      `${raw}\r\n${raw}.cmd\r\n`,
+      "win32",
+      () => false,
+    );
+
+    expect(resolved).toBe(`${raw}.cmd`);
+  });
+
+  test("resolveCommandFromWhichOutput preserves the first non-Windows result", () => {
+    expect(
+      resolveCommandFromWhichOutput("/usr/local/bin/pi\n/usr/bin/pi\n", "darwin"),
+    ).toBe("/usr/local/bin/pi");
+  });
+
+  test("shouldSpawnViaShell only flags Windows command scripts", () => {
+    expect(
+      shouldSpawnViaShell(
+        String.raw`C:\Users\Andrew\AppData\Roaming\npm\pi.cmd`,
+        "win32",
+      ),
+    ).toBe(true);
+    expect(shouldSpawnViaShell(String.raw`C:\tools\pi.exe`, "win32")).toBe(false);
+    expect(shouldSpawnViaShell("/usr/local/bin/pi.cmd", "darwin")).toBe(false);
+  });
+
+  test("buildWindowsCommandScriptSpawnCommand wraps command scripts for Bun.spawn", () => {
+    const command = buildWindowsCommandScriptSpawnCommand(
+      String.raw`C:\Users\Andrew Ramos\AppData\Roaming\npm\pi.cmd`,
+      ["--mode", "rpc"],
+      "win32",
+      String.raw`C:\Windows\System32\cmd.exe`,
+    );
+
+    expect(command).toEqual([
+      String.raw`C:\Windows\System32\cmd.exe`,
+      "/d",
+      "/s",
+      "/c",
+      String.raw`"C:\Users\Andrew Ramos\AppData\Roaming\npm\pi.cmd" --mode rpc`,
+    ]);
+  });
+
+  test("buildWindowsCommandScriptSpawnCommand ignores native executables", () => {
+    expect(
+      buildWindowsCommandScriptSpawnCommand(
+        String.raw`C:\tools\pi.exe`,
+        ["--mode", "rpc"],
+        "win32",
+      ),
+    ).toBeNull();
+  });
+});
 
 // ---------------------------------------------------------------------------
 // SessionManager

--- a/packages/ai/ai.test.ts
+++ b/packages/ai/ai.test.ts
@@ -15,6 +15,7 @@ import type {
 } from "./types.ts";
 import {
   buildWindowsCommandScriptSpawnCommand,
+  killWindowsProcessTree,
   resolveCommandFromWhichOutput,
   resolveWindowsCommandShim,
   shouldSpawnViaShell,
@@ -146,6 +147,38 @@ describe("command path helpers", () => {
         "win32",
       ),
     ).toBeNull();
+  });
+
+  test("killWindowsProcessTree invokes taskkill with tree flags on Windows", () => {
+    const calls: Array<{
+      command: string;
+      args: string[];
+      options: { stdio: "ignore"; windowsHide: boolean };
+    }> = [];
+    const killed = killWindowsProcessTree(1234, "win32", (command, args, options) => {
+      calls.push({ command, args, options });
+      return { status: 0 };
+    });
+
+    expect(killed).toBe(true);
+    expect(calls).toEqual([
+      {
+        command: "taskkill",
+        args: ["/pid", "1234", "/t", "/f"],
+        options: { stdio: "ignore", windowsHide: true },
+      },
+    ]);
+  });
+
+  test("killWindowsProcessTree skips non-Windows platforms", () => {
+    let called = false;
+    const killed = killWindowsProcessTree(1234, "darwin", () => {
+      called = true;
+      return { status: 0 };
+    });
+
+    expect(killed).toBe(false);
+    expect(called).toBe(false);
   });
 });
 

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -12,6 +12,7 @@
     "./endpoints": "./endpoints.ts",
     "./providers/claude-agent-sdk": "./providers/claude-agent-sdk.ts",
     "./providers/codex-sdk": "./providers/codex-sdk.ts",
+    "./providers/command-path": "./providers/command-path.ts",
     "./providers/pi-sdk": "./providers/pi-sdk.ts",
     "./providers/opencode-sdk": "./providers/opencode-sdk.ts",
     "./providers/pi-sdk-node": "./providers/pi-sdk-node.ts"

--- a/packages/ai/providers/command-path.ts
+++ b/packages/ai/providers/command-path.ts
@@ -1,7 +1,13 @@
+import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 
 type Platform = NodeJS.Platform;
 type ExistsFn = (path: string) => boolean;
+type TaskkillFn = (
+	command: string,
+	args: string[],
+	options: { stdio: "ignore"; windowsHide: boolean },
+) => { status: number | null; error?: Error };
 
 const WINDOWS_EXECUTABLE_EXTENSIONS = [".cmd", ".exe", ".bat", ".com"] as const;
 const WINDOWS_SHELL_EXTENSIONS = new Set([".cmd", ".bat"]);
@@ -85,4 +91,25 @@ export function buildWindowsCommandScriptSpawnCommand(
 		"/c",
 		[commandPath, ...args].map(quoteWindowsShellArg).join(" "),
 	];
+}
+
+export function killWindowsProcessTree(
+	pid: number | null | undefined,
+	platform: Platform = process.platform,
+	runTaskkill: TaskkillFn = spawnSync as TaskkillFn,
+): boolean {
+	if (
+		platform !== "win32" ||
+		typeof pid !== "number" ||
+		!Number.isFinite(pid) ||
+		pid <= 0
+	) {
+		return false;
+	}
+
+	const result = runTaskkill("taskkill", ["/pid", String(pid), "/t", "/f"], {
+		stdio: "ignore",
+		windowsHide: true,
+	});
+	return !result.error && result.status === 0;
 }

--- a/packages/ai/providers/command-path.ts
+++ b/packages/ai/providers/command-path.ts
@@ -1,0 +1,88 @@
+import { existsSync } from "node:fs";
+
+type Platform = NodeJS.Platform;
+type ExistsFn = (path: string) => boolean;
+
+const WINDOWS_EXECUTABLE_EXTENSIONS = [".cmd", ".exe", ".bat", ".com"] as const;
+const WINDOWS_SHELL_EXTENSIONS = new Set([".cmd", ".bat"]);
+
+function trimCommandPath(commandPath: string): string {
+	return commandPath.trim();
+}
+
+function getKnownWindowsExtension(commandPath: string): string | null {
+	const match = trimCommandPath(commandPath).match(/\.(cmd|exe|bat|com)$/i);
+	return match ? `.${match[1].toLowerCase()}` : null;
+}
+
+export function resolveWindowsCommandShim(
+	commandPath: string,
+	platform: Platform = process.platform,
+	exists: ExistsFn = existsSync,
+): string {
+	const candidate = trimCommandPath(commandPath);
+	if (!candidate || platform !== "win32" || getKnownWindowsExtension(candidate)) {
+		return candidate;
+	}
+
+	for (const ext of WINDOWS_EXECUTABLE_EXTENSIONS) {
+		const pathWithExtension = `${candidate}${ext}`;
+		if (exists(pathWithExtension)) return pathWithExtension;
+	}
+
+	return candidate;
+}
+
+export function resolveCommandFromWhichOutput(
+	output: string,
+	platform: Platform = process.platform,
+	exists: ExistsFn = existsSync,
+): string | null {
+	const candidates = output
+		.split(/\r?\n/)
+		.map(trimCommandPath)
+		.filter(Boolean);
+
+	if (candidates.length === 0) return null;
+	if (platform !== "win32") return candidates[0] ?? null;
+
+	for (const candidate of candidates) {
+		const resolved = resolveWindowsCommandShim(candidate, platform, exists);
+		if (getKnownWindowsExtension(resolved)) return resolved;
+	}
+
+	return resolveWindowsCommandShim(candidates[0] ?? "", platform, exists) || null;
+}
+
+export function shouldSpawnViaShell(
+	commandPath: string,
+	platform: Platform = process.platform,
+): boolean {
+	if (platform !== "win32") return false;
+	const ext = getKnownWindowsExtension(commandPath);
+	return ext ? WINDOWS_SHELL_EXTENSIONS.has(ext) : false;
+}
+
+function quoteWindowsShellArg(arg: string): string {
+	if (!arg || /[\s"&()^|<>]/.test(arg)) {
+		return `"${arg.replace(/"/g, '\\"')}"`;
+	}
+	return arg;
+}
+
+export function buildWindowsCommandScriptSpawnCommand(
+	commandPath: string,
+	args: string[],
+	platform: Platform = process.platform,
+	comspec: string | undefined = process.env.ComSpec,
+): string[] | null {
+	if (!shouldSpawnViaShell(commandPath, platform)) return null;
+
+	return [
+		comspec || "cmd.exe",
+		"/d",
+		"/s",
+		"/c",
+		[commandPath, ...args].map(quoteWindowsShellArg).join(" "),
+	];
+}

--- a/packages/ai/providers/pi-sdk-node.ts
+++ b/packages/ai/providers/pi-sdk-node.ts
@@ -20,8 +20,8 @@ import type {
 } from "../types.ts";
 import { registerProviderFactory } from "../provider.ts";
 import {
+	buildWindowsCommandScriptSpawnCommand,
 	resolveWindowsCommandShim,
-	shouldSpawnViaShell,
 } from "./command-path.ts";
 
 // Re-export mapPiEvent from shared (runtime-agnostic)
@@ -51,12 +51,18 @@ class PiProcessNode {
 
 	async spawn(piPath: string, cwd: string): Promise<void> {
 		const commandPath = resolveWindowsCommandShim(piPath);
+		const command =
+			buildWindowsCommandScriptSpawnCommand(commandPath, ["--mode", "rpc"]) ?? [
+				commandPath,
+				"--mode",
+				"rpc",
+			];
 		let proc: ChildProcess;
 		try {
-			proc = spawn(commandPath, ["--mode", "rpc"], {
+			const [file, ...args] = command;
+			proc = spawn(file, args, {
 				cwd,
 				stdio: ["pipe", "pipe", "pipe"],
-				shell: shouldSpawnViaShell(commandPath),
 			});
 		} catch (err) {
 			const error = err instanceof Error ? err : new Error(String(err));

--- a/packages/ai/providers/pi-sdk-node.ts
+++ b/packages/ai/providers/pi-sdk-node.ts
@@ -19,6 +19,10 @@ import type {
 	PiSDKConfig,
 } from "../types.ts";
 import { registerProviderFactory } from "../provider.ts";
+import {
+	resolveWindowsCommandShim,
+	shouldSpawnViaShell,
+} from "./command-path.ts";
 
 // Re-export mapPiEvent from shared (runtime-agnostic)
 export { mapPiEvent } from "./pi-events.ts";
@@ -46,24 +50,59 @@ class PiProcessNode {
 	private _alive = false;
 
 	async spawn(piPath: string, cwd: string): Promise<void> {
-		this.proc = spawn(piPath, ["--mode", "rpc"], {
-			cwd,
-			stdio: ["pipe", "pipe", "pipe"],
-		});
-		this._alive = true;
+		const commandPath = resolveWindowsCommandShim(piPath);
+		let proc: ChildProcess;
+		try {
+			proc = spawn(commandPath, ["--mode", "rpc"], {
+				cwd,
+				stdio: ["pipe", "pipe", "pipe"],
+				shell: shouldSpawnViaShell(commandPath),
+			});
+		} catch (err) {
+			const error = err instanceof Error ? err : new Error(String(err));
+			this.handleProcessEnd(error);
+			throw error;
+		}
 
-		this.readStream();
-
-		this.proc.on("exit", () => {
-			this._alive = false;
-			for (const [, pending] of this.pendingRequests) {
-				pending.reject(new Error("Pi process exited unexpectedly"));
-			}
-			this.pendingRequests.clear();
-			for (const listener of this.listeners) {
-				listener({ type: "process_exited" });
-			}
+		this.proc = proc;
+		proc.once("exit", () => {
+			this.handleProcessEnd(new Error("Pi process exited unexpectedly"));
 		});
+
+		await new Promise<void>((resolve, reject) => {
+			const cleanup = () => {
+				proc.off("spawn", onSpawn);
+				proc.off("error", onError);
+			};
+			const onSpawn = () => {
+				cleanup();
+				this._alive = true;
+				this.readStream();
+				resolve();
+			};
+			const onError = (err: Error) => {
+				cleanup();
+				this.handleProcessEnd(err);
+				reject(err);
+			};
+
+			proc.once("spawn", onSpawn);
+			proc.once("error", onError);
+		});
+	}
+
+	private handleProcessEnd(error: Error): void {
+		if (!this.proc && this.pendingRequests.size === 0) return;
+
+		this._alive = false;
+		this.proc = null;
+		for (const [, pending] of this.pendingRequests) {
+			pending.reject(error);
+		}
+		this.pendingRequests.clear();
+		for (const listener of this.listeners) {
+			listener({ type: "process_exited", error: error.message });
+		}
 	}
 
 	private readStream(): void {

--- a/packages/ai/providers/pi-sdk-node.ts
+++ b/packages/ai/providers/pi-sdk-node.ts
@@ -21,6 +21,7 @@ import type {
 import { registerProviderFactory } from "../provider.ts";
 import {
 	buildWindowsCommandScriptSpawnCommand,
+	killWindowsProcessTree,
 	resolveWindowsCommandShim,
 } from "./command-path.ts";
 
@@ -107,7 +108,7 @@ class PiProcessNode {
 		}
 		this.pendingRequests.clear();
 		for (const listener of this.listeners) {
-			listener({ type: "process_exited", error: error.message });
+			listener({ type: "process_exited" });
 		}
 	}
 
@@ -180,9 +181,12 @@ class PiProcessNode {
 
 	kill(): void {
 		this._alive = false;
-		if (this.proc) {
-			this.proc.kill();
-			this.proc = null;
+		const proc = this.proc;
+		this.proc = null;
+		if (proc) {
+			if (!killWindowsProcessTree(proc.pid)) {
+				proc.kill();
+			}
 		}
 		this.listeners.length = 0;
 		for (const [, pending] of this.pendingRequests) {

--- a/packages/ai/providers/pi-sdk.ts
+++ b/packages/ai/providers/pi-sdk.ts
@@ -18,6 +18,7 @@ import type {
 } from "../types.ts";
 import {
 	buildWindowsCommandScriptSpawnCommand,
+	killWindowsProcessTree,
 	resolveWindowsCommandShim,
 } from "./command-path.ts";
 
@@ -55,27 +56,40 @@ class PiProcess {
 				"--mode",
 				"rpc",
 			];
-		this.proc = Bun.spawn(command, {
-			cwd,
-			stdin: "pipe",
-			stdout: "pipe",
-			stderr: "pipe",
-		});
+		try {
+			this.proc = Bun.spawn(command, {
+				cwd,
+				stdin: "pipe",
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+		} catch (err) {
+			const error = err instanceof Error ? err : new Error(String(err));
+			this.handleProcessEnd(error);
+			throw error;
+		}
 		this._alive = true;
 
 		this.readStream();
 
 		this.proc.exited.then(() => {
-			this._alive = false;
-			for (const [, pending] of this.pendingRequests) {
-				pending.reject(new Error("Pi process exited unexpectedly"));
-			}
-			this.pendingRequests.clear();
-			// Signal active query listeners so the drain loop exits with an error
-			for (const listener of this.listeners) {
-				listener({ type: "process_exited" });
-			}
+			this.handleProcessEnd(new Error("Pi process exited unexpectedly"));
 		});
+	}
+
+	private handleProcessEnd(error: Error): void {
+		if (!this.proc && this.pendingRequests.size === 0) return;
+
+		this._alive = false;
+		this.proc = null;
+		for (const [, pending] of this.pendingRequests) {
+			pending.reject(error);
+		}
+		this.pendingRequests.clear();
+		// Signal active query listeners so the drain loop exits with an error
+		for (const listener of this.listeners) {
+			listener({ type: "process_exited" });
+		}
 	}
 
 	private async readStream(): Promise<void> {
@@ -164,9 +178,12 @@ class PiProcess {
 
 	kill(): void {
 		this._alive = false;
-		if (this.proc) {
-			this.proc.kill();
-			this.proc = null;
+		const proc = this.proc;
+		this.proc = null;
+		if (proc) {
+			if (!killWindowsProcessTree(proc.pid)) {
+				proc.kill();
+			}
 		}
 		this.listeners.length = 0;
 		for (const [, pending] of this.pendingRequests) {

--- a/packages/ai/providers/pi-sdk.ts
+++ b/packages/ai/providers/pi-sdk.ts
@@ -16,6 +16,10 @@ import type {
 	CreateSessionOptions,
 	PiSDKConfig,
 } from "../types.ts";
+import {
+	buildWindowsCommandScriptSpawnCommand,
+	resolveWindowsCommandShim,
+} from "./command-path.ts";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -44,7 +48,14 @@ class PiProcess {
 	private _alive = false;
 
 	async spawn(piPath: string, cwd: string): Promise<void> {
-		this.proc = Bun.spawn([piPath, "--mode", "rpc"], {
+		const commandPath = resolveWindowsCommandShim(piPath);
+		const command =
+			buildWindowsCommandScriptSpawnCommand(commandPath, ["--mode", "rpc"]) ?? [
+				commandPath,
+				"--mode",
+				"rpc",
+			];
+		this.proc = Bun.spawn(command, {
 			cwd,
 			stdin: "pipe",
 			stdout: "pipe",

--- a/packages/server/ai-runtime.ts
+++ b/packages/server/ai-runtime.ts
@@ -6,6 +6,7 @@ import {
   type AIEndpoints,
   type PiSDKConfig,
 } from "@plannotator/ai";
+import { resolveWindowsCommandShim } from "@plannotator/ai/providers/command-path";
 
 export interface AIRuntime {
   endpoints: AIEndpoints;
@@ -54,8 +55,9 @@ export async function createAIRuntime(options: CreateAIRuntimeOptions = {}): Pro
 
   try {
     const { PiSDKProvider } = await import("@plannotator/ai/providers/pi-sdk");
-    const piPath = Bun.which("pi");
-    if (piPath) {
+    const rawPiPath = Bun.which("pi");
+    if (rawPiPath) {
+      const piPath = resolveWindowsCommandShim(rawPiPath);
       const provider = await createProvider({
         type: "pi-sdk",
         cwd,

--- a/scripts/smoke-pi-extension-ai-runtime.ts
+++ b/scripts/smoke-pi-extension-ai-runtime.ts
@@ -1,0 +1,140 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+
+import { createPiAIRuntime } from "../apps/pi-extension/server/ai-runtime.ts";
+
+function writeText(path: string, content: string): void {
+	writeFileSync(path, content.replace(/\n/g, "\r\n"), "utf-8");
+}
+
+async function main(): Promise<void> {
+	if (process.platform !== "win32") {
+		console.log("Skipping Pi extension AI runtime smoke: Windows-only.");
+		return;
+	}
+
+	const tempDir = mkdtempSync(join(tmpdir(), "plannotator-pi-ai-smoke-"));
+	const fakeBin = join(tempDir, "bin");
+	const pathEnvKey =
+		Object.keys(process.env).find((key) => key.toLowerCase() === "path") ??
+		"PATH";
+	const originalPath = process.env[pathEnvKey] ?? "";
+
+	try {
+		mkdirSync(fakeBin, { recursive: true });
+		writeText(
+			join(fakeBin, "where.cmd"),
+			`@echo off
+if /I "%~1"=="pi" (
+  echo %~dp0pi
+  echo %~dp0pi.cmd
+  exit /b 0
+)
+exit /b 1
+`,
+		);
+		writeText(
+			join(fakeBin, "pi"),
+			`extensionless npm shim placeholder
+`,
+		);
+		writeText(
+			join(fakeBin, "pi.cmd"),
+			`@echo off
+node "%~dp0pi-rpc.cjs" %*
+`,
+		);
+		writeFileSync(
+			join(fakeBin, "pi-rpc.cjs"),
+			`
+const fs = require("node:fs");
+const readline = require("node:readline");
+const marker = require("node:path").join(__dirname, "spawned.txt");
+
+fs.writeFileSync(marker, process.argv.slice(2).join(" "), "utf8");
+
+if (process.argv[2] !== "--mode" || process.argv[3] !== "rpc") {
+  console.error("unexpected args:", process.argv.slice(2).join(" "));
+  process.exit(2);
+}
+
+const rl = readline.createInterface({ input: process.stdin });
+rl.on("line", (line) => {
+  if (!line.trim()) return;
+  const message = JSON.parse(line);
+  if (message.type === "get_available_models") {
+    process.stdout.write(JSON.stringify({
+      type: "response",
+      id: message.id,
+      success: true,
+      data: {
+        models: [
+          { provider: "fake", id: "windows-smoke", name: "Windows smoke" }
+        ]
+      }
+    }) + "\\n");
+    return;
+  }
+  process.stdout.write(JSON.stringify({
+    type: "response",
+    id: message.id,
+    success: true,
+    data: {}
+  }) + "\\n");
+});
+`,
+			"utf-8",
+		);
+
+		process.env[pathEnvKey] = `${fakeBin}${delimiter}${originalPath}`;
+
+		const runtime = await createPiAIRuntime({
+			cwd: tempDir,
+			getCwd: () => tempDir,
+		});
+		if (!runtime) throw new Error("createPiAIRuntime returned null");
+
+		try {
+			const response = await runtime.endpoints["/api/ai/capabilities"](
+				new Request("http://localhost/api/ai/capabilities"),
+			);
+			if (!response.ok) {
+				throw new Error(`/api/ai/capabilities returned ${response.status}`);
+			}
+
+			const body = (await response.json()) as {
+				providers?: Array<{
+					id: string;
+					name: string;
+					models?: Array<{ id: string; label: string }>;
+				}>;
+			};
+			const piProvider = body.providers?.find(
+				(provider) => provider.name === "pi-sdk",
+			);
+			if (!piProvider) {
+				throw new Error(`pi-sdk provider missing: ${JSON.stringify(body)}`);
+			}
+			if (
+				!piProvider.models?.some(
+					(model) => model.id === "fake/windows-smoke",
+				)
+			) {
+				throw new Error(`fake Pi model missing: ${JSON.stringify(body)}`);
+			}
+
+			console.log("Pi extension AI runtime Windows shim smoke passed.");
+		} finally {
+			runtime.dispose();
+		}
+	} finally {
+		process.env[pathEnvKey] = originalPath;
+		rmSync(tempDir, { recursive: true, force: true });
+	}
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});

--- a/scripts/smoke-pi-extension-ai-runtime.ts
+++ b/scripts/smoke-pi-extension-ai-runtime.ts
@@ -12,23 +12,18 @@ function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function removeTempDirBestEffort(path: string): Promise<void> {
-	for (let attempt = 0; attempt < 8; attempt++) {
+async function removeTempDirWithRetry(path: string): Promise<void> {
+	let lastError: unknown;
+	for (let attempt = 0; attempt < 20; attempt++) {
 		try {
 			rmSync(path, { recursive: true, force: true });
 			return;
 		} catch (error) {
-			if (attempt === 7) {
-				console.warn(
-					`Warning: failed to remove smoke temp dir ${path}: ${
-						error instanceof Error ? error.message : String(error)
-					}`,
-				);
-				return;
-			}
+			lastError = error;
 			await sleep(250);
 		}
 	}
+	throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }
 
 async function main(): Promise<void> {
@@ -74,8 +69,10 @@ node "%~dp0pi-rpc.cjs" %*
 const fs = require("node:fs");
 const readline = require("node:readline");
 const marker = require("node:path").join(__dirname, "spawned.txt");
+const lock = fs.openSync(require("node:path").join(__dirname, "child.lock"), "w");
 
 fs.writeFileSync(marker, process.argv.slice(2).join(" "), "utf8");
+fs.writeSync(lock, String(process.pid));
 
 if (process.argv[2] !== "--mode" || process.argv[3] !== "rpc") {
   console.error("unexpected args:", process.argv.slice(2).join(" "));
@@ -96,7 +93,7 @@ rl.on("line", (line) => {
           { provider: "fake", id: "windows-smoke", name: "Windows smoke" }
         ]
       }
-    }) + "\\n", () => process.exit(0));
+    }) + "\\n");
     return;
   }
   process.stdout.write(JSON.stringify({
@@ -106,6 +103,8 @@ rl.on("line", (line) => {
     data: {}
   }) + "\\n");
 });
+
+setInterval(() => {}, 1000);
 `,
 			"utf-8",
 		);
@@ -153,7 +152,7 @@ rl.on("line", (line) => {
 		}
 	} finally {
 		process.env[pathEnvKey] = originalPath;
-		await removeTempDirBestEffort(tempDir);
+		await removeTempDirWithRetry(tempDir);
 	}
 }
 

--- a/scripts/smoke-pi-extension-ai-runtime.ts
+++ b/scripts/smoke-pi-extension-ai-runtime.ts
@@ -8,6 +8,29 @@ function writeText(path: string, content: string): void {
 	writeFileSync(path, content.replace(/\n/g, "\r\n"), "utf-8");
 }
 
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function removeTempDirBestEffort(path: string): Promise<void> {
+	for (let attempt = 0; attempt < 8; attempt++) {
+		try {
+			rmSync(path, { recursive: true, force: true });
+			return;
+		} catch (error) {
+			if (attempt === 7) {
+				console.warn(
+					`Warning: failed to remove smoke temp dir ${path}: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				);
+				return;
+			}
+			await sleep(250);
+		}
+	}
+}
+
 async function main(): Promise<void> {
 	if (process.platform !== "win32") {
 		console.log("Skipping Pi extension AI runtime smoke: Windows-only.");
@@ -73,7 +96,7 @@ rl.on("line", (line) => {
           { provider: "fake", id: "windows-smoke", name: "Windows smoke" }
         ]
       }
-    }) + "\\n");
+    }) + "\\n", () => process.exit(0));
     return;
   }
   process.stdout.write(JSON.stringify({
@@ -130,7 +153,7 @@ rl.on("line", (line) => {
 		}
 	} finally {
 		process.env[pathEnvKey] = originalPath;
-		rmSync(tempDir, { recursive: true, force: true });
+		await removeTempDirBestEffort(tempDir);
 	}
 }
 


### PR DESCRIPTION
## Summary
- resolve Windows npm command shims before spawning Pi from both Bun and Node providers
- handle Pi Node spawn failures without crashing the Pi extension server
- add a Windows CI/release smoke for the Pi extension AI runtime with an extensionless npm-style pi shim

## Verification
- bun test
- bun test packages/ai/ai.test.ts
- bun build scripts/smoke-pi-extension-ai-runtime.ts --target=node --outfile /tmp/pi-ai-runtime-smoke.mjs && node /tmp/pi-ai-runtime-smoke.mjs
- TypeScript checks for shared, ai, server, ui, and pi-extension via TypeScript 5.8.3
- git diff --check

Closes #789