### PR TITLE
Fix review/plan/annotate sessions dying after 5 minutes

### DIFF
--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -680,7 +680,12 @@ async function runDaemonSessionRequest(request: PluginRequest, options: { plugin
     };
   } catch (err) {
     unregisterInterruptCleanup?.();
-    await cancelCreatedSession();
+    // Deliberately do NOT cancel the session here. A client-side failure while
+    // waiting for the result (e.g. a dropped long-poll connection) must not tear
+    // down a session that is alive and working in the browser — sessions never
+    // die. Leaving it up lets the tab keep functioning and the agent re-attach to
+    // the same session via its match key on resubmit. Genuine user aborts are
+    // handled separately by the SIGINT/SIGTERM cleanup handler.
     fail("daemon-session-failed", errorMessage(err));
   }
 }

--- a/packages/server/daemon/client.ts
+++ b/packages/server/daemon/client.ts
@@ -22,6 +22,14 @@ export type DaemonDiscoveryResult =
   | { ok: true; state: DaemonState; status: DaemonStatus; client: DaemonClient }
   | { ok: false; code: "missing" | "stale" | "malformed" | "incompatible" | "unhealthy" | "mismatch"; message: string; state?: unknown };
 
+interface DaemonRequestOptions {
+  /** Disable the client-side request timeout (for long-poll routes like waitForResult). */
+  noTimeout?: boolean;
+}
+
+/** RequestInit plus Bun's non-standard `timeout` extension (`false` disables the default ~5min timeout). */
+type BunRequestInit = RequestInit & { timeout?: boolean };
+
 export class DaemonClient {
   readonly state: DaemonState;
   private readonly fetchImpl: typeof fetch;
@@ -51,7 +59,13 @@ export class DaemonClient {
   }
 
   async waitForResult<T = unknown>(id: string): Promise<DaemonSessionResultResponse<T> | DaemonErrorResponse> {
-    return this.getJson(`/daemon/sessions/${encodeURIComponent(id)}/result`) as Promise<DaemonSessionResultResponse<T> | DaemonErrorResponse>;
+    // This is a long-poll: the daemon holds the response open until the user
+    // acts on the session (which can take far longer than any normal request).
+    // Disable the client-side timeout so the wait lasts as long as the review
+    // takes — the daemon already disables its own idle timeout for this route.
+    return this.getJson(`/daemon/sessions/${encodeURIComponent(id)}/result`, {
+      noTimeout: true,
+    }) as Promise<DaemonSessionResultResponse<T> | DaemonErrorResponse>;
   }
 
   async cancelSession(id: string): Promise<DaemonCancelSessionResponse | DaemonErrorResponse> {
@@ -68,11 +82,11 @@ export class DaemonClient {
     }) as Promise<DaemonShutdownResponse | DaemonErrorResponse>;
   }
 
-  async getJson(path: string): Promise<unknown> {
-    return this.requestJson(path, { method: "GET" });
+  async getJson(path: string, opts: DaemonRequestOptions = {}): Promise<unknown> {
+    return this.requestJson(path, { method: "GET" }, opts);
   }
 
-  private async requestJson(path: string, init: RequestInit): Promise<unknown> {
+  private async requestJson(path: string, init: RequestInit, opts: DaemonRequestOptions = {}): Promise<unknown> {
     const headers = new Headers(init.headers);
     if (init.body && !headers.has("content-type")) headers.set("content-type", "application/json");
     if (path !== "/daemon/capabilities") {
@@ -82,10 +96,15 @@ export class DaemonClient {
       }
     }
 
-    const res = await this.fetchImpl(`${this.state.baseUrl}${path}`, {
-      ...init,
-      headers,
-    });
+    const requestInit: BunRequestInit = { ...init, headers };
+    // Bun's fetch applies a default ~5-minute timeout to every request. For
+    // long-poll routes that intentionally hold the connection open (waitForResult),
+    // disable it so the client matches the daemon, which already calls
+    // server.timeout(req, 0) on these requests. Without this the client aborts at
+    // ~300s and tears the session down on its way out.
+    if (opts.noTimeout) requestInit.timeout = false;
+
+    const res = await this.fetchImpl(`${this.state.baseUrl}${path}`, requestInit);
     try {
       return await res.json();
     } catch {


### PR DESCRIPTION
## Problem

Review (and plan/annotate) sessions die ~5 minutes after opening if the user hasn't acted yet. The browser tab loses its session (404), and the CLI prints \`The operation timed out.\` and exits 1.

## Root cause (verified)

The command waits for the user's decision via a **long-poll**: `DaemonClient.waitForResult()` issues a single `GET /daemon/sessions/:id/result` that the daemon holds open until the session resolves.

- **Daemon side is correct:** before parking on `await store.waitForResult(id)`, the `/result` handler calls `disableIdleTimeout()` → `server.timeout(req, 0)`, so the server holds the connection open indefinitely.
- **Client side was missing the matching knob:** `requestJson()` calls `fetch()` with no `timeout`/`signal`, so it inherits **Bun's default ~5-minute fetch timeout**. After ~300s the client aborts *its own* request, throws, and the CLI's `catch` block calls `cancelCreatedSession()` — tearing down a session that was alive and healthy the whole time.

Observed lifecycle (lifecycle instrumentation): `session-created` → **293s later** → `cancelled (reason "Session cancelled.")` → `removed`. The daemon never restarted; the session was `active` the entire time. The client gave up and killed it.

## Fix

1. **`packages/server/daemon/client.ts`** — disable the client-side timeout for the `waitForResult` long-poll only (Bun's `timeout: false`), threaded through a scoped `noTimeout` request option. All other requests keep their default timeout.
2. **`apps/hook/server/index.ts`** — on a client-side wait failure, **do not cancel the session**. A dropped long-poll must not tear down a session that's alive in the browser ("sessions never die"); leaving it up lets the tab keep working and the agent re-attach via match key on resubmit. Genuine user aborts are still handled by the existing SIGINT/SIGTERM cleanup handler.

## Verification

- `bun run typecheck` — clean.
- `bun test packages/server/daemon/` — 109 pass / 0 fail.
- Manual: open a review, wait >5 min before acting → session stays alive and the decision still returns (no more 300s death). *(Recommend a human run-through before merge.)*

## Notes

- `timeout: false` is Bun's documented knob and matches the observed ~300s death. If a lower-level idle cutoff ever surfaces, the fully runtime-agnostic alternative is a bounded re-poll loop (server returns "still pending" every ~30s, client re-issues). Not needed for localhost CLI↔daemon today.