### PR TITLE
Fix Amp plugin Bun env leak

### DIFF
--- a/apps/amp-plugin/plannotator.test.ts
+++ b/apps/amp-plugin/plannotator.test.ts
@@ -4,6 +4,7 @@ import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
+  buildEnv,
   buildPlannotatorEnv,
   extractTextFromThreadMessage,
   findFirstPositionalArg,
@@ -209,6 +210,17 @@ describe("Amp Plannotator plugin helpers", () => {
       PLANNOTATOR_CWD: "/repo",
       PLANNOTATOR_READY_FILE: "/tmp/ready.jsonl",
     });
+  });
+
+  test("does not let Amp's Bun mode leak into the Plannotator binary", () => {
+    const originalBeBun = process.env.BUN_BE_BUN;
+
+    try {
+      process.env.BUN_BE_BUN = "1";
+      expect(buildEnv({ PLANNOTATOR_ORIGIN: "amp" }).BUN_BE_BUN).toBeUndefined();
+    } finally {
+      restoreEnv("BUN_BE_BUN", originalBeBun);
+    }
   });
 
   test("matches shared Plannotator data directory semantics", () => {

--- a/apps/amp-plugin/plannotator.ts
+++ b/apps/amp-plugin/plannotator.ts
@@ -555,11 +555,12 @@ function normalizeDirectory(value: string | undefined): string | null {
   }
 }
 
-function buildEnv(extra: Record<string, string>): Record<string, string> {
+export function buildEnv(extra: Record<string, string>): Record<string, string> {
   const env: Record<string, string> = {};
   for (const [key, value] of Object.entries(process.env)) {
     if (typeof value === "string") env[key] = value;
   }
+  delete env.BUN_BE_BUN;
   return { ...env, ...extra };
 }
 


### PR DESCRIPTION
## Summary
- strip Amp's `BUN_BE_BUN` env var before spawning the standalone Plannotator binary
- add a regression test so the Amp plugin cannot leak Bun mode into child Plannotator commands

## Why
Amp runs plugins under Bun with `BUN_BE_BUN=1`. If the standalone Plannotator binary inherits that env var, it behaves like `bun` instead of Plannotator, causing commands like `annotate` to fail with `Script not found "annotate"`.

## Verification
- `bun test apps/amp-plugin/plannotator.test.ts`
- `bun build apps/amp-plugin/plannotator.ts --outfile /tmp/plannotator-amp-plugin-check.js`
- `git diff --check`