### PR TITLE
fix(ui): align list markers to first line in clean diff view

### DIFF
--- a/packages/ui/components/BlockRenderer.tsx
+++ b/packages/ui/components/BlockRenderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Block } from "../types";
 import { InlineMarkdown } from "./InlineMarkdown";
-import { ListMarker } from "./ListMarker";
+import { ListItemBody } from "./ListItemBody";
 import { CodeBlock } from "./blocks/CodeBlock";
 import { HtmlBlock } from "./blocks/HtmlBlock";
 import { Callout } from "./blocks/Callout";
@@ -82,7 +82,6 @@ export const BlockRenderer: React.FC<{
         : block.checked;
       const isInteractive = isCheckbox && !!onToggleCheckbox;
       const textClass = `text-sm leading-relaxed ${isCheckbox && isChecked ? 'text-muted-foreground line-through' : 'text-foreground/90'}`;
-      const paragraphs = block.content.split(/\n\n+/);
       const inlineProps = { imageBaseDir, onImageClick, onOpenLinkedDoc, onOpenCodeFile, githubRepo, onNavigateAnchor };
       return (
         <div
@@ -90,27 +89,17 @@ export const BlockRenderer: React.FC<{
           data-block-id={block.id}
           style={{ marginLeft: `${indent}rem` }}
         >
-          <ListMarker
+          <ListItemBody
             level={block.level || 0}
             ordered={block.ordered}
             orderedIndex={orderedIndex}
             checked={isChecked}
             interactive={isInteractive}
             onToggle={isInteractive ? () => onToggleCheckbox!(block.id, !isChecked) : undefined}
+            textClassName={textClass}
+            content={block.content}
+            renderInline={(text) => <InlineMarkdown {...inlineProps} text={text} />}
           />
-          {paragraphs.length === 1 ? (
-            <span className={textClass}>
-              <InlineMarkdown {...inlineProps} text={block.content} />
-            </span>
-          ) : (
-            <div className={textClass}>
-              {paragraphs.map((para, i) => (
-                <p key={i} className={i > 0 ? 'mt-3' : ''}>
-                  <InlineMarkdown {...inlineProps} text={para} />
-                </p>
-              ))}
-            </div>
-          )}
         </div>
       );
     }

--- a/packages/ui/components/ListItemBody.tsx
+++ b/packages/ui/components/ListItemBody.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { ListMarker } from './ListMarker';
+
+/**
+ * Shared list-item body: the marker plus the item's text content. Used by the
+ * main Viewer (BlockRenderer) and the plan-diff clean view (both the inline
+ * modified-block render and SimpleBlockRenderer).
+ *
+ * Callers own the surrounding row element so each surface keeps its own
+ * concerns (indent, data attributes, hover-prop spread, diff wrapper classes).
+ * This component owns the parts that must stay identical: marker selection and
+ * the single-paragraph `<span>` vs multi-paragraph `<div><p>...</p></div>`
+ * split, so a fix to either never has to be repeated per surface.
+ */
+interface ListItemBodyProps {
+  level: number;
+  ordered?: boolean;
+  orderedIndex?: number | null;
+  checked?: boolean; // undefined = not a checkbox
+  interactive?: boolean;
+  onToggle?: () => void;
+  textClassName: string;
+  content: string;
+  renderInline: (text: string) => React.ReactNode;
+}
+
+export const ListItemBody: React.FC<ListItemBodyProps> = ({
+  level,
+  ordered,
+  orderedIndex,
+  checked,
+  interactive,
+  onToggle,
+  textClassName,
+  content,
+  renderInline,
+}) => {
+  const paragraphs = content.split(/\n\n+/);
+  return (
+    <>
+      <ListMarker
+        level={level}
+        ordered={ordered}
+        orderedIndex={orderedIndex}
+        checked={checked}
+        interactive={interactive}
+        onToggle={onToggle}
+      />
+      {paragraphs.length === 1 ? (
+        <span className={textClassName}>{renderInline(content)}</span>
+      ) : (
+        <div className={textClassName}>
+          {paragraphs.map((para, i) => (
+            <p key={i} className={i > 0 ? 'mt-3' : ''}>
+              {renderInline(para)}
+            </p>
+          ))}
+        </div>
+      )}
+    </>
+  );
+};

--- a/packages/ui/components/ListMarker.tsx
+++ b/packages/ui/components/ListMarker.tsx
@@ -45,7 +45,7 @@ export const ListMarker: React.FC<ListMarkerProps> = ({
 
   return (
     <span
-      className={`select-none shrink-0 flex items-center gap-1${interactive ? ' cursor-pointer' : ''}`}
+      className={`select-none shrink-0 self-start flex items-center gap-1${interactive ? ' cursor-pointer' : ''}`}
       onClick={handleClick}
       role={interactive ? 'checkbox' : undefined}
       aria-checked={interactive ? checked : undefined}

--- a/packages/ui/components/plan-diff/PlanCleanDiffView.tsx
+++ b/packages/ui/components/plan-diff/PlanCleanDiffView.tsx
@@ -462,7 +462,7 @@ const headingStyleFor = (level: number): string =>
   HEADING_STYLE_BY_LEVEL[level] || HEADING_STYLE_FALLBACK;
 
 const PARAGRAPH_CLASS = "mb-4 leading-relaxed text-foreground/90 text-[15px]";
-const LIST_ITEM_ROW_CLASS = "flex gap-3 my-1.5";
+const LIST_ITEM_ROW_CLASS = "flex items-start gap-3 my-1.5";
 const listItemIndentRem = (level: number): string => `${level * 1.25}rem`;
 const listItemTextClass = (isCheckbox: boolean, checked?: boolean): string =>
   `text-sm leading-relaxed ${isCheckbox && checked ? "text-muted-foreground line-through" : "text-foreground/90"}`;

--- a/packages/ui/components/plan-diff/PlanCleanDiffView.tsx
+++ b/packages/ui/components/plan-diff/PlanCleanDiffView.tsx
@@ -9,7 +9,7 @@
 import React, { useEffect, useRef, useState, useCallback } from "react";
 import hljs from "highlight.js";
 import { parseMarkdownToBlocks, computeListIndices } from "../../utils/parser";
-import { ListMarker } from "../ListMarker";
+import { ListItemBody } from "../ListItemBody";
 import type { Block, Annotation, EditorMode, ImageAttachment } from "../../types";
 import { AnnotationType } from "../../types";
 import type {
@@ -528,7 +528,6 @@ const InlineModifiedBlock: React.FC<InlineModifiedBlockProps> = ({
   if (wrap.type === "list-item") {
     const listLevel = wrap.listLevel || 0;
     const isCheckbox = wrap.checked !== undefined;
-    const paragraphs = unified.split(/\n\n+/);
     return (
       <div
         data-diff-block-index={index}
@@ -536,25 +535,15 @@ const InlineModifiedBlock: React.FC<InlineModifiedBlockProps> = ({
         style={{ marginLeft: listItemIndentRem(listLevel), ...hoverStyle }}
         {...hoverRest}
       >
-        <ListMarker
+        <ListItemBody
           level={listLevel}
           ordered={wrap.ordered}
           orderedIndex={wrap.orderedStart ?? 1}
           checked={wrap.checked}
+          textClassName={listItemTextClass(isCheckbox, wrap.checked)}
+          content={unified}
+          renderInline={(text) => <InlineMarkdown text={text} />}
         />
-        {paragraphs.length === 1 ? (
-          <span className={listItemTextClass(isCheckbox, wrap.checked)}>
-            <InlineMarkdown text={unified} />
-          </span>
-        ) : (
-          <div className={listItemTextClass(isCheckbox, wrap.checked)}>
-            {paragraphs.map((para, i) => (
-              <p key={i} className={i > 0 ? "mt-3" : ""}>
-                <InlineMarkdown text={para} />
-              </p>
-            ))}
-          </div>
-        )}
       </div>
     );
   }
@@ -631,31 +620,20 @@ const SimpleBlockRenderer: React.FC<{ block: Block; orderedIndex?: number | null
     case "list-item": {
       const listLevel = block.level || 0;
       const isCheckbox = block.checked !== undefined;
-      const paragraphs = block.content.split(/\n\n+/);
       return (
         <div
           className={LIST_ITEM_ROW_CLASS}
           style={{ marginLeft: listItemIndentRem(listLevel) }}
         >
-          <ListMarker
+          <ListItemBody
             level={listLevel}
             ordered={block.ordered}
             orderedIndex={orderedIndex}
             checked={block.checked}
+            textClassName={listItemTextClass(isCheckbox, block.checked)}
+            content={block.content}
+            renderInline={(text) => <InlineMarkdown text={text} />}
           />
-          {paragraphs.length === 1 ? (
-            <span className={listItemTextClass(isCheckbox, block.checked)}>
-              <InlineMarkdown text={block.content} />
-            </span>
-          ) : (
-            <div className={listItemTextClass(isCheckbox, block.checked)}>
-              {paragraphs.map((para, i) => (
-                <p key={i} className={i > 0 ? "mt-3" : ""}>
-                  <InlineMarkdown text={para} />
-                </p>
-              ))}
-            </div>
-          )}
         </div>
       );
     }


### PR DESCRIPTION
List markers (bullets and ordered numbers) render vertically centered against the full wrapped height of a list item in the plan-diff clean "Show Changes" view, instead of sitting on the first line. It only shows up on items long enough to soft-wrap, and it makes it hard to tell where each item begins.

The marker component (`ListMarker`) wraps its glyph in an inner `flex items-center`, which only renders correctly when the parent row pins its children to the top. The main viewer's row does that with `items-start`; the clean diff view's row class did not, so the marker stretched to the item's full height and `items-center` then centered the glyph.

The fix makes correctness intrinsic to the shared component: `ListMarker` now carries `self-start`, so it can't stretch regardless of the parent row's `align-items`. No call site has to remember the contract, and a future fourth consumer can't reintroduce the bug. The diff row also gets `items-start` for parity with the main viewer.

A second commit extracts the duplicated marker-plus-paragraph scaffold (which is why this fix would otherwise need to be applied in three places) into a `ListItemBody` component. Each call site keeps its own row wrapper (indent, data attributes, hover props, interactivity). It's a structural-only change with no behavior difference, so feel free to drop that commit if you'd rather not take the refactor; the fix stands on its own underneath it.