### PR TITLE
Add Auto Mode option to Permission Mode dropdown

### DIFF
--- a/packages/ui/utils/permissionMode.ts
+++ b/packages/ui/utils/permissionMode.ts
@@ -5,8 +5,9 @@
  * Claude Code 2.1.7+ supports updatedPermissions in hook responses.
  *
  * Available modes:
- * - bypassPermissions: Auto-approve all tool calls
  * - acceptEdits: Auto-approve file edits only
+ * - auto: Autonomous execution gated by a model-based safety classifier (Claude Code 2026-03+, Sonnet 4.6+)
+ * - bypassPermissions: Auto-approve all tool calls
  * - default: Manually approve each tool call
  */
 
@@ -15,7 +16,7 @@ import { storage } from './storage';
 const STORAGE_KEY_MODE = 'plannotator-permission-mode';
 const STORAGE_KEY_CONFIGURED = 'plannotator-permission-mode-configured';
 
-export type PermissionMode = 'bypassPermissions' | 'acceptEdits' | 'default';
+export type PermissionMode = 'bypassPermissions' | 'acceptEdits' | 'auto' | 'default';
 
 export interface PermissionModeSettings {
   mode: PermissionMode;
@@ -27,6 +28,11 @@ export const PERMISSION_MODE_OPTIONS: { value: PermissionMode; label: string; de
     value: 'acceptEdits',
     label: 'Auto-accept Edits',
     description: 'Auto-approve file edits, ask for other tools',
+  },
+  {
+    value: 'auto',
+    label: 'Auto Mode',
+    description: 'Autonomous execution with a safety classifier (requires Claude Code 2026-03+ and Sonnet 4.6+)',
   },
   {
     value: 'bypassPermissions',


### PR DESCRIPTION
## Summary

- Adds `auto` as a fourth option in the Permission Mode dropdown so users can opt into [Claude Code Auto Mode](https://www.anthropic.com/engineering/claude-code-auto-mode) after approving a plan.
- Auto Mode is a March 2026 Claude Code feature: autonomous execution gated by a Sonnet 4.6-based safety classifier — less interrupting than `acceptEdits`, safer than `bypassPermissions`.
- Single-file change: extends the `PermissionMode` union + `PERMISSION_MODE_OPTIONS` array in `packages/ui/utils/permissionMode.ts`. The Settings dropdown and first-time setup modal both iterate that array, so no other UI changes are needed. The hook stdout payload (`updatedPermissions[].mode`) is already generic over the mode string, so server-side plumbing requires no changes either.

## Why this is safe to send to all Claude Code installs

Claude Code's `setMode` handler treats unknown mode values gracefully — older installs that pre-date Auto Mode support will silently keep the previous mode rather than crash. No version-gating UI is required.

## References

- Anthropic blog: https://www.anthropic.com/engineering/claude-code-auto-mode
- Permission modes doc: https://code.claude.com/docs/en/permission-modes
- Hook response schema: https://code.claude.com/docs/en/hooks

## Test plan

- [x] `bun run typecheck` (all 5 packages: shared, ai, server, ui, pi)
- [x] `bun run --cwd apps/review build` succeeds
- [x] `bun run build:hook` succeeds; grep confirms "Auto Mode" present in `apps/hook/dist/index.html`
- [x] `bun run build:opencode` succeeds; grep confirms "Auto Mode" present in `apps/opencode-plugin/plannotator.html`
- [ ] Manual smoke: trigger a plan, open Settings → Permission Mode → verify 4 options (Auto-accept Edits, Auto Mode, Bypass Permissions, Manual Approval). Select Auto Mode, approve, confirm Claude Code session indicator shows `auto`.
- [ ] First-time setup modal renders the Auto Mode card alongside existing options.