### PR TITLE
Fix flickering AI-tip input in label settings

### DIFF
--- a/packages/ui/components/Settings.tsx
+++ b/packages/ui/components/Settings.tsx
@@ -1466,8 +1466,8 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
 
                     <style>{`
                       @keyframes tip-slide-open {
-                        from { max-height: 0; opacity: 0; }
-                        to   { max-height: 60px; opacity: 1; }
+                        from { opacity: 0; transform: translateY(-4px); }
+                        to   { opacity: 1; transform: translateY(0); }
                       }
                     `}</style>
                     <div className="space-y-1.5">


### PR DESCRIPTION
## TL;DR
The Settings > Labels AI-tip (lightbulb) input flickered intensely on open. Root cause: the open animation animated `max-height` (a layout property), which fed a layout loop inside the scroll viewport and restarted the animation ~40x/s. Switched the keyframe to `opacity` + `transform` (compositor-only), eliminating the flicker.

## Background / Context
Each Quick Label row has a lightbulb ("Add AI instruction tip") that opens a tip editor sliding in below the row. The slide used a `max-height: 0 -> 60px` keyframe. Expected: a smooth one-time reveal. Actual: rapid, continuous flicker on every open (#829).

## Observed problem
- `tip-slide-open` animates `max-height`, a layout/reflow property, with no `animation-fill-mode`.
- The keyframe end (60px) exceeds the input's natural height (~31px).
- The editor sits inside an OverlayScrollbars viewport + flex `min-h-0` container; animating its height feeds a layout loop that restarts the animation ~40x/second, jittering height between 8-31px.
- Reporter-suggested causes (`key={index}` remount, unbatched setState, ResizeObserver loop, scroll-into-view churn) were measured and ruled out: 0 node remounts, 0 DOM/style mutations, 0 scroll events, 1 ResizeObserver fire.

## Fix approach
Animate compositor-only properties (`opacity` + `transform: translateY`) instead of `max-height`. No layout property is animated, so the loop cannot form. The keyframe end state equals the element's natural rendered state, so no `animation-fill-mode` is needed. The parent row already has `overflow-hidden`, so the initial `translateY(-4px)` is clipped cleanly.

## Modified files
- `packages/ui/components/Settings.tsx` — `tip-slide-open` keyframe (2 lines).

## Verification criteria
Clicking the lightbulb opens the tip editor with no flicker; the editor settles at its natural height; typing, Enter-to-save, Esc-to-cancel, and toggling labels with/without tips all behave normally.

## Test list
Verified on the live demo (share.plannotator.ai) by patching the page's keyframe in place with the fix CSS, in the real layout:

| Metric (450ms window) | Before (max-height) | After (opacity+transform) |
| --- | --- | --- |
| Animation restarts | 17 | 0 |
| Height reversals | 10 | 0 |
| Editor height | 8<->31px jitter | 31px stable |

## References
- Issue #829

Closes #829
