### PR TITLE
fix(image): prevent path traversal in /api/image endpoint

### DIFF
--- a/apps/pi-extension/server/handlers.ts
+++ b/apps/pi-extension/server/handlers.ts
@@ -7,7 +7,7 @@ import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import type { IncomingMessage } from "node:http";
 import { tmpdir } from "node:os";
-import { join, resolve as resolvePath } from "node:path";
+import { join, normalize, resolve as resolvePath } from "node:path";
 import { saveDraft, loadDraft, deleteDraft } from "../generated/draft.js";
 import { FAVICON_SVG } from "../generated/favicon.js";
 
@@ -51,6 +51,23 @@ function getExtension(filePath: string): string {
 	return filePath.slice(lastDot + 1).toLowerCase();
 }
 
+/**
+ * Check whether resolved path is within an allowed root directory
+ * (project root or the uploads temp directory).
+ */
+function isWithinAllowedRoot(resolved: string): boolean {
+	const normalizedResolved = normalize(resolved);
+	const projectRoot = normalize(process.cwd());
+	const uploadDir = normalize(UPLOAD_DIR);
+
+	return (
+		normalizedResolved === projectRoot ||
+		normalizedResolved.startsWith(projectRoot + "/") ||
+		normalizedResolved === uploadDir ||
+		normalizedResolved.startsWith(uploadDir + "/")
+	);
+}
+
 function validateImagePath(rawPath: string): {
 	valid: boolean;
 	resolved: string;
@@ -64,6 +81,14 @@ function validateImagePath(rawPath: string): {
 			valid: false,
 			resolved,
 			error: "Path does not point to a supported image file",
+		};
+	}
+
+	if (!isWithinAllowedRoot(resolved)) {
+		return {
+			valid: false,
+			resolved,
+			error: "Access denied: path is outside project root",
 		};
 	}
 

--- a/packages/server/image.test.ts
+++ b/packages/server/image.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, expect, test } from "bun:test";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { validateImagePath, validateUploadExtension, UPLOAD_DIR } from "./image";
 
 describe("UPLOAD_DIR", () => {
@@ -20,26 +21,49 @@ describe("UPLOAD_DIR", () => {
 });
 
 describe("validateImagePath", () => {
-  test("accepts supported extensions", () => {
+  test("accepts supported extensions within project root", () => {
     for (const ext of ["png", "jpg", "jpeg", "gif", "webp", "svg", "avif"]) {
-      const result = validateImagePath(`/tmp/image.${ext}`);
+      const result = validateImagePath(`image.${ext}`);
       expect(result.valid).toBe(true);
     }
   });
 
+  test("accepts images within UPLOAD_DIR", () => {
+    const result = validateImagePath(join(UPLOAD_DIR, "test.png"));
+    expect(result.valid).toBe(true);
+  });
+
   test("rejects unsupported extensions", () => {
-    expect(validateImagePath("/tmp/file.txt").valid).toBe(false);
-    expect(validateImagePath("/tmp/script.js").valid).toBe(false);
-    expect(validateImagePath("/tmp/page.html").valid).toBe(false);
+    expect(validateImagePath("file.txt").valid).toBe(false);
+    expect(validateImagePath("script.js").valid).toBe(false);
+    expect(validateImagePath("page.html").valid).toBe(false);
   });
 
   test("rejects files with no extension", () => {
-    expect(validateImagePath("/tmp/noextension").valid).toBe(false);
+    expect(validateImagePath("noextension").valid).toBe(false);
   });
 
   test("resolves path", () => {
     const result = validateImagePath("relative/image.png");
     expect(result.resolved).toMatch(/^\//); // absolute on POSIX
+  });
+
+  test("rejects path traversal outside project root", () => {
+    const result = validateImagePath("/etc/passwd.png");
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("outside project root");
+  });
+
+  test("rejects ../ traversal escaping project root", () => {
+    const result = validateImagePath("../../../etc/secret.png");
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("outside project root");
+  });
+
+  test("rejects absolute path outside project root", () => {
+    const result = validateImagePath("/tmp/outside/image.png");
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("outside project root");
   });
 });
 

--- a/packages/server/image.ts
+++ b/packages/server/image.ts
@@ -1,4 +1,4 @@
-import { resolve, join } from "path";
+import { resolve, join, normalize } from "path";
 import { tmpdir } from "os";
 
 const ALLOWED_IMAGE_EXTENSIONS = new Set([
@@ -27,6 +27,23 @@ function hasImageExtension(filePath: string): boolean {
   return ALLOWED_IMAGE_EXTENSIONS.has(getExtension(filePath));
 }
 
+/**
+ * Check whether resolved path is within an allowed root directory
+ * (project root or the uploads temp directory).
+ */
+function isWithinAllowedRoot(resolved: string): boolean {
+  const normalizedResolved = normalize(resolved);
+  const projectRoot = normalize(process.cwd());
+  const uploadDir = normalize(UPLOAD_DIR);
+
+  return (
+    normalizedResolved === projectRoot ||
+    normalizedResolved.startsWith(projectRoot + "/") ||
+    normalizedResolved === uploadDir ||
+    normalizedResolved.startsWith(uploadDir + "/")
+  );
+}
+
 export function validateImagePath(rawPath: string): {
   valid: boolean;
   resolved: string;
@@ -39,6 +56,14 @@ export function validateImagePath(rawPath: string): {
       valid: false,
       resolved,
       error: "Path does not point to a supported image file",
+    };
+  }
+
+  if (!isWithinAllowedRoot(resolved)) {
+    return {
+      valid: false,
+      resolved,
+      error: "Access denied: path is outside project root",
     };
   }
 


### PR DESCRIPTION
## Vulnerability Summary

The `/api/image` endpoint in both `packages/server/image.ts` and `apps/pi-extension/server/handlers.ts` is vulnerable to path traversal (CWE-22). The `path` query parameter is user-controlled and is resolved to an absolute filesystem path using `resolve()`, but the only validation performed is an image-extension check. An attacker can supply a traversal payload (e.g., `../../../etc/hostname.svg` or an absolute path like `/home/user/.ssh/id_rsa.png`) to read any file on the filesystem, as long as it has a recognized image extension.

**Affected files:**
- `packages/server/image.ts` — `validateImagePath()` (used by `shared-handlers.ts` which serves all plan/review/annotate servers)
- `apps/pi-extension/server/handlers.ts` — duplicate `validateImagePath()` for the PI extension servers

**Data flow:**
1. User sends `GET /api/image?path=../../../etc/hostname.svg`
2. `url.searchParams.get("path")` extracts the raw path — no sanitization
3. `validateImagePath()` calls `resolve(rawPath)` → produces an absolute path
4. Extension check passes (`.svg` is allowed)
5. `Bun.file(resolved)` / `readFileSync(resolved)` reads and returns the file contents

The `base` query parameter follows the same vulnerable flow — `resolvePath(base, imagePath)` can also escape the project directory.

## Risk Assessment

**Severity: Medium**

The vulnerability is constrained to files with image extensions (.png, .jpg, .svg, .gif, etc.), which limits the blast radius. However:

- `.svg` files are plain-text XML and can contain arbitrary content. If an SVG file exists outside the project root (config templates, exported data, etc.), its contents are fully readable.
- In **remote sessions** (SSH, `PLANNOTATOR_REMOTE=1`), the server binds to `0.0.0.0` — making the unauthenticated `/api/image` endpoint network-accessible.
- **Shared plans** can embed malicious image references. When a victim opens a shared plan, the markdown renderer generates `/api/image?path=../../other-project/secret.svg` requests, reading files from the victim's filesystem.
- There is **no authentication** on any endpoint (confirmed by the codebase's own agent instruction docs: "No authentication").

## Proof of Concept

Start any Plannotator server (plan, review, or annotate). Then:

```bash
# Read a file outside the project root — any file with an image extension.
# For example, if /etc/hostname.svg existed:
curl "http://localhost:<PORT>/api/image?path=../../../etc/hostname.svg"

# Using an absolute path:
curl "http://localhost:<PORT>/api/image?path=/tmp/outside-project/data.png"

# Using the 'base' parameter to escape:
curl "http://localhost:<PORT>/api/image?path=secret.png&base=/etc"
```

In each case, the server returns the file contents with a 200 response. Without this fix, `validateImagePath()` only checks the extension — any path that resolves to an image-extension file is served regardless of location.

You can verify the vulnerability by placing a test file outside the project directory:

```bash
echo "LEAKED" > /tmp/test-traversal.svg
curl "http://localhost:<PORT>/api/image?path=/tmp/test-traversal.svg"
# Returns: LEAKED
```

After applying this fix, the same requests return `403 Access denied: path is outside project root`.

## Fix Description

This PR adds an `isWithinAllowedRoot()` containment check to `validateImagePath()` in both server implementations. The function:

1. Resolves and normalizes the requested path
2. Normalizes the project root (`process.cwd()`) and the upload temp directory (`UPLOAD_DIR`)
3. Verifies the resolved path starts with one of these two allowed roots (using exact prefix matching with trailing `/` to prevent prefix-bypass attacks like `/project-root-evil/...`)

The check is added to `validateImagePath()` itself, so it protects both the primary `path` parameter and the fallback `base` parameter resolution — every code path that serves images goes through this function.

**Files changed:**
- `packages/server/image.ts` — added `isWithinAllowedRoot()` and integrated it into `validateImagePath()`
- `apps/pi-extension/server/handlers.ts` — same change for the PI extension's copy of the validation logic
- `packages/server/image.test.ts` — added test cases for traversal rejection (absolute paths, `../` sequences, paths outside project root) and updated existing tests to use project-relative paths

## Test Results

The existing test suite was extended with three new path-traversal test cases. All tests pass:

- ✅ `accepts supported extensions within project root` — image files inside the project are still served
- ✅ `accepts images within UPLOAD_DIR` — uploaded temp files are still accessible
- ✅ `rejects unsupported extensions` — non-image files still rejected
- ✅ `rejects files with no extension` — extensionless files still rejected
- ✅ `resolves path` — relative paths resolve to absolute (existing behavior preserved)
- ✅ **`rejects path traversal outside project root`** — `/etc/passwd.png` → 403
- ✅ **`rejects ../ traversal escaping project root`** — `../../../etc/secret.png` → 403
- ✅ **`rejects absolute path outside project root`** — `/tmp/outside/image.png` → 403

## Adversarial Review

Before submitting, we attempted to disprove this finding. We checked whether any framework-level middleware, authentication gate, or path sanitization existed upstream of `validateImagePath()`. There is none — the codebase's own documentation confirms "No authentication" on all endpoints. We also considered whether the image-extension restriction alone was sufficient mitigation; it is not, because `.svg` files are plain-text XML and can contain sensitive data. The `base` parameter could also be used to pivot the resolve root, but the fix covers that path too since `validateImagePath()` is called on the resolved result.