### PR TITLE
Fix Pi approval continuation follow-up display

### DIFF
--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -1165,9 +1165,16 @@ Execute each step in order. After completing a step, include [DONE:n] in your re
 	pi.on("agent_end", async (_event, ctx) => {
 		if (phase === "executing" && justApprovedPlan) {
 			justApprovedPlan = false;
-			pi.sendUserMessage("Continue with the approved plan.", {
-				deliverAs: "followUp",
-			});
+			let attempts = 0;
+			const continueWhenIdle = (): void => {
+				if (!ctx.isIdle()) {
+					attempts += 1;
+					if (attempts <= 200) setTimeout(continueWhenIdle, 50);
+					return;
+				}
+				pi.sendUserMessage("Continue with the approved plan.");
+			};
+			setTimeout(continueWhenIdle, 0);
 			return;
 		}
 


### PR DESCRIPTION
## Summary

Follow-up to #805.

- Keep the Pi approved-plan continuation, but stop sending it as an immediate `followUp` from `agent_end`.
- Wait until Pi reports the session is idle, then send the continuation as a normal extension user message.
- Cap the wait at 10 seconds so the extension cannot poll forever.

## Background

#804 fixed an approval-path crash in the Pi extension. Approved plans return `terminate: true`, then Plannotator sends a small continuation message so Pi starts executing the approved plan:

```ts
pi.sendUserMessage("Continue with the approved plan.");
```

That direct call was unsafe from inside the `agent_end` handler because Pi can still consider the agent run active while `agent_end` extension listeners are settling. #805 fixed the crash by sending the continuation as:

```ts
pi.sendUserMessage("Continue with the approved plan.", { deliverAs: "followUp" });
```

That keeps execution working, but it has a UI side effect in current Pi TUI: the continuation is rendered as a queued pending message even though the approved plan is already starting:

```text
Follow-up: Continue with the approved plan.
↳ Alt+Up to edit all queued messages
```

This is confusing because users see a pending follow-up while the agent is already working.

## Why this approach

I checked the current Pi source instead of relying on observed behavior:

- `agent_end` is emitted before the run is fully idle; `isStreaming` remains true until awaited `agent_end` listeners settle.
- `sendUserMessage()` without `deliverAs` throws while streaming.
- `deliverAs: "followUp"` pushes the text into Pi's follow-up queue, and the interactive UI renders queued follow-ups with the `Follow-up:` prefix.

So the extension needs to avoid both extremes:

1. Sending immediately without `deliverAs` can recreate #804.
2. Sending immediately with `deliverAs: "followUp"` creates the visible queued-message row.

The smallest plugin-side solution is to defer the continuation until Pi reports idle, then send a normal user message. That starts the implementation turn without using the visible follow-up queue.

The polling is bounded at 200 attempts × 50ms = 10 seconds. If Pi never becomes idle, Plannotator stops waiting instead of looping forever or creating a stale follow-up queue entry.

## Testing

- `git diff --check`
- Manual local Pi extension test:
  - Approve plan in browser.
  - Agent continues with `Continue with the approved plan.` as a normal message.
  - No persistent `Follow-up: Continue with the approved plan.` pending row remains.
- Not run: `bun run typecheck` (Bun is not installed in this environment: `bun: command not found`).
