### PR TITLE
fix(ui): keep annotation comment popover open while it has unsaved content

### DIFF
--- a/packages/ui/components/CommentPopover.tsx
+++ b/packages/ui/components/CommentPopover.tsx
@@ -5,6 +5,7 @@ import { AttachmentsButton } from './AttachmentsButton';
 import { submitHint } from '../utils/platform';
 import { useDraggable } from '../hooks/useDraggable';
 import { SparklesIcon } from './SparklesIcon';
+import { hasUnsavedContent } from '../utils/commentContent';
 
 export interface CommentAskAIContext {
   kind: 'general' | 'selection';
@@ -98,6 +99,8 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
   const [position, setPosition] = useState<{ top: number; left: number; flipAbove: boolean; width: number } | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
+  const hasContentRef = useRef(false);
+  hasContentRef.current = hasUnsavedContent(text, allowImages ? images : []);
   const { dragPosition, dragHandleProps, wasDragged, reset: resetDrag } = useDraggable(popoverRef);
 
   useEffect(() => {
@@ -157,6 +160,7 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
       // Don't close if clicking inside a child portal (AttachmentsButton, ImageAnnotator, etc.)
       const el = target as HTMLElement;
       if (el.closest?.('[data-popover-layer]')) return;
+      if (hasContentRef.current) return;
       onClose();
     };
 

--- a/packages/ui/components/Viewer.tsx
+++ b/packages/ui/components/Viewer.tsx
@@ -241,6 +241,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
     handleToolbarClose,
     handleRequestComment,
     handleCommentSubmit: hookCommentSubmit,
+    handleCommentDraftChange: hookCommentDraftChange,
     handleCommentClose: hookCommentClose,
     handleFloatingQuickLabel: hookFloatingQuickLabel,
     handleQuickLabelPickerDismiss: hookQuickLabelPickerDismiss,
@@ -840,6 +841,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
               isGlobal={false}
               initialText={hookCommentPopover.initialText}
               onSubmit={hookCommentSubmit}
+              onDraftChange={hookCommentDraftChange}
               onClose={hookCommentClose}
               onAskAI={onAskAI}
               askAIContext={{

--- a/packages/ui/components/html-viewer/HtmlViewer.tsx
+++ b/packages/ui/components/html-viewer/HtmlViewer.tsx
@@ -316,6 +316,7 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
               initialText={hook.commentPopover.initialText}
               isGlobal={false}
               onSubmit={hook.handleCommentSubmit}
+              onDraftChange={hook.handleCommentDraftChange}
               onClose={hook.handleCommentClose}
               onAskAI={onAskAI}
               askAIContext={{

--- a/packages/ui/components/html-viewer/useHtmlAnnotation.ts
+++ b/packages/ui/components/html-viewer/useHtmlAnnotation.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef, type RefObject } from "react"
 import { AnnotationType, type Annotation, type EditorMode, type ImageAttachment } from "../../types";
 import type { QuickLabel } from "../../utils/quickLabels";
 import { getIdentity } from "../../utils/identity";
+import { hasUnsavedContent } from "../../utils/commentContent";
 import type {
   ToolbarState,
   CommentPopoverState,
@@ -76,6 +77,7 @@ export function useHtmlAnnotation({
   commentPopoverRef.current = commentPopover;
   const quickLabelPickerRef = useRef(quickLabelPicker);
   quickLabelPickerRef.current = quickLabelPicker;
+  const commentDirtyRef = useRef(false);
 
   const onAddRef = useRef(onAddAnnotation);
   onAddRef.current = onAddAnnotation;
@@ -122,6 +124,7 @@ export function useHtmlAnnotation({
       const type = e.data.type;
 
       if (type === `${PREFIX}selection`) {
+        if (commentDirtyRef.current) return;
         const msg = e.data as BridgeSelectionMessage;
         pendingTextRef.current = msg.text;
         const anchor = positionAnchor(msg.rect);
@@ -298,13 +301,19 @@ export function useHtmlAnnotation({
         images,
       });
 
+      commentDirtyRef.current = false;
       setCommentPopover(null);
       pendingTextRef.current = "";
     },
     [iframeRef],
   );
 
+  const handleCommentDraftChange = useCallback((text: string, images?: ImageAttachment[]) => {
+    commentDirtyRef.current = hasUnsavedContent(text, images ?? []);
+  }, []);
+
   const handleCommentClose = useCallback(() => {
+    commentDirtyRef.current = false;
     setCommentPopover(null);
     pendingTextRef.current = "";
   }, []);
@@ -390,6 +399,7 @@ export function useHtmlAnnotation({
     handleToolbarClose,
     handleRequestComment,
     handleCommentSubmit,
+    handleCommentDraftChange,
     handleCommentClose,
     handleFloatingQuickLabel,
     handleQuickLabelPickerDismiss,

--- a/packages/ui/hooks/useAnnotationHighlighter.ts
+++ b/packages/ui/hooks/useAnnotationHighlighter.ts
@@ -12,6 +12,7 @@ import { AnnotationType } from '../types';
 import type { QuickLabel } from '../utils/quickLabels';
 import { getIdentity } from '../utils/identity';
 import { transformPlainText } from '../utils/inlineTransforms';
+import { hasUnsavedContent } from '../utils/commentContent';
 
 // --- Exported state types ---
 
@@ -59,6 +60,7 @@ export interface UseAnnotationHighlighterReturn {
   handleToolbarClose: () => void;
   handleRequestComment: (initialChar?: string) => void;
   handleCommentSubmit: (text: string, images?: ImageAttachment[]) => void;
+  handleCommentDraftChange: (text: string, images?: ImageAttachment[]) => void;
   handleCommentClose: () => void;
   handleFloatingQuickLabel: (label: QuickLabel) => void;
   handleQuickLabelPickerDismiss: () => void;
@@ -82,6 +84,7 @@ export function useAnnotationHighlighter({
   const onAddAnnotationRef = useRef(onAddAnnotation);
   const onSelectAnnotationRef = useRef(onSelectAnnotation);
   const pendingSourceRef = useRef<any>(null);
+  const commentDirtyRef = useRef(false);
   const justCreatedIdRef = useRef<string | null>(null);
   const lastMousePosRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
 
@@ -511,6 +514,7 @@ export function useAnnotationHighlighter({
             const sel = window.getSelection();
             if (!sel || sel.isCollapsed || sel.rangeCount === 0) return;
             if (!containerRef.current?.contains(sel.anchorNode)) return;
+            if (commentDirtyRef.current) return;
             highlighter.fromRange(sel.getRangeAt(0));
           }, 400);
         }
@@ -637,6 +641,13 @@ export function useAnnotationHighlighter({
     setToolbarState(null);
   };
 
+  const setCommentDirty = useCallback((dirty: boolean) => {
+    if (commentDirtyRef.current === dirty) return;
+    commentDirtyRef.current = dirty;
+    if (dirty) highlighterRef.current?.stop();
+    else highlighterRef.current?.run();
+  }, []);
+
   const handleCommentSubmit = (text: string, images?: ImageAttachment[]) => {
     if (!commentPopover) return;
     if (commentPopover.source && highlighterRef.current) {
@@ -647,10 +658,16 @@ export function useAnnotationHighlighter({
       pendingSourceRef.current = null;
       window.getSelection()?.removeAllRanges();
     }
+    setCommentDirty(false);
     setCommentPopover(null);
   };
 
+  const handleCommentDraftChange = useCallback((text: string, images?: ImageAttachment[]) => {
+    setCommentDirty(hasUnsavedContent(text, images ?? []));
+  }, [setCommentDirty]);
+
   const handleCommentClose = useCallback(() => {
+    setCommentDirty(false);
     setCommentPopover(prev => {
       if (prev?.source && highlighterRef.current) {
         highlighterRef.current.remove(prev.source.id);
@@ -659,7 +676,7 @@ export function useAnnotationHighlighter({
       return null;
     });
     window.getSelection()?.removeAllRanges();
-  }, []);
+  }, [setCommentDirty]);
 
   const handleFloatingQuickLabel = useCallback((label: QuickLabel) => {
     if (!quickLabelPicker?.source || !highlighterRef.current) return;
@@ -691,6 +708,7 @@ export function useAnnotationHighlighter({
     handleToolbarClose,
     handleRequestComment,
     handleCommentSubmit,
+    handleCommentDraftChange,
     handleCommentClose,
     handleFloatingQuickLabel,
     handleQuickLabelPickerDismiss,

--- a/packages/ui/utils/commentContent.test.ts
+++ b/packages/ui/utils/commentContent.test.ts
@@ -1,0 +1,27 @@
+import { describe, test, expect } from 'bun:test';
+import { hasUnsavedContent } from './commentContent';
+import type { ImageAttachment } from '../types';
+
+const img: ImageAttachment = { path: '/tmp/x.png', name: 'x' };
+
+describe('hasUnsavedContent', () => {
+  test('empty buffer has nothing to protect', () => {
+    expect(hasUnsavedContent('', [])).toBe(false);
+  });
+
+  test('whitespace-only text has nothing to protect', () => {
+    expect(hasUnsavedContent('   \n\t ', [])).toBe(false);
+  });
+
+  test('typed text is protected', () => {
+    expect(hasUnsavedContent('hi', [])).toBe(true);
+  });
+
+  test('an attached image is protected even with no text', () => {
+    expect(hasUnsavedContent('', [img])).toBe(true);
+  });
+
+  test('an attached image is protected even with whitespace-only text', () => {
+    expect(hasUnsavedContent('   ', [img])).toBe(true);
+  });
+});

--- a/packages/ui/utils/commentContent.ts
+++ b/packages/ui/utils/commentContent.ts
@@ -1,0 +1,5 @@
+import type { ImageAttachment } from '../types';
+
+export function hasUnsavedContent(text: string, images: ImageAttachment[]): boolean {
+  return text.trim().length > 0 || images.length > 0;
+}


### PR DESCRIPTION
> [!WARNING]
> **WIP — do not merge.** Opening as a draft to share the approach. I haven't got sign-off on the implementation direction in #821 yet (only the go-ahead to take the issue). Happy to adjust before this leaves draft.

Closes #821

## What

The annotation comment popover discarded an in-progress comment when the user clicked elsewhere or selected other text (e.g. to copy a snippet into their comment). Now the popover stays open and keeps its text while it holds unsaved content; the only exits are the explicit ones (Escape, the close button, ⌘/Ctrl+Enter to submit).

## How it works

Two separate paths could drop the comment:

1. **Outside click** — `CommentPopover`'s capture-phase `pointerdown` handler called `onClose()` on any click outside. Now it bails when the buffer is dirty.
2. **New text selection** (the dominant one) — selecting text made web-highlighter wrap it and fire `CREATE`, whose handler ran `setCommentPopover(null)` and opened a fresh popover, wiping the in-progress text.

The fix centers on a small dirty signal:

- **`packages/ui/utils/commentContent.ts`** — `hasUnsavedContent(text, images)`, the single predicate for "is there content worth protecting."
- **`packages/ui/hooks/useAnnotationHighlighter.ts`** — while the popover is dirty, the highlighter is paused (`stop()`); a new selection then stays a plain, copyable browser selection and the existing popover is untouched. It resumes (`run()`) on submit/close. Wired via a new `handleCommentDraftChange` fed by the popover's `onDraftChange`.
- **`packages/ui/components/CommentPopover.tsx`** — outside-click now no-ops while dirty (mirrored into a ref so the listener doesn't re-subscribe per keystroke).
- **`packages/ui/components/html-viewer/useHtmlAnnotation.ts`** — same fix for the HTML/annotate surface, which uses an iframe message bridge instead of web-highlighter: the `selection` message early-returns while dirty.

## Notes

- An empty popover still dismisses on outside click and still yields to a new selection — no behavior change there.
- Expanded dialog mode was already non-dismissing on backdrop clicks; unchanged.
- The shadow concern: only the text-selection comment popover is covered (the issue's surface). The plan-diff block-comment popover uses a different hover model and isn't affected.

## Testing

- `bun run typecheck` clean; `bun test` 1369 pass / 0 fail (added `commentContent.test.ts`).
- No DOM/component test harness exists in the repo, so the click-outside/selection wiring is verified manually; only the pure `hasUnsavedContent` predicate is unit-tested. Flagging this as the weak spot — open to adding happy-dom if you'd want real coverage.
- Manual (plan review + HTML annotate): type a comment, select other text → popover stays, text intact, new selection is live for ⌘C; empty popover still replaced by a new selection; Escape/X/⌘↵ unchanged.
