### PR TITLE
Fix Pi plan approval continuation delivery

### DIFF
--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -1165,9 +1165,9 @@ Execute each step in order. After completing a step, include [DONE:n] in your re
 	pi.on("agent_end", async (_event, ctx) => {
 		if (phase === "executing" && justApprovedPlan) {
 			justApprovedPlan = false;
-			setTimeout(() => {
-				pi.sendUserMessage("Continue with the approved plan.");
-			}, 0);
+			pi.sendUserMessage("Continue with the approved plan.", {
+				deliverAs: "followUp",
+			});
 			return;
 		}
 


### PR DESCRIPTION
## Summary

Fixes #804.

- Queue the Pi plan approval continuation as a follow-up message.
- Remove the unreliable `setTimeout(0)` workaround.
- Align the approval continuation with existing review/annotation feedback delivery.

## Why

Approved plans return `terminate: true`, so Pi may still consider the agent turn active when `agent_end` fires. Calling `pi.sendUserMessage()` without a delivery mode can therefore fail with `Agent is already processing`. `deliverAs: "followUp"` tells Pi to queue the continuation safely.

## Testing

- `git diff --check`
- Not run: `bun run typecheck` (Bun is not installed in this environment: `bun: command not found`)