### PR TITLE
Project resolution: project → worktree → session model, history, and UI

### DIFF
--- a/apps/frontend/src/components/landing/ActiveSessionRow.tsx
+++ b/apps/frontend/src/components/landing/ActiveSessionRow.tsx
@@ -1,0 +1,32 @@
+import { Link } from "@tanstack/react-router";
+import { cn } from "@/lib/utils";
+import type { SessionSummary } from "../../daemon/contracts";
+import { getSessionModeMeta, formatSessionLabel } from "../../shared/session-meta";
+import { ROW, pad } from "../sidebar/row-style";
+
+/**
+ * Flat (depth-0) live-session row reusing the sidebar row look. Unlike the
+ * sidebar's `SessionRow`, this is not tied to a tree depth or `useMatchRoute`;
+ * the conjoined view renders a flat list of sessions.
+ */
+export function ActiveSessionRow({ session }: { session: SessionSummary }) {
+  const meta = getSessionModeMeta(session.mode);
+  const Icon = meta.icon;
+  const label = formatSessionLabel(session.label, session.mode);
+  return (
+    <Link
+      to="/s/$sessionId"
+      params={{ sessionId: session.id }}
+      style={pad(0)}
+      title={label}
+      className={cn(ROW)}
+    >
+      <span className="size-3.5 shrink-0" aria-hidden />
+      <Icon className="size-3 shrink-0 text-muted-foreground/55" />
+      <span className="truncate">{label}</span>
+      <span className="ml-auto shrink-0 pl-1 text-[10px] text-muted-foreground/45">
+        {meta.label}
+      </span>
+    </Link>
+  );
+}

--- a/apps/frontend/src/components/landing/ConjoinedSessionsHistory.tsx
+++ b/apps/frontend/src/components/landing/ConjoinedSessionsHistory.tsx
@@ -1,0 +1,112 @@
+import { useMemo, useState } from "react";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useDaemonEventStore } from "../../daemon/events/event-store";
+import { useProjectStore } from "../../stores/project-store";
+import { useHistoryStore } from "../../stores/history-store";
+import { useConjoinedHistory } from "./use-conjoined-history";
+import { ActiveSessionRow } from "./ActiveSessionRow";
+import { HistoryRow } from "./HistoryRow";
+
+interface ConjoinedSessionsHistoryProps {
+  onFullView: () => void;
+}
+
+/**
+ * Compact conjoined Sessions + History surface. Sits under the project selector
+ * on the landing page, replacing the old flat "Active sessions" list. An
+ * Active⇄All toggle (default Active) switches between live sessions and history;
+ * a project filter narrows both. A "Full view →" button expands to the
+ * full-screen carousel slide.
+ */
+export function ConjoinedSessionsHistory({ onFullView }: ConjoinedSessionsHistoryProps) {
+  const sessions = useDaemonEventStore((s) => s.sessions);
+  const projects = useProjectStore((s) => s.projects);
+  const entries = useHistoryStore((s) => s.entries);
+  const historyLoading = useHistoryStore((s) => s.loading);
+
+  const [activeOrAll, setActiveOrAll] = useState<"active" | "all">("active");
+  // Stores a project NAME (history is keyed by name); null = all projects.
+  const [projectFilter, setProjectFilter] = useState<string | null>(null);
+
+  // Only fetch history when "All" is selected.
+  useConjoinedHistory(activeOrAll === "all", projectFilter);
+
+  const topLevel = useMemo(() => projects.filter((p) => !p.parentCwd), [projects]);
+  const nameToCwd = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const p of topLevel) map[p.name] = p.cwd;
+    return map;
+  }, [topLevel]);
+
+  const filteredSessions = useMemo(() => {
+    if (!projectFilter) return sessions;
+    const cwd = nameToCwd[projectFilter];
+    return sessions.filter((s) => (s.projectCwd ?? s.cwd) === cwd);
+  }, [sessions, projectFilter, nameToCwd]);
+
+  const filteredEntries = useMemo(() => {
+    if (!projectFilter) return entries;
+    return entries.filter((e) => e.project === projectFilter);
+  }, [entries, projectFilter]);
+
+  return (
+    <div className="rounded-lg border border-border">
+      <div className="flex items-center gap-2 border-b border-border bg-muted/30 px-3 py-2">
+        <Tabs value={activeOrAll} onValueChange={(v) => setActiveOrAll(v as "active" | "all")}>
+          <TabsList className="h-6 gap-1">
+            <TabsTrigger value="active" className="px-2 py-0.5 text-[11px]">
+              Active
+            </TabsTrigger>
+            <TabsTrigger value="all" className="px-2 py-0.5 text-[11px]">
+              All
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
+        <select
+          value={projectFilter ?? ""}
+          onChange={(e) => setProjectFilter(e.target.value || null)}
+          className="rounded border border-border bg-background px-1.5 py-0.5 text-[11px] text-foreground"
+        >
+          <option value="">All projects</option>
+          {topLevel.map((p) => (
+            <option key={p.cwd} value={p.name}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={onFullView}
+          className="ml-auto text-[12px] text-muted-foreground hover:text-foreground"
+        >
+          Full view →
+        </button>
+      </div>
+
+      <div className="max-h-[300px] overflow-y-auto px-1 py-1">
+        {activeOrAll === "active" ? (
+          filteredSessions.length > 0 ? (
+            filteredSessions.map((session) => (
+              <ActiveSessionRow key={session.id} session={session} />
+            ))
+          ) : (
+            <div className="py-6 text-center text-sm text-muted-foreground">No active sessions</div>
+          )
+        ) : filteredEntries.length > 0 ? (
+          filteredEntries.map((entry) => (
+            <HistoryRow
+              key={`${entry.project}/${entry.worktree ?? ""}/${entry.slug}`}
+              entry={entry}
+              cwd={nameToCwd[entry.project] ?? ""}
+              density="compact"
+            />
+          ))
+        ) : (
+          <div className="py-6 text-center text-sm text-muted-foreground">
+            {historyLoading ? "Loading history…" : "No history"}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/landing/FullSessionsHistoryView.tsx
+++ b/apps/frontend/src/components/landing/FullSessionsHistoryView.tsx
@@ -1,0 +1,148 @@
+import { useMemo, useState } from "react";
+import { Folder } from "lucide-react";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useDaemonEventStore } from "../../daemon/events/event-store";
+import { useProjectStore } from "../../stores/project-store";
+import { useHistoryStore } from "../../stores/history-store";
+import { useConjoinedHistory } from "./use-conjoined-history";
+import { ActiveSessionRow } from "./ActiveSessionRow";
+import { HistoryRow } from "./HistoryRow";
+import { PRGroup } from "./git-dashboard/PRGroup";
+
+interface FullSessionsHistoryViewProps {
+  active: boolean;
+  onBack: () => void;
+}
+
+/**
+ * Full-screen conjoined Sessions + History browse. Carousel slide 2, mirroring
+ * the Git Dashboard full-page pattern (container, Back button, grouped rows).
+ */
+export function FullSessionsHistoryView({ active, onBack }: FullSessionsHistoryViewProps) {
+  const sessions = useDaemonEventStore((s) => s.sessions);
+  const projects = useProjectStore((s) => s.projects);
+  const entries = useHistoryStore((s) => s.entries);
+  const historyLoading = useHistoryStore((s) => s.loading);
+
+  const [activeOrAll, setActiveOrAll] = useState<"active" | "all">("active");
+  const [projectFilter, setProjectFilter] = useState<string | null>(null);
+
+  useConjoinedHistory(active && activeOrAll === "all", projectFilter);
+
+  const topLevel = useMemo(() => projects.filter((p) => !p.parentCwd), [projects]);
+  const nameToCwd = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const p of topLevel) map[p.name] = p.cwd;
+    return map;
+  }, [topLevel]);
+
+  const filteredSessions = useMemo(() => {
+    if (!projectFilter) return sessions;
+    const cwd = nameToCwd[projectFilter];
+    return sessions.filter((s) => (s.projectCwd ?? s.cwd) === cwd);
+  }, [sessions, projectFilter, nameToCwd]);
+
+  const filteredEntries = useMemo(() => {
+    if (!projectFilter) return entries;
+    return entries.filter((e) => e.project === projectFilter);
+  }, [entries, projectFilter]);
+
+  // Group entries / sessions by project name for PRGroup-style sections.
+  const entryGroups = useMemo(() => groupBy(filteredEntries, (e) => e.project), [filteredEntries]);
+  const sessionGroups = useMemo(
+    () => groupBy(filteredSessions, (s) => s.project),
+    [filteredSessions],
+  );
+
+  const isAll = activeOrAll === "all";
+  const isEmpty = isAll ? filteredEntries.length === 0 : filteredSessions.length === 0;
+
+  return (
+    <div className="h-full overflow-auto">
+      <div className="mx-auto w-full max-w-5xl px-6 py-10 md:py-14">
+        <div className="mb-8">
+          <button
+            type="button"
+            onClick={onBack}
+            className="text-[12px] text-muted-foreground hover:text-foreground"
+          >
+            ← Back
+          </button>
+        </div>
+
+        <div className="sticky top-0 z-10 mb-6 flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2">
+          <Tabs value={activeOrAll} onValueChange={(v) => setActiveOrAll(v as "active" | "all")}>
+            <TabsList className="h-7 gap-1">
+              <TabsTrigger value="active" className="px-2.5 py-0.5 text-xs">
+                Active
+              </TabsTrigger>
+              <TabsTrigger value="all" className="px-2.5 py-0.5 text-xs">
+                All
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
+          <select
+            value={projectFilter ?? ""}
+            onChange={(e) => setProjectFilter(e.target.value || null)}
+            className="rounded border border-border bg-background px-2 py-1 text-xs text-foreground"
+          >
+            <option value="">All projects</option>
+            {topLevel.map((p) => (
+              <option key={p.cwd} value={p.name}>
+                {p.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {isAll && historyLoading && isEmpty && (
+          <div className="py-20 text-center text-sm text-muted-foreground">Loading history…</div>
+        )}
+
+        {isEmpty && !(isAll && historyLoading) && (
+          <div className="py-20 text-center text-sm text-muted-foreground">
+            {isAll ? "No history found across your projects" : "No active sessions"}
+          </div>
+        )}
+
+        {!isEmpty && isAll && (
+          <section className="flex flex-col gap-2">
+            {Object.entries(entryGroups).map(([project, groupEntries]) => (
+              <PRGroup key={project} title={project} icon={Folder} count={groupEntries.length}>
+                {groupEntries.map((entry) => (
+                  <HistoryRow
+                    key={`${entry.project}/${entry.worktree ?? ""}/${entry.slug}`}
+                    entry={entry}
+                    cwd={nameToCwd[entry.project] ?? ""}
+                    density="full"
+                  />
+                ))}
+              </PRGroup>
+            ))}
+          </section>
+        )}
+
+        {!isEmpty && !isAll && (
+          <section className="flex flex-col gap-2">
+            {Object.entries(sessionGroups).map(([project, groupSessions]) => (
+              <PRGroup key={project} title={project} icon={Folder} count={groupSessions.length}>
+                {groupSessions.map((session) => (
+                  <ActiveSessionRow key={session.id} session={session} />
+                ))}
+              </PRGroup>
+            ))}
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function groupBy<T>(items: T[], key: (item: T) => string): Record<string, T[]> {
+  const out: Record<string, T[]> = {};
+  for (const item of items) {
+    const k = key(item);
+    (out[k] ??= []).push(item);
+  }
+  return out;
+}

--- a/apps/frontend/src/components/landing/HistoryRow.tsx
+++ b/apps/frontend/src/components/landing/HistoryRow.tsx
@@ -1,0 +1,125 @@
+import { useCallback, useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { FileClock } from "lucide-react";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+import { daemonApiClient } from "../../daemon/api/client";
+import type { HistoryIndexEntry } from "../../daemon/contracts";
+import { ROW, pad } from "../sidebar/row-style";
+import { formatRelativeTime } from "./git-dashboard/use-git-dashboard";
+
+/**
+ * Turn a history slug (`my-plan-2026-05-29`) into a readable title by stripping
+ * the trailing date stamp and de-kebabing.
+ */
+export function prettySlug(slug: string): string {
+  const withoutDate = slug.replace(/-\d{4}-\d{2}-\d{2}$/, "");
+  return withoutDate.replace(/-/g, " ") || slug;
+}
+
+/**
+ * Derive the directory portion of an absolute file path. History markdown files
+ * always live in an existing directory, so this yields a valid cwd the daemon
+ * can resolve a project against even when the live project registry has no
+ * matching entry (project removed, or added under a custom name).
+ */
+function dirnameOf(filePath: string): string {
+  const sep = filePath.includes("\\") && !filePath.includes("/") ? "\\" : "/";
+  const trimmed = filePath.replace(/[\\/]+$/, "");
+  const idx = trimmed.lastIndexOf(sep);
+  if (idx <= 0) return trimmed.slice(0, idx + 1) || sep;
+  return trimmed.slice(0, idx);
+}
+
+interface HistoryRowProps {
+  entry: HistoryIndexEntry;
+  /** Owning project cwd (name→cwd lookup). Empty string when unknown. */
+  cwd: string;
+  density: "compact" | "full";
+}
+
+export function HistoryRow({ entry, cwd, density }: HistoryRowProps) {
+  const [launching, setLaunching] = useState(false);
+  const navigate = useNavigate();
+
+  const handleOpen = useCallback(async () => {
+    if (!entry.latestVersionPath) {
+      toast.error("This history entry has no readable plan file");
+      return;
+    }
+    setLaunching(true);
+    // `cwd` is empty when the live project registry has no entry for this
+    // history project (project removed, or registered under a custom name).
+    // Fall back to the directory of the (absolute) history file so the daemon
+    // always receives a resolvable cwd instead of throwing on an empty one.
+    const sessionCwd = cwd || dirnameOf(entry.latestVersionPath);
+    const result = await daemonApiClient.createAnnotateSession(sessionCwd, entry.latestVersionPath);
+    setLaunching(false);
+    if (result.ok) {
+      void navigate({ to: "/s/$sessionId", params: { sessionId: result.data.session.id } });
+    } else {
+      toast.error("Failed to open plan", { description: result.error.message });
+    }
+  }, [cwd, entry.latestVersionPath, navigate]);
+
+  const title = prettySlug(entry.slug);
+
+  if (density === "compact") {
+    return (
+      <button
+        type="button"
+        onClick={handleOpen}
+        disabled={launching}
+        style={pad(0)}
+        title={title}
+        className={cn(ROW, launching && "opacity-60")}
+      >
+        <span className="size-3.5 shrink-0" aria-hidden />
+        <FileClock className="size-3 shrink-0 text-muted-foreground/55" />
+        <span className="truncate">{title}</span>
+        <span className="ml-auto shrink-0 pl-1 text-[10px] tabular-nums text-muted-foreground/45">
+          {entry.latest ? formatRelativeTime(entry.latest) : ""}
+        </span>
+        <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground/40">
+          v{entry.versionCount}
+        </span>
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleOpen}
+      disabled={launching}
+      className={cn(
+        "group flex w-full items-center gap-3 rounded-xl px-3.5 py-2.5 text-left transition-colors hover:bg-surface-1",
+        launching && "opacity-60",
+      )}
+    >
+      <FileClock className="size-4 shrink-0 text-muted-foreground/60" />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium text-foreground">{title}</p>
+        <p className="mt-0.5 truncate text-xs text-muted-foreground">
+          {entry.project}
+          {entry.worktree && (
+            <>
+              {" / "}
+              {entry.worktree}
+            </>
+          )}
+        </p>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        {entry.latest && (
+          <span className="text-[11px] text-muted-foreground">
+            {formatRelativeTime(entry.latest)}
+          </span>
+        )}
+        <span className="rounded-full bg-surface-1 px-1.5 py-px text-[10px] tabular-nums text-muted-foreground">
+          v{entry.versionCount}
+        </span>
+      </div>
+    </button>
+  );
+}

--- a/apps/frontend/src/components/landing/LandingPage.tsx
+++ b/apps/frontend/src/components/landing/LandingPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Link, useNavigate } from "@tanstack/react-router";
+import { useNavigate } from "@tanstack/react-router";
 import {
   Code2,
   Folder,
@@ -17,14 +17,14 @@ import { ASCII_BANNER } from "./ascii-banner";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { useProjectStore, projectStore } from "../../stores/project-store";
 import { GitDashboard } from "./git-dashboard/GitDashboard";
+import { ConjoinedSessionsHistory } from "./ConjoinedSessionsHistory";
+import { FullSessionsHistoryView } from "./FullSessionsHistoryView";
 import { useDaemonEventStore } from "../../daemon/events/event-store";
 import { daemonApiClient } from "../../daemon/api/client";
-import { getSessionModeMeta, formatSessionLabel } from "../../shared/session-meta";
 import { buildStacks, type PRStack } from "./buildStacks";
 import type {
   ProjectEntry,
   PRListItem,
-  SessionSummary,
   WorktreeEntry,
 } from "../../daemon/contracts";
 
@@ -221,12 +221,12 @@ export function LandingPage({ onAddProject }: LandingPageProps) {
                         </div>
                       )}
 
-                      {sessions.length > 0 && (
+                      {(projects.length > 0 || sessions.length > 0) && (
                         <div>
                           <div className="mb-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-                            Active sessions
+                            Sessions &amp; history
                           </div>
-                          <SessionList sessions={sessions} />
+                          <ConjoinedSessionsHistory onFullView={() => setViewIndex(2)} />
                         </div>
                       )}
 
@@ -247,6 +247,9 @@ export function LandingPage({ onAddProject }: LandingPageProps) {
             </div>
             <div className="h-full w-full shrink-0">
               <GitDashboard active={viewIndex === 1} onBack={() => setViewIndex(0)} />
+            </div>
+            <div className="h-full w-full shrink-0">
+              <FullSessionsHistoryView active={viewIndex === 2} onBack={() => setViewIndex(0)} />
             </div>
           </div>
         </div>
@@ -709,35 +712,6 @@ function WorktreeList({
           </span>
         </button>
       ))}
-    </div>
-  );
-}
-
-function SessionList({ sessions }: { sessions: SessionSummary[] }) {
-  return (
-    <div className="overflow-hidden rounded-lg border border-border">
-      {sessions.map((session, i) => {
-        const meta = getSessionModeMeta(session.mode);
-        const Icon = meta.icon;
-        return (
-          <Link
-            key={session.id}
-            to="/s/$sessionId"
-            params={{ sessionId: session.id }}
-            className={cn(
-              "flex w-full items-center gap-3 px-3 py-2 text-left text-[13px]",
-              i > 0 && "border-t border-border",
-              "text-foreground hover:bg-surface-1",
-            )}
-          >
-            <Icon className="size-3.5 shrink-0 text-muted-foreground/50" />
-            <span className="text-muted-foreground">
-              {formatSessionLabel(session.label, session.mode)}
-            </span>
-            <span className="ml-auto text-[11px] text-muted-foreground/50">{meta.label}</span>
-          </Link>
-        );
-      })}
     </div>
   );
 }

--- a/apps/frontend/src/components/landing/use-conjoined-history.ts
+++ b/apps/frontend/src/components/landing/use-conjoined-history.ts
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+import { useHistoryStore } from "../../stores/history-store";
+
+const STALE_MS = 30_000;
+
+/**
+ * Fetch history into `historyStore` whenever the conjoined view needs the "All"
+ * data. Mirrors `use-git-dashboard`'s staleness effect: refetch when active and
+ * either the data is stale or the project filter (by NAME) changed.
+ *
+ * @param active   Whether the surface currently needs history (i.e. "All" mode
+ *                 and the view is visible).
+ * @param projectName  The project-name filter (null/undefined = all projects).
+ */
+export function useConjoinedHistory(active: boolean, projectName: string | null) {
+  const loading = useHistoryStore((s) => s.loading);
+  const lastFetchedAt = useHistoryStore((s) => s.lastFetchedAt);
+  const lastProjectKey = useHistoryStore((s) => s.lastProjectKey);
+  const fetchHistory = useHistoryStore((s) => s.fetchHistory);
+
+  useEffect(() => {
+    if (!active) return;
+    const key = projectName ?? "";
+    const stale =
+      !lastFetchedAt || Date.now() - lastFetchedAt > STALE_MS || key !== lastProjectKey;
+    if (stale && !loading) {
+      void fetchHistory(projectName ?? undefined);
+    }
+  }, [active, projectName, lastFetchedAt, lastProjectKey, loading, fetchHistory]);
+}

--- a/apps/frontend/src/components/sidebar/AppSidebar.tsx
+++ b/apps/frontend/src/components/sidebar/AppSidebar.tsx
@@ -4,6 +4,7 @@ import * as Collapsible from "@radix-ui/react-collapsible";
 import { ChevronRight, Folder, GitBranch, Moon, Settings, Sun } from "lucide-react";
 import { TaterSpriteSidebar } from "./TaterSpriteSidebar";
 import { useActiveProjectCwd } from "./useActiveProjectCwd";
+import { ROW, pad } from "./row-style";
 import { appStore, useAppStore } from "../../stores/app-store";
 import { cn } from "@/lib/utils";
 import {
@@ -29,15 +30,6 @@ import { formatSessionLabel, getSessionModeMeta } from "../../shared/session-met
 
 /** Non-terminal session statuses — the only ones the sidebar surfaces. */
 const LIVE_STATUSES = new Set<string>(["active", "idle", "awaiting-resubmission"]);
-
-/** One disclosure-width per nesting level; depth-based left pad is the only indent. */
-const INDENT = 14;
-const pad = (depth: number) => ({ paddingLeft: `${8 + depth * INDENT}px` });
-
-/** Shared compact row. ~26px tall, single-line, truncating. */
-const ROW =
-  "group/row flex h-[26px] w-full items-center gap-1.5 rounded-md pr-2 text-left text-xs " +
-  "text-sidebar-foreground/85 transition-colors hover:bg-sidebar-accent/50";
 
 const CHEVRON =
   "size-3.5 shrink-0 text-muted-foreground/45 transition-transform duration-150 " +

--- a/apps/frontend/src/components/sidebar/AppSidebar.tsx
+++ b/apps/frontend/src/components/sidebar/AppSidebar.tsx
@@ -1,42 +1,210 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { Link, useMatchRoute } from "@tanstack/react-router";
-import { Moon, Settings, Sun } from "lucide-react";
+import * as Collapsible from "@radix-ui/react-collapsible";
+import { ChevronRight, Folder, GitBranch, Moon, Settings, Sun } from "lucide-react";
 import { TaterSpriteSidebar } from "./TaterSpriteSidebar";
-import { appStore } from "../../stores/app-store";
+import { useActiveProjectCwd } from "./useActiveProjectCwd";
+import { appStore, useAppStore } from "../../stores/app-store";
 import { cn } from "@/lib/utils";
 import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
-  SidebarGroup,
-  SidebarGroupContent,
-  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
 import { useTheme } from "@plannotator/ui/components/ThemeProvider";
+import { buildSessionTree } from "@plannotator/ui/utils/sessionTree";
+import type {
+  SessionTreeProject,
+  SessionTreeWorktree,
+} from "@plannotator/ui/utils/sessionTree";
+import type { DaemonSessionSummary } from "@plannotator/shared/daemon-protocol";
 import { useDaemonEventStore } from "../../daemon/events/event-store";
+import { useProjectStore } from "../../stores/project-store";
 import type { SessionSummary } from "../../daemon/contracts";
-import { getSessionModeMeta, formatSessionLabel } from "../../shared/session-meta";
+import { formatSessionLabel, getSessionModeMeta } from "../../shared/session-meta";
 
-const MODE_ORDER = ["plan", "review", "annotate", "goal-setup"];
+/** Non-terminal session statuses — the only ones the sidebar surfaces. */
+const LIVE_STATUSES = new Set<string>(["active", "idle", "awaiting-resubmission"]);
+
+/** One disclosure-width per nesting level; depth-based left pad is the only indent. */
+const INDENT = 14;
+const pad = (depth: number) => ({ paddingLeft: `${8 + depth * INDENT}px` });
+
+/** Shared compact row. ~26px tall, single-line, truncating. */
+const ROW =
+  "group/row flex h-[26px] w-full items-center gap-1.5 rounded-md pr-2 text-left text-xs " +
+  "text-sidebar-foreground/85 transition-colors hover:bg-sidebar-accent/50";
+
+const CHEVRON =
+  "size-3.5 shrink-0 text-muted-foreground/45 transition-transform duration-150 " +
+  "group-data-[state=open]/disc:rotate-90";
+
+function SessionRow({
+  session,
+  depth,
+  matchRoute,
+}: {
+  session: DaemonSessionSummary;
+  depth: number;
+  matchRoute: ReturnType<typeof useMatchRoute>;
+}) {
+  const isActive = !!matchRoute({
+    to: "/s/$sessionId",
+    params: { sessionId: session.id },
+  });
+  const Icon = getSessionModeMeta(session.mode).icon;
+  return (
+    <Link
+      to="/s/$sessionId"
+      params={{ sessionId: session.id }}
+      style={pad(depth)}
+      className={cn(
+        ROW,
+        isActive &&
+          "bg-sidebar-accent font-medium text-sidebar-accent-foreground hover:bg-sidebar-accent",
+      )}
+      title={formatSessionLabel(session.label, session.mode)}
+    >
+      {/* spacer where a chevron would sit, so the mode icon aligns under sibling icons */}
+      <span className="size-3.5 shrink-0" aria-hidden />
+      <Icon className="size-3 shrink-0 text-muted-foreground/55" />
+      <span className="truncate">{formatSessionLabel(session.label, session.mode)}</span>
+    </Link>
+  );
+}
+
+function WorktreeNode({
+  worktree,
+  depth,
+  matchRoute,
+}: {
+  worktree: SessionTreeWorktree;
+  depth: number;
+  matchRoute: ReturnType<typeof useMatchRoute>;
+}) {
+  const collapsed = useAppStore((s) => s.collapsedWorktrees.has(worktree.cwd));
+  const toggle = useAppStore((s) => s.toggleWorktreeCollapse);
+  if (worktree.sessions.length === 0) return null;
+  return (
+    <Collapsible.Root open={!collapsed} onOpenChange={() => toggle(worktree.cwd)}>
+      <Collapsible.Trigger
+        style={pad(depth)}
+        className={cn(ROW, "group/disc text-sidebar-foreground/70")}
+        title={worktree.name}
+      >
+        <ChevronRight className={CHEVRON} />
+        <GitBranch className="size-3 shrink-0 text-muted-foreground/55" />
+        <span className="truncate">{worktree.name}</span>
+        <span className="ml-auto pl-1 text-[10px] tabular-nums text-muted-foreground/45">
+          {worktree.sessions.length}
+        </span>
+      </Collapsible.Trigger>
+      <Collapsible.Content>
+        {worktree.sessions.map((session) => (
+          <SessionRow
+            key={session.id}
+            session={session}
+            depth={depth + 1}
+            matchRoute={matchRoute}
+          />
+        ))}
+      </Collapsible.Content>
+    </Collapsible.Root>
+  );
+}
+
+function ProjectNode({
+  project,
+  isOpen,
+  onToggle,
+  matchRoute,
+}: {
+  project: SessionTreeProject;
+  isOpen: boolean;
+  onToggle: () => void;
+  matchRoute: ReturnType<typeof useMatchRoute>;
+}) {
+  const liveCount =
+    project.directSessions.length +
+    project.worktrees.reduce((sum, wt) => sum + wt.sessions.length, 0);
+
+  return (
+    <Collapsible.Root open={isOpen} onOpenChange={onToggle}>
+      <Collapsible.Trigger
+        style={pad(0)}
+        className={cn(ROW, "group/disc font-medium text-sidebar-foreground/90")}
+        title={project.name}
+      >
+        <ChevronRight className={CHEVRON} />
+        <Folder className="size-3.5 shrink-0 text-muted-foreground/60" />
+        <span className="truncate">{project.name}</span>
+        {liveCount > 0 && (
+          <span className="ml-auto pl-1 text-[10px] tabular-nums text-muted-foreground/45">
+            {liveCount}
+          </span>
+        )}
+      </Collapsible.Trigger>
+      <Collapsible.Content>
+        {project.directSessions.map((session) => (
+          <SessionRow key={session.id} session={session} depth={1} matchRoute={matchRoute} />
+        ))}
+        {project.worktrees.map((worktree) => (
+          <WorktreeNode
+            key={worktree.cwd}
+            worktree={worktree}
+            depth={1}
+            matchRoute={matchRoute}
+          />
+        ))}
+        {liveCount === 0 && (
+          <div
+            style={pad(1)}
+            className="flex h-6 items-center text-[11px] text-muted-foreground/40"
+          >
+            No live sessions
+          </div>
+        )}
+      </Collapsible.Content>
+    </Collapsible.Root>
+  );
+}
 
 export function AppSidebarContent() {
   const sessions = useDaemonEventStore((s) => s.sessions);
+  const projects = useProjectStore((p) => p.projects);
+  const expandedProjects = useAppStore((s) => s.expandedProjects);
+  const toggleProjectExpand = useAppStore((s) => s.toggleProjectExpand);
+  const activeProjectCwd = useActiveProjectCwd();
   const { resolvedMode, setMode } = useTheme();
   const matchRoute = useMatchRoute();
 
-  const grouped = useMemo(() => {
-    const map = new Map<string, SessionSummary[]>();
-    for (const s of sessions) {
-      const list = map.get(s.mode) ?? [];
-      list.push(s);
-      map.set(s.mode, list);
+  // Live-only: exclude terminal sessions (completed/cancelled/expired/failed).
+  const liveSessions = useMemo<SessionSummary[]>(
+    () => sessions.filter((s) => LIVE_STATUSES.has(s.status)),
+    [sessions],
+  );
+
+  // buildSessionTree only reads project/worktree placement fields, never `mode`,
+  // so the (widened) SessionSummary.mode is safe to narrow at this boundary.
+  const tree = useMemo(
+    () => buildSessionTree(projects, liveSessions as DaemonSessionSummary[]),
+    [projects, liveSessions],
+  );
+
+  // Active project is open by default — seed it into expandedProjects exactly once
+  // per cwd (one-shot guard) so a later explicit collapse isn't re-opened. Effect
+  // depends only on activeProjectCwd, never on expandedProjects.
+  const seededProjects = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    if (activeProjectCwd && !seededProjects.current.has(activeProjectCwd)) {
+      seededProjects.current.add(activeProjectCwd);
+      appStore.getState().setProjectExpanded(activeProjectCwd, true);
     }
-    return map;
-  }, [sessions]);
+  }, [activeProjectCwd]);
 
   const toggleTheme = useCallback(() => {
     setMode(resolvedMode === "dark" ? "light" : "dark");
@@ -72,52 +240,22 @@ export function AppSidebarContent() {
         </Link>
       </SidebarHeader>
 
-      <SidebarContent className="pt-4">
-        {MODE_ORDER.map((mode) => {
-          const modeSessions = grouped.get(mode);
-          if (!modeSessions?.length) return null;
-          const meta = getSessionModeMeta(mode);
-
-          const Icon = meta.icon;
-          return (
-            <SidebarGroup key={mode}>
-              <SidebarGroupLabel>
-                <Icon className="size-3.5 text-muted-foreground/60" />
-                {meta.label}s
-              </SidebarGroupLabel>
-              <SidebarGroupContent>
-                <SidebarMenu>
-                  {modeSessions.map((session) => {
-                    const isActive = !!matchRoute({
-                      to: "/s/$sessionId",
-                      params: { sessionId: session.id },
-                    });
-                    const isTerminal =
-                      session.status === "completed" || session.status === "cancelled";
-
-                    return (
-                      <SidebarMenuItem key={session.id}>
-                        <SidebarMenuButton asChild isActive={isActive} className="h-7 pr-7 text-xs">
-                          <Link to="/s/$sessionId" params={{ sessionId: session.id }}>
-                            <span className="size-3.5 shrink-0" aria-hidden />
-                            <span
-                              className={cn(
-                                "truncate",
-                                isTerminal && "text-muted-foreground/60 line-through",
-                              )}
-                            >
-                              {formatSessionLabel(session.label, session.mode)}
-                            </span>
-                          </Link>
-                        </SidebarMenuButton>
-                      </SidebarMenuItem>
-                    );
-                  })}
-                </SidebarMenu>
-              </SidebarGroupContent>
-            </SidebarGroup>
-          );
-        })}
+      <SidebarContent className="gap-0 px-1 py-2">
+        {tree.length === 0 ? (
+          <div className="px-3 py-2 text-[11px] text-muted-foreground/50">
+            No projects yet
+          </div>
+        ) : (
+          tree.map((project) => (
+            <ProjectNode
+              key={project.cwd}
+              project={project}
+              isOpen={expandedProjects.has(project.cwd)}
+              onToggle={() => toggleProjectExpand(project.cwd)}
+              matchRoute={matchRoute}
+            />
+          ))
+        )}
       </SidebarContent>
 
       <SidebarFooter>

--- a/apps/frontend/src/components/sidebar/row-style.ts
+++ b/apps/frontend/src/components/sidebar/row-style.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared sidebar row styling. Lifted out of `AppSidebar.tsx` so the conjoined
+ * sessions+history surface can render Active rows with the exact same look
+ * without coupling to the sidebar's tree-row component (which depends on
+ * `useMatchRoute` and `DaemonSessionSummary`).
+ */
+
+/** One disclosure-width per nesting level; depth-based left pad is the only indent. */
+export const INDENT = 14;
+export const pad = (depth: number) => ({ paddingLeft: `${8 + depth * INDENT}px` });
+
+/** Shared compact row. ~26px tall, single-line, truncating. */
+export const ROW =
+  "group/row flex h-[26px] w-full items-center gap-1.5 rounded-md pr-2 text-left text-xs " +
+  "text-sidebar-foreground/85 transition-colors hover:bg-sidebar-accent/50";

--- a/apps/frontend/src/components/sidebar/useActiveProjectCwd.test.ts
+++ b/apps/frontend/src/components/sidebar/useActiveProjectCwd.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "vitest";
+import { activeProjectCwdOf } from "./useActiveProjectCwd";
+import type { SessionSummary } from "../../daemon/contracts";
+
+function session(overrides: Partial<SessionSummary> & { id: string }): SessionSummary {
+  return {
+    mode: "plan",
+    status: "active",
+    url: "http://localhost/s/x",
+    project: "proj",
+    label: "plugin-plan-claude-code-proj-main",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("activeProjectCwdOf", () => {
+  test("returns null when no active session id", () => {
+    const sessions = [session({ id: "a", projectCwd: "/p" })];
+    expect(activeProjectCwdOf(sessions, null)).toBeNull();
+  });
+
+  test("returns null when active id matches no session", () => {
+    const sessions = [session({ id: "a", projectCwd: "/p" })];
+    expect(activeProjectCwdOf(sessions, "missing")).toBeNull();
+  });
+
+  test("prefers projectCwd of the active session", () => {
+    const sessions = [
+      session({ id: "a", projectCwd: "/owner", cwd: "/worktree" }),
+      session({ id: "b", projectCwd: "/other" }),
+    ];
+    expect(activeProjectCwdOf(sessions, "a")).toBe("/owner");
+  });
+
+  test("falls back to cwd when projectCwd is absent (pre-migration row)", () => {
+    const sessions = [session({ id: "a", cwd: "/legacy-cwd" })];
+    expect(activeProjectCwdOf(sessions, "a")).toBe("/legacy-cwd");
+  });
+
+  test("returns null when active session has neither projectCwd nor cwd", () => {
+    const sessions = [session({ id: "a" })];
+    expect(activeProjectCwdOf(sessions, "a")).toBeNull();
+  });
+
+  test("selects the active session, not the first", () => {
+    const sessions = [
+      session({ id: "a", projectCwd: "/a" }),
+      session({ id: "b", projectCwd: "/b" }),
+    ];
+    expect(activeProjectCwdOf(sessions, "b")).toBe("/b");
+  });
+});

--- a/apps/frontend/src/components/sidebar/useActiveProjectCwd.ts
+++ b/apps/frontend/src/components/sidebar/useActiveProjectCwd.ts
@@ -1,0 +1,32 @@
+import { useMemo } from "react";
+import { useAppStore } from "../../stores/app-store";
+import { useDaemonEventStore } from "../../daemon/events/event-store";
+import type { SessionSummary } from "../../daemon/contracts";
+
+/**
+ * Owning-project key for a session, with cwd fallback for pre-migration rows.
+ * MUST match `owningProjectKey` in packages/ui/utils/sessionTree.ts so the
+ * sidebar's "active project" lines up with the tree node a session lands under.
+ */
+export function activeProjectCwdOf(
+  sessions: SessionSummary[],
+  activeSessionId: string | null,
+): string | null {
+  if (!activeSessionId) return null;
+  const session = sessions.find((s) => s.id === activeSessionId);
+  if (!session) return null;
+  return session.projectCwd ?? session.cwd ?? null;
+}
+
+/**
+ * Derive the cwd of the project that owns the currently-active session.
+ * Never stored — single source of truth is `activeSessionId` + live sessions.
+ */
+export function useActiveProjectCwd(): string | null {
+  const sessions = useDaemonEventStore((s) => s.sessions);
+  const activeSessionId = useAppStore((s) => s.activeSessionId);
+  return useMemo(
+    () => activeProjectCwdOf(sessions, activeSessionId),
+    [sessions, activeSessionId],
+  );
+}

--- a/apps/frontend/src/daemon/api/client.test.ts
+++ b/apps/frontend/src/daemon/api/client.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test, vi } from "vitest";
+import { createDaemonApiClient } from "./client";
+
+function jsonResponse(body: unknown, init: { status?: number } = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const sessionResponse = {
+  ok: true,
+  session: {
+    id: "sess_1",
+    mode: "annotate",
+    status: "active",
+    url: "http://localhost/s/sess_1",
+    project: "repo",
+    label: "plugin-annotate-plannotator-frontend-plan",
+    createdAt: "2026-05-29T00:00:00.000Z",
+    updatedAt: "2026-05-29T00:00:00.000Z",
+  },
+};
+
+describe("getHistory", () => {
+  test("hits /daemon/history?project=repo when a name is given", async () => {
+    const fetchImpl = vi.fn(async (_url: RequestInfo | URL, _init?: RequestInit) =>
+      jsonResponse({ ok: true, history: [] }),
+    );
+    const client = createDaemonApiClient({ fetch: fetchImpl as unknown as typeof fetch });
+
+    const result = await client.getHistory("repo");
+
+    expect(result.ok).toBe(true);
+    const url = String(fetchImpl.mock.calls[0][0]);
+    expect(url).toContain("/daemon/history?project=repo");
+  });
+
+  test("omits the query string when no project is given", async () => {
+    const fetchImpl = vi.fn(async (_url: RequestInfo | URL, _init?: RequestInit) =>
+      jsonResponse({ ok: true, history: [] }),
+    );
+    const client = createDaemonApiClient({ fetch: fetchImpl as unknown as typeof fetch });
+
+    await client.getHistory();
+
+    const url = String(fetchImpl.mock.calls[0][0]);
+    expect(url).toContain("/daemon/history");
+    expect(url).not.toContain("?project=");
+  });
+
+  test("rejects a payload missing latestVersionPath", async () => {
+    const bad = {
+      ok: true,
+      history: [{ project: "repo", slug: "s", versionCount: 1, latest: "x" }],
+    };
+    const fetchImpl = vi.fn(async (_url: RequestInfo | URL, _init?: RequestInit) =>
+      jsonResponse(bad),
+    );
+    const client = createDaemonApiClient({ fetch: fetchImpl as unknown as typeof fetch });
+
+    const result = await client.getHistory();
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.kind).toBe("invalid-payload");
+  });
+
+  test("accepts a well-formed history entry", async () => {
+    const good = {
+      ok: true,
+      history: [
+        {
+          project: "repo",
+          slug: "my-plan-2026-05-29",
+          versionCount: 2,
+          latest: "2026-05-29T00:00:00.000Z",
+          latestVersionPath: "/tmp/repo/my-plan/002.md",
+        },
+      ],
+    };
+    const fetchImpl = vi.fn(async (_url: RequestInfo | URL, _init?: RequestInit) =>
+      jsonResponse(good),
+    );
+    const client = createDaemonApiClient({ fetch: fetchImpl as unknown as typeof fetch });
+
+    const result = await client.getHistory();
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data.history).toHaveLength(1);
+  });
+});
+
+describe("createAnnotateSession", () => {
+  test("POSTs /daemon/sessions with an annotate request body", async () => {
+    const fetchImpl = vi.fn(async (_url: RequestInfo | URL, _init?: RequestInit) =>
+      jsonResponse(sessionResponse),
+    );
+    const client = createDaemonApiClient({ fetch: fetchImpl as unknown as typeof fetch });
+
+    const result = await client.createAnnotateSession("/proj", "/proj/plan.md");
+
+    expect(result.ok).toBe(true);
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(String(url)).toContain("/daemon/sessions");
+    const requestInit = init as RequestInit;
+    expect(requestInit.method).toBe("POST");
+    const body = JSON.parse(String(requestInit.body));
+    expect(body).toEqual({
+      request: {
+        action: "annotate",
+        origin: "plannotator-frontend",
+        cwd: "/proj",
+        filePath: "/proj/plan.md",
+      },
+    });
+  });
+});

--- a/apps/frontend/src/daemon/api/client.ts
+++ b/apps/frontend/src/daemon/api/client.ts
@@ -15,6 +15,8 @@ import type {
   DirectoryListResponse,
   PRListResponse,
   PRDetailedListResponse,
+  HistoryListResponse,
+  HistoryIndexEntry,
 } from "../contracts";
 import {
   DaemonHubActionError,
@@ -73,6 +75,8 @@ export interface DaemonApiClient {
   listPRs(cwd: string): Promise<DaemonApiResult<PRListResponse>>;
   listDetailedPRs(cwd: string): Promise<DaemonApiResult<PRDetailedListResponse>>;
   createReviewSession(cwd: string, prUrl?: string): Promise<DaemonApiResult<SessionResponse>>;
+  createAnnotateSession(cwd: string, filePath: string): Promise<DaemonApiResult<SessionResponse>>;
+  getHistory(projectName?: string): Promise<DaemonApiResult<HistoryListResponse>>;
 }
 
 type ResponseGuard<T> = (value: unknown) => value is T;
@@ -198,6 +202,24 @@ function isPRList(value: unknown): value is PRListResponse {
 
 function isPRDetailedList(value: unknown): value is PRDetailedListResponse {
   return hasOkTrue(value) && Array.isArray((value as { prs?: unknown }).prs);
+}
+
+function isHistoryIndexEntry(value: unknown): value is HistoryIndexEntry {
+  return (
+    isRecord(value) &&
+    typeof value.project === "string" &&
+    typeof value.slug === "string" &&
+    typeof value.versionCount === "number" &&
+    typeof value.latest === "string" &&
+    typeof value.latestVersionPath === "string" &&
+    (value.worktree === undefined || typeof value.worktree === "string")
+  );
+}
+
+function isHistoryList(value: unknown): value is HistoryListResponse {
+  if (!hasOkTrue(value)) return false;
+  const history = (value as { history?: unknown }).history;
+  return Array.isArray(history) && history.every(isHistoryIndexEntry);
 }
 
 function isSessionBootstrap(value: unknown): value is SessionBootstrap {
@@ -518,6 +540,33 @@ export function createDaemonApiClient(options: DaemonApiClientOptions = {}): Dae
             ...(prUrl && { prUrl }),
           },
         }),
+      );
+    },
+
+    createAnnotateSession(cwd, filePath) {
+      return requestJson(
+        fetchImpl,
+        joinUrl(options.baseUrl, "/daemon/sessions"),
+        isSessionResponse,
+        jsonPost({
+          request: {
+            action: "annotate",
+            origin: "plannotator-frontend",
+            cwd,
+            filePath,
+          },
+        }),
+      );
+    },
+
+    getHistory(projectName) {
+      const query = projectName
+        ? `?${new URLSearchParams({ project: projectName }).toString()}`
+        : "";
+      return requestJson(
+        fetchImpl,
+        joinUrl(options.baseUrl, `/daemon/history${query}`),
+        isHistoryList,
       );
     },
 

--- a/apps/frontend/src/daemon/contracts.ts
+++ b/apps/frontend/src/daemon/contracts.ts
@@ -9,6 +9,9 @@ import type {
   DaemonStatus,
   DaemonWebSocketServerMessage,
 } from "@plannotator/shared/daemon-protocol";
+import type { HistoryIndexEntry } from "@plannotator/shared/storage";
+
+export type { HistoryIndexEntry } from "@plannotator/shared/storage";
 
 export type SessionView = DaemonSessionView;
 export type SessionMode = SessionView | (string & {});
@@ -104,6 +107,11 @@ export interface PRListResponse {
   defaultBranch?: string;
   error?: "no-remote" | "no-cli" | "auth-failed" | "fetch-failed";
   message?: string;
+}
+
+export interface HistoryListResponse {
+  ok: true;
+  history: HistoryIndexEntry[];
 }
 
 export type SessionLifecycleStatus = DaemonSessionStatus;

--- a/apps/frontend/src/stores/app-store.test.ts
+++ b/apps/frontend/src/stores/app-store.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "vitest";
+import { createAppStore } from "./app-store";
+
+describe("appStore expand actions", () => {
+  test("expandedProjects starts empty", () => {
+    const store = createAppStore();
+    expect(store.getState().expandedProjects.size).toBe(0);
+  });
+
+  test("toggleProjectExpand adds a project when absent", () => {
+    const store = createAppStore();
+    expect(store.getState().expandedProjects.has("/a")).toBe(false);
+    store.getState().toggleProjectExpand("/a");
+    expect(store.getState().expandedProjects.has("/a")).toBe(true);
+  });
+
+  test("toggleProjectExpand removes a project when present", () => {
+    const store = createAppStore();
+    store.getState().toggleProjectExpand("/a");
+    expect(store.getState().expandedProjects.has("/a")).toBe(true);
+    store.getState().toggleProjectExpand("/a");
+    expect(store.getState().expandedProjects.has("/a")).toBe(false);
+  });
+
+  test("setProjectExpanded(open=true) is idempotent", () => {
+    const store = createAppStore();
+    store.getState().setProjectExpanded("/a", true);
+    store.getState().setProjectExpanded("/a", true);
+    expect(store.getState().expandedProjects.has("/a")).toBe(true);
+    expect(store.getState().expandedProjects.size).toBe(1);
+  });
+
+  test("setProjectExpanded(open=false) removes and is idempotent", () => {
+    const store = createAppStore();
+    store.getState().setProjectExpanded("/a", true);
+    store.getState().setProjectExpanded("/a", false);
+    store.getState().setProjectExpanded("/a", false);
+    expect(store.getState().expandedProjects.has("/a")).toBe(false);
+    expect(store.getState().expandedProjects.size).toBe(0);
+  });
+
+  test("immer produces a new Set reference on mutation (state change is observable)", () => {
+    const store = createAppStore();
+    const before = store.getState().expandedProjects;
+    store.getState().toggleProjectExpand("/a");
+    const after = store.getState().expandedProjects;
+    expect(after).not.toBe(before);
+  });
+
+  test("multiple projects are tracked independently", () => {
+    const store = createAppStore();
+    store.getState().toggleProjectExpand("/a");
+    store.getState().toggleProjectExpand("/b");
+    store.getState().toggleProjectExpand("/a");
+    expect(store.getState().expandedProjects.has("/a")).toBe(false);
+    expect(store.getState().expandedProjects.has("/b")).toBe(true);
+  });
+
+  test("instances do not share expansion state", () => {
+    const a = createAppStore();
+    const b = createAppStore();
+    a.getState().toggleProjectExpand("/a");
+    expect(a.getState().expandedProjects.has("/a")).toBe(true);
+    expect(b.getState().expandedProjects.has("/a")).toBe(false);
+  });
+});

--- a/apps/frontend/src/stores/app-store.ts
+++ b/apps/frontend/src/stores/app-store.ts
@@ -1,7 +1,12 @@
 import { createStore } from "zustand/vanilla";
 import { useStore } from "zustand";
 import { immer } from "zustand/middleware/immer";
+import { enableMapSet } from "immer";
 import type { SessionBootstrap } from "../daemon/contracts";
+
+// expandedProjects is a Set drafted inside immer producers; immer 10 requires
+// this plugin to be loaded before any Set/Map is mutated in a recipe.
+enableMapSet();
 
 export interface VisitedSession {
   sessionId: string;
@@ -13,6 +18,14 @@ export interface AppState {
   settingsOpen: boolean;
   activeSessionId: string | null;
   visitedSessions: Record<string, VisitedSession>;
+  /** cwds of projects the user has explicitly toggled open in the sidebar. */
+  expandedProjects: Set<string>;
+  /**
+   * cwds of worktrees the user has explicitly COLLAPSED. Worktrees default to
+   * expanded (so their live sessions show when the project is open); this tracks
+   * the exceptions.
+   */
+  collapsedWorktrees: Set<string>;
 }
 
 export interface AppActions {
@@ -21,6 +34,9 @@ export interface AppActions {
   activateSession(sessionId: string, bootstrap: SessionBootstrap): void;
   deactivateSession(): void;
   removeSession(sessionId: string): void;
+  toggleProjectExpand(cwd: string): void;
+  setProjectExpanded(cwd: string, open: boolean): void;
+  toggleWorktreeCollapse(cwd: string): void;
 }
 
 export type AppStore = AppState & AppActions;
@@ -30,12 +46,17 @@ const initialState: AppState = {
   settingsOpen: false,
   activeSessionId: null,
   visitedSessions: {},
+  expandedProjects: new Set<string>(),
+  collapsedWorktrees: new Set<string>(),
 };
 
 export function createAppStore(initial: Partial<AppState> = {}) {
   return createStore<AppStore>()(
     immer((set) => ({
       ...initialState,
+      // Fresh Sets per store so instances don't share expansion state.
+      expandedProjects: new Set<string>(initialState.expandedProjects),
+      collapsedWorktrees: new Set<string>(initialState.collapsedWorktrees),
       ...initial,
       setAddProjectOpen(open) {
         set((state) => {
@@ -65,6 +86,33 @@ export function createAppStore(initial: Partial<AppState> = {}) {
           delete state.visitedSessions[sessionId];
           if (state.activeSessionId === sessionId) {
             state.activeSessionId = null;
+          }
+        });
+      },
+      toggleProjectExpand(cwd) {
+        set((state) => {
+          if (state.expandedProjects.has(cwd)) {
+            state.expandedProjects.delete(cwd);
+          } else {
+            state.expandedProjects.add(cwd);
+          }
+        });
+      },
+      setProjectExpanded(cwd, open) {
+        set((state) => {
+          if (open) {
+            state.expandedProjects.add(cwd);
+          } else {
+            state.expandedProjects.delete(cwd);
+          }
+        });
+      },
+      toggleWorktreeCollapse(cwd) {
+        set((state) => {
+          if (state.collapsedWorktrees.has(cwd)) {
+            state.collapsedWorktrees.delete(cwd);
+          } else {
+            state.collapsedWorktrees.add(cwd);
           }
         });
       },

--- a/apps/frontend/src/stores/history-store.test.ts
+++ b/apps/frontend/src/stores/history-store.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { historyStore } from "./history-store";
+import type { DaemonApiClient } from "../daemon/api/client";
+import type { HistoryIndexEntry } from "../daemon/contracts";
+
+function makeEntry(over: Partial<HistoryIndexEntry> = {}): HistoryIndexEntry {
+  return {
+    project: "repo",
+    slug: "my-plan-2026-05-29",
+    versionCount: 2,
+    latest: "2026-05-29T00:00:00.000Z",
+    latestVersionPath: "/tmp/history/repo/my-plan-2026-05-29/002.md",
+    ...over,
+  };
+}
+
+function fakeClient(impl: Partial<DaemonApiClient>): DaemonApiClient {
+  return impl as DaemonApiClient;
+}
+
+beforeEach(() => {
+  historyStore.getState().clear();
+});
+
+describe("historyStore.fetchHistory", () => {
+  test("success populates entries, lastFetchedAt and lastProjectKey", async () => {
+    const entries = [makeEntry()];
+    const client = fakeClient({
+      getHistory: async () => ({ ok: true, data: { ok: true, history: entries } }),
+    });
+
+    await historyStore.getState().fetchHistory("repo", client);
+
+    const state = historyStore.getState();
+    expect(state.entries).toEqual(entries);
+    expect(state.loading).toBe(false);
+    expect(state.error).toBeUndefined();
+    expect(state.lastProjectKey).toBe("repo");
+    expect(typeof state.lastFetchedAt).toBe("number");
+  });
+
+  test("undefined projectName stores empty-string lastProjectKey", async () => {
+    const client = fakeClient({
+      getHistory: async () => ({ ok: true, data: { ok: true, history: [] } }),
+    });
+    await historyStore.getState().fetchHistory(undefined, client);
+    expect(historyStore.getState().lastProjectKey).toBe("");
+  });
+
+  test("passes the project name to the client", async () => {
+    let received: string | undefined = "UNSET";
+    const client = fakeClient({
+      getHistory: async (name) => {
+        received = name;
+        return { ok: true, data: { ok: true, history: [] } };
+      },
+    });
+    await historyStore.getState().fetchHistory("alpha", client);
+    expect(received).toBe("alpha");
+  });
+
+  test("error sets error and clears loading", async () => {
+    const client = fakeClient({
+      getHistory: async () => ({
+        ok: false,
+        error: { kind: "network-error", message: "boom" },
+      }),
+    });
+
+    await historyStore.getState().fetchHistory("repo", client);
+
+    const state = historyStore.getState();
+    expect(state.loading).toBe(false);
+    expect(state.error).toBe("boom");
+    expect(state.entries).toEqual([]);
+  });
+
+  test("clear() resets entries, timestamp, key and error", async () => {
+    const client = fakeClient({
+      getHistory: async () => ({ ok: true, data: { ok: true, history: [makeEntry()] } }),
+    });
+    await historyStore.getState().fetchHistory("repo", client);
+    historyStore.getState().clear();
+
+    const state = historyStore.getState();
+    expect(state.entries).toEqual([]);
+    expect(state.lastFetchedAt).toBeNull();
+    expect(state.lastProjectKey).toBe("");
+    expect(state.error).toBeUndefined();
+  });
+});

--- a/apps/frontend/src/stores/history-store.ts
+++ b/apps/frontend/src/stores/history-store.ts
@@ -1,0 +1,72 @@
+import { createStore } from "zustand/vanilla";
+import { useStore } from "zustand";
+import { immer } from "zustand/middleware/immer";
+import type { HistoryIndexEntry } from "../daemon/contracts";
+import type { DaemonApiClient } from "../daemon/api/client";
+import { daemonApiClient } from "../daemon/api/client";
+
+export interface HistoryState {
+  entries: HistoryIndexEntry[];
+  loading: boolean;
+  error?: string;
+  lastFetchedAt: number | null;
+  /** The project NAME the entries were last fetched for ("" = all projects). */
+  lastProjectKey: string;
+}
+
+export interface HistoryActions {
+  fetchHistory(projectName?: string, client?: DaemonApiClient): Promise<void>;
+  clear(): void;
+}
+
+export type HistoryStore = HistoryState & HistoryActions;
+
+const initialState: HistoryState = {
+  entries: [],
+  loading: false,
+  lastFetchedAt: null,
+  lastProjectKey: "",
+};
+
+export const historyStore = createStore<HistoryStore>()(
+  immer((set) => ({
+    ...initialState,
+
+    async fetchHistory(projectName, client = daemonApiClient) {
+      set((state) => {
+        state.loading = true;
+        state.error = undefined;
+      });
+
+      const result = await client.getHistory(projectName);
+
+      if (!result.ok) {
+        set((state) => {
+          state.loading = false;
+          state.error = result.error.message;
+        });
+        return;
+      }
+
+      set((state) => {
+        state.entries = result.data.history;
+        state.loading = false;
+        state.lastFetchedAt = Date.now();
+        state.lastProjectKey = projectName ?? "";
+      });
+    },
+
+    clear() {
+      set((state) => {
+        state.entries = [];
+        state.lastFetchedAt = null;
+        state.lastProjectKey = "";
+        state.error = undefined;
+      });
+    },
+  })),
+);
+
+export function useHistoryStore<T>(selector: (state: HistoryStore) => T): T {
+  return useStore(historyStore, selector);
+}

--- a/goals/architecture/decisions/core-model-and-project-ux.md
+++ b/goals/architecture/decisions/core-model-and-project-ux.md
@@ -1,0 +1,72 @@
+# Decision Fact: Core Model (resolveProject) & Project-Based UX
+
+**Status:** Decided (normative) · **Date:** 2026-05-29 · **Owner:** Michael Ramos
+**Scope:** The one-line core pipeline, and *why* the project/worktree/session model
+exists — what UX it must enable. Synthesizes the two companion facts:
+`./project-worktree-session-hierarchy.md` (the data model) and
+`./cwd-worktree-collection-contract.md` (how cwd/worktree arrive).
+
+---
+
+## The fact (canonical statement)
+
+**Core model:**
+```
+agent → cli(resolveProject) → daemon
+```
+
+- Everything talks to the **CLI**. The CLI's `resolveProject` step is the **single
+  point** that turns "wherever the agent is" into the canonical **project (+ optional
+  worktree)** a session belongs to. It is the bridge between the cwd contract (how
+  cwd/worktree are collected) and the data model (project → worktree → session).
+- `resolveProject` is **the core model step** — not an add-on. Project/worktree
+  membership is defined here and nowhere else; every downstream consumer (registry,
+  session record, history, UI) reads what it stamps.
+
+## Why it exists — the UX this model must enable (normative goals)
+
+The whole point of resolving sessions to a stable project (and optional worktree) is
+**project-based UX**:
+
+1. **Group sessions under a single project** — a project shows all its sessions.
+2. **Group worktrees (and their sessions) under that project** — `project → worktree
+   → session` is navigable in the UI, not a flat list.
+3. **Per-project history** — a project's plan/annotate history is viewable scoped to
+   that project (and, where relevant, that worktree).
+4. **Global history** — history is *also* queryable across all projects (the
+   cross-project view; replaces the old "archive" browse use case, which the
+   per-plan version browser never covered).
+
+These are the acceptance goals the model is built to serve; the data model and the
+cwd contract are the means.
+
+---
+
+## Verification criteria (checkable, moving forward)
+
+- [ ] **VC1 — Single resolution point.** Project/worktree membership for a session is
+      produced by `resolveProject` and nothing re-derives it independently. (Today's
+      known violation: history writers still call `detectProjectName(cwd)` — see
+      `../project-resolution-followups.md` #1.)
+- [ ] **VC2 — Grouping is derivable.** Given the live sessions + registry, the UI can
+      render `project → worktree → session` purely by grouping on the
+      `projectCwd`/`worktree.cwd` keys the resolver stamps (no extra lookups).
+- [ ] **VC3 — Per-project history.** History is addressable by project (and worktree
+      where applicable), consistent with the resolved owning project.
+- [ ] **VC4 — Global history.** A cross-project history query/endpoint exists and
+      lists across all projects.
+
+---
+
+## Consistency check (no discrepancy with companion facts)
+
+- **Data model** (`project-worktree-session-hierarchy.md`): unchanged and matched —
+  this fact names the pipeline step that *produces* that hierarchy. The middle tier
+  ("worktree") is the generalized sub-scope (git worktree **or** sub-repo under a
+  declared workspace), per rule 4 there.
+- **cwd contract** (`cwd-worktree-collection-contract.md`): unchanged and matched —
+  `cli(resolveProject)` is exactly the CLI-authoritative, git-root-normalizing step
+  that contract describes; host enrichment remains optional.
+- VC3/VC4 here (per-project + global history) are the *goal* statements; the
+  *migration work* to reach them is tracked in `../project-resolution-followups.md`
+  (#1 history→resolver, #3 global view, #4 aggregation + UI tree).

--- a/goals/architecture/decisions/phase4-ui-surfaces.md
+++ b/goals/architecture/decisions/phase4-ui-surfaces.md
@@ -1,0 +1,104 @@
+# Decision Fact: Phase 4 UI Surfaces (launcher / sidebar / sessions+history)
+
+**Status:** Decided (normative) · **Date:** 2026-05-29 · **Owner:** Michael Ramos
+**Scope:** How the project → worktree → session data model surfaces in the UI. Builds
+on `./project-worktree-session-hierarchy.md` (the model), `./core-model-and-project-ux.md`
+(the UX goals), and the Phase 2/3 primitives: `buildSessionTree` (packages/ui/utils)
+and `GET /daemon/history`.
+
+---
+
+## The facts
+
+1. **The launcher does not change.** The front-page "Select project → launch" flow
+   (select a project, start Code Review / plan / etc.) stays exactly as it is today.
+   Selecting projects to start new work is untouched.
+
+2. **The sidebar groups by project, not by type.** It changes from today's grouping
+   by session type (plan / review / annotate, in `AppSidebar.tsx`) to
+   **project → worktree → session**, rendered from `buildSessionTree`.
+
+3. **The sidebar shows live sessions only.** No history in the sidebar — it is the
+   at-a-glance "what's running where."
+
+4. **The sidebar lists ALL projects, but only the active one is expanded.** Every
+   project appears; the active project is auto-expanded; the rest are collapsed but
+   expandable to reveal their live sessions.
+
+5. **The active project is the owning project of the current session.** Whatever
+   session is open determines which project is expanded.
+
+6. **History is browsable and filterable by project** — both per-project ("this
+   project's past plans") and global ("everything"). New; does not exist today.
+
+7. **Active sessions and history are conjoined into one surface.** A single view with
+   an **Active ⇄ All** filter (All surfaces history) plus a **project filter**. A
+   **full-page "full history" view** — modeled on the Git Dashboard's full-screen
+   carousel-slide-with-Back pattern (`LandingPage` `viewIndex` carousel + `GitDashboard`
+   `onBack`) — shows the complete history browse.
+
+---
+
+## Surfaces → primitives
+
+| Surface | Renders | Powered by |
+|---|---|---|
+| Launcher | unchanged | existing `ProjectTable` / selection |
+| Sidebar (`AppSidebar.tsx`) | all projects → worktrees → live sessions; active expanded | `buildSessionTree(projects, sessions)` — needs `projectStore` as a 2nd input |
+| Sessions + History (conjoined) | live sessions + history, Active⇄All + project filter; full-page mode | live sessions (`useDaemonEventStore`) + `GET /daemon/history`; full-page via the carousel/full-screen pattern |
+
+---
+
+## Verification criteria
+
+- [ ] **VC1 — Launcher untouched.** Select-project → launch behaves identically to before.
+- [ ] **VC2 — Sidebar tree.** Sidebar renders `project → worktree → session` from
+      `buildSessionTree` (closes hierarchy VC6).
+- [ ] **VC3 — Sidebar state.** All projects listed; active project auto-expanded;
+      others collapsed but expandable; live sessions only.
+- [ ] **VC4 — Active project.** The expanded project equals the owning project of the
+      currently-open session.
+- [ ] **VC5 — Counts reconcile.** Every live session appears exactly once in the
+      sidebar under its project/worktree (closes hierarchy VC7).
+- [ ] **VC6 — Conjoined view.** One surface with Active⇄All + project filter; "All"
+      includes history (from `/daemon/history`).
+- [ ] **VC7 — Full history page.** A full-page history browse exists, following the
+      Git Dashboard full-screen pattern.
+
+---
+
+## State plan (frontend)
+
+Audited against the live stores. Owner intent (reuse what's in state; add only what's
+missing) holds — almost everything is already there.
+
+**Reuse as-is:** live sessions (`useDaemonEventStore.sessions`, already carry
+`projectCwd`/`worktree`), `projectStore.projects`, `appStore.activeSessionId`.
+
+**Derive (not stored):**
+- Session tree → `useMemo(buildSessionTree(projects, sessions))`. Signature is exactly
+  `(projects, sessions)` — both already in stores; no third input.
+- Active project → selector `activeSessionId → session → projectCwd ?? cwd` (same
+  owning-key fallback as `sessionTree.ts`). Derived, never stored (single source of truth).
+
+**New (the whole added surface):**
+1. `appStore`: `expandedProjects: Set<string>` + `toggleProjectExpand(cwd)` /
+   `setProjectExpanded(cwd, open)`. **Immer: yes** (Set mutation). In `appStore` so it
+   survives sidebar remounts.
+2. New `stores/history-store.ts` — clone of `git-dashboard-store` (`entries`, `loading`,
+   `error`, `lastFetchedAt`, `lastProjectKey`; `fetchHistory(projectCwd?)`, `clear()`).
+   **Immer: yes**.
+3. `daemonApiClient.getHistory(projectCwd?)` + `HistoryListResponse` type/guard
+   (mirror the PR-detailed list). Route exists; client method doesn't.
+
+**Local `useState` (no store):** conjoined-view `activeOrAll`, `projectFilter`,
+`fullHistoryViewIndex` — flat, view-local scalars (no Immer).
+
+Net for the sidebar slice specifically: extend `appStore` (expand state + active-project
+selector) + rewrite `AppSidebar.tsx` to render `buildSessionTree`. The history store +
+client method belong to the conjoined-view slice (later).
+
+## Out of scope (this phase)
+
+The plan/review/annotate session screens themselves; the resolver/registry/history
+backend (done in Phases 1–3); any redesign beyond the three surfaces above.

--- a/goals/architecture/decisions/project-worktree-session-hierarchy.md
+++ b/goals/architecture/decisions/project-worktree-session-hierarchy.md
@@ -29,13 +29,19 @@ project -> worktree -> session
 3. **If a session belongs to a worktree, that worktree must belong to the same
    project the session belongs to.** A session can never reference a worktree of a
    different project.
-4. **A worktree belongs to exactly one project** (its root/main repository). A
-   worktree never floats free and is never itself a project.
+4. **A worktree belongs to exactly one project.** "Worktree" is the **sub-scope
+   tier** generally — a git worktree, **or** a sub-repo sitting under a declared
+   (often non-git) workspace root. Its owning project is the project it *resolves
+   under*: the **main repo** for a true git worktree, or the **declared workspace
+   root** for a sub-repo (e.g. `mygroup/a` → project `mygroup`, worktree `a`). A
+   worktree never floats free and is never itself a top-level project.
 5. **Resolution at launch time:**
    - Launched in a normal repo/directory → `project = that repo`, `worktree = none`.
    - Launched in a git worktree → `project = the root/main repo`, `worktree = that
-     worktree`. The session rolls up to the root project and is *tagged* with the
-     worktree it came from.
+     worktree`. The session rolls up to the root project, tagged with the worktree.
+   - Launched under a **declared workspace root** → `project = the declared root`,
+     `worktree = the sub-repo/worktree you're in` (or none if directly in the root).
+     This is how the non-git `mygroup/` workspace of sibling repos is modeled.
 
 ---
 

--- a/goals/architecture/plan-history-usage-map.md
+++ b/goals/architecture/plan-history-usage-map.md
@@ -1,0 +1,95 @@
+# Plan Version History — Usage Map (current state)
+
+> Where/who/how plan version history is used today, traced before any restructure.
+> Read-only audit, 2026-05-29, branch `feat/project-resolution`. This is the
+> reference for moving history onto the project → worktree → session data model and
+> for adding a global (cross-project) history view.
+
+## What history is
+
+Every plan you submit is auto-saved to disk as a numbered version, so you can see
+how it changed over time (the version browser + plan diff). On-disk layout:
+
+```
+~/.plannotator/history/{project}/{slug}/NNN.md     (001.md, 002.md, …)
+```
+- `slug` = first `# heading` of the plan, sanitized, + `-YYYY-MM-DD` (same heading,
+  same day → same slug → same folder). `generateSlug`, `storage.ts:49`.
+- Only **two** path segments today: `{project}` and `{slug}`. **No worktree level.**
+- Storage fns live in `packages/shared/storage.ts` (re-exported by
+  `packages/server/storage.ts`): `getHistoryDir`, `saveToHistory`,
+  `getPlanVersion`, `getPlanVersionPath`, `getVersionCount`, `listVersions`,
+  `generateSlug`. All hard-code the 2-segment `history/{project}/{slug}` path.
+
+## Writers (who saves history)
+
+| Session type | Writes history? | Where |
+|---|---|---|
+| **plan** | ✅ | `packages/server/index.ts:151` (init), `:427` (resubmit) |
+| **annotate** (single file) | ✅ | `packages/server/annotate.ts:146` (init), `:345` (resubmit) |
+| annotate (folder / last-message) | ❌ | gated by `isFileBased` |
+| **review** | ❌ | no history calls at all |
+
+**Key fact / the divergence:** both writers compute the `{project}` segment with
+`detectProjectName(cwd)` on the **operational cwd**, *inside the per-session servers*
+— NOT via the new `resolveProject`. `session-factory` resolves the owning project
+for the session record + registry, but it delegates plan/annotate creation to
+`createPlannotatorSession`/`createAnnotateSession`, which re-derive project from cwd
+themselves (`index.ts:150`, `annotate.ts:140`). So **history is still keyed by the
+launch folder, not the resolved owning project** — a plan run in a worktree files
+under the worktree's name.
+
+The `slug` is fixed at session init (from the first plan's heading) and reused for
+every resubmit.
+
+## Readers (who shows history)
+
+- **Plan server** (`index.ts`): `GET /api/plan/version?v=N`, `GET /api/plan/versions`,
+  `POST /api/plan/vscode-diff` (uses `getPlanVersionPath`), and `GET /api/plan`
+  returns inline `previousPlan` + `versionInfo {version, totalVersions, project}`.
+- **Annotate server** (`annotate.ts`): `GET /api/plan/version`, `GET /api/plan/versions`
+  (gated by `isFileBased`).
+- **Frontend**: `usePlanDiff.ts` (`selectBaseVersion` → `/api/plan/version`,
+  `fetchVersions` → `/api/plan/versions`); `VersionBrowser.tsx` sidebar; the plan
+  diff engine; `session-revision` updates on resubmit; `previousPlan`/`project` fed
+  into Ask-AI context (`packages/ai/context.ts:162,169`).
+- Reads are **session-scoped**: the `project`+`slug` set at init are threaded through
+  the session closure; nothing re-derives them, and nothing reads across sessions.
+
+## Global / cross-project history
+
+**Does not exist.** Every read needs an explicit `{project, slug}`; nothing
+enumerates the `history/` root to list across projects. The only root-level touch is
+**deletion**: `DELETE /daemon/projects` does `rm -rf history/{projectName}/`
+(`server.ts:565`), triggered by the dashboard "Remove project" action. No "recent
+plans", search, or cross-project listing anywhere.
+
+## Coupling: write key vs read key
+
+- **Write**: `{project}` = `sanitizeTag(detectProjectName(cwd))` (operational cwd).
+- **Read**: same `{project}`/`{slug}` reused within the session; no normalization
+  layer between writer and reader.
+- **Risk**: if the `{project}` key ever changes for the same plan (repo rename,
+  worktree, or the `resolveProject` vs `detectProjectName` divergence), old versions
+  become invisible — readers only find what writers wrote under that exact key.
+
+## Restructure implications
+
+**To make history follow project → worktree → session** (`history/{project}/{worktree?}/{slug}/`):
+1. Add a `worktree?` segment to all 6 storage fns (signature change).
+2. Update all 4 `saveToHistory` call sites to pass it.
+3. Decide the project-delete cleanup scope (`server.ts:571`) — delete whole project,
+   or per-worktree.
+4. Switch the writers from `detectProjectName(cwd)` to the resolver's owning project
+   (thread `resolved.projectName` + worktree into the per-session servers) so the
+   on-disk key matches the data model. (This also fixes the divergence above.)
+5. Keep `session-factory`'s `matchKey` (`scopeKey`-based, already worktree-aware)
+   consistent with the on-disk key if they're meant to correlate.
+
+**To add a global (cross-project) view** — net-new:
+- A function enumerating `history/` → project → (worktree?) → slug → versions.
+- A new unscoped daemon endpoint (e.g. `GET /daemon/history`) — the existing
+  `/api/plan/*` endpoints are session-bound and can't serve this.
+
+**Desired end state (from the owner):** per-project history that mirrors the data
+model, plus a global view that simply queries across all projects.

--- a/goals/architecture/project-resolution-followups.md
+++ b/goals/architecture/project-resolution-followups.md
@@ -1,0 +1,70 @@
+# Project Resolution — Follow-ups / Backlog
+
+> Open items after the project-resolution backend landed (branch
+> `feat/project-resolution`, 2026-05-29). The resolver + registry + session
+> attribution + 40 tests are done; these are the not-yet-migrated edges and the
+> next layers. Context: `./decisions/project-worktree-session-hierarchy.md`,
+> `./decisions/cwd-worktree-collection-contract.md`, `./plan-history-usage-map.md`.
+
+## 1. Migrate history onto the resolver (NOT a regression — unmigrated)
+
+**Why:** the resolver is new; the plan/annotate servers still compute the history
+`{project}` segment via `detectProjectName(cwd)` on the operational cwd, independent
+of `resolveProject`. So the registry/live session attribute a worktree plan to the
+main repo, but its **history files quietly land under the worktree's folder**. Two
+attribution systems disagree.
+
+**Fix:**
+- Thread the resolved owning project (`resolved.projectName`, + worktree) from
+  `session-factory` into `createPlannotatorSession` / `createAnnotateSession` instead
+  of re-deriving from cwd (`packages/server/index.ts:150`, `annotate.ts:140`).
+- Move history layout to mirror the data model: `history/{project}/{worktree?}/{slug}/`
+  — add a `worktree?` segment to the 6 storage fns in `packages/shared/storage.ts`
+  and the 4 `saveToHistory` call sites.
+- Reconcile the project-delete cleanup (`server.ts:571`, `rm -rf history/{name}`)
+  with the new layout.
+- Keep consistent with `session-factory`'s `scopeKey` matchKey (already
+  worktree-aware).
+
+**Size:** ~4 backend files. **Risk:** low. **Note:** old history written under the
+pre-migration key becomes invisible to new sessions unless we add a fallback/migration
+read — decide whether to migrate existing folders or just start fresh.
+
+## 2. Session snapshot meta missing the new keys
+
+The disk snapshot (`sessions/{id}.json`, written only on `complete()`) has
+`meta: { project, origin, cwd, label }` — no `projectCwd`/`worktree`
+(`session-store.ts:84`). The live record/summary carry them; the snapshot doesn't.
+Add them to `SessionSnapshot.meta` + `writeSnapshot`, and rehydrate on startup
+(`runtime.ts`). Small. Low priority (snapshots are rare).
+
+## 3. Global (cross-project) history view — net-new
+
+No cross-project history query exists today; every read needs an explicit
+`{project, slug}`. Desired end state (owner): per-project history that mirrors the
+model, plus a **global** view that queries across all projects.
+- New fn enumerating `history/` → project → (worktree?) → slug → versions.
+- New unscoped endpoint (e.g. `GET /daemon/history`) — the `/api/plan/*` endpoints
+  are session-bound and can't serve this.
+
+## 4. Aggregation layer + UI tree (`project → worktree → session`)
+
+Membership (forward edges) is done; the reverse/aggregate edges (project has many
+sessions/worktrees, worktree has many sessions) are not materialized.
+- A pure **tree builder**: `(declared roots + worktree rows, sessions[]) → tree`,
+  grouping the live session list by the `projectCwd`/`worktree.cwd` keys the resolver
+  now stamps. Unit-testable like the resolver.
+- Landing-page UI to render the tree (today projects + sessions are separate regions;
+  worktrees are a display-time filter). This is the larger piece.
+
+## 5. Frontend "add project" → declared path
+
+The manual `POST /daemon/projects` now marks entries `declared: true` (enables the
+non-git workspace / `mygroup/` case). The landing "add project" button works through
+that path but hasn't been wired/verified for declaring a workspace root explicitly.
+
+## 6. Doc drift
+
+`CLAUDE.md` documents plan/review matchKeys as `plan:project:slug` /
+`review:project:branch`; they're now keyed on the operational scope
+(`scopeKey`-based) to keep worktrees distinct. Update the doc.

--- a/goals/performance/long-running-session-costs.md
+++ b/goals/performance/long-running-session-costs.md
@@ -1,0 +1,114 @@
+# The Cost of Long-Running Sessions (UI rendering)
+
+> Investigation, 2026-05-29. "Sessions never die" (they suspend/idle and stay alive
+> until cancel or daemon restart) — this documents what that costs in the frontend,
+> what the current optimizations cover, and where it breaks. Reconciles with
+> `./findings.md`. Read-only audit; cites file:line.
+
+## The core model (and its assumption)
+
+Every session you **visit** is added to `appStore.visitedSessions` and rendered as a
+**permanently-mounted** panel in `Layout.tsx:67-83` — switching sessions only toggles
+`visibility`/`contentVisibility`, it never unmounts. `appStore.removeSession()` exists
+but is **never called anywhere** (`s.$sessionId.tsx:22-32` only ever *adds*). There is
+**no eviction, LRU, or cap.**
+
+So the frontend was built assuming sessions are **few and transient**. The single-server
+"sessions never die" model violates that: open N sessions over a daemon's lifetime → N
+heavy surfaces (code-review diff viewers, plan editors) stay mounted simultaneously,
+forever, until a page reload.
+
+## What holds up (and to what scale)
+
+These keep the **active** session and **switching** cheap:
+
+- **`SessionSurface` is `React.memo`'d** (`SessionSurface.tsx:21`) + Layout uses
+  selector-based Zustand — switching active session doesn't re-render the others.
+- **`contentVisibility: hidden` + `containIntrinsicSize`** on inactive panels
+  (`Layout.tsx:75`) — the browser skips *paint/layout* for hidden sessions (big win;
+  only the active session pays render cost).
+- **Code-review Zustand store** (annotations/files/diff-options slices) + selector
+  subscriptions + `FileTreeNodeItem` memo — the active code-review surface is the
+  optimized one.
+- **Daemon-shell stores** (app/project/event/git-dashboard) are selector-based, so
+  unrelated updates don't cascade.
+
+**Verdict: fine at 1–2 sessions, OK at 3–5.** Beyond that the structural gaps dominate.
+
+## What fails as sessions accumulate
+
+**1. Memory / DOM grows unbounded (no eviction).**
+Each mounted surface is ~5–20 MB and tens of thousands of DOM nodes; nothing tears them
+down. Worse, within a code-review session, Pierre diffs **never unmount once viewed**
+(`LazyFileDiff` sets `mounted=true`, never false; findings #16) and the file tree isn't
+virtualized — so a 50-file review keeps ~50 diff trees in the DOM, per session. N
+sessions stack: ~5–10 MB added per session opened, never reclaimed.
+
+**2. Every hidden session keeps doing work (pollers/subscriptions/listeners).**
+`contentVisibility` stops *painting* but not *JS*. Each mounted session keeps running,
+even when hidden:
+- 3–4 daemon WS subscriptions (external-annotations, agent-jobs, session-revision) each
+  with a **2s HTTP polling fallback** (`useDaemonSessionTransport.ts`, `useExternalAnnotations.ts:21`, `useAgentJobs.ts:20`);
+- a 500ms draft-autosave debounce when there are edits;
+- global `keydown` listeners (`code-review App.tsx:734`, `plan App.tsx:842`) — every
+  keystroke fires on all K sessions;
+- MutationObserver / ResizeObserver / IntersectionObserver per session;
+- `configStore.listeners` grows ~O(15·N) and never shrinks.
+- The `useSessionVisible()` signal exists but is **only used for `document.title`** — it
+  does **not** gate any of the above. So K hidden sessions = K× pollers + listeners
+  running. Idle CPU creeps up (~15–25% at 5–10 sessions).
+
+**3. List churn: every session event re-renders everything, unvirtualized.**
+`event-store.ts:67-71` replaces the `sessions` array on **every** `session-updated`
+(status flips, `updatedAt` bumps). That re-runs the sidebar's `buildSessionTree`
+(`AppSidebar.tsx:185`) and re-renders the whole tree + the conjoined sessions/history
+lists — **none are virtualized**. With many live sessions emitting events, this is
+repeated full-array work per event.
+
+**4. The App monoliths still reconcile on hot paths.**
+Code-review `App.tsx` (~2600 lines) keeps hot-path state in `useState` (split-drag,
+all-files scroll) that fires ~60×/sec during drag/scroll → full App reconcile;
+`ReviewSidebar`'s memo is **commented out**. `contentVisibility` skips *rendering* the
+hidden sessions but not React's *reconciliation* of the active monolith. Plan-review is
+even less optimized (largely `useState`).
+
+**5. 19 MB single-file bundle, zero code-splitting.**
+`vite.config.ts` (`viteSingleFile` + `inlineDynamicImports` + `cssCodeSplit:false`) →
+one ~19 MB artifact: both apps, highlight.js, @pierre/diffs, dockview, mermaid, viz.js,
+50+ theme CSS, all fonts base64-inlined. No `React.lazy`. Parsed/compiled up front,
+resident per tab regardless of how many sessions or which mode is active.
+
+## Survivability estimate
+
+| Sessions | Behavior |
+|---|---|
+| 1–2 | Fully fine. |
+| 3–5 | OK — `contentVisibility` + memo + selectors carry it; active session ~60fps. |
+| 5–10 | **Degraded** — ~100–150 MB, idle CPU ~15–25% (pollers), occasional scroll/drag jank. |
+| 10+ | **Fails** — 200 MB+, GC pauses (100–200ms), <20fps interaction; user closes tabs or it crashes. |
+
+## Reconciliation with findings.md
+
+This isn't new debt — it's the **same** open items in `findings.md`, **amplified** by the
+never-die model (they go from "one session degrades over time" → "N sessions stack"):
+- Tier 1: SessionSurface memo (fixed) + contentVisibility (mitigates DOM weight) + the
+  App.tsx monolith (#3, **open**).
+- Tier 3: scroll/resize re-renders, per-file observers (**open**).
+- Tier 5: unbounded growth — Maps never purged, pollers/listeners accumulate (#26–#30,
+  **open**) — this is the one the session model makes acute.
+- Tier 6: no code-splitting, eager mermaid/viz.js (#31–#37, **open**).
+
+## What would make it survivable (priority order)
+
+1. **Evict / cap mounted sessions** — keep only the active + a small recent set mounted;
+   unmount the rest (re-mount on revisit from bootstrap). The single highest-leverage fix
+   for the never-die model; directly bounds 1, 2, and the DOM side of 4.
+2. **Gate per-session work on visibility** — thread `useSessionVisible()` into the
+   subscription/poller hooks so hidden sessions pause (kills the K× pollers/listeners).
+3. **Virtualize** the file tree, the diff list, and the session/history lists.
+4. **De-monolith the App hot paths** — move split-drag/scroll state into the store with
+   selectors; re-enable the `ReviewSidebar` memo.
+5. **Code-split** — lazy-load code-review vs plan-review; defer mermaid/viz.js.
+
+Note: the daemon/AI layer already evicts idle sessions server-side
+(`packages/ai/session-manager.ts`); the **frontend has no equivalent** — that's the gap.

--- a/packages/server/annotate.ts
+++ b/packages/server/annotate.ts
@@ -70,6 +70,10 @@ export interface AnnotateServerOptions {
   onReady?: (url: string, isRemote: boolean, port: number) => void;
   /** Optional daemon event bridge for live session-scoped events. */
   sessionEvents?: SessionEventBridge;
+  /** Resolved owning project name for history keying. Absent → detectProjectName(cwd) fallback. */
+  project?: string;
+  /** Worktree segment for history keying. Present only if the session sits in a worktree. */
+  worktreeSeg?: string;
 }
 
 export interface AnnotateSession {
@@ -105,6 +109,8 @@ export async function createAnnotateSession(
     gate = false,
     rawHtml: initialRawHtml,
     renderHtml = false,
+    project: optionalProject,
+    worktreeSeg,
   } = options;
   let markdown = initialMarkdown;
   let rawHtml = initialRawHtml;
@@ -137,19 +143,19 @@ export async function createAnnotateSession(
 
   // Version history (single-file annotate only — folders have no single document to track)
   const isFileBased = mode === "annotate";
-  const project = isFileBased ? ((await detectProjectName(cwd)) ?? "_unknown") : "";
+  const project = isFileBased ? (optionalProject ?? (await detectProjectName(cwd)) ?? "_unknown") : "";
   const slug = isFileBased ? generateSlug(markdown) : "";
   let previousPlan: string | null = null;
   let versionInfo: { version: number; totalVersions: number; project: string } | null = null;
 
   if (isFileBased && markdown.trim()) {
-    const historyResult = saveToHistory(project, slug, markdown);
+    const historyResult = saveToHistory(project, slug, markdown, worktreeSeg);
     previousPlan = historyResult.version > 1
-      ? getPlanVersion(project, slug, historyResult.version - 1)
+      ? getPlanVersion(project, slug, historyResult.version - 1, worktreeSeg)
       : null;
     versionInfo = {
       version: historyResult.version,
-      totalVersions: getVersionCount(project, slug),
+      totalVersions: getVersionCount(project, slug, worktreeSeg),
       project,
     };
   }
@@ -191,14 +197,14 @@ export async function createAnnotateSession(
             if (!vParam) return new Response("Missing v parameter", { status: 400 });
             const v = parseInt(vParam, 10);
             if (isNaN(v) || v < 1) return new Response("Invalid version number", { status: 400 });
-            const content = getPlanVersion(project, slug, v);
+            const content = getPlanVersion(project, slug, v, worktreeSeg);
             if (content === null) return Response.json({ error: "Version not found" }, { status: 404 });
             return Response.json({ plan: content, version: v });
           }
 
           // API: List all versions
           if (url.pathname === "/api/plan/versions" && isFileBased) {
-            return Response.json({ project, slug, versions: listVersions(project, slug) });
+            return Response.json({ project, slug, versions: listVersions(project, slug, worktreeSeg) });
           }
 
           // API: Update user config (write-back to ~/.plannotator/config.json)
@@ -342,13 +348,13 @@ export async function createAnnotateSession(
     lastDecision = null;
     rawHtml = newRawHtml;
     if (isFileBased && newMarkdown.trim()) {
-      const historyResult = saveToHistory(project, slug, newMarkdown);
+      const historyResult = saveToHistory(project, slug, newMarkdown, worktreeSeg);
       previousPlan = historyResult.version > 1
-        ? getPlanVersion(project, slug, historyResult.version - 1)
+        ? getPlanVersion(project, slug, historyResult.version - 1, worktreeSeg)
         : null;
       versionInfo = {
         version: historyResult.version,
-        totalVersions: getVersionCount(project, slug),
+        totalVersions: getVersionCount(project, slug, worktreeSeg),
         project,
       };
     }

--- a/packages/server/daemon/project-registry.ts
+++ b/packages/server/daemon/project-registry.ts
@@ -3,7 +3,7 @@ import { getPlannotatorDataDir } from "@plannotator/shared/data-dir";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { execSync } from "child_process";
 import { homedir } from "os";
-import { join, resolve, dirname } from "path";
+import { join, resolve, dirname, basename } from "path";
 
 export interface ProjectRegistryOptions {
   baseDir?: string;
@@ -50,6 +50,7 @@ export function registerProject(
   name: string,
   cwd: string,
   options: ProjectRegistryOptions = {},
+  declared = false,
 ): DaemonProjectEntry {
   const entries = readProjectRegistry(options);
   const now = new Date().toISOString();
@@ -57,10 +58,11 @@ export function registerProject(
   if (existing) {
     existing.name = name;
     existing.lastSeen = now;
+    if (declared) existing.declared = true; // sticky: never auto-unset a declared root
     writeProjectRegistry(entries, options);
     return existing;
   }
-  const entry: DaemonProjectEntry = { name, cwd, lastSeen: now };
+  const entry: DaemonProjectEntry = { name, cwd, lastSeen: now, ...(declared && { declared: true }) };
   entries.push(entry);
   writeProjectRegistry(entries, options);
   return entry;
@@ -112,6 +114,7 @@ export function addProject(
   cwd: string,
   name: string | undefined,
   options: ProjectRegistryOptions = {},
+  declared = false,
 ): DaemonProjectEntry {
   const resolved = cwd.startsWith("~/")
     ? join(homedir(), cwd.slice(2))
@@ -142,6 +145,7 @@ export function addProject(
       existing.lastSeen = now;
       existing.parentCwd = wt.parentCwd;
       existing.branch = wt.branch;
+      if (declared) existing.declared = true;
       writeProjectRegistry(entries, options);
       return existing;
     }
@@ -151,11 +155,58 @@ export function addProject(
       lastSeen: now,
       parentCwd: wt.parentCwd,
       branch: wt.branch,
+      ...(declared && { declared: true }),
     };
     entries.push(entry);
     writeProjectRegistry(entries, options);
     return entry;
   }
 
-  return registerProject(projectName, resolved, options);
+  return registerProject(projectName, resolved, options, declared);
+}
+
+/** User-declared project roots (registry entries flagged `declared`). */
+export function getDeclaredRoots(
+  options: ProjectRegistryOptions = {},
+): Array<{ cwd: string; name: string }> {
+  return readProjectRegistry(options)
+    .filter((e) => e.declared === true)
+    .map((e) => ({ cwd: e.cwd, name: e.name }));
+}
+
+/**
+ * Persist a resolved project (the owning root, plus its worktree/sub-repo child when
+ * present). Used by auto-add at session-create time. Never sets `declared` — declared
+ * roots are created only via the explicit add path.
+ */
+export function registerResolvedProject(
+  resolved: { projectCwd: string; projectName: string; worktree?: { cwd: string; branch?: string } },
+  options: ProjectRegistryOptions = {},
+): void {
+  // Owning project (preserves an existing `declared` flag).
+  registerProject(resolved.projectName, resolved.projectCwd, options);
+
+  // Sub-scope (worktree or sub-repo) as a child row under the project.
+  if (resolved.worktree && resolved.worktree.cwd !== resolved.projectCwd) {
+    const entries = readProjectRegistry(options);
+    const now = new Date().toISOString();
+    const childCwd = resolved.worktree.cwd;
+    const childName = basename(childCwd) || resolved.projectName;
+    const existing = entries.find((e) => e.cwd === childCwd);
+    if (existing) {
+      existing.name = childName;
+      existing.lastSeen = now;
+      existing.parentCwd = resolved.projectCwd;
+      existing.branch = resolved.worktree.branch;
+    } else {
+      entries.push({
+        name: childName,
+        cwd: childCwd,
+        lastSeen: now,
+        parentCwd: resolved.projectCwd,
+        branch: resolved.worktree.branch,
+      });
+    }
+    writeProjectRegistry(entries, options);
+  }
 }

--- a/packages/server/daemon/project-resolution.integration.test.ts
+++ b/packages/server/daemon/project-resolution.integration.test.ts
@@ -61,8 +61,13 @@ let workspace = "";
 let wsA = "";
 let wsB = "";
 let wsNotes = "";
+let wsADeep = "";
+let wsAWtInside = "";
+let wsAWtInsideDeep = "";
+let wsAWtOutside = "";
 let outer = "";
 let inner = "";
+let innerDeep = "";
 let plain = "";
 
 beforeAll(() => {
@@ -86,10 +91,21 @@ beforeAll(() => {
   wsA = initRepo(join(workspace, "a"));
   wsB = initRepo(join(workspace, "b"));
   wsNotes = mkdir(join(workspace, "notes"));
+  wsADeep = mkdir(join(wsA, "packages", "x")); // deep cwd inside a sub-repo
 
-  // nested repos: outer repo containing an independent inner repo
+  // worktree of sub-repo wsA, located INSIDE the workspace, + a deep subdir in it
+  wsAWtInside = join(workspace, "a-wt");
+  sh(`git ${GIT_ID} worktree add -b feat/a-in ${wsAWtInside}`, wsA);
+  wsAWtInsideDeep = mkdir(join(wsAWtInside, "src", "deep"));
+
+  // worktree of sub-repo wsA, located OUTSIDE the workspace
+  wsAWtOutside = join(ROOT, "ws-a-wt");
+  sh(`git ${GIT_ID} worktree add -b feat/a-out ${wsAWtOutside}`, wsA);
+
+  // nested repos: outer repo containing an independent inner repo + deep subdir
   outer = initRepo(join(ROOT, "outer"));
   inner = initRepo(join(outer, "inner"));
+  innerDeep = mkdir(join(inner, "src", "deep"));
 
   // plain non-git standalone dir
   plain = mkdir(join(ROOT, "plain", "nested"));
@@ -298,5 +314,45 @@ describe("registry persistence (registerResolvedProject)", () => {
     const entries = readProjectRegistry({ baseDir: reg });
     expect(entries.filter((e) => e.cwd === solo)).toHaveLength(1);
     expect(entries.filter((e) => e.cwd === soloWtFeat)).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe("context crossings (deep cwd × declared × worktree)", () => {
+  function declareWorkspace(): string {
+    const reg = freshReg();
+    addProject(workspace, "workspace", { baseDir: reg }, true);
+    return reg;
+  }
+
+  test("deep cwd inside a sub-repo of a declared workspace → owns workspace, sub-scope is the sub-repo", () => {
+    const r = resolveProject(wsADeep, { baseDir: declareWorkspace() });
+    expect(r.projectCwd).toBe(workspace); // declared root wins
+    expect(r.worktree?.cwd).toBe(wsA); // sub-scope = the git repo it sits in, not the deep dir
+    expect(r.worktree?.branch).toBeTruthy();
+  });
+
+  test("deep cwd inside a nested repo (no declared) → innermost repo root", () => {
+    const r = resolveProject(innerDeep, { baseDir: freshReg() });
+    expect(r.projectCwd).toBe(inner); // not outer, not innerDeep
+    expect(r.worktree).toBeUndefined();
+  });
+
+  test("worktree INSIDE a declared workspace → owns workspace, sub-scope is the worktree dir (does not roll up to the sub-repo)", () => {
+    const r = resolveProject(wsAWtInside, { baseDir: declareWorkspace() });
+    expect(r.projectCwd).toBe(workspace); // declared root governs
+    expect(r.worktree?.cwd).toBe(wsAWtInside); // the worktree dir itself, NOT wsA
+  });
+
+  test("deep cwd inside a worktree inside a declared workspace → same workspace + worktree sub-scope", () => {
+    const r = resolveProject(wsAWtInsideDeep, { baseDir: declareWorkspace() });
+    expect(r.projectCwd).toBe(workspace);
+    expect(r.worktree?.cwd).toBe(wsAWtInside);
+  });
+
+  test("worktree OUTSIDE the declared workspace → ignores the declaration, rolls up to its own main repo", () => {
+    const r = resolveProject(wsAWtOutside, { baseDir: declareWorkspace() });
+    expect(r.projectCwd).toBe(wsA); // not workspace (worktree dir isn't under it), not wsAWtOutside
+    expect(r.worktree).toEqual({ cwd: wsAWtOutside, branch: "feat/a-out" });
   });
 });

--- a/packages/server/daemon/project-resolution.integration.test.ts
+++ b/packages/server/daemon/project-resolution.integration.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Integration tests for project resolution against REAL filesystems and REAL git.
+ *
+ * Each scenario builds an actual directory tree (git repos, linked worktrees,
+ * detached worktrees, nested repos, non-git workspaces of sibling repos, declared
+ * roots), runs the real resolver (`resolveProject`, which shells out to git) and the
+ * real registry I/O (`registerResolvedProject` / `addProject` writing a temp
+ * projects.json), and asserts the owning project / worktree tag / registry rows.
+ *
+ * Everything lives under one temp root that is realpath'd (macOS /var → /private/var)
+ * and removed in afterAll.
+ */
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { execSync } from "child_process";
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync, realpathSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { resolveProject } from "./project-resolver";
+import {
+  registerResolvedProject,
+  addProject,
+  getDeclaredRoots,
+  readProjectRegistry,
+} from "./project-registry";
+
+const GIT_ID = "-c user.email=t@t.dev -c user.name=Test -c commit.gpgsign=false";
+const sh = (cmd: string, cwd: string) =>
+  execSync(cmd, { cwd, encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+
+let ROOT = "";
+let regCounter = 0;
+
+/** A fresh empty registry dir (so resolve() sees no declared roots unless we add). */
+function freshReg(): string {
+  const dir = join(ROOT, "reg", String(regCounter++));
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function initRepo(dir: string): string {
+  mkdirSync(dir, { recursive: true });
+  sh("git init -q", dir);
+  writeFileSync(join(dir, "README.md"), "init\n");
+  sh(`git ${GIT_ID} add -A`, dir);
+  sh(`git ${GIT_ID} commit -q -m init`, dir);
+  return dir;
+}
+
+function mkdir(dir: string): string {
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+// Shared layout (built once).
+let solo = "";
+let soloSub = "";
+let soloWtFeat = "";
+let soloWtFeatDeep = "";
+let soloWtDetached = "";
+let workspace = "";
+let wsA = "";
+let wsB = "";
+let wsNotes = "";
+let outer = "";
+let inner = "";
+let plain = "";
+
+beforeAll(() => {
+  ROOT = realpathSync(mkdtempSync(join(tmpdir(), "pl-res-")));
+
+  // solo git repo + nested subdir
+  solo = initRepo(join(ROOT, "solo"));
+  soloSub = mkdir(join(solo, "packages", "ui"));
+
+  // linked worktree on a branch (sibling of solo) + a deep subdir inside it
+  soloWtFeat = join(ROOT, "solo-wt-feat");
+  sh(`git ${GIT_ID} worktree add -b feat/x ${soloWtFeat}`, solo);
+  soloWtFeatDeep = mkdir(join(soloWtFeat, "src", "deep"));
+
+  // detached-HEAD worktree
+  soloWtDetached = join(ROOT, "solo-wt-detached");
+  sh(`git ${GIT_ID} worktree add --detach ${soloWtDetached}`, solo);
+
+  // non-git workspace of sibling repos + a non-git subdir
+  workspace = mkdir(join(ROOT, "workspace"));
+  wsA = initRepo(join(workspace, "a"));
+  wsB = initRepo(join(workspace, "b"));
+  wsNotes = mkdir(join(workspace, "notes"));
+
+  // nested repos: outer repo containing an independent inner repo
+  outer = initRepo(join(ROOT, "outer"));
+  inner = initRepo(join(outer, "inner"));
+
+  // plain non-git standalone dir
+  plain = mkdir(join(ROOT, "plain", "nested"));
+});
+
+afterAll(() => {
+  if (ROOT) rmSync(ROOT, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+describe("plain git repo (no declared roots)", () => {
+  test("launched at repo root → project is the repo", () => {
+    const r = resolveProject(solo, { baseDir: freshReg() });
+    expect(r.projectCwd).toBe(solo);
+    expect(r.projectName).toBe("solo");
+    expect(r.worktree).toBeUndefined();
+  });
+
+  test("launched in a nested subdir → project is the repo root (VC8)", () => {
+    const r = resolveProject(soloSub, { baseDir: freshReg() });
+    expect(r.projectCwd).toBe(solo); // not solo/packages/ui
+    expect(r.projectName).toBe("solo");
+    expect(r.worktree).toBeUndefined();
+  });
+
+  test("trailing slash on cwd is normalized", () => {
+    const r = resolveProject(solo + "/", { baseDir: freshReg() });
+    expect(r.projectCwd).toBe(solo);
+  });
+});
+
+describe("worktrees roll up to the main repo (VC2/VC3)", () => {
+  test("worktree on a branch → owns main repo, tagged {cwd, branch}", () => {
+    const r = resolveProject(soloWtFeat, { baseDir: freshReg() });
+    expect(r.projectCwd).toBe(solo);
+    expect(r.projectName).toBe("solo");
+    expect(r.worktree).toEqual({ cwd: soloWtFeat, branch: "feat/x" });
+  });
+
+  test("subdir inside a worktree → still owns main repo, scope is the worktree root", () => {
+    const r = resolveProject(soloWtFeatDeep, { baseDir: freshReg() });
+    expect(r.projectCwd).toBe(solo);
+    expect(r.worktree).toEqual({ cwd: soloWtFeat, branch: "feat/x" });
+  });
+
+  test("detached-HEAD worktree → tagged with no branch", () => {
+    const r = resolveProject(soloWtDetached, { baseDir: freshReg() });
+    expect(r.projectCwd).toBe(solo);
+    expect(r.worktree?.cwd).toBe(soloWtDetached);
+    expect(r.worktree?.branch).toBeUndefined();
+  });
+
+  test("two worktrees of one repo → same owning project, distinct scopes", () => {
+    const reg = freshReg();
+    const a = resolveProject(soloWtFeat, { baseDir: reg });
+    const b = resolveProject(soloWtDetached, { baseDir: reg });
+    expect(a.projectCwd).toBe(solo);
+    expect(b.projectCwd).toBe(solo);
+    expect(a.worktree?.cwd).not.toBe(b.worktree?.cwd);
+  });
+});
+
+describe("non-git directories", () => {
+  test("plain non-git dir → the directory itself is the project", () => {
+    const r = resolveProject(plain, { baseDir: freshReg() });
+    expect(r.projectCwd).toBe(plain);
+    expect(r.projectName).toBe("nested");
+    expect(r.worktree).toBeUndefined();
+  });
+
+  test("non-git workspace root (not declared) → resolves to itself, sibling repos do NOT roll up", () => {
+    const reg = freshReg();
+    expect(resolveProject(workspace, { baseDir: reg }).projectCwd).toBe(workspace);
+    // a sub-repo with no declaration is its own project (git toplevel)
+    const a = resolveProject(wsA, { baseDir: reg });
+    expect(a.projectCwd).toBe(wsA);
+    expect(a.worktree).toBeUndefined();
+  });
+});
+
+describe("nested repos", () => {
+  test("inner repo wins over outer (git toplevel is innermost)", () => {
+    const r = resolveProject(inner, { baseDir: freshReg() });
+    expect(r.projectCwd).toBe(inner);
+    expect(r.projectName).toBe("inner");
+  });
+
+  test("outer repo root → outer", () => {
+    const r = resolveProject(outer, { baseDir: freshReg() });
+    expect(r.projectCwd).toBe(outer);
+  });
+});
+
+describe("declared workspace roots (mygroup/ case)", () => {
+  function declared(...roots: Array<{ cwd: string; name: string }>): string {
+    const reg = freshReg();
+    for (const r of roots) addProject(r.cwd, r.name, { baseDir: reg }, true);
+    return reg;
+  }
+
+  test("session in a sub-repo → owns the declared workspace, sub-repo is the worktree tier", () => {
+    const reg = declared({ cwd: workspace, name: "workspace" });
+    const r = resolveProject(wsA, { baseDir: reg });
+    expect(r.projectCwd).toBe(workspace); // declared root supersedes git toplevel wsA
+    expect(r.projectName).toBe("workspace");
+    expect(r.worktree?.cwd).toBe(wsA);
+    expect(r.worktree?.branch).toBeTruthy(); // wsA is a real repo on its default branch
+  });
+
+  test("session directly in the declared non-git workspace → no sub-scope", () => {
+    const reg = declared({ cwd: workspace, name: "workspace" });
+    const r = resolveProject(workspace, { baseDir: reg });
+    expect(r.projectCwd).toBe(workspace);
+    expect(r.worktree).toBeUndefined();
+  });
+
+  test("session in a non-git subdir of a declared workspace → no sub-scope", () => {
+    const reg = declared({ cwd: workspace, name: "workspace" });
+    const r = resolveProject(wsNotes, { baseDir: reg });
+    expect(r.projectCwd).toBe(workspace);
+    expect(r.worktree).toBeUndefined();
+  });
+
+  test("nearest (deepest) declared root wins", () => {
+    const reg = declared(
+      { cwd: ROOT, name: "root" },
+      { cwd: workspace, name: "workspace" },
+    );
+    const r = resolveProject(wsA, { baseDir: reg });
+    expect(r.projectCwd).toBe(workspace); // not ROOT
+  });
+
+  test("a declared root that is NOT an ancestor is ignored → falls through to git", () => {
+    const reg = declared({ cwd: mkdir(join(ROOT, "elsewhere")), name: "elsewhere" });
+    const r = resolveProject(solo, { baseDir: reg });
+    expect(r.projectCwd).toBe(solo); // git toplevel; declared root irrelevant
+  });
+
+  test("declared root supersedes git even when cwd IS a sub-repo root", () => {
+    const reg = declared({ cwd: workspace, name: "workspace" });
+    const r = resolveProject(wsB, { baseDir: reg });
+    expect(r.projectCwd).toBe(workspace);
+    expect(r.worktree?.cwd).toBe(wsB);
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe("registry persistence (registerResolvedProject)", () => {
+  test("worktree session writes owning repo + child worktree row", () => {
+    const reg = freshReg();
+    registerResolvedProject(resolveProject(soloWtFeat, { baseDir: reg }), { baseDir: reg });
+    const entries = readProjectRegistry({ baseDir: reg });
+
+    const owner = entries.find((e) => e.cwd === solo);
+    const child = entries.find((e) => e.cwd === soloWtFeat);
+    expect(owner).toBeTruthy();
+    expect(owner?.parentCwd).toBeUndefined();
+    expect(owner?.declared).toBeUndefined(); // auto-add never declares
+    expect(child).toBeTruthy();
+    expect(child?.parentCwd).toBe(solo);
+    expect(child?.branch).toBe("feat/x");
+  });
+
+  test("plain repo session writes a single owning row, no child", () => {
+    const reg = freshReg();
+    registerResolvedProject(resolveProject(soloSub, { baseDir: reg }), { baseDir: reg });
+    const entries = readProjectRegistry({ baseDir: reg });
+    expect(entries.map((e) => e.cwd)).toEqual([solo]);
+    expect(entries[0].declared).toBeUndefined();
+  });
+
+  test("declared workspace: declaration is sticky, sub-repo registers as a child", () => {
+    const reg = freshReg();
+    addProject(workspace, "workspace", { baseDir: reg }, true);
+    // a session under it auto-registers; must NOT clear the declared flag
+    registerResolvedProject(resolveProject(wsA, { baseDir: reg }), { baseDir: reg });
+    const entries = readProjectRegistry({ baseDir: reg });
+
+    const ws = entries.find((e) => e.cwd === workspace);
+    const a = entries.find((e) => e.cwd === wsA);
+    expect(ws?.declared).toBe(true); // sticky
+    expect(a?.parentCwd).toBe(workspace);
+  });
+
+  test("getDeclaredRoots returns only declared entries", () => {
+    const reg = freshReg();
+    addProject(workspace, "workspace", { baseDir: reg }, true); // declared
+    registerResolvedProject(resolveProject(solo, { baseDir: reg }), { baseDir: reg }); // auto
+    const roots = getDeclaredRoots({ baseDir: reg });
+    expect(roots.map((r) => r.cwd)).toEqual([workspace]);
+  });
+
+  test("re-declaring an auto-added project promotes it to declared (sticky upgrade)", () => {
+    const reg = freshReg();
+    registerResolvedProject(resolveProject(solo, { baseDir: reg }), { baseDir: reg }); // auto
+    expect(readProjectRegistry({ baseDir: reg }).find((e) => e.cwd === solo)?.declared).toBeUndefined();
+    addProject(solo, "solo", { baseDir: reg }, true); // manual declare
+    expect(readProjectRegistry({ baseDir: reg }).find((e) => e.cwd === solo)?.declared).toBe(true);
+  });
+
+  test("idempotent: registering the same worktree session twice keeps one row each", () => {
+    const reg = freshReg();
+    const resolved = resolveProject(soloWtFeat, { baseDir: reg });
+    registerResolvedProject(resolved, { baseDir: reg });
+    registerResolvedProject(resolved, { baseDir: reg });
+    const entries = readProjectRegistry({ baseDir: reg });
+    expect(entries.filter((e) => e.cwd === solo)).toHaveLength(1);
+    expect(entries.filter((e) => e.cwd === soloWtFeat)).toHaveLength(1);
+  });
+});

--- a/packages/server/daemon/project-resolver.test.ts
+++ b/packages/server/daemon/project-resolver.test.ts
@@ -1,0 +1,133 @@
+import { test, expect, describe } from "bun:test";
+import {
+  resolveProjectCore,
+  type GitProbe,
+  type DeclaredRoot,
+} from "./project-resolver";
+import type { WorktreeDetection } from "./project-registry";
+
+/**
+ * Fake git probe driven by a fixture map. Keys are cwds.
+ *  - toplevels[cwd]  → git toplevel (absent = not a git repo)
+ *  - worktrees[cwd]  → WorktreeDetection (absent = { isWorktree: false })
+ *  - branches[cwd]   → branch
+ */
+function fakeGit(fixture: {
+  toplevels?: Record<string, string>;
+  worktrees?: Record<string, WorktreeDetection>;
+  branches?: Record<string, string>;
+}): GitProbe {
+  return {
+    toplevel: (cwd) => fixture.toplevels?.[cwd] ?? null,
+    worktree: (cwd) => fixture.worktrees?.[cwd] ?? { isWorktree: false },
+    branch: (cwd) => fixture.branches?.[cwd],
+  };
+}
+
+const noDeclared: DeclaredRoot[] = [];
+
+describe("resolveProjectCore — git toplevel normalization (VC8)", () => {
+  test("plain repo launched at root → project is the repo root", () => {
+    const git = fakeGit({ toplevels: { "/work/a": "/work/a" } });
+    const r = resolveProjectCore("/work/a", noDeclared, git);
+    expect(r.projectCwd).toBe("/work/a");
+    expect(r.projectName).toBe("a");
+    expect(r.worktree).toBeUndefined();
+  });
+
+  test("plain repo launched in a SUBDIR → project is still the repo root, not the subdir", () => {
+    const git = fakeGit({ toplevels: { "/work/a/packages/ui": "/work/a" } });
+    const r = resolveProjectCore("/work/a/packages/ui", noDeclared, git);
+    expect(r.projectCwd).toBe("/work/a"); // not /work/a/packages/ui
+    expect(r.projectName).toBe("a");
+  });
+
+  test("trailing slash on cwd is normalized", () => {
+    const git = fakeGit({ toplevels: { "/work/a": "/work/a" } });
+    const r = resolveProjectCore("/work/a/", noDeclared, git);
+    expect(r.projectCwd).toBe("/work/a");
+  });
+});
+
+describe("resolveProjectCore — worktree rollup (VC2/VC3)", () => {
+  test("session in a worktree → owns the MAIN repo, tagged with the worktree", () => {
+    const git = fakeGit({
+      toplevels: { "/work/a-feature": "/work/a-feature" },
+      worktrees: {
+        "/work/a-feature": { isWorktree: true, parentCwd: "/work/a", branch: "feat/x" },
+      },
+    });
+    const r = resolveProjectCore("/work/a-feature", noDeclared, git);
+    expect(r.projectCwd).toBe("/work/a"); // VC2 — rolls up to root
+    expect(r.projectName).toBe("a");
+    expect(r.worktree).toEqual({ cwd: "/work/a-feature", branch: "feat/x" }); // VC3 — tagged
+  });
+
+  test("detached-HEAD worktree → tagged with no branch", () => {
+    const git = fakeGit({
+      toplevels: { "/work/a-wt": "/work/a-wt" },
+      worktrees: { "/work/a-wt": { isWorktree: true, parentCwd: "/work/a" } },
+    });
+    const r = resolveProjectCore("/work/a-wt", noDeclared, git);
+    expect(r.projectCwd).toBe("/work/a");
+    expect(r.worktree).toEqual({ cwd: "/work/a-wt", branch: undefined });
+  });
+});
+
+describe("resolveProjectCore — non-git fallback", () => {
+  test("non-git directory → the directory itself is the project", () => {
+    const r = resolveProjectCore("/tmp/scratch", noDeclared, fakeGit({}));
+    expect(r.projectCwd).toBe("/tmp/scratch");
+    expect(r.projectName).toBe("scratch");
+    expect(r.worktree).toBeUndefined();
+  });
+});
+
+describe("resolveProjectCore — declared roots (workspace of repos, VC for mygroup/)", () => {
+  const mygroup: DeclaredRoot[] = [{ cwd: "/work/mygroup", name: "mygroup" }];
+
+  test("session in a sub-repo → owns the declared workspace, sub-repo as the worktree tier", () => {
+    const git = fakeGit({ toplevels: { "/work/mygroup/a": "/work/mygroup/a" }, branches: { "/work/mygroup/a": "main" } });
+    const r = resolveProjectCore("/work/mygroup/a", mygroup, git);
+    expect(r.projectCwd).toBe("/work/mygroup"); // declared root wins over git toplevel /work/mygroup/a
+    expect(r.projectName).toBe("mygroup");
+    expect(r.worktree).toEqual({ cwd: "/work/mygroup/a", branch: "main" });
+  });
+
+  test("session directly in the declared (non-git) workspace → no sub-scope", () => {
+    const r = resolveProjectCore("/work/mygroup", mygroup, fakeGit({}));
+    expect(r.projectCwd).toBe("/work/mygroup");
+    expect(r.worktree).toBeUndefined();
+  });
+
+  test("declared root supersedes the git boundary even at the sub-repo root", () => {
+    const git = fakeGit({ toplevels: { "/work/mygroup/b": "/work/mygroup/b" } });
+    const r = resolveProjectCore("/work/mygroup/b", mygroup, git);
+    expect(r.projectCwd).toBe("/work/mygroup"); // NOT /work/mygroup/b
+    expect(r.worktree?.cwd).toBe("/work/mygroup/b");
+  });
+
+  test("nearest (deepest) declared root wins", () => {
+    const declared: DeclaredRoot[] = [
+      { cwd: "/work", name: "work" },
+      { cwd: "/work/mygroup", name: "mygroup" },
+    ];
+    const git = fakeGit({ toplevels: { "/work/mygroup/a/src": "/work/mygroup/a" } });
+    const r = resolveProjectCore("/work/mygroup/a/src", declared, git);
+    expect(r.projectCwd).toBe("/work/mygroup"); // deepest ancestor, not /work
+    expect(r.worktree?.cwd).toBe("/work/mygroup/a");
+  });
+
+  test("a declared root that is NOT an ancestor is ignored → falls through to git", () => {
+    const declared: DeclaredRoot[] = [{ cwd: "/other/space", name: "other" }];
+    const git = fakeGit({ toplevels: { "/work/a": "/work/a" } });
+    const r = resolveProjectCore("/work/a", declared, git);
+    expect(r.projectCwd).toBe("/work/a"); // git toplevel, declared root irrelevant
+  });
+
+  test("declared root with no deeper repo (cwd == sub-repo but no git) → no worktree tier", () => {
+    const r = resolveProjectCore("/work/mygroup/notes", mygroup, fakeGit({}));
+    expect(r.projectCwd).toBe("/work/mygroup");
+    expect(r.worktree).toBeUndefined();
+  });
+});

--- a/packages/server/daemon/project-resolver.test.ts
+++ b/packages/server/daemon/project-resolver.test.ts
@@ -131,3 +131,26 @@ describe("resolveProjectCore — declared roots (workspace of repos, VC for mygr
     expect(r.worktree).toBeUndefined();
   });
 });
+
+describe("resolveProjectCore — Windows path separators (#822 review)", () => {
+  test("declared workspace root matches a nested repo despite backslash paths", () => {
+    // Declared root + cwd arrive with backslashes; git's --show-toplevel emits
+    // forward slashes. norm() reconciles them so the ancestor check still matches.
+    const declared: DeclaredRoot[] = [{ cwd: "C:\\work\\group", name: "group" }];
+    const git = fakeGit({
+      toplevels: { "C:/work/group/repo": "C:/work/group/repo" },
+      branches: { "C:/work/group/repo": "main" },
+    });
+    const r = resolveProjectCore("C:\\work\\group\\repo", declared, git);
+    expect(r.projectCwd).toBe("C:/work/group"); // declared root wins, not the repo
+    expect(r.projectName).toBe("group");
+    expect(r.worktree).toEqual({ cwd: "C:/work/group/repo", branch: "main" });
+  });
+
+  test("plain Windows repo → repo root with a clean basename", () => {
+    const git = fakeGit({ toplevels: { "C:/work/app": "C:/work/app" } });
+    const r = resolveProjectCore("C:\\work\\app", noDeclared, git);
+    expect(r.projectCwd).toBe("C:/work/app");
+    expect(r.projectName).toBe("app");
+  });
+});

--- a/packages/server/daemon/project-resolver.ts
+++ b/packages/server/daemon/project-resolver.ts
@@ -1,0 +1,165 @@
+import { basename } from "path";
+import { execSync } from "child_process";
+import {
+  detectWorktree,
+  getDeclaredRoots,
+  type ProjectRegistryOptions,
+  type WorktreeDetection,
+} from "./project-registry";
+
+/**
+ * Resolves which PROJECT a session belongs to from the directory it launched in.
+ *
+ * Implements the decision fact in
+ * goals/architecture/decisions/{project-worktree-session-hierarchy,
+ * cwd-worktree-collection-contract}.md:
+ *
+ *   resolve(cwd):
+ *     1. nearest DECLARED project root at/above cwd  → use it  (read-only)
+ *     2. else git toplevel                           → use it
+ *     3. else cwd
+ *
+ * A session always belongs to exactly one project (its `projectCwd`). It may also
+ * belong to one sub-scope under that project — a git worktree, or (under a declared
+ * non-git workspace root) the specific sub-repo it sits in — reported as `worktree`.
+ *
+ * The git calls are injected (`GitProbe`) so the walk-up / rollup logic is unit
+ * testable without real repositories.
+ */
+
+/** A registry entry the user explicitly declared as a project root. */
+export interface DeclaredRoot {
+  cwd: string;
+  name: string;
+}
+
+export interface ResolvedProject {
+  /** Owning project root — always set. The session belongs to exactly this project. */
+  projectCwd: string;
+  projectName: string;
+  /**
+   * Optional sub-scope the session sits in: a git worktree, or a sub-repo under a
+   * declared workspace root. Absent for a session launched directly in the project.
+   */
+  worktree?: { cwd: string; branch?: string };
+}
+
+export interface GitProbe {
+  /** `git rev-parse --show-toplevel`, or null when cwd is not in a git repo. */
+  toplevel(cwd: string): string | null;
+  /** Worktree detection (main-repo rollup + branch). */
+  worktree(cwd: string): WorktreeDetection;
+  /** `git rev-parse --abbrev-ref HEAD`, or undefined when detached/unavailable. */
+  branch(cwd: string): string | undefined;
+}
+
+/** Strip trailing slashes (but keep root "/"). */
+function norm(p: string): string {
+  const trimmed = p.replace(/\/+$/, "");
+  return trimmed === "" ? "/" : trimmed;
+}
+
+/** Is `child` the same as, or nested under, `ancestor`? (path-segment aware) */
+function isAtOrUnder(child: string, ancestor: string): boolean {
+  if (child === ancestor) return true;
+  const base = ancestor === "/" ? "/" : ancestor + "/";
+  return child.startsWith(base);
+}
+
+function nameOf(cwd: string): string {
+  return basename(norm(cwd)) || "unknown";
+}
+
+/**
+ * Pure resolution core. `declaredRoots` are the user-declared project roots from the
+ * registry; `git` performs the (injected) git probes.
+ */
+export function resolveProjectCore(
+  cwd: string,
+  declaredRoots: DeclaredRoot[],
+  git: GitProbe,
+): ResolvedProject {
+  const c = norm(cwd);
+
+  // 1. Nearest declared root at/above cwd wins (deepest match).
+  const ancestors = declaredRoots
+    .map((d) => ({ name: d.name, cwd: norm(d.cwd) }))
+    .filter((d) => isAtOrUnder(c, d.cwd))
+    .sort((a, b) => b.cwd.length - a.cwd.length);
+
+  if (ancestors.length > 0) {
+    const root = ancestors[0];
+    // Sub-scope under a declared root: the git repo/worktree the session sits in,
+    // when it is deeper than the declared root itself.
+    const top = git.toplevel(c);
+    let worktree: ResolvedProject["worktree"];
+    if (top) {
+      const t = norm(top);
+      if (t !== root.cwd && isAtOrUnder(t, root.cwd)) {
+        worktree = { cwd: t, branch: git.branch(c) };
+      }
+    }
+    return { projectCwd: root.cwd, projectName: root.name, worktree };
+  }
+
+  // 2. Git toplevel.
+  const top = git.toplevel(c);
+  if (top) {
+    const wt = git.worktree(c);
+    if (wt.isWorktree && wt.parentCwd) {
+      const parent = norm(wt.parentCwd);
+      return {
+        projectCwd: parent,
+        projectName: nameOf(parent),
+        worktree: { cwd: norm(top), branch: wt.branch },
+      };
+    }
+    const t = norm(top);
+    return { projectCwd: t, projectName: nameOf(t) };
+  }
+
+  // 3. Non-git: the directory itself is the project.
+  return { projectCwd: c, projectName: nameOf(c) };
+}
+
+/**
+ * Resolve the owning project for `cwd` using the registry's declared roots and real
+ * git. This is the production entry point used at session-create time.
+ */
+export function resolveProject(
+  cwd: string,
+  options: ProjectRegistryOptions = {},
+): ResolvedProject {
+  return resolveProjectCore(cwd, getDeclaredRoots(options), defaultGitProbe);
+}
+
+/** Default git probe backed by `git` via execSync. */
+export const defaultGitProbe: GitProbe = {
+  toplevel(cwd: string): string | null {
+    try {
+      const out = execSync("git rev-parse --show-toplevel", {
+        cwd,
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+      return out || null;
+    } catch {
+      return null;
+    }
+  },
+  worktree(cwd: string): WorktreeDetection {
+    return detectWorktree(cwd);
+  },
+  branch(cwd: string): string | undefined {
+    try {
+      const b = execSync("git rev-parse --abbrev-ref HEAD", {
+        cwd,
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+      return b && b !== "HEAD" ? b : undefined;
+    } catch {
+      return undefined;
+    }
+  },
+};

--- a/packages/server/daemon/project-resolver.ts
+++ b/packages/server/daemon/project-resolver.ts
@@ -53,9 +53,20 @@ export interface GitProbe {
   branch(cwd: string): string | undefined;
 }
 
-/** Strip trailing slashes (but keep root "/"). */
+/**
+ * Normalize a path for comparison: convert backslashes to forward slashes, then
+ * strip trailing slashes (but keep root "/").
+ *
+ * Every path the resolver compares (input cwd, declared roots, git toplevel) flows
+ * through here, so normalizing separators once makes `isAtOrUnder` correct on Windows
+ * too — without this, a declared root `C:\work\group` never prefix-matches a session
+ * at `C:\work\group\repo` because the ancestor check appends `/`. Git's
+ * `--show-toplevel` already emits forward slashes on every platform, so after this
+ * the three sources agree. (A literal backslash in a POSIX directory name is not a
+ * real project root, so collapsing it is an acceptable trade.)
+ */
 function norm(p: string): string {
-  const trimmed = p.replace(/\/+$/, "");
+  const trimmed = p.replace(/\\/g, "/").replace(/\/+$/, "");
   return trimmed === "" ? "/" : trimmed;
 }
 

--- a/packages/server/daemon/server.ts
+++ b/packages/server/daemon/server.ts
@@ -529,7 +529,8 @@ export function createDaemonFetchHandler(options: DaemonServerOptions): DaemonFe
         }
         const name = typeof body.name === "string" && body.name.length > 0 ? body.name : undefined;
         try {
-          const entry = addProject(body.cwd, name);
+          // Manual add = an explicit project-root declaration (supersedes git boundaries).
+          const entry = addProject(body.cwd, name, {}, true);
           return json({ ok: true, project: entry }, { status: 201 });
         } catch (err) {
           return json(

--- a/packages/server/daemon/server.ts
+++ b/packages/server/daemon/server.ts
@@ -25,6 +25,7 @@ import { readSnapshot } from "./session-store";
 import { parseRemoteUrl, parseRemoteHost } from "@plannotator/shared/repo";
 import { detectPlatform, checkPRAuth, fetchPRList, fetchPRDetailedList } from "../pr";
 import type { PRRef, PRListItem, PRDetailedListItem } from "@plannotator/shared/pr-types";
+import { listAllHistory } from "../storage";
 
 const RESULT_DELETE_GRACE_MS = 2_000;
 const DAEMON_AUTH_COOKIE_MAX_AGE_SECONDS = 7 * 24 * 60 * 60;
@@ -718,6 +719,15 @@ export function createDaemonFetchHandler(options: DaemonServerOptions): DaemonFe
         } catch {
           return json({ ok: true, prs: [], platform: null });
         }
+      }
+
+      if (url.pathname === "/daemon/history" && req.method === "GET") {
+        const projectFilter = url.searchParams.get("project") ?? undefined;
+        let history = listAllHistory();
+        if (projectFilter) {
+          history = history.filter((entry) => entry.project === projectFilter);
+        }
+        return json({ ok: true, history });
       }
 
       // --- Global settings endpoints (no session context needed) ---

--- a/packages/server/daemon/session-factory.test.ts
+++ b/packages/server/daemon/session-factory.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { DaemonSessionStore } from "./session-store";
-import { createDaemonSessionFactory } from "./session-factory";
+import { createDaemonSessionFactory, worktreeSegment } from "./session-factory";
 import type { DaemonFetchContext } from "./server";
 
 let dirs: string[] = [];
@@ -484,5 +484,33 @@ describe("createDaemonSessionFactory", () => {
     expect(completed.status).toBe("completed");
     const result = completed.result as { exit?: boolean };
     expect(result.exit).toBe(true);
+  });
+});
+
+describe("worktreeSegment — collision-free worktree history keys (#822 review)", () => {
+  test("distinct worktrees whose branches sanitize to the same label do NOT collide", () => {
+    const a = worktreeSegment({ cwd: "/work/a-feat_x", branch: "feat_x" });
+    const b = worktreeSegment({ cwd: "/work/a-feat-x", branch: "feat-x" });
+    // Both branch labels normalize to "feat-x"; only the cwd hash keeps them apart.
+    expect(a.startsWith("feat-x-")).toBe(true);
+    expect(b.startsWith("feat-x-")).toBe(true);
+    expect(a).not.toBe(b);
+  });
+
+  test("an unsanitizable branch still yields a non-empty, non-flat segment", () => {
+    const seg = worktreeSegment({ cwd: "/work/wt-x", branch: "x" });
+    // 1-char branch → sanitizeTag returns null; must NOT drop to undefined/flat.
+    expect(seg).toBeTruthy();
+    expect(seg.startsWith("wt-")).toBe(true);
+  });
+
+  test("deterministic: the same worktree cwd always maps to the same segment", () => {
+    expect(worktreeSegment({ cwd: "/work/a-wt", branch: "feat/x" })).toBe(
+      worktreeSegment({ cwd: "/work/a-wt", branch: "feat/x" }),
+    );
+  });
+
+  test("readable branch label is preserved as a prefix", () => {
+    expect(worktreeSegment({ cwd: "/work/a-wt", branch: "feature" }).startsWith("feature-")).toBe(true);
   });
 });

--- a/packages/server/daemon/session-factory.ts
+++ b/packages/server/daemon/session-factory.ts
@@ -33,6 +33,7 @@ import { createRemoteShareNotice } from "../share-url";
 import { registerResolvedProject } from "./project-registry";
 import { resolveProject } from "./project-resolver";
 import { sanitizeTag } from "@plannotator/shared/project";
+import { contentHash } from "@plannotator/shared/draft";
 import {
   gitRuntime,
   prepareLocalReviewDiff,
@@ -64,6 +65,23 @@ export interface DaemonSessionFactoryOptions {
 
 const DEFAULT_SESSION_TTL_MS = 96 * 60 * 60 * 1000;
 const SESSION_TIMEOUT_GRACE_MS = 60_000;
+
+/**
+ * Stable, collision-free, never-empty history-folder segment for a worktree.
+ *
+ * `sanitizeTag` alone is lossy as a key: a short/empty branch (e.g. a 1-char branch)
+ * sanitizes to null and would drop the segment entirely — history then falls back
+ * into the project's flat path and mixes with the main checkout — and distinct
+ * branches can normalize to the same value (`feat_x` and `feat-x` both → `feat-x`),
+ * merging two worktrees' histories. Disambiguate every segment with a short hash of
+ * the worktree's absolute path (its stable, unique identity), keeping a readable
+ * branch/dir label as a prefix when one is available.
+ */
+export function worktreeSegment(worktree: { cwd: string; branch?: string }): string {
+  const label = sanitizeTag(worktree.branch || basename(worktree.cwd));
+  const id = contentHash(worktree.cwd).slice(0, 8);
+  return label ? `${label}-${id}` : `wt-${id}`;
+}
 
 type AnnotateInput = {
   markdown: string;
@@ -596,12 +614,10 @@ export function createDaemonSessionFactory(options: DaemonSessionFactoryOptions)
     // matchKey discriminator: the operational scope (worktree/sub-repo, else project
     // root) so distinct worktrees of one project don't collide on reactivation.
     const scopeKey = worktree?.cwd ?? projectCwd;
-    // History keying segment: nest worktree history under a worktree segment so
-    // distinct worktrees of one project never collide/shadow each other. Coalesce
-    // an unsanitizable branch (e.g. <2 chars) to undefined → flat layout.
-    const worktreeSeg = worktree
-      ? sanitizeTag(worktree.branch || basename(worktree.cwd)) ?? undefined
-      : undefined;
+    // History keying segment: nest worktree history under a per-worktree segment so
+    // distinct worktrees of one project never collide or shadow each other. See
+    // worktreeSegment — it is stable, unique, and never empty (no flat-path fallback).
+    const worktreeSeg = worktree ? worktreeSegment(worktree) : undefined;
     try {
       const tmp = tmpdir();
       if (!cwd.startsWith(tmp)) registerResolvedProject(resolved);

--- a/packages/server/daemon/session-factory.ts
+++ b/packages/server/daemon/session-factory.ts
@@ -32,6 +32,7 @@ import { createReviewSession } from "../review";
 import { createRemoteShareNotice } from "../share-url";
 import { registerResolvedProject } from "./project-registry";
 import { resolveProject } from "./project-resolver";
+import { sanitizeTag } from "@plannotator/shared/project";
 import {
   gitRuntime,
   prepareLocalReviewDiff,
@@ -595,6 +596,12 @@ export function createDaemonSessionFactory(options: DaemonSessionFactoryOptions)
     // matchKey discriminator: the operational scope (worktree/sub-repo, else project
     // root) so distinct worktrees of one project don't collide on reactivation.
     const scopeKey = worktree?.cwd ?? projectCwd;
+    // History keying segment: nest worktree history under a worktree segment so
+    // distinct worktrees of one project never collide/shadow each other. Coalesce
+    // an unsanitizable branch (e.g. <2 chars) to undefined → flat layout.
+    const worktreeSeg = worktree
+      ? sanitizeTag(worktree.branch || basename(worktree.cwd)) ?? undefined
+      : undefined;
     try {
       const tmp = tmpdir();
       if (!cwd.startsWith(tmp)) registerResolvedProject(resolved);
@@ -638,6 +645,8 @@ export function createDaemonSessionFactory(options: DaemonSessionFactoryOptions)
         shareBaseUrl,
         pasteApiUrl,
         sessionEvents,
+        project,
+        worktreeSeg,
         opencodeClient: request.availableAgents
           ? { app: { agents: async () => ({ data: request.availableAgents }) } }
           : undefined,
@@ -698,6 +707,8 @@ export function createDaemonSessionFactory(options: DaemonSessionFactoryOptions)
         shareBaseUrl,
         pasteApiUrl,
         sessionEvents,
+        project,
+        worktreeSeg,
       });
       const record = context.store.create({
         id,

--- a/packages/server/daemon/session-factory.ts
+++ b/packages/server/daemon/session-factory.ts
@@ -29,9 +29,9 @@ import { generateSlug } from "../storage";
 import { createAnnotateSession } from "../annotate";
 import { createGoalSetupSession } from "../goal-setup";
 import { createReviewSession } from "../review";
-import { detectProjectName } from "../project";
 import { createRemoteShareNotice } from "../share-url";
-import { addProject } from "./project-registry";
+import { registerResolvedProject } from "./project-registry";
+import { resolveProject } from "./project-resolver";
 import {
   gitRuntime,
   prepareLocalReviewDiff,
@@ -581,17 +581,23 @@ export function createDaemonSessionFactory(options: DaemonSessionFactoryOptions)
     context: DaemonFetchContext,
   ): Promise<DaemonSessionRecord> {
     const request = createRequest.request;
+    // `cwd` is the OPERATIONAL directory the agent launched in (used for git ops,
+    // file reads, diffs). It is NOT the project — agents `cd` around and may launch
+    // from a subdir or worktree. Resolve the owning project (git root / declared
+    // workspace root) for attribution, keeping `cwd` operational. See
+    // goals/architecture/decisions/cwd-worktree-collection-contract.md.
     const cwd = getRequestCwd(request);
-    const project = (await detectProjectName(cwd)) ?? "_unknown";
-    let branch: string | undefined;
-    try {
-      const { execSync } = await import("child_process");
-      const b = execSync("git rev-parse --abbrev-ref HEAD", { cwd, encoding: "utf-8" }).trim();
-      if (b && b !== "HEAD") branch = b;
-    } catch {}
+    const resolved = resolveProject(cwd);
+    const project = resolved.projectName || "_unknown";
+    const projectCwd = resolved.projectCwd;
+    const worktree = resolved.worktree;
+    const branch = worktree?.branch;
+    // matchKey discriminator: the operational scope (worktree/sub-repo, else project
+    // root) so distinct worktrees of one project don't collide on reactivation.
+    const scopeKey = worktree?.cwd ?? projectCwd;
     try {
       const tmp = tmpdir();
-      if (!cwd.startsWith(tmp)) addProject(cwd, project);
+      if (!cwd.startsWith(tmp)) registerResolvedProject(resolved);
     } catch {}
     const id = createDaemonSessionId();
     const url = makeSessionUrl(context.endpoint.baseUrl, id);
@@ -607,7 +613,7 @@ export function createDaemonSessionFactory(options: DaemonSessionFactoryOptions)
 
     if (request.action === "plan") {
       const plan = await readPlanRequest(request, cwd);
-      const matchKey = `plan:${project}:${generateSlug(plan)}`;
+      const matchKey = `plan:${scopeKey}:${generateSlug(plan)}`;
 
       const existing = findMatchingSession(context.store, matchKey);
       if (existing && existing.session.updateContent) {
@@ -642,6 +648,8 @@ export function createDaemonSessionFactory(options: DaemonSessionFactoryOptions)
         url,
         project,
         cwd,
+        projectCwd,
+        ...(worktree && { worktree }),
         label: branch ? `plugin-plan-${request.origin}-${project}-${branch}` : `plugin-plan-${request.origin}-${project}`,
         origin: request.origin,
         matchKey,
@@ -660,9 +668,9 @@ export function createDaemonSessionFactory(options: DaemonSessionFactoryOptions)
       const isSingleFile = input.mode === "annotate";
       const isFolder = input.mode === "annotate-folder";
       const matchKey = isSingleFile
-        ? `annotate:${project}:${input.filePath}`
+        ? `annotate:${scopeKey}:${input.filePath}`
         : isFolder && input.folderPath
-          ? `annotate:${project}:folder:${input.folderPath}`
+          ? `annotate:${scopeKey}:folder:${input.folderPath}`
           : undefined;
 
       if (matchKey) {
@@ -697,6 +705,8 @@ export function createDaemonSessionFactory(options: DaemonSessionFactoryOptions)
         url,
         project,
         cwd,
+        projectCwd,
+        ...(worktree && { worktree }),
         label: input.folderPath
           ? `plugin-annotate-${request.origin}-${basename(input.folderPath)}${branch ? `-${branch}` : ""}`
           : `plugin-annotate-${request.origin}-${input.mode === "annotate-last" ? "last" : basename(input.filePath)}${branch ? `-${branch}` : ""}`,
@@ -716,7 +726,7 @@ export function createDaemonSessionFactory(options: DaemonSessionFactoryOptions)
       const input = await prepareReviewInput(request, cwd);
       const reviewMatchKey = input.prMetadata
         ? `review:${input.prMetadata.url}`
-        : branch ? `review:${project}:${branch}` : `review:${project}`;
+        : branch ? `review:${scopeKey}:${branch}` : `review:${scopeKey}`;
 
       const existingReview = findMatchingSession(context.store, reviewMatchKey, RESUBMIT_OR_IDLE_STATUSES);
       if (existingReview && existingReview.session.updateContent) {
@@ -770,6 +780,8 @@ export function createDaemonSessionFactory(options: DaemonSessionFactoryOptions)
         url,
         project,
         cwd,
+        projectCwd,
+        ...(worktree && { worktree }),
         label: input.prMetadata
           ? `plugin-${getMRLabel(input.prMetadata).toLowerCase()}-review-${getDisplayRepo(input.prMetadata)}${getMRNumberLabel(input.prMetadata)}`
           : branch ? `plugin-review-${request.origin}-${project}-${branch}` : `plugin-review-${request.origin}-${project}`,
@@ -804,6 +816,8 @@ export function createDaemonSessionFactory(options: DaemonSessionFactoryOptions)
         url,
         project,
         cwd,
+        projectCwd,
+        ...(worktree && { worktree }),
         label: branch ? `goal-setup-${bundle.stage}-${request.goalSlug || project}-${branch}` : `goal-setup-${bundle.stage}-${request.goalSlug || project}`,
         origin: request.origin,
         ttlMs,

--- a/packages/server/daemon/session-store.ts
+++ b/packages/server/daemon/session-store.ts
@@ -7,6 +7,7 @@ import type {
   DaemonSessionMode,
   DaemonSessionStatus,
   DaemonSessionSummary,
+  DaemonWorktreeRef,
 } from "@plannotator/shared/daemon-protocol";
 import type { SessionRequestHandler } from "../session-handler";
 
@@ -17,6 +18,8 @@ export interface DaemonSessionRecord<TResult = unknown> {
   url: string;
   project: string;
   cwd?: string;
+  projectCwd?: string;
+  worktree?: DaemonWorktreeRef;
   label: string;
   origin?: string;
   matchKey?: string;
@@ -39,6 +42,8 @@ export interface CreateDaemonSessionInput<TResult = unknown> {
   url: string;
   project: string;
   cwd?: string;
+  projectCwd?: string;
+  worktree?: DaemonWorktreeRef;
   label: string;
   origin?: string;
   matchKey?: string;
@@ -170,6 +175,8 @@ export class DaemonSessionStore {
       project: input.project,
       label: input.label,
       ...(input.cwd && { cwd: input.cwd }),
+      ...(input.projectCwd && { projectCwd: input.projectCwd }),
+      ...(input.worktree && { worktree: input.worktree }),
       ...(input.origin && { origin: input.origin }),
       ...(input.matchKey && { matchKey: input.matchKey }),
       ...(input.ttlMs !== undefined && { ttlMs: input.ttlMs }),
@@ -214,6 +221,8 @@ export class DaemonSessionStore {
       url: record.url,
       project: record.project,
       ...(record.cwd && { cwd: record.cwd }),
+      ...(record.projectCwd && { projectCwd: record.projectCwd }),
+      ...(record.worktree && { worktree: record.worktree }),
       label: record.label,
       ...(record.origin && { origin: record.origin }),
       createdAt: record.createdAt,

--- a/packages/server/history-index.test.ts
+++ b/packages/server/history-index.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Global History Index Integration Tests
+ *
+ * Builds a fake history tree under the active history root and verifies
+ * listAllHistory() enumerates flat (project/slug) and worktree-segmented
+ * (project/worktreeSeg/slug) layouts, skipping stray/empty/malformed dirs.
+ *
+ * NOTE: storage.ts captures its data dir at module load, and bun shares the
+ * module registry across test files in a single run — so we cannot reliably
+ * point the module at a temp PLANNOTATOR_DATA_DIR after the fact. Instead, this
+ * test writes a uniquely-named project tree under the module's real history root
+ * (mirroring storage.test.ts, which writes to the same root under "test-project")
+ * and asserts only on its own entries, then removes that project subtree. The
+ * unique project names guarantee isolation from any other history on disk.
+ *
+ * Run: bun test packages/server/history-index.test.ts
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { getPlannotatorDataDir } from "@plannotator/shared/data-dir";
+import { listAllHistory, type HistoryIndexEntry } from "./storage";
+
+const STAMP = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+const FLAT_PROJECT = `hidx-flat-${STAMP}`;
+const WT_PROJECT = `hidx-wt-${STAMP}`;
+
+const historyRoot = join(getPlannotatorDataDir(), "history");
+const flatRoot = join(historyRoot, FLAT_PROJECT);
+const wtRoot = join(historyRoot, WT_PROJECT);
+
+beforeAll(() => {
+  // Flat layout — slug dirs directly under the project.
+  // alpha has 2 versions, beta has 1.
+  mkdirSync(join(flatRoot, "alpha-slug"), { recursive: true });
+  writeFileSync(join(flatRoot, "alpha-slug", "001.md"), "# A v1");
+  writeFileSync(join(flatRoot, "alpha-slug", "002.md"), "# A v2");
+  mkdirSync(join(flatRoot, "beta-slug"), { recursive: true });
+  writeFileSync(join(flatRoot, "beta-slug", "001.md"), "# B v1");
+
+  // Worktree-segmented layout — worktreeSeg dir holds slug subdirs.
+  // branch-a/wt-slug has 3 versions; branch-b/wt-slug has 1.
+  mkdirSync(join(wtRoot, "branch-a", "wt-slug"), { recursive: true });
+  writeFileSync(join(wtRoot, "branch-a", "wt-slug", "001.md"), "# WA v1");
+  writeFileSync(join(wtRoot, "branch-a", "wt-slug", "002.md"), "# WA v2");
+  writeFileSync(join(wtRoot, "branch-a", "wt-slug", "003.md"), "# WA v3");
+  mkdirSync(join(wtRoot, "branch-b", "wt-slug"), { recursive: true });
+  writeFileSync(join(wtRoot, "branch-b", "wt-slug", "001.md"), "# WB v1");
+
+  // Stray / malformed entries that must be skipped:
+  // - empty slug-shaped dir (no version files) directly under a project
+  mkdirSync(join(flatRoot, "empty-slug"), { recursive: true });
+  // - a non-version file inside an otherwise-empty dir (still no NNN.md → skip)
+  mkdirSync(join(flatRoot, "notes-only"), { recursive: true });
+  writeFileSync(join(flatRoot, "notes-only", "readme.md"), "not a version");
+  // - a worktreeSeg-shaped dir whose only child slug dir is empty → no entries
+  mkdirSync(join(wtRoot, "empty-branch", "no-versions"), { recursive: true });
+  // - a stray file at the project-children level (non-dir) → skip
+  writeFileSync(join(flatRoot, "stray-file.md"), "junk");
+});
+
+afterAll(() => {
+  rmSync(flatRoot, { recursive: true, force: true });
+  rmSync(wtRoot, { recursive: true, force: true });
+});
+
+function find(
+  entries: HistoryIndexEntry[],
+  project: string,
+  slug: string,
+  worktree?: string,
+): HistoryIndexEntry | undefined {
+  return entries.find(
+    (e) => e.project === project && e.slug === slug && e.worktree === worktree,
+  );
+}
+
+describe("listAllHistory", () => {
+  test("enumerates flat and worktree-segmented layouts", () => {
+    const entries = listAllHistory();
+
+    const alpha = find(entries, FLAT_PROJECT, "alpha-slug");
+    expect(alpha).toBeDefined();
+    expect(alpha!.worktree).toBeUndefined();
+    expect(alpha!.versionCount).toBe(2);
+    expect(alpha!.latest).toBeTruthy();
+
+    const beta = find(entries, FLAT_PROJECT, "beta-slug");
+    expect(beta).toBeDefined();
+    expect(beta!.worktree).toBeUndefined();
+    expect(beta!.versionCount).toBe(1);
+
+    const wtA = find(entries, WT_PROJECT, "wt-slug", "branch-a");
+    expect(wtA).toBeDefined();
+    expect(wtA!.worktree).toBe("branch-a");
+    expect(wtA!.versionCount).toBe(3);
+    expect(wtA!.latest).toBeTruthy();
+
+    const wtB = find(entries, WT_PROJECT, "wt-slug", "branch-b");
+    expect(wtB).toBeDefined();
+    expect(wtB!.worktree).toBe("branch-b");
+    expect(wtB!.versionCount).toBe(1);
+  });
+
+  test("emits exactly the expected entries for the seeded projects", () => {
+    const entries = listAllHistory();
+    const flat = entries.filter((e) => e.project === FLAT_PROJECT);
+    const wt = entries.filter((e) => e.project === WT_PROJECT);
+    // 2 flat slugs, 2 worktree-segmented slugs. Strays excluded.
+    expect(flat).toHaveLength(2);
+    expect(wt).toHaveLength(2);
+  });
+
+  test("skips stray, empty, and malformed directories", () => {
+    const entries = listAllHistory();
+    expect(find(entries, FLAT_PROJECT, "empty-slug")).toBeUndefined();
+    expect(find(entries, FLAT_PROJECT, "notes-only")).toBeUndefined();
+    expect(find(entries, FLAT_PROJECT, "stray-file.md")).toBeUndefined();
+    expect(find(entries, WT_PROJECT, "no-versions", "empty-branch")).toBeUndefined();
+  });
+
+  test("distinguishes worktree-segmented from flat (no false flat entries)", () => {
+    const entries = listAllHistory();
+    // A worktreeSeg dir itself must never be reported as a flat slug.
+    expect(find(entries, WT_PROJECT, "branch-a")).toBeUndefined();
+    expect(find(entries, WT_PROJECT, "branch-b")).toBeUndefined();
+    // Every seeded proj-wt entry carries a worktree segment.
+    const wtEntries = entries.filter((e) => e.project === WT_PROJECT);
+    expect(wtEntries.every((e) => e.worktree !== undefined)).toBe(true);
+  });
+});

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -74,6 +74,10 @@ export interface ServerOptions {
   opencodeClient?: OpencodeClient;
   /** Optional daemon event bridge for live session-scoped events. */
   sessionEvents?: SessionEventBridge;
+  /** Resolved owning project name for history keying. Absent → detectProjectName(cwd) fallback. */
+  project?: string;
+  /** Worktree segment for history keying. Present only if the session sits in a worktree. */
+  worktreeSeg?: string;
 }
 
 
@@ -100,7 +104,7 @@ export interface PlannotatorSession {
 export async function createPlannotatorSession(
   options: ServerOptions
 ): Promise<PlannotatorSession> {
-  const { cwd = process.cwd(), plan: initialPlan, origin, permissionMode, sharingEnabled = true, shareBaseUrl, pasteApiUrl, planFilePath } = options;
+  const { cwd = process.cwd(), plan: initialPlan, origin, permissionMode, sharingEnabled = true, shareBaseUrl, pasteApiUrl, planFilePath, project: optionalProject, worktreeSeg } = options;
   let plan = initialPlan;
   const resolvePlanStoragePath = (customPath?: string | null): string | undefined => {
     if (!customPath?.trim()) return undefined;
@@ -147,16 +151,16 @@ export async function createPlannotatorSession(
   let lastDecision: 'approved' | 'denied' | null = null;
 
   repoInfo = await getRepoInfo(cwd);
-  project = (await detectProjectName(cwd)) ?? "_unknown";
-  const historyResult = saveToHistory(project, slug, plan);
+  project = optionalProject ?? (await detectProjectName(cwd)) ?? "_unknown";
+  const historyResult = saveToHistory(project, slug, plan, worktreeSeg);
   currentPlanPath = historyResult.path;
   previousPlan =
     historyResult.version > 1
-      ? getPlanVersion(project, slug, historyResult.version - 1)
+      ? getPlanVersion(project, slug, historyResult.version - 1, worktreeSeg)
       : null;
   versionInfo = {
     version: historyResult.version,
-    totalVersions: getVersionCount(project, slug),
+    totalVersions: getVersionCount(project, slug, worktreeSeg),
     project,
   };
 
@@ -172,7 +176,7 @@ export async function createPlannotatorSession(
             if (isNaN(v) || v < 1) {
               return new Response("Invalid version number", { status: 400 });
             }
-            const content = getPlanVersion(project, slug, v);
+            const content = getPlanVersion(project, slug, v, worktreeSeg);
             if (content === null) {
               return Response.json({ error: "Version not found" }, { status: 404 });
             }
@@ -184,7 +188,7 @@ export async function createPlannotatorSession(
             return Response.json({
               project,
               slug,
-              versions: listVersions(project, slug),
+              versions: listVersions(project, slug, worktreeSeg),
             });
           }
 
@@ -260,7 +264,7 @@ export async function createPlannotatorSession(
                 return Response.json({ error: "Missing baseVersion" }, { status: 400 });
               }
 
-              const basePath = getPlanVersionPath(project, slug, body.baseVersion);
+              const basePath = getPlanVersionPath(project, slug, body.baseVersion, worktreeSeg);
               if (!basePath) {
                 return Response.json({ error: `Version ${body.baseVersion} not found` }, { status: 404 });
               }
@@ -424,14 +428,14 @@ export async function createPlannotatorSession(
   function handleUpdateContent(newPlan: string) {
     plan = newPlan;
     lastDecision = null;
-    const historyResult = saveToHistory(project, slug, newPlan);
+    const historyResult = saveToHistory(project, slug, newPlan, worktreeSeg);
     currentPlanPath = historyResult.path;
     previousPlan = historyResult.version > 1
-      ? getPlanVersion(project, slug, historyResult.version - 1)
+      ? getPlanVersion(project, slug, historyResult.version - 1, worktreeSeg)
       : null;
     versionInfo = {
       version: historyResult.version,
-      totalVersions: getVersionCount(project, slug),
+      totalVersions: getVersionCount(project, slug, worktreeSeg),
       project,
     };
     externalAnnotations?.clearAll();

--- a/packages/server/storage.test.ts
+++ b/packages/server/storage.test.ts
@@ -7,8 +7,9 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, readFileSync, readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { generateSlug, getPlanDir, savePlan, saveToHistory, getPlanVersion, getVersionCount, listVersions } from "./storage";
+import { join, sep } from "node:path";
+import { generateSlug, getPlanDir, savePlan, saveToHistory, getPlanVersion, getPlanVersionPath, getVersionCount, listVersions } from "./storage";
+import { sanitizeTag } from "./project";
 
 const tempDirs: string[] = [];
 
@@ -172,5 +173,102 @@ describe("listVersions", () => {
     expect(versions[0].version).toBe(1);
     expect(versions[1].version).toBe(2);
     expect(versions[0].timestamp).toBeTruthy();
+  });
+});
+
+describe("history with worktreeSeg", () => {
+  test("nests history under the worktree segment when present", () => {
+    const slug = `wt-present-${Date.now()}`;
+    const result = saveToHistory("proj", slug, "# V1", "feature-branch");
+    expect(result.version).toBe(1);
+    expect(result.path).toContain(`history${sep}proj${sep}feature-branch${sep}${slug}`);
+  });
+
+  test("writes flat layout when worktreeSeg is absent (back-compat)", () => {
+    const slug = `flat-absent-${Date.now()}`;
+    const result = saveToHistory("flatproj", slug, "# C");
+    expect(result.version).toBe(1);
+    // No extra segment between project and slug — path ends in proj/slug/001.md directly.
+    expect(result.path).toEndWith(`history${sep}flatproj${sep}${slug}${sep}001.md`);
+    expect(getPlanVersion("flatproj", slug, 1)).toBe("# C");
+    expect(getVersionCount("flatproj", slug)).toBe(1);
+  });
+
+  test("isolates segments so reader==writer never crosses worktrees", () => {
+    const slug = `wt-iso-${Date.now()}`;
+    // branch-a gets 2 versions, branch-b gets 1, flat layout gets none.
+    saveToHistory("proj", slug, "# A1", "branch-a");
+    saveToHistory("proj", slug, "# A2", "branch-a");
+    saveToHistory("proj", slug, "# B1", "branch-b");
+
+    expect(getVersionCount("proj", slug, "branch-a")).toBe(2);
+    expect(getVersionCount("proj", slug, "branch-b")).toBe(1);
+    expect(getVersionCount("proj", slug)).toBe(0);
+
+    expect(getPlanVersion("proj", slug, 1, "branch-a")).toBe("# A1");
+    expect(getPlanVersion("proj", slug, 1, "branch-b")).toBe("# B1");
+    expect(getPlanVersion("proj", slug, 1)).toBeNull();
+
+    const aVersions = listVersions("proj", slug, "branch-a");
+    expect(aVersions).toHaveLength(2);
+    expect(aVersions[0].version).toBe(1);
+    expect(aVersions[1].version).toBe(2);
+
+    const bVersions = listVersions("proj", slug, "branch-b");
+    expect(bVersions).toHaveLength(1);
+    expect(bVersions[0].version).toBe(1);
+
+    expect(listVersions("proj", slug)).toEqual([]);
+  });
+
+  test("getPlanVersionPath returns the segmented path or null", () => {
+    const slug = `wt-path-${Date.now()}`;
+    saveToHistory("proj", slug, "# V1", "branch-x");
+    const path = getPlanVersionPath("proj", slug, 1, "branch-x");
+    expect(path).not.toBeNull();
+    expect(path!).toContain(`history${sep}proj${sep}branch-x${sep}${slug}`);
+    expect(path!).toEndWith(`001.md`);
+    // Missing version → null.
+    expect(getPlanVersionPath("proj", slug, 99, "branch-x")).toBeNull();
+    // Wrong segment → null (no shadowing).
+    expect(getPlanVersionPath("proj", slug, 1, "branch-y")).toBeNull();
+  });
+
+  test("detached worktree → segment derived from basename", () => {
+    const slug = `wt-detached-${Date.now()}`;
+    // Mirror session-factory: no branch → sanitizeTag(basename(worktree.cwd)).
+    const seg = sanitizeTag("my-wt-dir") ?? undefined;
+    expect(seg).toBe("my-wt-dir");
+    const result = saveToHistory("proj", slug, "# V1", seg);
+    expect(result.path).toContain(`history${sep}proj${sep}my-wt-dir${sep}${slug}`);
+  });
+
+  test("branch with slashes collapses to a single dir level", () => {
+    const slug = `wt-slash-${Date.now()}`;
+    const seg = sanitizeTag("feature/foo") ?? undefined;
+    expect(seg).toBe("featurefoo");
+    const result = saveToHistory("proj", slug, "# V1", seg);
+    expect(result.path).toContain(`history${sep}proj${sep}featurefoo${sep}${slug}`);
+    // Never a nested feature/foo directory tree.
+    expect(result.path).not.toContain(`history${sep}proj${sep}feature${sep}foo`);
+  });
+
+  test("no worktree → undefined segment → flat layout", () => {
+    const slug = `wt-none-${Date.now()}`;
+    const worktree: { branch?: string; cwd: string } | undefined = undefined;
+    const seg = worktree ? sanitizeTag((worktree as any).branch || "") ?? undefined : undefined;
+    expect(seg).toBeUndefined();
+    const result = saveToHistory("proj", slug, "# V1", seg);
+    expect(result.path).toContain(`history${sep}proj${sep}${slug}`);
+  });
+});
+
+describe("worktreeSeg formula (sanitizeTag)", () => {
+  test("strips slashes from branch names", () => {
+    expect(sanitizeTag("feature/foo")).toBe("featurefoo");
+  });
+
+  test("preserves 2-char segments (does not coalesce to null)", () => {
+    expect(sanitizeTag("ab")).toBe("ab");
   });
 });

--- a/packages/server/storage.ts
+++ b/packages/server/storage.ts
@@ -10,4 +10,7 @@ export {
   getPlanVersionPath,
   getVersionCount,
   listVersions,
+  listAllHistory,
 } from "@plannotator/shared/storage";
+
+export type { HistoryIndexEntry } from "@plannotator/shared/storage";

--- a/packages/shared/daemon-protocol.ts
+++ b/packages/shared/daemon-protocol.ts
@@ -88,6 +88,16 @@ export interface DaemonSessionSummary {
   expiresAt?: string;
   error?: string;
   remoteShare?: DaemonRemoteShareNotice;
+  /** Owning project root (git root or declared workspace root). */
+  projectCwd?: string;
+  /** Sub-scope the session sits in under its project (worktree / sub-repo), if any. */
+  worktree?: DaemonWorktreeRef;
+}
+
+/** A sub-scope a session sits in under its owning project: a git worktree or sub-repo. */
+export interface DaemonWorktreeRef {
+  cwd: string;
+  branch?: string;
 }
 
 export interface DaemonRemoteShareNotice {
@@ -136,6 +146,8 @@ export interface DaemonProjectEntry {
   lastSeen: string;
   parentCwd?: string;
   branch?: string;
+  /** True when the user explicitly declared this directory as a project root. */
+  declared?: boolean;
 }
 
 export interface DaemonProjectListResponse {

--- a/packages/shared/list-history.test.ts
+++ b/packages/shared/list-history.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for listAllHistory() / latestVersionPath.
+ *
+ * DATA_DIR is captured once at storage-module load, and other suites in the same
+ * bun process may import storage before this file's hooks run — so we do NOT try
+ * to override the data dir. Instead we anchor onto the REAL history root via
+ * saveToHistory() (which returns the absolute path it wrote), craft the
+ * gap/worktree fixtures under that same root, and clean up only our own dirs.
+ *
+ * Run: bun test packages/shared/list-history.test.ts
+ */
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync, utimesSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { listAllHistory, saveToHistory } from "./storage";
+
+const GAP_PROJECT = `lh-gap-${process.pid}-${Date.now()}`;
+const WT_PROJECT = `lh-wt-${process.pid}-${Date.now()}`;
+
+// saveToHistory writes history/<project>/<slug>/001.md — its dirname's dirname's
+// dirname is the history root.
+const anchor = saveToHistory(GAP_PROJECT, "anchor-slug", "# anchor");
+const historyRoot = dirname(dirname(dirname(anchor.path)));
+
+function writeVersion(parts: string[], name: string, content: string, mtimeSec: number): string {
+  const dir = join(historyRoot, ...parts);
+  mkdirSync(dir, { recursive: true });
+  const filePath = join(dir, name);
+  writeFileSync(filePath, content);
+  utimesSync(filePath, mtimeSec, mtimeSec);
+  return filePath;
+}
+
+afterAll(() => {
+  rmSync(join(historyRoot, GAP_PROJECT), { recursive: true, force: true });
+  rmSync(join(historyRoot, WT_PROJECT), { recursive: true, force: true });
+});
+
+describe("listAllHistory latestVersionPath", () => {
+  test("latestVersionPath points at the highest-mtime file under a version gap (001,003 — no 002)", () => {
+    writeVersion([GAP_PROJECT, "gap-slug"], "001.md", "# v1", 1_000);
+    const newest = writeVersion([GAP_PROJECT, "gap-slug"], "003.md", "# v3", 3_000);
+
+    const history = listAllHistory();
+    const entry = history.find((e) => e.project === GAP_PROJECT && e.slug === "gap-slug");
+    expect(entry).toBeDefined();
+    // Count is 2 (001 + 003). The latest path must be 003.md (newest mtime),
+    // NOT the path reconstructed from versionCount=2 (which would be 002.md).
+    expect(entry!.versionCount).toBe(2);
+    expect(entry!.latestVersionPath).toBe(newest);
+    expect(entry!.latestVersionPath.endsWith("003.md")).toBe(true);
+    expect(entry!.worktree).toBeUndefined();
+  });
+
+  test("worktree-layout entry populates worktree and latestVersionPath", () => {
+    writeVersion([WT_PROJECT, "branch-x", "wt-slug"], "001.md", "# a", 1_000);
+    const newest = writeVersion([WT_PROJECT, "branch-x", "wt-slug"], "002.md", "# b", 5_000);
+
+    const history = listAllHistory();
+    const entry = history.find(
+      (e) => e.project === WT_PROJECT && e.worktree === "branch-x" && e.slug === "wt-slug",
+    );
+    expect(entry).toBeDefined();
+    expect(entry!.versionCount).toBe(2);
+    expect(entry!.worktree).toBe("branch-x");
+    expect(entry!.latestVersionPath).toBe(newest);
+    expect(entry!.latestVersionPath.endsWith("002.md")).toBe(true);
+  });
+});

--- a/packages/shared/storage.ts
+++ b/packages/shared/storage.ts
@@ -269,6 +269,12 @@ export interface HistoryIndexEntry {
   versionCount: number;
   /** ISO mtime of the newest version file. Empty string if none readable. */
   latest: string;
+  /**
+   * Absolute path to the newest (highest-mtime) version file. Empty string if
+   * none readable. Derived from the same mtime scan as `latest` — correct under
+   * version-number gaps (do not reconstruct from versionCount).
+   */
+  latestVersionPath: string;
 }
 
 /**
@@ -288,7 +294,9 @@ function isSlugDir(dirPath: string): boolean {
  * Compute version count + newest mtime (ISO) for a slug dir in one pass.
  * Returns null if the directory has no version files.
  */
-function summarizeSlugDir(slugPath: string): { versionCount: number; latest: string } | null {
+function summarizeSlugDir(
+  slugPath: string
+): { versionCount: number; latest: string; latestVersionPath: string } | null {
   let entries: string[];
   try {
     entries = readdirSync(slugPath);
@@ -298,21 +306,24 @@ function summarizeSlugDir(slugPath: string): { versionCount: number; latest: str
   let versionCount = 0;
   let latestMs = -1;
   let latest = "";
+  let latestPath = "";
   for (const entry of entries) {
     if (!VERSION_FILE_RE.test(entry)) continue;
     versionCount++;
     try {
-      const stat = statSync(join(slugPath, entry));
+      const filePath = join(slugPath, entry);
+      const stat = statSync(filePath);
       const ms = stat.mtime.getTime();
       if (ms > latestMs) {
         latestMs = ms;
         latest = stat.mtime.toISOString();
+        latestPath = filePath;
       }
     } catch {
-      // Unreadable version file: still counts, but contributes no mtime.
+      // Unreadable version file: still counts, but contributes no mtime/path.
     }
   }
-  return versionCount > 0 ? { versionCount, latest } : null;
+  return versionCount > 0 ? { versionCount, latest, latestVersionPath: latestPath } : null;
 }
 
 /**

--- a/packages/shared/storage.ts
+++ b/packages/shared/storage.ts
@@ -253,3 +253,149 @@ export function listVersions(
     return [];
   }
 }
+
+// --- Global History Index ---
+
+const VERSION_FILE_RE = /^\d+\.md$/;
+
+/**
+ * A single entry in the global history index: one row per
+ * {project, optional worktree, slug} that has stored versions.
+ */
+export interface HistoryIndexEntry {
+  project: string;
+  worktree?: string;
+  slug: string;
+  versionCount: number;
+  /** ISO mtime of the newest version file. Empty string if none readable. */
+  latest: string;
+}
+
+/**
+ * Whether a directory is a slug dir — i.e. it directly contains at least one
+ * version file matching /^\d+\.md$/. Returns false on any read error.
+ */
+function isSlugDir(dirPath: string): boolean {
+  try {
+    const entries = readdirSync(dirPath);
+    return entries.some((e) => VERSION_FILE_RE.test(e));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Compute version count + newest mtime (ISO) for a slug dir in one pass.
+ * Returns null if the directory has no version files.
+ */
+function summarizeSlugDir(slugPath: string): { versionCount: number; latest: string } | null {
+  let entries: string[];
+  try {
+    entries = readdirSync(slugPath);
+  } catch {
+    return null;
+  }
+  let versionCount = 0;
+  let latestMs = -1;
+  let latest = "";
+  for (const entry of entries) {
+    if (!VERSION_FILE_RE.test(entry)) continue;
+    versionCount++;
+    try {
+      const stat = statSync(join(slugPath, entry));
+      const ms = stat.mtime.getTime();
+      if (ms > latestMs) {
+        latestMs = ms;
+        latest = stat.mtime.toISOString();
+      }
+    } catch {
+      // Unreadable version file: still counts, but contributes no mtime.
+    }
+  }
+  return versionCount > 0 ? { versionCount, latest } : null;
+}
+
+/**
+ * Enumerate the entire history tree under DATA_DIR/history.
+ *
+ * Layout: history/{project}/{slug}/NNN.md  OR
+ *         history/{project}/{worktreeSeg}/{slug}/NNN.md
+ *
+ * Disambiguation: a project's direct child dir is treated as a SLUG dir when it
+ * directly contains any version file (/^\d+\.md$/). Otherwise it is treated as a
+ * worktreeSeg dir and its own children are enumerated as slug dirs. Stray, empty,
+ * or malformed directories (no version files anywhere beneath) are skipped.
+ *
+ * Defensive: a missing history root returns []. Non-directories and unreadable
+ * entries are skipped rather than throwing.
+ *
+ * Returns one entry per {project, worktree?, slug} with versionCount + latest mtime.
+ */
+export function listAllHistory(): HistoryIndexEntry[] {
+  const historyRoot = join(DATA_DIR, "history");
+  const results: HistoryIndexEntry[] = [];
+
+  let projects: string[];
+  try {
+    projects = readdirSync(historyRoot);
+  } catch {
+    return results;
+  }
+
+  for (const project of projects) {
+    const projectPath = join(historyRoot, project);
+    try {
+      if (!statSync(projectPath).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+
+    let children: string[];
+    try {
+      children = readdirSync(projectPath);
+    } catch {
+      continue;
+    }
+
+    for (const child of children) {
+      const childPath = join(projectPath, child);
+      try {
+        if (!statSync(childPath).isDirectory()) continue;
+      } catch {
+        continue;
+      }
+
+      if (isSlugDir(childPath)) {
+        // child is a slug dir directly under the project (flat layout).
+        const summary = summarizeSlugDir(childPath);
+        if (summary) {
+          results.push({ project, slug: child, ...summary });
+        }
+        continue;
+      }
+
+      // Otherwise treat child as a worktreeSeg dir and enumerate its slug dirs.
+      let slugDirs: string[];
+      try {
+        slugDirs = readdirSync(childPath);
+      } catch {
+        continue;
+      }
+      for (const slug of slugDirs) {
+        const slugPath = join(childPath, slug);
+        try {
+          if (!statSync(slugPath).isDirectory()) continue;
+        } catch {
+          continue;
+        }
+        if (!isSlugDir(slugPath)) continue; // stray/empty/non-slug dir → skip
+        const summary = summarizeSlugDir(slugPath);
+        if (summary) {
+          results.push({ project, worktree: child, slug, ...summary });
+        }
+      }
+    }
+  }
+
+  return results;
+}

--- a/packages/shared/storage.ts
+++ b/packages/shared/storage.ts
@@ -106,11 +106,13 @@ export function saveFinalSnapshot(
 
 /**
  * Get the history directory for a project/slug combination, creating it if needed.
- * History is always stored in ~/.plannotator/history/{project}/{slug}/.
+ * History is stored in ~/.plannotator/history/{project}/{worktreeSeg?}/{slug}/.
+ * The optional worktreeSeg segment is present only when the session sits in a
+ * worktree, so distinct worktrees of one project never collide.
  * Not affected by the customPath setting (that only affects decision saves).
  */
-export function getHistoryDir(project: string, slug: string): string {
-  const historyDir = join(DATA_DIR, "history", project, slug);
+export function getHistoryDir(project: string, slug: string, worktreeSeg?: string): string {
+  const historyDir = join(DATA_DIR, "history", project, ...(worktreeSeg ? [worktreeSeg] : []), slug);
   mkdirSync(historyDir, { recursive: true });
   return historyDir;
 }
@@ -144,9 +146,10 @@ function getNextVersionNumber(historyDir: string): number {
 export function saveToHistory(
   project: string,
   slug: string,
-  plan: string
+  plan: string,
+  worktreeSeg?: string
 ): { version: number; path: string; isNew: boolean } {
-  const historyDir = getHistoryDir(project, slug);
+  const historyDir = getHistoryDir(project, slug, worktreeSeg);
   const nextVersion = getNextVersionNumber(historyDir);
 
   // Deduplicate: check if latest version has identical content
@@ -175,9 +178,10 @@ export function saveToHistory(
 export function getPlanVersion(
   project: string,
   slug: string,
-  version: number
+  version: number,
+  worktreeSeg?: string
 ): string | null {
-  const historyDir = join(DATA_DIR, "history", project, slug);
+  const historyDir = join(DATA_DIR, "history", project, ...(worktreeSeg ? [worktreeSeg] : []), slug);
   const fileName = `${String(version).padStart(3, "0")}.md`;
   const filePath = join(historyDir, fileName);
 
@@ -195,9 +199,10 @@ export function getPlanVersion(
 export function getPlanVersionPath(
   project: string,
   slug: string,
-  version: number
+  version: number,
+  worktreeSeg?: string
 ): string | null {
-  const historyDir = join(DATA_DIR, "history", project, slug);
+  const historyDir = join(DATA_DIR, "history", project, ...(worktreeSeg ? [worktreeSeg] : []), slug);
   const fileName = `${String(version).padStart(3, "0")}.md`;
   const filePath = join(historyDir, fileName);
   return existsSync(filePath) ? filePath : null;
@@ -207,8 +212,8 @@ export function getPlanVersionPath(
  * Get the number of versions stored for a project/slug.
  * Returns 0 if the directory doesn't exist.
  */
-export function getVersionCount(project: string, slug: string): number {
-  const historyDir = join(DATA_DIR, "history", project, slug);
+export function getVersionCount(project: string, slug: string, worktreeSeg?: string): number {
+  const historyDir = join(DATA_DIR, "history", project, ...(worktreeSeg ? [worktreeSeg] : []), slug);
   try {
     const entries = readdirSync(historyDir);
     return entries.filter((e) => /^\d+\.md$/.test(e)).length;
@@ -223,9 +228,10 @@ export function getVersionCount(project: string, slug: string): number {
  */
 export function listVersions(
   project: string,
-  slug: string
+  slug: string,
+  worktreeSeg?: string
 ): Array<{ version: number; timestamp: string }> {
-  const historyDir = join(DATA_DIR, "history", project, slug);
+  const historyDir = join(DATA_DIR, "history", project, ...(worktreeSeg ? [worktreeSeg] : []), slug);
   try {
     const entries = readdirSync(historyDir);
     const versions: Array<{ version: number; timestamp: string }> = [];

--- a/packages/ui/utils/sessionTree.test.ts
+++ b/packages/ui/utils/sessionTree.test.ts
@@ -1,0 +1,391 @@
+import { describe, test, expect } from "bun:test";
+import type {
+  DaemonProjectEntry,
+  DaemonSessionSummary,
+} from "@plannotator/shared/daemon-protocol";
+import { buildSessionTree } from "./sessionTree";
+
+// --- helpers ---------------------------------------------------------------
+
+function project(
+  partial: Partial<DaemonProjectEntry> & { name: string; cwd: string },
+): DaemonProjectEntry {
+  return {
+    lastSeen: "2026-01-01T00:00:00.000Z",
+    ...partial,
+  };
+}
+
+let sessionCounter = 0;
+function session(
+  partial: Partial<DaemonSessionSummary> & { project: string },
+): DaemonSessionSummary {
+  sessionCounter += 1;
+  return {
+    id: partial.id ?? `s-${sessionCounter}`,
+    mode: partial.mode ?? "plan",
+    status: partial.status ?? "active",
+    url: partial.url ?? "http://localhost/s/x",
+    project: partial.project,
+    cwd: partial.cwd,
+    label: partial.label ?? "label",
+    createdAt: partial.createdAt ?? "2026-01-01T00:00:00.000Z",
+    updatedAt: partial.updatedAt ?? "2026-01-01T00:00:00.000Z",
+    projectCwd: partial.projectCwd,
+    worktree: partial.worktree,
+  } as DaemonSessionSummary;
+}
+
+/** Count every session that landed anywhere in the tree. */
+function allTreeSessionIds(tree: ReturnType<typeof buildSessionTree>): string[] {
+  const ids: string[] = [];
+  for (const p of tree) {
+    for (const s of p.directSessions) ids.push(s.id);
+    for (const w of p.worktrees) for (const s of w.sessions) ids.push(s.id);
+  }
+  return ids;
+}
+
+// --- tests -----------------------------------------------------------------
+
+describe("buildSessionTree", () => {
+  test("empty inputs produce an empty tree", () => {
+    expect(buildSessionTree([], [])).toEqual([]);
+  });
+
+  test("projects with no sessions still appear", () => {
+    const tree = buildSessionTree(
+      [project({ name: "my-app", cwd: "/work/my-app" })],
+      [],
+    );
+    expect(tree).toHaveLength(1);
+    expect(tree[0].name).toBe("my-app");
+    expect(tree[0].cwd).toBe("/work/my-app");
+    expect(tree[0].directSessions).toEqual([]);
+    expect(tree[0].worktrees).toEqual([]);
+  });
+
+  test("project with only direct sessions", () => {
+    const s1 = session({ project: "my-app", projectCwd: "/work/my-app", id: "a" });
+    const s2 = session({ project: "my-app", projectCwd: "/work/my-app", id: "b" });
+    const tree = buildSessionTree(
+      [project({ name: "my-app", cwd: "/work/my-app" })],
+      [s1, s2],
+    );
+    expect(tree).toHaveLength(1);
+    expect(tree[0].directSessions.map((s) => s.id).sort()).toEqual(["a", "b"]);
+    expect(tree[0].worktrees).toEqual([]);
+  });
+
+  test("project with worktrees and sessions", () => {
+    const direct = session({
+      project: "my-app",
+      projectCwd: "/work/my-app",
+      id: "direct",
+    });
+    const wtSession = session({
+      project: "my-app",
+      projectCwd: "/work/my-app",
+      id: "wt",
+      worktree: { cwd: "/work/my-app/wt-1", branch: "feature-x" },
+    });
+    const tree = buildSessionTree(
+      [
+        project({ name: "my-app", cwd: "/work/my-app" }),
+        project({
+          name: "feature-x",
+          cwd: "/work/my-app/wt-1",
+          parentCwd: "/work/my-app",
+          branch: "feature-x",
+        }),
+      ],
+      [direct, wtSession],
+    );
+    expect(tree).toHaveLength(1);
+    const node = tree[0];
+    expect(node.directSessions.map((s) => s.id)).toEqual(["direct"]);
+    expect(node.worktrees).toHaveLength(1);
+    expect(node.worktrees[0].cwd).toBe("/work/my-app/wt-1");
+    expect(node.worktrees[0].name).toBe("feature-x");
+    expect(node.worktrees[0].sessions.map((s) => s.id)).toEqual(["wt"]);
+  });
+
+  test("registry worktree row with zero sessions still appears", () => {
+    const tree = buildSessionTree(
+      [
+        project({ name: "my-app", cwd: "/work/my-app" }),
+        project({
+          name: "empty-wt",
+          cwd: "/work/my-app/wt-empty",
+          parentCwd: "/work/my-app",
+        }),
+      ],
+      [],
+    );
+    expect(tree).toHaveLength(1);
+    expect(tree[0].worktrees).toHaveLength(1);
+    expect(tree[0].worktrees[0].name).toBe("empty-wt");
+    expect(tree[0].worktrees[0].sessions).toEqual([]);
+  });
+
+  test("session with worktree not in registry is synthesized", () => {
+    const s = session({
+      project: "my-app",
+      projectCwd: "/work/my-app",
+      id: "synth",
+      worktree: { cwd: "/work/my-app/ghost", branch: "ghost-branch" },
+    });
+    const tree = buildSessionTree(
+      [project({ name: "my-app", cwd: "/work/my-app" })],
+      [s],
+    );
+    expect(tree[0].worktrees).toHaveLength(1);
+    expect(tree[0].worktrees[0].cwd).toBe("/work/my-app/ghost");
+    expect(tree[0].worktrees[0].branch).toBe("ghost-branch");
+    // name falls back to branch when synthesized
+    expect(tree[0].worktrees[0].name).toBe("ghost-branch");
+    expect(tree[0].worktrees[0].sessions.map((x) => x.id)).toEqual(["synth"]);
+  });
+
+  test("synthesized worktree without branch names from cwd basename", () => {
+    const s = session({
+      project: "my-app",
+      projectCwd: "/work/my-app",
+      id: "nb",
+      worktree: { cwd: "/work/my-app/dir-name" },
+    });
+    const tree = buildSessionTree(
+      [project({ name: "my-app", cwd: "/work/my-app" })],
+      [s],
+    );
+    expect(tree[0].worktrees[0].name).toBe("dir-name");
+    expect(tree[0].worktrees[0].branch).toBeUndefined();
+  });
+
+  test("registry worktree without branch is backfilled from session", () => {
+    const s = session({
+      project: "my-app",
+      projectCwd: "/work/my-app",
+      id: "bf",
+      worktree: { cwd: "/work/my-app/wt-1", branch: "from-session" },
+    });
+    const tree = buildSessionTree(
+      [
+        project({ name: "my-app", cwd: "/work/my-app" }),
+        project({
+          name: "wt-1",
+          cwd: "/work/my-app/wt-1",
+          parentCwd: "/work/my-app",
+          // no branch on the registry row
+        }),
+      ],
+      [s],
+    );
+    expect(tree[0].worktrees[0].branch).toBe("from-session");
+    // registry name is preserved (not overwritten by branch)
+    expect(tree[0].worktrees[0].name).toBe("wt-1");
+  });
+
+  test("session with no projectCwd falls back to cwd", () => {
+    const s = session({ project: "legacy", cwd: "/work/legacy", id: "leg" });
+    const tree = buildSessionTree(
+      [project({ name: "legacy", cwd: "/work/legacy" })],
+      [s],
+    );
+    expect(tree).toHaveLength(1);
+    expect(tree[0].directSessions.map((x) => x.id)).toEqual(["leg"]);
+  });
+
+  test("orphan session with no matching project row gets a synthesized node", () => {
+    const s = session({
+      project: "ghost-proj",
+      projectCwd: "/work/ghost",
+      id: "orphan",
+    });
+    const tree = buildSessionTree([], [s]);
+    expect(tree).toHaveLength(1);
+    expect(tree[0].cwd).toBe("/work/ghost");
+    expect(tree[0].name).toBe("ghost"); // basename of cwd
+    expect(tree[0].declared).toBeUndefined();
+    expect(tree[0].directSessions.map((x) => x.id)).toEqual(["orphan"]);
+  });
+
+  test("session with neither projectCwd nor cwd is anchored, not dropped", () => {
+    const s = session({ project: "no-cwd", id: "homeless" });
+    const tree = buildSessionTree([], [s]);
+    expect(tree).toHaveLength(1);
+    expect(allTreeSessionIds(tree)).toEqual(["homeless"]);
+  });
+
+  test("multiple projects are sorted by name", () => {
+    const tree = buildSessionTree(
+      [
+        project({ name: "zebra", cwd: "/work/zebra" }),
+        project({ name: "alpha", cwd: "/work/alpha" }),
+        project({ name: "mango", cwd: "/work/mango" }),
+      ],
+      [],
+    );
+    expect(tree.map((p) => p.name)).toEqual(["alpha", "mango", "zebra"]);
+  });
+
+  test("worktrees are sorted by name within a project", () => {
+    const tree = buildSessionTree(
+      [
+        project({ name: "app", cwd: "/work/app" }),
+        project({ name: "wt-zeta", cwd: "/work/app/z", parentCwd: "/work/app" }),
+        project({ name: "wt-alpha", cwd: "/work/app/a", parentCwd: "/work/app" }),
+      ],
+      [],
+    );
+    expect(tree[0].worktrees.map((w) => w.name)).toEqual(["wt-alpha", "wt-zeta"]);
+  });
+
+  test("duplicate project names sort deterministically by cwd regardless of input order", () => {
+    const a = project({ name: "dup", cwd: "/a" });
+    const b = project({ name: "dup", cwd: "/b" });
+    const forward = buildSessionTree([a, b], []).map((p) => p.cwd);
+    const reversed = buildSessionTree([b, a], []).map((p) => p.cwd);
+    expect(forward).toEqual(["/a", "/b"]);
+    expect(reversed).toEqual(["/a", "/b"]);
+  });
+
+  test("duplicate worktree names sort deterministically by cwd regardless of input order", () => {
+    const root = project({ name: "app", cwd: "/work/app" });
+    const wtA = project({ name: "dup", cwd: "/work/app/a", parentCwd: "/work/app" });
+    const wtB = project({ name: "dup", cwd: "/work/app/b", parentCwd: "/work/app" });
+    const forward = buildSessionTree([root, wtA, wtB], [])[0].worktrees.map((w) => w.cwd);
+    const reversed = buildSessionTree([root, wtB, wtA], [])[0].worktrees.map((w) => w.cwd);
+    expect(forward).toEqual(["/work/app/a", "/work/app/b"]);
+    expect(reversed).toEqual(["/work/app/a", "/work/app/b"]);
+  });
+
+  test("sessions sorted by createdAt descending", () => {
+    const older = session({
+      project: "app",
+      projectCwd: "/work/app",
+      id: "older",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    const newer = session({
+      project: "app",
+      projectCwd: "/work/app",
+      id: "newer",
+      createdAt: "2026-02-01T00:00:00.000Z",
+    });
+    // pass in ascending order to prove sort independence from input order
+    const tree = buildSessionTree(
+      [project({ name: "app", cwd: "/work/app" })],
+      [older, newer],
+    );
+    expect(tree[0].directSessions.map((s) => s.id)).toEqual(["newer", "older"]);
+  });
+
+  test("declared workspace with sub-repos (declared flag preserved)", () => {
+    const rootSession = session({
+      project: "monorepo",
+      projectCwd: "/work/monorepo",
+      id: "root",
+    });
+    const subSession = session({
+      project: "monorepo",
+      projectCwd: "/work/monorepo",
+      id: "sub",
+      worktree: { cwd: "/work/monorepo/packages/api", branch: "api-work" },
+    });
+    const tree = buildSessionTree(
+      [
+        project({ name: "monorepo", cwd: "/work/monorepo", declared: true }),
+        project({
+          name: "api",
+          cwd: "/work/monorepo/packages/api",
+          parentCwd: "/work/monorepo",
+        }),
+      ],
+      [rootSession, subSession],
+    );
+    expect(tree).toHaveLength(1);
+    expect(tree[0].declared).toBe(true);
+    expect(tree[0].directSessions.map((s) => s.id)).toEqual(["root"]);
+    expect(tree[0].worktrees).toHaveLength(1);
+    expect(tree[0].worktrees[0].name).toBe("api");
+    expect(tree[0].worktrees[0].sessions.map((s) => s.id)).toEqual(["sub"]);
+  });
+
+  test("worktree session whose owning project key has no top-level node", () => {
+    // session has projectCwd that matches no top-level project row at all
+    const s = session({
+      project: "stray",
+      projectCwd: "/work/stray",
+      id: "stray-wt",
+      worktree: { cwd: "/work/stray/wt", branch: "b" },
+    });
+    const tree = buildSessionTree([], [s]);
+    expect(tree).toHaveLength(1);
+    expect(tree[0].cwd).toBe("/work/stray");
+    expect(tree[0].worktrees).toHaveLength(1);
+    expect(tree[0].worktrees[0].sessions.map((x) => x.id)).toEqual(["stray-wt"]);
+  });
+
+  test("sessions with equal createdAt sort deterministically by id (tie-break)", () => {
+    const ts = "2026-02-02T00:00:00.000Z";
+    const s1 = session({ project: "p", cwd: "/work/p", id: "zzz", createdAt: ts });
+    const s2 = session({ project: "p", cwd: "/work/p", id: "aaa", createdAt: ts });
+    const proj = [project({ name: "p", cwd: "/work/p" })];
+    const fwd = buildSessionTree(proj, [s1, s2])[0].directSessions.map((s) => s.id);
+    const rev = buildSessionTree(proj, [s2, s1])[0].directSessions.map((s) => s.id);
+    expect(fwd).toEqual(["aaa", "zzz"]);
+    expect(rev).toEqual(["aaa", "zzz"]);
+  });
+
+  test("counts reconcile: every input session appears exactly once", () => {
+    const sessions: DaemonSessionSummary[] = [
+      session({ project: "a", projectCwd: "/work/a", id: "1" }),
+      session({
+        project: "a",
+        projectCwd: "/work/a",
+        id: "2",
+        worktree: { cwd: "/work/a/wt1", branch: "x" },
+      }),
+      session({
+        project: "a",
+        projectCwd: "/work/a",
+        id: "3",
+        worktree: { cwd: "/work/a/wt1", branch: "x" },
+      }),
+      session({ project: "b", projectCwd: "/work/b", id: "4" }),
+      session({ project: "legacy", cwd: "/work/legacy", id: "5" }), // cwd fallback
+      session({ project: "orphan", projectCwd: "/work/orphan", id: "6" }), // orphan
+      session({ project: "none", id: "7" }), // no cwd at all
+      session({
+        project: "b",
+        projectCwd: "/work/b",
+        id: "8",
+        worktree: { cwd: "/work/b/ghost", branch: "g" },
+      }),
+    ];
+    const projects: DaemonProjectEntry[] = [
+      project({ name: "a", cwd: "/work/a" }),
+      project({ name: "wt1", cwd: "/work/a/wt1", parentCwd: "/work/a" }),
+      project({ name: "b", cwd: "/work/b" }),
+      project({ name: "legacy", cwd: "/work/legacy" }),
+      // an empty worktree row that should still appear
+      project({ name: "empty", cwd: "/work/a/empty", parentCwd: "/work/a" }),
+    ];
+    const tree = buildSessionTree(projects, sessions);
+
+    const seen = allTreeSessionIds(tree).sort();
+    expect(seen).toEqual(["1", "2", "3", "4", "5", "6", "7", "8"]);
+    // exactly once each
+    expect(seen).toHaveLength(8);
+    expect(new Set(seen).size).toBe(8);
+
+    // empty worktree row still rendered
+    const a = tree.find((p) => p.cwd === "/work/a")!;
+    expect(a.worktrees.map((w) => w.name).sort()).toEqual(["empty", "wt1"]);
+    const wt1 = a.worktrees.find((w) => w.cwd === "/work/a/wt1")!;
+    expect(wt1.sessions.map((s) => s.id).sort()).toEqual(["2", "3"]);
+    const empty = a.worktrees.find((w) => w.cwd === "/work/a/empty")!;
+    expect(empty.sessions).toEqual([]);
+  });
+});

--- a/packages/ui/utils/sessionTree.ts
+++ b/packages/ui/utils/sessionTree.ts
@@ -1,0 +1,215 @@
+import type {
+  DaemonProjectEntry,
+  DaemonSessionSummary,
+} from "@plannotator/shared/daemon-protocol";
+
+/**
+ * A worktree (or sub-repo) node under a project. Holds the sessions scoped to
+ * that worktree's working directory.
+ */
+export interface SessionTreeWorktree {
+  cwd: string;
+  branch?: string;
+  name: string;
+  sessions: DaemonSessionSummary[];
+}
+
+/**
+ * A top-level project node. `directSessions` are sessions anchored to the
+ * project root with no worktree scope; `worktrees` collect everything else.
+ */
+export interface SessionTreeProject {
+  cwd: string;
+  name: string;
+  declared?: boolean;
+  /** Sessions in the project root (no worktree). */
+  directSessions: DaemonSessionSummary[];
+  worktrees: SessionTreeWorktree[];
+}
+
+/** Owning-project key for a session, with cwd fallback for pre-migration rows. */
+function owningProjectKey(session: DaemonSessionSummary): string | undefined {
+  return session.projectCwd ?? session.cwd;
+}
+
+/** Derive a stable, human-readable name for a worktree from its cwd/branch. */
+function worktreeName(cwd: string, branch?: string): string {
+  if (branch && branch.length > 0) return branch;
+  const trimmed = cwd.replace(/[/\\]+$/, "");
+  const segments = trimmed.split(/[/\\]/);
+  const last = segments[segments.length - 1];
+  return last && last.length > 0 ? last : cwd;
+}
+
+/** Derive a stable, human-readable name for an orphan/synthesized project. */
+function projectNameFromCwd(cwd: string): string {
+  const trimmed = cwd.replace(/[/\\]+$/, "");
+  const segments = trimmed.split(/[/\\]/);
+  const last = segments[segments.length - 1];
+  return last && last.length > 0 ? last : cwd;
+}
+
+/** createdAt descending (newest first); session id breaks ties for full determinism. */
+function byCreatedAtDesc(a: DaemonSessionSummary, b: DaemonSessionSummary): number {
+  if (a.createdAt < b.createdAt) return 1;
+  if (a.createdAt > b.createdAt) return -1;
+  return byNameAsc(a.id, b.id);
+}
+
+function byNameAsc(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+/**
+ * A mutable accumulator mirroring SessionTreeProject. Worktrees are keyed by
+ * cwd while building so sessions can find their node in O(1); the final shape
+ * flattens the map into a sorted array.
+ */
+interface ProjectAccumulator {
+  cwd: string;
+  name: string;
+  declared?: boolean;
+  directSessions: DaemonSessionSummary[];
+  worktrees: Map<string, SessionTreeWorktree>;
+}
+
+/**
+ * Build an immutable session tree from the daemon's live projects + sessions.
+ *
+ * Grouping rules:
+ * - Owning-project key for a session = `projectCwd ?? cwd` (fallback so
+ *   pre-migration sessions without `projectCwd` still attach somewhere).
+ * - Top-level projects are entries with NO `parentCwd`. Worktree rows are
+ *   entries WITH `parentCwd` (which points at the owning project's cwd).
+ * - Each top-level project seeds its worktrees from registry worktree rows
+ *   whose `parentCwd === project.cwd` (worktrees appear even with zero sessions).
+ * - A session with `worktree.cwd` lands under the matching worktree node in its
+ *   owning project; a missing node is synthesized from the session's worktree.
+ *   A session with no worktree is a `directSession` of its owning project.
+ * - Orphan safety: a session whose owning-project key matches no top-level
+ *   project node gets a minimal synthesized project node (sessions are never
+ *   dropped).
+ * - Determinism: projects and worktrees sort by name; sessions by createdAt
+ *   desc. Input order is never relied upon.
+ */
+export function buildSessionTree(
+  projects: DaemonProjectEntry[],
+  sessions: DaemonSessionSummary[],
+): SessionTreeProject[] {
+  // 1. Seed top-level project nodes and stash worktree rows by parent.
+  const nodes = new Map<string, ProjectAccumulator>();
+  const worktreeRowsByParent = new Map<string, DaemonProjectEntry[]>();
+
+  for (const entry of projects) {
+    if (entry.parentCwd) {
+      const list = worktreeRowsByParent.get(entry.parentCwd);
+      if (list) list.push(entry);
+      else worktreeRowsByParent.set(entry.parentCwd, [entry]);
+      continue;
+    }
+    // Top-level project. Last-writer-wins on duplicate cwd.
+    nodes.set(entry.cwd, {
+      cwd: entry.cwd,
+      name: entry.name,
+      declared: entry.declared,
+      directSessions: [],
+      worktrees: new Map<string, SessionTreeWorktree>(),
+    });
+  }
+
+  // 2. Seed declared worktree nodes from registry rows (zero-session worktrees
+  //    still show). Worktree rows whose parent has no top-level node are
+  //    ignored here; if a session references them they'll be synthesized below.
+  for (const [parentCwd, rows] of worktreeRowsByParent) {
+    const parent = nodes.get(parentCwd);
+    if (!parent) continue;
+    for (const row of rows) {
+      if (parent.worktrees.has(row.cwd)) continue;
+      parent.worktrees.set(row.cwd, {
+        cwd: row.cwd,
+        branch: row.branch,
+        name: row.name || worktreeName(row.cwd, row.branch),
+        sessions: [],
+      });
+    }
+  }
+
+  // Synthesize a minimal top-level project node for an orphan session.
+  function ensureProjectNode(cwd: string): ProjectAccumulator {
+    let node = nodes.get(cwd);
+    if (!node) {
+      node = {
+        cwd,
+        name: projectNameFromCwd(cwd),
+        declared: undefined,
+        directSessions: [],
+        worktrees: new Map<string, SessionTreeWorktree>(),
+      };
+      nodes.set(cwd, node);
+    }
+    return node;
+  }
+
+  // 3. Place each session.
+  for (const session of sessions) {
+    const key = owningProjectKey(session);
+    if (!key) {
+      // No projectCwd and no cwd: anchor under a stable synthetic key so the
+      // session is never dropped.
+      const node = ensureProjectNode("");
+      placeSession(node, session);
+      continue;
+    }
+    const node = ensureProjectNode(key);
+    placeSession(node, session);
+  }
+
+  // 4. Freeze into sorted output.
+  const result: SessionTreeProject[] = [];
+  for (const node of nodes.values()) {
+    const worktrees = Array.from(node.worktrees.values());
+    for (const wt of worktrees) {
+      wt.sessions.sort(byCreatedAtDesc);
+    }
+    worktrees.sort((a, b) => byNameAsc(a.name, b.name) || byNameAsc(a.cwd, b.cwd));
+    node.directSessions.sort(byCreatedAtDesc);
+    result.push({
+      cwd: node.cwd,
+      name: node.name,
+      declared: node.declared,
+      directSessions: node.directSessions,
+      worktrees,
+    });
+  }
+  // cwd is the unique Map key, so it is a stable tiebreaker when two projects
+  // share a name (e.g. the same repo basename checked out in two locations).
+  // Without it, equal names fall back to Map iteration order, which is not
+  // deterministic across input orderings.
+  result.sort((a, b) => byNameAsc(a.name, b.name) || byNameAsc(a.cwd, b.cwd));
+  return result;
+}
+
+/** Route a session into the correct worktree node or directSessions. */
+function placeSession(node: ProjectAccumulator, session: DaemonSessionSummary): void {
+  const wt = session.worktree;
+  if (wt && wt.cwd) {
+    let wtNode = node.worktrees.get(wt.cwd);
+    if (!wtNode) {
+      wtNode = {
+        cwd: wt.cwd,
+        branch: wt.branch,
+        name: worktreeName(wt.cwd, wt.branch),
+        sessions: [],
+      };
+      node.worktrees.set(wt.cwd, wtNode);
+    } else if (!wtNode.branch && wt.branch) {
+      // Backfill branch onto a registry-seeded node that lacked one.
+      wtNode.branch = wt.branch;
+    }
+    wtNode.sessions.push(session);
+    return;
+  }
+  node.directSessions.push(session);
+}


### PR DESCRIPTION
## Project resolution: project → worktree → session model, history, and UI

Layered on top of #733 (`feat/single-server-runtime`). Squash-merges into it.

Establishes a single, correct ownership model — **a session always belongs to one project, optionally a worktree** — and surfaces it end to end. Decision facts in `goals/architecture/decisions/`.

### Backend
- **Resolver** (`project-resolver.ts`): `resolveProject(cwd)` → owning project + optional worktree. Rules: nearest **declared** root → git toplevel → cwd. Worktrees roll up to the main repo (tagged with branch); declared non-git workspaces (`mygroup/` of sibling repos) become the project. Git-injected → pure & testable.
- **Registry**: declared-root support (sticky), worktree/sub-repo child rows, `registerResolvedProject`.
- **Session attribution**: sessions carry `projectCwd` + `worktree`; operational `cwd` preserved for git ops.
- **History → resolver** (Phase 1): history now keys on the resolved owning project, nested `history/{project}/{worktree?}/{slug}/`; reader == writer.
- **Global history** (Phase 3): `listAllHistory()` + `GET /daemon/history`.

### Frontend
- **Session-tree builder** (Phase 2): pure `buildSessionTree(projects, sessions)` → `project → worktree → session`, orphan-safe.
- **Sidebar** (Phase 4): regrouped from by-type to **project → worktree → session**, live-only, active project auto-expanded, worktrees collapsible.
- **Sessions + History view** (Phase 4): conjoined **Active⇄All** + project filter under the project selector, a full-screen mode, and **click a history entry to open the saved plan** (via annotate-a-file).

### Tests
~40 resolver/registry tests (real git/fs integration incl. worktree × declared crossings) + history, tree-builder, history-store, and client tests. Full suite green (**1527 pass**); typecheck + single-file build clean. Backend verified live through the compiled daemon (worktree rollup, history layout, `/daemon/history`) and via a real Claude hook → CLI → daemon probe.

### Not in this PR / follow-ups
- **The Sessions+History view has passed typecheck/build/tests + adversarial review, but not yet a manual browser click-through** — good first review target.
- Deferred (in `project-resolution-followups.md`): session-snapshot meta (`projectCwd`/`worktree`), the "Add project → declared workspace" UI verification, CLAUDE.md matchKey/history-layout doc updates, and test-hygiene (a couple of tests write to the real history dir).
- `long-running-session-costs.md` documents the perf tail of the never-die session model (eviction/virtualization recommended) — informational, not addressed here.
