### PR TITLE
fix(annotate): improve error message for unsupported file types

### DIFF
--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -902,7 +902,20 @@ if (args[0] === "sessions") {
           process.exit(1);
         }
         if (resolved.kind === "not_found") {
-          console.error(`File not found: ${resolved.input}`);
+          // Check if file exists but has unsupported type
+          const resolvedPath = resolveUserPath(resolved.input, projectRoot);
+          const fileExists = existsSync(resolvedPath);
+
+          if (fileExists) {
+            const ext = path.extname(resolvedPath).toLowerCase();
+            console.error(
+              `File type not supported: ${ext}\n` +
+              `Only .md, .mdx, .html, .htm files are supported.\n` +
+              `For code review, use: plannotator review [file]`
+            );
+          } else {
+            console.error(`File not found: ${resolved.input}`);
+          }
           process.exit(1);
         }
 


### PR DESCRIPTION
- When a file exists but has an unsupported type (.cs, .ts, .py, etc.), show 'File type not supported' instead of misleading 'File not found'
- Display supported file types (.md, .mdx, .html, .htm)
- Suggest using 'plannotator review' for code files
- Maintains backward compatibility for actual missing files

Fixes #757