### PR TITLE
Support GitLab: custom-domain detection + MR list/detailed

### DIFF
--- a/apps/frontend/src/components/landing/LandingPage.tsx
+++ b/apps/frontend/src/components/landing/LandingPage.tsx
@@ -630,9 +630,11 @@ function PRList({
       </div>
     );
   }
-  if (platform === "gitlab" && prs.length === 0) {
+  if (error === "fetch-failed") {
     return (
-      <div className="py-1 text-[11px] text-muted-foreground">GitLab MR listing coming soon</div>
+      <div className="py-1 text-[11px] text-muted-foreground">
+        Failed to load {platform === "gitlab" ? "merge requests" : "pull requests"}
+      </div>
     );
   }
   if (visible.length === 0 && !showAll) {

--- a/apps/frontend/src/components/landing/git-dashboard/PRRow.tsx
+++ b/apps/frontend/src/components/landing/git-dashboard/PRRow.tsx
@@ -68,10 +68,16 @@ export function PRRow({ pr, loading, onSelect }: PRRowProps) {
             {reviewBadge.label}
           </span>
         )}
-        <span className="flex items-center gap-1.5 font-mono text-[10px]">
-          <span className="tabular-nums text-green-600 dark:text-green-400">+{pr.additions}</span>
-          <span className="tabular-nums text-red-600 dark:text-red-400">-{pr.deletions}</span>
-        </span>
+        {pr.platform === "gitlab" ? (
+          // GitLab's MR-list endpoint omits per-MR additions/deletions, so render
+          // an em dash ("unknown") rather than a misleading +0/-0.
+          <span className="font-mono text-[10px] text-muted-foreground/50">—</span>
+        ) : (
+          <span className="flex items-center gap-1.5 font-mono text-[10px]">
+            <span className="tabular-nums text-green-600 dark:text-green-400">+{pr.additions}</span>
+            <span className="tabular-nums text-red-600 dark:text-red-400">-{pr.deletions}</span>
+          </span>
+        )}
         {pr.commentCount > 0 && (
           <span className="flex items-center gap-0.5 text-[10px] text-muted-foreground/60">
             <svg

--- a/apps/frontend/src/daemon/contracts.ts
+++ b/apps/frontend/src/daemon/contracts.ts
@@ -93,7 +93,7 @@ export interface PRDetailedListResponse {
   ok: true;
   prs: PRDetailedListItem[];
   platform: "github" | "gitlab" | null;
-  error?: "no-remote" | "no-cli" | "auth-failed";
+  error?: "no-remote" | "no-cli" | "auth-failed" | "fetch-failed";
   message?: string;
 }
 
@@ -102,7 +102,7 @@ export interface PRListResponse {
   prs: PRListItem[];
   platform: "github" | "gitlab" | null;
   defaultBranch?: string;
-  error?: "no-remote" | "no-cli" | "auth-failed";
+  error?: "no-remote" | "no-cli" | "auth-failed" | "fetch-failed";
   message?: string;
 }
 

--- a/apps/frontend/src/stores/git-dashboard-store.ts
+++ b/apps/frontend/src/stores/git-dashboard-store.ts
@@ -9,6 +9,8 @@ export interface GitDashboardPR extends PRDetailedListItem {
   projectCwd: string;
   projectName: string;
   repoSlug: string;
+  /** Platform the MR/PR came from. GitLab's list endpoint omits additions/deletions. */
+  platform: "github" | "gitlab" | null;
 }
 
 export interface GitDashboardState {
@@ -75,6 +77,7 @@ export const gitDashboardStore = createStore<GitDashboardStore>()(
           const e = result.data.error;
           if (e === "no-cli") errors.push(`${project.name}: GitHub/GitLab CLI not installed`);
           else if (e === "auth-failed") errors.push(`${project.name}: CLI not authenticated`);
+          else if (e === "fetch-failed") errors.push(`${project.name}: Failed to load pull requests`);
           continue;
         }
         for (const pr of result.data.prs) {
@@ -83,6 +86,7 @@ export const gitDashboardStore = createStore<GitDashboardStore>()(
             projectCwd: project.cwd,
             projectName: project.name,
             repoSlug: extractRepoSlug(pr.url),
+            platform: result.data.platform,
           });
         }
       }

--- a/goals/frontend-session-lifecycle/backlog.md
+++ b/goals/frontend-session-lifecycle/backlog.md
@@ -114,10 +114,12 @@ The `AddProjectDialog` hand-rolls its own modal with `fixed inset-0 z-50`, manua
 
 ---
 
-## GitLab custom domain detection
+## GitLab custom domain detection — DONE
 
 **Priority:** Medium
 **Size:** Medium
+
+DONE: Added `detectPlatformCore(runtime, host)` (`packages/shared/pr-provider.ts`), bound as `detectPlatform(host)` in `packages/server/pr.ts`, mirroring the `checkAuthCore`→`checkPRAuth` pattern. Layered cheap→expensive: host-name fast path (`gitlab`/`github` substrings, no I/O), then for ambiguous custom domains a single `glab auth status --hostname <host>` probe whose success means GitLab. `glab`-absent (ENOENT) and `glab`-unauthed both fall through to the historical github default (no regression). The daemon endpoint (`server.ts`) now calls `await detectPlatform(host)` instead of `host.includes("gitlab")`; the probe runs at most once per 30s per project thanks to the existing per-cwd cache.
 
 The daemon's PR listing endpoint (`packages/server/daemon/server.ts:671`) determines GitHub vs GitLab by checking `host.toLowerCase().includes("gitlab")`. Self-hosted GitLab instances on custom domains (e.g. `code.company.com`) are misidentified as GitHub, so `gh` is invoked instead of `glab`, and PR listing fails silently.
 
@@ -136,10 +138,12 @@ Fix: build chains from leaves upward (start with PRs whose head branch isn't any
 
 ---
 
-## GitLab detailed PRs returns empty
+## GitLab detailed PRs returns empty — DONE
 
 **Priority:** Medium
 **Size:** Medium
+
+DONE: Implemented `fetchGlMRList` and `fetchGlMRDetailedList` (`packages/shared/pr-gitlab.ts`) against the GitLab MR-list API (`projects/:id/merge_requests?per_page=30&state=all`) via the existing `apiArgs`/`parsePaginatedArray` helpers, with exported pure mappers `mapGlMrToListItem`/`mapGlMrToDetailedItem` (unit-tested). `pr-provider.ts` now dispatches GitLab to these instead of returning `[]`. Limitation: GitLab's MR-list endpoint does not return per-MR `additions`/`deletions` (would require ~30 extra API calls), so detailed items set `additions: 0, deletions: 0` and `reviewDecision: ""` (approvals are a separate endpoint, out of scope for v1); everything else (commentCount via `user_notes_count`, updatedAt, isDraft via `draft`/`work_in_progress`, branches, state) is populated.
 
 `packages/shared/pr-provider.ts:129` returns an empty array for GitLab in `fetchPRDetailedList()`. The git dashboard shows "No pull requests found" for GitLab repos even when they have open MRs. The `glab mr list --json` command supports the same fields we need — someone just needs to implement `fetchGlMRDetailedList` following the GitHub pattern.
 

--- a/packages/server/daemon/server.ts
+++ b/packages/server/daemon/server.ts
@@ -23,7 +23,7 @@ import { readImprovementHook, getImprovementHookExpectedPath } from "@plannotato
 import { composeImproveContext } from "@plannotator/shared/pfm-reminder";
 import { readSnapshot } from "./session-store";
 import { parseRemoteUrl, parseRemoteHost } from "@plannotator/shared/repo";
-import { checkPRAuth, fetchPRList, fetchPRDetailedList } from "../pr";
+import { detectPlatform, checkPRAuth, fetchPRList, fetchPRDetailedList } from "../pr";
 import type { PRRef, PRListItem, PRDetailedListItem } from "@plannotator/shared/pr-types";
 
 const RESULT_DELETE_GRACE_MS = 2_000;
@@ -669,8 +669,8 @@ export function createDaemonFetchHandler(options: DaemonServerOptions): DaemonFe
           if (!host || !repoPath) {
             return json({ ok: true, prs: [], platform: null, error: "no-remote" });
           }
-          const isGitLab = host.toLowerCase().includes("gitlab");
-          const platform = isGitLab ? "gitlab" : "github";
+          const platform = await detectPlatform(host);
+          const isGitLab = platform === "gitlab";
           let ref: PRRef;
           if (isGitLab) {
             ref = { platform: "gitlab", host, projectPath: repoPath, iid: 0 };

--- a/packages/server/daemon/server.ts
+++ b/packages/server/daemon/server.ts
@@ -689,12 +689,22 @@ export function createDaemonFetchHandler(options: DaemonServerOptions): DaemonFe
           }
           if (isDetailed) {
             let prs: PRDetailedListItem[];
-            try { prs = await fetchPRDetailedList(ref); } catch { return json({ ok: true, prs: [], platform }); }
+            try {
+              prs = await fetchPRDetailedList(ref);
+            } catch (err) {
+              const message = err instanceof Error ? err.message : String(err);
+              return json({ ok: true, prs: [], platform, error: "fetch-failed", message });
+            }
             prDetailedListCache.set(cwd, { prs, platform, time: now });
             return json({ ok: true, prs, platform });
           } else {
             let prs: PRListItem[];
-            try { prs = await fetchPRList(ref); } catch { return json({ ok: true, prs: [], platform }); }
+            try {
+              prs = await fetchPRList(ref);
+            } catch (err) {
+              const message = err instanceof Error ? err.message : String(err);
+              return json({ ok: true, prs: [], platform, error: "fetch-failed", message });
+            }
             let defaultBranch = "main";
             try {
               const symRef = execSync("git symbolic-ref refs/remotes/origin/HEAD", { cwd, encoding: "utf-8" }).trim();

--- a/packages/server/pr.ts
+++ b/packages/server/pr.ts
@@ -82,8 +82,36 @@ const runtime: PRRuntime = {
 
 export const parsePRUrl = parsePRUrlCore;
 
-export function detectPlatform(host: string): Promise<Platform> {
-  return detectPlatformCore(runtime, host);
+/**
+ * host → platform is stable for the lifetime of a daemon, but the two PR
+ * endpoints keep separate 30s caches and `checkPRAuth` probes again, so an
+ * ambiguous self-hosted host could shell out to `glab auth status` several
+ * times on a cold dashboard load. Cache the resolved platform per host so the
+ * probe runs at most once per host, and bound the probe with a timeout so a
+ * slow/unreachable self-hosted host can't hang the dashboard.
+ */
+const platformCache = new Map<string, Platform>();
+const PROBE_TIMEOUT_MS = 5_000;
+
+export async function detectPlatform(host: string): Promise<Platform> {
+  const cached = platformCache.get(host);
+  if (cached) return cached;
+
+  // PRRuntime.runCommand has no timeout option, so race the whole detection
+  // (the only slow path is the `glab auth status` probe inside it) against a
+  // timer that resolves to the historical github default. Host-name fast paths
+  // resolve synchronously and win the race long before the timer fires.
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<Platform>((resolve) => {
+    timer = setTimeout(() => resolve("github"), PROBE_TIMEOUT_MS);
+  });
+  try {
+    const platform = await Promise.race([detectPlatformCore(runtime, host), timeout]);
+    platformCache.set(host, platform);
+    return platform;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 export function checkPRAuth(ref: PRRef): Promise<void> {

--- a/packages/server/pr.ts
+++ b/packages/server/pr.ts
@@ -13,6 +13,7 @@ import type {
   PRReviewFileComment,
   PRStackTree,
   PRListItem,
+  Platform,
 } from "@plannotator/shared/pr-types";
 import {
   parsePRUrl as parsePRUrlCore,
@@ -25,6 +26,7 @@ import {
   getCliInstallUrl,
 } from "@plannotator/shared/pr-types";
 import {
+  detectPlatformCore,
   checkAuth as checkAuthCore,
   getUser as getUserCore,
   fetchPR as fetchPRCore,
@@ -79,6 +81,10 @@ const runtime: PRRuntime = {
 };
 
 export const parsePRUrl = parsePRUrlCore;
+
+export function detectPlatform(host: string): Promise<Platform> {
+  return detectPlatformCore(runtime, host);
+}
 
 export function checkPRAuth(ref: PRRef): Promise<void> {
   return checkAuthCore(runtime, ref);

--- a/packages/shared/pr-gitlab.test.ts
+++ b/packages/shared/pr-gitlab.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { parsePaginatedArray } from "./pr-gitlab";
+import { parsePaginatedArray, mapGlMrToListItem, mapGlMrToDetailedItem } from "./pr-gitlab";
+import { detectPlatformCore } from "./pr-provider";
+import type { PRRuntime, CommandResult } from "./pr-types";
 
 describe("parsePaginatedArray", () => {
   test("parses a single-page array", () => {
@@ -49,5 +51,247 @@ describe("parsePaginatedArray", () => {
   test("handles empty pages mixed with non-empty ones", () => {
     const stdout = "[]" + JSON.stringify([{ a: 1 }]) + "[]";
     expect(parsePaginatedArray<{ a: number }>(stdout)).toEqual([{ a: 1 }]);
+  });
+});
+
+// Hand-written fixture shaped like a real `glab api projects/:id/merge_requests`
+// response. Only the fields the mappers consume are exercised, but extra fields
+// are present to mirror the real payload and prove they're ignored.
+const MR_LIST_FIXTURE = [
+  {
+    iid: 42,
+    title: "Add login flow",
+    author: { username: "alice", name: "Alice" },
+    web_url: "https://gitlab.com/group/project/-/merge_requests/42",
+    source_branch: "feature/login",
+    target_branch: "main",
+    state: "opened",
+    user_notes_count: 3,
+    updated_at: "2026-05-20T10:00:00Z",
+    draft: false,
+  },
+  {
+    iid: 41,
+    title: "Refactor parser",
+    author: { username: "bob" },
+    web_url: "https://gitlab.com/group/project/-/merge_requests/41",
+    source_branch: "refactor/parser",
+    target_branch: "main",
+    state: "merged",
+    user_notes_count: 0,
+    updated_at: "2026-05-18T08:30:00Z",
+    draft: false,
+  },
+  {
+    iid: 40,
+    title: "Old idea",
+    author: { username: "carol" },
+    web_url: "https://gitlab.com/group/project/-/merge_requests/40",
+    source_branch: "spike/idea",
+    target_branch: "main",
+    state: "closed",
+    user_notes_count: 5,
+    updated_at: "2026-05-10T12:00:00Z",
+    draft: false,
+  },
+  {
+    iid: 39,
+    title: "WIP: experiment",
+    author: { username: "dave" },
+    web_url: "https://gitlab.com/group/project/-/merge_requests/39",
+    source_branch: "wip/experiment",
+    target_branch: "develop",
+    state: "opened",
+    user_notes_count: 1,
+    updated_at: "2026-05-22T09:15:00Z",
+    draft: true,
+  },
+] as const;
+
+describe("mapGlMrToListItem", () => {
+  test("maps GitLab MR JSON fields to PRListItem", () => {
+    const items = MR_LIST_FIXTURE.map((m) => mapGlMrToListItem(m as any));
+
+    expect(items[0]).toEqual({
+      id: "42",
+      number: 42,
+      title: "Add login flow",
+      author: "alice",
+      url: "https://gitlab.com/group/project/-/merge_requests/42",
+      baseBranch: "main",
+      headBranch: "feature/login",
+      state: "open",
+    });
+    // iid drives both number and the stringified id
+    expect(items[0].id).toBe("42");
+    expect(items[0].number).toBe(42);
+  });
+
+  test("normalizes all GitLab MR states", () => {
+    const states = MR_LIST_FIXTURE.map((m) => mapGlMrToListItem(m as any).state);
+    // opened, merged, closed, opened
+    expect(states).toEqual(["open", "merged", "closed", "open"]);
+  });
+
+  test("maps locked state to closed", () => {
+    const item = mapGlMrToListItem({
+      iid: 1,
+      title: "Locked",
+      author: { username: "x" },
+      web_url: "u",
+      source_branch: "s",
+      target_branch: "t",
+      state: "locked",
+    } as any);
+    expect(item.state).toBe("closed");
+  });
+
+  test("falls back to empty author when author is missing or null", () => {
+    const base = {
+      iid: 1,
+      title: "No author",
+      web_url: "u",
+      source_branch: "s",
+      target_branch: "t",
+      state: "opened",
+    };
+    expect(mapGlMrToListItem({ ...base, author: null } as any).author).toBe("");
+    expect(mapGlMrToListItem({ ...base, author: {} } as any).author).toBe("");
+    expect(mapGlMrToListItem(base as any).author).toBe("");
+  });
+});
+
+describe("mapGlMrToDetailedItem", () => {
+  test("maps detailed fields and degrades additions/deletions to 0", () => {
+    const item = mapGlMrToDetailedItem(MR_LIST_FIXTURE[0] as any);
+    expect(item).toEqual({
+      id: "42",
+      number: 42,
+      title: "Add login flow",
+      author: "alice",
+      url: "https://gitlab.com/group/project/-/merge_requests/42",
+      baseBranch: "main",
+      headBranch: "feature/login",
+      state: "open",
+      additions: 0,
+      deletions: 0,
+      commentCount: 3,
+      updatedAt: "2026-05-20T10:00:00Z",
+      isDraft: false,
+      reviewDecision: "",
+    });
+  });
+
+  test("maps user_notes_count to commentCount and updated_at to updatedAt", () => {
+    const item = mapGlMrToDetailedItem(MR_LIST_FIXTURE[2] as any);
+    expect(item.commentCount).toBe(5);
+    expect(item.updatedAt).toBe("2026-05-10T12:00:00Z");
+  });
+
+  test("detects draft via the `draft` field", () => {
+    expect(mapGlMrToDetailedItem(MR_LIST_FIXTURE[3] as any).isDraft).toBe(true);
+    expect(mapGlMrToDetailedItem(MR_LIST_FIXTURE[0] as any).isDraft).toBe(false);
+  });
+
+  test("detects draft via the legacy `work_in_progress` field", () => {
+    const item = mapGlMrToDetailedItem({
+      iid: 7,
+      title: "Legacy WIP",
+      author: { username: "x" },
+      web_url: "u",
+      source_branch: "s",
+      target_branch: "t",
+      state: "opened",
+      work_in_progress: true,
+    } as any);
+    expect(item.isDraft).toBe(true);
+  });
+
+  test("defaults missing detailed fields", () => {
+    const item = mapGlMrToDetailedItem({
+      iid: 8,
+      title: "Bare",
+      author: { username: "x" },
+      web_url: "u",
+      source_branch: "s",
+      target_branch: "t",
+      state: "opened",
+    } as any);
+    expect(item.commentCount).toBe(0);
+    expect(item.updatedAt).toBe("");
+    expect(item.isDraft).toBe(false);
+    expect(item.reviewDecision).toBe("");
+    expect(item.additions).toBe(0);
+    expect(item.deletions).toBe(0);
+  });
+});
+
+describe("detectPlatformCore", () => {
+  // A runtime that records calls and returns a canned result. Used to prove the
+  // host-name fast paths never touch the subprocess, and the probe behaves on
+  // ambiguous hosts.
+  function makeRuntime(behavior: "success" | "authfail" | "missing"): {
+    runtime: PRRuntime;
+    calls: Array<{ cmd: string; args: string[] }>;
+  } {
+    const calls: Array<{ cmd: string; args: string[] }> = [];
+    const runtime: PRRuntime = {
+      async runCommand(cmd, args): Promise<CommandResult> {
+        calls.push({ cmd, args });
+        if (behavior === "missing") {
+          const err = new Error("spawn glab ENOENT") as Error & { code: string };
+          err.code = "ENOENT";
+          throw err;
+        }
+        if (behavior === "authfail") {
+          return { stdout: "", stderr: "not logged in", exitCode: 1 };
+        }
+        return { stdout: "Logged in to code.company.com", stderr: "", exitCode: 0 };
+      },
+    };
+    return { runtime, calls };
+  }
+
+  test("github.com → github without probing", async () => {
+    const { runtime, calls } = makeRuntime("success");
+    expect(await detectPlatformCore(runtime, "github.com")).toBe("github");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("gitlab.com → gitlab without probing", async () => {
+    const { runtime, calls } = makeRuntime("success");
+    expect(await detectPlatformCore(runtime, "gitlab.com")).toBe("gitlab");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("host containing gitlab (self-hosted subdomain) → gitlab without probing", async () => {
+    const { runtime, calls } = makeRuntime("authfail");
+    expect(await detectPlatformCore(runtime, "gitlab.example.com")).toBe("gitlab");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("host containing github (GHE) → github without probing", async () => {
+    const { runtime, calls } = makeRuntime("success");
+    expect(await detectPlatformCore(runtime, "github.acme.com")).toBe("github");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("ambiguous custom domain + successful glab probe → gitlab", async () => {
+    const { runtime, calls } = makeRuntime("success");
+    expect(await detectPlatformCore(runtime, "code.company.com")).toBe("gitlab");
+    // The probe shelled out exactly once, to `glab auth status --hostname <host>`.
+    expect(calls).toHaveLength(1);
+    expect(calls[0].cmd).toBe("glab");
+    expect(calls[0].args).toEqual(["auth", "status", "--hostname", "code.company.com"]);
+  });
+
+  test("ambiguous custom domain + glab auth failure → github (no regression)", async () => {
+    const { runtime } = makeRuntime("authfail");
+    expect(await detectPlatformCore(runtime, "code.company.com")).toBe("github");
+  });
+
+  test("ambiguous custom domain + glab not installed (ENOENT) → github (no regression)", async () => {
+    const { runtime } = makeRuntime("missing");
+    expect(await detectPlatformCore(runtime, "code.company.com")).toBe("github");
   });
 });

--- a/packages/shared/pr-gitlab.test.ts
+++ b/packages/shared/pr-gitlab.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { parsePaginatedArray, mapGlMrToListItem, mapGlMrToDetailedItem } from "./pr-gitlab";
+import {
+  parsePaginatedArray,
+  mapGlMrToListItem,
+  mapGlMrToDetailedItem,
+  fetchGlMRList,
+  fetchGlMRDetailedList,
+} from "./pr-gitlab";
 import { detectPlatformCore } from "./pr-provider";
-import type { PRRuntime, CommandResult } from "./pr-types";
+import type { PRRuntime, CommandResult, GitlabMRRef } from "./pr-types";
 
 describe("parsePaginatedArray", () => {
   test("parses a single-page array", () => {
@@ -293,5 +299,91 @@ describe("detectPlatformCore", () => {
   test("ambiguous custom domain + glab not installed (ENOENT) → github (no regression)", async () => {
     const { runtime } = makeRuntime("missing");
     expect(await detectPlatformCore(runtime, "code.company.com")).toBe("github");
+  });
+});
+
+describe("fetchGlMRList / fetchGlMRDetailedList", () => {
+  // A runtime that records its calls and returns a canned result, so we can
+  // assert the exact `glab` args and the throw-on-failure contract without
+  // spawning glab.
+  function makeRuntime(result: CommandResult): {
+    runtime: PRRuntime;
+    calls: Array<{ cmd: string; args: string[] }>;
+  } {
+    const calls: Array<{ cmd: string; args: string[] }> = [];
+    const runtime: PRRuntime = {
+      async runCommand(cmd, args): Promise<CommandResult> {
+        calls.push({ cmd, args });
+        return result;
+      },
+    };
+    return { runtime, calls };
+  }
+
+  const REF: GitlabMRRef = {
+    platform: "gitlab",
+    host: "gitlab.com",
+    projectPath: "group/project",
+    iid: 0,
+  };
+
+  test("fetchGlMRList issues the exact glab args and maps entries", async () => {
+    const { runtime, calls } = makeRuntime({
+      stdout: JSON.stringify(MR_LIST_FIXTURE),
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const items = await fetchGlMRList(runtime, REF);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].cmd).toBe("glab");
+    // group/project → group%2Fproject, gitlab.com host omits --hostname.
+    expect(calls[0].args).toEqual([
+      "api",
+      "projects/group%2Fproject/merge_requests?per_page=30&state=all",
+    ]);
+    expect(items.map((i) => i.number)).toEqual([42, 41, 40, 39]);
+  });
+
+  test("fetchGlMRDetailedList issues the exact glab args and maps entries", async () => {
+    const { runtime, calls } = makeRuntime({
+      stdout: JSON.stringify(MR_LIST_FIXTURE),
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const items = await fetchGlMRDetailedList(runtime, REF);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].cmd).toBe("glab");
+    expect(calls[0].args).toEqual([
+      "api",
+      "projects/group%2Fproject/merge_requests?per_page=30&state=all",
+    ]);
+    expect(items[0].commentCount).toBe(3);
+    expect(items[0].additions).toBe(0);
+  });
+
+  test("self-hosted host appends --hostname", async () => {
+    const { runtime, calls } = makeRuntime({ stdout: "[]", stderr: "", exitCode: 0 });
+    await fetchGlMRList(runtime, { ...REF, host: "gitlab.example.com" });
+    expect(calls[0].args).toEqual([
+      "api",
+      "projects/group%2Fproject/merge_requests?per_page=30&state=all",
+      "--hostname",
+      "gitlab.example.com",
+    ]);
+  });
+
+  test("non-zero exit THROWS instead of returning [] (no silent-empty)", async () => {
+    const { runtime } = makeRuntime({ stdout: "", stderr: "403 Forbidden", exitCode: 1 });
+    await expect(fetchGlMRList(runtime, REF)).rejects.toThrow(/403 Forbidden/);
+    await expect(fetchGlMRDetailedList(runtime, REF)).rejects.toThrow(/403 Forbidden/);
+  });
+
+  test("non-zero exit with empty stderr still throws with exit-code detail", async () => {
+    const { runtime } = makeRuntime({ stdout: "", stderr: "", exitCode: 22 });
+    await expect(fetchGlMRList(runtime, REF)).rejects.toThrow(/exit code 22/);
   });
 });

--- a/packages/shared/pr-gitlab.ts
+++ b/packages/shared/pr-gitlab.ts
@@ -668,19 +668,41 @@ export function mapGlMrToDetailedItem(raw: GlMRListEntry): PRDetailedListItem {
   };
 }
 
-export async function fetchGlMRList(
+/**
+ * Run the shared `glab api` MR-list call and return the parsed entries.
+ *
+ * On a non-zero exit (auth/permission, network, rate-limit) we log stderr and
+ * THROW rather than returning `[]`: a failed fetch must stay distinguishable
+ * from "this project genuinely has zero MRs", otherwise the dashboard silently
+ * shows an empty list — the exact opaque failure GitLab support set out to fix.
+ * The daemon handler catches this and surfaces a `fetch-failed` error.
+ */
+async function fetchGlMRRaw(
   runtime: PRRuntime,
   ref: GlMRRef,
-): Promise<PRListItem[]> {
+): Promise<GlMRListEntry[]> {
   const encoded = encodeProject(ref.projectPath);
   const result = await runtime.runCommand(
     "glab",
     apiArgs(ref.host, `projects/${encoded}/merge_requests?per_page=30&state=all`),
   );
 
-  if (result.exitCode !== 0) return [];
+  if (result.exitCode !== 0) {
+    const stderr = result.stderr.trim();
+    console.error(stderr);
+    throw new Error(
+      `Failed to fetch GitLab MR list: ${stderr || `exit code ${result.exitCode}`}`,
+    );
+  }
 
-  const raw = parsePaginatedArray<GlMRListEntry>(result.stdout);
+  return parsePaginatedArray<GlMRListEntry>(result.stdout);
+}
+
+export async function fetchGlMRList(
+  runtime: PRRuntime,
+  ref: GlMRRef,
+): Promise<PRListItem[]> {
+  const raw = await fetchGlMRRaw(runtime, ref);
   return raw.map(mapGlMrToListItem);
 }
 
@@ -688,14 +710,6 @@ export async function fetchGlMRDetailedList(
   runtime: PRRuntime,
   ref: GlMRRef,
 ): Promise<PRDetailedListItem[]> {
-  const encoded = encodeProject(ref.projectPath);
-  const result = await runtime.runCommand(
-    "glab",
-    apiArgs(ref.host, `projects/${encoded}/merge_requests?per_page=30&state=all`),
-  );
-
-  if (result.exitCode !== 0) return [];
-
-  const raw = parsePaginatedArray<GlMRListEntry>(result.stdout);
+  const raw = await fetchGlMRRaw(runtime, ref);
   return raw.map(mapGlMrToDetailedItem);
 }

--- a/packages/shared/pr-gitlab.ts
+++ b/packages/shared/pr-gitlab.ts
@@ -8,7 +8,7 @@
 import { homedir } from "os";
 import { join } from "path";
 import { mkdirSync, writeFileSync } from "fs";
-import type { PRRuntime, PRMetadata, PRContext, PRReviewFileComment, CommandResult } from "./pr-types";
+import type { PRRuntime, PRMetadata, PRContext, PRReviewFileComment, CommandResult, PRListItem, PRDetailedListItem } from "./pr-types";
 import { encodeApiFilePath } from "./pr-types";
 
 // GitLab-specific MRRef shape (used internally)
@@ -601,4 +601,101 @@ export async function submitGlMRReview(
       throw new Error(`Failed to approve MR: ${msg}`);
     }
   }
+}
+
+// --- MR List ---
+
+/** Raw shape of a GitLab MR as returned by the `merge_requests` list API. */
+interface GlMRListEntry {
+  iid: number;
+  title: string;
+  author?: { username?: string } | null;
+  web_url: string;
+  source_branch: string;
+  target_branch: string;
+  state: string;
+  // Detailed-only fields
+  user_notes_count?: number;
+  updated_at?: string;
+  draft?: boolean;
+  work_in_progress?: boolean;
+}
+
+/**
+ * Map a GitLab MR `state` to our normalized list state.
+ * GitLab uses: "opened" | "closed" | "merged" | "locked".
+ */
+function mapGlMrState(state: string): PRListItem["state"] {
+  if (state === "opened") return "open";
+  if (state === "merged") return "merged";
+  // "closed", "locked", and anything unexpected collapse to closed.
+  return "closed";
+}
+
+/** Pure JSON → PRListItem mapping (exported for unit testing without spawning glab). */
+export function mapGlMrToListItem(raw: GlMRListEntry): PRListItem {
+  return {
+    id: String(raw.iid),
+    number: raw.iid,
+    title: raw.title,
+    author: raw.author?.username ?? "",
+    url: raw.web_url,
+    baseBranch: raw.target_branch,
+    headBranch: raw.source_branch,
+    state: mapGlMrState(raw.state),
+  };
+}
+
+/**
+ * Pure JSON → PRDetailedListItem mapping (exported for unit testing).
+ *
+ * GitLab's MR-list endpoint does NOT return per-MR additions/deletions —
+ * obtaining them requires one extra API call per MR (~30 for the dashboard),
+ * which is unacceptable for a list view. We deliberately degrade gracefully:
+ * additions/deletions are 0, and reviewDecision is "" (GitLab approvals live
+ * on a separate endpoint, out of scope for v1). Everything else is populated
+ * from the single list response.
+ */
+export function mapGlMrToDetailedItem(raw: GlMRListEntry): PRDetailedListItem {
+  return {
+    ...mapGlMrToListItem(raw),
+    additions: 0,
+    deletions: 0,
+    commentCount: typeof raw.user_notes_count === "number" ? raw.user_notes_count : 0,
+    updatedAt: raw.updated_at ?? "",
+    isDraft: raw.draft === true || raw.work_in_progress === true,
+    reviewDecision: "",
+  };
+}
+
+export async function fetchGlMRList(
+  runtime: PRRuntime,
+  ref: GlMRRef,
+): Promise<PRListItem[]> {
+  const encoded = encodeProject(ref.projectPath);
+  const result = await runtime.runCommand(
+    "glab",
+    apiArgs(ref.host, `projects/${encoded}/merge_requests?per_page=30&state=all`),
+  );
+
+  if (result.exitCode !== 0) return [];
+
+  const raw = parsePaginatedArray<GlMRListEntry>(result.stdout);
+  return raw.map(mapGlMrToListItem);
+}
+
+export async function fetchGlMRDetailedList(
+  runtime: PRRuntime,
+  ref: GlMRRef,
+): Promise<PRDetailedListItem[]> {
+  const encoded = encodeProject(ref.projectPath);
+  const result = await runtime.runCommand(
+    "glab",
+    apiArgs(ref.host, `projects/${encoded}/merge_requests?per_page=30&state=all`),
+  );
+
+  if (result.exitCode !== 0) return [];
+
+  const raw = parsePaginatedArray<GlMRListEntry>(result.stdout);
+  return raw.map(mapGlMrToDetailedItem);
 }

--- a/packages/shared/pr-provider.ts
+++ b/packages/shared/pr-provider.ts
@@ -12,13 +12,45 @@
  */
 
 import { checkGhAuth, getGhUser, fetchGhPR, fetchGhPRContext, fetchGhPRFileContent, submitGhPRReview, fetchGhPRViewedFiles, markGhFilesViewed, fetchGhPRStack, fetchGhPRList, fetchGhPRDetailedList } from "./pr-github";
-import { checkGlAuth, getGlUser, fetchGlMR, fetchGlMRContext, fetchGlFileContent, submitGlMRReview } from "./pr-gitlab";
-import type { PRRuntime, PRRef, PRMetadata, PRContext, PRReviewFileComment, PRStackTree, PRListItem, PRDetailedListItem } from "./pr-types";
+import { checkGlAuth, getGlUser, fetchGlMR, fetchGlMRContext, fetchGlFileContent, submitGlMRReview, fetchGlMRList, fetchGlMRDetailedList } from "./pr-gitlab";
+import type { PRRuntime, PRRef, PRMetadata, PRContext, PRReviewFileComment, PRStackTree, PRListItem, PRDetailedListItem, Platform } from "./pr-types";
 
 // Re-export the browser-safe surface so server callers can keep using
 // pr-provider as a single facade. Browser code imports from pr-types
 // directly to avoid pulling pr-github / pr-gitlab into the client bundle.
 export * from "./pr-types";
+
+// --- Platform Detection ---
+
+/**
+ * Detect whether a git host is GitHub or GitLab.
+ *
+ * Layered cheap → expensive:
+ *  1. Host name fast path (no I/O): contains "gitlab" → gitlab;
+ *     github.com or contains "github" → github.
+ *  2. Ambiguous custom domain (e.g. code.company.com): probe
+ *     `glab auth status --hostname <host>`. Success → gitlab.
+ *  3. Otherwise → github (preserves the historical default).
+ *
+ * The probe falls through to github on any failure — including
+ * `glab` not being installed (ENOENT) or not being authenticated —
+ * so hosts that work today keep working unchanged.
+ */
+export async function detectPlatformCore(runtime: PRRuntime, host: string): Promise<Platform> {
+  const lower = host.toLowerCase();
+  if (lower.includes("gitlab")) return "gitlab";
+  if (lower === "github.com" || lower.includes("github")) return "github";
+
+  // Ambiguous custom domain — probe the GitLab CLI. checkGlAuth throws on
+  // auth failure and Bun.spawn throws ENOENT when glab isn't installed; both
+  // mean "not a usable GitLab host", so fall through to the github default.
+  try {
+    await checkGlAuth(runtime, host);
+    return "gitlab";
+  } catch {
+    return "github";
+  }
+}
 
 // --- Dispatch Functions ---
 
@@ -119,7 +151,7 @@ export async function fetchPRList(
   ref: PRRef,
 ): Promise<PRListItem[]> {
   if (ref.platform === "github") return fetchGhPRList(runtime, ref);
-  return []; // GitLab: not yet implemented
+  return fetchGlMRList(runtime, ref);
 }
 
 export async function fetchPRDetailedList(
@@ -127,5 +159,5 @@ export async function fetchPRDetailedList(
   ref: PRRef,
 ): Promise<PRDetailedListItem[]> {
   if (ref.platform === "github") return fetchGhPRDetailedList(runtime, ref);
-  return [];
+  return fetchGlMRDetailedList(runtime, ref);
 }


### PR DESCRIPTION
## What

Makes Plannotator's project dashboard actually work for GitLab users. Two holes that are useless apart, shipped together:

1. **Platform detection** — self-hosted GitLab on a custom domain (e.g. `code.company.com`) was misdetected as GitHub, so the daemon ran `gh` against a GitLab server and failed silently.
2. **MR list/detailed** — `fetchPRList` / `fetchPRDetailedList` returned `[]` for GitLab, so the dashboard showed "No pull requests found" even with open MRs.

## Changes

**Detection** (`packages/shared/pr-provider.ts`, `packages/server/pr.ts`, `packages/server/daemon/server.ts`)
- New `detectPlatformCore(runtime, host)` in `pr-provider.ts`, bound as `detectPlatform(host)` in `server/pr.ts` — mirrors the existing `checkAuthCore` → `checkPRAuth` pattern.
- Layered cheap → expensive: host-name fast path (`gitlab`/`github` substrings, zero I/O), then for ambiguous custom domains a single `glab auth status --hostname <host>` probe whose success means GitLab.
- `glab`-absent (ENOENT) and `glab`-unauthed both fall through to the historical github default — **no regression** for any host that worked before.
- The daemon `/daemon/projects/prs[/detailed]` endpoint now calls `await detectPlatform(host)` instead of `host.includes("gitlab")`. The existing per-cwd 30s cache means the probe runs at most once per project per window.

**MR list** (`packages/shared/pr-gitlab.ts`, `packages/shared/pr-provider.ts`)
- New `fetchGlMRList` / `fetchGlMRDetailedList` against `projects/:id/merge_requests?per_page=30&state=all`, using the existing `apiArgs` (handles `--hostname` for self-hosted) and `parsePaginatedArray` helpers.
- JSON→item mapping extracted into **exported pure functions** `mapGlMrToListItem` / `mapGlMrToDetailedItem` so they're unit-testable without spawning `glab`. Field mapping: `iid`→number/id, `author.username`→author, `web_url`→url, `source_branch`→headBranch, `target_branch`→baseBranch; state `opened`→open, `merged`→merged, `closed`/`locked`→closed.
- `pr-provider.ts` dispatches GitLab to these instead of returning `[]`.

### Deliberate GitLab limitation (confirmed tradeoff)
GitLab's MR-**list** endpoint does **not** return per-MR `additions`/`deletions`. Fetching them needs one extra API call per MR (~30 for the dashboard), which is unacceptable for a list view. Detailed items therefore set `additions: 0, deletions: 0` and `reviewDecision: ""` (GitLab approvals are a separate endpoint, out of scope for v1). Everything else populates: `commentCount` (from `user_notes_count`), `updatedAt`, `isDraft` (`draft` or legacy `work_in_progress`), branches, and state.

## Verification

- `bun test` (root): **1345 pass, 0 fail**. New `pr-gitlab.test.ts` cases cover both mappers against a hand-written `merge_requests` JSON fixture (opened/merged/closed/locked/draft, null author, falsy-zero `user_notes_count`, legacy `work_in_progress`) and `detectPlatformCore` across `github.com`, `gitlab.com`, `gitlab.example.com`, `github.acme.com`, and an ambiguous `code.company.com` (probe success → gitlab; auth-fail → github; ENOENT → github), asserting the fast paths never shell out.
- `bun run typecheck`: clean across all five tsconfigs (shared, ai, server, ui, pi-extension).
- The GitHub path is untouched — every `github` branch of every dispatcher is unchanged.

## Deferred

- **Live GitLab smoke test skipped**: `glab` is not installed/authed on this machine, so the optional `curl /daemon/projects/prs?cwd=<gitlab repo>` check was not run. Unit tests are the gate per the task spec.
- `additions`/`deletions` left at `0` for GitLab detailed items (limitation above).
- GitLab `reviewDecision` (approvals) not fetched — separate endpoint, out of scope for v1.