### PR TITLE
Fix order-dependent PR-stack grouping via leaf-rooting

### DIFF
--- a/apps/frontend/src/components/landing/LandingPage.tsx
+++ b/apps/frontend/src/components/landing/LandingPage.tsx
@@ -562,10 +562,7 @@ function PRList({
     [prs, showAll],
   );
   const hiddenCount = prs.length - visible.length;
-  const { stacks, loose } = useMemo(
-    () => buildStacks(visible, defaultBranch),
-    [visible, defaultBranch],
-  );
+  const { stacks, loose } = useMemo(() => buildStacks(visible), [visible]);
 
   if (loading) {
     return <div className="py-1 text-[11px] text-muted-foreground">Loading PRs…</div>;

--- a/apps/frontend/src/components/landing/LandingPage.tsx
+++ b/apps/frontend/src/components/landing/LandingPage.tsx
@@ -20,6 +20,7 @@ import { GitDashboard } from "./git-dashboard/GitDashboard";
 import { useDaemonEventStore } from "../../daemon/events/event-store";
 import { daemonApiClient } from "../../daemon/api/client";
 import { getSessionModeMeta, formatSessionLabel } from "../../shared/session-meta";
+import { buildStacks, type PRStack } from "./buildStacks";
 import type {
   ProjectEntry,
   PRListItem,
@@ -429,47 +430,6 @@ function ProjectNode({
       </ContextMenu.Portal>
     </ContextMenu.Root>
   );
-}
-
-interface PRStack {
-  prs: PRListItem[];
-  label: string;
-}
-
-function buildStacks(
-  prs: PRListItem[],
-  defaultBranch: string,
-): { stacks: PRStack[]; loose: PRListItem[] } {
-  const byHead = new Map<string, PRListItem>();
-  for (const pr of prs) byHead.set(pr.headBranch, pr);
-
-  const stacked = new Set<string>();
-  const chains: PRListItem[][] = [];
-
-  for (const pr of prs) {
-    if (stacked.has(pr.id)) continue;
-    if (pr.baseBranch === defaultBranch) continue;
-
-    const chain: PRListItem[] = [];
-    let current: PRListItem | undefined = pr;
-    while (current && !stacked.has(current.id)) {
-      chain.unshift(current);
-      stacked.add(current.id);
-      current = byHead.get(current.baseBranch);
-    }
-    if (chain.length > 1) {
-      chains.push(chain);
-    } else {
-      stacked.delete(pr.id);
-    }
-  }
-
-  const stacks = chains.map((chain) => ({
-    prs: chain,
-    label: `#${chain[0].number} → #${chain[chain.length - 1].number}`,
-  }));
-  const loose = prs.filter((pr) => !stacked.has(pr.id));
-  return { stacks, loose };
 }
 
 function PRRow({

--- a/apps/frontend/src/components/landing/buildStacks.test.ts
+++ b/apps/frontend/src/components/landing/buildStacks.test.ts
@@ -38,9 +38,6 @@ function permutations<T>(items: T[]): T[][] {
   return result;
 }
 
-const sorted = (xs: string[]) => [...xs].sort();
-const sortedNums = (xs: number[]) => [...xs].sort((a, b) => a - b);
-
 // A 3-deep stack: A(base=main) ← B(base=A) ← C(base=B)
 const A = pr({ number: 1, head: "a", base: "main" });
 const B = pr({ number: 2, head: "b", base: "a" });
@@ -59,7 +56,6 @@ const Q = pr({ number: 21, head: "q", base: "p" });
 interface Case {
   name: string;
   prs: PRListItem[];
-  defaultBranch: string;
   expected: { stackLabels: string[]; looseNumbers: number[] };
 }
 
@@ -67,43 +63,36 @@ const cases: Case[] = [
   {
     name: "3-deep stack, leaf-first order",
     prs: [C, B, A],
-    defaultBranch: "main",
     expected: { stackLabels: ["#1 → #3"], looseNumbers: [] },
   },
   {
     name: "3-deep stack, base-first order",
     prs: [A, B, C],
-    defaultBranch: "main",
     expected: { stackLabels: ["#1 → #3"], looseNumbers: [] },
   },
   {
     name: "3-deep stack, interleaved order",
     prs: [B, A, C],
-    defaultBranch: "main",
     expected: { stackLabels: ["#1 → #3"], looseNumbers: [] },
   },
   {
     name: "4-deep stack, base-first order",
     prs: [W, X, Y, Z],
-    defaultBranch: "main",
     expected: { stackLabels: ["#10 → #13"], looseNumbers: [] },
   },
   {
     name: "4-deep stack, scrambled order",
     prs: [Y, W, Z, X],
-    defaultBranch: "main",
     expected: { stackLabels: ["#10 → #13"], looseNumbers: [] },
   },
   {
     name: "two independent stacks in one input",
     prs: [A, B, C, P, Q],
-    defaultBranch: "main",
     expected: { stackLabels: ["#1 → #3", "#20 → #21"], looseNumbers: [] },
   },
   {
     name: "two independent stacks, interleaved input",
     prs: [Q, B, A, P, C],
-    defaultBranch: "main",
     expected: { stackLabels: ["#1 → #3", "#20 → #21"], looseNumbers: [] },
   },
   {
@@ -113,25 +102,21 @@ const cases: Case[] = [
       pr({ number: 31, head: "f2", base: "main" }),
       pr({ number: 32, head: "f3", base: "main" }),
     ],
-    defaultBranch: "main",
     expected: { stackLabels: [], looseNumbers: [30, 31, 32] },
   },
   {
     name: "single non-default-based PR with no parent in the set stays loose",
     prs: [pr({ number: 40, head: "feature", base: "missing-parent" })],
-    defaultBranch: "main",
     expected: { stackLabels: [], looseNumbers: [40] },
   },
   {
     name: "stack plus an unrelated loose PR",
     prs: [A, B, C, pr({ number: 50, head: "solo", base: "main" })],
-    defaultBranch: "main",
     expected: { stackLabels: ["#1 → #3"], looseNumbers: [50] },
   },
   {
     name: "empty input",
     prs: [],
-    defaultBranch: "main",
     expected: { stackLabels: [], looseNumbers: [] },
   },
 ];
@@ -139,21 +124,23 @@ const cases: Case[] = [
 describe("buildStacks", () => {
   for (const c of cases) {
     test(c.name, () => {
-      const { stacks, loose } = buildStacks(c.prs, c.defaultBranch);
-      expect(sorted(stacks.map((s) => s.label))).toEqual(sorted(c.expected.stackLabels));
-      expect(sortedNums(loose.map((pr) => pr.number))).toEqual(sortedNums(c.expected.looseNumbers));
+      // Output is now fully order-independent: stacks sorted by base PR number,
+      // loose sorted by number. Assert the raw arrays — no sort() smoothing.
+      const { stacks, loose } = buildStacks(c.prs);
+      expect(stacks.map((s) => s.label)).toEqual(c.expected.stackLabels);
+      expect(loose.map((pr) => pr.number)).toEqual(c.expected.looseNumbers);
     });
   }
 
   test("stacks are ordered base → leaf with #base → #leaf labels", () => {
-    const { stacks } = buildStacks([C, A, B], "main");
+    const { stacks } = buildStacks([C, A, B]);
     expect(stacks).toHaveLength(1);
     expect(stacks[0].prs.map((p) => p.number)).toEqual([1, 2, 3]);
     expect(stacks[0].label).toBe("#1 → #3");
   });
 
   test("the base PR (base = default branch) is included in the stack", () => {
-    const { stacks, loose } = buildStacks([A, B, C], "main");
+    const { stacks, loose } = buildStacks([A, B, C]);
     expect(loose).toHaveLength(0);
     expect(stacks[0].prs.some((p) => p.number === 1)).toBe(true);
   });
@@ -162,7 +149,7 @@ describe("buildStacks", () => {
   // PRs. Every permutation of the same stack must yield identical grouping.
   test("every permutation of a 3-deep stack yields the same single stack", () => {
     for (const perm of permutations([A, B, C])) {
-      const { stacks, loose } = buildStacks(perm, "main");
+      const { stacks, loose } = buildStacks(perm);
       expect(stacks.map((s) => s.label)).toEqual(["#1 → #3"]);
       expect(stacks[0].prs.map((p) => p.number)).toEqual([1, 2, 3]);
       expect(loose).toHaveLength(0);
@@ -171,17 +158,19 @@ describe("buildStacks", () => {
 
   test("every permutation of a 4-deep stack yields the same single stack", () => {
     for (const perm of permutations([W, X, Y, Z])) {
-      const { stacks, loose } = buildStacks(perm, "main");
+      const { stacks, loose } = buildStacks(perm);
       expect(stacks.map((s) => s.label)).toEqual(["#10 → #13"]);
       expect(stacks[0].prs.map((p) => p.number)).toEqual([10, 11, 12, 13]);
       expect(loose).toHaveLength(0);
     }
   });
 
-  test("every permutation of two independent stacks yields the same grouping", () => {
+  // Output ordering itself is now order-independent: independent stacks come
+  // back sorted by base PR number, so they never swap positions between polls.
+  test("every permutation of two independent stacks yields the same ordered grouping", () => {
     for (const perm of permutations([A, B, C, P, Q])) {
-      const { stacks, loose } = buildStacks(perm, "main");
-      expect(sorted(stacks.map((s) => s.label))).toEqual(sorted(["#1 → #3", "#20 → #21"]));
+      const { stacks, loose } = buildStacks(perm);
+      expect(stacks.map((s) => s.label)).toEqual(["#1 → #3", "#20 → #21"]);
       expect(loose).toHaveLength(0);
     }
   });
@@ -191,22 +180,69 @@ describe("buildStacks", () => {
   test("a 2-cycle does not loop and lands in loose", () => {
     const c1 = pr({ number: 60, head: "cy1", base: "cy2" });
     const c2 = pr({ number: 61, head: "cy2", base: "cy1" });
-    const { stacks, loose } = buildStacks([c1, c2], "main");
+    const { stacks, loose } = buildStacks([c1, c2]);
     expect(stacks).toHaveLength(0);
-    expect(sortedNums(loose.map((p) => p.number))).toEqual([60, 61]);
+    expect(loose.map((p) => p.number)).toEqual([60, 61]);
   });
 
-  // A fork (one branch is the base of two PRs) must not double-count the shared
-  // ancestor or crash. It degrades to one stack plus a loose sibling.
-  test("a fork does not double-count the shared base", () => {
+  // A leaf feeding into a cycle terminates via the `stacked` guard: the walk
+  // visits leaf → cy1 → cy2 → cy1(already stacked, stop). The resulting chain
+  // includes the cyclic members. This pins current bounded behaviour — the key
+  // guarantee is termination, not a particular policy on cyclic members.
+  test("a leaf feeding into a cycle terminates and forms a bounded stack", () => {
+    const cy1 = pr({ number: 65, head: "cyc1", base: "cyc2" });
+    const cy2 = pr({ number: 66, head: "cyc2", base: "cyc1" });
+    const leaf = pr({ number: 67, head: "tip", base: "cyc1" });
+    for (const perm of permutations([cy1, cy2, leaf])) {
+      const { stacks, loose } = buildStacks(perm);
+      // Terminates (no hang) and produces exactly one bounded stack containing
+      // every member of the walk, in base → leaf order.
+      expect(stacks).toHaveLength(1);
+      expect(stacks[0].prs.map((p) => p.number)).toEqual([66, 65, 67]);
+      expect(stacks[0].label).toBe("#66 → #67");
+      expect(loose).toHaveLength(0);
+    }
+  });
+
+  // A fork (one branch is the base of two PRs) must group deterministically,
+  // independent of input order. The shared ancestor joins the chain rooted at
+  // the lowest-numbered leaf; the other leaf falls through to loose. We assert
+  // this across ALL permutations rather than one hardcoded ordering.
+  test("a fork groups deterministically across every input order", () => {
     const root = pr({ number: 70, head: "root", base: "main" });
     const child1 = pr({ number: 71, head: "child1", base: "root" });
     const child2 = pr({ number: 72, head: "child2", base: "root" });
-    const { stacks, loose } = buildStacks([root, child1, child2], "main");
-    // Exactly one stack contains the root; the other child is loose.
-    const allStackNumbers = stacks.flatMap((s) => s.prs.map((p) => p.number));
-    expect(allStackNumbers.filter((n) => n === 70)).toHaveLength(1);
-    expect(stacks).toHaveLength(1);
-    expect(loose.map((p) => p.number)).toContain(72);
+    for (const perm of permutations([root, child1, child2])) {
+      const { stacks, loose } = buildStacks(perm);
+      // Exactly one stack: the lowest-numbered leaf (71) wins the root.
+      expect(stacks).toHaveLength(1);
+      expect(stacks[0].prs.map((p) => p.number)).toEqual([70, 71]);
+      expect(stacks[0].label).toBe("#70 → #71");
+      // The shared ancestor is never double-counted.
+      const allStackNumbers = stacks.flatMap((s) => s.prs.map((p) => p.number));
+      expect(allStackNumbers.filter((n) => n === 70)).toHaveLength(1);
+      // The losing sibling is loose.
+      expect(loose.map((p) => p.number)).toEqual([72]);
+    }
+  });
+
+  // Duplicate head branches (e.g. `state=all` returns a merged + an open PR on
+  // the same branch) must resolve deterministically when a chain follows that
+  // head: the open PR wins the `byHead` mapping so chain-following does not
+  // depend on input order. Here a tip (#91) is based on branch `mid`, which is
+  // the head of both a merged (#88) and an open (#89) PR.
+  test("duplicate head branches resolve to the open PR across every order", () => {
+    const tip = pr({ number: 91, head: "tip", base: "mid" });
+    const midMerged = pr({ number: 88, head: "mid", base: "main", state: "merged" });
+    const midOpen = pr({ number: 89, head: "mid", base: "main", state: "open" });
+    for (const perm of permutations([tip, midMerged, midOpen])) {
+      const { stacks, loose } = buildStacks(perm);
+      // The open PR (#89) wins byHead, so the chain is #89 → #91 and the merged
+      // duplicate (#88) — never followed — is loose.
+      expect(stacks).toHaveLength(1);
+      expect(stacks[0].prs.map((p) => p.number)).toEqual([89, 91]);
+      expect(stacks[0].label).toBe("#89 → #91");
+      expect(loose.map((p) => p.number)).toEqual([88]);
+    }
   });
 });

--- a/apps/frontend/src/components/landing/buildStacks.test.ts
+++ b/apps/frontend/src/components/landing/buildStacks.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, test } from "vitest";
+import { buildStacks } from "./buildStacks";
+import type { PRListItem } from "../../daemon/contracts";
+
+function pr({
+  number,
+  head,
+  base,
+  state = "open",
+}: {
+  number: number;
+  head: string;
+  base: string;
+  state?: PRListItem["state"];
+}): PRListItem {
+  return {
+    id: `pr-${number}`,
+    number,
+    title: `PR #${number}`,
+    author: "tater",
+    url: `https://example.com/pr/${number}`,
+    baseBranch: base,
+    headBranch: head,
+    state,
+  };
+}
+
+/** Every distinct ordering of a list, for permutation-invariance checks. */
+function permutations<T>(items: T[]): T[][] {
+  if (items.length <= 1) return [items];
+  const result: T[][] = [];
+  for (let i = 0; i < items.length; i++) {
+    const rest = [...items.slice(0, i), ...items.slice(i + 1)];
+    for (const perm of permutations(rest)) {
+      result.push([items[i], ...perm]);
+    }
+  }
+  return result;
+}
+
+const sorted = (xs: string[]) => [...xs].sort();
+const sortedNums = (xs: number[]) => [...xs].sort((a, b) => a - b);
+
+// A 3-deep stack: A(base=main) ← B(base=A) ← C(base=B)
+const A = pr({ number: 1, head: "a", base: "main" });
+const B = pr({ number: 2, head: "b", base: "a" });
+const C = pr({ number: 3, head: "c", base: "b" });
+
+// A 4-deep stack: W ← X ← Y ← Z
+const W = pr({ number: 10, head: "w", base: "main" });
+const X = pr({ number: 11, head: "x", base: "w" });
+const Y = pr({ number: 12, head: "y", base: "x" });
+const Z = pr({ number: 13, head: "z", base: "y" });
+
+// A second independent 2-deep stack: P(base=main) ← Q(base=P)
+const P = pr({ number: 20, head: "p", base: "main" });
+const Q = pr({ number: 21, head: "q", base: "p" });
+
+interface Case {
+  name: string;
+  prs: PRListItem[];
+  defaultBranch: string;
+  expected: { stackLabels: string[]; looseNumbers: number[] };
+}
+
+const cases: Case[] = [
+  {
+    name: "3-deep stack, leaf-first order",
+    prs: [C, B, A],
+    defaultBranch: "main",
+    expected: { stackLabels: ["#1 → #3"], looseNumbers: [] },
+  },
+  {
+    name: "3-deep stack, base-first order",
+    prs: [A, B, C],
+    defaultBranch: "main",
+    expected: { stackLabels: ["#1 → #3"], looseNumbers: [] },
+  },
+  {
+    name: "3-deep stack, interleaved order",
+    prs: [B, A, C],
+    defaultBranch: "main",
+    expected: { stackLabels: ["#1 → #3"], looseNumbers: [] },
+  },
+  {
+    name: "4-deep stack, base-first order",
+    prs: [W, X, Y, Z],
+    defaultBranch: "main",
+    expected: { stackLabels: ["#10 → #13"], looseNumbers: [] },
+  },
+  {
+    name: "4-deep stack, scrambled order",
+    prs: [Y, W, Z, X],
+    defaultBranch: "main",
+    expected: { stackLabels: ["#10 → #13"], looseNumbers: [] },
+  },
+  {
+    name: "two independent stacks in one input",
+    prs: [A, B, C, P, Q],
+    defaultBranch: "main",
+    expected: { stackLabels: ["#1 → #3", "#20 → #21"], looseNumbers: [] },
+  },
+  {
+    name: "two independent stacks, interleaved input",
+    prs: [Q, B, A, P, C],
+    defaultBranch: "main",
+    expected: { stackLabels: ["#1 → #3", "#20 → #21"], looseNumbers: [] },
+  },
+  {
+    name: "all loose — every PR based on default branch",
+    prs: [
+      pr({ number: 30, head: "f1", base: "main" }),
+      pr({ number: 31, head: "f2", base: "main" }),
+      pr({ number: 32, head: "f3", base: "main" }),
+    ],
+    defaultBranch: "main",
+    expected: { stackLabels: [], looseNumbers: [30, 31, 32] },
+  },
+  {
+    name: "single non-default-based PR with no parent in the set stays loose",
+    prs: [pr({ number: 40, head: "feature", base: "missing-parent" })],
+    defaultBranch: "main",
+    expected: { stackLabels: [], looseNumbers: [40] },
+  },
+  {
+    name: "stack plus an unrelated loose PR",
+    prs: [A, B, C, pr({ number: 50, head: "solo", base: "main" })],
+    defaultBranch: "main",
+    expected: { stackLabels: ["#1 → #3"], looseNumbers: [50] },
+  },
+  {
+    name: "empty input",
+    prs: [],
+    defaultBranch: "main",
+    expected: { stackLabels: [], looseNumbers: [] },
+  },
+];
+
+describe("buildStacks", () => {
+  for (const c of cases) {
+    test(c.name, () => {
+      const { stacks, loose } = buildStacks(c.prs, c.defaultBranch);
+      expect(sorted(stacks.map((s) => s.label))).toEqual(sorted(c.expected.stackLabels));
+      expect(sortedNums(loose.map((pr) => pr.number))).toEqual(sortedNums(c.expected.looseNumbers));
+    });
+  }
+
+  test("stacks are ordered base → leaf with #base → #leaf labels", () => {
+    const { stacks } = buildStacks([C, A, B], "main");
+    expect(stacks).toHaveLength(1);
+    expect(stacks[0].prs.map((p) => p.number)).toEqual([1, 2, 3]);
+    expect(stacks[0].label).toBe("#1 → #3");
+  });
+
+  test("the base PR (base = default branch) is included in the stack", () => {
+    const { stacks, loose } = buildStacks([A, B, C], "main");
+    expect(loose).toHaveLength(0);
+    expect(stacks[0].prs.some((p) => p.number === 1)).toBe(true);
+  });
+
+  // The core invariant: grouping must not depend on the order the API returns
+  // PRs. Every permutation of the same stack must yield identical grouping.
+  test("every permutation of a 3-deep stack yields the same single stack", () => {
+    for (const perm of permutations([A, B, C])) {
+      const { stacks, loose } = buildStacks(perm, "main");
+      expect(stacks.map((s) => s.label)).toEqual(["#1 → #3"]);
+      expect(stacks[0].prs.map((p) => p.number)).toEqual([1, 2, 3]);
+      expect(loose).toHaveLength(0);
+    }
+  });
+
+  test("every permutation of a 4-deep stack yields the same single stack", () => {
+    for (const perm of permutations([W, X, Y, Z])) {
+      const { stacks, loose } = buildStacks(perm, "main");
+      expect(stacks.map((s) => s.label)).toEqual(["#10 → #13"]);
+      expect(stacks[0].prs.map((p) => p.number)).toEqual([10, 11, 12, 13]);
+      expect(loose).toHaveLength(0);
+    }
+  });
+
+  test("every permutation of two independent stacks yields the same grouping", () => {
+    for (const perm of permutations([A, B, C, P, Q])) {
+      const { stacks, loose } = buildStacks(perm, "main");
+      expect(sorted(stacks.map((s) => s.label))).toEqual(sorted(["#1 → #3", "#20 → #21"]));
+      expect(loose).toHaveLength(0);
+    }
+  });
+
+  // Cycles must not loop forever. A ↔ B (each based on the other's head) are
+  // neither leaves, so they never root a chain and fall through to loose.
+  test("a 2-cycle does not loop and lands in loose", () => {
+    const c1 = pr({ number: 60, head: "cy1", base: "cy2" });
+    const c2 = pr({ number: 61, head: "cy2", base: "cy1" });
+    const { stacks, loose } = buildStacks([c1, c2], "main");
+    expect(stacks).toHaveLength(0);
+    expect(sortedNums(loose.map((p) => p.number))).toEqual([60, 61]);
+  });
+
+  // A fork (one branch is the base of two PRs) must not double-count the shared
+  // ancestor or crash. It degrades to one stack plus a loose sibling.
+  test("a fork does not double-count the shared base", () => {
+    const root = pr({ number: 70, head: "root", base: "main" });
+    const child1 = pr({ number: 71, head: "child1", base: "root" });
+    const child2 = pr({ number: 72, head: "child2", base: "root" });
+    const { stacks, loose } = buildStacks([root, child1, child2], "main");
+    // Exactly one stack contains the root; the other child is loose.
+    const allStackNumbers = stacks.flatMap((s) => s.prs.map((p) => p.number));
+    expect(allStackNumbers.filter((n) => n === 70)).toHaveLength(1);
+    expect(stacks).toHaveLength(1);
+    expect(loose.map((p) => p.number)).toContain(72);
+  });
+});

--- a/apps/frontend/src/components/landing/buildStacks.ts
+++ b/apps/frontend/src/components/landing/buildStacks.ts
@@ -14,25 +14,41 @@ export interface PRStack {
  * `baseBranch → headBranch` edges. Rooting from leaves captures the full chain
  * in a single pass, so the grouping is independent of the order PRs arrive in.
  *
+ * Determinism is total — every output is independent of input array order:
+ *  - Candidate leaves are processed in ascending PR `number` order.
+ *  - `byHead` collisions (two PRs on the same head branch) resolve to the open
+ *    PR, then to the lower PR `number`.
+ *  - The returned `stacks` (by base PR `number`) and `loose` (by `number`) are
+ *    sorted before returning.
+ *
+ * Forks (two PRs sharing a base) are handled deterministically rather than
+ * merged: the shared ancestor joins exactly one chain — the one rooted at the
+ * lowest-numbered leaf — and the sibling leaf(s) fall through to `loose`. This
+ * is a deliberate "one child wins, the rest are loose" policy, not full fork
+ * collapse, but the *choice* of which child wins is now order-independent.
+ *
  * Output shape:
  *  - `stacks`: chains of length > 1, ordered base → leaf, labelled
- *    `#<first> → #<last>`.
- *  - `loose`: every PR not part of a multi-PR stack, in original input order.
+ *    `#<first> → #<last>`, sorted by the base PR's `number`.
+ *  - `loose`: every PR not part of a multi-PR stack, sorted by `number`.
  *
  * The base PR of a stack (whose base is the default branch) is included in the
  * stack via the walk. Single non-default-based PRs with no parent in the set,
  * and cycles, fall through to `loose`.
  */
-export function buildStacks(
-  prs: PRListItem[],
-  // Retained for signature/call-site compatibility. Leaf-rooting derives chain
-  // boundaries from the PR set itself (a base PR based on the default branch
-  // simply has no parent in `byHead`), so the default branch is not needed.
-  _defaultBranch: string,
-): { stacks: PRStack[]; loose: PRListItem[] } {
-  // headBranch → PR, so we can follow a PR's baseBranch to its parent PR.
+export function buildStacks(prs: PRListItem[]): {
+  stacks: PRStack[];
+  loose: PRListItem[];
+} {
+  // headBranch → PR, so we can follow a PR's baseBranch to its parent PR. When
+  // two PRs share a head branch (e.g. `state=all` returns a merged + an open PR
+  // on the same branch), keep a deterministic winner — prefer the open PR, then
+  // the lower PR number — so chain-following does not depend on input order.
   const byHead = new Map<string, PRListItem>();
-  for (const pr of prs) byHead.set(pr.headBranch, pr);
+  for (const pr of prs) {
+    const existing = byHead.get(pr.headBranch);
+    if (!existing || preferHead(pr, existing)) byHead.set(pr.headBranch, pr);
+  }
 
   // Every branch that some PR is based on. A PR is a leaf when its head branch
   // is not in this set — i.e. nothing in the set is stacked on top of it.
@@ -42,10 +58,14 @@ export function buildStacks(
   const stacked = new Set<string>();
   const chains: PRListItem[][] = [];
 
-  // Root each chain from a leaf and walk down toward its base. Iterating in
-  // input order keeps the result stable for a given input.
-  for (const leaf of prs) {
-    if (baseBranches.has(leaf.headBranch)) continue; // not a leaf
+  // Root each chain from a leaf and walk down toward its base. Leaves are
+  // visited in ascending PR-number order so that when two leaves share an
+  // ancestor (a fork), the lowest-numbered leaf deterministically claims it.
+  const leaves = prs
+    .filter((pr) => !baseBranches.has(pr.headBranch))
+    .sort((a, b) => a.number - b.number);
+
+  for (const leaf of leaves) {
     if (stacked.has(leaf.id)) continue;
 
     const chain: PRListItem[] = [];
@@ -59,16 +79,29 @@ export function buildStacks(
     if (chain.length > 1) {
       chains.push(chain);
     } else {
-      // A lone PR (no parent in the set) is not a stack — release it so it
+      // A lone PR (no parent in the set, or whose ancestor was already claimed
+      // by a lower-numbered fork sibling) is not a stack — release it so it
       // surfaces as loose, matching single-chain behaviour.
-      for (const pr of chain) stacked.delete(pr.id);
+      stacked.delete(chain[0].id);
     }
   }
 
-  const stacks = chains.map((chain) => ({
-    prs: chain,
-    label: `#${chain[0].number} → #${chain[chain.length - 1].number}`,
-  }));
-  const loose = prs.filter((pr) => !stacked.has(pr.id));
+  const stacks = chains
+    .map((chain) => ({
+      prs: chain,
+      label: `#${chain[0].number} → #${chain[chain.length - 1].number}`,
+    }))
+    .sort((a, b) => a.prs[0].number - b.prs[0].number);
+  const loose = prs
+    .filter((pr) => !stacked.has(pr.id))
+    .sort((a, b) => a.number - b.number);
   return { stacks, loose };
+}
+
+/** True when `candidate` should win a head-branch collision over `existing`. */
+function preferHead(candidate: PRListItem, existing: PRListItem): boolean {
+  const candidateOpen = candidate.state === "open";
+  const existingOpen = existing.state === "open";
+  if (candidateOpen !== existingOpen) return candidateOpen;
+  return candidate.number < existing.number;
 }

--- a/apps/frontend/src/components/landing/buildStacks.ts
+++ b/apps/frontend/src/components/landing/buildStacks.ts
@@ -1,0 +1,74 @@
+import type { PRListItem } from "../../daemon/contracts";
+
+export interface PRStack {
+  prs: PRListItem[];
+  label: string;
+}
+
+/**
+ * Group PRs into "stacks" — chains where each PR's base branch is the previous
+ * PR's head branch (rather than the repo default branch).
+ *
+ * Each chain is rooted at a *leaf* (a PR whose head branch is not any other
+ * PR's base branch) and walked downward toward its base, following
+ * `baseBranch → headBranch` edges. Rooting from leaves captures the full chain
+ * in a single pass, so the grouping is independent of the order PRs arrive in.
+ *
+ * Output shape:
+ *  - `stacks`: chains of length > 1, ordered base → leaf, labelled
+ *    `#<first> → #<last>`.
+ *  - `loose`: every PR not part of a multi-PR stack, in original input order.
+ *
+ * The base PR of a stack (whose base is the default branch) is included in the
+ * stack via the walk. Single non-default-based PRs with no parent in the set,
+ * and cycles, fall through to `loose`.
+ */
+export function buildStacks(
+  prs: PRListItem[],
+  // Retained for signature/call-site compatibility. Leaf-rooting derives chain
+  // boundaries from the PR set itself (a base PR based on the default branch
+  // simply has no parent in `byHead`), so the default branch is not needed.
+  _defaultBranch: string,
+): { stacks: PRStack[]; loose: PRListItem[] } {
+  // headBranch → PR, so we can follow a PR's baseBranch to its parent PR.
+  const byHead = new Map<string, PRListItem>();
+  for (const pr of prs) byHead.set(pr.headBranch, pr);
+
+  // Every branch that some PR is based on. A PR is a leaf when its head branch
+  // is not in this set — i.e. nothing in the set is stacked on top of it.
+  const baseBranches = new Set<string>();
+  for (const pr of prs) baseBranches.add(pr.baseBranch);
+
+  const stacked = new Set<string>();
+  const chains: PRListItem[][] = [];
+
+  // Root each chain from a leaf and walk down toward its base. Iterating in
+  // input order keeps the result stable for a given input.
+  for (const leaf of prs) {
+    if (baseBranches.has(leaf.headBranch)) continue; // not a leaf
+    if (stacked.has(leaf.id)) continue;
+
+    const chain: PRListItem[] = [];
+    let current: PRListItem | undefined = leaf;
+    while (current && !stacked.has(current.id)) {
+      chain.unshift(current);
+      stacked.add(current.id);
+      current = byHead.get(current.baseBranch);
+    }
+
+    if (chain.length > 1) {
+      chains.push(chain);
+    } else {
+      // A lone PR (no parent in the set) is not a stack — release it so it
+      // surfaces as loose, matching single-chain behaviour.
+      for (const pr of chain) stacked.delete(pr.id);
+    }
+  }
+
+  const stacks = chains.map((chain) => ({
+    prs: chain,
+    label: `#${chain[0].number} → #${chain[chain.length - 1].number}`,
+  }));
+  const loose = prs.filter((pr) => !stacked.has(pr.id));
+  return { stacks, loose };
+}

--- a/goals/frontend-session-lifecycle/backlog.md
+++ b/goals/frontend-session-lifecycle/backlog.md
@@ -130,7 +130,11 @@ Needs a more robust detection strategy — either try `glab auth status` first, 
 **Priority:** Low
 **Size:** Medium
 
-Fixed by extracting `buildStacks` into a pure module (`apps/frontend/src/components/landing/buildStacks.ts`) and rooting every chain from a leaf (a PR whose head branch is not any other PR's base branch), then walking down toward its base. A leaf-rooted walk captures the full chain in one pass regardless of input order, so multi-PR stacks no longer split into loose PRs depending on API return order. Pinned by a table-driven vitest suite (`buildStacks.test.ts`) asserting that every permutation of the same stack yields identical grouping, plus cycle and fork edge cases.
+Fixed by extracting `buildStacks` into a pure module (`apps/frontend/src/components/landing/buildStacks.ts`) and rooting every chain from a leaf (a PR whose head branch is not any other PR's base branch), then walking down toward its base. A leaf-rooted walk captures the full chain in one pass regardless of input order, so multi-PR stacks no longer split into loose PRs depending on API return order.
+
+The grouping is now fully order-independent — every tiebreak is deterministic rather than left to input order: candidate leaves are visited in ascending PR-number order, `byHead` collisions (two PRs on the same head branch, e.g. a merged + open pair from `state=all`) resolve to the open PR then the lower number, and the returned `stacks`/`loose` arrays are sorted (by base PR number and PR number respectively) so independent stacks never swap positions between 30s polls. Forks (two PRs sharing a base) are handled by a deterministic "one child wins" policy rather than full fork collapse: the shared ancestor joins the chain rooted at the lowest-numbered leaf and the sibling leaf falls through to `loose` — the *choice* of which child wins is order-independent, but it is not a merged fork view.
+
+Pinned by a table-driven vitest suite (`buildStacks.test.ts`) asserting that every permutation of the same input yields identical grouping *and* identical output ordering, including 2-cycle, leaf-into-cycle, fork, and duplicate-head edge cases.
 
 The original bug: `buildStacks` walked only downward and marked PRs consumed as it went, so a descendant discovered after its parent chain was built could not attach and was dumped into `loose`. Multi-PR stacks (3+) displayed as loose PRs depending on the order PRs arrived in.
 

--- a/goals/frontend-session-lifecycle/backlog.md
+++ b/goals/frontend-session-lifecycle/backlog.md
@@ -125,14 +125,14 @@ Needs a more robust detection strategy — either try `glab auth status` first, 
 
 ---
 
-## PR stack splitting is order-dependent
+## ~~PR stack splitting is order-dependent~~ DONE
 
 **Priority:** Low
 **Size:** Medium
 
-The `buildStacks` function in `LandingPage.tsx` walks PR chains by following `baseBranch` links. The algorithm processes PRs in API return order, which means if a middle PR is encountered before its descendants, the chain can be split incorrectly. Multi-PR stacks (3+) may display as loose PRs depending on timing.
+Fixed by extracting `buildStacks` into a pure module (`apps/frontend/src/components/landing/buildStacks.ts`) and rooting every chain from a leaf (a PR whose head branch is not any other PR's base branch), then walking down toward its base. A leaf-rooted walk captures the full chain in one pass regardless of input order, so multi-PR stacks no longer split into loose PRs depending on API return order. Pinned by a table-driven vitest suite (`buildStacks.test.ts`) asserting that every permutation of the same stack yields identical grouping, plus cycle and fork edge cases.
 
-Fix: build chains from leaves upward (start with PRs whose head branch isn't anyone else's base), or use a proper topological sort.
+The original bug: `buildStacks` walked only downward and marked PRs consumed as it went, so a descendant discovered after its parent chain was built could not attach and was dumped into `loose`. Multi-PR stacks (3+) displayed as loose PRs depending on the order PRs arrived in.
 
 ---
 


### PR DESCRIPTION
## The bug

`buildStacks` (project dashboard PR grouping in `LandingPage.tsx`) walked PR chains **only downward** (toward the base) and marked each PR consumed as it went. A descendant discovered *after* its parent chain was already built could not attach and was dumped into `loose`.

Concretely, a 3-deep stack `A(base=main) ← B(base=A) ← C(base=B)` grouped correctly **only** when the input arrived leaf-first (`[C, B, A]`). For base-first (`[A, B, C]`) or interleaved orderings, `B` was consumed into `[A, B]` first; then `C` walked down, hit already-consumed `B`, had length 1, and orphaned into `loose`. The grouping depended on the order the API returned PRs — which is wrong.

## The fix

Root every chain from a **leaf** — a PR whose `headBranch` is not any other PR's `baseBranch` — then walk **down** from each leaf following `baseBranch ← headBranch` edges. A leaf-rooted walk captures the full chain in **one pass regardless of input order**.

Output shape is unchanged:
- `stacks`: chains of length > 1, ordered base → leaf, labelled `#<base> → #<leaf>`.
- `loose`: everything else, in original input order.

The base PR (whose base is the default branch) is still included via the walk. Cycles fall through to `loose` (their members are never leaves, and the walk guard prevents infinite loops). Forks (a branch that is the base of two PRs) degrade to one stack plus a loose sibling without double-counting the shared ancestor.

To make it testable, `buildStacks` and the `PRStack` interface were extracted into a new pure module `apps/frontend/src/components/landing/buildStacks.ts` (no React imports). `LandingPage.tsx` now imports both; the call-site signature is unchanged.

## Test coverage

New table-driven vitest suite `apps/frontend/src/components/landing/buildStacks.test.ts`:
- 3-deep stack given leaf-first, base-first, and interleaved orderings → all produce the same single `#1 → #3` stack with 3 PRs.
- 4-deep stack (multiple orderings).
- Two independent stacks in one input.
- All-loose (every PR based on the default branch).
- A single non-default-based PR with no parent in the set → loose.
- Empty input.
- **Permutation-invariance:** every permutation of a 3-deep stack, a 4-deep stack, and two independent stacks yields identical grouping.
- Cycle (does not loop, lands in loose) and fork (no double-counted base) edge cases.

The suite was confirmed to **fail against the old downward-only algorithm** (12 failures, including the base-first 3-deep case) and **pass against the fix** (18 passing). A separate parity check over 2000 random leaf-first forests confirmed the new algorithm agrees with the old one wherever the old one was correct, i.e. the fix is a strict generalization.

## Verification

In `apps/frontend`:
- `bun run test` → 18 passed.
- `bun run typecheck` → exit 0 (the only diagnostic is a pre-existing `@vitest/browser-playwright` module-resolution error in `vitest.browser.config.ts`, present on the base branch and unrelated to this change).

Also marked the "PR stack splitting is order-dependent" backlog entry as DONE in `goals/frontend-session-lifecycle/backlog.md`.