### PR TITLE
Integrate with the Kiro CLI harness (skills + custom agent)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,9 @@ plannotator/
 │   │   └── lib/                  # Shared command wrapper helpers
 │   ├── marketing/                # Marketing site, docs, and blog (plannotator.ai)
 │   │   └── astro.config.mjs      # Astro 5 static site with content collections
+│   ├── kiro-cli/                 # Kiro CLI integration source (consumed by scripts/install.sh; auto-detected via ~/.kiro)
+│   │   ├── agents/plannotator.json   # Example Kiro custom agent
+│   │   └── skills/               # Kiro-specific skill packages (review, annotate, archive); setup-goal + visual-explainer install from apps/skills
 │   ├── paste-service/            # Paste service for short URL sharing
 │   │   ├── core/                 # Platform-agnostic logic (handler, storage interface, cors)
 │   │   ├── stores/               # Storage backends (fs, kv, s3)
@@ -128,7 +131,7 @@ claude --plugin-dir ./apps/hook
 | `PLANNOTATOR_SHARE` | Set to `disabled` to turn off URL sharing entirely. Default: enabled. |
 | `PLANNOTATOR_SHARE_URL` | Custom base URL for share links (self-hosted portal). Default: `https://share.plannotator.ai`. |
 | `PLANNOTATOR_PASTE_URL` | Base URL of the paste service API for short URL sharing. Default: `https://plannotator-paste.plannotator.workers.dev`. |
-| `PLANNOTATOR_ORIGIN` | Explicit agent-origin override at the top of the detection chain. Valid values: `claude-code`, `amp`, `droid`, `opencode`, `codex`, `copilot-cli`, `gemini-cli`, `pi`. Invalid values silently fall through to env-based detection. Unset by default. |
+| `PLANNOTATOR_ORIGIN` | Explicit agent-origin override at the top of the detection chain. Valid values: `claude-code`, `amp`, `droid`, `opencode`, `codex`, `copilot-cli`, `gemini-cli`, `kiro-cli`, `pi`. Invalid values silently fall through to env-based detection. Unset by default. |
 | `PLANNOTATOR_JINA` | Set to `0` / `false` to disable Jina Reader for URL annotation, or `1` / `true` to enable. Default: enabled. Can also be set via `~/.plannotator/config.json` (`{ "jina": false }`) or per-invocation via `--no-jina`. |
 | `JINA_API_KEY` | Optional Jina Reader API key for higher rate limits (500 RPM vs 20 RPM unauthenticated). Free keys include 10M tokens. |
 | `PLANNOTATOR_DATA_DIR` | Override the base data directory. Supports `~` expansion. Default: `~/.plannotator`. All data (plans, history, drafts, config, hooks, sessions, debug logs, IPC registry) is stored under this directory. |

--- a/apps/kiro-cli/README.md
+++ b/apps/kiro-cli/README.md
@@ -1,0 +1,44 @@
+# Plannotator Kiro CLI Integration
+
+Source package for Plannotator's Kiro CLI support. These files are consumed by the main installer
+(`scripts/install.sh`) — there is **no separate Kiro installer**. A Kiro user installs with the same
+one-liner as everyone else.
+
+## Contents
+
+- `skills/` — Kiro-specific skill packages (`plannotator-review`, `plannotator-annotate`,
+  `plannotator-archive`), each baking `PLANNOTATOR_ORIGIN=kiro-cli` into its command.
+- `agents/plannotator.json` — an example Kiro custom agent that exposes the Plannotator skills via
+  `skill://` resources and a `plannotator`-scoped `shell` tool.
+
+## How it installs
+
+`scripts/install.sh` auto-detects Kiro (if `~/.kiro` exists or `kiro-cli` is on PATH — the same
+convention used for Codex and Gemini) and installs:
+
+- the 3 Kiro-specific skills above → `~/.kiro/skills`
+- the 2 shared skills `plannotator-setup-goal` and `plannotator-visual-explainer` (pulled from
+  `apps/skills/`, not duplicated here) → `~/.kiro/skills`
+- the example agent `agents/plannotator.json` → `~/.kiro/agents/plannotator.json` (an existing file
+  is never overwritten)
+
+```bash
+curl -fsSL https://plannotator.ai/install.sh | bash
+```
+
+## Use the Plannotator agent
+
+The installed agent wires all five skills via `skill://` resources and, in its prompt, documents
+which skill to use for which task (review, annotate, archive, setup-goal, visual-explainer). Launch
+it:
+
+```bash
+kiro-cli chat --agent plannotator
+```
+
+Or add the same `skill://~/.kiro/skills/plannotator-*/SKILL.md` resources to one of your own agents.
+
+## Schema note
+
+`agents/plannotator.json` is a conservative example. If Kiro changes its custom-agent schema, adapt
+the installed copy at `~/.kiro/agents/plannotator.json`.

--- a/apps/kiro-cli/agents/plannotator.json
+++ b/apps/kiro-cli/agents/plannotator.json
@@ -1,0 +1,20 @@
+{
+  "name": "plannotator",
+  "description": "Kiro custom agent wiring for Plannotator review and annotation workflows.",
+  "prompt": "You run Plannotator, which opens a browser UI for human review and annotation. Choose the skill that matches the task:\n- plannotator-review: review the current code changes (git/jj diff) or a pull request before continuing; optionally pass a PR URL.\n- plannotator-annotate: annotate a markdown or HTML file, a folder of docs, or a URL, then act on the returned annotations.\n- plannotator-archive: browse previously approved/denied plan decisions (read-only).\n- plannotator-setup-goal: turn an idea into a structured goal package by interviewing the user, building a fact sheet, then a plan.\n- plannotator-visual-explainer: generate a polished, self-contained HTML visual (implementation plan, PR walkthrough, or diagram) and open it for review.\nEach skill runs a `plannotator` shell command. plannotator-review, plannotator-annotate, and plannotator-archive set PLANNOTATOR_ORIGIN=kiro-cli.",
+  "tools": [
+    "shell"
+  ],
+  "allowedTools": [
+    "shell"
+  ],
+  "toolsSettings": {
+    "shell": {
+      "allowedCommands": ["plannotator .*"]
+    }
+  },
+  "resources": [
+    "skill://.kiro/skills/plannotator-*/SKILL.md",
+    "skill://~/.kiro/skills/plannotator-*/SKILL.md"
+  ]
+}

--- a/apps/kiro-cli/skills/plannotator-annotate/SKILL.md
+++ b/apps/kiro-cli/skills/plannotator-annotate/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: plannotator-annotate
+description: Open Plannotator's annotation UI for a file, folder, or URL, then address the returned annotations.
+---
+
+# Plannotator Annotate (Kiro)
+
+Run:
+
+```bash
+PLANNOTATOR_ORIGIN=kiro-cli plannotator annotate $ARGUMENTS
+```
+
+`$ARGUMENTS` should be a markdown file path, folder path, html file path, or URL.

--- a/apps/kiro-cli/skills/plannotator-archive/SKILL.md
+++ b/apps/kiro-cli/skills/plannotator-archive/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: plannotator-archive
+description: Open the read-only Plannotator archive browser for prior plan decisions.
+---
+
+# Plannotator Archive (Kiro)
+
+Run:
+
+```bash
+PLANNOTATOR_ORIGIN=kiro-cli plannotator archive
+```

--- a/apps/kiro-cli/skills/plannotator-review/SKILL.md
+++ b/apps/kiro-cli/skills/plannotator-review/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: plannotator-review
+description: Open Plannotator's browser-based code review UI and address the returned feedback.
+---
+
+# Plannotator Review (Kiro)
+
+Run:
+
+```bash
+PLANNOTATOR_ORIGIN=kiro-cli plannotator review
+```
+
+You may append an optional PR URL:
+
+```bash
+PLANNOTATOR_ORIGIN=kiro-cli plannotator review <pr-url>
+```

--- a/apps/marketing/src/content/docs/getting-started/installation.md
+++ b/apps/marketing/src/content/docs/getting-started/installation.md
@@ -1,6 +1,6 @@
 ---
 title: "Installation"
-description: "How to install Plannotator for Claude Code, Codex, OpenCode, Pi, Amp, Droid, and other agent hosts."
+description: "How to install Plannotator for Claude Code, Codex, OpenCode, Kiro CLI, Pi, Amp, Droid, and other agent hosts."
 sidebar:
   order: 1
 section: "Getting Started"
@@ -115,6 +115,32 @@ curl -fsSL https://plannotator.ai/install.sh | bash
 ```
 
 This also clears any cached plugin versions.
+
+## Kiro CLI
+
+Kiro is auto-detected — no extra flag or step. If `~/.kiro` exists (or `kiro-cli` is on your PATH) when you run the installer, Plannotator's Kiro skills install automatically, the same way Codex and Gemini are handled. This works on every platform; use the installer for your OS:
+
+**macOS / Linux / WSL:**
+
+```bash
+curl -fsSL https://plannotator.ai/install.sh | bash
+```
+
+**Windows PowerShell:**
+
+```powershell
+irm https://plannotator.ai/install.ps1 | iex
+```
+
+**Windows CMD:**
+
+```cmd
+curl -fsSL https://plannotator.ai/install.cmd -o install.cmd && install.cmd && del install.cmd
+```
+
+On Windows the installer checks for `%USERPROFILE%\.kiro` (or `kiro-cli` on your PATH). This installs the Kiro skills to `~/.kiro/skills` and the Plannotator agent to `~/.kiro/agents/plannotator.json` (an existing agent file is never overwritten). If you install Kiro *after* Plannotator, just re-run the installer.
+
+See the [Kiro guide](/docs/guides/kiro-cli/) for the skill list and the Plannotator agent.
 
 ## Kilo Code
 

--- a/apps/marketing/src/content/docs/guides/kiro-cli.md
+++ b/apps/marketing/src/content/docs/guides/kiro-cli.md
@@ -1,0 +1,84 @@
+---
+title: "Kiro CLI"
+description: "Plannotator skills and a custom-agent example for Kiro CLI."
+sidebar:
+  order: 16
+section: "Guides"
+---
+
+Plannotator supports Kiro CLI through installable skills plus an example custom agent. Skills are
+invoked on demand — there are no background hooks, matching how Plannotator integrates with Droid
+and Copilot CLI.
+
+## Setup
+
+Kiro is auto-detected. If `~/.kiro` exists (or `kiro-cli` is on your PATH) when you run the
+installer, the Kiro skills install automatically — the same convention used for Codex and Gemini.
+No extra flags or steps. Auto-detection works on every platform; use the installer for your OS:
+
+**macOS / Linux / WSL:**
+
+```bash
+curl -fsSL https://plannotator.ai/install.sh | bash
+```
+
+**Windows PowerShell:**
+
+```powershell
+irm https://plannotator.ai/install.ps1 | iex
+```
+
+**Windows CMD:**
+
+```cmd
+curl -fsSL https://plannotator.ai/install.cmd -o install.cmd && install.cmd && del install.cmd
+```
+
+This installs the Kiro skills to `~/.kiro/skills` and the Plannotator agent to
+`~/.kiro/agents/plannotator.json`. If you install Kiro *after* Plannotator, just re-run the installer.
+See [Use the Plannotator agent](#use-the-plannotator-agent) below.
+
+## Installed Kiro skills
+
+Kiro-specific skills (run with `PLANNOTATOR_ORIGIN=kiro-cli`):
+
+- `plannotator-review`
+- `plannotator-annotate`
+- `plannotator-archive`
+
+Shared skills (installed from Plannotator's canonical `apps/skills/` set, not duplicated):
+
+- `plannotator-setup-goal`
+- `plannotator-visual-explainer`
+
+The shared skills show the default agent badge rather than "Kiro CLI" — origin is cosmetic for
+Kiro and has no functional effect.
+
+## Use the Plannotator agent
+
+The installer writes the agent to `~/.kiro/agents/plannotator.json`. It wires every Plannotator skill
+through the `resources` field (`skill://` URIs), grants the `shell` tool scoped to `plannotator`
+commands, and its prompt spells out which skill to use for which task:
+
+| Skill | Use it to |
+|-------|-----------|
+| `plannotator-review` | Review the current code changes or a pull request |
+| `plannotator-annotate` | Annotate a markdown/HTML file, folder, or URL |
+| `plannotator-archive` | Browse prior approved/denied plan decisions |
+| `plannotator-setup-goal` | Turn an idea into a structured goal package |
+| `plannotator-visual-explainer` | Generate a polished visual HTML explainer |
+
+Launch it:
+
+```bash
+kiro-cli chat --agent plannotator
+```
+
+Prefer your own agent? Add the same `skill://~/.kiro/skills/plannotator-*/SKILL.md` resources to any
+custom agent's `resources` list.
+
+## Assumptions
+
+The custom-agent JSON is intentionally conservative because Kiro's schema can evolve. If your Kiro
+version expects different field names for resources or tool permissions, edit
+`~/.kiro/agents/plannotator.json` for your runtime.

--- a/apps/marketing/src/content/docs/reference/environment-variables.md
+++ b/apps/marketing/src/content/docs/reference/environment-variables.md
@@ -16,7 +16,7 @@ All Plannotator environment variables and their defaults.
 | `PLANNOTATOR_PORT` | random (local) / `19432` (remote) | Fixed server port. When not set, local sessions use a random port; remote sessions default to `19432`. |
 | `PLANNOTATOR_BROWSER` | system default | Custom browser to open the UI in. macOS: app name or path. Linux/Windows: executable path. Can also be a script. Takes priority over `BROWSER`. Also settable per-invocation with `--browser`. |
 | `BROWSER` | (none) | Standard env var for specifying a browser. VS Code sets this automatically in devcontainers. Used as fallback when `PLANNOTATOR_BROWSER` is not set. |
-| `PLANNOTATOR_ORIGIN` | auto-detect | Explicit agent-origin override. Valid values: `claude-code`, `amp`, `droid`, `opencode`, `codex`, `copilot-cli`, `pi`, `gemini-cli`. Invalid values silently fall through to env-based detection. |
+| `PLANNOTATOR_ORIGIN` | auto-detect | Explicit agent-origin override. Valid values: `claude-code`, `amp`, `droid`, `opencode`, `codex`, `copilot-cli`, `pi`, `gemini-cli`, `kiro-cli`. Invalid values silently fall through to env-based detection. |
 | `PLANNOTATOR_READY_FILE` | (none) | Internal host-plugin side channel. When set, Plannotator appends server-ready JSON lines containing the local UI URL. |
 | `PLANNOTATOR_SKIP_BROWSER_OPEN` | unset | Internal host-plugin flag. Set to `1` to prevent Plannotator from opening the browser itself when the host will open the URL. |
 | `PLANNOTATOR_SHARE` | enabled | Set to `disabled` to turn off sharing. Hides share UI and import options. |

--- a/packages/shared/agents.ts
+++ b/packages/shared/agents.ts
@@ -20,6 +20,7 @@ export const AGENT_CONFIG = {
   'claude-code': { name: 'Claude Code', badge: 'bg-orange-500/15 text-orange-400', aiProviderTypes: ['claude-agent-sdk'] },
   'amp':         { name: 'Amp',         badge: 'bg-lime-500/15 text-lime-400' },
   'droid':       { name: 'Droid',       badge: 'bg-cyan-500/15 text-cyan-400' },
+  'kiro-cli':    { name: 'Kiro CLI',    badge: 'bg-amber-500/15 text-amber-400' },
   'opencode':    { name: 'OpenCode',    badge: 'bg-emerald-500/15 text-emerald-400', aiProviderTypes: ['opencode-sdk'] },
   'copilot-cli': { name: 'GitHub Copilot', badge: 'bg-blue-500/15 text-blue-400' },
   'pi':          { name: 'Pi',          badge: 'bg-violet-500/15 text-violet-400', aiProviderTypes: ['pi-sdk'] },

--- a/packages/shared/config.ts
+++ b/packages/shared/config.ts
@@ -41,6 +41,7 @@ export type PromptRuntime =
   | "claude-code"
   | "amp"
   | "droid"
+  | "kiro-cli"
   | "opencode"
   | "copilot-cli"
   | "pi"

--- a/packages/shared/prompts.ts
+++ b/packages/shared/prompts.ts
@@ -18,6 +18,7 @@ export const PLAN_TOOL_NAMES: Record<PromptRuntime, string> = {
   "claude-code": "ExitPlanMode",
   amp: "ExitPlanMode",
   droid: "ExitPlanMode",
+  "kiro-cli": "ExitPlanMode",
   opencode: "submit_plan",
   "copilot-cli": "exit_plan_mode",
   pi: "plannotator_submit_plan",

--- a/scripts/install.cmd
+++ b/scripts/install.cmd
@@ -413,6 +413,11 @@ if exist "%USERPROFILE%\.codex" (
         if /i not "%%C"=="skills" if /i not "%%C"==".DS_Store" set "CODEX_AVAILABLE=1"
     )
 )
+REM Kiro is auto-detected like Codex/Gemini: PATH executable or an existing %USERPROFILE%\.kiro.
+set "KIRO_AVAILABLE=0"
+where kiro-cli >nul 2>&1
+if !ERRORLEVEL! equ 0 set "KIRO_AVAILABLE=1"
+if exist "%USERPROFILE%\.kiro" set "KIRO_AVAILABLE=1"
 if "!CODEX_AVAILABLE!"=="1" (
     echo.
     echo Codex detected.
@@ -525,13 +530,15 @@ if !ERRORLEVEL! equ 0 (
     )
     set "CODEX_SKILLS_DIR=%USERPROFILE%\.codex\skills"
     set "AGENTS_SKILLS_DIR=%USERPROFILE%\.agents\skills"
+    set "KIRO_SKILLS_DIR=%USERPROFILE%\.kiro\skills"
+    set "KIRO_AGENTS_DIR=%USERPROFILE%\.kiro\agents"
     set "SKILLS_TMP=%TEMP%\plannotator-skills-%RANDOM%"
     mkdir "!SKILLS_TMP!" >nul 2>&1
 
     git clone --depth 1 --filter=blob:none --sparse "https://github.com/!REPO!.git" --branch "!TAG!" "!SKILLS_TMP!\repo" >nul 2>&1
     if !ERRORLEVEL! equ 0 (
         pushd "!SKILLS_TMP!\repo"
-        git sparse-checkout set apps/skills >nul 2>&1
+        git sparse-checkout set apps/skills apps/kiro-cli >nul 2>&1
 
         if exist "apps\skills" (
             if not exist "!CLAUDE_SKILLS_DIR!" mkdir "!CLAUDE_SKILLS_DIR!"
@@ -548,6 +555,22 @@ if !ERRORLEVEL! equ 0 (
                 echo Installed skills to !CLAUDE_SKILLS_DIR!\, Codex command skills to !CODEX_SKILLS_DIR!\, and shared agent skills to !AGENTS_SKILLS_DIR!\
             ) else (
                 echo Installed skills to !CLAUDE_SKILLS_DIR!\ and shared agent skills to !AGENTS_SKILLS_DIR!\
+            )
+            if "!KIRO_AVAILABLE!"=="1" if exist "apps\kiro-cli\skills" (
+                if not exist "!KIRO_SKILLS_DIR!" mkdir "!KIRO_SKILLS_DIR!"
+                REM Kiro-specific skills with origin baked in come from apps/kiro-cli/skills.
+                if exist "apps\kiro-cli\skills\plannotator-review" xcopy /s /i /y /q "apps\kiro-cli\skills\plannotator-review" "!KIRO_SKILLS_DIR!\plannotator-review\" >nul 2>&1
+                if exist "apps\kiro-cli\skills\plannotator-annotate" xcopy /s /i /y /q "apps\kiro-cli\skills\plannotator-annotate" "!KIRO_SKILLS_DIR!\plannotator-annotate\" >nul 2>&1
+                if exist "apps\kiro-cli\skills\plannotator-archive" xcopy /s /i /y /q "apps\kiro-cli\skills\plannotator-archive" "!KIRO_SKILLS_DIR!\plannotator-archive\" >nul 2>&1
+                REM Shared skills come from apps/skills, not duplicated into apps/kiro-cli/skills.
+                if exist "apps\skills\plannotator-setup-goal" xcopy /s /i /y /q "apps\skills\plannotator-setup-goal" "!KIRO_SKILLS_DIR!\plannotator-setup-goal\" >nul 2>&1
+                if exist "apps\skills\plannotator-visual-explainer" xcopy /s /i /y /q "apps\skills\plannotator-visual-explainer" "!KIRO_SKILLS_DIR!\plannotator-visual-explainer\" >nul 2>&1
+                REM Plannotator custom agent — don't clobber a user's existing one.
+                if not exist "!KIRO_AGENTS_DIR!\plannotator.json" if exist "apps\kiro-cli\agents\plannotator.json" (
+                    if not exist "!KIRO_AGENTS_DIR!" mkdir "!KIRO_AGENTS_DIR!"
+                    copy /y "apps\kiro-cli\agents\plannotator.json" "!KIRO_AGENTS_DIR!\plannotator.json" >nul 2>&1
+                )
+                echo Installed Kiro skills to !KIRO_SKILLS_DIR!\ and agent to !KIRO_AGENTS_DIR!\plannotator.json
             )
         )
 
@@ -687,6 +710,19 @@ echo """
     ) > "%USERPROFILE%\.gemini\commands\plannotator-annotate.toml"
 
     echo Installed Gemini slash commands to %USERPROFILE%\.gemini\commands\
+)
+
+echo.
+echo ==========================================
+echo   KIRO CLI USERS
+echo ==========================================
+echo.
+if "!KIRO_AVAILABLE!"=="1" (
+    echo Kiro skills are installed to %USERPROFILE%\.kiro\skills\
+    echo The Plannotator agent is installed to %USERPROFILE%\.kiro\agents\plannotator.json
+    echo Launch it: kiro-cli chat --agent plannotator
+) else (
+    echo Kiro was not detected. After installing Kiro, rerun this installer to add Kiro skills.
 )
 
 echo.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -295,6 +295,8 @@ if (Test-Path $codexDir) {
         Select-Object -First 1)
 }
 $codexAvailable = [bool](Get-Command codex -ErrorAction SilentlyContinue) -or $codexHomeHasUserConfig
+# Kiro is auto-detected like Codex/Gemini: PATH executable or an existing ~/.kiro.
+$kiroAvailable = [bool](Get-Command kiro-cli -ErrorAction SilentlyContinue) -or (Test-Path "$env:USERPROFILE\.kiro")
 
 if ($codexAvailable) {
     $codexExePath = "$installDir\plannotator.exe"
@@ -572,7 +574,7 @@ if (Get-Command git -ErrorAction SilentlyContinue) {
             # only on the success path) leaks the location stack if a
             # PS-native cmdlet (Copy-Item etc.) throws under Stop.
             try {
-                git sparse-checkout set apps/skills 2>$null
+                git sparse-checkout set apps/skills apps/kiro-cli 2>$null
 
                 if (Test-Path "apps\skills") {
                     $items = Get-ChildItem "apps\skills" -ErrorAction SilentlyContinue
@@ -591,6 +593,24 @@ if (Get-Command git -ErrorAction SilentlyContinue) {
                             Write-Host "Installed skills to $claudeSkillsDir\, Codex command skills to $codexSkillsDir\, and shared agent skills to $agentsSkillsDir\"
                         } else {
                             Write-Host "Installed skills to $claudeSkillsDir\ and shared agent skills to $agentsSkillsDir\"
+                        }
+                        if ($kiroAvailable -and (Test-Path "apps\kiro-cli\skills")) {
+                            $kiroSkillsDir = "$env:USERPROFILE\.kiro\skills"
+                            New-Item -ItemType Directory -Force -Path $kiroSkillsDir | Out-Null
+                            # Kiro-specific skills (origin baked in) come from apps/kiro-cli/skills.
+                            Copy-SkillIfPresent "apps\kiro-cli\skills\plannotator-review" $kiroSkillsDir
+                            Copy-SkillIfPresent "apps\kiro-cli\skills\plannotator-annotate" $kiroSkillsDir
+                            Copy-SkillIfPresent "apps\kiro-cli\skills\plannotator-archive" $kiroSkillsDir
+                            # Shared skills come from apps/skills (not duplicated into apps/kiro-cli/skills).
+                            Copy-SkillIfPresent "apps\skills\plannotator-setup-goal" $kiroSkillsDir
+                            Copy-SkillIfPresent "apps\skills\plannotator-visual-explainer" $kiroSkillsDir
+                            # Plannotator custom agent — don't clobber a user's existing one.
+                            $kiroAgentsDir = "$env:USERPROFILE\.kiro\agents"
+                            if (-not (Test-Path "$kiroAgentsDir\plannotator.json") -and (Test-Path "apps\kiro-cli\agents\plannotator.json")) {
+                                New-Item -ItemType Directory -Force -Path $kiroAgentsDir | Out-Null
+                                Copy-Item -Force "apps\kiro-cli\agents\plannotator.json" "$kiroAgentsDir\plannotator.json"
+                            }
+                            Write-Host "Installed Kiro skills to $kiroSkillsDir\ and agent to $kiroAgentsDir\plannotator.json"
                         }
                     }
                 }
@@ -733,6 +753,18 @@ Write-Host ""
 Write-Host "Install or update the extension:"
 Write-Host ""
 Write-Host "  pi install npm:@plannotator/pi-extension"
+Write-Host ""
+Write-Host "=========================================="
+Write-Host "  KIRO CLI USERS"
+Write-Host "=========================================="
+Write-Host ""
+if ($kiroAvailable) {
+    Write-Host "Kiro skills are installed to $env:USERPROFILE\.kiro\skills\"
+    Write-Host "The Plannotator agent is installed to $env:USERPROFILE\.kiro\agents\plannotator.json"
+    Write-Host "Launch it: kiro-cli chat --agent plannotator"
+} else {
+    Write-Host "Kiro was not detected. After installing Kiro, rerun this installer to add Kiro skills."
+}
 Write-Host ""
 Write-Host "=========================================="
 Write-Host "  CLAUDE CODE USERS: YOU ARE ALL SET!"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -332,6 +332,11 @@ if command -v codex >/dev/null 2>&1 || codex_home_has_user_config; then
     codex_available=1
 fi
 
+kiro_available=0
+if command -v kiro-cli >/dev/null 2>&1 || [ -d "$HOME/.kiro" ]; then
+    kiro_available=1
+fi
+
 if [ "$codex_available" -eq 1 ]; then
     CODEX_DIR="$HOME/.codex"
     CODEX_CONFIG="$CODEX_DIR/config.toml"
@@ -772,6 +777,7 @@ if command -v git &>/dev/null; then
     CLAUDE_SKILLS_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills"
     CODEX_SKILLS_DIR="$HOME/.codex/skills"
     AGENTS_SKILLS_DIR="$HOME/.agents/skills"
+    KIRO_SKILLS_DIR="$HOME/.kiro/skills"
     skills_tmp=$(mktemp -d)
 
     copy_skill_if_present() {
@@ -800,7 +806,7 @@ if command -v git &>/dev/null; then
         git clone --depth 1 --filter=blob:none --sparse \
             "https://github.com/${REPO}.git" --branch "$latest_tag" repo 2>/dev/null
         cd repo
-        git sparse-checkout set apps/skills 2>/dev/null
+        git sparse-checkout set apps/skills apps/kiro-cli 2>/dev/null
         [ -d "apps/skills" ]
         [ "$(ls -A apps/skills 2>/dev/null)" ]
         mkdir -p "$CLAUDE_SKILLS_DIR" "$AGENTS_SKILLS_DIR"
@@ -813,6 +819,22 @@ if command -v git &>/dev/null; then
             copy_skill_if_present apps/skills/plannotator-review "$CODEX_SKILLS_DIR"
             copy_skill_if_present apps/skills/plannotator-annotate "$CODEX_SKILLS_DIR"
             copy_skill_if_present apps/skills/plannotator-last "$CODEX_SKILLS_DIR"
+        fi
+        if [ "$kiro_available" -eq 1 ] && [ -d "apps/kiro-cli/skills" ] && [ -n "$(ls -A apps/kiro-cli/skills 2>/dev/null)" ]; then
+            mkdir -p "$KIRO_SKILLS_DIR"
+            # Kiro-specific skills (origin baked in) come from apps/kiro-cli/skills.
+            copy_skill_if_present apps/kiro-cli/skills/plannotator-review "$KIRO_SKILLS_DIR"
+            copy_skill_if_present apps/kiro-cli/skills/plannotator-annotate "$KIRO_SKILLS_DIR"
+            copy_skill_if_present apps/kiro-cli/skills/plannotator-archive "$KIRO_SKILLS_DIR"
+            # Shared skills come from apps/skills (not duplicated into apps/kiro-cli/skills).
+            copy_skill_if_present apps/skills/plannotator-setup-goal "$KIRO_SKILLS_DIR"
+            copy_skill_if_present apps/skills/plannotator-visual-explainer "$KIRO_SKILLS_DIR"
+            # Plannotator custom agent — don't clobber a user's existing one.
+            if [ ! -f "$HOME/.kiro/agents/plannotator.json" ] && [ -f "apps/kiro-cli/agents/plannotator.json" ]; then
+                mkdir -p "$HOME/.kiro/agents"
+                cp apps/kiro-cli/agents/plannotator.json "$HOME/.kiro/agents/plannotator.json"
+            fi
+            echo "Installed Kiro skills to ${KIRO_SKILLS_DIR}/ and agent to ~/.kiro/agents/plannotator.json"
         fi
     ); then
         if [ "$codex_available" -eq 1 ]; then
@@ -983,6 +1005,18 @@ if [ "$codex_available" -eq 1 ]; then
 else
     echo "Codex was not detected. After installing Codex, rerun this installer to add"
     echo "the Stop hook and Codex skills."
+fi
+echo ""
+echo "=========================================="
+echo "  KIRO CLI USERS"
+echo "=========================================="
+echo ""
+if [ "$kiro_available" -eq 1 ]; then
+    echo "Kiro skills are installed to ~/.kiro/skills/"
+    echo "The Plannotator agent is installed to ~/.kiro/agents/plannotator.json"
+    echo "Launch it: kiro-cli chat --agent plannotator"
+else
+    echo "Kiro was not detected. After installing Kiro, rerun this installer to add Kiro skills."
 fi
 echo ""
 echo "=========================================="

--- a/scripts/install.test.ts
+++ b/scripts/install.test.ts
@@ -80,6 +80,29 @@ describe("install.sh", () => {
     expect(script).toContain('Skipping skills install (git not found)');
   });
 
+  test("auto-installs Kiro skills when ~/.kiro is detected (no flag)", () => {
+    // Auto-detected like Codex/Gemini — never gated behind a bespoke flag.
+    expect(script).toContain("kiro_available=0");
+    expect(script).toContain('[ -d "$HOME/.kiro" ]');
+    expect(script).toContain("KIRO_SKILLS_DIR");
+    expect(script).toContain("$HOME/.kiro/skills");
+    expect(script).toContain('if [ "$kiro_available" -eq 1 ]');
+    // Kiro-specific skills (origin baked in) come from apps/kiro-cli/skills.
+    expect(script).toContain('copy_skill_if_present apps/kiro-cli/skills/plannotator-review "$KIRO_SKILLS_DIR"');
+    expect(script).toContain('copy_skill_if_present apps/kiro-cli/skills/plannotator-annotate "$KIRO_SKILLS_DIR"');
+    expect(script).toContain('copy_skill_if_present apps/kiro-cli/skills/plannotator-archive "$KIRO_SKILLS_DIR"');
+    // Shared skills come from apps/skills (not duplicated into apps/kiro-cli/skills).
+    expect(script).toContain('copy_skill_if_present apps/skills/plannotator-setup-goal "$KIRO_SKILLS_DIR"');
+    expect(script).toContain('copy_skill_if_present apps/skills/plannotator-visual-explainer "$KIRO_SKILLS_DIR"');
+    // sparse-checkout fetches apps/kiro-cli (skills + agent example).
+    expect(script).toContain("git sparse-checkout set apps/skills apps/kiro-cli");
+    // The installer also writes the example custom agent to ~/.kiro/agents.
+    expect(script).toContain('cp apps/kiro-cli/agents/plannotator.json "$HOME/.kiro/agents/plannotator.json"');
+    // Parity: no bespoke flag, like every other agent.
+    expect(script).not.toContain("--kiro");
+    expect(script).not.toContain("INSTALL_KIRO");
+  });
+
   test("cleans only legacy command-overlap agent skills", () => {
     expect(script).toContain("LEGACY_AGENTS_SKILLS_DIR");
     expect(script).toContain("plannotator-review plannotator-annotate plannotator-last");


### PR DESCRIPTION

  ## Summary                                                                  
                                                                              
  Integrates Plannotator with the **Kiro CLI** harness (closes #794).         
                                                                              
  Kiro is supported through its native extension model — **installable skills 
  + a custom agent** — not a plugin or hook. The integration is **universal   
  and auto-detected**: when ~/.kiro exists (or kiro-cli is on PATH), the      
  installer wires everything up automatically, the same convention already    
  used for Codex and Gemini. No flag, no separate installer.                  
                                                                              
  ## What's included                                                          
                                                                              
  • packages/shared — adds the kiro-cli agent origin (badge, prompt runtime,  
  PLAN_TOOL_NAMES). Origin is cosmetic for Kiro (no dedicated Ask-AI provider),
  so it falls through to the saved/server default like gemini-cli.            
  • apps/kiro-cli — 3 origin-baked skills (review, annotate, archive) + an    
  example custom agent that exposes every skill via skill:// resources and a  
  plannotator-scoped shell tool. setup-goal + visual-explainer install from   
  the canonical apps/skills/ set (no content duplication).                    
  • scripts/install.sh — auto-detects ~/.kiro, sparse-checks out apps/kiro-cli,
  installs 3 Kiro skills + 2 shared skills + the agent (never clobbering an   
  existing one). Covered by scripts/install.test.ts.                          
  • scripts/install.ps1** + **install.cmd — Windows parity, mirroring the     
  existing Codex pattern (detection → sparse-checkout → copy → summary).      
  • **Docs** — installation guide, new Kiro guide, AGENTS.md, and env-var     
  reference.                                                                  
                                                                              
  ## Test plan                                                                
                                                                              
  • bun test scripts/install.test.ts — **61/61** (includes Kiro auto-detect,  
  the skill+agent copy, and negative assertions that no --kiro flag / separate
  installer exists)                                                           
  • bun test packages/shared/ — **359/359**                                   
  • bun run typecheck — **clean**                                             
  • Manually installed from the working tree into a real ~/.kiro and launched 
  kiro-cli chat --agent plannotator; skills open the Plannotator UI with the  
  Kiro CLI origin badge.                                                      
                                                                              
  ## ⚠️ Reviewer note                                                         
                                                                              
  The **Windows installers (**install.ps1** / **install.cmd**) were statically
  verified only** — PowerShell brace balance + cmd paren-nesting checked, but 
  not runtime-tested on Windows (no Windows host available, and install.test. 
  ts                                                                          
  only exercises install.sh). A Windows smoke-test before merge would be      
  welcome.                                                                    
                                                                              
  🤖 Generated with Claude Code https://claude.com/claude-code                

