### PR TITLE
fix(server): launch Glimpse via node on Windows instead of unspawnable npm shim

### DIFF
--- a/packages/server/browser.ts
+++ b/packages/server/browser.ts
@@ -139,6 +139,26 @@ async function openGlimpse(url: string): Promise<boolean> {
   ];
   const html = buildGlimpseHtml(url);
 
+  // On Windows, `glimpseui` resolves to an npm script shim, not an exe, which
+  // spawn() can't launch without a shell. `shell: true` would break the stdin
+  // HTML pipe below, so run the package entry with node directly instead.
+  let command = glimpseCli;
+  let spawnArgs = args;
+  if (process.platform === "win32" && !/\.exe$/i.test(glimpseCli)) {
+    const node = Bun.which("node");
+    const entry = path.join(
+      path.dirname(glimpseCli),
+      "node_modules",
+      "glimpseui",
+      "bin",
+      "glimpse.mjs"
+    );
+    if (node && fs.existsSync(entry)) {
+      command = node;
+      spawnArgs = [entry, ...args];
+    }
+  }
+
   return await new Promise<boolean>((resolve) => {
     let settled = false;
     let successTimer: ReturnType<typeof setTimeout> | undefined;
@@ -149,7 +169,7 @@ async function openGlimpse(url: string): Promise<boolean> {
       resolve(opened);
     };
 
-    const child = spawn(glimpseCli, args, {
+    const child = spawn(command, spawnArgs, {
       detached: true,
       stdio: ["pipe", "ignore", "ignore"],
     });


### PR DESCRIPTION
## Problem
On Windows, Glimpse never launches — plannotator always falls back to a browser tab even when `glimpseui` is on PATH and `PLANNOTATOR_BROWSER` is unset.

`openGlimpse()` does `spawn(Bun.which("glimpseui"), args, { detached: true })`. On Windows npm installs `glimpseui` only as **script shims** (`glimpseui.cmd`, the extensionless shebang launcher) — there is no native `glimpseui.exe`. `spawn()` without a shell can't launch these, so `openGlimpse()` always resolves `false` → browser fallback.

Replicating the exact spawn:

| spawn target | result |
|---|---|
| `glimpseui` / sh shim, no shell | `error: ENOENT` |
| `glimpseui.cmd`, no shell | throws `EINVAL` (Node/Bun refuse `.cmd` without `shell: true`) |
| `glimpseui` with `shell: true` | child exits code 1 |
| `node …/glimpseui/bin/glimpse.mjs <flags>` + HTML on stdin | **window opens, stays alive ✅** |

## Why not `shell: true`?
`openGlimpse()` pipes the HTML to the child via `child.stdin.end(html)`. Routing through `cmd.exe` → `.cmd` shim severs that stdin pipe, so `glimpse.mjs` receives no HTML and exits 1 (the code-1 row above). It also reintroduces arg-quoting/injection concerns (`DEP0190`). Running the entry point with `node` directly keeps the pipe intact and avoids the shell layer entirely.

## Fix
On `win32`, when the resolved `glimpseui` is not an `.exe`, resolve the package entry (`<dir>/node_modules/glimpseui/bin/glimpse.mjs`, exactly what npm's generated `.cmd` invokes) and spawn it with `node`. Non-Windows and a future real `.exe` are unaffected.

```ts
let command = glimpseCli;
let spawnArgs = args;
if (process.platform === "win32" && !/\.exe$/i.test(glimpseCli)) {
  const node = Bun.which("node");
  const entry = path.join(path.dirname(glimpseCli), "node_modules", "glimpseui", "bin", "glimpse.mjs");
  if (node && fs.existsSync(entry)) { command = node; spawnArgs = [entry, ...args]; }
}
```

Environment where reproduced: plannotator `0.19.27`, `glimpseui` `0.8.1`, WebView2 Runtime installed, Windows 11. Closes #860.
