### PR TITLE
Replace ConfigStore with Zustand vanilla store

### DIFF
--- a/apps/frontend/src/components/settings/AppSettingsDialog.tsx
+++ b/apps/frontend/src/components/settings/AppSettingsDialog.tsx
@@ -100,7 +100,7 @@ export function AppSettingsDialog() {
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
         if (data?.config) {
-          configStore.init(data.config);
+          configStore.getState().init(data.config);
           setLegacyTabMode(!!data.config.legacyTabMode);
         }
       })

--- a/bun.lock
+++ b/bun.lock
@@ -249,6 +249,7 @@
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "unique-username-generator": "^1.5.1",
+        "zustand": "^5.0.13",
       },
       "devDependencies": {
         "@types/bun": "^1.2.0",

--- a/packages/plannotator-code-review/App.tsx
+++ b/packages/plannotator-code-review/App.tsx
@@ -838,7 +838,7 @@ const ReviewApp: React.FC<{ __embedded?: boolean; headerLeft?: React.ReactNode; 
         serverConfig?: { displayName?: string; gitUser?: string };
         lastDecision?: 'approved' | 'feedback' | 'exited' | null;
       }) => {
-        configStore.init(data.serverConfig);
+        configStore.getState().init(data.serverConfig);
         setGitUser(data.serverConfig?.gitUser);
         if ((data.serverConfig as { legacyTabMode?: boolean } | undefined)?.legacyTabMode) setLegacyTabMode(true);
         const apiFiles = parseDiffToFiles(data.rawPatch);
@@ -912,7 +912,7 @@ const ReviewApp: React.FC<{ __embedded?: boolean; headerLeft?: React.ReactNode; 
   }, [diffTypeSetupPending, aiCheckComplete, showAISetup]);
 
   const handleDiffStyleChange = useCallback((style: 'split' | 'unified') => {
-    configStore.set('diffStyle', style);
+    configStore.getState().set('diffStyle', style);
   }, []);
 
   // Handle line selection from diff viewer

--- a/packages/plannotator-code-review/components/DiffOptionsPopover.tsx
+++ b/packages/plannotator-code-review/components/DiffOptionsPopover.tsx
@@ -123,41 +123,41 @@ export const DiffOptionsPopover: React.FC = () => {
                 <div className="text-[10px] uppercase tracking-wide text-muted-foreground/70 mb-1">Layout</div>
                 <div className="flex items-center gap-2">
                   <div className="flex-1">
-                    <CompactSegmented options={DIFF_STYLE_OPTIONS} value={diffStyle} onChange={(v) => configStore.set('diffStyle', v)} />
+                    <CompactSegmented options={DIFF_STYLE_OPTIONS} value={diffStyle} onChange={(v) => configStore.getState().set('diffStyle', v)} />
                   </div>
                   <div className="w-px h-5 bg-border/50 flex-shrink-0" />
                   <div className="flex-1">
-                    <CompactSegmented options={OVERFLOW_OPTIONS} value={diffOverflow} onChange={(v) => configStore.set('diffOverflow', v)} />
+                    <CompactSegmented options={OVERFLOW_OPTIONS} value={diffOverflow} onChange={(v) => configStore.getState().set('diffOverflow', v)} />
                   </div>
                 </div>
               </div>
               <div>
                 <div className="text-[10px] uppercase tracking-wide text-muted-foreground/70 mb-1">Indicators</div>
-                <CompactSegmented options={INDICATOR_OPTIONS} value={diffIndicators} onChange={(v) => configStore.set('diffIndicators', v)} />
+                <CompactSegmented options={INDICATOR_OPTIONS} value={diffIndicators} onChange={(v) => configStore.getState().set('diffIndicators', v)} />
               </div>
               <div>
                 <div className="text-[10px] uppercase tracking-wide text-muted-foreground/70 mb-1">Inline diff</div>
-                <CompactSegmented options={LINE_DIFF_OPTIONS} value={diffLineDiffType} onChange={(v) => configStore.set('diffLineDiffType', v)} />
+                <CompactSegmented options={LINE_DIFF_OPTIONS} value={diffLineDiffType} onChange={(v) => configStore.getState().set('diffLineDiffType', v)} />
               </div>
             </div>
 
             <div className="border-t border-border/50" />
 
             <div>
-              <CompactToggle checked={diffShowLineNumbers} onChange={(v) => configStore.set('diffShowLineNumbers', v)} label="Line numbers" />
-              <CompactToggle checked={diffShowBackground} onChange={(v) => configStore.set('diffShowBackground', v)} label="Diff background" />
+              <CompactToggle checked={diffShowLineNumbers} onChange={(v) => configStore.getState().set('diffShowLineNumbers', v)} label="Line numbers" />
+              <CompactToggle checked={diffShowBackground} onChange={(v) => configStore.getState().set('diffShowBackground', v)} label="Diff background" />
               {diffShowBackground && (
                 <div className="pl-3 pr-0.5 pb-1 -mt-0.5">
-                  <CompactSegmented options={LINE_BG_INTENSITY_OPTIONS} value={diffLineBgIntensity} onChange={(v) => configStore.set('diffLineBgIntensity', v)} />
+                  <CompactSegmented options={LINE_BG_INTENSITY_OPTIONS} value={diffLineBgIntensity} onChange={(v) => configStore.getState().set('diffLineBgIntensity', v)} />
                 </div>
               )}
-              <CompactToggle checked={diffHideWhitespace} onChange={(v) => configStore.set('diffHideWhitespace', v)} label="Hide whitespace" />
+              <CompactToggle checked={diffHideWhitespace} onChange={(v) => configStore.getState().set('diffHideWhitespace', v)} label="Hide whitespace" />
               <CompactStepper
                 label="Tab size"
                 value={diffTabSize}
                 min={1}
                 max={8}
-                onChange={(v) => configStore.set('diffTabSize', v)}
+                onChange={(v) => configStore.getState().set('diffTabSize', v)}
               />
             </div>
           </div>

--- a/packages/plannotator-code-review/components/ReviewSidebar.tsx
+++ b/packages/plannotator-code-review/components/ReviewSidebar.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { CodeAnnotation, type EditorAnnotation } from '@plannotator/ui/types';
-import { isCurrentUser } from '@plannotator/ui/utils/identity';
 import { useConfigValue } from '@plannotator/ui/config';
 import { EditorAnnotationCard } from '@plannotator/ui/components/EditorAnnotationCard';
 import { CopyButton } from './CopyButton';
@@ -144,7 +143,7 @@ export const ReviewSidebar: React.FC<ReviewSidebarProps> = /* React.memo */({
   onOpenPRPanel,
 }) => {
   const totalCount = annotations.length + (editorAnnotations?.length ?? 0);
-  useConfigValue('displayName');
+  const displayName = useConfigValue('displayName');
   const [copied, setCopied] = useState(false);
 
   const handleQuickCopy = async () => {
@@ -229,8 +228,8 @@ export const ReviewSidebar: React.FC<ReviewSidebarProps> = /* React.memo */({
               <ConventionalLabelBadge label={annotation.conventionalLabel} decorations={annotation.decorations} />
             )}
             {annotation.author && (
-              <span className={`text-[10px] truncate max-w-[100px] ${isCurrentUser(annotation.author) ? 'text-muted-foreground/50' : 'text-muted-foreground/70'}`}>
-                {annotation.author}{isCurrentUser(annotation.author) && ' (me)'}
+              <span className={`text-[10px] truncate max-w-[100px] ${annotation.author === displayName ? 'text-muted-foreground/50' : 'text-muted-foreground/70'}`}>
+                {annotation.author}{annotation.author === displayName && ' (me)'}
               </span>
             )}
           </div>

--- a/packages/plannotator-code-review/components/ReviewSidebar.tsx
+++ b/packages/plannotator-code-review/components/ReviewSidebar.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { CodeAnnotation, type EditorAnnotation } from '@plannotator/ui/types';
 import { isCurrentUser } from '@plannotator/ui/utils/identity';
+import { useConfigValue } from '@plannotator/ui/config';
 import { EditorAnnotationCard } from '@plannotator/ui/components/EditorAnnotationCard';
 import { CopyButton } from './CopyButton';
 import { ConventionalLabelBadge } from './ConventionalLabelPicker';
@@ -143,6 +144,7 @@ export const ReviewSidebar: React.FC<ReviewSidebarProps> = /* React.memo */({
   onOpenPRPanel,
 }) => {
   const totalCount = annotations.length + (editorAnnotations?.length ?? 0);
+  useConfigValue('displayName');
   const [copied, setCopied] = useState(false);
 
   const handleQuickCopy = async () => {

--- a/packages/plannotator-plan-review/App.tsx
+++ b/packages/plannotator-plan-review/App.tsx
@@ -729,7 +729,7 @@ const App: React.FC<{ __embedded?: boolean; headerLeft?: React.ReactNode; onOpen
   }, [pendingSharedAnnotations, clearPendingSharedAnnotations, resetExternalHighlights]);
 
   const handleTaterModeChange = useCallback((enabled: boolean) => {
-    configStore.set('taterMode', enabled);
+    configStore.getState().set('taterMode', enabled);
   }, []);
 
   const handleEditorModeChange = (mode: EditorMode) => {
@@ -758,7 +758,7 @@ const App: React.FC<{ __embedded?: boolean; headerLeft?: React.ReactNode; onOpen
       })
       .then((data: { plan: string; origin?: Origin; mode?: 'annotate' | 'annotate-last' | 'annotate-folder' | 'goal-setup'; goalSetup?: GoalSetupBundle; filePath?: string; sourceInfo?: string; sourceConverted?: boolean; gate?: boolean; renderAs?: 'html' | 'markdown'; rawHtml?: string; sharingEnabled?: boolean; shareBaseUrl?: string; pasteApiUrl?: string; repoInfo?: { display: string; branch?: string; host?: string }; previousPlan?: string | null; versionInfo?: { version: number; totalVersions: number; project: string }; projectRoot?: string; isWSL?: boolean; serverConfig?: { displayName?: string; gitUser?: string }; lastDecision?: 'approved' | 'denied' | 'exited' | 'feedback' | null }) => {
         // Initialize config store with server-provided values (config file > cookie > default)
-        configStore.init(data.serverConfig);
+        configStore.getState().init(data.serverConfig);
         setGitUser(data.serverConfig?.gitUser);
         if ((data.serverConfig as { legacyTabMode?: boolean } | undefined)?.legacyTabMode) setLegacyTabMode(true);
         if (data.mode === 'goal-setup' && data.goalSetup) {
@@ -1163,7 +1163,7 @@ const App: React.FC<{ __embedded?: boolean; headerLeft?: React.ReactNode; onOpen
       images: input.images,
       originalCode: input.originalCode,
       createdAt: Date.now(),
-      author: configStore.get('displayName') || undefined,
+      author: configStore.getState().get('displayName') || undefined,
     };
     setCodeAnnotations(prev => [...prev, annotation]);
     setSelectedAnnotationId(null);

--- a/packages/ui/components/AnnotationPanel.tsx
+++ b/packages/ui/components/AnnotationPanel.tsx
@@ -53,7 +53,7 @@ export const AnnotationPanel: React.FC<PanelProps> = ({
   onOtherFileAnnotationsClick,
 }) => {
   const isMobile = useIsMobile();
-  useConfigValue('displayName');
+  const displayName = useConfigValue('displayName');
   const [copiedText, setCopiedText] = useState(false);
   const listRef = useRef<HTMLDivElement>(null);
   const sortedAnnotations = [...annotations].sort((a, b) => a.createdA - b.createdA);
@@ -139,6 +139,7 @@ export const AnnotationPanel: React.FC<PanelProps> = ({
                   key={entry.annotation.id}
                   annotation={entry.annotation}
                   isSelected={selectedId === entry.annotation.id}
+                  isMe={isCurrentUser(entry.annotation.author)}
                   onSelect={() => onSelect(entry.annotation.id)}
                   onDelete={() => onDelete(entry.annotation.id)}
                   onEdit={onEdit ? (updates: Partial<Annotation>) => onEdit(entry.annotation.id, updates) : undefined}
@@ -148,6 +149,7 @@ export const AnnotationPanel: React.FC<PanelProps> = ({
                   key={entry.annotation.id}
                   annotation={entry.annotation}
                   isSelected={selectedId === entry.annotation.id}
+                  isMe={isCurrentUser(entry.annotation.author)}
                   onSelect={() => onSelectCodeAnnotation?.(entry.annotation.id)}
                   onDelete={() => onDeleteCodeAnnotation?.(entry.annotation.id)}
                   onEdit={onEditCodeAnnotation ? (updates: Partial<CodeAnnotation>) => onEditCodeAnnotation(entry.annotation.id, updates) : undefined}
@@ -257,10 +259,11 @@ function formatTimestamp(ts: number): string {
 const AnnotationCard: React.FC<{
   annotation: Annotation;
   isSelected: boolean;
+  isMe: boolean;
   onSelect: () => void;
   onDelete: () => void;
   onEdit?: (updates: Partial<Annotation>) => void;
-}> = ({ annotation, isSelected, onSelect, onDelete, onEdit }) => {
+}> = ({ annotation, isSelected, isMe, onSelect, onDelete, onEdit }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [editText, setEditText] = useState(annotation.text || '');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -366,11 +369,11 @@ const AnnotationCard: React.FC<{
     >
       {/* Author */}
       {annotation.author && (
-        <div className={`flex items-center gap-1.5 text-[10px] font-mono truncate mb-1.5 ${isCurrentUser(annotation.author) ? 'text-muted-foreground/60' : 'text-muted-foreground'}`}>
+        <div className={`flex items-center gap-1.5 text-[10px] font-mono truncate mb-1.5 ${isMe ? 'text-muted-foreground/60' : 'text-muted-foreground'}`}>
           <svg className="w-3 h-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
           </svg>
-          <span className="truncate">{annotation.author}{isCurrentUser(annotation.author) && ' (me)'}</span>
+          <span className="truncate">{annotation.author}{isMe && ' (me)'}</span>
         </div>
       )}
 
@@ -525,10 +528,11 @@ const AnnotationCard: React.FC<{
 const CodeAnnotationCard: React.FC<{
   annotation: CodeAnnotation;
   isSelected: boolean;
+  isMe: boolean;
   onSelect: () => void;
   onDelete: () => void;
   onEdit?: (updates: Partial<CodeAnnotation>) => void;
-}> = ({ annotation, isSelected, onSelect, onDelete, onEdit }) => {
+}> = ({ annotation, isSelected, isMe, onSelect, onDelete, onEdit }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [editText, setEditText] = useState(annotation.text || '');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -565,11 +569,11 @@ const CodeAnnotationCard: React.FC<{
       }`}
     >
       {annotation.author && (
-        <div className={`flex items-center gap-1.5 text-[10px] font-mono truncate mb-1.5 ${isCurrentUser(annotation.author) ? 'text-muted-foreground/60' : 'text-muted-foreground'}`}>
+        <div className={`flex items-center gap-1.5 text-[10px] font-mono truncate mb-1.5 ${isMe ? 'text-muted-foreground/60' : 'text-muted-foreground'}`}>
           <svg className="w-3 h-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
           </svg>
-          <span className="truncate">{annotation.author}{isCurrentUser(annotation.author) && ' (me)'}</span>
+          <span className="truncate">{annotation.author}{isMe && ' (me)'}</span>
         </div>
       )}
 

--- a/packages/ui/components/AnnotationPanel.tsx
+++ b/packages/ui/components/AnnotationPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Annotation, AnnotationType, Block, type CodeAnnotation, type EditorAnnotation } from '../types';
 import { isCurrentUser } from '../utils/identity';
+import { useConfigValue } from '../config';
 import { ImageThumbnail } from './ImageThumbnail';
 import { EditorAnnotationCard } from './EditorAnnotationCard';
 import { useIsMobile } from '../hooks/useIsMobile';
@@ -52,6 +53,7 @@ export const AnnotationPanel: React.FC<PanelProps> = ({
   onOtherFileAnnotationsClick,
 }) => {
   const isMobile = useIsMobile();
+  useConfigValue('displayName');
   const [copiedText, setCopiedText] = useState(false);
   const listRef = useRef<HTMLDivElement>(null);
   const sortedAnnotations = [...annotations].sort((a, b) => a.createdA - b.createdA);

--- a/packages/ui/components/DiffTypeSetupDialog.tsx
+++ b/packages/ui/components/DiffTypeSetupDialog.tsx
@@ -41,12 +41,12 @@ export const DiffTypeSetupDialog: React.FC<DiffTypeSetupDialogProps> = ({
   onComplete,
 }) => {
   const [selected, setSelected] = useState<DefaultDiffType>(
-    () => configStore.get('defaultDiffType')
+    () => configStore.getState().get('defaultDiffType')
   );
   const [imageHovered, setImageHovered] = useState(false);
 
   const handleDone = () => {
-    configStore.set('defaultDiffType', selected);
+    configStore.getState().set('defaultDiffType', selected);
     markDiffTypeSetupDone();
     onComplete(selected);
   };

--- a/packages/ui/components/Settings.tsx
+++ b/packages/ui/components/Settings.tsx
@@ -179,7 +179,7 @@ export const GitTab: React.FC = () => {
           <button
             key={opt.value}
             type="button"
-            onClick={() => configStore.set('defaultDiffType', opt.value)}
+            onClick={() => configStore.getState().set('defaultDiffType', opt.value)}
             className={`w-full flex items-start gap-3 p-3 rounded-lg border transition-colors text-left ${
               defaultDiffType === opt.value
                 ? 'border-primary bg-primary/5'
@@ -233,7 +233,7 @@ export const ReviewDisplayTab: React.FC = () => {
             <div className="text-sm font-medium">Code Font</div>
             <select
               value={diffFontFamily}
-              onChange={(e) => configStore.set('diffFontFamily', e.target.value)}
+              onChange={(e) => configStore.getState().set('diffFontFamily', e.target.value)}
               className="px-2 py-1 text-xs rounded-md bg-muted/50 border border-border text-foreground"
               style={diffFontFamily ? { fontFamily: `'${diffFontFamily}', monospace` } : undefined}
             >
@@ -247,7 +247,7 @@ export const ReviewDisplayTab: React.FC = () => {
             <div className="flex items-center gap-1">
               <button
                 type="button"
-                onClick={() => configStore.set('diffFontSize', `${Math.max(8, fontSizeNum - 1)}px`)}
+                onClick={() => configStore.getState().set('diffFontSize', `${Math.max(8, fontSizeNum - 1)}px`)}
                 disabled={fontSizeNum <= 8}
                 className="h-7 w-7 rounded-md bg-muted text-foreground flex items-center justify-center text-xs font-medium disabled:opacity-30"
               >
@@ -256,7 +256,7 @@ export const ReviewDisplayTab: React.FC = () => {
               <span className="w-8 text-center text-xs font-mono tabular-nums">{fontSizeNum}px</span>
               <button
                 type="button"
-                onClick={() => configStore.set('diffFontSize', `${Math.min(24, fontSizeNum + 1)}px`)}
+                onClick={() => configStore.getState().set('diffFontSize', `${Math.min(24, fontSizeNum + 1)}px`)}
                 disabled={fontSizeNum >= 24}
                 className="h-7 w-7 rounded-md bg-muted text-foreground flex items-center justify-center text-xs font-medium disabled:opacity-30"
               >
@@ -269,7 +269,7 @@ export const ReviewDisplayTab: React.FC = () => {
             <div className="flex items-center gap-1">
               <button
                 type="button"
-                onClick={() => configStore.set('diffTabSize', Math.max(1, diffTabSize - 1))}
+                onClick={() => configStore.getState().set('diffTabSize', Math.max(1, diffTabSize - 1))}
                 disabled={diffTabSize <= 1}
                 className="h-7 w-7 rounded-md bg-muted text-foreground flex items-center justify-center text-xs font-medium disabled:opacity-30"
               >
@@ -278,7 +278,7 @@ export const ReviewDisplayTab: React.FC = () => {
               <span className="w-8 text-center text-xs font-mono tabular-nums">{diffTabSize}</span>
               <button
                 type="button"
-                onClick={() => configStore.set('diffTabSize', Math.min(8, diffTabSize + 1))}
+                onClick={() => configStore.getState().set('diffTabSize', Math.min(8, diffTabSize + 1))}
                 disabled={diffTabSize >= 8}
                 className="h-7 w-7 rounded-md bg-muted text-foreground flex items-center justify-center text-xs font-medium disabled:opacity-30"
               >
@@ -302,19 +302,19 @@ export const ReviewDisplayTab: React.FC = () => {
         <h3 className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Layout</h3>
         <div className="flex items-center justify-between gap-4">
           <div className="text-sm font-medium shrink-0">Diff Style</div>
-          <SegmentedControl options={DIFF_STYLE_OPTIONS} value={diffStyle} onChange={(v) => configStore.set('diffStyle', v)} />
+          <SegmentedControl options={DIFF_STYLE_OPTIONS} value={diffStyle} onChange={(v) => configStore.getState().set('diffStyle', v)} />
         </div>
         <div className="flex items-center justify-between gap-4">
           <div className="text-sm font-medium shrink-0">Line Overflow</div>
-          <SegmentedControl options={OVERFLOW_OPTIONS} value={diffOverflow} onChange={(v) => configStore.set('diffOverflow', v)} />
+          <SegmentedControl options={OVERFLOW_OPTIONS} value={diffOverflow} onChange={(v) => configStore.getState().set('diffOverflow', v)} />
         </div>
         <div className="flex items-center justify-between gap-4">
           <div className="text-sm font-medium shrink-0">Change Indicators</div>
-          <SegmentedControl options={INDICATOR_OPTIONS} value={diffIndicators} onChange={(v) => configStore.set('diffIndicators', v)} />
+          <SegmentedControl options={INDICATOR_OPTIONS} value={diffIndicators} onChange={(v) => configStore.getState().set('diffIndicators', v)} />
         </div>
         <div className="flex items-center justify-between gap-4">
           <div className="text-sm font-medium shrink-0">Inline Diff</div>
-          <SegmentedControl options={LINE_DIFF_OPTIONS} value={diffLineDiffType} onChange={(v) => configStore.set('diffLineDiffType', v)} />
+          <SegmentedControl options={LINE_DIFF_OPTIONS} value={diffLineDiffType} onChange={(v) => configStore.getState().set('diffLineDiffType', v)} />
         </div>
       </section>
 
@@ -325,23 +325,23 @@ export const ReviewDisplayTab: React.FC = () => {
         <h3 className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Options</h3>
         <ToggleSwitch
           checked={diffShowLineNumbers}
-          onChange={(v) => configStore.set('diffShowLineNumbers', v)}
+          onChange={(v) => configStore.getState().set('diffShowLineNumbers', v)}
           label="Line Numbers"
         />
         <ToggleSwitch
           checked={diffHideWhitespace}
-          onChange={(v) => configStore.set('diffHideWhitespace', v)}
+          onChange={(v) => configStore.getState().set('diffHideWhitespace', v)}
           label="Hide Whitespace"
         />
         <ToggleSwitch
           checked={diffShowBackground}
-          onChange={(v) => configStore.set('diffShowBackground', v)}
+          onChange={(v) => configStore.getState().set('diffShowBackground', v)}
           label="Line Backgrounds"
         />
         {diffShowBackground && (
           <div className="flex items-center justify-between gap-4 pl-4">
             <div className="text-sm font-medium shrink-0">Intensity</div>
-            <SegmentedControl options={LINE_BG_INTENSITY_OPTIONS} value={diffLineBgIntensity} onChange={(v) => configStore.set('diffLineBgIntensity', v)} />
+            <SegmentedControl options={LINE_BG_INTENSITY_OPTIONS} value={diffLineBgIntensity} onChange={(v) => configStore.getState().set('diffLineBgIntensity', v)} />
           </div>
         )}
       </section>
@@ -396,7 +396,7 @@ export const CommentsTab: React.FC = () => {
 
   const save = (next: CCLabelConfig[]) => {
     setLabels(next);
-    configStore.set('conventionalLabels', JSON.stringify(next));
+    configStore.getState().set('conventionalLabels', JSON.stringify(next));
   };
 
   const updateLabel = (index: number, updates: Partial<CCLabelConfig>) => {
@@ -419,14 +419,14 @@ export const CommentsTab: React.FC = () => {
 
   const resetToDefaults = () => {
     setLabels(DEFAULT_CC_LABELS);
-    configStore.set('conventionalLabels', null);
+    configStore.getState().set('conventionalLabels', null);
   };
 
   return (
     <>
       <ToggleSwitch
         checked={conventionalComments}
-        onChange={(v) => configStore.set('conventionalComments', v)}
+        onChange={(v) => configStore.getState().set('conventionalComments', v)}
         label="Conventional Comments"
         description="Add structured labels to review comments"
       />
@@ -675,7 +675,7 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
     savePermissionModeSettings(mode);
   };
 
-  // Server write-back is handled automatically by configStore.set() (debounced POST /api/config)
+  // Server write-back is handled automatically by configStore.getState().set() (debounced POST /api/config)
 
   const handleRegenerateIdentity = () => {
     const oldIdentity = identity;

--- a/packages/ui/components/settings/PlanDisplayTab.tsx
+++ b/packages/ui/components/settings/PlanDisplayTab.tsx
@@ -117,7 +117,7 @@ export const PlanDisplayTab: React.FC<PlanDisplayTabProps> = ({ onUIPreferencesC
       <div className="border-t border-border" />
       <ToggleSwitch
         checked={taterMode}
-        onChange={(v) => configStore.set('taterMode', v)}
+        onChange={(v) => configStore.getState().set('taterMode', v)}
         label="Tater Mode"
       />
     </div>

--- a/packages/ui/config/configStore.ts
+++ b/packages/ui/config/configStore.ts
@@ -1,22 +1,23 @@
 /**
- * ConfigStore — Unified config resolver for Plannotator
+ * ConfigStore — Zustand-based config for Plannotator
  *
- * Singleton that resolves settings with precedence:
- *   server config file > cookie > default
+ * Resolves settings with precedence: server config > cookie > default.
+ * Selector-based subscriptions: components only re-render when their
+ * specific setting changes (unlike the old broadcast-to-all pattern).
  *
- * Works both inside and outside React. React components subscribe
- * via useSyncExternalStore (see useConfig.ts).
- *
- * Server-synced settings automatically write back to ~/.plannotator/config.json
+ * Server-synced settings write back to ~/.plannotator/config.json
  * via a debounced POST /api/config.
  */
 
+import { createStore, useStore } from 'zustand';
 import { SETTINGS, type SettingName, type SettingsMap } from './settings';
 import { apiFetch } from '../utils/api';
 
-type Listener = () => void;
+/** Infer the value type from a SettingDef */
+export type SettingValue<K extends SettingName> = SettingsMap[K] extends { defaultValue: infer D }
+  ? D extends (...args: unknown[]) => infer R ? R : D
+  : never;
 
-/** Deep-merge source into target, recursing into plain objects. */
 function deepMerge(target: Record<string, unknown>, source: Record<string, unknown>): void {
   for (const key of Object.keys(source)) {
     if (
@@ -30,100 +31,83 @@ function deepMerge(target: Record<string, unknown>, source: Record<string, unkno
   }
 }
 
-/** Infer the value type from a SettingDef */
-type SettingValue<K extends SettingName> = SettingsMap[K] extends { defaultValue: infer D }
-  ? D extends (...args: unknown[]) => infer R ? R : D
-  : never;
+type ConfigState = {
+  [K in SettingName]: SettingValue<K>;
+} & {
+  get: <K extends SettingName>(key: K) => SettingValue<K>;
+  set: <K extends SettingName>(key: K, value: SettingValue<K>) => void;
+  init: (serverConfig?: Record<string, unknown>) => void;
+};
 
-class ConfigStore {
-  private values = new Map<string, unknown>();
-  private listeners = new Set<Listener>();
-  private version = 0;
-  private pendingServerWrites: Record<string, unknown> = {};
-  private serverSyncTimer: ReturnType<typeof setTimeout> | null = null;
+let pendingServerWrites: Record<string, unknown> = {};
+let serverSyncTimer: ReturnType<typeof setTimeout> | null = null;
 
-  constructor() {
-    // Eagerly resolve all settings from synchronous sources (cookie > default).
-    // The store is safe to read from the moment it's created.
-    for (const [name, def] of Object.entries(SETTINGS)) {
-      const fromCookie = def.fromCookie();
-      const defaultVal = typeof def.defaultValue === 'function'
-        ? (def.defaultValue as () => unknown)()
-        : def.defaultValue;
-      const resolved = fromCookie ?? defaultVal;
-      this.values.set(name, resolved);
-      // Persist generated defaults to cookie so the value is stable across calls
-      if (fromCookie === undefined) {
-        def.toCookie(resolved as never);
-      }
+function scheduleServerSync(): void {
+  if (serverSyncTimer) clearTimeout(serverSyncTimer);
+  serverSyncTimer = setTimeout(() => {
+    const payload = { ...pendingServerWrites };
+    pendingServerWrites = {};
+    apiFetch('/api/config', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }).catch(() => {});
+  }, 300);
+}
+
+function resolveInitialValues(): Record<string, unknown> {
+  const values: Record<string, unknown> = {};
+  for (const [name, def] of Object.entries(SETTINGS)) {
+    const fromCookie = def.fromCookie();
+    const defaultVal = typeof def.defaultValue === 'function'
+      ? (def.defaultValue as () => unknown)()
+      : def.defaultValue;
+    const resolved = fromCookie ?? defaultVal;
+    values[name] = resolved;
+    if (fromCookie === undefined) {
+      def.toCookie(resolved as never);
     }
   }
+  return values;
+}
 
-  /**
-   * Apply server config overrides.
-   * Call once after fetching /api/plan or /api/diff.
-   *
-   * Server values take precedence over the cookie/default already resolved
-   * by the constructor. Settings without a server value are left untouched.
-   */
-  init(serverConfig?: Record<string, unknown>): void {
-    if (serverConfig) {
-      for (const [name, def] of Object.entries(SETTINGS)) {
-        if (def.serverKey && def.fromServer) {
-          const fromServer = def.fromServer(serverConfig);
-          if (fromServer !== undefined) {
-            this.values.set(name, fromServer);
-            def.toCookie(fromServer as never);
-          }
-        }
-      }
-    }
-    this.notify();
-  }
+export const configStore = createStore<ConfigState>()((set, get) => ({
+  ...resolveInitialValues() as { [K in SettingName]: SettingValue<K> },
 
-  /** Get a resolved config value. Works outside React. */
-  get<K extends SettingName>(key: K): SettingValue<K> {
-    return this.values.get(key) as SettingValue<K>;
-  }
+  get: <K extends SettingName>(key: K): SettingValue<K> => {
+    return get()[key] as SettingValue<K>;
+  },
 
-  /** Set a config value. Writes cookie (sync), queues server write-back if applicable. */
-  set<K extends SettingName>(key: K, value: SettingValue<K>): void {
+  set: <K extends SettingName>(key: K, value: SettingValue<K>): void => {
     const def = SETTINGS[key];
-    this.values.set(key, value);
     def.toCookie(value as never);
 
     if (def.serverKey && def.toServer) {
-      deepMerge(this.pendingServerWrites, def.toServer(value as never) as Record<string, unknown>);
-      this.scheduleServerSync();
+      deepMerge(pendingServerWrites, def.toServer(value as never) as Record<string, unknown>);
+      scheduleServerSync();
     }
 
-    this.notify();
-  }
+    set({ [key]: value } as Partial<ConfigState>);
+  },
 
-  /** Subscribe to changes. Returns unsubscribe function. */
-  subscribe(listener: Listener): () => void {
-    this.listeners.add(listener);
-    return () => this.listeners.delete(listener);
-  }
+  init: (serverConfig?: Record<string, unknown>): void => {
+    if (!serverConfig) return;
+    const updates: Record<string, unknown> = {};
+    for (const [name, def] of Object.entries(SETTINGS)) {
+      if (def.serverKey && def.fromServer) {
+        const fromServer = def.fromServer(serverConfig);
+        if (fromServer !== undefined) {
+          updates[name] = fromServer;
+          def.toCookie(fromServer as never);
+        }
+      }
+    }
+    if (Object.keys(updates).length > 0) {
+      set(updates as Partial<ConfigState>);
+    }
+  },
+}));
 
-  private notify(): void {
-    this.version++;
-    for (const fn of this.listeners) fn();
-  }
-
-  private scheduleServerSync(): void {
-    if (this.serverSyncTimer) clearTimeout(this.serverSyncTimer);
-    this.serverSyncTimer = setTimeout(() => {
-      const payload = { ...this.pendingServerWrites };
-      this.pendingServerWrites = {};
-      apiFetch('/api/config', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      }).catch(() => {}); // best-effort
-    }, 300);
-  }
+export function useConfigStore<T>(selector: (state: ConfigState) => T): T {
+  return useStore(configStore, selector);
 }
-
-export const configStore = new ConfigStore();
-export type { SettingValue };

--- a/packages/ui/config/configStore.ts
+++ b/packages/ui/config/configStore.ts
@@ -71,11 +71,11 @@ function resolveInitialValues(): Record<string, unknown> {
   return values;
 }
 
-export const configStore = createStore<ConfigState>()((set, get) => ({
+export const configStore = createStore<ConfigState>()((setState, getState) => ({
   ...resolveInitialValues() as { [K in SettingName]: SettingValue<K> },
 
   get: <K extends SettingName>(key: K): SettingValue<K> => {
-    return get()[key] as SettingValue<K>;
+    return getState()[key] as SettingValue<K>;
   },
 
   set: <K extends SettingName>(key: K, value: SettingValue<K>): void => {
@@ -87,7 +87,7 @@ export const configStore = createStore<ConfigState>()((set, get) => ({
       scheduleServerSync();
     }
 
-    set({ [key]: value } as Partial<ConfigState>);
+    setState({ [key]: value } as Partial<ConfigState>);
   },
 
   init: (serverConfig?: Record<string, unknown>): void => {
@@ -103,7 +103,7 @@ export const configStore = createStore<ConfigState>()((set, get) => ({
       }
     }
     if (Object.keys(updates).length > 0) {
-      set(updates as Partial<ConfigState>);
+      setState(updates as Partial<ConfigState>);
     }
   },
 }));

--- a/packages/ui/config/index.ts
+++ b/packages/ui/config/index.ts
@@ -1,2 +1,2 @@
-export { configStore } from './configStore';
+export { configStore, useConfigStore, type SettingValue } from './configStore';
 export { useConfigValue } from './useConfig';

--- a/packages/ui/config/useConfig.ts
+++ b/packages/ui/config/useConfig.ts
@@ -1,20 +1,14 @@
 /**
  * React hook for consuming ConfigStore values.
  *
- * Uses useSyncExternalStore for concurrent-mode-safe subscriptions
- * to the singleton configStore — no context provider needed.
+ * Uses Zustand selector-based subscriptions — components only re-render
+ * when their specific setting changes.
  */
 
-import { useCallback, useSyncExternalStore } from 'react';
-import { configStore, type SettingValue } from './configStore';
+import { useConfigStore, type SettingValue } from './configStore';
 import type { SettingName } from './settings';
 
-/** Read a config value reactively. Re-renders when the store changes. */
+/** Read a config value reactively. Re-renders only when this key changes. */
 export function useConfigValue<K extends SettingName>(key: K): SettingValue<K> {
-  const subscribe = useCallback(
-    (onStoreChange: () => void) => configStore.subscribe(onStoreChange),
-    [],
-  );
-  const getSnapshot = useCallback(() => configStore.get(key), [key]);
-  return useSyncExternalStore(subscribe, getSnapshot);
+  return useConfigStore((s) => s[key]) as SettingValue<K>;
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -35,7 +35,8 @@
     "perfect-freehand": "^1.2.2",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
-    "unique-username-generator": "^1.5.1"
+    "unique-username-generator": "^1.5.1",
+    "zustand": "^5.0.13"
   },
   "devDependencies": {
     "@types/bun": "^1.2.0",

--- a/packages/ui/utils/identity.ts
+++ b/packages/ui/utils/identity.ts
@@ -17,7 +17,7 @@ import { generateIdentity } from './generateIdentity';
  * Get current identity from ConfigStore.
  */
 export function getIdentity(): string {
-  return configStore.get('displayName');
+  return configStore.getState().get('displayName');
 }
 
 /**
@@ -27,7 +27,7 @@ export function getIdentity(): string {
 export function setCustomIdentity(name: string): string {
   const trimmed = name.trim();
   if (!trimmed) return getIdentity(); // reject empty
-  configStore.set('displayName', trimmed);
+  configStore.getState().set('displayName', trimmed);
   return trimmed;
 }
 
@@ -37,7 +37,7 @@ export function setCustomIdentity(name: string): string {
  */
 export function regenerateIdentity(): string {
   const identity = generateIdentity();
-  configStore.set('displayName', identity);
+  configStore.getState().set('displayName', identity);
   return identity;
 }
 
@@ -46,5 +46,5 @@ export function regenerateIdentity(): string {
  */
 export function isCurrentUser(author: string | undefined): boolean {
   if (!author) return false;
-  return author === configStore.get('displayName');
+  return author === configStore.getState().get('displayName');
 }


### PR DESCRIPTION
## Summary

Replace the hand-rolled `ConfigStore` class (broadcast-to-all-subscribers) with a Zustand store (selector-based subscriptions). Components only re-render when their specific setting changes.

## What changed

- `packages/ui/config/configStore.ts` — `ConfigStore` class → `createStore` from `zustand/vanilla`. All 19 settings as flat state properties. `get`/`set`/`init` actions on the store state.
- `packages/ui/config/useConfig.ts` — `useSyncExternalStore` → `useConfigStore(selector)`. `useConfigValue('key')` signature unchanged.
- 8 consumer files — `configStore.set()` → `configStore.getState().set()` (mechanical)
- Cookie persistence and 300ms debounced server sync identical to before

## Performance impact

Before: 1 setting change → notify all ~60 subscribers → 60 getSnapshot() checks → React reconciles ~58 components unnecessarily.

After: 1 setting change → only subscribers of that key re-render → 2-3 components.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun test` passes (1,331 tests, 0 failures)
- [x] 13 files changed, net -20 lines