### PR TITLE
feat(ui): render markdown math

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -238,6 +238,7 @@
         "@viz-js/viz": "^3.25.0",
         "diff": "^8.0.3",
         "highlight.js": "^11.11.1",
+        "katex": "^0.16.28",
         "lucide-react": "^1.14.0",
         "marked": "^17.0.6",
         "mermaid": "^11.12.2",
@@ -1346,7 +1347,7 @@
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
-    "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+    "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "common-ancestor-path": ["common-ancestor-path@1.0.1", "", {}, "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w=="],
 
@@ -2780,6 +2781,8 @@
 
     "@vscode/vsce/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
+    "@vscode/vsce/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
     "@vscode/vsce/glob": ["glob@11.1.0", "", { "dependencies": { "foreground-child": "^3.3.1", "jackspeak": "^4.1.1", "minimatch": "^10.1.1", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw=="],
 
     "@vscode/vsce/hosted-git-info": ["hosted-git-info@4.1.0", "", { "dependencies": { "lru-cache": "^6.0.0" } }, "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA=="],
@@ -2847,8 +2850,6 @@
     "hast-util-raw/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
-
-    "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "magicast/@babel/parser": ["@babel/parser@7.29.0", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww=="],
 

--- a/packages/ui/components/BlockRenderer.tsx
+++ b/packages/ui/components/BlockRenderer.tsx
@@ -7,6 +7,7 @@ import { HtmlBlock } from "./blocks/HtmlBlock";
 import { Callout } from "./blocks/Callout";
 import { AlertBlock } from "./blocks/AlertBlock";
 import { TableBlock } from "./blocks/TableBlock";
+import { MathBlock } from "./blocks/MathBlock";
 
 export const BlockRenderer: React.FC<{
   block: Block;
@@ -119,6 +120,9 @@ export const BlockRenderer: React.FC<{
           onNavigateAnchor={onNavigateAnchor}
         />
       );
+
+    case 'math':
+      return <MathBlock block={block} />;
 
     case 'hr':
       return <hr className="border-border/30 my-8" data-block-id={block.id} />;

--- a/packages/ui/components/InlineMarkdown.test.ts
+++ b/packages/ui/components/InlineMarkdown.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect } from 'bun:test';
-import { trimUrlTail } from './InlineMarkdown';
+import { InlineMarkdown, trimUrlTail } from './InlineMarkdown';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 
 describe('trimUrlTail', () => {
   test('trims trailing period', () => {
@@ -36,5 +38,32 @@ describe('trimUrlTail', () => {
 
   test('leaves URL alone when no trailing punctuation', () => {
     expect(trimUrlTail('https://foo.com/path')).toBe('https://foo.com/path');
+  });
+});
+
+describe('InlineMarkdown math', () => {
+  test('renders inline math with KaTeX markup', () => {
+    const html = renderToStaticMarkup(createElement(InlineMarkdown, { text: 'Area is $A=\\pi r^2$.' }));
+    expect(html).toContain('katex');
+    expect(html).toContain('math-inline');
+    expect(html).toContain('mord mathnormal');
+  });
+
+  test('does not render escaped dollar-delimited text as math', () => {
+    const html = renderToStaticMarkup(createElement(InlineMarkdown, { text: 'Price is \\$5$ today' }));
+    expect(html).not.toContain('katex');
+    expect(html).toContain('$5$ today');
+  });
+
+  test('does not treat spaced dollar text as inline math', () => {
+    const html = renderToStaticMarkup(createElement(InlineMarkdown, { text: 'Keep $ not math $ here' }));
+    expect(html).not.toContain('katex');
+    expect(html).toContain('$ not math $ here');
+  });
+
+  test('leaves double-dollar text to the block parser', () => {
+    const html = renderToStaticMarkup(createElement(InlineMarkdown, { text: '$$x$$' }));
+    expect(html).not.toContain('katex');
+    expect(html).toContain('$$x$$');
   });
 });

--- a/packages/ui/components/InlineMarkdown.tsx
+++ b/packages/ui/components/InlineMarkdown.tsx
@@ -7,6 +7,7 @@ import { getImageSrc } from "./ImageThumbnail";
 import { useCodePathValidation, type CodePathValidationContextValue } from "./CodePathValidationContext";
 import type { ValidationEntry } from "../hooks/useValidatedCodePaths";
 import { CodeFilePicker } from "./CodeFilePicker";
+import { renderMathToHtml } from "./blocks/MathBlock";
 
 /**
  * Decide how a candidate code-file path should render based on validation state:
@@ -260,6 +261,17 @@ const CodeFileIcon = () => (
   </svg>
 );
 
+const InlineMath: React.FC<{ tex: string }> = ({ tex }) => {
+  const html = useMemo(() => renderMathToHtml(tex, false), [tex]);
+
+  return (
+    <span
+      className="math-inline text-foreground"
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+};
+
 // Trim trailing sentence punctuation from a bare URL, but keep closing
 // brackets when they balance an opener inside the URL (Wikipedia-style
 // https://…/Function_(mathematics) should keep its closing paren).
@@ -381,7 +393,7 @@ function emitPlainTextWithBareUrls(
  * Scanner that walks a text string and emits React nodes for inline markdown:
  * emphasis (**bold**, *italic*, _italic_, ***both***), `code`, ~~strikethrough~~,
  * [label](url) / ![alt](src) / <autolink>, bare https:// URLs, [[wiki-links]],
- * hex color swatches (#fff / #123abc), @mentions, #issue-refs, and backslash
+ * inline math ($...$), hex color swatches (#fff / #123abc), @mentions, #issue-refs, and backslash
  * escapes. Plain-text chunks outside these patterns pass through
  * `transformPlainText` for emoji shortcodes + smart punctuation.
  */
@@ -412,13 +424,37 @@ export const InlineMarkdown: React.FC<{
       continue;
     }
 
-    // Backslash escaping: \. \* \_ \` \[ \~ etc. — emit literal char, hide backslash
-    match = remaining.match(/^\\([\\*_`\[\]~!.()\-#>+|{}&])/);
+    // Backslash escaping: \. \* \_ \` \[ \~ \$ etc. — emit literal char, hide backslash
+    match = remaining.match(/^\\([\\*_`\[\]~!.()\-#>+|{}&$])/);
     if (match) {
       parts.push(match[1]);
       remaining = remaining.slice(2);
       previousChar = match[1];
       continue;
+    }
+
+    // Inline math: $...$ — require non-space content and avoid $$ display fences.
+    if (remaining.startsWith('$') && previousChar !== '$' && !remaining.startsWith('$$')) {
+      let end = -1;
+      for (let i = 1; i < remaining.length; i++) {
+        if (remaining[i] === '\\') {
+          i++;
+          continue;
+        }
+        if (remaining[i] === '$') {
+          end = i;
+          break;
+        }
+      }
+      if (end > 1) {
+        const tex = remaining.slice(1, end);
+        if (tex.trim() && !/^\s|\s$/.test(tex)) {
+          parts.push(<InlineMath key={key++} tex={tex} />);
+          remaining = remaining.slice(end + 1);
+          previousChar = '$';
+          continue;
+        }
+      }
     }
 
     // Bare URL autolink: https://… preceded by word boundary.
@@ -962,7 +998,7 @@ export const InlineMarkdown: React.FC<{
     // `h` mid-word (e.g. ":heart:", "hello"), and splitting on it breaks
     // multi-char patterns like emoji shortcodes. Bare URLs are instead
     // detected inline via emitPlainTextWithBareUrls() below.
-    const nextSpecial = remaining.slice(1).search(/[\*_`\[!~\\<#@]/);
+    const nextSpecial = remaining.slice(1).search(/[\*_`\[!~\\<#@$]/);
     const plainText = nextSpecial === -1 ? remaining : remaining.slice(0, nextSpecial + 1);
     emitPlainTextWithBareUrls(plainText, previousChar, parts, () => key++, onOpenCodeFile, validation, imageBaseDir);
     previousChar = plainText[plainText.length - 1] || previousChar;

--- a/packages/ui/components/blocks/MathBlock.tsx
+++ b/packages/ui/components/blocks/MathBlock.tsx
@@ -1,0 +1,30 @@
+import React, { useMemo } from 'react';
+import katex from 'katex';
+import type { Block } from '../../types';
+
+type MathBlockProps = {
+  block: Block;
+};
+
+export const renderMathToHtml = (tex: string, displayMode: boolean): string => (
+  katex.renderToString(tex, {
+    displayMode,
+    throwOnError: false,
+    strict: 'warn',
+    trust: false,
+    output: 'html',
+  })
+);
+
+export const MathBlock: React.FC<MathBlockProps> = ({ block }) => {
+  const html = useMemo(() => renderMathToHtml(block.content, true), [block.content]);
+
+  return (
+    <div
+      className="math-block my-5 overflow-x-auto py-2 text-foreground"
+      data-block-id={block.id}
+      data-block-type="math"
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+};

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -29,6 +29,7 @@
     "@viz-js/viz": "^3.25.0",
     "diff": "^8.0.3",
     "highlight.js": "^11.11.1",
+    "katex": "^0.16.28",
     "lucide-react": "^1.14.0",
     "marked": "^17.0.6",
     "mermaid": "^11.12.2",

--- a/packages/ui/theme.css
+++ b/packages/ui/theme.css
@@ -1,5 +1,7 @@
 /* Plannotator Theme System — imports all themes, provides Tailwind bridge + base styles */
 
+@import "katex/dist/katex.min.css";
+
 /* Theme files — each defines .theme-{name} (dark) and .theme-{name}.light */
 @import "./themes/plannotator.css";
 @import "./themes/claude-plus.css";
@@ -97,6 +99,27 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-feature-settings: "ss01", "ss02", "cv01";
+}
+
+.math-inline {
+  display: inline-block;
+  max-width: 100%;
+  vertical-align: -0.08em;
+}
+
+.math-block {
+  max-width: 100%;
+}
+
+.math-inline .katex,
+.math-block .katex {
+  color: inherit;
+  font-size: 1.02em;
+}
+
+.math-block .katex-display {
+  margin: 0;
+  text-align: center;
 }
 
 /* Subtle grid background */

--- a/packages/ui/types.ts
+++ b/packages/ui/types.ts
@@ -57,7 +57,7 @@ export type AlertKind = 'note' | 'tip' | 'warning' | 'caution' | 'important';
 
 export interface Block {
   id: string;
-  type: 'paragraph' | 'heading' | 'blockquote' | 'list-item' | 'code' | 'hr' | 'table' | 'html' | 'directive';
+  type: 'paragraph' | 'heading' | 'blockquote' | 'list-item' | 'code' | 'hr' | 'table' | 'html' | 'directive' | 'math';
   content: string; // Plain text, or raw (unsanitized) HTML for type === 'html'
   level?: number; // For headings (1-6) or list indentation
   language?: string; // For code blocks (e.g., 'rust', 'typescript')
@@ -68,6 +68,7 @@ export interface Block {
   directiveKind?: string; // For directive containers (e.g. ':::note' → 'note')
   order: number; // Sorting order
   startLine: number; // 1-based line number in source
+  sourceLineCount?: number; // Number of source lines consumed when it differs from content lines
 }
 
 export interface DiffResult {

--- a/packages/ui/utils/parser.test.ts
+++ b/packages/ui/utils/parser.test.ts
@@ -155,6 +155,47 @@ describe("parseMarkdownToBlocks — code fences", () => {
   });
 });
 
+describe("parseMarkdownToBlocks — display math", () => {
+  test("multi-line $$ block produces a math block", () => {
+    const md = "$$\n\\int_0^1 x^2 dx = \\frac{1}{3}\n$$";
+    const blocks = parseMarkdownToBlocks(md);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].type).toBe("math");
+    expect(blocks[0].content).toBe("\\int_0^1 x^2 dx = \\frac{1}{3}");
+    expect(blocks[0].startLine).toBe(1);
+    expect(blocks[0].sourceLineCount).toBe(3);
+  });
+
+  test("single-line $$ block produces a math block", () => {
+    const blocks = parseMarkdownToBlocks("before\n\n$$ E = mc^2 $$\n\nafter");
+    expect(blocks.map((b) => b.type)).toEqual(["paragraph", "math", "paragraph"]);
+    expect(blocks[1].content).toBe("E = mc^2");
+    expect(blocks[1].startLine).toBe(3);
+    expect(blocks[1].sourceLineCount).toBe(1);
+  });
+
+  test("display math does not swallow following paragraphs", () => {
+    const md = "$$\na^2 + b^2 = c^2\n$$\n\nText after.";
+    const blocks = parseMarkdownToBlocks(md);
+    expect(blocks.map((b) => b.type)).toEqual(["math", "paragraph"]);
+    expect(blocks[1].content).toBe("Text after.");
+  });
+
+  test("unclosed display math extends to EOF", () => {
+    const blocks = parseMarkdownToBlocks("$$\nx + y");
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].type).toBe("math");
+    expect(blocks[0].content).toBe("x + y");
+  });
+
+  test("empty single-line display math does not swallow following content", () => {
+    const blocks = parseMarkdownToBlocks("$$$$\n\nAfter");
+    expect(blocks.map((b) => b.type)).toEqual(["math", "paragraph"]);
+    expect(blocks[0].content).toBe("");
+    expect(blocks[1].content).toBe("After");
+  });
+});
+
 describe("parseMarkdownToBlocks — tables", () => {
   test("pipe-delimited table parses correctly", () => {
     const md = "| A | B |\n|---|---|\n| 1 | 2 |";
@@ -988,5 +1029,13 @@ describe("exportAnnotations — line labels", () => {
   test("no sourceConverted means no caveat", () => {
     const output = exportAnnotations(blocks, [{ blockId: blocks[0].id, type: "COMMENT", text: "ok", originalText: "Heading", startOffset: 0 }]);
     expect(output).not.toContain("converted markdown");
+  });
+
+  test("math block line labels cover source fences", () => {
+    const mathBlocks = parseMarkdownToBlocks("Intro\n\n$$\nx + y\n$$");
+    const math = mathBlocks.find(b => b.type === "math")!;
+    const anns = [{ blockId: math.id, type: "COMMENT", text: "clarify", originalText: "x + y", startOffset: 0 }];
+    const output = exportAnnotations(mathBlocks, anns);
+    expect(output).toContain("(lines 3–5)");
   });
 });

--- a/packages/ui/utils/parser.ts
+++ b/packages/ui/utils/parser.ts
@@ -285,6 +285,48 @@ export const parseMarkdownToBlocks = (markdown: string): Block[] => {
       continue;
     }
 
+    // Display math: $$ ... $$
+    if (trimmed.startsWith('$$')) {
+      flush();
+      const mathStartLine = currentLineNum;
+      const firstLineAfterOpening = trimmed.slice(2).trim();
+      const closesOnOpeningLine =
+        firstLineAfterOpening.endsWith('$$') &&
+        (firstLineAfterOpening.length > 2 || trimmed.length >= 4);
+      const mathLines: string[] = [];
+
+      if (closesOnOpeningLine && firstLineAfterOpening.length > 2) {
+        mathLines.push(firstLineAfterOpening.slice(0, -2).trim());
+      } else if (!closesOnOpeningLine && firstLineAfterOpening.length > 0) {
+        mathLines.push(firstLineAfterOpening);
+      }
+
+      if (!closesOnOpeningLine) {
+        while (i + 1 < lines.length) {
+          i++;
+          const nextTrimmed = lines[i].trim();
+          if (nextTrimmed.endsWith('$$')) {
+            const beforeClosing = lines[i].replace(/\s*\$\$\s*$/, '');
+            if (beforeClosing.trim().length > 0) {
+              mathLines.push(beforeClosing);
+            }
+            break;
+          }
+          mathLines.push(lines[i]);
+        }
+      }
+
+      blocks.push({
+        id: `block-${currentId++}`,
+        type: 'math',
+        content: mathLines.join('\n'),
+        order: currentId,
+        startLine: mathStartLine,
+        sourceLineCount: i + contentStartLine - mathStartLine + 1,
+      });
+      continue;
+    }
+
     // Tables (lines starting with |)
     if (trimmed.startsWith('|')) {
       flush();
@@ -466,6 +508,9 @@ export interface ExportAnnotationsOptions {
 
 /** Compute the end line of a block from its content and type. */
 const blockEndLine = (block: Block): number => {
+  if (block.sourceLineCount && block.sourceLineCount > 0) {
+    return block.startLine + block.sourceLineCount - 1;
+  }
   if (!block.content) return block.startLine;
   const contentLines = block.content.split('\n').length;
   if (block.type === 'code') return block.startLine + contentLines + 1;


### PR DESCRIPTION
Summary
- Add KaTeX rendering for inline `$...$` and display `$$...$$` math in plan/review markdown.
- Preserve escaped dollar text and keep math block annotations accurate.

Validation
- bun test
- PATH=/Users/xxq/Documents/codes/plannotator/packages/ui/node_modules/.bin:$PATH bun run typecheck
- git diff --check
- Browser verification of inline and display math rendering