### PR TITLE
Fix Mermaid block sizing, zoom retention, and pinpoint drag

### DIFF
--- a/packages/ui/components/MermaidBlock.test.ts
+++ b/packages/ui/components/MermaidBlock.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { normalizeMermaidSvgMarkup } from './MermaidBlock';
+import { normalizeMermaidSvgMarkup } from './mermaidSvg';
 
 describe('normalizeMermaidSvgMarkup', () => {
   test('replaces natural max-width with max-width:none', () => {

--- a/packages/ui/components/MermaidBlock.test.ts
+++ b/packages/ui/components/MermaidBlock.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'bun:test';
+import { normalizeMermaidSvgMarkup } from './MermaidBlock';
+
+describe('normalizeMermaidSvgMarkup', () => {
+  test('replaces natural max-width with max-width:none', () => {
+    const input = '<svg style="max-width: 85.125px;" viewBox="0 0 346 278" width="100%"><g/></svg>';
+    const expected =
+      '<svg style="max-width: none" viewBox="0 0 346 278" width="100%" preserveAspectRatio="xMidYMid meet" height="100%"><g/></svg>';
+
+    expect(normalizeMermaidSvgMarkup(input)).toBe(expected);
+  });
+
+  test('adds preserveAspectRatio when missing', () => {
+    const input = '<svg viewBox="0 0 1 1"></svg>';
+    const expected =
+      '<svg viewBox="0 0 1 1" style="max-width: none" preserveAspectRatio="xMidYMid meet" height="100%"></svg>';
+
+    expect(normalizeMermaidSvgMarkup(input)).toBe(expected);
+  });
+
+  test('adds height=100% when missing', () => {
+    const input = '<svg viewBox="0 0 1 1" preserveAspectRatio="none"></svg>';
+    const expected =
+      '<svg viewBox="0 0 1 1" preserveAspectRatio="none" style="max-width: none" height="100%"></svg>';
+
+    expect(normalizeMermaidSvgMarkup(input)).toBe(expected);
+  });
+
+  test('preserves existing preserveAspectRatio and height', () => {
+    const input = '<svg viewBox="0 0 1 1" preserveAspectRatio="none" height="200"></svg>';
+    const expected =
+      '<svg viewBox="0 0 1 1" preserveAspectRatio="none" height="200" style="max-width: none"></svg>';
+
+    expect(normalizeMermaidSvgMarkup(input)).toBe(expected);
+  });
+
+  test('injects style attribute when mermaid omits one', () => {
+    const input = '<svg viewBox="0 0 1 1" width="100%"></svg>';
+    const expected =
+      '<svg viewBox="0 0 1 1" width="100%" style="max-width: none" preserveAspectRatio="xMidYMid meet" height="100%"></svg>';
+
+    expect(normalizeMermaidSvgMarkup(input)).toBe(expected);
+  });
+
+  test('only normalizes the root <svg> tag', () => {
+    const input =
+      '<svg style="max-width: 100px;" viewBox="0 0 1 1"><defs><marker><svg viewBox="0 0 5 5"/></marker></defs></svg>';
+    const expected =
+      '<svg style="max-width: none" viewBox="0 0 1 1" preserveAspectRatio="xMidYMid meet" height="100%"><defs><marker><svg viewBox="0 0 5 5"/></marker></defs></svg>';
+
+    expect(normalizeMermaidSvgMarkup(input)).toBe(expected);
+  });
+
+  test('leaves non-svg input unchanged', () => {
+    const input = 'plain text';
+    const expected = 'plain text';
+
+    expect(normalizeMermaidSvgMarkup(input)).toBe(expected);
+  });
+});

--- a/packages/ui/components/MermaidBlock.tsx
+++ b/packages/ui/components/MermaidBlock.tsx
@@ -57,6 +57,36 @@ function parseViewBox(svgEl: SVGSVGElement): ViewBox | null {
   return { x, y, width, height };
 }
 
+// Bake sizing attrs into the SVG markup so they survive repeated
+// dangerouslySetInnerHTML re-injection — imperative setAttribute gets wiped.
+export function normalizeMermaidSvgMarkup(markup: string): string {
+  return markup.replace(/<svg\b([^>]*)>/i, (_match, attrs: string) => {
+    let next = attrs;
+
+    if (/\bstyle\s*=\s*"/i.test(next)) {
+      next = next.replace(/\bstyle\s*=\s*"([^"]*)"/i, (_m, styleVal: string) => {
+        const rules = styleVal
+          .split(';')
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0 && !/^max-width\s*:/i.test(s));
+        rules.push('max-width: none');
+        return `style="${rules.join('; ')}"`;
+      });
+    } else {
+      next += ' style="max-width: none"';
+    }
+
+    if (!/\bpreserveAspectRatio\s*=/i.test(next)) {
+      next += ' preserveAspectRatio="xMidYMid meet"';
+    }
+    if (!/\bheight\s*=/i.test(next)) {
+      next += ' height="100%"';
+    }
+
+    return `<svg${next}>`;
+  });
+}
+
 // Parse base viewBox from Mermaid SVG markup before DOM mount
 function parseViewBoxFromMarkup(markup: string): ViewBox | null {
   const viewBoxMatch = markup.match(/viewBox\s*=\s*"([^"]+)"/i);
@@ -191,8 +221,9 @@ export const MermaidBlock: React.FC<{ block: Block }> = ({ block }) => {
         const id = `mermaid-${block.id}`;
         const { svg: renderedSvg } = await mermaid.render(id, block.content);
         if (!cancelled) {
-          naturalBoundsRef.current = parseViewBoxFromMarkup(renderedSvg);
-          setSvg(renderedSvg);
+          const normalizedSvg = normalizeMermaidSvgMarkup(renderedSvg);
+          naturalBoundsRef.current = parseViewBoxFromMarkup(normalizedSvg);
+          setSvg(normalizedSvg);
           setError(null);
         }
       } catch (err) {

--- a/packages/ui/components/MermaidBlock.tsx
+++ b/packages/ui/components/MermaidBlock.tsx
@@ -157,7 +157,7 @@ function fitBoundsToContainer(bounds: ViewBox, containerRect: DOMRect): ViewBox 
 /**
  * Renders a mermaid diagram block with zoom controls.
  */
-export const MermaidBlock: React.FC<{ block: Block }> = ({ block }) => {
+const MermaidBlockImpl: React.FC<{ block: Block }> = ({ block }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const expandedOverlayRef = useRef<HTMLDivElement>(null);
   const [svg, setSvg] = useState('');
@@ -598,3 +598,10 @@ export const MermaidBlock: React.FC<{ block: Block }> = ({ block }) => {
     </>
   );
 };
+
+export const MermaidBlock = React.memo(
+  MermaidBlockImpl,
+  (prev, next) =>
+    prev.block.id === next.block.id &&
+    prev.block.content === next.block.content,
+);

--- a/packages/ui/components/MermaidBlock.tsx
+++ b/packages/ui/components/MermaidBlock.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useState, useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import mermaid from 'mermaid';
 import type { Block } from '../types';
+import { normalizeMermaidSvgMarkup } from './mermaidSvg';
 
 mermaid.initialize({
   startOnLoad: false,
@@ -55,36 +56,6 @@ function parseViewBox(svgEl: SVGSVGElement): ViewBox | null {
   const [x, y, width, height] = values;
   if (width <= 0 || height <= 0) return null;
   return { x, y, width, height };
-}
-
-// Bake sizing attrs into the SVG markup so they survive repeated
-// dangerouslySetInnerHTML re-injection — imperative setAttribute gets wiped.
-export function normalizeMermaidSvgMarkup(markup: string): string {
-  return markup.replace(/<svg\b([^>]*)>/i, (_match, attrs: string) => {
-    let next = attrs;
-
-    if (/\bstyle\s*=\s*"/i.test(next)) {
-      next = next.replace(/\bstyle\s*=\s*"([^"]*)"/i, (_m, styleVal: string) => {
-        const rules = styleVal
-          .split(';')
-          .map((s) => s.trim())
-          .filter((s) => s.length > 0 && !/^max-width\s*:/i.test(s));
-        rules.push('max-width: none');
-        return `style="${rules.join('; ')}"`;
-      });
-    } else {
-      next += ' style="max-width: none"';
-    }
-
-    if (!/\bpreserveAspectRatio\s*=/i.test(next)) {
-      next += ' preserveAspectRatio="xMidYMid meet"';
-    }
-    if (!/\bheight\s*=/i.test(next)) {
-      next += ' height="100%"';
-    }
-
-    return `<svg${next}>`;
-  });
 }
 
 // Parse base viewBox from Mermaid SVG markup before DOM mount

--- a/packages/ui/components/MermaidBlock.tsx
+++ b/packages/ui/components/MermaidBlock.tsx
@@ -559,6 +559,7 @@ const MermaidBlockImpl: React.FC<{ block: Block }> = ({ block }) => {
   const diagramBody = (
     <div
       ref={containerRef}
+      data-pinpoint-ignore=""
       className={`rounded-xl bg-muted/30 border border-border/30 overflow-hidden select-none cursor-grab ${isExpanded ? 'h-full min-h-0' : 'h-[min(65vh,36rem)] min-h-[20rem]'}`}
       dangerouslySetInnerHTML={{ __html: svg }}
       onMouseDown={handleMouseDown}

--- a/packages/ui/components/mermaidSvg.ts
+++ b/packages/ui/components/mermaidSvg.ts
@@ -1,0 +1,33 @@
+// Pure SVG-markup helpers for MermaidBlock. Kept free of React and the
+// mermaid library so they can be unit-tested without loading mermaid's
+// browser-only `initialize()` (which throws in headless test environments).
+
+// Bake sizing attrs into the SVG markup so they survive repeated
+// dangerouslySetInnerHTML re-injection — imperative setAttribute gets wiped.
+export function normalizeMermaidSvgMarkup(markup: string): string {
+  return markup.replace(/<svg\b([^>]*)>/i, (_match, attrs: string) => {
+    let next = attrs;
+
+    if (/\bstyle\s*=\s*"/i.test(next)) {
+      next = next.replace(/\bstyle\s*=\s*"([^"]*)"/i, (_m, styleVal: string) => {
+        const rules = styleVal
+          .split(';')
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0 && !/^max-width\s*:/i.test(s));
+        rules.push('max-width: none');
+        return `style="${rules.join('; ')}"`;
+      });
+    } else {
+      next += ' style="max-width: none"';
+    }
+
+    if (!/\bpreserveAspectRatio\s*=/i.test(next)) {
+      next += ' preserveAspectRatio="xMidYMid meet"';
+    }
+    if (!/\bheight\s*=/i.test(next)) {
+      next += ' height="100%"';
+    }
+
+    return `<svg${next}>`;
+  });
+}


### PR DESCRIPTION
I've been a regular user of Plannotator and have been actively recommending it to my team as well. While using it, I came across a bug related to Mermaid, so I decided to submit a PR to fix it.

## Summary

This PR bundles fixes for several regressions in `packages/ui/components/MermaidBlock.tsx`. They share a single root cause — the parent component re-injects the rendered SVG via `dangerouslySetInnerHTML` 4–5 times during mount and again on every parent re-render. Each re-injection wipes any imperative DOM attribute changes the component made after render (sizing, viewBox, etc.).

Each scenario is shipped as its own commit so the bug → fix mapping is reviewable independently.

| # | Scenario | Fix | Commit |
|---|----------|-----|--------|
| 1 | At-rest SVG sizing attrs wiped by re-injection (short diagrams render as a "dot", long diagrams overflow vertically with the wrong height) | Bake sizing attrs into the SVG markup string | https://github.com/backnotprop/plannotator/pull/819/commits/faad82cceb39c182341d625e05a35edcd1ea31b4 |
| 2 | Parent-tree re-renders unrelated to Pinpoint (sidebar toggle, selecting another block, etc.) reset the live Mermaid state (zoomed viewBox, pan, etc.) to the natural viewBox | Wrap `MermaidBlock` in `React.memo` | https://github.com/backnotprop/plannotator/pull/819/commits/c9daf7e016c982519b32c0502eb4e80ed3b29a69 |
| 3 | In Pinpoint mode, releasing a pan-drag inside a Mermaid block creates an unwanted whole-block annotation | `data-pinpoint-ignore=""` on the grab container | https://github.com/backnotprop/plannotator/pull/819/commits/8ad6c44163db0d57034eb51f0586155c4972fe6d |

The fixture diagrams used for testing can be reproduced via this [shared link](https://share.plannotator.ai/#fVbtbho5FH2Vq1RapVLbVUjSSv2x0QCBZpsPGpK0XQcpxr4wVjz2yPZAKVTah9gn3CdZXXtmgK7UPwj7nrkfx_cee31QHrw_eAFX6AquJDygC0pwDQNtlyLnLsAd-vBoHk0G0oqqQBMgWFigU7MV5HYJI82NsYEH68Chkeg8cAJET3oF2po5zBqHb8jZixcwVnNTlfAb3Jip5U4qM49R4fCu_5IwT09PRUrr0cy26fQfDQBAxu49Olgor4IHrwJO4PXrP6C7zrRDLlfgcK58QIfy7Ef6pkuIzTUuofLoNtBj5yagAyy40pNdzPk35YMy8w302aWdKwNeOERTg3ox1Dkbo5GJCiV4UNbsuTqPqMH6IQK2aQxiiK_oNzBkYwxQcu-X1snJrv3abuADGxPDDj0FKp0tylCDPqQU0mIYFxdsoLQm2ExprHEX0fQnGynxDIrKRR98bfwzGj-ynjUzNa8cgrGhLaZBfYyoSzYOdAChCtYp3hR5GY1XNZO5LXCfqn60X687gwzQ8Kne8nC95eGm_v7mbjTZNRIJV2njJjoaJTZXhKzdjCJyXAmB3rfwtDvgSlcON_CpYTK41T6Rn6Lfm7S4iotbdhv7GCT3eWzOGnsbzWN2abkEh8IWBQElCGsCmsblOMLuasK4CGqhwgqC4-JZmXmNuouoe_YRsQSP3lP_cK0WzdHdR8DD-tLObRUa1h62rH1m50Y2n052zcTbfdr4HL18YfW80SSBsEWpMVCgp6eneiB7OYpnWwUYqRK1MgiHM-sEynaWfzWW3bp0KvmQ3Tiiz9MC5eTlji1mkx2xW1woXILgrmEtO0q2Tt0LPldlSarApXTom27MOgl2nFq6RdkybFnIjhPoJIFKvorCVWDIbXOY2UnCnK5He-aa5-w0MtlzKFWgPOUGukd1brQEiYEr3eaV8J-51hg20O2w9Bd4FfJ9TJebZ-oG42ckQ91jNkaNIsCUm-dGhxIbvSN23B_vaUwDSDz0OqyrbIHBKbEbqpsY6B3_b7J6yXOf9bjWMBo228lfLa-9491VGuLzdVaF3Dr1PebxY0flNllZOrtAuYHBUZITV4ClLtgVw00fBXUWwTppImdpQqFA7_m8af1BynF4xPooHMbTUWaBJli3qjHDGtNhPYc8YAoXx7Id2GEqanjMLryvkIyo2tEfpiKHJ0nIReWDLX66D4apS4anbIgGHcVpW07zKba404R7yz5wI8HOZnRNLrnD3Fa-qWv4NqHebb01qgDCyhb2LhFuZDNK7cTWszRIhd2Snq3jb6MPcbHViOzk523Shh43AnXrPK50mtStIHStXEHAbwE8Cjpx2r_LlW_WgHRN-p_eAyFHUliPMEUSG54eAFLxueMFTDHnC_Tw79__wDLHkKOLnzR25UFoVZYoX7V2L5zVWtXPCA-Gh8rR2-IVENm7bqZt0o6O0Xjg8WJQU43x6fEaLvxeQNJurgzdXqjmOc06RT8jaBavRIltTme1g-_WFr-X3ABfcKXpWouWvkW_ky25VqZC8IW1IdcruoHtNk8-C_vVn1GGI43cIwjS42hUAQsPfGoX2L6ecutCW8IhBXL2lwJdj_KX2Ddf4-9f7WmnU93zqRJLtWcQlNLMpk7kTnlr3jyag1cH_OA9m_z4Dw).

---

## Scenario 1 — At-rest SVG sizing attrs wiped by re-injection

### How to reproduce

1. Open the [shared link](https://share.plannotator.ai/#fVbtbho5FH2Vq1RapVLbVUjSSv2x0QCBZpsPGpK0XQcpxr4wVjz2yPZAKVTah9gn3CdZXXtmgK7UPwj7nrkfx_cee31QHrw_eAFX6AquJDygC0pwDQNtlyLnLsAd-vBoHk0G0oqqQBMgWFigU7MV5HYJI82NsYEH68Chkeg8cAJET3oF2po5zBqHb8jZixcwVnNTlfAb3Jip5U4qM49R4fCu_5IwT09PRUrr0cy26fQfDQBAxu49Olgor4IHrwJO4PXrP6C7zrRDLlfgcK58QIfy7Ef6pkuIzTUuofLoNtBj5yagAyy40pNdzPk35YMy8w302aWdKwNeOERTg3ox1Dkbo5GJCiV4UNbsuTqPqMH6IQK2aQxiiK_oNzBkYwxQcu-X1snJrv3abuADGxPDDj0FKp0tylCDPqQU0mIYFxdsoLQm2ExprHEX0fQnGynxDIrKRR98bfwzGj-ynjUzNa8cgrGhLaZBfYyoSzYOdAChCtYp3hR5GY1XNZO5LXCfqn60X687gwzQ8Kne8nC95eGm_v7mbjTZNRIJV2njJjoaJTZXhKzdjCJyXAmB3rfwtDvgSlcON_CpYTK41T6Rn6Lfm7S4iotbdhv7GCT3eWzOGnsbzWN2abkEh8IWBQElCGsCmsblOMLuasK4CGqhwgqC4-JZmXmNuouoe_YRsQSP3lP_cK0WzdHdR8DD-tLObRUa1h62rH1m50Y2n052zcTbfdr4HL18YfW80SSBsEWpMVCgp6eneiB7OYpnWwUYqRK1MgiHM-sEynaWfzWW3bp0KvmQ3Tiiz9MC5eTlji1mkx2xW1woXILgrmEtO0q2Tt0LPldlSarApXTom27MOgl2nFq6RdkybFnIjhPoJIFKvorCVWDIbXOY2UnCnK5He-aa5-w0MtlzKFWgPOUGukd1brQEiYEr3eaV8J-51hg20O2w9Bd4FfJ9TJebZ-oG42ckQ91jNkaNIsCUm-dGhxIbvSN23B_vaUwDSDz0OqyrbIHBKbEbqpsY6B3_b7J6yXOf9bjWMBo228lfLa-9491VGuLzdVaF3Dr1PebxY0flNllZOrtAuYHBUZITV4ClLtgVw00fBXUWwTppImdpQqFA7_m8af1BynF4xPooHMbTUWaBJli3qjHDGtNhPYc8YAoXx7Id2GEqanjMLryvkIyo2tEfpiKHJ0nIReWDLX66D4apS4anbIgGHcVpW07zKba404R7yz5wI8HOZnRNLrnD3Fa-qWv4NqHebb01qgDCyhb2LhFuZDNK7cTWszRIhd2Snq3jb6MPcbHViOzk523Shh43AnXrPK50mtStIHStXEHAbwE8Cjpx2r_LlW_WgHRN-p_eAyFHUliPMEUSG54eAFLxueMFTDHnC_Tw79__wDLHkKOLnzR25UFoVZYoX7V2L5zVWtXPCA-Gh8rR2-IVENm7bqZt0o6O0Xjg8WJQU43x6fEaLvxeQNJurgzdXqjmOc06RT8jaBavRIltTme1g-_WFr-X3ABfcKXpWouWvkW_ky25VqZC8IW1IdcruoHtNk8-C_vVn1GGI43cIwjS42hUAQsPfGoX2L6ecutCW8IhBXL2lwJdj_KX2Ddf4-9f7WmnU93zqRJLtWcQlNLMpk7kTnlr3jyag1cH_OA9m_z4Dw), or any equivalent markdown with three Mermaid blocks: a short `flowchart LR  X --> Y --> Z`, a long top-down checkout flow, and a top-down signup flow.
2. Run `plannotator annotate <file>` and wait for the editor to mount.
3. Observe the three blocks at rest (no interaction) — the short diagram renders as a tiny "dot" (85 × 66 px), and the long diagram overflows its container vertically with the wrong height (498 × 1667 px).

### As-is vs to-be

| As-is (pre-fix) | To-be (post-fix) |
|---|---|
| <img width="659" height="738" alt="wrong height as-is" src="https://github.com/user-attachments/assets/6d321a86-72fb-4709-9585-e649f545b8e0" /> | <img width="728" height="760" alt="wrong height to-be" src="https://github.com/user-attachments/assets/b13cce96-3d80-4678-b0ff-513bd64175c6" /> |

### Fix

Mermaid 11.x emits the root `<svg>` with `style="max-width: <natural-px>;"`, `width="100%"`, a `viewBox`, and **no** `preserveAspectRatio` / `height`. The component previously corrected this in a `useEffect` via `setAttribute`, but the parent's `dangerouslySetInnerHTML` re-injects the cached markup 4–5 times during mount; each re-injection replaces the live `<svg>` with the original Mermaid string, wiping the imperative attrs. The `useEffect` only runs once because its `svg` state dep does not change between re-injections.

The fix normalizes the rendered SVG string before storing it in state: `max-width: none`, `preserveAspectRatio="xMidYMid meet"`, and `height="100%"` are baked into the markup itself, so every re-injection carries them along. The imperative `useEffect` is kept as defense-in-depth.

A unit test (`packages/ui/components/MermaidBlock.test.ts`, 7 cases) covers the regex normalization end-to-end including the edge cases (existing styles preserved, no style attr present, nested `<svg>` inside `<marker>` untouched, non-SVG input passes through).

### Commit

https://github.com/backnotprop/plannotator/pull/819/commits/faad82cceb39c182341d625e05a35edcd1ea31b4 — Pin Mermaid SVG sizing attrs into markup so they survive re-injection

---

## Scenario 2 — Parent-tree re-renders (Pinpoint-unrelated) reset the live Mermaid state

When the parent component (e.g. Viewer) re-renders for any reason, MermaidBlock's `dangerouslySetInnerHTML` is re-run against the cached markup string, and any state held only on the live DOM via `setAttribute` (zoomed viewBox, pan position) snaps back to the natural Mermaid viewBox stored in the markup. The zoom *ref* is kept in React state so the badge still reads correctly, but the SVG attribute is silently reset on every re-injection.

This scenario covers re-render triggers **unrelated to Pinpoint** — sidebar toggles, selecting another block, arbitrary parent state changes.

### How to reproduce

1. Open the [shared link](https://share.plannotator.ai/#fVbtbho5FH2Vq1RapVLbVUjSSv2x0QCBZpsPGpK0XQcpxr4wVjz2yPZAKVTah9gn3CdZXXtmgK7UPwj7nrkfx_cee31QHrw_eAFX6AquJDygC0pwDQNtlyLnLsAd-vBoHk0G0oqqQBMgWFigU7MV5HYJI82NsYEH68Chkeg8cAJET3oF2po5zBqHb8jZixcwVnNTlfAb3Jip5U4qM49R4fCu_5IwT09PRUrr0cy26fQfDQBAxu49Olgor4IHrwJO4PXrP6C7zrRDLlfgcK58QIfy7Ef6pkuIzTUuofLoNtBj5yagAyy40pNdzPk35YMy8w302aWdKwNeOERTg3ox1Dkbo5GJCiV4UNbsuTqPqMH6IQK2aQxiiK_oNzBkYwxQcu-X1snJrv3abuADGxPDDj0FKp0tylCDPqQU0mIYFxdsoLQm2ExprHEX0fQnGynxDIrKRR98bfwzGj-ynjUzNa8cgrGhLaZBfYyoSzYOdAChCtYp3hR5GY1XNZO5LXCfqn60X687gwzQ8Kne8nC95eGm_v7mbjTZNRIJV2njJjoaJTZXhKzdjCJyXAmB3rfwtDvgSlcON_CpYTK41T6Rn6Lfm7S4iotbdhv7GCT3eWzOGnsbzWN2abkEh8IWBQElCGsCmsblOMLuasK4CGqhwgqC4-JZmXmNuouoe_YRsQSP3lP_cK0WzdHdR8DD-tLObRUa1h62rH1m50Y2n052zcTbfdr4HL18YfW80SSBsEWpMVCgp6eneiB7OYpnWwUYqRK1MgiHM-sEynaWfzWW3bp0KvmQ3Tiiz9MC5eTlji1mkx2xW1woXILgrmEtO0q2Tt0LPldlSarApXTom27MOgl2nFq6RdkybFnIjhPoJIFKvorCVWDIbXOY2UnCnK5He-aa5-w0MtlzKFWgPOUGukd1brQEiYEr3eaV8J-51hg20O2w9Bd4FfJ9TJebZ-oG42ckQ91jNkaNIsCUm-dGhxIbvSN23B_vaUwDSDz0OqyrbIHBKbEbqpsY6B3_b7J6yXOf9bjWMBo228lfLa-9491VGuLzdVaF3Dr1PebxY0flNllZOrtAuYHBUZITV4ClLtgVw00fBXUWwTppImdpQqFA7_m8af1BynF4xPooHMbTUWaBJli3qjHDGtNhPYc8YAoXx7Id2GEqanjMLryvkIyo2tEfpiKHJ0nIReWDLX66D4apS4anbIgGHcVpW07zKba404R7yz5wI8HOZnRNLrnD3Fa-qWv4NqHebb01qgDCyhb2LhFuZDNK7cTWszRIhd2Snq3jb6MPcbHViOzk523Shh43AnXrPK50mtStIHStXEHAbwE8Cjpx2r_LlW_WgHRN-p_eAyFHUliPMEUSG54eAFLxueMFTDHnC_Tw79__wDLHkKOLnzR25UFoVZYoX7V2L5zVWtXPCA-Gh8rR2-IVENm7bqZt0o6O0Xjg8WJQU43x6fEaLvxeQNJurgzdXqjmOc06RT8jaBavRIltTme1g-_WFr-X3ABfcKXpWouWvkW_ky25VqZC8IW1IdcruoHtNk8-C_vVn1GGI43cIwjS42hUAQsPfGoX2L6ecutCW8IhBXL2lwJdj_KX2Ddf4-9f7WmnU93zqRJLtWcQlNLMpk7kTnlr3jyag1cH_OA9m_z4Dw) and zoom in (or pan) a Mermaid block so its live viewBox differs from the natural one. **Pinpoint mode is left off.**
2. Trigger any action that causes the parent Viewer to re-render — toggle the sidebar, select another block, etc.
3. Observe that the Mermaid block snaps back to the natural viewBox.

### As-is vs to-be

| As-is (pre-fix) | To-be (post-fix) |
|---|---|
| <video src="https://github.com/user-attachments/assets/79563bcb-e3f4-49c3-b082-95f64df1baa2" controls></video> | <video src="https://github.com/user-attachments/assets/17a80bf0-c385-4987-9e72-2ed83c069b6d" controls></video> |

### Fix

Wrap `MermaidBlock` in `React.memo` with a custom comparator on `block.id` + `block.content`. This matches the convention `HtmlBlock` already uses in the same package. The upstream `blocks` array comes from `useMemo([markdown])` in the editor App (`packages/editor/App.tsx`), so referential equality holds as long as the markdown is unchanged — memo bails out of the re-render, the `dangerouslySetInnerHTML` is not re-run, and the live SVG state is preserved regardless of the trigger.

### Commit

https://github.com/backnotprop/plannotator/pull/819/commits/c9daf7e016c982519b32c0502eb4e80ed3b29a69 — Memoize MermaidBlock to preserve zoomed viewBox across pinpoint hover

---

## Scenario 3 — Whole-block annotation on Pinpoint drag release

When Pinpoint mode is on and the user drags inside a Mermaid block, releasing the drag fires a synthetic `click` after `mouseup`. The Pinpoint overlay's click handler catches the synthetic click and calls `highlighter.fromRange()` over the entire Mermaid block, creating an unwanted whole-block annotation.

### How to reproduce

1. Open the [shared link](https://share.plannotator.ai/#fVbtbho5FH2Vq1RapVLbVUjSSv2x0QCBZpsPGpK0XQcpxr4wVjz2yPZAKVTah9gn3CdZXXtmgK7UPwj7nrkfx_cee31QHrw_eAFX6AquJDygC0pwDQNtlyLnLsAd-vBoHk0G0oqqQBMgWFigU7MV5HYJI82NsYEH68Chkeg8cAJET3oF2po5zBqHb8jZixcwVnNTlfAb3Jip5U4qM49R4fCu_5IwT09PRUrr0cy26fQfDQBAxu49Olgor4IHrwJO4PXrP6C7zrRDLlfgcK58QIfy7Ef6pkuIzTUuofLoNtBj5yagAyy40pNdzPk35YMy8w302aWdKwNeOERTg3ox1Dkbo5GJCiV4UNbsuTqPqMH6IQK2aQxiiK_oNzBkYwxQcu-X1snJrv3abuADGxPDDj0FKp0tylCDPqQU0mIYFxdsoLQm2ExprHEX0fQnGynxDIrKRR98bfwzGj-ynjUzNa8cgrGhLaZBfYyoSzYOdAChCtYp3hR5GY1XNZO5LXCfqn60X687gwzQ8Kne8nC95eGm_v7mbjTZNRIJV2njJjoaJTZXhKzdjCJyXAmB3rfwtDvgSlcON_CpYTK41T6Rn6Lfm7S4iotbdhv7GCT3eWzOGnsbzWN2abkEh8IWBQElCGsCmsblOMLuasK4CGqhwgqC4-JZmXmNuouoe_YRsQSP3lP_cK0WzdHdR8DD-tLObRUa1h62rH1m50Y2n052zcTbfdr4HL18YfW80SSBsEWpMVCgp6eneiB7OYpnWwUYqRK1MgiHM-sEynaWfzWW3bp0KvmQ3Tiiz9MC5eTlji1mkx2xW1woXILgrmEtO0q2Tt0LPldlSarApXTom27MOgl2nFq6RdkybFnIjhPoJIFKvorCVWDIbXOY2UnCnK5He-aa5-w0MtlzKFWgPOUGukd1brQEiYEr3eaV8J-51hg20O2w9Bd4FfJ9TJebZ-oG42ckQ91jNkaNIsCUm-dGhxIbvSN23B_vaUwDSDz0OqyrbIHBKbEbqpsY6B3_b7J6yXOf9bjWMBo228lfLa-9491VGuLzdVaF3Dr1PebxY0flNllZOrtAuYHBUZITV4ClLtgVw00fBXUWwTppImdpQqFA7_m8af1BynF4xPooHMbTUWaBJli3qjHDGtNhPYc8YAoXx7Id2GEqanjMLryvkIyo2tEfpiKHJ0nIReWDLX66D4apS4anbIgGHcVpW07zKba404R7yz5wI8HOZnRNLrnD3Fa-qWv4NqHebb01qgDCyhb2LhFuZDNK7cTWszRIhd2Snq3jb6MPcbHViOzk523Shh43AnXrPK50mtStIHStXEHAbwE8Cjpx2r_LlW_WgHRN-p_eAyFHUliPMEUSG54eAFLxueMFTDHnC_Tw79__wDLHkKOLnzR25UFoVZYoX7V2L5zVWtXPCA-Gh8rR2-IVENm7bqZt0o6O0Xjg8WJQU43x6fEaLvxeQNJurgzdXqjmOc06RT8jaBavRIltTme1g-_WFr-X3ABfcKXpWouWvkW_ky25VqZC8IW1IdcruoHtNk8-C_vVn1GGI43cIwjS42hUAQsPfGoX2L6ecutCW8IhBXL2lwJdj_KX2Ddf4-9f7WmnU93zqRJLtWcQlNLMpk7kTnlr3jyag1cH_OA9m_z4Dw) and zoom in × 2 (or pan) a Mermaid block.
2. Toggle Pinpoint mode ON.
3. mousedown inside the diagram → drag (pan) → release → a whole-block annotation is created.

### As-is vs to-be 

| As-is (pre-fix) | To-be (post-fix) |
|---|---|
| <video src="https://github.com/user-attachments/assets/04274641-1da1-448e-8040-bb89d4088c57" controls></video> | <video src="https://github.com/user-attachments/assets/7aa2a3fd-ddcd-413d-a58a-a8f8bbf21394" controls></video> |

### Fix

Add `data-pinpoint-ignore=""` to the grab container `<div>`. `usePinpoint`'s existing `SKIP_SELECTORS` in `packages/ui/utils/blockTargeting.ts` already matches that attribute for both hover and click — a one-attribute opt-out using a public extension point with no changes to the Pinpoint hook itself. The synthetic `click` after a short pan drag never reaches the Pinpoint overlay, so no unwanted whole-block annotation is created.

**Trade-off:** Mermaid blocks no longer support whole-block annotation via Pinpoint. Annotations on diagrams go through standard text selection instead. The reasoning is that drag and zoom ergonomics on diagrams matter more than the ability to target the diagram as a whole, and the surrounding text blocks still accept Pinpoint clicks for context annotations.

### Commit

https://github.com/backnotprop/plannotator/pull/819/commits/8ad6c44163db0d57034eb51f0586155c4972fe6d — Skip pinpoint targeting inside Mermaid grab area to keep drag clean
