### PR TITLE
fix(markdown): keep custom angle autolinks literal

### DIFF
--- a/packages/ui/components/InlineMarkdown.test.ts
+++ b/packages/ui/components/InlineMarkdown.test.ts
@@ -1,5 +1,11 @@
 import { describe, test, expect } from 'bun:test';
-import { trimUrlTail } from './InlineMarkdown';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { InlineMarkdown, trimUrlTail } from './InlineMarkdown';
+
+function renderInline(text: string): string {
+  return renderToStaticMarkup(React.createElement(InlineMarkdown, { text }));
+}
 
 describe('trimUrlTail', () => {
   test('trims trailing period', () => {
@@ -36,5 +42,41 @@ describe('trimUrlTail', () => {
 
   test('leaves URL alone when no trailing punctuation', () => {
     expect(trimUrlTail('https://foo.com/path')).toBe('https://foo.com/path');
+  });
+});
+
+describe('InlineMarkdown angle autolinks', () => {
+  test('keeps xref contents literal', () => {
+    const html = renderInline('For more information, see the <xref:path_to_api`22?hello> class.');
+
+    expect(html).toContain('<span>&lt;xref:path_to_api`22?hello&gt;</span>');
+    expect(html).not.toContain('<code');
+    expect(html).not.toContain('<em');
+  });
+
+  test('keeps URL and email autolinks clickable', () => {
+    const html = renderInline('Visit <https://www.example.com> or <user@example.com>.');
+
+    expect(html).toContain('href="https://www.example.com"');
+    expect(html).toContain('href="mailto:user@example.com"');
+  });
+
+  test('keeps comparison text as plain prose', () => {
+    const html = renderInline('Math: x < y > z.');
+
+    expect(html).toBe('Math: x &lt; y &gt; z.');
+  });
+
+  test('keeps other scheme autolinks literal', () => {
+    const html = renderInline('Open <file://path/to/file> or <custom:value_with-dash.ext>.');
+
+    expect(html).toContain('<span>&lt;file://path/to/file&gt;</span>');
+    expect(html).toContain('<span>&lt;custom:value_with-dash.ext&gt;</span>');
+  });
+
+  test('does not consume incomplete angle autolinks', () => {
+    const html = renderInline('Broken <xref:path_to_api`22?hello is plain.');
+
+    expect(html).toBe('Broken &lt;xref:path_to_api`22?hello is plain.');
   });
 });

--- a/packages/ui/components/InlineMarkdown.tsx
+++ b/packages/ui/components/InlineMarkdown.tsx
@@ -486,6 +486,17 @@ export const InlineMarkdown: React.FC<{
       continue;
     }
 
+    // Keep custom autolinks literal; their contents should not
+    // recurse into markdown parsing.
+    match = remaining.match(/^<([A-Za-z][A-Za-z0-9.+-]{0,31}:[^\s<>]*)>/);
+    if (match) {
+      const content = match[1];
+      parts.push(<span key={key++}>{`<${content}>`}</span>);
+      remaining = remaining.slice(match[0].length);
+      previousChar = ">";
+      continue;
+    }
+
     // Strikethrough: ~~text~~
     match = remaining.match(/^~~([\s\S]+?)~~/);
     if (match) {


### PR DESCRIPTION
Closes #836

Custom-scheme autolinks such as `` <xref:path_to_api`22?hello> `` were falling through to plain-text processing, where their contents got re-parsed as inline markdown (backticks, asterisks, etc.) — producing broken styling.

## Fix

Add an autolink branch in `InlineMarkdown` that matches angle-bracket links carrying an explicit URI scheme and renders their contents **literally**, without recursing into the markdown parser. It sits *after* the existing `<https://…>` and `<email>` branches, so those stay clickable; only the remaining scheme autolinks are emitted as literal text.

The pattern is intentionally scoped to CommonMark autolink syntax — a scheme prefix followed by non-whitespace content:

```
/^<([A-Za-z][A-Za-z0-9.+-]{0,31}:[^\s<>]*)>/
```

Requiring a `scheme:` prefix (and forbidding internal whitespace) is what keeps ordinary prose untouched — the important difference from a naive `<...>` catch-all:

- `Math: x < y > z` → left as plain text
- `List<String>`, `Map<K, V>` → left as plain text
- `<xref:…>`, `<file://…>`, `<custom:…>` → rendered as literal text (no inner markdown parsing)

## Changes

- **`packages/ui/components/InlineMarkdown.tsx`** — new scheme-autolink branch; contents rendered in a plain `<span>` so they inherit the surrounding text style and never recurse into the inline parser.
- **`packages/ui/components/InlineMarkdown.test.ts`** — render-based tests (`renderToStaticMarkup`) asserting: `xref` contents stay literal (no `<code>` / `<em>` emitted), `<https://…>` / `<…@…>` remain clickable, comparison prose stays plain, other schemes render literally, and an unclosed `<…` is not consumed.
