### PR TITLE
Fix Amp plugin workspace cwd

### DIFF
--- a/apps/amp-plugin/plannotator.test.ts
+++ b/apps/amp-plugin/plannotator.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import {
   buildPlannotatorEnv,
   extractTextFromThreadMessage,
@@ -12,6 +13,7 @@ import {
   isNoActionFeedback,
   parseAnnotateDecision,
   parseReviewTargetInput,
+  resolveAmpWorkspaceRoot,
   resolveCwd,
   splitCommandArgs,
 } from "./plannotator";
@@ -105,10 +107,12 @@ describe("Amp Plannotator plugin helpers", () => {
     const commandCwd = mkdtempSync(join(tmpdir(), "plannotator-amp-command-"));
     const originalPwd = process.env.PWD;
     const originalOverride = process.env.PLANNOTATOR_CWD;
+    const originalLogFile = process.env.AMP_LOG_FILE;
 
     try {
       process.env.PWD = processPwd;
       delete process.env.PLANNOTATOR_CWD;
+      process.env.AMP_LOG_FILE = join(processPwd, "missing-amp.log");
 
       const cwd = await resolveCwd(commandContextWithCwd(commandCwd));
 
@@ -116,8 +120,68 @@ describe("Amp Plannotator plugin helpers", () => {
     } finally {
       restoreEnv("PWD", originalPwd);
       restoreEnv("PLANNOTATOR_CWD", originalOverride);
+      restoreEnv("AMP_LOG_FILE", originalLogFile);
       rmSync(processPwd, { recursive: true, force: true });
       rmSync(commandCwd, { recursive: true, force: true });
+    }
+  });
+
+  test("resolves Amp workspace root from the parent CLI log", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "plannotator-amp-log-"));
+    const oldWorkspace = mkdtempSync(join(tempDir, "old-workspace-"));
+    const currentWorkspace = mkdtempSync(join(tempDir, "current-workspace-"));
+    const logPath = join(tempDir, "cli.log");
+
+    try {
+      writeFileSync(
+        logPath,
+        [
+          JSON.stringify({
+            pid: 123,
+            workspaceRoot: pathToFileURL(oldWorkspace).href,
+          }),
+          JSON.stringify({
+            pid: 456,
+            workspaceRoot: pathToFileURL(currentWorkspace).href,
+          }),
+        ].join("\n"),
+        "utf8",
+      );
+
+      expect(resolveAmpWorkspaceRoot({ logPath, parentPid: 456 })).toBe(currentWorkspace);
+      expect(resolveAmpWorkspaceRoot({ logPath, parentPid: 999 })).toBe(currentWorkspace);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("uses Amp workspace log before plugin runtime cwd", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "plannotator-amp-cwd-"));
+    const workspace = mkdtempSync(join(tempDir, "workspace-"));
+    const pluginCwd = mkdtempSync(join(tempDir, "plugins-"));
+    const logPath = join(tempDir, "cli.log");
+    const originalLogFile = process.env.AMP_LOG_FILE;
+    const originalOverride = process.env.PLANNOTATOR_CWD;
+
+    try {
+      process.env.AMP_LOG_FILE = logPath;
+      delete process.env.PLANNOTATOR_CWD;
+      writeFileSync(
+        logPath,
+        JSON.stringify({
+          pid: process.ppid,
+          workspaceRoot: pathToFileURL(workspace).href,
+        }),
+        "utf8",
+      );
+
+      const cwd = await resolveCwd(commandContextWithCwd(pluginCwd));
+
+      expect(cwd).toBe(workspace);
+    } finally {
+      restoreEnv("AMP_LOG_FILE", originalLogFile);
+      restoreEnv("PLANNOTATOR_CWD", originalOverride);
+      rmSync(tempDir, { recursive: true, force: true });
     }
   });
 
@@ -165,6 +229,7 @@ describe("Amp Plannotator plugin helpers", () => {
     expect(
       getPlannotatorCommandCandidates({
         home: "/Users/alice",
+        pluginDir: "/Users/alice/.config/amp/plugins",
         platform: "darwin",
         env: {},
       }),
@@ -176,6 +241,7 @@ describe("Amp Plannotator plugin helpers", () => {
     expect(
       getPlannotatorCommandCandidates({
         home: String.raw`C:\Users\alice`,
+        pluginDir: String.raw`C:\Users\alice\.config\amp\plugins`,
         platform: "win32",
         env: {
           LOCALAPPDATA: String.raw`C:\Users\alice\AppData\Local`,
@@ -193,6 +259,7 @@ describe("Amp Plannotator plugin helpers", () => {
     expect(
       getPlannotatorCommandCandidates({
         home: "/Users/alice",
+        pluginDir: "/Users/alice/.config/amp/plugins",
         platform: "darwin",
         env: { PLANNOTATOR_BIN: "/opt/plannotator/bin/plannotator" },
       }),

--- a/apps/amp-plugin/plannotator.ts
+++ b/apps/amp-plugin/plannotator.ts
@@ -1,7 +1,7 @@
 import type { PluginAPI, PluginCommandContext, ThreadMessage } from "@ampcode/plugin";
 import { existsSync, readFileSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { randomUUID } from "node:crypto";
 
 const CATEGORY = "Plannotator";
@@ -470,6 +470,9 @@ export async function resolveCwd(ctx: CommandContext): Promise<string> {
   const explicitCwd = normalizeDirectory(process.env.PLANNOTATOR_CWD);
   if (explicitCwd) return explicitCwd;
 
+  const ampWorkspaceRoot = resolveAmpWorkspaceRoot();
+  if (ampWorkspaceRoot) return ampWorkspaceRoot;
+
   try {
     const result = await ctx.$`pwd`;
     const cwd = normalizeDirectory(result.stdout);
@@ -482,6 +485,55 @@ export async function resolveCwd(ctx: CommandContext): Promise<string> {
   if (shellPwd) return shellPwd;
 
   return normalizeDirectory(process.cwd()) ?? process.cwd();
+}
+
+export function resolveAmpWorkspaceRoot(
+  options: { logPath?: string; parentPid?: number } = {},
+): string | null {
+  const logPath = options.logPath ?? process.env.AMP_LOG_FILE ?? join(getAmpCacheDir(), "logs", "cli.log");
+  if (!existsSync(logPath)) return null;
+
+  const parentPid = options.parentPid ?? process.ppid;
+  const lines = readFileSync(logPath, "utf8").split(/\r?\n/).filter(Boolean);
+  let latestWorkspace: string | null = null;
+
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    let entry: { pid?: unknown; workspaceRoot?: unknown };
+    try {
+      entry = JSON.parse(lines[i]) as { pid?: unknown; workspaceRoot?: unknown };
+    } catch {
+      continue;
+    }
+
+    const workspace = normalizeWorkspaceRoot(entry.workspaceRoot);
+    if (!workspace) continue;
+
+    latestWorkspace ??= workspace;
+    if (entry.pid === parentPid) return workspace;
+  }
+
+  return latestWorkspace;
+}
+
+function normalizeWorkspaceRoot(value: unknown): string | null {
+  if (typeof value !== "string" || !value.trim()) return null;
+
+  try {
+    const path = value.startsWith("file://") ? fileUrlToPath(value) : value;
+    return normalizeDirectory(path);
+  } catch {
+    return null;
+  }
+}
+
+function fileUrlToPath(value: string): string {
+  const url = new URL(value);
+  if (url.protocol !== "file:") throw new Error(`Unsupported URL protocol: ${url.protocol}`);
+
+  const pathname = decodeURIComponent(url.pathname);
+  return process.platform === "win32" && /^\/[A-Za-z]:/.test(pathname)
+    ? pathname.slice(1)
+    : pathname;
 }
 
 export function buildPlannotatorEnv(cwd: string, readyFile: string | null): Record<string, string> {
@@ -652,11 +704,12 @@ export function getPlannotatorCommandCandidates(
   options: {
     env?: Record<string, string | undefined>;
     home?: string;
+    pluginDir?: string;
     platform?: string;
   } = {},
 ): string[][] {
   const env = options.env ?? process.env;
-  const home = options.home ?? homedir();
+  const homes = getHomeDirectoryCandidates(env, options.home, options.pluginDir ?? import.meta.dir);
   const platform = options.platform ?? process.platform;
   const candidates: string[][] = [];
 
@@ -667,10 +720,13 @@ export function getPlannotatorCommandCandidates(
     const localAppData = normalizeExecutablePath(env.LOCALAPPDATA);
     if (localAppData) candidates.push([join(localAppData, "plannotator", "plannotator.exe")]);
 
-    const userProfile = normalizeExecutablePath(env.USERPROFILE) ?? home;
-    candidates.push([join(userProfile, ".local", "bin", "plannotator.exe")]);
+    for (const home of homes) {
+      candidates.push([join(home, ".local", "bin", "plannotator.exe")]);
+    }
   } else {
-    candidates.push([join(home, ".local", "bin", "plannotator")]);
+    for (const home of homes) {
+      candidates.push([join(home, ".local", "bin", "plannotator")]);
+    }
   }
 
   candidates.push(["plannotator"]);
@@ -683,6 +739,41 @@ function normalizeExecutablePath(value: string | undefined): string | null {
   return candidate;
 }
 
+function getHomeDirectoryCandidates(
+  env: Record<string, string | undefined>,
+  explicitHome: string | undefined,
+  pluginDir: string,
+): string[] {
+  return dedupeStrings([
+    normalizeExecutablePath(explicitHome),
+    normalizeExecutablePath(env.HOME),
+    normalizeExecutablePath(env.USERPROFILE),
+    deriveHomeFromAmpPluginDir(pluginDir),
+    explicitHome === undefined ? normalizeExecutablePath(homedir()) : null,
+  ]);
+}
+
+function deriveHomeFromAmpPluginDir(pluginDir: string): string | null {
+  const pluginsDir = resolve(pluginDir);
+  const ampDir = dirname(pluginsDir);
+  const configDir = dirname(ampDir);
+
+  if (
+    basename(pluginsDir) === "plugins" &&
+    basename(ampDir) === "amp" &&
+    basename(configDir) === ".config"
+  ) {
+    return dirname(configDir);
+  }
+
+  return null;
+}
+
+function getAmpCacheDir(): string {
+  const cacheHome = normalizeExecutablePath(process.env.XDG_CACHE_HOME);
+  return cacheHome ? join(cacheHome, "amp") : join(homedir(), ".cache", "amp");
+}
+
 function dedupeCommands(commands: string[][]): string[][] {
   const seen = new Set<string>();
   const deduped: string[][] = [];
@@ -691,6 +782,17 @@ function dedupeCommands(commands: string[][]): string[][] {
     if (seen.has(key)) continue;
     seen.add(key);
     deduped.push(command);
+  }
+  return deduped;
+}
+
+function dedupeStrings(values: Array<string | null>): string[] {
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+  for (const value of values) {
+    if (!value || seen.has(value)) continue;
+    seen.add(value);
+    deduped.push(value);
   }
   return deduped;
 }


### PR DESCRIPTION
## Summary
- Resolve the real Amp workspace root from Amp's CLI log before falling back to `ctx.$`
- Keep globally installed Amp plugins from running Plannotator in `~/.config/amp/plugins`
- Make Amp plugin binary discovery more robust when plugin home differs from OS home

## Why
In production/global Amp plugin installs, `ctx.$` reports the plugin directory (`~/.config/amp/plugins`) rather than the active workspace. Development masked this because we used source/env mode. This caused Plannotator commands to run from the wrong cwd and contributed to the production Amp failures.

## Verification
- `bunx --bun bun@1.3.14 test apps/amp-plugin/plannotator.test.ts`
- `bun build apps/amp-plugin/plannotator.ts --outfile /tmp/plannotator-amp-plugin.js`
- `git diff --check HEAD~1..HEAD`