### PR TITLE
Add Amp plugin integration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -328,3 +328,57 @@ jobs:
             throw "install.cmd exited $($p.ExitCode) but not via the unknown-flag guard. Expected 'Unknown option:' in stderr but got: $stderr"
           }
           Write-Host "✓ Unknown flag rejected with exit code $($p.ExitCode) via the unknown-flag guard"
+
+  install-ps1-windows:
+    # End-to-end integration test for scripts/install.ps1 on real PowerShell.
+    # This specifically covers PLANNOTATOR_DATA_DIR tilde expansion because
+    # installer config lookup happens before any shared runtime code is loaded.
+    name: install.ps1 (Windows integration)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run install.ps1 end-to-end
+        shell: pwsh
+        run: .\scripts\install.ps1 v0.17.1 -SkipAttestation
+
+      - name: Config opt-in resolves PLANNOTATOR_DATA_DIR tilde paths
+        shell: pwsh
+        run: |
+          $configDir = Join-Path $env:USERPROFILE "plannotator-ci-config"
+          New-Item -ItemType Directory -Force -Path $configDir | Out-Null
+          Set-Content -Path (Join-Path $configDir "config.json") -Value '{ "verifyAttestation": true }' -NoNewline
+
+          $installedBinary = "$env:LOCALAPPDATA\plannotator\plannotator.exe"
+          if (-not (Test-Path $installedBinary)) {
+            throw "Expected $installedBinary to exist from the earlier install.ps1 step, but it's missing."
+          }
+          $baselineHash = (Get-FileHash $installedBinary -Algorithm SHA256).Hash
+          $baselineWriteTime = (Get-Item $installedBinary).LastWriteTime
+
+          $env:PLANNOTATOR_DATA_DIR = '~\plannotator-ci-config'
+          $stderrFile = New-TemporaryFile
+          $p = Start-Process -Wait -PassThru -NoNewWindow pwsh `
+            -ArgumentList '-NoProfile','-ExecutionPolicy','Bypass','-File','.\scripts\install.ps1','v0.17.1' `
+            -RedirectStandardError $stderrFile.FullName
+          $stderr = Get-Content $stderrFile.FullName -Raw -ErrorAction SilentlyContinue
+          Remove-Item $stderrFile.FullName -ErrorAction SilentlyContinue
+
+          if ($p.ExitCode -eq 0) {
+            throw "install.ps1 should have found config.json via PLANNOTATOR_DATA_DIR=~\plannotator-ci-config and rejected v0.17.1, but exited 0."
+          }
+          if ($stderr -notmatch 'predates') {
+            throw "install.ps1 exited $($p.ExitCode), but not via the expected attestation pre-flight. Expected 'predates' in stderr, got: $stderr"
+          }
+
+          $postHash = (Get-FileHash $installedBinary -Algorithm SHA256).Hash
+          $postWriteTime = (Get-Item $installedBinary).LastWriteTime
+          if ($postHash -ne $baselineHash) {
+            throw "Binary at $installedBinary was overwritten during the rejected config-driven verifyAttestation run."
+          }
+          if ($postWriteTime -ne $baselineWriteTime) {
+            throw "Binary at $installedBinary had its LastWriteTime modified during the rejected config-driven verifyAttestation run."
+          }
+
+          Write-Host "✓ PLANNOTATOR_DATA_DIR tilde expansion found config.json"
+          Write-Host "✓ Config-driven verifyAttestation rejected before download/install"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,13 @@ plannotator/
 │   │   ├── index.ts              # Plugin entry with submit_plan tool + review/annotate event handlers
 │   │   ├── plannotator.html      # Built plan review app
 │   │   └── review-editor.html    # Built code review app
+│   ├── amp-plugin/               # Amp plugin
+│   │   ├── plannotator.ts        # Native Amp command-palette integration
+│   │   └── README.md             # Install and local development notes
+│   ├── droid-plugin/             # Droid plugin
+│   │   ├── .factory-plugin/plugin.json
+│   │   ├── commands/             # Slash command entrypoints
+│   │   └── lib/                  # Shared command wrapper helpers
 │   ├── marketing/                # Marketing site, docs, and blog (plannotator.ai)
 │   │   └── astro.config.mjs      # Astro 5 static site with content collections
 │   ├── paste-service/            # Paste service for short URL sharing
@@ -121,7 +128,7 @@ claude --plugin-dir ./apps/hook
 | `PLANNOTATOR_SHARE` | Set to `disabled` to turn off URL sharing entirely. Default: enabled. |
 | `PLANNOTATOR_SHARE_URL` | Custom base URL for share links (self-hosted portal). Default: `https://share.plannotator.ai`. |
 | `PLANNOTATOR_PASTE_URL` | Base URL of the paste service API for short URL sharing. Default: `https://plannotator-paste.plannotator.workers.dev`. |
-| `PLANNOTATOR_ORIGIN` | Explicit agent-origin override at the top of the detection chain. Valid values: `claude-code`, `opencode`, `codex`, `copilot-cli`, `gemini-cli`, `pi`. Invalid values silently fall through to env-based detection. Unset by default. |
+| `PLANNOTATOR_ORIGIN` | Explicit agent-origin override at the top of the detection chain. Valid values: `claude-code`, `amp`, `droid`, `opencode`, `codex`, `copilot-cli`, `gemini-cli`, `pi`. Invalid values silently fall through to env-based detection. Unset by default. |
 | `PLANNOTATOR_JINA` | Set to `0` / `false` to disable Jina Reader for URL annotation, or `1` / `true` to enable. Default: enabled. Can also be set via `~/.plannotator/config.json` (`{ "jina": false }`) or per-invocation via `--no-jina`. |
 | `JINA_API_KEY` | Optional Jina Reader API key for higher rate limits (500 RPM vs 20 RPM unauthenticated). Free keys include 10M tokens. |
 | `PLANNOTATOR_DATA_DIR` | Override the base data directory. Supports `~` expansion. Default: `~/.plannotator`. All data (plans, history, drafts, config, hooks, sessions, debug logs, IPC registry) is stored under this directory. |
@@ -181,6 +188,8 @@ Ask AI providers are detected independently from installed/authenticated local C
 | Origin | Preferred Ask AI provider |
 |--------|---------------------------|
 | `claude-code` | `claude-agent-sdk` |
+| `amp` | no dedicated provider; fallback to saved/server default |
+| `droid` | no dedicated provider; fallback to saved/server default |
 | `codex` | `codex-sdk` |
 | `opencode` | `opencode-sdk` |
 | `pi` | `pi-sdk` |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Plannotator
 
-Interactive Plan & Code Review for AI Coding Agents. Mark up and refine your plans or code diffs using a visual UI, share for team collaboration, and seamlessly integrate with **Claude Code**, **Copilot CLI**, **Gemini CLI**, **OpenCode**, **Pi**, **Codex**, and **Droid**.
+Review AI-agent plans and code diffs in a browser. Add inline annotations, send structured feedback back to your agent, and share encrypted review links with teammates. Works with **Claude Code**, **Copilot CLI**, **Gemini CLI**, **OpenCode**, **Pi**, **Codex**, **Droid**, and **Amp**.
 
 **Plan Mode Demos:**
 <table>

--- a/apps/amp-plugin/README.md
+++ b/apps/amp-plugin/README.md
@@ -1,0 +1,54 @@
+# Plannotator for Amp
+
+This is a native Amp plugin for the manual Plannotator workflows:
+
+- `Plannotator: Review changes`
+- `Plannotator: Review changes or PR` (leave blank for local changes)
+- `Plannotator: Annotate file`
+- `Plannotator: Annotate last answer`
+
+Amp commands live in the command palette, not as slash commands. This plugin does
+not intercept Amp's planning flow.
+
+## Install
+
+Install the `plannotator` CLI first:
+
+```bash
+curl -fsSL https://plannotator.ai/install.sh | bash
+```
+
+Then install the Amp plugin:
+
+```bash
+mkdir -p ~/.config/amp/plugins
+curl -fsSL https://raw.githubusercontent.com/backnotprop/plannotator/main/apps/amp-plugin/plannotator.ts \
+  -o ~/.config/amp/plugins/plannotator.ts
+```
+
+Restart Amp or run `plugins: reload` from the command palette.
+
+For project-local installation, copy the plugin to:
+
+```text
+.amp/plugins/plannotator.ts
+```
+
+## Local Development
+
+From a Plannotator checkout:
+
+```bash
+mkdir -p .amp/plugins
+ln -sf ../../apps/amp-plugin/plannotator.ts .amp/plugins/plannotator.ts
+export PLANNOTATOR_AMP_USE_SOURCE=1
+export PLANNOTATOR_CWD="$PWD"
+```
+
+Run `plugins: reload` in Amp. When the plugin is loaded from this repository, it
+runs the checkout's source entrypoint instead of a global `plannotator` binary.
+You can also point directly at a source entry:
+
+```bash
+export PLANNOTATOR_AMP_SOURCE_ENTRY=/path/to/plannotator/apps/hook/server/index.ts
+```

--- a/apps/amp-plugin/plannotator.test.ts
+++ b/apps/amp-plugin/plannotator.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import {
   buildPlannotatorEnv,
   extractTextFromThreadMessage,
   findFirstPositionalArg,
   formatAnnotationFeedback,
+  getPlannotatorDataDir,
   isNoActionFeedback,
   parseAnnotateDecision,
   parseReviewTargetInput,
@@ -60,7 +61,7 @@ describe("Amp Plannotator plugin helpers", () => {
 
   test("detects non-action outputs", () => {
     expect(isNoActionFeedback("Review session closed without feedback.")).toBe(true);
-    expect(isNoActionFeedback("Code review completed — no changes requested.")).toBe(true);
+    expect(isNoActionFeedback("Code review completed — no changes requested.")).toBe(false);
     expect(isNoActionFeedback("Please fix this bug.")).toBe(false);
   });
 
@@ -71,6 +72,16 @@ describe("Amp Plannotator plugin helpers", () => {
     ]);
     expect(splitCommandArgs('"https://example.com/a path"')).toEqual([
       "https://example.com/a path",
+    ]);
+    expect(splitCommandArgs(String.raw`docs/My\ File.md --gate`)).toEqual([
+      "docs/My File.md",
+      "--gate",
+    ]);
+    expect(splitCommandArgs(String.raw`C:\Users\alice\plan.md`)).toEqual([
+      String.raw`C:\Users\alice\plan.md`,
+    ]);
+    expect(splitCommandArgs(String.raw`"C:\Users\alice\My Plan.md"`)).toEqual([
+      String.raw`C:\Users\alice\My Plan.md`,
     ]);
   });
 
@@ -133,6 +144,20 @@ describe("Amp Plannotator plugin helpers", () => {
       PLANNOTATOR_CWD: "/repo",
       PLANNOTATOR_READY_FILE: "/tmp/ready.jsonl",
     });
+  });
+
+  test("matches shared Plannotator data directory semantics", () => {
+    const originalDataDir = process.env.PLANNOTATOR_DATA_DIR;
+
+    try {
+      process.env.PLANNOTATOR_DATA_DIR = String.raw`~\plannotator-data`;
+      expect(getPlannotatorDataDir()).toBe(join(homedir(), "plannotator-data"));
+
+      process.env.PLANNOTATOR_DATA_DIR = "relative-plannotator-data";
+      expect(getPlannotatorDataDir()).toBe(resolve("relative-plannotator-data"));
+    } finally {
+      restoreEnv("PLANNOTATOR_DATA_DIR", originalDataDir);
+    }
   });
 });
 

--- a/apps/amp-plugin/plannotator.test.ts
+++ b/apps/amp-plugin/plannotator.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   extractTextFromThreadMessage,
   findFirstPositionalArg,
   formatAnnotationFeedback,
   isNoActionFeedback,
   parseAnnotateDecision,
+  parseReviewTargetInput,
+  resolveCwd,
   splitCommandArgs,
 } from "./plannotator";
 
@@ -72,4 +77,66 @@ describe("Amp Plannotator plugin helpers", () => {
     expect(findFirstPositionalArg(["--no-jina", "https://example.com"])).toBe("https://example.com");
     expect(findFirstPositionalArg(["--browser", "Google Chrome", "docs/plan.md"])).toBe("docs/plan.md");
   });
+
+  test("distinguishes canceled review target prompts from blank local reviews", () => {
+    expect(parseReviewTargetInput(undefined)).toBeNull();
+    expect(parseReviewTargetInput("   ")).toEqual([]);
+    expect(parseReviewTargetInput("--git https://github.com/org/repo/pull/1")).toEqual([
+      "--git",
+      "https://github.com/org/repo/pull/1",
+    ]);
+  });
+
+  test("prefers Amp command cwd over process PWD", async () => {
+    const processPwd = mkdtempSync(join(tmpdir(), "plannotator-amp-process-"));
+    const commandCwd = mkdtempSync(join(tmpdir(), "plannotator-amp-command-"));
+    const originalPwd = process.env.PWD;
+    const originalOverride = process.env.PLANNOTATOR_CWD;
+
+    try {
+      process.env.PWD = processPwd;
+      delete process.env.PLANNOTATOR_CWD;
+
+      const cwd = await resolveCwd(commandContextWithCwd(commandCwd));
+
+      expect(cwd).toBe(commandCwd);
+    } finally {
+      restoreEnv("PWD", originalPwd);
+      restoreEnv("PLANNOTATOR_CWD", originalOverride);
+      rmSync(processPwd, { recursive: true, force: true });
+      rmSync(commandCwd, { recursive: true, force: true });
+    }
+  });
+
+  test("lets PLANNOTATOR_CWD override Amp command cwd", async () => {
+    const explicitCwd = mkdtempSync(join(tmpdir(), "plannotator-amp-explicit-"));
+    const commandCwd = mkdtempSync(join(tmpdir(), "plannotator-amp-command-"));
+    const originalOverride = process.env.PLANNOTATOR_CWD;
+
+    try {
+      process.env.PLANNOTATOR_CWD = explicitCwd;
+
+      const cwd = await resolveCwd(commandContextWithCwd(commandCwd));
+
+      expect(cwd).toBe(explicitCwd);
+    } finally {
+      restoreEnv("PLANNOTATOR_CWD", originalOverride);
+      rmSync(explicitCwd, { recursive: true, force: true });
+      rmSync(commandCwd, { recursive: true, force: true });
+    }
+  });
 });
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
+
+function commandContextWithCwd(cwd: string): Parameters<typeof resolveCwd>[0] {
+  return {
+    $: async () => ({ exitCode: 0, stdout: `${cwd}\n`, stderr: "" }),
+  } as Parameters<typeof resolveCwd>[0];
+}

--- a/apps/amp-plugin/plannotator.test.ts
+++ b/apps/amp-plugin/plannotator.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import {
+  extractTextFromThreadMessage,
+  findFirstPositionalArg,
+  formatAnnotationFeedback,
+  isNoActionFeedback,
+  parseAnnotateDecision,
+  splitCommandArgs,
+} from "./plannotator";
+
+describe("Amp Plannotator plugin helpers", () => {
+  test("extracts visible assistant text blocks", () => {
+    const text = extractTextFromThreadMessage({
+      role: "assistant",
+      id: "m-1",
+      content: [
+        { type: "thinking", thinking: "hidden reasoning" },
+        { type: "text", text: "First paragraph." },
+        { type: "tool_use", id: "tool-1", name: "bash", input: {} },
+        { type: "text", text: "Second paragraph." },
+      ],
+    });
+
+    expect(text).toBe("First paragraph.\n\nSecond paragraph.");
+  });
+
+  test("parses structured annotate decisions", () => {
+    expect(parseAnnotateDecision('{"decision":"approved"}')).toEqual({ decision: "approved" });
+    expect(parseAnnotateDecision("")).toEqual({ decision: "dismissed" });
+    expect(parseAnnotateDecision("plain feedback")).toBeNull();
+  });
+
+  test("wraps actionable annotation feedback for Amp thread append", () => {
+    expect(
+      formatAnnotationFeedback(
+        { decision: "annotated", feedback: "Comment: tighten this section." },
+        { kind: "message" },
+      ),
+    ).toBe(
+      "# Message Annotations\n\nComment: tighten this section.\n\nPlease address the annotation feedback above.",
+    );
+  });
+
+  test("wraps file annotation feedback with target path", () => {
+    expect(
+      formatAnnotationFeedback(
+        { decision: "annotated", feedback: "Comment: tighten this section." },
+        { kind: "file", filePath: "docs/plan.md" },
+      ),
+    ).toBe(
+      "# Markdown Annotations\n\nFile: docs/plan.md\n\nComment: tighten this section.\n\nPlease address the annotation feedback above.",
+    );
+  });
+
+  test("detects non-action outputs", () => {
+    expect(isNoActionFeedback("Review session closed without feedback.")).toBe(true);
+    expect(isNoActionFeedback("Code review completed — no changes requested.")).toBe(true);
+    expect(isNoActionFeedback("Please fix this bug.")).toBe(false);
+  });
+
+  test("splits review target arguments without invoking a shell", () => {
+    expect(splitCommandArgs("--git https://github.com/org/repo/pull/1")).toEqual([
+      "--git",
+      "https://github.com/org/repo/pull/1",
+    ]);
+    expect(splitCommandArgs('"https://example.com/a path"')).toEqual([
+      "https://example.com/a path",
+    ]);
+  });
+
+  test("finds annotate target after flags", () => {
+    expect(findFirstPositionalArg(["--no-jina", "https://example.com"])).toBe("https://example.com");
+    expect(findFirstPositionalArg(["--browser", "Google Chrome", "docs/plan.md"])).toBe("docs/plan.md");
+  });
+});

--- a/apps/amp-plugin/plannotator.test.ts
+++ b/apps/amp-plugin/plannotator.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  buildPlannotatorEnv,
   extractTextFromThreadMessage,
   findFirstPositionalArg,
   formatAnnotationFeedback,
@@ -124,6 +125,14 @@ describe("Amp Plannotator plugin helpers", () => {
       rmSync(explicitCwd, { recursive: true, force: true });
       rmSync(commandCwd, { recursive: true, force: true });
     }
+  });
+
+  test("ready-file mode preserves Plannotator browser opening", () => {
+    expect(buildPlannotatorEnv("/repo", "/tmp/ready.jsonl")).toEqual({
+      PLANNOTATOR_ORIGIN: "amp",
+      PLANNOTATOR_CWD: "/repo",
+      PLANNOTATOR_READY_FILE: "/tmp/ready.jsonl",
+    });
   });
 });
 

--- a/apps/amp-plugin/plannotator.ts
+++ b/apps/amp-plugin/plannotator.ts
@@ -1,0 +1,760 @@
+import type { PluginAPI, PluginCommandContext, ThreadMessage } from "@ampcode/plugin";
+import { existsSync, readFileSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { randomUUID } from "node:crypto";
+
+const CATEGORY = "Plannotator";
+const INSTALL_URL = "https://plannotator.ai/docs/getting-started/installation/";
+const READY_TIMEOUT_MS = 30_000;
+const MIN_READY_FILE_VERSION = "0.19.24";
+const MIN_STDIN_LAST_VERSION = "0.19.24";
+const RUNTIME = "amp";
+
+const DEFAULT_ANNOTATE_FILE_FEEDBACK_PROMPT =
+  "# Markdown Annotations\n\n{{fileHeader}}: {{filePath}}\n\n{{feedback}}\n\nPlease address the annotation feedback above.";
+const DEFAULT_ANNOTATE_MESSAGE_FEEDBACK_PROMPT =
+  "# Message Annotations\n\n{{feedback}}\n\nPlease address the annotation feedback above.";
+
+type CommandContext = PluginCommandContext;
+type ReadyResult = "opened" | "exited" | "timeout";
+
+interface RunResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+  error?: string;
+}
+
+interface AnnotateDecision {
+  decision: "approved" | "dismissed" | "annotated";
+  feedback?: string;
+}
+
+interface ExitState {
+  done: boolean;
+}
+
+interface PlannotatorRuntime {
+  command: string[];
+  source: "cli" | "source";
+  version: string | null;
+  features: {
+    readyFile: boolean;
+    stdinLast: boolean;
+  };
+}
+
+let runtimePromise: Promise<PlannotatorRuntime> | null = null;
+
+export default function plannotatorAmpPlugin(amp: PluginAPI) {
+  amp.logger.log("[plannotator] Amp plugin initialized");
+
+  amp.registerCommand(
+    "plannotator-review",
+    {
+      title: "Review changes",
+      category: CATEGORY,
+      description: "Open Plannotator code review for the current workspace changes.",
+    },
+    async (ctx) => {
+      const result = await runPlannotator(amp, ctx, ["review"]);
+      await handleReviewResult(ctx, result);
+    },
+  );
+
+  amp.registerCommand(
+    "plannotator-review-target",
+    {
+      title: "Review changes or PR",
+      category: CATEGORY,
+      description: "Open Plannotator code review for local changes, a PR/MR URL, or review arguments.",
+    },
+    async (ctx) => {
+      const target = await ctx.ui.input({
+        title: "Review changes or PR",
+        helpText: "Leave blank for local git changes, or enter a GitHub PR/GitLab MR URL or review arguments such as --git.",
+        submitButtonText: "Review",
+      });
+
+      const reviewArgs = target?.trim() ? splitCommandArgs(target) : [];
+      const result = await runPlannotator(amp, ctx, ["review", ...reviewArgs]);
+      await handleReviewResult(ctx, result);
+    },
+  );
+
+  amp.registerCommand(
+    "plannotator-annotate",
+    {
+      title: "Annotate file",
+      category: CATEGORY,
+      description: "Open Plannotator annotation UI for a markdown/html file, folder, or URL.",
+    },
+    async (ctx) => {
+      const target = await ctx.ui.input({
+        title: "Annotate",
+        helpText: "Enter a markdown/html file, folder, or URL.",
+        submitButtonText: "Annotate",
+      });
+      if (!target?.trim()) return;
+
+      const args = splitCommandArgs(target);
+      if (args.length === 0) return;
+      const filePath = findFirstPositionalArg(args) ?? args[0];
+
+      const result = await runPlannotator(amp, ctx, ["annotate", ...args, "--json"]);
+      await handleAnnotateResult(ctx, result, { kind: "file", filePath });
+    },
+  );
+
+  amp.registerCommand(
+    "plannotator-last",
+    {
+      title: "Annotate last answer",
+      category: CATEGORY,
+      description: "Open Plannotator annotation UI for Amp's latest assistant message.",
+    },
+    async (ctx) => {
+      if (!ctx.thread) {
+        await ctx.ui.notify("No active Amp thread.");
+        return;
+      }
+
+      const message = await getLatestAssistantText(ctx);
+      if (!message) {
+        await ctx.ui.notify("No assistant message found in this thread.");
+        return;
+      }
+
+      const runtime = await getPlannotatorRuntime();
+      let tempFile: string | null = null;
+      let result: RunResult;
+
+      try {
+        if (runtime.features.stdinLast) {
+          result = await runPlannotator(
+            amp,
+            ctx,
+            ["annotate-last", "--stdin", "--json"],
+            { stdin: message, runtime },
+          );
+        } else {
+          tempFile = join(tmpdir(), `plannotator-amp-last-${process.pid}-${Date.now()}-${randomUUID()}.md`);
+          writeFileSync(tempFile, message, "utf8");
+          result = await runPlannotator(amp, ctx, ["annotate", tempFile, "--json"], { runtime });
+        }
+      } finally {
+        if (tempFile) {
+          try {
+            unlinkSync(tempFile);
+          } catch {
+            // Best-effort cleanup for the fallback message file.
+          }
+        }
+      }
+
+      await handleAnnotateResult(ctx, result, { kind: "message" });
+    },
+  );
+}
+
+export function extractTextFromThreadMessage(message: ThreadMessage): string {
+  if (message.role !== "assistant") return "";
+  return message.content
+    .filter((block) => block.type === "text" && block.text.trim())
+    .map((block) => block.text.trim())
+    .join("\n\n")
+    .trim();
+}
+
+export function parseAnnotateDecision(raw: string): AnnotateDecision | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return { decision: "dismissed" };
+
+  try {
+    const parsed = JSON.parse(trimmed) as Partial<AnnotateDecision>;
+    if (
+      parsed &&
+      (parsed.decision === "approved" ||
+        parsed.decision === "dismissed" ||
+        parsed.decision === "annotated")
+    ) {
+      return {
+        decision: parsed.decision,
+        feedback: typeof parsed.feedback === "string" ? parsed.feedback : undefined,
+      };
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+export function formatAnnotationFeedback(
+  decision: AnnotateDecision,
+  options: { kind: "file"; filePath: string } | { kind: "message" },
+): string | null {
+  if (decision.decision !== "annotated") return null;
+
+  const feedback = decision.feedback?.trim();
+  if (!feedback || isNoActionFeedback(feedback)) return null;
+
+  const config = loadPlannotatorConfig();
+  if (options.kind === "file") {
+    const template = getConfiguredPrompt(config, "fileFeedback", DEFAULT_ANNOTATE_FILE_FEEDBACK_PROMPT);
+    return resolveTemplate(template, {
+      fileHeader: "File",
+      filePath: options.filePath,
+      feedback,
+    });
+  }
+
+  const template = getConfiguredPrompt(config, "messageFeedback", DEFAULT_ANNOTATE_MESSAGE_FEEDBACK_PROMPT);
+  return resolveTemplate(template, { feedback });
+}
+
+export function isNoActionFeedback(output: string): boolean {
+  const normalized = output.trim().toLowerCase();
+  return (
+    normalized === "" ||
+    normalized === "review session closed without feedback." ||
+    normalized === "annotation session closed." ||
+    normalized === "approved." ||
+    normalized === "the user approved." ||
+    normalized.includes("no changes requested") ||
+    normalized.includes("has no feedback")
+  );
+}
+
+export function splitCommandArgs(input: string): string[] {
+  const args: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+
+  for (const char of input.trim()) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+
+    if (char === "\\" && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      if (current) {
+        args.push(current);
+        current = "";
+      }
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (escaped) current += "\\";
+  if (current) args.push(current);
+  return args;
+}
+
+export function findFirstPositionalArg(args: string[]): string | null {
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--") return args[i + 1] ?? null;
+    if (arg === "--browser") {
+      i += 1;
+      continue;
+    }
+    if (!arg.startsWith("-")) return arg;
+  }
+
+  return null;
+}
+
+async function getLatestAssistantText(ctx: CommandContext): Promise<string | null> {
+  if (!ctx.thread) return null;
+
+  const latest = await ctx.thread.messages({ from: "end", limit: 1, roles: ["assistant"] });
+  const latestText = latest.map(extractTextFromThreadMessage).find(Boolean);
+  if (latestText) return latestText;
+
+  const recent = await ctx.thread.messages({ from: "end", limit: 20, roles: ["assistant"] });
+  for (let i = recent.length - 1; i >= 0; i -= 1) {
+    const text = extractTextFromThreadMessage(recent[i]);
+    if (text) return text;
+  }
+
+  return null;
+}
+
+async function handleReviewResult(ctx: CommandContext, result: RunResult): Promise<void> {
+  if (await notifyFailure(ctx, result, "review")) return;
+
+  const output = result.stdout.trim();
+  if (isNoActionFeedback(output)) {
+    await ctx.ui.notify(output || "Review session closed without feedback.");
+    return;
+  }
+
+  await appendFeedback(ctx, output);
+}
+
+async function handleAnnotateResult(
+  ctx: CommandContext,
+  result: RunResult,
+  options: { kind: "file"; filePath: string } | { kind: "message" },
+): Promise<void> {
+  if (await notifyFailure(ctx, result, "annotate")) return;
+
+  const decision = parseAnnotateDecision(result.stdout);
+  if (decision?.decision === "approved") {
+    await ctx.ui.notify("Approved.");
+    return;
+  }
+  if (decision?.decision === "dismissed") {
+    await ctx.ui.notify("Annotation session closed.");
+    return;
+  }
+
+  const feedback = decision
+    ? formatAnnotationFeedback(decision, options)
+    : result.stdout.trim();
+
+  if (!feedback || isNoActionFeedback(feedback)) {
+    await ctx.ui.notify("Annotation session closed without feedback.");
+    return;
+  }
+
+  await appendFeedback(ctx, feedback);
+}
+
+async function appendFeedback(ctx: CommandContext, content: string): Promise<void> {
+  if (!ctx.thread) {
+    await ctx.ui.notify("Plannotator produced feedback, but there is no active Amp thread.");
+    return;
+  }
+
+  await ctx.thread.append([{ type: "user-message", content }]);
+}
+
+async function notifyFailure(
+  ctx: CommandContext,
+  result: RunResult,
+  mode: "review" | "annotate",
+): Promise<boolean> {
+  if (!result.error && result.status === 0) return false;
+
+  const details = [result.error, result.stderr.trim(), result.stdout.trim()]
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+  const missingExecutable = /\bENOENT\b/i.test(details) ||
+    /executable not found/i.test(details) ||
+    /command not found/i.test(details);
+  const installHint = missingExecutable
+    ? `\n\nInstall the CLI first: ${INSTALL_URL}`
+    : "";
+
+  await ctx.ui.notify(`Plannotator ${mode} failed.${details ? `\n\n${details}` : ""}${installHint}`);
+  return true;
+}
+
+async function runPlannotator(
+  amp: PluginAPI,
+  ctx: CommandContext,
+  args: string[],
+  options: { stdin?: string; runtime?: PlannotatorRuntime } = {},
+): Promise<RunResult> {
+  const cwd = await resolveCwd(ctx);
+  const runtime = options.runtime ?? await getPlannotatorRuntime();
+  const readyFile = runtime.features.readyFile
+    ? join(tmpdir(), `plannotator-amp-${process.pid}-${Date.now()}-${randomUUID()}.jsonl`)
+    : null;
+  const command = [...runtime.command, ...args];
+  const envExtra: Record<string, string> = {
+    PLANNOTATOR_ORIGIN: RUNTIME,
+    PLANNOTATOR_CWD: cwd,
+  };
+  if (readyFile) {
+    envExtra.PLANNOTATOR_READY_FILE = readyFile;
+    envExtra.PLANNOTATOR_SKIP_BROWSER_OPEN = "1";
+  }
+  const env = buildEnv(envExtra);
+
+  let proc: Bun.Subprocess<"ignore" | "pipe", "pipe", "pipe">;
+  try {
+    proc = Bun.spawn(command, {
+      cwd,
+      env,
+      stdin: options.stdin ? "pipe" : "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+  } catch (error) {
+    return {
+      status: 1,
+      stdout: "",
+      stderr: "",
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  if (options.stdin && proc.stdin) {
+    proc.stdin.write(options.stdin);
+    proc.stdin.end();
+  }
+
+  const exitState: ExitState = { done: false };
+  const stdoutPromise = new Response(proc.stdout).text();
+  const stderrPromise = collectStderr(amp, ctx, proc.stderr);
+  const exitedPromise = proc.exited.finally(() => {
+    exitState.done = true;
+  });
+
+  let readyPromise: Promise<ReadyResult> | null = null;
+  if (readyFile) {
+    readyPromise = openWhenReady(ctx, readyFile, exitState);
+    const readyResult = await readyPromise;
+    if (readyResult === "timeout") {
+      try {
+        proc.kill();
+      } catch {
+        // Process may already have exited.
+      }
+    }
+  }
+
+  const status = await exitedPromise;
+  const [stdout, stderr] = await Promise.all([stdoutPromise, stderrPromise]);
+
+  try {
+    if (readyFile) unlinkSync(readyFile);
+  } catch {
+    // Temporary ready file may not exist if the command failed early.
+  }
+
+  const readyTimedOut = readyPromise ? (await readyPromise) === "timeout" : false;
+  return {
+    status,
+    stdout,
+    stderr,
+    ...(readyTimedOut ? { error: "Timed out waiting for Plannotator to publish its browser URL." } : {}),
+  };
+}
+
+async function resolveCwd(ctx: CommandContext): Promise<string> {
+  const explicitCwd = normalizeDirectory(process.env.PLANNOTATOR_CWD);
+  if (explicitCwd) return explicitCwd;
+
+  const shellPwd = normalizeDirectory(process.env.PWD);
+  if (shellPwd) return shellPwd;
+
+  try {
+    const result = await ctx.$`pwd`;
+    const cwd = normalizeDirectory(result.stdout);
+    if (cwd) return cwd;
+  } catch {
+    // Fall through to process cwd.
+  }
+
+  return normalizeDirectory(process.cwd()) ?? process.cwd();
+}
+
+function normalizeDirectory(value: string | undefined): string | null {
+  const candidate = value?.trim();
+  if (!candidate || candidate === "undefined" || candidate === "null") return null;
+
+  try {
+    return statSync(candidate).isDirectory() ? candidate : null;
+  } catch {
+    return null;
+  }
+}
+
+function buildEnv(extra: Record<string, string>): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (typeof value === "string") env[key] = value;
+  }
+  return { ...env, ...extra };
+}
+
+async function collectStderr(
+  amp: PluginAPI,
+  ctx: CommandContext,
+  stream: ReadableStream<Uint8Array>,
+): Promise<string> {
+  const decoder = new TextDecoder();
+  const reader = stream.getReader();
+  const seenUrls = new Set<string>();
+  let output = "";
+  let lineBuffer = "";
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+
+    const text = decoder.decode(value, { stream: true });
+    output += text;
+    lineBuffer += text;
+
+    const lines = lineBuffer.split(/\r?\n/);
+    lineBuffer = lines.pop() ?? "";
+    for (const line of lines) {
+      await notifyUrls(ctx, line, seenUrls);
+    }
+  }
+
+  const tail = decoder.decode();
+  output += tail;
+  if (tail) lineBuffer += tail;
+  if (lineBuffer) await notifyUrls(ctx, lineBuffer, seenUrls);
+
+  if (output.trim()) amp.logger.log(output.trim());
+  return output;
+}
+
+async function notifyUrls(
+  ctx: CommandContext,
+  text: string,
+  seenUrls: Set<string>,
+): Promise<void> {
+  const matches = text.match(/https?:\/\/[^\s)]+/g) ?? [];
+  for (const rawUrl of matches) {
+    const url = rawUrl.replace(/[.,;]+$/, "");
+    if (seenUrls.has(url)) continue;
+    seenUrls.add(url);
+    await ctx.ui.notify(`Plannotator link:\n${url}`);
+  }
+}
+
+async function openWhenReady(
+  ctx: CommandContext,
+  readyFile: string,
+  exitState: ExitState,
+): Promise<ReadyResult> {
+  const deadline = Date.now() + READY_TIMEOUT_MS;
+  const opened = new Set<string>();
+
+  while (Date.now() < deadline) {
+    if (existsSync(readyFile)) {
+      const lines = readFileSync(readyFile, "utf8").split(/\r?\n/).filter(Boolean);
+      for (const line of lines) {
+        let payload: { url?: unknown };
+        try {
+          payload = JSON.parse(line) as { url?: unknown };
+        } catch {
+          // Keep polling; the writer may still be appending the line.
+          continue;
+        }
+
+        if (typeof payload.url !== "string" || opened.has(payload.url)) continue;
+        opened.add(payload.url);
+
+        try {
+          await ctx.system.open(payload.url);
+          return "opened";
+        } catch {
+          await ctx.ui.notify(`Open Plannotator:\n${payload.url}`);
+          return "opened";
+        }
+      }
+    }
+
+    if (exitState.done) return "exited";
+    await sleep(100);
+  }
+
+  return "timeout";
+}
+
+async function getPlannotatorRuntime(): Promise<PlannotatorRuntime> {
+  runtimePromise ??= resolvePlannotatorRuntime();
+  return runtimePromise;
+}
+
+async function resolvePlannotatorRuntime(): Promise<PlannotatorRuntime> {
+  const explicitSource = process.env.PLANNOTATOR_AMP_SOURCE_ENTRY;
+  const sourceEntry = explicitSource
+    ? resolve(explicitSource)
+    : process.env.PLANNOTATOR_AMP_USE_SOURCE === "1"
+      ? findSourceEntry(import.meta.dir)
+      : null;
+
+  if (sourceEntry && existsSync(sourceEntry)) {
+    return {
+      command: [getBunExecutable(), sourceEntry],
+      source: "source",
+      version: "source",
+      features: { readyFile: true, stdinLast: true },
+    };
+  }
+
+  const command = ["plannotator"];
+  const version = detectPlannotatorVersion(command);
+  return {
+    command,
+    source: "cli",
+    version,
+    features: {
+      readyFile: semverGte(version, MIN_READY_FILE_VERSION),
+      stdinLast: semverGte(version, MIN_STDIN_LAST_VERSION),
+    },
+  };
+}
+
+function findSourceEntry(startDir: string): string | null {
+  const root = findRepoRoot(startDir);
+  if (!root) return null;
+
+  const sourceEntry = join(root, "apps", "hook", "server", "index.ts");
+  return existsSync(sourceEntry) ? sourceEntry : null;
+}
+
+function findRepoRoot(startDir: string): string | null {
+  let dir = resolve(startDir);
+
+  while (true) {
+    const packageJsonPath = join(dir, "package.json");
+    if (existsSync(packageJsonPath)) {
+      try {
+        const pkg = JSON.parse(readFileSync(packageJsonPath, "utf8")) as { name?: unknown };
+        if (pkg.name === "plannotator") return dir;
+      } catch {
+        // Ignore malformed package.json while walking upward.
+      }
+    }
+
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+function getBunExecutable(): string {
+  const candidates = [process.execPath, Bun.argv[0], Bun.which?.("bun"), "bun"];
+  for (const candidate of candidates) {
+    if (typeof candidate !== "string") continue;
+    const value = candidate.trim();
+    if (!value || value === "undefined" || value === "null") continue;
+    return value;
+  }
+
+  return "bun";
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+}
+
+function detectPlannotatorVersion(command: string[]): string | null {
+  try {
+    const result = Bun.spawnSync([...command, "--version"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    if (result.exitCode !== 0) return null;
+
+    const output = new TextDecoder().decode(result.stdout).trim();
+    const match = output.match(/\b(\d+\.\d+\.\d+)\b/);
+    return match?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function semverGte(actual: string | null, minimum: string): boolean {
+  if (!actual) return false;
+  const actualParts = actual.split(".").map((part) => Number(part));
+  const minimumParts = minimum.split(".").map((part) => Number(part));
+
+  for (let i = 0; i < 3; i += 1) {
+    const actualPart = actualParts[i] ?? 0;
+    const minimumPart = minimumParts[i] ?? 0;
+    if (actualPart > minimumPart) return true;
+    if (actualPart < minimumPart) return false;
+  }
+
+  return true;
+}
+
+type PromptConfig = {
+  prompts?: {
+    annotate?: {
+      fileFeedback?: unknown;
+      messageFeedback?: unknown;
+      runtimes?: Partial<Record<typeof RUNTIME, {
+        fileFeedback?: unknown;
+        messageFeedback?: unknown;
+      }>>;
+    };
+  };
+};
+
+function loadPlannotatorConfig(): PromptConfig {
+  try {
+    const configPath = join(getPlannotatorDataDir(), "config.json");
+    if (!existsSync(configPath)) return {};
+
+    const parsed = JSON.parse(readFileSync(configPath, "utf8")) as unknown;
+    return parsed && typeof parsed === "object" ? parsed as PromptConfig : {};
+  } catch {
+    return {};
+  }
+}
+
+function getPlannotatorDataDir(): string {
+  const override = process.env.PLANNOTATOR_DATA_DIR;
+  if (override?.trim()) {
+    const value = override.trim();
+    return value === "~" || value.startsWith("~/")
+      ? join(homedir(), value.slice(2))
+      : value;
+  }
+
+  return join(homedir(), ".plannotator");
+}
+
+function getConfiguredPrompt(
+  config: PromptConfig,
+  key: "fileFeedback" | "messageFeedback",
+  fallback: string,
+): string {
+  const annotate = config.prompts?.annotate;
+  const runtimePrompt = normalizePrompt(annotate?.runtimes?.[RUNTIME]?.[key]);
+  const genericPrompt = normalizePrompt(annotate?.[key]);
+  return runtimePrompt ?? genericPrompt ?? fallback;
+}
+
+function normalizePrompt(prompt: unknown): string | undefined {
+  if (typeof prompt !== "string") return undefined;
+  return prompt.trim() ? prompt : undefined;
+}
+
+function resolveTemplate(
+  template: string,
+  vars: Record<string, string | undefined>,
+): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (match, key) => {
+    const value = vars[key];
+    return value !== undefined ? value : match;
+  });
+}

--- a/apps/amp-plugin/plannotator.ts
+++ b/apps/amp-plugin/plannotator.ts
@@ -17,7 +17,7 @@ const DEFAULT_ANNOTATE_MESSAGE_FEEDBACK_PROMPT =
   "# Message Annotations\n\n{{feedback}}\n\nPlease address the annotation feedback above.";
 
 type CommandContext = PluginCommandContext;
-type ReadyResult = "opened" | "exited" | "timeout";
+type ReadyResult = "ready" | "exited" | "timeout";
 
 interface RunResult {
   status: number;
@@ -396,15 +396,7 @@ async function runPlannotator(
     ? join(tmpdir(), `plannotator-amp-${process.pid}-${Date.now()}-${randomUUID()}.jsonl`)
     : null;
   const command = [...runtime.command, ...args];
-  const envExtra: Record<string, string> = {
-    PLANNOTATOR_ORIGIN: RUNTIME,
-    PLANNOTATOR_CWD: cwd,
-  };
-  if (readyFile) {
-    envExtra.PLANNOTATOR_READY_FILE = readyFile;
-    envExtra.PLANNOTATOR_SKIP_BROWSER_OPEN = "1";
-  }
-  const env = buildEnv(envExtra);
+  const env = buildEnv(buildPlannotatorEnv(cwd, readyFile));
 
   let proc: Bun.Subprocess<"ignore" | "pipe", "pipe", "pipe">;
   try {
@@ -438,7 +430,7 @@ async function runPlannotator(
 
   let readyPromise: Promise<ReadyResult> | null = null;
   if (readyFile) {
-    readyPromise = openWhenReady(ctx, readyFile, exitState);
+    readyPromise = waitForReadyFile(readyFile, exitState);
     const readyResult = await readyPromise;
     if (readyResult === "timeout") {
       try {
@@ -483,6 +475,14 @@ export async function resolveCwd(ctx: CommandContext): Promise<string> {
   if (shellPwd) return shellPwd;
 
   return normalizeDirectory(process.cwd()) ?? process.cwd();
+}
+
+export function buildPlannotatorEnv(cwd: string, readyFile: string | null): Record<string, string> {
+  return {
+    PLANNOTATOR_ORIGIN: RUNTIME,
+    PLANNOTATOR_CWD: cwd,
+    ...(readyFile ? { PLANNOTATOR_READY_FILE: readyFile } : {}),
+  };
 }
 
 function normalizeDirectory(value: string | undefined): string | null {
@@ -553,13 +553,12 @@ async function notifyUrls(
   }
 }
 
-async function openWhenReady(
-  ctx: CommandContext,
+async function waitForReadyFile(
   readyFile: string,
   exitState: ExitState,
 ): Promise<ReadyResult> {
   const deadline = Date.now() + READY_TIMEOUT_MS;
-  const opened = new Set<string>();
+  const seen = new Set<string>();
 
   while (Date.now() < deadline) {
     if (existsSync(readyFile)) {
@@ -573,16 +572,9 @@ async function openWhenReady(
           continue;
         }
 
-        if (typeof payload.url !== "string" || opened.has(payload.url)) continue;
-        opened.add(payload.url);
-
-        try {
-          await ctx.system.open(payload.url);
-          return "opened";
-        } catch {
-          await ctx.ui.notify(`Open Plannotator:\n${payload.url}`);
-          return "opened";
-        }
+        if (typeof payload.url !== "string" || seen.has(payload.url)) continue;
+        seen.add(payload.url);
+        return "ready";
       }
     }
 

--- a/apps/amp-plugin/plannotator.ts
+++ b/apps/amp-plugin/plannotator.ts
@@ -224,7 +224,6 @@ export function isNoActionFeedback(output: string): boolean {
     normalized === "annotation session closed." ||
     normalized === "approved." ||
     normalized === "the user approved." ||
-    normalized.includes("no changes requested") ||
     normalized.includes("has no feedback")
   );
 }
@@ -233,17 +232,26 @@ export function splitCommandArgs(input: string): string[] {
   const args: string[] = [];
   let current = "";
   let quote: "'" | '"' | null = null;
-  let escaped = false;
 
-  for (const char of input.trim()) {
-    if (escaped) {
-      current += char;
-      escaped = false;
-      continue;
-    }
+  const text = input.trim();
+  for (let i = 0; i < text.length; i += 1) {
+    const char = text[i];
 
     if (char === "\\" && quote !== "'") {
-      escaped = true;
+      const next = text[i + 1];
+      const escapesNext =
+        next !== undefined &&
+        (next === "\\" ||
+          /\s/.test(next) ||
+          next === quote ||
+          (!quote && (next === "'" || next === '"')));
+
+      if (escapesNext) {
+        current += next;
+        i += 1;
+      } else {
+        current += char;
+      }
       continue;
     }
 
@@ -272,7 +280,6 @@ export function splitCommandArgs(input: string): string[] {
     current += char;
   }
 
-  if (escaped) current += "\\";
   if (current) args.push(current);
   return args;
 }
@@ -720,16 +727,17 @@ function loadPlannotatorConfig(): PromptConfig {
   }
 }
 
-function getPlannotatorDataDir(): string {
-  const override = process.env.PLANNOTATOR_DATA_DIR;
-  if (override?.trim()) {
-    const value = override.trim();
-    return value === "~" || value.startsWith("~/")
-      ? join(homedir(), value.slice(2))
-      : value;
+export function getPlannotatorDataDir(): string {
+  const value = process.env.PLANNOTATOR_DATA_DIR?.trim();
+  if (!value) return join(homedir(), ".plannotator");
+
+  const home = homedir();
+  if (value === "~") return home;
+  if (value.startsWith("~/") || value.startsWith("~\\")) {
+    return join(home, value.slice(2));
   }
 
-  return join(homedir(), ".plannotator");
+  return resolve(value);
 }
 
 function getConfiguredPrompt(

--- a/apps/amp-plugin/plannotator.ts
+++ b/apps/amp-plugin/plannotator.ts
@@ -77,7 +77,9 @@ export default function plannotatorAmpPlugin(amp: PluginAPI) {
         submitButtonText: "Review",
       });
 
-      const reviewArgs = target?.trim() ? splitCommandArgs(target) : [];
+      const reviewArgs = parseReviewTargetInput(target);
+      if (!reviewArgs) return;
+
       const result = await runPlannotator(amp, ctx, ["review", ...reviewArgs]);
       await handleReviewResult(ctx, result);
     },
@@ -289,6 +291,11 @@ export function findFirstPositionalArg(args: string[]): string | null {
   return null;
 }
 
+export function parseReviewTargetInput(target: string | undefined): string[] | null {
+  if (target === undefined) return null;
+  return target.trim() ? splitCommandArgs(target) : [];
+}
+
 async function getLatestAssistantText(ctx: CommandContext): Promise<string | null> {
   if (!ctx.thread) return null;
 
@@ -460,20 +467,20 @@ async function runPlannotator(
   };
 }
 
-async function resolveCwd(ctx: CommandContext): Promise<string> {
+export async function resolveCwd(ctx: CommandContext): Promise<string> {
   const explicitCwd = normalizeDirectory(process.env.PLANNOTATOR_CWD);
   if (explicitCwd) return explicitCwd;
-
-  const shellPwd = normalizeDirectory(process.env.PWD);
-  if (shellPwd) return shellPwd;
 
   try {
     const result = await ctx.$`pwd`;
     const cwd = normalizeDirectory(result.stdout);
     if (cwd) return cwd;
   } catch {
-    // Fall through to process cwd.
+    // Fall through to process-level cwd fallbacks.
   }
+
+  const shellPwd = normalizeDirectory(process.env.PWD);
+  if (shellPwd) return shellPwd;
 
   return normalizeDirectory(process.cwd()) ?? process.cwd();
 }

--- a/apps/droid-plugin/README.md
+++ b/apps/droid-plugin/README.md
@@ -2,7 +2,7 @@
 
 Plannotator's Droid plugin ships the manual slash-command workflow only:
 
-- `/plannotator-review`
+- `/plannotator-review [PR_URL]` (no args reviews local changes)
 - `/plannotator-annotate <file|folder|url>`
 - `/plannotator-last`
 - `/plannotator-archive`

--- a/apps/hook/server/cli.test.ts
+++ b/apps/hook/server/cli.test.ts
@@ -23,6 +23,7 @@ describe("CLI top-level help", () => {
     expect(output).toContain("plannotator [--browser <name>]");
     expect(output).toContain("plannotator review [--git] [PR_URL]");
     expect(output).toContain("plannotator annotate <file.md | file.html | https://... | folder/>");
+    expect(output).toContain("plannotator annotate-last [--stdin]");
     expect(output).toContain("plannotator setup-goal <interview|facts>");
     expect(output).toContain("running 'plannotator' without arguments is for hook integration");
   });

--- a/apps/hook/server/cli.ts
+++ b/apps/hook/server/cli.ts
@@ -27,6 +27,7 @@ export function formatTopLevelHelp(): string {
     "  plannotator [--browser <name>]",
     "  plannotator review [--git] [PR_URL]",
     "  plannotator annotate <file.md | file.html | https://... | folder/>  [--no-jina] [--gate] [--json] [--hook]",
+    "  plannotator annotate-last [--stdin] [--gate] [--json] [--hook]",
     "  plannotator setup-goal <interview|facts> <bundle.json | -> [--json]",
     "  plannotator last",
     "  plannotator archive",

--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -261,6 +261,7 @@ const pasteApiUrl = process.env.PLANNOTATOR_PASTE_URL || undefined;
 // Detect calling agent from environment variables set by agent runtimes.
 // Priority:
 //   PLANNOTATOR_ORIGIN (explicit override, validated against AGENT_CONFIG)
+//   > Amp plugin wrappers (PLANNOTATOR_ORIGIN=amp)
 //   > Droid command wrappers (PLANNOTATOR_ORIGIN=droid)
 //   > Codex (CODEX_THREAD_ID)
 //   > Copilot CLI (COPILOT_CLI)
@@ -845,13 +846,21 @@ if (args[0] === "sessions") {
   // ============================================
 
   const projectRoot = process.env.PLANNOTATOR_CWD || process.cwd();
+  const stdinIdx = args.indexOf("--stdin");
+  const stdinFlag = stdinIdx !== -1;
+  if (stdinFlag) args.splice(stdinIdx, 1);
   const codexThreadId = process.env.CODEX_THREAD_ID;
   const isCodex = !!codexThreadId;
   const isDroid = detectedOrigin === "droid";
 
   let lastMessage: RenderedMessage | null = null;
 
-  if (codexThreadId) {
+  if (stdinFlag) {
+    const text = (await Bun.stdin.text()).trim();
+    if (text) {
+      lastMessage = { messageId: "stdin", text, lineNumbers: [] };
+    }
+  } else if (codexThreadId) {
     // Codex path: find rollout by thread ID
     if (process.env.PLANNOTATOR_DEBUG) {
       console.error(`[DEBUG] Codex detected, thread ID: ${codexThreadId}`);
@@ -947,7 +956,9 @@ if (args[0] === "sessions") {
   }
 
   if (!lastMessage) {
-    console.error("No rendered assistant message found in session logs.");
+    console.error(stdinFlag
+      ? "No message content received on stdin."
+      : "No rendered assistant message found in session logs.");
     process.exit(1);
   }
 

--- a/apps/marketing/public/assets/icon-amp.svg
+++ b/apps/marketing/public/assets/icon-amp.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Amp">
+  <rect width="32" height="32" rx="7" fill="#0f172a"/>
+  <path d="M8 24 15.2 7h1.6L24 24h-3.1l-1.5-3.8h-6.8L11.1 24H8Zm5.5-6.2h5l-2.5-6.5-2.5 6.5Z" fill="#bef264"/>
+</svg>

--- a/apps/marketing/public/assets/icon-amp.svg
+++ b/apps/marketing/public/assets/icon-amp.svg
@@ -1,4 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Amp">
-  <rect width="32" height="32" rx="7" fill="#0f172a"/>
-  <path d="M8 24 15.2 7h1.6L24 24h-3.1l-1.5-3.8h-6.8L11.1 24H8Zm5.5-6.2h5l-2.5-6.5-2.5 6.5Z" fill="#bef264"/>
-</svg>
+<svg height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><title>Amp</title><path d="M15.087 23.18L12.03 24l-2.097-7.823-5.738 5.738-2.251-2.251 5.718-5.719-7.769-2.082.82-3.057 11.294 3.08 3.08 11.295z" fill="#F34E3F"></path><path d="M19.505 18.762l-3.057.82-2.564-9.573-9.572-2.564.819-3.057 11.295 3.079 3.08 11.295z" fill="#F34E3F"></path><path d="M23.893 14.374l-3.057.82-2.565-9.572L8.7 3.057 9.52 0l11.295 3.08 3.079 11.294z" fill="#F34E3F"></path></svg>

--- a/apps/marketing/src/components/landing/HeroSection.astro
+++ b/apps/marketing/src/components/landing/HeroSection.astro
@@ -64,6 +64,15 @@ import AnnoReplace from './AnnoReplace.astro';
         </button>
         <button
           class="agent-btn"
+          data-agent="amp"
+          data-command="curl -fsSL https://plannotator.ai/install.sh | bash"
+          data-video=""
+        >
+          <img src="/assets/icon-amp.svg" alt="" class="w-4 h-4 rounded-sm" />
+          <span>Amp</span>
+        </button>
+        <button
+          class="agent-btn"
           data-agent="copilot"
           data-command="curl -fsSL https://plannotator.ai/install.sh | bash"
           data-video=""
@@ -230,6 +239,22 @@ import AnnoReplace from './AnnoReplace.astro';
         link: {
           text: 'Read the Droid install docs',
           url: '/docs/getting-started/installation/#droid'
+        }
+      },
+      amp: {
+        steps: [
+          'mkdir -p ~/.config/amp/plugins',
+          'curl -fsSL https://raw.githubusercontent.com/backnotprop/plannotator/main/apps/amp-plugin/plannotator.ts -o ~/.config/amp/plugins/plannotator.ts',
+          'Run plugins: reload in Amp',
+          'Plannotator: Review changes',
+          'Plannotator: Review changes or PR',
+          'Plannotator: Annotate file',
+          'Plannotator: Annotate last answer'
+        ],
+        detail: 'Commands-only integration. Installs command-palette actions in Amp:',
+        link: {
+          text: 'Read the Amp install docs',
+          url: '/docs/getting-started/installation/#amp'
         }
       },
       opencode: {

--- a/apps/marketing/src/components/landing/HeroSection.astro
+++ b/apps/marketing/src/components/landing/HeroSection.astro
@@ -68,7 +68,7 @@ import AnnoReplace from './AnnoReplace.astro';
           data-command="curl -fsSL https://plannotator.ai/install.sh | bash"
           data-video=""
         >
-          <img src="/assets/icon-amp.svg" alt="" class="w-4 h-4 rounded-sm" />
+          <img src="/assets/icon-amp.svg" alt="" class="w-4 h-4" />
           <span>Amp</span>
         </button>
         <button

--- a/apps/marketing/src/components/landing/HeroSection.astro
+++ b/apps/marketing/src/components/landing/HeroSection.astro
@@ -36,7 +36,7 @@ import AnnoReplace from './AnnoReplace.astro';
       <!-- Agent selector buttons -->
       <div class="flex flex-wrap items-center gap-1.5 mb-4" id="agent-selector">
         <button
-          class="agent-btn active"
+          class="agent-btn"
           data-agent="amp"
           data-command="curl -fsSL https://plannotator.ai/install.sh | bash"
           data-video=""
@@ -45,7 +45,7 @@ import AnnoReplace from './AnnoReplace.astro';
           <span>Amp</span>
         </button>
         <button
-          class="agent-btn"
+          class="agent-btn active"
           data-agent="claude"
           data-command="curl -fsSL https://plannotator.ai/install.sh | bash"
           data-video="https://www.youtube.com/watch?v=a_AT7cEN_9I"
@@ -370,8 +370,8 @@ import AnnoReplace from './AnnoReplace.astro';
       btn.addEventListener('click', function() { setAgent(btn); });
     });
 
-    // Init default (first button)
-    setAgent(buttons[0]);
+    // Init default
+    setAgent(document.querySelector('.agent-btn[data-agent="claude"]') || buttons[0]);
 
     if (copyBtn) {
       copyBtn.addEventListener('click', function() {

--- a/apps/marketing/src/components/landing/HeroSection.astro
+++ b/apps/marketing/src/components/landing/HeroSection.astro
@@ -34,9 +34,18 @@ import AnnoReplace from './AnnoReplace.astro';
     <!-- Agent selector + install area -->
     <div class="animate-fade-up animate-delay-2 mt-10">
       <!-- Agent selector buttons -->
-      <div class="flex flex-wrap items-center gap-2 mb-4" id="agent-selector">
+      <div class="flex flex-wrap items-center gap-1.5 mb-4" id="agent-selector">
         <button
           class="agent-btn active"
+          data-agent="amp"
+          data-command="curl -fsSL https://plannotator.ai/install.sh | bash"
+          data-video=""
+        >
+          <img src="/assets/icon-amp.svg" alt="" class="w-4 h-4" />
+          <span>Amp</span>
+        </button>
+        <button
+          class="agent-btn"
           data-agent="claude"
           data-command="curl -fsSL https://plannotator.ai/install.sh | bash"
           data-video="https://www.youtube.com/watch?v=a_AT7cEN_9I"
@@ -55,30 +64,21 @@ import AnnoReplace from './AnnoReplace.astro';
         </button>
         <button
           class="agent-btn"
-          data-agent="droid"
-          data-command="curl -fsSL https://plannotator.ai/install.sh | bash"
-          data-video=""
-        >
-          <img src="/assets/icon-droid.png" alt="" class="w-4 h-4 rounded-sm" />
-          <span>Droid</span>
-        </button>
-        <button
-          class="agent-btn"
-          data-agent="amp"
-          data-command="curl -fsSL https://plannotator.ai/install.sh | bash"
-          data-video=""
-        >
-          <img src="/assets/icon-amp.svg" alt="" class="w-4 h-4" />
-          <span>Amp</span>
-        </button>
-        <button
-          class="agent-btn"
           data-agent="copilot"
           data-command="curl -fsSL https://plannotator.ai/install.sh | bash"
           data-video=""
         >
           <img src="/assets/icon-copilot.svg" alt="" class="w-4 h-4 icon-copilot" />
           <span>Copilot</span>
+        </button>
+        <button
+          class="agent-btn"
+          data-agent="droid"
+          data-command="curl -fsSL https://plannotator.ai/install.sh | bash"
+          data-video=""
+        >
+          <img src="/assets/icon-droid.png" alt="" class="w-4 h-4 rounded-sm" />
+          <span>Droid</span>
         </button>
         <button
           class="agent-btn"

--- a/apps/marketing/src/content/docs/getting-started/installation.md
+++ b/apps/marketing/src/content/docs/getting-started/installation.md
@@ -1,6 +1,6 @@
 ---
 title: "Installation"
-description: "How to install Plannotator for Claude Code, Codex, OpenCode, Pi, Droid, and other agent hosts."
+description: "How to install Plannotator for Claude Code, Codex, OpenCode, Pi, Amp, Droid, and other agent hosts."
 sidebar:
   order: 1
 section: "Getting Started"
@@ -193,6 +193,39 @@ pi -e npm:@plannotator/pi-extension
 Start plan mode with `pi --plan`, or toggle mid-session with `/plannotator` or `Ctrl+Alt+P`. The extension provides file-based plan review, code review (`/plannotator-review`), markdown annotation (`/plannotator-annotate`), bash safety gating during planning, and progress tracking during execution.
 
 See [Plannotator Meets Pi](/blog/plannotator-meets-pi) for the full walkthrough.
+
+## Amp
+
+Plannotator's Amp integration is currently commands-only. It adds command-palette actions for code review, file annotation, and annotating Amp's latest assistant message.
+
+Install the CLI first:
+
+```bash
+curl -fsSL https://plannotator.ai/install.sh | bash
+```
+
+Then install the Amp plugin:
+
+```bash
+mkdir -p ~/.config/amp/plugins
+curl -fsSL https://raw.githubusercontent.com/backnotprop/plannotator/main/apps/amp-plugin/plannotator.ts \
+  -o ~/.config/amp/plugins/plannotator.ts
+```
+
+Restart Amp or run `plugins: reload` from the command palette.
+
+This adds:
+
+```text
+Plannotator: Review changes
+Plannotator: Review changes or PR
+Plannotator: Annotate file
+Plannotator: Annotate last answer
+```
+
+For `Plannotator: Review changes or PR`, leave the input blank to review local changes, or enter a PR/MR URL.
+
+The plugin uses Amp's thread API for `Annotate last answer`, so it does not read transcript logs.
 
 ## Droid
 

--- a/apps/marketing/src/content/docs/guides/custom-feedback.md
+++ b/apps/marketing/src/content/docs/guides/custom-feedback.md
@@ -107,7 +107,7 @@ The resolution order is:
 
 Blank or whitespace-only values are treated as "not set" and fall through to the next level. This means you can clear a runtime override by setting it to `""` without affecting others.
 
-Valid runtime keys: `claude-code`, `opencode`, `copilot-cli`, `pi`, `codex`, `gemini-cli`.
+Valid runtime keys: `claude-code`, `amp`, `droid`, `opencode`, `copilot-cli`, `pi`, `codex`, `gemini-cli`.
 
 ## Full config example
 

--- a/apps/marketing/src/content/docs/reference/environment-variables.md
+++ b/apps/marketing/src/content/docs/reference/environment-variables.md
@@ -16,7 +16,9 @@ All Plannotator environment variables and their defaults.
 | `PLANNOTATOR_PORT` | random (local) / `19432` (remote) | Fixed server port. When not set, local sessions use a random port; remote sessions default to `19432`. |
 | `PLANNOTATOR_BROWSER` | system default | Custom browser to open the UI in. macOS: app name or path. Linux/Windows: executable path. Can also be a script. Takes priority over `BROWSER`. Also settable per-invocation with `--browser`. |
 | `BROWSER` | (none) | Standard env var for specifying a browser. VS Code sets this automatically in devcontainers. Used as fallback when `PLANNOTATOR_BROWSER` is not set. |
-| `PLANNOTATOR_ORIGIN` | auto-detect | Explicit agent-origin override. Valid values: `claude-code`, `opencode`, `codex`, `copilot-cli`, `gemini-cli`. Invalid values silently fall through to env-based detection. |
+| `PLANNOTATOR_ORIGIN` | auto-detect | Explicit agent-origin override. Valid values: `claude-code`, `amp`, `droid`, `opencode`, `codex`, `copilot-cli`, `pi`, `gemini-cli`. Invalid values silently fall through to env-based detection. |
+| `PLANNOTATOR_READY_FILE` | (none) | Internal host-plugin side channel. When set, Plannotator appends server-ready JSON lines containing the local UI URL. |
+| `PLANNOTATOR_SKIP_BROWSER_OPEN` | unset | Internal host-plugin flag. Set to `1` to prevent Plannotator from opening the browser itself when the host will open the URL. |
 | `PLANNOTATOR_SHARE` | enabled | Set to `disabled` to turn off sharing. Hides share UI and import options. |
 | `PLANNOTATOR_SHARE_URL` | `https://share.plannotator.ai` | Base URL for share links. Set this when self-hosting the share portal. |
 | `PLANNOTATOR_DATA_DIR` | `~/.plannotator` | Override the base data directory. Supports `~` expansion. All data (plans, history, drafts, config, hooks, sessions) is stored under this directory.* |

--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -323,8 +323,8 @@ import AnnoReplace from '../components/landing/AnnoReplace.astro';
               <span class="cap-desc">Annotate the agent's last message</span>
             </div>
             <div class="cap-item">
-              <code class="cap-cmd">/plannotator-review &lt;null|pr-url&gt;</code>
-              <span class="cap-desc">Code review for local changes or GitHub and GitLab PRs</span>
+              <code class="cap-cmd">/plannotator-review [PR_URL]</code>
+              <span class="cap-desc">Leave blank for local changes, or pass a GitHub/GitLab PR URL</span>
             </div>
           </div>
           <div class="cap-group">

--- a/apps/marketing/src/styles/global.css
+++ b/apps/marketing/src/styles/global.css
@@ -378,14 +378,14 @@
 .agent-btn {
   display: inline-flex;
   align-items: center;
-  gap: 0.375rem;
-  padding: 0.375rem 0.75rem;
+  gap: 0.25rem;
+  padding: 0.3125rem 0.5rem;
   border-radius: 0.375rem;
   border: 1px solid var(--border);
   background: oklch(from var(--card) l c h / 0.4);
   backdrop-filter: blur(8px);
   color: var(--muted-foreground);
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   font-weight: 500;
   cursor: pointer;
   transition: all 0.15s ease;

--- a/packages/server/shared-handlers.test.ts
+++ b/packages/server/shared-handlers.test.ts
@@ -2,21 +2,18 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { handleServerReady } from "./shared-handlers";
+import { handleServerReady, writeServerReadyMetadata } from "./shared-handlers";
 
-describe("handleServerReady", () => {
-  test("writes host-plugin ready metadata without opening a browser", async () => {
+describe("writeServerReadyMetadata", () => {
+  test("writes host-plugin ready metadata", () => {
     const dir = mkdtempSync(join(tmpdir(), "plannotator-ready-"));
-    const readyFile = join(dir, "ready.jsonl");
-    let opened = false;
+    const readyFile = join(dir, "nested", "ready.jsonl");
 
     try {
-      await handleServerReady("http://localhost:12345", false, 12345, {
-        readyFile,
-        skipBrowserOpen: true,
-        openBrowser: async () => {
-          opened = true;
-        },
+      writeServerReadyMetadata(readyFile, {
+        url: "http://localhost:12345",
+        isRemote: false,
+        port: 12345,
       });
       const [line] = readFileSync(readyFile, "utf8").trim().split(/\r?\n/);
       expect(JSON.parse(line)).toEqual({
@@ -24,9 +21,23 @@ describe("handleServerReady", () => {
         isRemote: false,
         port: 12345,
       });
-      expect(opened).toBe(false);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("handleServerReady", () => {
+  test("does not open a browser when host-plugin mode handles it", async () => {
+    let opened = false;
+
+    await handleServerReady("http://localhost:12345", false, 12345, {
+      skipBrowserOpen: true,
+      openBrowser: async () => {
+        opened = true;
+      },
+    });
+
+    expect(opened).toBe(false);
   });
 });

--- a/packages/server/shared-handlers.test.ts
+++ b/packages/server/shared-handlers.test.ts
@@ -8,31 +8,24 @@ describe("handleServerReady", () => {
   test("writes host-plugin ready metadata without opening a browser", async () => {
     const dir = mkdtempSync(join(tmpdir(), "plannotator-ready-"));
     const readyFile = join(dir, "ready.jsonl");
-    const previousReadyFile = process.env.PLANNOTATOR_READY_FILE;
-    const previousSkipOpen = process.env.PLANNOTATOR_SKIP_BROWSER_OPEN;
-
-    process.env.PLANNOTATOR_READY_FILE = readyFile;
-    process.env.PLANNOTATOR_SKIP_BROWSER_OPEN = "1";
+    let opened = false;
 
     try {
-      await handleServerReady("http://localhost:12345", false, 12345);
+      await handleServerReady("http://localhost:12345", false, 12345, {
+        readyFile,
+        skipBrowserOpen: true,
+        openBrowser: async () => {
+          opened = true;
+        },
+      });
       const [line] = readFileSync(readyFile, "utf8").trim().split(/\r?\n/);
       expect(JSON.parse(line)).toEqual({
         url: "http://localhost:12345",
         isRemote: false,
         port: 12345,
       });
+      expect(opened).toBe(false);
     } finally {
-      if (previousReadyFile === undefined) {
-        delete process.env.PLANNOTATOR_READY_FILE;
-      } else {
-        process.env.PLANNOTATOR_READY_FILE = previousReadyFile;
-      }
-      if (previousSkipOpen === undefined) {
-        delete process.env.PLANNOTATOR_SKIP_BROWSER_OPEN;
-      } else {
-        process.env.PLANNOTATOR_SKIP_BROWSER_OPEN = previousSkipOpen;
-      }
       rmSync(dir, { recursive: true, force: true });
     }
   });

--- a/packages/server/shared-handlers.test.ts
+++ b/packages/server/shared-handlers.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { handleServerReady } from "./shared-handlers";
+
+describe("handleServerReady", () => {
+  test("writes host-plugin ready metadata without opening a browser", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "plannotator-ready-"));
+    const readyFile = join(dir, "ready.jsonl");
+    const previousReadyFile = process.env.PLANNOTATOR_READY_FILE;
+    const previousSkipOpen = process.env.PLANNOTATOR_SKIP_BROWSER_OPEN;
+
+    process.env.PLANNOTATOR_READY_FILE = readyFile;
+    process.env.PLANNOTATOR_SKIP_BROWSER_OPEN = "1";
+
+    try {
+      await handleServerReady("http://localhost:12345", false, 12345);
+      const [line] = readFileSync(readyFile, "utf8").trim().split(/\r?\n/);
+      expect(JSON.parse(line)).toEqual({
+        url: "http://localhost:12345",
+        isRemote: false,
+        port: 12345,
+      });
+    } finally {
+      if (previousReadyFile === undefined) {
+        delete process.env.PLANNOTATOR_READY_FILE;
+      } else {
+        process.env.PLANNOTATOR_READY_FILE = previousReadyFile;
+      }
+      if (previousSkipOpen === undefined) {
+        delete process.env.PLANNOTATOR_SKIP_BROWSER_OPEN;
+      } else {
+        process.env.PLANNOTATOR_SKIP_BROWSER_OPEN = previousSkipOpen;
+      }
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/server/shared-handlers.ts
+++ b/packages/server/shared-handlers.ts
@@ -6,8 +6,7 @@
  * for plan + review.
  */
 
-import { mkdirSync } from "fs";
-import { appendFileSync } from "node:fs";
+import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { openBrowser as openBrowserImpl } from "./browser";
 import { validateImagePath, validateUploadExtension, UPLOAD_DIR } from "./image";
@@ -143,18 +142,28 @@ interface ServerReadyOptions {
   openBrowser?: typeof openBrowserImpl;
 }
 
+export interface ServerReadyMetadata {
+  url: string;
+  isRemote: boolean;
+  port: number;
+}
+
+export function writeServerReadyMetadata(readyFile: string, metadata: ServerReadyMetadata): void {
+  mkdirSync(dirname(readyFile), { recursive: true });
+  appendFileSync(readyFile, `${JSON.stringify(metadata)}\n`, "utf8");
+}
+
 /** Attempt to open the browser for the session URL. */
 export async function handleServerReady(
   url: string,
   isRemote: boolean,
-  _port: number,
+  port: number,
   options: ServerReadyOptions = {},
 ): Promise<void> {
   const readyFile = options.readyFile ?? process.env.PLANNOTATOR_READY_FILE;
   if (readyFile) {
     try {
-      mkdirSync(dirname(readyFile), { recursive: true });
-      appendFileSync(readyFile, `${JSON.stringify({ url, isRemote, port: _port })}\n`, "utf8");
+      writeServerReadyMetadata(readyFile, { url, isRemote, port });
     } catch (error) {
       if (options.readyFile) throw error;
       // Best effort: host plugins use this side channel to open the browser.

--- a/packages/server/shared-handlers.ts
+++ b/packages/server/shared-handlers.ts
@@ -8,7 +8,7 @@
 
 import { mkdirSync } from "fs";
 import { appendFileSync } from "node:fs";
-import { openBrowser } from "./browser";
+import { openBrowser as openBrowserImpl } from "./browser";
 import { validateImagePath, validateUploadExtension, UPLOAD_DIR } from "./image";
 import { saveDraft, loadDraft, deleteDraft } from "./draft";
 import { FAVICON_SVG } from "@plannotator/shared/favicon";
@@ -136,13 +136,20 @@ export function handleFavicon(): Response {
   });
 }
 
+interface ServerReadyOptions {
+  readyFile?: string;
+  skipBrowserOpen?: boolean;
+  openBrowser?: typeof openBrowserImpl;
+}
+
 /** Attempt to open the browser for the session URL. */
 export async function handleServerReady(
   url: string,
   isRemote: boolean,
   _port: number,
+  options: ServerReadyOptions = {},
 ): Promise<void> {
-  const readyFile = process.env.PLANNOTATOR_READY_FILE;
+  const readyFile = options.readyFile ?? process.env.PLANNOTATOR_READY_FILE;
   if (readyFile) {
     try {
       appendFileSync(readyFile, `${JSON.stringify({ url, isRemote, port: _port })}\n`, "utf8");
@@ -151,7 +158,8 @@ export async function handleServerReady(
     }
   }
 
-  if (process.env.PLANNOTATOR_SKIP_BROWSER_OPEN === "1") return;
+  const skipBrowserOpen = options.skipBrowserOpen ?? process.env.PLANNOTATOR_SKIP_BROWSER_OPEN === "1";
+  if (skipBrowserOpen) return;
 
-  await openBrowser(url, { isRemote });
+  await (options.openBrowser ?? openBrowserImpl)(url, { isRemote });
 }

--- a/packages/server/shared-handlers.ts
+++ b/packages/server/shared-handlers.ts
@@ -8,6 +8,7 @@
 
 import { mkdirSync } from "fs";
 import { appendFileSync } from "node:fs";
+import { dirname } from "node:path";
 import { openBrowser as openBrowserImpl } from "./browser";
 import { validateImagePath, validateUploadExtension, UPLOAD_DIR } from "./image";
 import { saveDraft, loadDraft, deleteDraft } from "./draft";
@@ -152,8 +153,10 @@ export async function handleServerReady(
   const readyFile = options.readyFile ?? process.env.PLANNOTATOR_READY_FILE;
   if (readyFile) {
     try {
+      mkdirSync(dirname(readyFile), { recursive: true });
       appendFileSync(readyFile, `${JSON.stringify({ url, isRemote, port: _port })}\n`, "utf8");
-    } catch {
+    } catch (error) {
+      if (options.readyFile) throw error;
       // Best effort: host plugins use this side channel to open the browser.
     }
   }

--- a/packages/server/shared-handlers.ts
+++ b/packages/server/shared-handlers.ts
@@ -7,6 +7,7 @@
  */
 
 import { mkdirSync } from "fs";
+import { appendFileSync } from "node:fs";
 import { openBrowser } from "./browser";
 import { validateImagePath, validateUploadExtension, UPLOAD_DIR } from "./image";
 import { saveDraft, loadDraft, deleteDraft } from "./draft";
@@ -141,5 +142,16 @@ export async function handleServerReady(
   isRemote: boolean,
   _port: number,
 ): Promise<void> {
+  const readyFile = process.env.PLANNOTATOR_READY_FILE;
+  if (readyFile) {
+    try {
+      appendFileSync(readyFile, `${JSON.stringify({ url, isRemote, port: _port })}\n`, "utf8");
+    } catch {
+      // Best effort: host plugins use this side channel to open the browser.
+    }
+  }
+
+  if (process.env.PLANNOTATOR_SKIP_BROWSER_OPEN === "1") return;
+
   await openBrowser(url, { isRemote });
 }

--- a/packages/shared/agents.ts
+++ b/packages/shared/agents.ts
@@ -18,6 +18,7 @@ type AgentConfigEntry = {
 
 export const AGENT_CONFIG = {
   'claude-code': { name: 'Claude Code', badge: 'bg-orange-500/15 text-orange-400', aiProviderTypes: ['claude-agent-sdk'] },
+  'amp':         { name: 'Amp',         badge: 'bg-lime-500/15 text-lime-400' },
   'droid':       { name: 'Droid',       badge: 'bg-cyan-500/15 text-cyan-400' },
   'opencode':    { name: 'OpenCode',    badge: 'bg-emerald-500/15 text-emerald-400', aiProviderTypes: ['opencode-sdk'] },
   'copilot-cli': { name: 'GitHub Copilot', badge: 'bg-blue-500/15 text-blue-400' },

--- a/packages/shared/config.ts
+++ b/packages/shared/config.ts
@@ -39,6 +39,7 @@ export type PromptSectionOverrides = Record<string, string | undefined>;
 
 export type PromptRuntime =
   | "claude-code"
+  | "amp"
   | "droid"
   | "opencode"
   | "copilot-cli"

--- a/packages/shared/prompts.ts
+++ b/packages/shared/prompts.ts
@@ -16,6 +16,7 @@ export function resolveTemplate(
 
 export const PLAN_TOOL_NAMES: Record<PromptRuntime, string> = {
   "claude-code": "ExitPlanMode",
+  amp: "ExitPlanMode",
   droid: "ExitPlanMode",
   opencode: "submit_plan",
   "copilot-cli": "exit_plan_mode",

--- a/scripts/install.cmd
+++ b/scripts/install.cmd
@@ -165,6 +165,9 @@ if defined PLANNOTATOR_DATA_DIR (
 ) else (
     set "_CONFIG_DIR=%USERPROFILE%\.plannotator"
 )
+if /i "!_CONFIG_DIR!"=="~" set "_CONFIG_DIR=%USERPROFILE%"
+if "!_CONFIG_DIR:~0,2!"=="~\" set "_CONFIG_DIR=%USERPROFILE%\!_CONFIG_DIR:~2!"
+if "!_CONFIG_DIR:~0,2!"=="~/" set "_CONFIG_DIR=%USERPROFILE%\!_CONFIG_DIR:~2!"
 if exist "!_CONFIG_DIR!\config.json" (
     findstr /r /c:"\"verifyAttestation\"[ 	]*:[ 	]*true" "!_CONFIG_DIR!\config.json" >nul 2>&1
     if !ERRORLEVEL! equ 0 set "VERIFY_ATTESTATION=1"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -97,7 +97,7 @@ $configDir = if ($env:PLANNOTATOR_DATA_DIR) { $env:PLANNOTATOR_DATA_DIR.Trim() }
 if ($configDir -eq "~") {
     $configDir = $env:USERPROFILE
 } elseif ($configDir.StartsWith("~/") -or $configDir.StartsWith('~\')) {
-    $configDir = Join-Path $env:USERPROFILE $configDir.Substring(2)
+    $configDir = Join-Path $env:USERPROFILE ($configDir.Substring(2))
 }
 $configPath = Join-Path $configDir "config.json"
 if (Test-Path $configPath) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -93,7 +93,13 @@ Write-Host "Installing plannotator $latestTag..."
 $verifyAttestationResolved = $false
 
 # Layer 3: config file (lowest precedence of the opt-in sources).
-$configPath = if ($env:PLANNOTATOR_DATA_DIR) { "$env:PLANNOTATOR_DATA_DIR\config.json" } else { "$env:USERPROFILE\.plannotator\config.json" }
+$configDir = if ($env:PLANNOTATOR_DATA_DIR) { $env:PLANNOTATOR_DATA_DIR.Trim() } else { Join-Path $env:USERPROFILE ".plannotator" }
+if ($configDir -eq "~") {
+    $configDir = $env:USERPROFILE
+} elseif ($configDir.StartsWith("~/") -or $configDir.StartsWith('~\')) {
+    $configDir = Join-Path $env:USERPROFILE $configDir.Substring(2)
+}
+$configPath = Join-Path $configDir "config.json"
 if (Test-Path $configPath) {
     try {
         $cfg = Get-Content $configPath -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop

--- a/scripts/install.test.ts
+++ b/scripts/install.test.ts
@@ -447,6 +447,7 @@ describe("install shared behavior", () => {
     expect(ps).toContain('$configDir -eq "~"');
     expect(ps).toContain('$configDir.StartsWith("~/")');
     expect(ps).toContain("$configDir.StartsWith('~\\')");
+    expect(ps).toContain("Join-Path $env:USERPROFILE ($configDir.Substring(2))");
     expect(ps).toContain('Join-Path $configDir "config.json"');
     expect(ps).toContain("ConvertFrom-Json");
     expect(ps).toContain("$cfg.verifyAttestation");

--- a/scripts/install.test.ts
+++ b/scripts/install.test.ts
@@ -398,6 +398,9 @@ describe("install.cmd", () => {
     // findstr pattern with escaped quotes; assert the key + findstr
     // separately rather than the quoted form)
     expect(script).toContain("PLANNOTATOR_DATA_DIR");
+    expect(script).toContain('if /i "!_CONFIG_DIR!"=="~" set "_CONFIG_DIR=%USERPROFILE%"');
+    expect(script).toContain('if "!_CONFIG_DIR:~0,2!"=="~\\" set "_CONFIG_DIR=%USERPROFILE%\\!_CONFIG_DIR:~2!"');
+    expect(script).toContain('if "!_CONFIG_DIR:~0,2!"=="~/" set "_CONFIG_DIR=%USERPROFILE%\\!_CONFIG_DIR:~2!"');
     expect(script).toContain("verifyAttestation");
     expect(script).toContain("findstr");
     // Layer 2: env var
@@ -441,6 +444,10 @@ describe("install shared behavior", () => {
   test("install.ps1 has three-layer opt-in resolution", () => {
     // Layer 3: config file via ConvertFrom-Json, respecting PLANNOTATOR_DATA_DIR
     expect(ps).toContain("PLANNOTATOR_DATA_DIR");
+    expect(ps).toContain('$configDir -eq "~"');
+    expect(ps).toContain('$configDir.StartsWith("~/")');
+    expect(ps).toContain("$configDir.StartsWith('~\\')");
+    expect(ps).toContain('Join-Path $configDir "config.json"');
     expect(ps).toContain("ConvertFrom-Json");
     expect(ps).toContain("$cfg.verifyAttestation");
     // Layer 2: env var


### PR DESCRIPTION
## Summary
- add a native Amp plugin with command-palette actions for review, annotate, and annotating the latest assistant answer
- add host-plugin ready-file handoff so Amp can open Plannotator URLs through ctx.system.open without hiding remote URLs
- add stdin support for annotate-last and wire Amp into origin/config/docs/marketing
- document optional review targets: blank/no args reviews local changes, PR/MR URL reviews remote changes

## Verification
- bun test apps/amp-plugin/plannotator.test.ts apps/hook/server/cli.test.ts packages/server/shared-handlers.test.ts packages/shared/prompts.test.ts packages/shared/prompts-integration.test.ts
- bun build apps/amp-plugin/plannotator.ts --outfile /tmp/plannotator-amp-plugin.js
- bun run build:marketing
- git diff --check

## Reference
- https://github.com/backnotprop/plannotator/issues/38#issuecomment-4538647533