### PR TITLE
Fix PR review reactivation posting against stale head commit

### DIFF
--- a/packages/server/daemon/session-factory.ts
+++ b/packages/server/daemon/session-factory.ts
@@ -724,6 +724,7 @@ export function createDaemonSessionFactory(options: DaemonSessionFactoryOptions)
         await existingReview.session.updateContent(
           input.prMetadata ? input.rawPatch : undefined,
           input.prMetadata ? input.gitRef : undefined,
+          input.prMetadata,
         );
         if (context.endpoint.isRemote && sharingEnabled) {
           existingReview.record.remoteShare = await createRemoteShareNotice(input.rawPatch, shareBaseUrl, "review changes", "diff only").catch(() => undefined);

--- a/packages/server/review.ts
+++ b/packages/server/review.ts
@@ -115,7 +115,7 @@ export interface ReviewSession {
   }>;
   setServerUrl: (url: string) => void;
   dispose: () => void;
-  updateContent?: (precomputedPatch?: string, precomputedGitRef?: string) => Promise<void>;
+  updateContent?: (precomputedPatch?: string, precomputedGitRef?: string, newPrMetadata?: PRMetadata) => Promise<void>;
   getSnapshot?: () => unknown;
 }
 
@@ -1156,7 +1156,7 @@ export async function createReviewSession(
   const exitHandler = () => agentJobs.killAll();
   process.once("exit", exitHandler);
 
-  async function handleUpdateContent(precomputedPatch?: string, precomputedGitRef?: string) {
+  async function handleUpdateContent(precomputedPatch?: string, precomputedGitRef?: string, newPrMetadata?: PRMetadata) {
     let patch: string;
     let label: string;
     if (precomputedPatch !== undefined) {
@@ -1173,6 +1173,31 @@ export async function createReviewSession(
     }
     currentPatch = patch;
     currentGitRef = label;
+    // When the agent resubmits a PR review (same PR, new commits pushed), the
+    // session is reactivated in place. Refresh the PR metadata so platform
+    // actions (approve / comment) target the CURRENT head commit instead of the
+    // SHA captured when the session was first created — otherwise we'd approve a
+    // stale commit (GitHub) or 409 on a SHA mismatch (GitLab). Mirrors the
+    // refresh in /api/pr-switch. Only fires in PR mode with fresh metadata.
+    if (newPrMetadata && isPRMode) {
+      prMetadata = newPrMetadata;
+      prRef = prRefFromMetadata(newPrMetadata);
+      // The submit path (/api/pr-action) resolves the target head SHA from
+      // prSwitchCache (keyed by PR url) — even for the current PR, since the
+      // client always sends `targetPrUrl`. Refresh that entry too, or approve/
+      // comment would still post against the stale creation-time SHA.
+      prSwitchCache.set(newPrMetadata.url, { metadata: newPrMetadata, rawPatch: patch });
+      originalPRPatch = patch;
+      originalPRGitRef = label;
+      originalPRError = currentError;
+      currentPRDiffScope = "layer";
+      prListCache = null;
+      prStackInfo = getPRStackInfo(newPrMetadata);
+      repoInfo = {
+        display: getDisplayRepo(newPrMetadata),
+        branch: `${getMRLabel(newPrMetadata)} ${getMRNumberLabel(newPrMetadata)}`,
+      };
+    }
     lastDecision = null;
     externalAnnotations.clearAll();
     editorAnnotations.clearAll();


### PR DESCRIPTION
## What

When a PR review session is **reactivated** (the agent resubmits the same PR after pushing new commits — matched by `review:${prUrl}`), the daemon refreshed the diff shown to the user but **not** the PR metadata. So approve/comment posted against the head SHA captured when the session was first created:
- **GitHub:** silently approves/comments against the *stale* commit.
- **GitLab:** 409 Conflict (the approve API rejects a SHA that isn't current HEAD).

This is the **P1** "PR reviews keep stale metadata on reuse" item in `goals/session-persistence/decisions.md`, plus the related **P2** "PR diff scope/baseline not reset on reuse."

## Fix

Thread the freshly-fetched `prMetadata` (the factory already re-fetches it on every resubmit) into `review.ts`'s `handleUpdateContent`, which now refreshes the closure state the same way `/api/pr-switch` already does: `prMetadata`, `prRef`, `originalPRPatch/GitRef/Error`, `currentPRDiffScope`, `prListCache`, `prStackInfo`, `repoInfo`.

**Key subtlety (caught in adversarial review):** the submit path (`/api/pr-action`) resolves the target head SHA from `prSwitchCache` (keyed by PR url), not from `prMetadata` directly — and the client always sends `targetPrUrl` even for the current PR. So the refresh must also update the `prSwitchCache` entry, or the fix would be a no-op for the common approve/comment path. That's included.

Files: `packages/server/review.ts`, `packages/server/daemon/session-factory.ts`.

## Verification

- Root `bun run typecheck` clean (all packages).
- `session-factory` tests 14/0.
- Reviewed adversarially (Opus) — the review caught the `prSwitchCache` gap, which is fixed here; re-verified after.

## Known limitation (not fixed here)

The `session-revision` WebSocket event still carries only `{ rawPatch, gitRef }`, so the browser's PR header (title/labels) can show stale text until refresh. This is **cosmetic** — the submit resolves the head SHA server-side, so correctness is unaffected. Logged as a follow-up.