### PR TITLE
feat(review): custom review profiles (backend)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,6 +309,7 @@ During normal plan review, an Archive sidebar tab provides the same browsing via
 | `/api/external-annotations` | PATCH | Update fields on a single annotation (`?id=`) |
 | `/api/external-annotations` | DELETE | Remove by `?id=`, `?source=`, or clear all |
 | `/api/agents/capabilities` | GET | Check available agent providers (claude, codex, tour) |
+| `/api/agents/review-profiles` | GET | List launchable review profiles (user dir + builtins) |
 | `/api/agents/jobs/stream` | GET | SSE stream for real-time agent job status updates |
 | `/api/agents/jobs` | GET | Snapshot of agent jobs (polling fallback, `?since=N` for version gating) |
 | `/api/agents/jobs` | POST | Launch an agent job (body: `{ provider, command, label }`) |

--- a/apps/pi-extension/server/agent-jobs.ts
+++ b/apps/pi-extension/server/agent-jobs.ts
@@ -83,15 +83,9 @@ export interface AgentJobHandlerOptions {
 		reviewProfileId?: string;
 		/** Resolved review profile label at launch time. Stored on AgentJobInfo. */
 		reviewProfileLabel?: string;
-		/**
-		 * Files changed in the patch snapshotted at launch. Surfaced back to
-		 * onJobComplete as meta.reviewChangedFiles so it can drop out-of-diff
-		 * findings against the diff the agent actually reviewed.
-		 */
-		reviewChangedFiles?: string[];
 	} | null>;
 	/** Called when a job completes successfully — parse results and push annotations. */
-	onJobComplete?: (job: AgentJobInfo, meta: { outputPath?: string; stdout?: string; cwd?: string; reviewChangedFiles?: string[] }) => void | Promise<void>;
+	onJobComplete?: (job: AgentJobInfo, meta: { outputPath?: string; stdout?: string; cwd?: string }) => void | Promise<void>;
 }
 
 export function createAgentJobHandler(options: AgentJobHandlerOptions) {
@@ -100,8 +94,6 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions) {
 	// --- State ---
 	const jobs = new Map<string, { info: AgentJobInfo; proc: ChildProcess | null }>();
 	const jobOutputPaths = new Map<string, string>();
-	// Launch-time changed-file lists, keyed by job id — read once in onJobComplete.
-	const jobChangedFiles = new Map<string, string[]>();
 	const subscribers = new Set<ServerResponse>();
 	let version = 0;
 
@@ -136,7 +128,7 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions) {
 		command: string[],
 		label: string,
 		outputPath?: string,
-		spawnOptions?: { captureStdout?: boolean; stdinPrompt?: string; cwd?: string; prompt?: string; engine?: string; model?: string; effort?: string; reasoningEffort?: string; fastMode?: boolean; prUrl?: string; diffScope?: string; diffContext?: AgentJobInfo["diffContext"]; reviewProfileId?: string; reviewProfileLabel?: string; reviewChangedFiles?: string[] },
+		spawnOptions?: { captureStdout?: boolean; stdinPrompt?: string; cwd?: string; prompt?: string; engine?: string; model?: string; effort?: string; reasoningEffort?: string; fastMode?: boolean; prUrl?: string; diffScope?: string; diffContext?: AgentJobInfo["diffContext"]; reviewProfileId?: string; reviewProfileLabel?: string },
 	): AgentJobInfo {
 		const id = crypto.randomUUID();
 		const source = jobSource(id);
@@ -195,7 +187,6 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions) {
 			jobs.set(id, { info, proc });
 			if (outputPath) jobOutputPaths.set(id, outputPath);
 			if (spawnOptions?.cwd) jobOutputPaths.set(`${id}:cwd`, spawnOptions.cwd);
-			if (spawnOptions?.reviewChangedFiles) jobChangedFiles.set(id, spawnOptions.reviewChangedFiles);
 			broadcast({ type: "job:started", job: { ...info } });
 
 			// --- Stdout capture (Claude JSONL streaming) ---
@@ -279,7 +270,6 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions) {
 							outputPath: jobOutputPath,
 							stdout: captureStdout ? stdoutBuf : undefined,
 							cwd: jobCwd,
-							reviewChangedFiles: jobChangedFiles.get(id),
 						});
 					} catch {
 						// Result ingestion failure shouldn't prevent job completion broadcast
@@ -287,7 +277,6 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions) {
 				}
 				jobOutputPaths.delete(id);
 				jobOutputPaths.delete(`${id}:cwd`);
-				jobChangedFiles.delete(id);
 
 				broadcast({ type: "job:completed", job: { ...entry.info } });
 			});
@@ -331,7 +320,6 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions) {
 		entry.info.endedAt = Date.now();
 		jobOutputPaths.delete(id);
 		jobOutputPaths.delete(`${id}:cwd`);
-		jobChangedFiles.delete(id);
 		broadcast({ type: "job:completed", job: { ...entry.info } });
 		return true;
 	}
@@ -467,7 +455,6 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions) {
 					let jobDiffContext: AgentJobInfo["diffContext"] | undefined;
 					let jobReviewProfileId: string | undefined;
 					let jobReviewProfileLabel: string | undefined;
-					let jobReviewChangedFiles: string[] | undefined;
 					if (options.buildCommand) {
 						// Thread config from POST body to buildCommand
 						const config: Record<string, unknown> = {};
@@ -496,7 +483,6 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions) {
 							jobDiffContext = built.diffContext;
 							jobReviewProfileId = built.reviewProfileId;
 							jobReviewProfileLabel = built.reviewProfileLabel;
-							jobReviewChangedFiles = built.reviewChangedFiles;
 						}
 					}
 
@@ -520,7 +506,6 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions) {
 						diffContext: jobDiffContext,
 						reviewProfileId: jobReviewProfileId,
 						reviewProfileLabel: jobReviewProfileLabel,
-						reviewChangedFiles: jobReviewChangedFiles,
 					});
 					json(res, { job }, 201);
 				} catch (err) {

--- a/apps/pi-extension/server/agent-jobs.ts
+++ b/apps/pi-extension/server/agent-jobs.ts
@@ -79,9 +79,19 @@ export interface AgentJobHandlerOptions {
 		diffScope?: string;
 		/** Diff context snapshot at launch (stored on AgentJobInfo for per-job "Copy All"). */
 		diffContext?: AgentJobInfo["diffContext"];
+		/** Resolved review profile id at launch time. Stored on AgentJobInfo. */
+		reviewProfileId?: string;
+		/** Resolved review profile label at launch time. Stored on AgentJobInfo. */
+		reviewProfileLabel?: string;
+		/**
+		 * Files changed in the patch snapshotted at launch. Surfaced back to
+		 * onJobComplete as meta.reviewChangedFiles so it can drop out-of-diff
+		 * findings against the diff the agent actually reviewed.
+		 */
+		reviewChangedFiles?: string[];
 	} | null>;
 	/** Called when a job completes successfully — parse results and push annotations. */
-	onJobComplete?: (job: AgentJobInfo, meta: { outputPath?: string; stdout?: string; cwd?: string }) => void | Promise<void>;
+	onJobComplete?: (job: AgentJobInfo, meta: { outputPath?: string; stdout?: string; cwd?: string; reviewChangedFiles?: string[] }) => void | Promise<void>;
 }
 
 export function createAgentJobHandler(options: AgentJobHandlerOptions) {
@@ -90,6 +100,8 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions) {
 	// --- State ---
 	const jobs = new Map<string, { info: AgentJobInfo; proc: ChildProcess | null }>();
 	const jobOutputPaths = new Map<string, string>();
+	// Launch-time changed-file lists, keyed by job id — read once in onJobComplete.
+	const jobChangedFiles = new Map<string, string[]>();
 	const subscribers = new Set<ServerResponse>();
 	let version = 0;
 
@@ -124,7 +136,7 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions) {
 		command: string[],
 		label: string,
 		outputPath?: string,
-		spawnOptions?: { captureStdout?: boolean; stdinPrompt?: string; cwd?: string; prompt?: string; engine?: string; model?: string; effort?: string; reasoningEffort?: string; fastMode?: boolean; prUrl?: string; diffScope?: string; diffContext?: AgentJobInfo["diffContext"] },
+		spawnOptions?: { captureStdout?: boolean; stdinPrompt?: string; cwd?: string; prompt?: string; engine?: string; model?: string; effort?: string; reasoningEffort?: string; fastMode?: boolean; prUrl?: string; diffScope?: string; diffContext?: AgentJobInfo["diffContext"]; reviewProfileId?: string; reviewProfileLabel?: string; reviewChangedFiles?: string[] },
 	): AgentJobInfo {
 		const id = crypto.randomUUID();
 		const source = jobSource(id);
@@ -146,6 +158,8 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions) {
 			...(spawnOptions?.prUrl && { prUrl: spawnOptions.prUrl }),
 			...(spawnOptions?.diffScope && { diffScope: spawnOptions.diffScope }),
 			...(spawnOptions?.diffContext && { diffContext: spawnOptions.diffContext }),
+			...(spawnOptions?.reviewProfileId && { reviewProfileId: spawnOptions.reviewProfileId }),
+			...(spawnOptions?.reviewProfileLabel && { reviewProfileLabel: spawnOptions.reviewProfileLabel }),
 		};
 
 		let proc: ChildProcess | null = null;
@@ -181,6 +195,7 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions) {
 			jobs.set(id, { info, proc });
 			if (outputPath) jobOutputPaths.set(id, outputPath);
 			if (spawnOptions?.cwd) jobOutputPaths.set(`${id}:cwd`, spawnOptions.cwd);
+			if (spawnOptions?.reviewChangedFiles) jobChangedFiles.set(id, spawnOptions.reviewChangedFiles);
 			broadcast({ type: "job:started", job: { ...info } });
 
 			// --- Stdout capture (Claude JSONL streaming) ---
@@ -264,6 +279,7 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions) {
 							outputPath: jobOutputPath,
 							stdout: captureStdout ? stdoutBuf : undefined,
 							cwd: jobCwd,
+							reviewChangedFiles: jobChangedFiles.get(id),
 						});
 					} catch {
 						// Result ingestion failure shouldn't prevent job completion broadcast
@@ -271,6 +287,7 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions) {
 				}
 				jobOutputPaths.delete(id);
 				jobOutputPaths.delete(`${id}:cwd`);
+				jobChangedFiles.delete(id);
 
 				broadcast({ type: "job:completed", job: { ...entry.info } });
 			});
@@ -314,6 +331,7 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions) {
 		entry.info.endedAt = Date.now();
 		jobOutputPaths.delete(id);
 		jobOutputPaths.delete(`${id}:cwd`);
+		jobChangedFiles.delete(id);
 		broadcast({ type: "job:completed", job: { ...entry.info } });
 		return true;
 	}
@@ -405,6 +423,22 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions) {
 			if (url.pathname === JOBS && req.method === "POST") {
 				try {
 					const body = await parseBody(req);
+
+					// Reject unknown fields rather than silently ignoring them (per the
+					// custom-reviews spec — a typo'd field should fail loud, not no-op).
+					const KNOWN_JOB_FIELDS = new Set([
+						"provider", "command", "label",
+						"engine", "model", "reasoningEffort", "effort", "fastMode",
+						"reviewProfileId",
+					]);
+					if (body && typeof body === "object") {
+						const unknown = Object.keys(body).filter((k) => !KNOWN_JOB_FIELDS.has(k));
+						if (unknown.length > 0) {
+							json(res, { error: `Unknown field(s): ${unknown.join(", ")}` }, 400);
+							return true;
+						}
+					}
+
 					const provider = typeof body.provider === "string" ? body.provider : "";
 					let rawCommand = Array.isArray(body.command) ? body.command : [];
 					let command = rawCommand.filter((c: unknown): c is string => typeof c === "string");
@@ -431,6 +465,9 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions) {
 					let jobPrUrl: string | undefined;
 					let jobDiffScope: string | undefined;
 					let jobDiffContext: AgentJobInfo["diffContext"] | undefined;
+					let jobReviewProfileId: string | undefined;
+					let jobReviewProfileLabel: string | undefined;
+					let jobReviewChangedFiles: string[] | undefined;
 					if (options.buildCommand) {
 						// Thread config from POST body to buildCommand
 						const config: Record<string, unknown> = {};
@@ -439,6 +476,7 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions) {
 						if (typeof body.reasoningEffort === "string") config.reasoningEffort = body.reasoningEffort;
 						if (typeof body.effort === "string") config.effort = body.effort;
 						if (body.fastMode === true) config.fastMode = true;
+						if (typeof body.reviewProfileId === "string") config.reviewProfileId = body.reviewProfileId;
 						const built = await options.buildCommand(provider, Object.keys(config).length > 0 ? config : undefined);
 						if (built) {
 							command = built.command;
@@ -456,6 +494,9 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions) {
 							jobPrUrl = built.prUrl;
 							jobDiffScope = built.diffScope;
 							jobDiffContext = built.diffContext;
+							jobReviewProfileId = built.reviewProfileId;
+							jobReviewProfileLabel = built.reviewProfileLabel;
+							jobReviewChangedFiles = built.reviewChangedFiles;
 						}
 					}
 
@@ -477,6 +518,9 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions) {
 						prUrl: jobPrUrl,
 						diffScope: jobDiffScope,
 						diffContext: jobDiffContext,
+						reviewProfileId: jobReviewProfileId,
+						reviewProfileLabel: jobReviewProfileLabel,
+						reviewChangedFiles: jobReviewChangedFiles,
 					});
 					json(res, { job }, 201);
 				} catch (err) {

--- a/apps/pi-extension/server/serverReview.ts
+++ b/apps/pi-extension/server/serverReview.ts
@@ -575,10 +575,28 @@ export async function startReviewServer(options: {
 				prRepo: getDisplayRepo(jobPrMeta),
 			} : jobPrUrl ? { prUrl: jobPrUrl } : {};
 
-			const profileLabel = job.reviewProfileLabel;
+			// Only tag annotations with a *custom* profile — the default review needs no tag.
+			const profileLabel =
+				job.reviewProfileId && job.reviewProfileId !== BUILTIN_DEFAULT_PROFILE.id
+					? job.reviewProfileLabel
+					: undefined;
 
-			if (job.provider === "codex" && meta.outputPath) {
-				const output = await parseCodexOutput(meta.outputPath);
+			// Map findings onto annotations and ingest. Shared by both engine branches;
+			// no-ops on an empty set so a clean (zero-finding) review stays "done".
+			const ingest = <T extends object>(transformed: readonly T[], logTag: string) => {
+				if (transformed.length === 0) return;
+				const annotations = transformed.map((a) => ({
+					...a,
+					...jobPrContext,
+					...(jobDiffScope && { diffScope: jobDiffScope }),
+					...(profileLabel && { reviewProfileLabel: profileLabel }),
+				}));
+				const result = externalAnnotations.addAnnotations({ annotations });
+				if ("error" in result) console.error(`[${logTag}] addAnnotations error:`, result.error);
+			};
+
+			if (job.provider === "codex") {
+				const output = meta.outputPath ? await parseCodexOutput(meta.outputPath) : null;
 				if (!output) {
 					// Process exited 0 but output is missing/unparseable — not a green run.
 					markJobReviewFailed(job, REVIEW_OUTPUT_FAILED);
@@ -592,23 +610,16 @@ export async function startReviewServer(options: {
 					confidence: output.overall_confidence_score,
 				};
 
-				if (output.findings.length > 0) {
-					const transformed = transformReviewFindings(
+				ingest(
+					transformReviewFindings(
 						output.findings,
 						job.source,
 						cwd,
 						"Codex",
 						workspace ? (filePath) => workspace.normalizeAnnotationPath(filePath) : undefined,
-					);
-					const annotations = transformed.map(a => ({
-						...a,
-						...jobPrContext,
-						...(jobDiffScope && { diffScope: jobDiffScope }),
-						...(profileLabel && { reviewProfileLabel: profileLabel }),
-					}));
-					const result = externalAnnotations.addAnnotations({ annotations });
-					if ("error" in result) console.error(`[codex-review] addAnnotations error:`, result.error);
-				}
+					),
+					"codex-review",
+				);
 				return;
 			}
 
@@ -628,22 +639,15 @@ export async function startReviewServer(options: {
 					confidence: total === 0 ? 1.0 : Math.max(0, 1.0 - (output.summary.important * 0.2)),
 				};
 
-				if (output.findings.length > 0) {
-					const transformed = transformClaudeFindings(
+				ingest(
+					transformClaudeFindings(
 						output.findings,
 						job.source,
 						cwd,
 						workspace ? (filePath) => workspace.normalizeAnnotationPath(filePath) : undefined,
-					);
-					const annotations = transformed.map(a => ({
-						...a,
-						...jobPrContext,
-						...(jobDiffScope && { diffScope: jobDiffScope }),
-						...(profileLabel && { reviewProfileLabel: profileLabel }),
-					}));
-					const result = externalAnnotations.addAnnotations({ annotations });
-					if ("error" in result) console.error(`[claude-review] addAnnotations error:`, result.error);
-				}
+					),
+					"claude-review",
+				);
 				return;
 			}
 

--- a/apps/pi-extension/server/serverReview.ts
+++ b/apps/pi-extension/server/serverReview.ts
@@ -72,7 +72,7 @@ import {
 } from "./pr.js";
 import { getRepoInfo } from "./project.js";
 import {
-	CODEX_REVIEW_SYSTEM_PROMPT,
+	composeCodexReviewPrompt,
 	buildCodexCommand,
 	generateOutputPath,
 	parseCodexOutput,
@@ -80,7 +80,7 @@ import {
 } from "../generated/codex-review.js";
 import { buildAgentReviewUserMessage, buildAgentReviewUserMessageForTarget, type WorkspaceReviewPromptContext } from "../generated/agent-review-message.js";
 import {
-	CLAUDE_REVIEW_PROMPT,
+	composeClaudeReviewPrompt,
 	buildClaudeCommand,
 	parseClaudeStreamOutput,
 	transformClaudeFindings,
@@ -107,6 +107,12 @@ import {
 	SemanticDiffResponseCache,
 } from "../generated/semantic-diff.js";
 import type { SemanticDiffAvailability, SemanticDiffResponse } from "../generated/semantic-diff-types.js";
+import { loadReviewProfiles } from "../generated/review-profile-loader.js";
+import {
+	BUILTIN_DEFAULT_PROFILE,
+	type ResolvedReviewProfile,
+	type ReviewProfilesResponse,
+} from "../generated/review-profiles.js";
 import {
 	canStageFiles,
 	detectRemoteDefaultCompareTarget,
@@ -150,6 +156,49 @@ const piCodeNavRuntime: CodeNavRuntime = {
 		});
 	},
 };
+
+// --- Review ingestion helpers (shared shape with packages/server/review.ts) ---
+
+// Calm, provider-neutral failure reasons. Never leak schema/CLI internals.
+const REVIEW_OUTPUT_FAILED = "Review finished but produced no usable findings.";
+const REVIEW_ALL_OUT_OF_DIFF = "Review findings were all outside the reviewed diff.";
+
+/**
+ * Drop findings whose file is not in the reviewed diff. Cheap guard, not a
+ * diff-anchoring module: a plain set-membership check against the launch
+ * patch's changed files. When the changed-file list is unavailable, keep
+ * everything rather than silently dropping.
+ */
+function filterToReviewedDiff<T extends { filePath: string }>(
+	annotations: T[],
+	changedFiles: string[] | undefined,
+): { kept: T[]; dropped: number } {
+	if (!changedFiles || changedFiles.length === 0) {
+		return { kept: annotations, dropped: 0 };
+	}
+	const allowed = new Set(changedFiles);
+	const kept = annotations.filter((a) => allowed.has(a.filePath));
+	return { kept, dropped: annotations.length - kept.length };
+}
+
+/** Flip a job to failed with a calm one-liner (Code Tour precedent). */
+function markJobReviewFailed(job: AgentJobInfo, error: string): void {
+	job.status = "failed";
+	job.error = error;
+}
+
+/**
+ * Reflect post-ingestion counts on the job summary so the detail panel can
+ * surface "N findings · M skipped (not in the reviewed diff)".
+ */
+function applyReviewFindingsSummary(job: AgentJobInfo, kept: number, dropped: number): void {
+	if (dropped <= 0 || !job.summary) return;
+	const note = `${kept} findings · ${dropped} skipped (not in the reviewed diff)`;
+	job.summary = {
+		...job.summary,
+		explanation: job.summary.explanation ? `${job.summary.explanation} — ${note}` : note,
+	};
+}
 
 /** Detect if running inside WSL (Windows Subsystem for Linux) */
 function detectWSL(): boolean {
@@ -474,6 +523,10 @@ export async function startReviewServer(options: {
 				);
 			}
 			const cwd = resolveAgentCwd();
+			// Files in the diff the agent will actually review. Threaded to
+			// onJobComplete so out-of-diff findings can be dropped against this
+			// snapshot, not whatever diff happens to be current at completion.
+			const launchChangedFiles = extractChangedFiles(currentPatch);
 			const workspacePrompt = getWorkspacePromptContext();
 			const hasAgentLocalAccess = !!workspacePrompt || !!options.worktreePool || !!options.agentCwd || !!options.gitContext;
 			const userMessageOptions = {
@@ -491,6 +544,23 @@ export async function startReviewServer(options: {
 				: null;
 			const launchPrUrl = prMeta?.url;
 			const launchDiffScope = isPRMode ? currentPRDiffScope : undefined;
+
+			// Resolve the requested review profile against the same target the
+			// agent will review. Repo profiles are scoped to a single unambiguous
+			// local repo (excluded in remote-only PR mode and ambiguous workspace
+			// mode), matching the discovery endpoint. Absent or unknown id →
+			// builtin:default, so today's "Run Review" stays byte-identical.
+			const requestedProfileId =
+				typeof config?.reviewProfileId === "string" ? config.reviewProfileId : undefined;
+			const profileRepoCwd =
+				!isPRMode && !isWorkspaceMode && options.gitContext
+					? options.gitContext.cwd
+					: undefined;
+			const reviewProfile: ResolvedReviewProfile = requestedProfileId
+				? loadReviewProfiles({ repoCwd: profileRepoCwd }).find((p) => p.id === requestedProfileId) ??
+					BUILTIN_DEFAULT_PROFILE
+				: BUILTIN_DEFAULT_PROFILE;
+
 			const diffContext: AgentJobInfo["diffContext"] | undefined = workspacePrompt
 				? { mode: String(currentDiffType), worktreePath: null }
 				: prMeta
@@ -510,7 +580,7 @@ export async function startReviewServer(options: {
 					prMetadata: prMeta,
 					config,
 				});
-				return built ? { ...built, prUrl: launchPrUrl, diffScope: launchDiffScope, diffContext } : built;
+				return built ? { ...built, prUrl: launchPrUrl, diffScope: launchDiffScope, diffContext, reviewProfileId: reviewProfile.id, reviewProfileLabel: reviewProfile.label } : built;
 			}
 
 			const userMessage = workspacePrompt
@@ -527,17 +597,17 @@ export async function startReviewServer(options: {
 				const reasoningEffort = typeof config?.reasoningEffort === "string" && config.reasoningEffort ? config.reasoningEffort : undefined;
 				const fastMode = config?.fastMode === true;
 				const outputPath = generateOutputPath();
-				const prompt = CODEX_REVIEW_SYSTEM_PROMPT + "\n\n---\n\n" + userMessage;
-				const command = await buildCodexCommand({ cwd, outputPath, prompt, model, reasoningEffort, fastMode });
-				return { command, outputPath, prompt, cwd, label: jobLabel, model, reasoningEffort, fastMode: fastMode || undefined, prUrl: launchPrUrl, diffScope: launchDiffScope, diffContext };
+				const prompt = composeCodexReviewPrompt(userMessage, reviewProfile);
+				const command = await buildCodexCommand({ cwd, outputPath, prompt, model, reasoningEffort, fastMode, reviewProfile });
+				return { command, outputPath, prompt, cwd, label: jobLabel, model, reasoningEffort, fastMode: fastMode || undefined, prUrl: launchPrUrl, diffScope: launchDiffScope, diffContext, reviewProfileId: reviewProfile.id, reviewProfileLabel: reviewProfile.label, reviewChangedFiles: launchChangedFiles };
 			}
 
 			if (provider === "claude") {
 				const model = typeof config?.model === "string" && config.model ? config.model : undefined;
 				const effort = typeof config?.effort === "string" && config.effort ? config.effort : undefined;
-				const prompt = CLAUDE_REVIEW_PROMPT + "\n\n---\n\n" + userMessage;
-				const { command, stdinPrompt } = buildClaudeCommand(prompt, model, effort);
-				return { command, stdinPrompt, prompt, cwd, label: jobLabel, captureStdout: true, model, effort, prUrl: launchPrUrl, diffScope: launchDiffScope, diffContext };
+				const prompt = composeClaudeReviewPrompt(userMessage, reviewProfile);
+				const { command, stdinPrompt } = buildClaudeCommand(prompt, model, effort, reviewProfile);
+				return { command, stdinPrompt, prompt, cwd, label: jobLabel, captureStdout: true, model, effort, prUrl: launchPrUrl, diffScope: launchDiffScope, diffContext, reviewProfileId: reviewProfile.id, reviewProfileLabel: reviewProfile.label, reviewChangedFiles: launchChangedFiles };
 			}
 
 			return null;
@@ -555,9 +625,15 @@ export async function startReviewServer(options: {
 				prRepo: getDisplayRepo(jobPrMeta),
 			} : jobPrUrl ? { prUrl: jobPrUrl } : {};
 
+			const profileLabel = job.reviewProfileLabel;
+
 			if (job.provider === "codex" && meta.outputPath) {
 				const output = await parseCodexOutput(meta.outputPath);
-				if (!output) return;
+				if (!output) {
+					// Process exited 0 but output is missing/unparseable — not a green run.
+					markJobReviewFailed(job, REVIEW_OUTPUT_FAILED);
+					return;
+				}
 
 				const hasBlockingFindings = output.findings.some(f => f.priority !== null && f.priority <= 1);
 				job.summary = {
@@ -567,16 +643,27 @@ export async function startReviewServer(options: {
 				};
 
 				if (output.findings.length > 0) {
-					const annotations = transformReviewFindings(
+					const transformed = transformReviewFindings(
 						output.findings,
 						job.source,
 						cwd,
 						"Codex",
 						workspace ? (filePath) => workspace.normalizeAnnotationPath(filePath) : undefined,
-					)
-						.map(a => ({ ...a, ...jobPrContext, ...(jobDiffScope && { diffScope: jobDiffScope }) }));
+					);
+					const { kept, dropped } = filterToReviewedDiff(transformed, meta.reviewChangedFiles);
+					if (kept.length === 0 && transformed.length > 0) {
+						markJobReviewFailed(job, REVIEW_ALL_OUT_OF_DIFF);
+						return;
+					}
+					const annotations = kept.map(a => ({
+						...a,
+						...jobPrContext,
+						...(jobDiffScope && { diffScope: jobDiffScope }),
+						...(profileLabel && { reviewProfileLabel: profileLabel }),
+					}));
 					const result = externalAnnotations.addAnnotations({ annotations });
 					if ("error" in result) console.error(`[codex-review] addAnnotations error:`, result.error);
+					else applyReviewFindingsSummary(job, kept.length, dropped);
 				}
 				return;
 			}
@@ -585,6 +672,7 @@ export async function startReviewServer(options: {
 				const output = parseClaudeStreamOutput(meta.stdout);
 				if (!output) {
 					console.error(`[claude-review] Failed to parse output (${meta.stdout.length} bytes, last 200: ${meta.stdout.slice(-200)})`);
+					markJobReviewFailed(job, REVIEW_OUTPUT_FAILED);
 					return;
 				}
 
@@ -596,15 +684,26 @@ export async function startReviewServer(options: {
 				};
 
 				if (output.findings.length > 0) {
-					const annotations = transformClaudeFindings(
+					const transformed = transformClaudeFindings(
 						output.findings,
 						job.source,
 						cwd,
 						workspace ? (filePath) => workspace.normalizeAnnotationPath(filePath) : undefined,
-					)
-						.map(a => ({ ...a, ...jobPrContext, ...(jobDiffScope && { diffScope: jobDiffScope }) }));
+					);
+					const { kept, dropped } = filterToReviewedDiff(transformed, meta.reviewChangedFiles);
+					if (kept.length === 0 && transformed.length > 0) {
+						markJobReviewFailed(job, REVIEW_ALL_OUT_OF_DIFF);
+						return;
+					}
+					const annotations = kept.map(a => ({
+						...a,
+						...jobPrContext,
+						...(jobDiffScope && { diffScope: jobDiffScope }),
+						...(profileLabel && { reviewProfileLabel: profileLabel }),
+					}));
 					const result = externalAnnotations.addAnnotations({ annotations });
 					if ("error" in result) console.error(`[claude-review] addAnnotations error:`, result.error);
+					else applyReviewFindingsSummary(job, kept.length, dropped);
 				}
 				return;
 			}
@@ -1299,6 +1398,30 @@ export async function startReviewServer(options: {
 			await handleUploadRequest(req, res);
 		} else if (url.pathname === "/api/agents" && req.method === "GET") {
 			json(res, { agents: [] });
+		} else if (
+			url.pathname === "/api/agents/review-profiles" &&
+			req.method === "GET"
+		) {
+			// Custom reviews discovery. Reloaded per request, no file watching.
+			// Repo profiles are scoped to a single unambiguous local repo:
+			// excluded in remote-only PR mode and ambiguous workspace mode.
+			const repoCwd =
+				!isPRMode && !isWorkspaceMode && options.gitContext
+					? options.gitContext.cwd
+					: undefined;
+			const profiles = loadReviewProfiles({ repoCwd });
+			const body: ReviewProfilesResponse = {
+				profiles: profiles.map((p) => ({
+					id: p.id,
+					label: p.label,
+					description: p.description,
+					engines: p.engines,
+					source: p.source,
+					sourcePath: p.sourcePath,
+					default: p.default,
+				})),
+			};
+			json(res, body);
 		} else if (url.pathname === "/api/git-add" && req.method === "POST") {
 			try {
 				const body = await parseBody(req);

--- a/apps/pi-extension/server/serverReview.ts
+++ b/apps/pi-extension/server/serverReview.ts
@@ -46,7 +46,7 @@ import type { WorktreePool } from "../generated/worktree-pool.js";
 
 import { createEditorAnnotationHandler } from "./annotations.js";
 import { createAgentJobHandler } from "./agent-jobs.js";
-import type { AgentJobInfo } from "../generated/agent-jobs.js";
+import { type AgentJobInfo, REVIEW_OUTPUT_FAILED, markJobReviewFailed } from "../generated/agent-jobs.js";
 import { createExternalAnnotationHandler } from "./external-annotations.js";
 import {
 	handleDraftRequest,
@@ -157,48 +157,8 @@ const piCodeNavRuntime: CodeNavRuntime = {
 	},
 };
 
-// --- Review ingestion helpers (shared shape with packages/server/review.ts) ---
-
-// Calm, provider-neutral failure reasons. Never leak schema/CLI internals.
-const REVIEW_OUTPUT_FAILED = "Review finished but produced no usable findings.";
-const REVIEW_ALL_OUT_OF_DIFF = "Review findings were all outside the reviewed diff.";
-
-/**
- * Drop findings whose file is not in the reviewed diff. Cheap guard, not a
- * diff-anchoring module: a plain set-membership check against the launch
- * patch's changed files. When the changed-file list is unavailable, keep
- * everything rather than silently dropping.
- */
-function filterToReviewedDiff<T extends { filePath: string }>(
-	annotations: T[],
-	changedFiles: string[] | undefined,
-): { kept: T[]; dropped: number } {
-	if (!changedFiles || changedFiles.length === 0) {
-		return { kept: annotations, dropped: 0 };
-	}
-	const allowed = new Set(changedFiles);
-	const kept = annotations.filter((a) => allowed.has(a.filePath));
-	return { kept, dropped: annotations.length - kept.length };
-}
-
-/** Flip a job to failed with a calm one-liner (Code Tour precedent). */
-function markJobReviewFailed(job: AgentJobInfo, error: string): void {
-	job.status = "failed";
-	job.error = error;
-}
-
-/**
- * Reflect post-ingestion counts on the job summary so the detail panel can
- * surface "N findings · M skipped (not in the reviewed diff)".
- */
-function applyReviewFindingsSummary(job: AgentJobInfo, kept: number, dropped: number): void {
-	if (dropped <= 0 || !job.summary) return;
-	const note = `${kept} findings · ${dropped} skipped (not in the reviewed diff)`;
-	job.summary = {
-		...job.summary,
-		explanation: job.summary.explanation ? `${job.summary.explanation} — ${note}` : note,
-	};
-}
+// Review ingestion completion semantics (REVIEW_OUTPUT_FAILED,
+// markJobReviewFailed) now live in the shared agent-jobs module.
 
 /** Detect if running inside WSL (Windows Subsystem for Linux) */
 function detectWSL(): boolean {
@@ -523,10 +483,6 @@ export async function startReviewServer(options: {
 				);
 			}
 			const cwd = resolveAgentCwd();
-			// Files in the diff the agent will actually review. Threaded to
-			// onJobComplete so out-of-diff findings can be dropped against this
-			// snapshot, not whatever diff happens to be current at completion.
-			const launchChangedFiles = extractChangedFiles(currentPatch);
 			const workspacePrompt = getWorkspacePromptContext();
 			const hasAgentLocalAccess = !!workspacePrompt || !!options.worktreePool || !!options.agentCwd || !!options.gitContext;
 			const userMessageOptions = {
@@ -545,19 +501,13 @@ export async function startReviewServer(options: {
 			const launchPrUrl = prMeta?.url;
 			const launchDiffScope = isPRMode ? currentPRDiffScope : undefined;
 
-			// Resolve the requested review profile against the same target the
-			// agent will review. Repo profiles are scoped to a single unambiguous
-			// local repo (excluded in remote-only PR mode and ambiguous workspace
-			// mode), matching the discovery endpoint. Absent or unknown id →
-			// builtin:default, so today's "Run Review" stays byte-identical.
+			// Resolve the requested review profile. Profiles come from the user
+			// dir plus builtins. Absent or unknown id → builtin:default, so
+			// today's "Run Review" stays byte-identical.
 			const requestedProfileId =
 				typeof config?.reviewProfileId === "string" ? config.reviewProfileId : undefined;
-			const profileRepoCwd =
-				!isPRMode && !isWorkspaceMode && options.gitContext
-					? options.gitContext.cwd
-					: undefined;
 			const reviewProfile: ResolvedReviewProfile = requestedProfileId
-				? loadReviewProfiles({ repoCwd: profileRepoCwd }).find((p) => p.id === requestedProfileId) ??
+				? loadReviewProfiles().find((p) => p.id === requestedProfileId) ??
 					BUILTIN_DEFAULT_PROFILE
 				: BUILTIN_DEFAULT_PROFILE;
 
@@ -598,16 +548,16 @@ export async function startReviewServer(options: {
 				const fastMode = config?.fastMode === true;
 				const outputPath = generateOutputPath();
 				const prompt = composeCodexReviewPrompt(userMessage, reviewProfile);
-				const command = await buildCodexCommand({ cwd, outputPath, prompt, model, reasoningEffort, fastMode, reviewProfile });
-				return { command, outputPath, prompt, cwd, label: jobLabel, model, reasoningEffort, fastMode: fastMode || undefined, prUrl: launchPrUrl, diffScope: launchDiffScope, diffContext, reviewProfileId: reviewProfile.id, reviewProfileLabel: reviewProfile.label, reviewChangedFiles: launchChangedFiles };
+				const command = await buildCodexCommand({ cwd, outputPath, prompt, model, reasoningEffort, fastMode });
+				return { command, outputPath, prompt, cwd, label: jobLabel, model, reasoningEffort, fastMode: fastMode || undefined, prUrl: launchPrUrl, diffScope: launchDiffScope, diffContext, reviewProfileId: reviewProfile.id, reviewProfileLabel: reviewProfile.label };
 			}
 
 			if (provider === "claude") {
 				const model = typeof config?.model === "string" && config.model ? config.model : undefined;
 				const effort = typeof config?.effort === "string" && config.effort ? config.effort : undefined;
 				const prompt = composeClaudeReviewPrompt(userMessage, reviewProfile);
-				const { command, stdinPrompt } = buildClaudeCommand(prompt, model, effort, reviewProfile);
-				return { command, stdinPrompt, prompt, cwd, label: jobLabel, captureStdout: true, model, effort, prUrl: launchPrUrl, diffScope: launchDiffScope, diffContext, reviewProfileId: reviewProfile.id, reviewProfileLabel: reviewProfile.label, reviewChangedFiles: launchChangedFiles };
+				const { command, stdinPrompt } = buildClaudeCommand(prompt, model, effort);
+				return { command, stdinPrompt, prompt, cwd, label: jobLabel, captureStdout: true, model, effort, prUrl: launchPrUrl, diffScope: launchDiffScope, diffContext, reviewProfileId: reviewProfile.id, reviewProfileLabel: reviewProfile.label };
 			}
 
 			return null;
@@ -650,12 +600,7 @@ export async function startReviewServer(options: {
 						"Codex",
 						workspace ? (filePath) => workspace.normalizeAnnotationPath(filePath) : undefined,
 					);
-					const { kept, dropped } = filterToReviewedDiff(transformed, meta.reviewChangedFiles);
-					if (kept.length === 0 && transformed.length > 0) {
-						markJobReviewFailed(job, REVIEW_ALL_OUT_OF_DIFF);
-						return;
-					}
-					const annotations = kept.map(a => ({
+					const annotations = transformed.map(a => ({
 						...a,
 						...jobPrContext,
 						...(jobDiffScope && { diffScope: jobDiffScope }),
@@ -663,15 +608,15 @@ export async function startReviewServer(options: {
 					}));
 					const result = externalAnnotations.addAnnotations({ annotations });
 					if ("error" in result) console.error(`[codex-review] addAnnotations error:`, result.error);
-					else applyReviewFindingsSummary(job, kept.length, dropped);
 				}
 				return;
 			}
 
-			if (job.provider === "claude" && meta.stdout) {
-				const output = parseClaudeStreamOutput(meta.stdout);
+			if (job.provider === "claude") {
+				const stdout = meta.stdout ?? "";
+				const output = parseClaudeStreamOutput(stdout);
 				if (!output) {
-					console.error(`[claude-review] Failed to parse output (${meta.stdout.length} bytes, last 200: ${meta.stdout.slice(-200)})`);
+					console.error(`[claude-review] Failed to parse output (${stdout.length} bytes, last 200: ${stdout.slice(-200)})`);
 					markJobReviewFailed(job, REVIEW_OUTPUT_FAILED);
 					return;
 				}
@@ -690,12 +635,7 @@ export async function startReviewServer(options: {
 						cwd,
 						workspace ? (filePath) => workspace.normalizeAnnotationPath(filePath) : undefined,
 					);
-					const { kept, dropped } = filterToReviewedDiff(transformed, meta.reviewChangedFiles);
-					if (kept.length === 0 && transformed.length > 0) {
-						markJobReviewFailed(job, REVIEW_ALL_OUT_OF_DIFF);
-						return;
-					}
-					const annotations = kept.map(a => ({
+					const annotations = transformed.map(a => ({
 						...a,
 						...jobPrContext,
 						...(jobDiffScope && { diffScope: jobDiffScope }),
@@ -703,7 +643,6 @@ export async function startReviewServer(options: {
 					}));
 					const result = externalAnnotations.addAnnotations({ annotations });
 					if ("error" in result) console.error(`[claude-review] addAnnotations error:`, result.error);
-					else applyReviewFindingsSummary(job, kept.length, dropped);
 				}
 				return;
 			}
@@ -1403,19 +1342,13 @@ export async function startReviewServer(options: {
 			req.method === "GET"
 		) {
 			// Custom reviews discovery. Reloaded per request, no file watching.
-			// Repo profiles are scoped to a single unambiguous local repo:
-			// excluded in remote-only PR mode and ambiguous workspace mode.
-			const repoCwd =
-				!isPRMode && !isWorkspaceMode && options.gitContext
-					? options.gitContext.cwd
-					: undefined;
-			const profiles = loadReviewProfiles({ repoCwd });
+			// Profiles come from the user dir plus builtins.
+			const profiles = loadReviewProfiles();
 			const body: ReviewProfilesResponse = {
 				profiles: profiles.map((p) => ({
 					id: p.id,
 					label: p.label,
 					description: p.description,
-					engines: p.engines,
 					source: p.source,
 					sourcePath: p.sourcePath,
 					default: p.default,

--- a/apps/pi-extension/vendor.sh
+++ b/apps/pi-extension/vendor.sh
@@ -7,19 +7,20 @@ cd "$(dirname "$0")"
 rm -rf generated
 mkdir -p generated generated/ai/providers
 
-for f in feedback-templates prompts review-core diff-paths cli-pagination jj-core vcs-core review-args storage draft project pr-types pr-provider pr-stack pr-github pr-gitlab checklist integrations-common repo reference-common favicon code-file resolve-file config external-annotation agent-jobs worktree worktree-pool html-to-markdown url-to-markdown tour annotate-args at-reference review-workspace-node review-workspace pfm-reminder improvement-hooks code-nav data-dir semantic-diff-types semantic-diff; do
+for f in feedback-templates prompts review-core diff-paths cli-pagination jj-core vcs-core review-args storage draft project pr-types pr-provider pr-stack pr-github pr-gitlab checklist integrations-common repo reference-common favicon code-file resolve-file config external-annotation agent-jobs worktree worktree-pool html-to-markdown url-to-markdown tour annotate-args at-reference review-workspace-node review-workspace pfm-reminder improvement-hooks code-nav data-dir semantic-diff-types semantic-diff review-profiles; do
   src="../../packages/shared/$f.ts"
   printf '// @generated — DO NOT EDIT. Source: packages/shared/%s.ts\n' "$f" | cat - "$src" > "generated/$f.ts"
 done
 
 # Vendor review agent modules from packages/server/ — rewrite imports for generated/ layout
-for f in agent-review-message codex-review claude-review path-utils; do
+for f in agent-review-message codex-review claude-review path-utils review-profile-loader; do
   src="../../packages/server/$f.ts"
   printf '// @generated — DO NOT EDIT. Source: packages/server/%s.ts\n' "$f" | cat - "$src" \
     | sed 's|from "./vcs"|from "./review-core.js"|' \
     | sed 's|from "./pr"|from "./pr-provider.js"|' \
     | sed 's|from "./path-utils"|from "./path-utils.js"|' \
     | sed 's|from "@plannotator/shared/review-workspace"|from "./review-workspace.js"|' \
+    | sed 's|from "@plannotator/shared/review-profiles"|from "./review-profiles.js"|' \
     | sed 's|from "@plannotator/shared/data-dir"|from "./data-dir"|' \
     > "generated/$f.ts"
 done

--- a/docs/agent-jobs-code-review-handoff.md
+++ b/docs/agent-jobs-code-review-handoff.md
@@ -1,0 +1,855 @@
+# Agent Jobs and Automated Code Review Handoff
+
+Last verified against the worktree on 2026-06-13.
+
+This document is a map for coding agents that need to modify or debug
+Plannotator's automated code review features. It covers:
+
+- The code review command path.
+- Background agent jobs for Claude, Codex, and Code Tour.
+- The programmatic protocols used to run Claude and Codex.
+- Programmatic creation of annotations over diffs.
+- The Ask AI provider layer, which is separate from background review jobs.
+- The Bun server and Pi server mirror points that must stay in parity.
+
+## Mental Model
+
+Plannotator has two distinct AI systems in code review mode.
+
+1. Background review agents:
+   - Launched from the Review Agents sidebar.
+   - Exposed over `/api/agents/*`.
+   - Spawn external CLI processes (`claude`, `codex`) and track them as jobs.
+   - Code review jobs emit findings as external diff annotations.
+   - Code Tour jobs emit a structured tour artifact and do not emit annotations.
+
+2. Ask AI:
+   - Launched from inline diff/UI questions.
+   - Exposed over `/api/ai/*`.
+   - Uses provider sessions from `@plannotator/ai`.
+   - Streams normalized `AIMessage` events.
+   - Does not create review annotations by itself.
+
+Keep these separate. They share diff context and UI surfaces, but their
+protocols, state stores, and result ingestion paths are different.
+
+## Code Review Entry Flow
+
+The host-facing command is `plannotator review [optional-pr-url]`.
+
+1. Agent skills or command wrappers invoke `plannotator review`.
+2. `apps/hook/server/index.ts` parses review args.
+3. It captures one of:
+   - local Git/JJ diff,
+   - nested workspace diff,
+   - remote PR/MR patch,
+   - PR/MR patch plus an optional local checkout for file access.
+4. It starts `startReviewServer()` from `packages/server/review.ts`.
+5. The browser review UI loads the review-editor bundle.
+6. The user or a background agent creates annotations.
+7. The UI posts `/api/feedback`.
+8. The server resolves `waitForDecision()`.
+9. The CLI prints feedback or approval text to stdout for the host agent.
+
+OpenCode has an internal bridge (`opencode-review`) that returns structured
+JSON instead of plain stdout, but it still starts the same review server.
+
+Codex manual code review uses the same CLI command from a Codex shell bang:
+
+```bash
+!plannotator review
+```
+
+## Background Agent Job Protocol
+
+Shared contract: `packages/shared/agent-jobs.ts`.
+
+State:
+
+- `AgentJobStatus`: `starting`, `running`, `done`, `failed`, `killed`.
+- `AgentJobInfo`: job id, source id, provider, label, status, timestamps,
+  command, cwd, prompt, summary, PR attribution, model/effort metadata, and
+  launch-time diff context.
+- `jobSource(id)`: creates the source string `agent-<first-8-id-chars>`.
+  This source is used to group annotations produced by the job.
+
+HTTP endpoints:
+
+| Endpoint | Method | Purpose |
+| --- | --- | --- |
+| `/api/agents/capabilities` | GET | Returns available providers. |
+| `/api/agents/jobs/stream` | GET | SSE stream. Sends an initial snapshot and later job/log events. |
+| `/api/agents/jobs?since=N` | GET | Polling fallback, 304 when version is unchanged. |
+| `/api/agents/jobs` | POST | Launch a job. |
+| `/api/agents/jobs/:id` | DELETE | Kill one job. |
+| `/api/agents/jobs` | DELETE | Kill all running jobs. |
+
+SSE events:
+
+- `snapshot`
+- `job:started`
+- `job:updated`
+- `job:completed`
+- `job:log`
+- `jobs:cleared` (currently a no-op on the UI side because kill-all emits
+  per-job completion events)
+
+Transport behavior:
+
+- SSE sends a heartbeat comment every 30 seconds.
+- UI falls back to 500 ms polling if it never receives a stream snapshot.
+- All job state is in memory and scoped to the review server lifetime.
+
+Spawn behavior:
+
+- The server builds commands for known providers. The UI sends provider and
+  configuration, not trusted argv.
+- Spawned processes receive:
+  - `PLANNOTATOR_AGENT_SOURCE=<job source>`
+  - `PLANNOTATOR_API_URL=<review server base url>`
+- These env vars let external tools post their own annotations with the same
+  source identity, although built-in Claude/Codex jobs ingest results directly
+  server-side.
+- Result ingestion runs before `job:completed` is broadcast, so annotations
+  should reach the UI before the job card switches to a terminal state.
+- Server shutdown calls `killAll()`.
+
+Capability detection:
+
+- `claude`: available when `claude` is on PATH.
+- `codex`: available when `codex` is on PATH.
+- `tour`: available when either `claude` or `codex` is on PATH.
+
+## Review Server Agent Launch Rules
+
+Main implementation: `packages/server/review.ts`.
+
+On agent launch, the server snapshots mutable review state before awaits:
+
+- current patch,
+- current diff type,
+- selected base,
+- PR metadata,
+- PR diff scope,
+- workspace context,
+- launch cwd.
+
+This matters because PR switches, diff switches, base switches, and checkout
+warmups can happen while a job is launching. The stored job metadata must match
+the diff the agent actually reviewed, not the diff currently displayed after a
+later UI action.
+
+Launch cwd rules:
+
+- Workspace review: use workspace root.
+- Local VCS review: resolve cwd from the active diff/worktree.
+- PR review with local checkout: wait for checkout before launching jobs that
+  claim local file access.
+- If a PR checkout cannot be produced, agent launch returns a 503 instead of
+  running in the wrong directory.
+
+Diff context rules:
+
+- Local and workspace jobs store `diffContext` on `AgentJobInfo`.
+- PR jobs store PR URL and PR diff scope instead.
+- The job detail panel uses the job's launch-time diff context for "Copy All",
+  not the UI's current diff context.
+
+## Programmatic Claude Code Review
+
+Implementation: `packages/server/claude-review.ts`.
+
+Claude uses a severity-oriented review schema:
+
+- `important`
+- `nit`
+- `pre_existing`
+
+Command shape:
+
+```text
+claude -p
+  --permission-mode dontAsk
+  --output-format stream-json
+  --verbose
+  --json-schema <inline schema>
+  --no-session-persistence
+  --model <model>
+  [--effort <effort>]
+  --tools Agent,Bash,Read,Glob,Grep
+  --allowedTools <read-only allowlist>
+  --disallowedTools <write/network/shell denylist>
+```
+
+Protocol details:
+
+- The review prompt is written to stdin, not passed as an argv argument.
+- stdout is captured because final structured output arrives in stream JSON.
+- stderr is captured for error tail and streamed as live logs.
+- stdout JSONL lines are formatted into readable live logs with
+  `formatClaudeLogEvent()`.
+- The final result is the last `type: "result"` event with
+  `structured_output`.
+- `parseClaudeStreamOutput()` returns null on errors or malformed output.
+
+Result transform:
+
+- `transformClaudeFindings()` converts findings into review annotations.
+- Paths are made relative to cwd.
+- Workspace mode can apply `workspace.normalizeAnnotationPath()`.
+- The annotation author is `Claude Code`.
+- `text` is prefixed with `[severity]`.
+- `severity` and `reasoning` are preserved on the annotation.
+- Side is always `new`, scope is `line`, type is `comment`.
+
+Summary:
+
+- `important == 0` means `Correct`.
+- Any important finding means `Issues Found`.
+- Confidence is derived from important finding count.
+
+UI defaults:
+
+- `packages/ui/hooks/useAgentSettings.ts` defaults review Claude to
+  `claude-opus-4-7` with effort `high`.
+- The server command builder also has a fallback model, but the UI normally
+  sends explicit settings.
+
+## Programmatic Codex Code Review
+
+Implementation: `packages/server/codex-review.ts`.
+
+Codex uses a priority-oriented schema modeled on Codex review output:
+
+- `priority`: 0, 1, 2, 3, or null.
+- `code_location.absolute_file_path`
+- `code_location.line_range.start/end`
+- `overall_correctness`
+- `overall_explanation`
+- `overall_confidence_score`
+
+Command shape:
+
+```text
+codex
+  [-m <model>]
+  [-c model_reasoning_effort=<effort>]
+  [-c service_tier=fast]
+  exec
+  --output-schema <materialized schema path>
+  -o <temp output path>
+  --full-auto
+  --ephemeral
+  -C <cwd>
+  <prompt>
+```
+
+Protocol details:
+
+- The output schema is materialized under the Plannotator data dir because the
+  compiled Bun binary virtual filesystem is not readable by external processes.
+- The prompt is passed as the final argv item.
+- Structured output is written to the `-o` file.
+- `parseCodexOutput()` reads and deletes the temp output file.
+- Debug logging goes to `codex-review-debug.log` only when
+  `PLANNOTATOR_DEBUG` is set.
+
+Result transform:
+
+- `transformReviewFindings()` converts Codex findings into review annotations.
+- Paths are made relative to cwd.
+- Workspace mode can apply `workspace.normalizeAnnotationPath()`.
+- The annotation author is `Codex`.
+- `text` is `title` plus `body`.
+- Side is always `new`, scope is `line`, type is `comment`.
+
+Summary:
+
+- If any P0/P1 finding exists, Plannotator overrides the freeform correctness
+  with `Issues Found`.
+- Otherwise it uses Codex's overall correctness/explanation/confidence.
+
+UI defaults:
+
+- `packages/ui/hooks/useAgentSettings.ts` defaults review Codex to
+  `gpt-5.3-codex`, reasoning `high`, fast mode off.
+
+## Prompt Construction for Review Jobs
+
+Shared prompt-target logic: `packages/server/agent-review-message.ts`.
+
+Target kinds:
+
+- `local`: local Git/JJ/P4/etc diff.
+- `pr`: PR/MR review.
+- `workspace`: multiple nested VCS repositories under one workspace root.
+
+Known local Git/JJ diff modes usually do not inline the patch. Instead the
+agent gets instructions such as `git diff --staged`, `git diff HEAD~1..HEAD`,
+`jj diff --git -r @`, or a merge-base recipe. Unknown modes fall back to
+inlining the patch.
+
+PR behavior:
+
+- Remote-only PR review can be just the PR URL.
+- PR with local checkout tells the agent it is in a local worktree at PR head
+  and should diff against `origin/<base>...HEAD`.
+- Full-stack stacked PR review inlines the accumulated stack diff.
+
+Workspace behavior:
+
+- The prompt inlines the combined workspace patch.
+- Changed paths are prefixed by child repo folder.
+- Findings must report paths exactly as shown in the diff.
+- Agents are told not to use bare repo-relative paths or absolute paths.
+
+## Code Tour Protocol
+
+Implementation:
+
+- Shared output types: `packages/shared/tour.ts`.
+- Server session: `packages/server/tour/tour-review.ts`.
+- UI fetch hook/dialog: `packages/review-editor/hooks/tour/useTourData.ts`,
+  `packages/review-editor/components/tour/TourDialog.tsx`.
+
+Code Tour uses the same `/api/agents/jobs` transport with provider `tour`.
+The launch payload includes `engine: "claude" | "codex"` and the model/effort
+settings for that engine.
+
+Tour output shape:
+
+- `title`
+- `greeting`
+- `intent`
+- `before`
+- `after`
+- `key_takeaways`
+- `stops`
+- `qa_checklist`
+
+Each stop has anchors with `file`, `line`, `end_line`, `hunk`, and `label`.
+The prompt requires every anchor hunk to contain real unified diff text.
+
+Claude tour:
+
+- Uses `claude -p`.
+- Uses stream JSON and an inline JSON schema.
+- Prompt is written to stdin.
+- stdout is captured and parsed by `parseTourStreamOutput()`.
+
+Codex tour:
+
+- Uses `codex exec`.
+- Materializes the tour schema to the Plannotator data dir.
+- Writes structured output to a temp file.
+- Parsed by `parseTourFileOutput()`.
+
+Tour result storage:
+
+- `createTourSession()` stores successful tours in an in-memory
+  `Map<jobId, CodeTourOutput>`.
+- Checklists are stored in a second in-memory map.
+- `GET /api/tour/:jobId` returns the tour plus checklist state.
+- `PUT /api/tour/:jobId/checklist` persists checklist booleans for the session.
+- If a process exits 0 but no usable tour is parsed, the job is changed to
+  `failed` with `TOUR_EMPTY_OUTPUT_ERROR`.
+
+Code Tour does not create external annotations. It is explanatory, not a
+finding pipeline.
+
+## External Diff Annotation Protocol
+
+Shared validation/store: `packages/shared/external-annotation.ts`.
+Bun HTTP adapter: `packages/server/external-annotations.ts`.
+Pi HTTP adapter: `apps/pi-extension/server/external-annotations.ts`.
+UI hook: `packages/ui/hooks/useExternalAnnotations.ts`.
+
+HTTP endpoints:
+
+| Endpoint | Method | Purpose |
+| --- | --- | --- |
+| `/api/external-annotations/stream` | GET | SSE snapshot and mutation stream. |
+| `/api/external-annotations?since=N` | GET | Polling fallback, 304 when unchanged. |
+| `/api/external-annotations` | POST | Add one annotation or a batch. |
+| `/api/external-annotations?id=<id>` | PATCH | Update one annotation. |
+| `/api/external-annotations?id=<id>` | DELETE | Delete one annotation. |
+| `/api/external-annotations?source=<source>` | DELETE | Delete annotations by source. |
+| `/api/external-annotations` | DELETE | Clear all external annotations. |
+
+Accepted POST forms:
+
+```json
+{
+  "source": "agent-example",
+  "filePath": "packages/server/review.ts",
+  "lineStart": 430,
+  "lineEnd": 470,
+  "side": "new",
+  "type": "comment",
+  "scope": "line",
+  "text": "This finding appears in the changed code."
+}
+```
+
+```json
+{
+  "annotations": [
+    {
+      "source": "agent-example",
+      "filePath": "packages/server/review.ts",
+      "lineStart": 430,
+      "lineEnd": 470,
+      "side": "new",
+      "type": "comment",
+      "scope": "line",
+      "text": "This finding appears in the changed code."
+    }
+  ]
+}
+```
+
+Review-mode fields:
+
+- Required:
+  - `source`
+  - `filePath`
+  - `lineStart`
+  - `lineEnd`
+  - one of `text` or `suggestedCode`
+- Optional:
+  - `side`: `old` or `new`, defaults to `new`.
+  - `type`: `comment`, `suggestion`, or `concern`, defaults to `comment`.
+  - `scope`: `line` or `file`, defaults to `line`.
+  - `suggestedCode`
+  - `originalCode`
+  - `author`
+  - `severity`
+  - `reasoning`
+
+Server-assigned fields:
+
+- `id`
+- `createdAt`
+
+Programmatic creation path for built-in agents:
+
+1. Claude/Codex process exits successfully.
+2. `onJobComplete()` parses provider output.
+3. Provider findings are transformed into the same review annotation input
+   shape accepted by the HTTP API.
+4. `externalAnnotations.addAnnotations({ annotations })` validates and stores
+   them without doing an HTTP round trip.
+5. The shared annotation store broadcasts an `add` event over SSE.
+
+Programmatic creation path for external tools:
+
+1. Read `PLANNOTATOR_API_URL`.
+2. Read `PLANNOTATOR_AGENT_SOURCE`.
+3. POST review annotation JSON to
+   `$PLANNOTATOR_API_URL/api/external-annotations`.
+4. Use the env-provided source so the UI groups annotations under the job.
+
+Diff anchoring:
+
+- Review annotations use post-change line numbers for `side: "new"` and
+  pre-change line numbers for `side: "old"`.
+- The diff UI maps `new` to Pierre `additions` and `old` to Pierre
+  `deletions`.
+- Line-scoped annotations render on `lineEnd`.
+- File-scoped annotations are sidebar/header comments, not gutter markers.
+- In PR stack mode, annotations can include `prUrl` and `diffScope`.
+
+## Manual Annotation Flow in Review UI
+
+Main owner: `packages/review-editor/App.tsx`.
+
+Manual line comments follow the same `CodeAnnotation` shape:
+
+1. User selects diff lines.
+2. `pendingSelection` records start, end, and side.
+3. `handleAddAnnotationForFile()` creates a `CodeAnnotation`.
+4. `useAnnotationFactory()` attaches PR context when applicable.
+5. Annotation is added to local state.
+
+External and local annotations are merged:
+
+- Local annotations live in `annotations`.
+- SSE-delivered annotations live in `externalAnnotations`.
+- `allAnnotations` dedupes draft-restored external annotations against live
+  SSE versions.
+- Editing or deleting an external annotation routes to PATCH/DELETE.
+
+Submission:
+
+- `exportReviewFeedback()` renders markdown from `allAnnotations`.
+- UI POSTs `/api/feedback` with `approved`, `feedback`, `annotations`, and
+  optional `agentSwitch`.
+- Server resolves the review decision promise.
+- The CLI prints feedback to stdout.
+
+## Diff Rendering of Annotations
+
+Single-file diff:
+
+- `packages/review-editor/components/DiffViewer.tsx`
+- Maps `CodeAnnotation` to Pierre line annotations:
+  - `side: "new"` -> `additions`
+  - `side: "old"` -> `deletions`
+  - `lineNumber: lineEnd`
+  - metadata includes id, type, text, suggestion, author, severity, reasoning,
+    conventional labels, and decorations.
+
+All-files diff:
+
+- `packages/review-editor/components/AllFilesCodeView.tsx`
+- Uses the same projection as the single-file diff.
+- Filters by file path, PR URL, and PR diff scope.
+- Updates only files whose annotation signature changed to avoid remounting
+  the whole code view.
+
+Sidebar and job details:
+
+- `packages/review-editor/components/ReviewSidebar.tsx` groups annotations by
+  file and, in multi-PR cases, by PR.
+- `packages/review-editor/dock/panels/ReviewAgentJobDetailPanel.tsx` groups
+  findings for one job source and preserves deleted findings as dismissed.
+
+## Ask AI Protocol
+
+This is separate from background review jobs.
+
+Core package: `packages/ai/`.
+Server mount: `packages/server/ai-runtime.ts`.
+Review UI hook: `packages/review-editor/hooks/useAIChat.ts`.
+Shared UI hook: `packages/ui/hooks/useAIChat.ts`.
+
+Provider contract:
+
+- `AIProvider`
+- `AISession`
+- `AIMessage`
+- `CreateSessionOptions`
+
+HTTP endpoints:
+
+| Endpoint | Method | Purpose |
+| --- | --- | --- |
+| `/api/ai/capabilities` | GET | Lists registered providers, models, and default provider. |
+| `/api/ai/session` | POST | Creates or forks a provider session. |
+| `/api/ai/query` | POST | Streams normalized `AIMessage` SSE events. |
+| `/api/ai/abort` | POST | Aborts active provider query. |
+| `/api/ai/permission` | POST | Sends user allow/deny response to a provider permission request. |
+| `/api/ai/sessions` | GET | Lists tracked in-memory sessions. |
+
+Context:
+
+- `packages/ai/context.ts` builds provider-neutral prompts for plan review,
+  code review, and annotate mode.
+- Code review context includes the diff patch, optional file path, optional
+  selected line range, selected code, and user annotations.
+- Large plan/diff inputs are truncated before prompt injection.
+
+Claude Agent SDK provider:
+
+- File: `packages/ai/providers/claude-agent-sdk.ts`.
+- Uses `@anthropic-ai/claude-agent-sdk`.
+- Supports true fork, resume, streaming, and tools.
+- Fresh sessions use Claude Code preset prompt plus appended Plannotator
+  context.
+- Forked sessions resume parent session with `forkSession: true` and inject a
+  Plannotator preamble on the first query.
+- Permission requests are bridged back with `control_response`.
+
+Codex SDK provider:
+
+- File: `packages/ai/providers/codex-sdk.ts`.
+- Uses `@openai/codex-sdk`.
+- Supports resume, streaming, and tools.
+- Does not support true fork. The endpoint layer falls back to a fresh session.
+- Defaults to read-only sandbox mode.
+- Maps Codex thread/item events into normalized AI messages.
+- Text deltas are computed from cumulative `agent_message` text updates.
+
+Provider registration:
+
+- Bun runtime registers Claude and Codex providers when their SDK packages can
+  be imported, passing explicit CLI paths when found. Pi and OpenCode providers
+  are registered only when their CLIs are found.
+- Pi runtime mirrors this through generated provider files and Node adapters.
+- The UI chooses a default provider from detected Plannotator origin, user
+  cookies, and server default.
+
+## Bun and Pi Runtime Parity
+
+Bun server source:
+
+- `packages/server/review.ts`
+- `packages/server/agent-jobs.ts`
+- `packages/server/external-annotations.ts`
+- `packages/server/ai-runtime.ts`
+
+Pi server mirror:
+
+- `apps/pi-extension/server/serverReview.ts`
+- `apps/pi-extension/server/agent-jobs.ts`
+- `apps/pi-extension/server/external-annotations.ts`
+- `apps/pi-extension/server/ai-runtime.ts`
+
+Shared or vendored sources:
+
+- `packages/shared/agent-jobs.ts`
+- `packages/shared/external-annotation.ts`
+- `packages/shared/tour.ts`
+- `packages/ai/*`
+- `packages/server/agent-review-message.ts`
+- `packages/server/claude-review.ts`
+- `packages/server/codex-review.ts`
+- `packages/server/tour/tour-review.ts`
+
+Pi vendoring:
+
+- `apps/pi-extension/vendor.sh` copies shared/server/AI modules into
+  `apps/pi-extension/generated/`.
+- If you add a new shared or review-agent source module needed by Pi, update
+  `vendor.sh`.
+- Do not edit generated files directly.
+
+## Relevant File Map
+
+Entry and command surfaces:
+
+- `apps/skills/core/plannotator-review/SKILL.md`: generic agent skill that
+  runs `plannotator review`.
+- `apps/skills/core/plannotator-review/agents/openai.yaml`: OpenAI skill
+  metadata.
+- `apps/skills/claude/plannotator-review/SKILL.md`: Claude-specific skill
+  with `Bash(plannotator:*)`.
+- `apps/hook/server/index.ts`: main CLI entry, review arg parsing, diff/PR
+  capture, server startup, stdout feedback.
+- `apps/opencode-plugin/index.ts`: OpenCode command interception and embedded
+  runtime bridge.
+- `apps/codex/README.md`: Codex user-facing command docs.
+- `apps/droid-plugin/commands/plannotator-review.js`: Droid wrapper.
+- `apps/pi-extension/index.ts`: Pi command registration.
+- `apps/pi-extension/plannotator-browser.ts`: Pi browser review startup.
+
+Review server and diff context:
+
+- `packages/server/review.ts`: central Bun code review server, endpoints,
+  agent jobs, external annotations, AI endpoints, PR mode, workspace mode.
+- `packages/server/review-workspace.ts`: server workspace diff support.
+- `packages/shared/review-workspace.ts`: workspace prompt/context contracts.
+- `packages/shared/review-core.ts`: shared review diff selection logic.
+- `packages/shared/review-args.ts`: review CLI arg parsing.
+- `packages/shared/pr-stack.ts`: stacked PR diff scope and full-stack diff
+  helpers.
+- `packages/server/pr.ts`: GitHub/GitLab PR metadata, diffs, reviews, viewed
+  files.
+- `packages/server/vcs.ts`: Git/JJ/P4 diff execution and CWD resolution.
+
+Agent job transport:
+
+- `packages/shared/agent-jobs.ts`: shared job types, events, state helpers.
+- `packages/server/agent-jobs.ts`: Bun HTTP/SSE/process adapter.
+- `apps/pi-extension/server/agent-jobs.ts`: Pi Node/http/process adapter.
+- `packages/ui/hooks/useAgentJobs.ts`: UI SSE/polling hook and launch/kill API.
+- `packages/ui/components/AgentsTab.tsx`: Review Agents launch panel and job
+  list.
+- `packages/ui/hooks/useAgentSettings.ts`: persisted agent mode/engine/model
+  defaults.
+
+Claude, Codex, and tour jobs:
+
+- `packages/server/agent-review-message.ts`: provider-neutral review user
+  message builder.
+- `packages/server/claude-review.ts`: Claude prompt, command builder, parser,
+  finding transform, live log formatter.
+- `packages/server/codex-review.ts`: Codex prompt, schema materialization,
+  command builder, output parser, finding transform.
+- `packages/server/tour/tour-review.ts`: tour prompt, schema, Claude/Codex
+  tour command builders, parsers, in-memory tour session.
+- `packages/shared/tour.ts`: tour output types shared with UI.
+
+External annotations:
+
+- `packages/shared/external-annotation.ts`: validation, in-memory store,
+  mutation events.
+- `packages/server/external-annotations.ts`: Bun HTTP/SSE adapter.
+- `apps/pi-extension/server/external-annotations.ts`: Pi Node/http adapter.
+- `packages/ui/hooks/useExternalAnnotations.ts`: UI SSE/polling hook.
+- `packages/ui/types.ts`: `CodeAnnotation`, `DiffAnnotationMetadata`, severity
+  styles.
+- `packages/review-editor/hooks/useAnnotationFactory.ts`: attaches PR context
+  to local annotations.
+- `packages/review-editor/utils/exportFeedback.ts`: renders annotation
+  markdown for agents and job detail copy.
+
+Review UI:
+
+- `packages/review-editor/App.tsx`: review UI state owner, annotation merge,
+  agent job hook, AI hook, feedback submission.
+- `packages/review-editor/components/DiffViewer.tsx`: single-file Pierre diff
+  rendering and annotation projection.
+- `packages/review-editor/components/AllFilesCodeView.tsx`: all-files diff
+  rendering and annotation projection.
+- `packages/review-editor/components/InlineAnnotation.tsx`: inline rendered
+  annotation body inside diff views, including severity, reasoning, and
+  suggested code display.
+- `packages/review-editor/components/ToolbarHost.tsx`: isolates toolbar state
+  from parent diff lists and exposes imperative annotation-edit hooks.
+- `packages/review-editor/hooks/useAnnotationToolbar.ts`: manual line/token
+  selection, draft preservation, suggestion original-code extraction, and
+  annotation submit/edit behavior.
+- `packages/review-editor/components/AnnotationToolbar.tsx`: floating form for
+  manual comments, suggestions, conventional labels, and Ask AI handoff.
+- `packages/review-editor/components/SuggestionBlock.tsx`: renders suggested
+  code blocks attached to annotations.
+- `packages/review-editor/components/SuggestionModal.tsx`: expanded editor for
+  larger suggested-code edits.
+- `packages/review-editor/components/ReviewSidebar.tsx`: annotations, AI, and
+  agents tabs.
+- `packages/review-editor/dock/ReviewStateContext.tsx`: shared dock panel
+  state.
+- `packages/review-editor/dock/JobLogsContext.tsx`: job log context for dock
+  panels.
+- `packages/review-editor/dock/panels/ReviewAgentJobDetailPanel.tsx`: job
+  detail, findings snapshot, logs, copied prompt/command.
+- `packages/review-editor/hooks/tour/useTourData.ts`: tour fetch/checklist
+  hook.
+- `packages/review-editor/components/tour/TourDialog.tsx`: tour UI.
+- `packages/review-editor/components/tour/TourStopCard.tsx`: tour stop and
+  diff hunk rendering.
+- `packages/review-editor/components/DiffHunkPreview.tsx`: robust tour hunk
+  preview rendering.
+- `packages/review-editor/utils/patchParser.ts`: extracts selected code from a
+  patch for suggestions and Ask AI prompts.
+
+Ask AI:
+
+- `packages/ai/types.ts`: provider/session/message contracts.
+- `packages/ai/provider.ts`: provider registry and factory creation.
+- `packages/ai/session-manager.ts`: in-memory AI session tracking and ID
+  remapping.
+- `packages/ai/endpoints.ts`: `/api/ai/*` endpoint implementations.
+- `packages/ai/context.ts`: context-to-prompt builders.
+- `packages/ai/base-session.ts`: shared session lifecycle/abort behavior.
+- `packages/ai/providers/claude-agent-sdk.ts`: Claude Agent SDK provider.
+- `packages/ai/providers/codex-sdk.ts`: Codex SDK provider.
+- `packages/server/ai-runtime.ts`: Bun provider registration and endpoint
+  mount.
+- `apps/pi-extension/server/ai-runtime.ts`: Pi provider registration and
+  Node/http bridge.
+- `packages/ui/hooks/useAIChat.ts`: shared UI session/query stream hook.
+- `packages/review-editor/hooks/useAIChat.ts`: code-review wrapper around the
+  shared hook.
+- `packages/ui/utils/aiProvider.ts`: provider/model default selection.
+
+Tests and verification:
+
+- `packages/server/agent-review-message.test.ts`: review prompt construction
+  including local diff instructions, workspace path rules, and Claude command
+  allowlist.
+- `packages/server/tour/tour-review.test.ts`: tour prompt construction,
+  Claude command allowlist, stream/file parsing.
+- `packages/server/external-annotations.test.ts`: external annotation SSE
+  idle-timeout behavior.
+- `packages/ai/ai.test.ts`: session manager, endpoint behavior, Codex SDK
+  event mapping, multi-provider capabilities.
+- `packages/review-editor/utils/exportFeedback.test.ts`: feedback markdown
+  formatting.
+- `packages/review-editor/utils/exportFeedback.workspace.test.ts`: workspace
+  feedback formatting.
+- `apps/pi-extension/server.test.ts`: Pi server review endpoint parity.
+
+## Change Checklist
+
+When changing background review agents:
+
+1. Update shared contracts first (`packages/shared/agent-jobs.ts` or
+   `packages/shared/external-annotation.ts`) if the wire shape changes.
+2. Update the Bun adapter in `packages/server/*`.
+3. Update the Pi adapter in `apps/pi-extension/server/*`.
+4. If Pi needs generated source changes, update `apps/pi-extension/vendor.sh`.
+5. Update UI hooks and components that consume the shape.
+6. Update export/feedback behavior if annotation metadata changes.
+7. Add or update tests for:
+   - command construction,
+   - provider output parsing,
+   - transform-to-annotation behavior,
+   - SSE/polling behavior,
+   - Pi parity when relevant.
+
+When changing Claude review:
+
+1. Keep command prompt-on-stdin behavior unless there is a strong reason to
+   change it.
+2. Keep the allowlist read-oriented and the denylist write/network/shell
+   oriented.
+3. Update `CLAUDE_REVIEW_SCHEMA_JSON`, parser, transform, UI severity display,
+   and tests together.
+4. Remember that tour-with-Claude also streams Claude JSONL and uses the same
+   live log formatter.
+
+When changing Codex review:
+
+1. Keep schema materialization to a real file.
+2. Keep temp output cleanup on success and failure.
+3. Update schema, parser, transform, and tests together.
+4. If a new Codex CLI flag is added, put global flags before `exec`.
+
+When changing Code Tour:
+
+1. Keep `tour` as a job provider, not an annotation producer.
+2. Keep tour output stored by job id and fetched through `/api/tour/:jobId`.
+3. Treat empty or malformed tour output as a failed job.
+4. Update shared tour types, schema, parser, UI hook, and dialog together.
+
+When changing external annotations:
+
+1. Preserve single-object and batch POST forms.
+2. Preserve SSE snapshot-on-connect and polling `since` fallback.
+3. Keep server-assigned ids and timestamps.
+4. Validate line numbers and required text/suggestion inputs server-side.
+5. Keep local and external annotation edit/delete paths distinct in the UI.
+
+When changing Ask AI:
+
+1. Do not confuse provider sessions with background review jobs.
+2. If provider capability semantics change, update `/api/ai/session` fork
+   fallback behavior.
+3. Keep permission responses normalized through `respondToPermission()`.
+4. Keep context truncation and review-specific prompt builders in
+   `packages/ai/context.ts`.
+
+## Common Failure Modes
+
+- Job launches in the wrong cwd:
+  check PR checkout warmup, `resolveAgentCwdReady()`, worktree path existence,
+  and launch-time state snapshotting.
+
+- Agent findings appear under the wrong PR or diff scope:
+  check `job.prUrl`, `job.diffScope`, PR switch cache, and transform mapping in
+  `onJobComplete()`.
+
+- Job detail "Copy All" has the wrong diff header:
+  check `job.diffContext` and `ReviewAgentJobDetailPanel`.
+
+- Claude job finishes with no findings and no verdict:
+  inspect stream JSON final result parsing and stdout capture.
+
+- Codex job exits 0 but no annotations appear:
+  inspect temp output file contents, schema path, `parseCodexOutput()`, and
+  transform validation errors from `externalAnnotations.addAnnotations()`.
+
+- Tour job auto-opens a 404:
+  it should not. `onJobComplete()` should mark malformed tour output as failed
+  before `job:completed`.
+
+- External annotations show in sidebar but not gutter:
+  check `filePath`, `scope`, `side`, `lineEnd`, PR URL, and diff scope filters.
+
+- External annotations disappear after delete but job details still show them:
+  this is intentional. Job detail snapshots deleted findings as dismissed.
+
+- Ask AI can read the wrong PR files:
+  check `/api/ai/session` PR checkout guard in `packages/server/review.ts`.

--- a/docs/custom-reviews.md
+++ b/docs/custom-reviews.md
@@ -1,14 +1,12 @@
 # Custom Reviews
 
-Status: design reference, not yet implemented.
-
 Custom reviews let a developer run a named review — "Security", "Performance",
 "API Contract" — through the existing Claude and Codex background review
 pipeline, instead of only the default review.
 
 This doc is the authoritative spec. It is deliberately small. The companion
-`agent-jobs-code-review-handoff.md` describes the current code this builds on;
-read it first if you are new to the review pipeline.
+`agent-jobs-code-review-handoff.md` describes the code this builds on; read it
+first if you are new to the review pipeline.
 
 ## What this is
 
@@ -29,7 +27,7 @@ Two rules keep this simple:
 1. **Zero-config by default.** A user who never makes a profile gets the full
    Default review, exactly as today. The picker adds one dropdown, nothing more.
 2. **Minimal input.** Authoring a profile means writing intent, not filling out
-   a schema. Anything we can infer (`id`, `label`, `engines`) we infer.
+   a schema. Anything we can infer (`id`, `label`) we infer.
 
 The user only ever thinks about three things: which engine, which review, and
 the review's intent. Schemas, provider output formats, job protocols, and
@@ -48,11 +46,10 @@ export interface ReviewProfile {
   label: string;         // inferred from id if omitted
   instructions: string;  // the only field a human must write
   description?: string;
-  engines?: Array<"claude" | "codex">; // defaults to all engines
 }
 
 export interface ResolvedReviewProfile extends ReviewProfile {
-  source: "builtin" | "user" | "repo";
+  source: "builtin" | "user";
   sourcePath?: string;
 }
 ```
@@ -66,25 +63,22 @@ and `source`; that is enough to answer "which review produced these findings?"
 
 ## Where profiles live
 
-Three sources, loaded in this order:
+Two sources, loaded in this order:
 
 | Source | Location | Notes |
 | --- | --- | --- |
 | `builtin` | in code | `builtin:default` is today's review, preserved. |
 | `user` | `${PLANNOTATOR_DATA_DIR}/reviews/*.json` | personal, available in every repo |
-| `repo` | `.plannotator/reviews/*.json` | checked in, shared with the team |
 
 Use the existing Plannotator data-dir abstraction for the user path. Do not
 hardcode `~/.plannotator` — the data dir is overridable.
 
 ### Inference
 
-For user and repo profiles, the loader fills in what the file omits:
+For user profiles, the loader fills in what the file omits:
 
-- `id` ← filename stem, namespaced by source: `security.json` → `user:security`
-  or `repo:security`.
+- `id` ← filename stem, namespaced by source: `security.json` → `user:security`.
 - `label` ← title-cased id: `api-contracts` → `API Contracts`.
-- `engines` ← all supported engines.
 
 Inference runs once at load time. The rest of the system only ever sees a
 fully-resolved profile.
@@ -94,19 +88,11 @@ fully-resolved profile.
 Kept trivial on purpose:
 
 - `builtin:default` is special-cased and always wins its name.
-- If a user and a repo profile resolve to the same bare name, the user one wins.
 - A malformed JSON file is skipped, with one log line. It does not break
   discovery.
 
-That is the whole collision story. No reserved-ID engine, no precedence
-framework — a sort and a `Map`.
-
-### Repo profiles
-
-A repo profile is just instructions handed to a CLI the developer already runs
-inside that repo. It escalates nothing the agent could not already do. The only
-thing worth surfacing is provenance: mark repo-sourced profiles with a small
-`repo` tag in the picker so the user knows where the option came from.
+That is the whole collision story. No reserved-ID machinery, no precedence
+framework — a `Map` with first-seen-wins.
 
 ## Discovery
 
@@ -122,8 +108,7 @@ export interface ReviewProfilesResponse {
     id: string;
     label: string;
     description?: string;
-    engines: Array<"claude" | "codex">;
-    source: "builtin" | "user" | "repo";
+    source: "builtin" | "user";
     sourcePath?: string;
     default?: boolean;
   }>;
@@ -151,11 +136,11 @@ export interface LaunchAgentJobRequest {
 }
 ```
 
-Today the Bun and Pi adapters forward only
-`{ engine?, model?, reasoningEffort?, effort?, fastMode? }` into `buildCommand`.
-Widen both to also parse and forward `reviewProfileId`, and reject unknown
-fields rather than ignoring them. Do **not** add an inline `reviewPrompt` — the
-launch API takes a profile id, never freeform prompt text.
+`reviewProfileId` selects which review's intent runs; engine and model are
+separate, independent runtime choices and are never carried on the profile. The
+Bun and Pi adapters both parse and forward `reviewProfileId` into `buildCommand`.
+There is no inline `reviewPrompt` — the launch API takes a profile id, never
+freeform prompt text.
 
 ### Job metadata
 
@@ -175,15 +160,9 @@ so the UI can show a small profile tag.
 
 Resolve the profile at the same boundary where `review.ts`'s `buildCommand`
 already snapshots launch state (patch, diff type, base, PR metadata, diff scope,
-workspace, cwd). Resolving there means a repo profile is read against the same
-target the agent will actually review.
+workspace, cwd).
 
-Repo-profile scoping, simplest safe version:
-
-- Built-in and user profiles: available everywhere.
-- Repo profiles: available only when there is one unambiguous local review repo.
-  In remote-only PR mode and ambiguous workspace mode, repo profiles are simply
-  absent from the picker.
+Built-in and user profiles are available everywhere.
 
 ## Prompt composition
 
@@ -198,7 +177,7 @@ instructions.
 ## Custom Review Profile
 
 Profile: <label>
-Source: <builtin|user|repo>
+Source: <builtin|user>
 
 <profile.instructions>
 
@@ -213,7 +192,10 @@ the default prompt is byte-for-byte today's prompt.
 ## Findings
 
 Both engines already parse into review findings and transform them into external
-annotations. Custom reviews change two things.
+annotations. **Every finding reaches the annotations panel** — nothing filters,
+drops, or hides findings based on diff overlap or anything else. Findings flow
+straight from transform to ingestion with only shape validation. Custom reviews
+change two things.
 
 ### One severity scale
 
@@ -235,24 +217,6 @@ small tag next to the byline — do not concatenate it into the author string.
 > `transformReviewFindings` (Codex) already takes an author argument. Carrying
 > the profile as metadata sidesteps a signature change on the Claude transform.
 
-### Keep findings honest to the diff
-
-Today findings flow straight from transform to `externalAnnotations.addAnnotations`
-with only shape validation. Add one cheap guard in `onJobComplete`, before
-ingestion: drop any finding whose file is not in the launch patch, and count how
-many were dropped.
-
-This is a ~15-line filter, not a module. No path-escape analysis, no rename
-normalization, no hunk-level validation. If every finding is dropped, fail the
-job (see below). Otherwise ingest the survivors and, if any were dropped,
-surface a calm one-liner:
-
-```txt
-8 findings · 2 skipped (not in the reviewed diff)
-```
-
-Never expose schema or provider internals in that message.
-
 ## Completion semantics
 
 Process success is not review success. Follow the Code Tour precedent already in
@@ -260,7 +224,6 @@ the codebase:
 
 - Process exits non-zero → job fails (today's behavior).
 - Output missing or unparseable → job fails.
-- Every finding dropped as out-of-diff → job fails.
 - Otherwise the job completes, and `job:completed` reflects the post-ingestion
   state.
 
@@ -288,7 +251,7 @@ packages/shared/review-profiles.ts
   Runtime-agnostic → vendored to Pi.
 
 packages/server/review-profile-loader.ts
-  Read built-in + user dir + repo dir, apply inference, return a flat list.
+  Read built-in + user dir, apply inference, return a flat list.
 ```
 
 Edits:
@@ -298,8 +261,8 @@ packages/shared/agent-jobs.ts          + reviewProfileId / reviewProfileLabel
 packages/server/agent-jobs.ts          parse + forward reviewProfileId
 apps/pi-extension/server/agent-jobs.ts mirror
 packages/server/review.ts              discovery route, launch-time resolution,
-                                       prompt composition, in-diff filter,
-                                       completion semantics, severity map
+                                       prompt composition, completion semantics,
+                                       severity map
 apps/pi-extension/server/serverReview.ts  mirror
 packages/server/claude-review.ts       prompt composition slot
 packages/server/codex-review.ts        prompt composition slot, priority→severity
@@ -318,43 +281,50 @@ The existing "Run Review" button keeps working throughout, because no
 4. Launch-time resolution in `review.ts`.
 5. Prompt composition.
 6. Severity normalization.
-7. In-diff filter + completion semantics.
+7. Completion semantics.
 
 Then, separately, the frontend (deferred): the engine/review picker in
-`AgentsTab.tsx`, sending `reviewProfileId` from `useAgentJobs.ts`, the repo tag,
-and the profile tag on annotations.
+`AgentsTab.tsx`, sending `reviewProfileId` from `useAgentJobs.ts`, and the
+profile tag on annotations.
 
 ## Tests
 
 Keep them proportional:
 
 - Inference: `security.json` → `user:security`, label title-casing.
-- Name clash: user beats repo; malformed file is skipped, not fatal.
+- Name clash: malformed file is skipped, not fatal.
 - Launch: `POST /api/agents/jobs` forwards `reviewProfileId`, rejects unknown
   fields, defaults to `builtin:default` when absent.
 - Prompt: custom section present for a profile, absent for default.
 - Severity: Codex priority maps to the shared scale.
-- Findings: out-of-diff finding is dropped; all-dropped fails the job.
 - Bun/Pi launch contracts stay compatible.
 
 One happy path and one failure path end to end:
 
 ```txt
-repo profile → launch Codex → parse → in-diff findings → annotations appear
-repo profile → provider exits 0 with junk → job fails → no annotations
+user profile → launch Codex → parse → findings → annotations appear
+user profile → provider exits 0 with junk → job fails → no annotations
 ```
 
 ## Deliberately not building
 
 Recorded so these stay cut, not silently reintroduced:
 
-- No precedence engine, reserved-ID system, or shadow-prevention rules. A sort
-  and a `Map`.
+- No precedence framework, reserved-ID system, or shadow-prevention rules. A
+  `Map` with first-seen-wins.
+- No per-repo profiles. Profiles are global-only
+  (`${PLANNOTATOR_DATA_DIR}/reviews/`); there is no repo source, repo trust, or
+  repo scoping.
+- No engine restriction on a profile. A profile is `id`/`label`/`instructions`
+  (`/description`); engine and model are independent runtime choices and are
+  never carried on the profile.
 - No content hashing / profile version tracking.
 - No structured discovery `diagnostics[]` channel. Skip-and-log.
 - No `ReviewEngineAdapter` interface or formal `NormalizedReviewResult` boundary.
   The two transforms returning a shared finding shape is enough.
-- No diff-anchoring module. A one-function in-diff filter.
+- No diff-anchoring or out-of-diff finding filter. Every finding reaches the
+  annotations panel; findings flow straight from transform to ingestion with
+  only shape validation.
 - No inline `reviewPrompt` in the launch API.
 - No temporary one-off profile workflow. If it's ever wanted, it's a thin layer
   that writes a user profile and launches by id — not part of this design.

--- a/docs/custom-reviews.md
+++ b/docs/custom-reviews.md
@@ -1,0 +1,363 @@
+# Custom Reviews
+
+Status: design reference, not yet implemented.
+
+Custom reviews let a developer run a named review — "Security", "Performance",
+"API Contract" — through the existing Claude and Codex background review
+pipeline, instead of only the default review.
+
+This doc is the authoritative spec. It is deliberately small. The companion
+`agent-jobs-code-review-handoff.md` describes the current code this builds on;
+read it first if you are new to the review pipeline.
+
+## What this is
+
+A review profile is a named bundle of review intent. You drop a JSON file in a
+folder, it shows up in the review picker, you pick it, findings come back the
+same way they do today.
+
+```json
+{ "instructions": "Focus only on security-impacting issues." }
+```
+
+That is a complete, valid profile.
+
+## Design rules
+
+Two rules keep this simple:
+
+1. **Zero-config by default.** A user who never makes a profile gets the full
+   Default review, exactly as today. The picker adds one dropdown, nothing more.
+2. **Minimal input.** Authoring a profile means writing intent, not filling out
+   a schema. Anything we can infer (`id`, `label`, `engines`) we infer.
+
+The user only ever thinks about three things: which engine, which review, and
+the review's intent. Schemas, provider output formats, job protocols, and
+annotation plumbing stay invisible. When a tidy internal contract and a simpler
+user experience conflict, the user experience wins — absorb the cost in the
+backend.
+
+This is a tool for open-source developers, not an enterprise config system.
+There is no governance layer (see [Deliberately not building](#deliberately-not-building)).
+
+## Data model
+
+```ts
+export interface ReviewProfile {
+  id: string;            // inferred from filename if omitted
+  label: string;         // inferred from id if omitted
+  instructions: string;  // the only field a human must write
+  description?: string;
+  engines?: Array<"claude" | "codex">; // defaults to all engines
+}
+
+export interface ResolvedReviewProfile extends ReviewProfile {
+  source: "builtin" | "user" | "repo";
+  sourcePath?: string;
+}
+```
+
+`instructions` is the reviewer focus. It is inserted into a bounded section of
+the provider prompt — it does not replace the provider's system or output-format
+instructions.
+
+No content hashing, no version tracking. The job stores the profile's `label`
+and `source`; that is enough to answer "which review produced these findings?"
+
+## Where profiles live
+
+Three sources, loaded in this order:
+
+| Source | Location | Notes |
+| --- | --- | --- |
+| `builtin` | in code | `builtin:default` is today's review, preserved. |
+| `user` | `${PLANNOTATOR_DATA_DIR}/reviews/*.json` | personal, available in every repo |
+| `repo` | `.plannotator/reviews/*.json` | checked in, shared with the team |
+
+Use the existing Plannotator data-dir abstraction for the user path. Do not
+hardcode `~/.plannotator` — the data dir is overridable.
+
+### Inference
+
+For user and repo profiles, the loader fills in what the file omits:
+
+- `id` ← filename stem, namespaced by source: `security.json` → `user:security`
+  or `repo:security`.
+- `label` ← title-cased id: `api-contracts` → `API Contracts`.
+- `engines` ← all supported engines.
+
+Inference runs once at load time. The rest of the system only ever sees a
+fully-resolved profile.
+
+### Name clashes
+
+Kept trivial on purpose:
+
+- `builtin:default` is special-cased and always wins its name.
+- If a user and a repo profile resolve to the same bare name, the user one wins.
+- A malformed JSON file is skipped, with one log line. It does not break
+  discovery.
+
+That is the whole collision story. No reserved-ID engine, no precedence
+framework — a sort and a `Map`.
+
+### Repo profiles
+
+A repo profile is just instructions handed to a CLI the developer already runs
+inside that repo. It escalates nothing the agent could not already do. The only
+thing worth surfacing is provenance: mark repo-sourced profiles with a small
+`repo` tag in the picker so the user knows where the option came from.
+
+## Discovery
+
+```txt
+GET /api/agents/review-profiles
+```
+
+Returns the resolved, launchable profiles:
+
+```ts
+export interface ReviewProfilesResponse {
+  profiles: Array<{
+    id: string;
+    label: string;
+    description?: string;
+    engines: Array<"claude" | "codex">;
+    source: "builtin" | "user" | "repo";
+    sourcePath?: string;
+    default?: boolean;
+  }>;
+}
+```
+
+Reload on each request. No file watching.
+
+## Launching
+
+Reuse the existing job launch endpoint. Add one field.
+
+```txt
+POST /api/agents/jobs
+```
+
+```ts
+export interface LaunchAgentJobRequest {
+  provider: "claude" | "codex" | "tour";
+  reviewProfileId?: string;   // absent → builtin:default
+  model?: string;
+  effort?: string;
+  reasoningEffort?: string;
+  fastMode?: boolean;
+}
+```
+
+Today the Bun and Pi adapters forward only
+`{ engine?, model?, reasoningEffort?, effort?, fastMode? }` into `buildCommand`.
+Widen both to also parse and forward `reviewProfileId`, and reject unknown
+fields rather than ignoring them. Do **not** add an inline `reviewPrompt` — the
+launch API takes a profile id, never freeform prompt text.
+
+### Job metadata
+
+Add two fields to `AgentJobInfo` (`packages/shared/agent-jobs.ts`, vendored to
+Pi):
+
+```ts
+reviewProfileId?: string;
+reviewProfileLabel?: string;
+```
+
+These give the job detail panel, logs, and exported markdown a stable answer to
+"which review profile ran?" `reviewProfileLabel` also rides on each annotation
+so the UI can show a small profile tag.
+
+## Launch-time resolution
+
+Resolve the profile at the same boundary where `review.ts`'s `buildCommand`
+already snapshots launch state (patch, diff type, base, PR metadata, diff scope,
+workspace, cwd). Resolving there means a repo profile is read against the same
+target the agent will actually review.
+
+Repo-profile scoping, simplest safe version:
+
+- Built-in and user profiles: available everywhere.
+- Repo profiles: available only when there is one unambiguous local review repo.
+  In remote-only PR mode and ambiguous workspace mode, repo profiles are simply
+  absent from the picker.
+
+## Prompt composition
+
+Deterministic and sectioned. Custom instructions never displace provider
+instructions.
+
+```txt
+<provider immutable review system prompt>
+
+<provider immutable output-format instructions>
+
+## Custom Review Profile
+
+Profile: <label>
+Source: <builtin|user|repo>
+
+<profile.instructions>
+
+---
+
+<existing buildAgentReviewUserMessage(...) output>
+```
+
+For `builtin:default`, the Custom Review Profile section is omitted entirely, so
+the default prompt is byte-for-byte today's prompt.
+
+## Findings
+
+Both engines already parse into review findings and transform them into external
+annotations. Custom reviews change two things.
+
+### One severity scale
+
+A user should see the same severity badges regardless of engine. Normalize to
+the shared `important | nit | pre_existing` scale:
+
+- Claude already emits this scale.
+- Codex emits `priority` 0–3 (or null). Map on ingest, e.g. `0,1 → important`,
+  `2 → nit`, `3/null → pre_existing`. Keep the map in one place so the UI never
+  has to know which engine ran.
+
+### Author and profile
+
+Keep `author` as the engine name (`Claude Code`, `Codex`) so the byline stays
+short. Carry the profile as `reviewProfileLabel` metadata and render it as a
+small tag next to the byline — do not concatenate it into the author string.
+
+> Note: `transformClaudeFindings` hardcodes `author: "Claude Code"`, while
+> `transformReviewFindings` (Codex) already takes an author argument. Carrying
+> the profile as metadata sidesteps a signature change on the Claude transform.
+
+### Keep findings honest to the diff
+
+Today findings flow straight from transform to `externalAnnotations.addAnnotations`
+with only shape validation. Add one cheap guard in `onJobComplete`, before
+ingestion: drop any finding whose file is not in the launch patch, and count how
+many were dropped.
+
+This is a ~15-line filter, not a module. No path-escape analysis, no rename
+normalization, no hunk-level validation. If every finding is dropped, fail the
+job (see below). Otherwise ingest the survivors and, if any were dropped,
+surface a calm one-liner:
+
+```txt
+8 findings · 2 skipped (not in the reviewed diff)
+```
+
+Never expose schema or provider internals in that message.
+
+## Completion semantics
+
+Process success is not review success. Follow the Code Tour precedent already in
+the codebase:
+
+- Process exits non-zero → job fails (today's behavior).
+- Output missing or unparseable → job fails.
+- Every finding dropped as out-of-diff → job fails.
+- Otherwise the job completes, and `job:completed` reflects the post-ingestion
+  state.
+
+A profile cannot turn a broken run into a green "0 findings."
+
+## Runtime parity
+
+Bun and Pi must behave the same. The launch contract, discovery endpoint, job
+metadata, and completion semantics all need to land in both:
+
+- `packages/server/review.ts` ↔ `apps/pi-extension/server/serverReview.ts`
+- `packages/server/agent-jobs.ts` ↔ `apps/pi-extension/server/agent-jobs.ts`
+
+New shared/server modules must be added to `apps/pi-extension/vendor.sh`. Every
+new module is paid twice (source + vendored copy), which is the main reason this
+design keeps the module count low.
+
+## Modules
+
+Two new files. Everything else is small edits.
+
+```txt
+packages/shared/review-profiles.ts
+  Types, shape validation, id-from-filename inference, name-clash resolution.
+  Runtime-agnostic → vendored to Pi.
+
+packages/server/review-profile-loader.ts
+  Read built-in + user dir + repo dir, apply inference, return a flat list.
+```
+
+Edits:
+
+```txt
+packages/shared/agent-jobs.ts          + reviewProfileId / reviewProfileLabel
+packages/server/agent-jobs.ts          parse + forward reviewProfileId
+apps/pi-extension/server/agent-jobs.ts mirror
+packages/server/review.ts              discovery route, launch-time resolution,
+                                       prompt composition, in-diff filter,
+                                       completion semantics, severity map
+apps/pi-extension/server/serverReview.ts  mirror
+packages/server/claude-review.ts       prompt composition slot
+packages/server/codex-review.ts        prompt composition slot, priority→severity
+apps/pi-extension/vendor.sh            add the new shared module
+```
+
+## Build order
+
+Backend only. The feature is fully drivable over HTTP — no UI required to test.
+The existing "Run Review" button keeps working throughout, because no
+`reviewProfileId` means `builtin:default`.
+
+1. Shared profile types + validation + inference.
+2. Profile loader + `GET /api/agents/review-profiles`.
+3. `reviewProfileId` parsing/forwarding in Bun and Pi adapters; job metadata.
+4. Launch-time resolution in `review.ts`.
+5. Prompt composition.
+6. Severity normalization.
+7. In-diff filter + completion semantics.
+
+Then, separately, the frontend (deferred): the engine/review picker in
+`AgentsTab.tsx`, sending `reviewProfileId` from `useAgentJobs.ts`, the repo tag,
+and the profile tag on annotations.
+
+## Tests
+
+Keep them proportional:
+
+- Inference: `security.json` → `user:security`, label title-casing.
+- Name clash: user beats repo; malformed file is skipped, not fatal.
+- Launch: `POST /api/agents/jobs` forwards `reviewProfileId`, rejects unknown
+  fields, defaults to `builtin:default` when absent.
+- Prompt: custom section present for a profile, absent for default.
+- Severity: Codex priority maps to the shared scale.
+- Findings: out-of-diff finding is dropped; all-dropped fails the job.
+- Bun/Pi launch contracts stay compatible.
+
+One happy path and one failure path end to end:
+
+```txt
+repo profile → launch Codex → parse → in-diff findings → annotations appear
+repo profile → provider exits 0 with junk → job fails → no annotations
+```
+
+## Deliberately not building
+
+Recorded so these stay cut, not silently reintroduced:
+
+- No precedence engine, reserved-ID system, or shadow-prevention rules. A sort
+  and a `Map`.
+- No content hashing / profile version tracking.
+- No structured discovery `diagnostics[]` channel. Skip-and-log.
+- No `ReviewEngineAdapter` interface or formal `NormalizedReviewResult` boundary.
+  The two transforms returning a shared finding shape is enough.
+- No diff-anchoring module. A one-function in-diff filter.
+- No inline `reviewPrompt` in the launch API.
+- No temporary one-off profile workflow. If it's ever wanted, it's a thin layer
+  that writes a user profile and launches by id — not part of this design.
+
+If one of these turns out to be genuinely needed, add it then, on evidence — not
+preemptively.

--- a/packages/server/agent-jobs-launch.test.ts
+++ b/packages/server/agent-jobs-launch.test.ts
@@ -111,17 +111,17 @@ describe("POST /api/agents/jobs — reviewProfileId launch plumbing", () => {
       async buildCommand() {
         return {
           command: ["true"],
-          reviewProfileId: "repo:api-contracts",
+          reviewProfileId: "user:api-contracts",
           reviewProfileLabel: "API Contracts",
         };
       },
     });
 
-    const res = await handler.handle(post({ provider: "claude", reviewProfileId: "repo:api-contracts" }), JOBS_URL);
+    const res = await handler.handle(post({ provider: "claude", reviewProfileId: "user:api-contracts" }), JOBS_URL);
 
     expect(res?.status).toBe(201);
     const { job } = await res!.json();
-    expect(job.reviewProfileId).toBe("repo:api-contracts");
+    expect(job.reviewProfileId).toBe("user:api-contracts");
     expect(job.reviewProfileLabel).toBe("API Contracts");
     handler.killAll();
   });

--- a/packages/server/agent-jobs-launch.test.ts
+++ b/packages/server/agent-jobs-launch.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Launch-plumbing tests for the custom-reviews `reviewProfileId` field.
+ *
+ * These exercise the Bun POST /api/agents/jobs handler contract that the Pi
+ * mirror must match byte-for-byte:
+ *  - `reviewProfileId` is parsed from the body and forwarded into buildCommand.
+ *  - Unknown fields are rejected (fail loud, not silently ignored).
+ *  - An absent id forwards no `reviewProfileId` (review.ts resolves that to
+ *    builtin:default).
+ *  - The launched job carries the reviewProfileId/Label stamped by buildCommand.
+ *
+ * `Bun.which` is mocked so capability detection reports providers available
+ * regardless of whether the host has the CLIs installed (CI parity).
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+const realWhich = Bun.which;
+beforeEach(() => {
+  // Make every provider "available" so the capability gate doesn't depend on
+  // the host having claude/codex installed.
+  (Bun as { which: typeof Bun.which }).which = (() => "/fake/bin") as typeof Bun.which;
+});
+afterEach(() => {
+  (Bun as { which: typeof Bun.which }).which = realWhich;
+});
+
+// Imported after the which-mock is in place at module top so the factory's
+// one-time capability scan sees available providers. createAgentJobHandler reads
+// Bun.which at call time (inside the factory), so import timing is irrelevant —
+// but the per-test beforeEach guarantees availability anyway.
+const { createAgentJobHandler } = await import("./agent-jobs");
+
+function post(body: unknown): Request {
+  return new Request("http://localhost/api/agents/jobs", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const JOBS_URL = new URL("http://localhost/api/agents/jobs");
+
+describe("POST /api/agents/jobs — reviewProfileId launch plumbing", () => {
+  test("forwards reviewProfileId into buildCommand config", async () => {
+    let seenConfig: Record<string, unknown> | undefined;
+    const handler = createAgentJobHandler({
+      mode: "review",
+      getServerUrl: () => "http://localhost:1234",
+      getCwd: () => "/tmp",
+      async buildCommand(_provider, config) {
+        seenConfig = config;
+        // Return a no-op command that won't actually spawn anything useful.
+        return { command: ["true"], reviewProfileId: "user:security", reviewProfileLabel: "Security" };
+      },
+    });
+
+    const res = await handler.handle(post({ provider: "codex", reviewProfileId: "user:security" }), JOBS_URL);
+
+    expect(res?.status).toBe(201);
+    expect(seenConfig?.reviewProfileId).toBe("user:security");
+    handler.killAll();
+  });
+
+  test("rejects unknown fields with 400", async () => {
+    const handler = createAgentJobHandler({
+      mode: "review",
+      getServerUrl: () => "http://localhost:1234",
+      getCwd: () => "/tmp",
+      async buildCommand() {
+        return { command: ["true"] };
+      },
+    });
+
+    const res = await handler.handle(post({ provider: "codex", reviewPrompt: "inline" }), JOBS_URL);
+
+    expect(res?.status).toBe(400);
+    const json = await res!.json();
+    expect(json.error).toContain("reviewPrompt");
+    handler.killAll();
+  });
+
+  test("absent reviewProfileId forwards no reviewProfileId in config", async () => {
+    let seenConfig: Record<string, unknown> | undefined;
+    let called = false;
+    const handler = createAgentJobHandler({
+      mode: "review",
+      getServerUrl: () => "http://localhost:1234",
+      getCwd: () => "/tmp",
+      async buildCommand(_provider, config) {
+        called = true;
+        seenConfig = config;
+        return { command: ["true"] };
+      },
+    });
+
+    const res = await handler.handle(post({ provider: "codex" }), JOBS_URL);
+
+    expect(res?.status).toBe(201);
+    expect(called).toBe(true);
+    // No config keys at all → buildCommand receives undefined (review.ts maps
+    // that to builtin:default).
+    expect(seenConfig?.reviewProfileId).toBeUndefined();
+    handler.killAll();
+  });
+
+  test("launched job carries reviewProfileId and reviewProfileLabel stamped by buildCommand", async () => {
+    const handler = createAgentJobHandler({
+      mode: "review",
+      getServerUrl: () => "http://localhost:1234",
+      getCwd: () => "/tmp",
+      async buildCommand() {
+        return {
+          command: ["true"],
+          reviewProfileId: "repo:api-contracts",
+          reviewProfileLabel: "API Contracts",
+        };
+      },
+    });
+
+    const res = await handler.handle(post({ provider: "claude", reviewProfileId: "repo:api-contracts" }), JOBS_URL);
+
+    expect(res?.status).toBe(201);
+    const { job } = await res!.json();
+    expect(job.reviewProfileId).toBe("repo:api-contracts");
+    expect(job.reviewProfileLabel).toBe("API Contracts");
+    handler.killAll();
+  });
+
+  test("a job launched without a profile omits the profile fields entirely", async () => {
+    const handler = createAgentJobHandler({
+      mode: "review",
+      getServerUrl: () => "http://localhost:1234",
+      getCwd: () => "/tmp",
+      async buildCommand() {
+        return { command: ["true"] };
+      },
+    });
+
+    const res = await handler.handle(post({ provider: "codex" }), JOBS_URL);
+
+    expect(res?.status).toBe(201);
+    const { job } = await res!.json();
+    expect("reviewProfileId" in job).toBe(false);
+    expect("reviewProfileLabel" in job).toBe(false);
+    handler.killAll();
+  });
+});

--- a/packages/server/agent-jobs.ts
+++ b/packages/server/agent-jobs.ts
@@ -91,18 +91,12 @@ export interface AgentJobHandlerOptions {
     reviewProfileId?: string;
     /** Resolved review profile label at launch time. Stored on AgentJobInfo. */
     reviewProfileLabel?: string;
-    /**
-     * Files changed in the patch snapshotted at launch. Surfaced back to
-     * onJobComplete as meta.reviewChangedFiles so it can drop out-of-diff
-     * findings against the diff the agent actually reviewed.
-     */
-    reviewChangedFiles?: string[];
   } | null>;
   /**
    * Called after a job process exits with exit code 0.
    * Use for result ingestion (e.g., reading an output file and pushing annotations).
    */
-  onJobComplete?: (job: AgentJobInfo, meta: { outputPath?: string; stdout?: string; cwd?: string; reviewChangedFiles?: string[] }) => void | Promise<void>;
+  onJobComplete?: (job: AgentJobInfo, meta: { outputPath?: string; stdout?: string; cwd?: string }) => void | Promise<void>;
 }
 
 export function createAgentJobHandler(options: AgentJobHandlerOptions): AgentJobHandler {
@@ -111,8 +105,6 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions): AgentJob
   // --- State ---
   const jobs = new Map<string, { info: AgentJobInfo; proc: ReturnType<typeof Bun.spawn> | null }>();
   const jobOutputPaths = new Map<string, string>();
-  // Launch-time changed-file lists, keyed by job id — read once in onJobComplete.
-  const jobChangedFiles = new Map<string, string[]>();
   const subscribers = new Set<ReadableStreamDefaultController>();
   const encoder = new TextEncoder();
   let version = 0;
@@ -148,7 +140,7 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions): AgentJob
     command: string[],
     label: string,
     outputPath?: string,
-    spawnOptions?: { captureStdout?: boolean; stdinPrompt?: string; cwd?: string; prompt?: string; engine?: string; model?: string; effort?: string; reasoningEffort?: string; fastMode?: boolean; prUrl?: string; diffScope?: string; diffContext?: AgentJobInfo["diffContext"]; reviewProfileId?: string; reviewProfileLabel?: string; reviewChangedFiles?: string[] },
+    spawnOptions?: { captureStdout?: boolean; stdinPrompt?: string; cwd?: string; prompt?: string; engine?: string; model?: string; effort?: string; reasoningEffort?: string; fastMode?: boolean; prUrl?: string; diffScope?: string; diffContext?: AgentJobInfo["diffContext"]; reviewProfileId?: string; reviewProfileLabel?: string },
   ): AgentJobInfo {
     const id = crypto.randomUUID();
     const source = jobSource(id);
@@ -207,7 +199,6 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions): AgentJob
       jobs.set(id, { info, proc });
       if (outputPath) jobOutputPaths.set(id, outputPath);
       if (spawnOptions?.cwd) jobOutputPaths.set(`${id}:cwd`, spawnOptions.cwd);
-      if (spawnOptions?.reviewChangedFiles) jobChangedFiles.set(id, spawnOptions.reviewChangedFiles);
       broadcast({ type: "job:started", job: { ...info } });
 
       // Drain stderr: capture tail for error reporting + broadcast live log deltas
@@ -307,7 +298,6 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions): AgentJob
               outputPath,
               stdout: captureStdout ? stdoutBuf : undefined,
               cwd: jobCwd,
-              reviewChangedFiles: jobChangedFiles.get(id),
             });
           } catch {
             // Result ingestion failure shouldn't prevent job completion broadcast
@@ -315,7 +305,6 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions): AgentJob
         }
         jobOutputPaths.delete(id);
         jobOutputPaths.delete(`${id}:cwd`);
-        jobChangedFiles.delete(id);
 
         broadcast({ type: "job:completed", job: { ...entry.info } });
       }).catch(() => {
@@ -352,7 +341,6 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions): AgentJob
     entry.info.endedAt = Date.now();
     jobOutputPaths.delete(id);
     jobOutputPaths.delete(`${id}:cwd`);
-    jobChangedFiles.delete(id);
     broadcast({ type: "job:completed", job: { ...entry.info } });
     return true;
   }
@@ -495,7 +483,6 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions): AgentJob
           let jobDiffContext: AgentJobInfo["diffContext"] | undefined;
           let jobReviewProfileId: string | undefined;
           let jobReviewProfileLabel: string | undefined;
-          let jobReviewChangedFiles: string[] | undefined;
           if (options.buildCommand) {
             // Thread config from POST body to buildCommand
             const config: Record<string, unknown> = {};
@@ -524,7 +511,6 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions): AgentJob
               jobDiffContext = built.diffContext;
               jobReviewProfileId = built.reviewProfileId;
               jobReviewProfileLabel = built.reviewProfileLabel;
-              jobReviewChangedFiles = built.reviewChangedFiles;
             }
           }
 
@@ -550,7 +536,6 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions): AgentJob
             diffContext: jobDiffContext,
             reviewProfileId: jobReviewProfileId,
             reviewProfileLabel: jobReviewProfileLabel,
-            reviewChangedFiles: jobReviewChangedFiles,
           });
           return Response.json({ job }, { status: 201 });
         } catch (err) {

--- a/packages/server/agent-jobs.ts
+++ b/packages/server/agent-jobs.ts
@@ -87,12 +87,22 @@ export interface AgentJobHandlerOptions {
     diffScope?: string;
     /** Diff context snapshot at launch (stored on AgentJobInfo for per-job "Copy All"). */
     diffContext?: AgentJobInfo["diffContext"];
+    /** Resolved review profile id at launch time. Stored on AgentJobInfo. */
+    reviewProfileId?: string;
+    /** Resolved review profile label at launch time. Stored on AgentJobInfo. */
+    reviewProfileLabel?: string;
+    /**
+     * Files changed in the patch snapshotted at launch. Surfaced back to
+     * onJobComplete as meta.reviewChangedFiles so it can drop out-of-diff
+     * findings against the diff the agent actually reviewed.
+     */
+    reviewChangedFiles?: string[];
   } | null>;
   /**
    * Called after a job process exits with exit code 0.
    * Use for result ingestion (e.g., reading an output file and pushing annotations).
    */
-  onJobComplete?: (job: AgentJobInfo, meta: { outputPath?: string; stdout?: string; cwd?: string }) => void | Promise<void>;
+  onJobComplete?: (job: AgentJobInfo, meta: { outputPath?: string; stdout?: string; cwd?: string; reviewChangedFiles?: string[] }) => void | Promise<void>;
 }
 
 export function createAgentJobHandler(options: AgentJobHandlerOptions): AgentJobHandler {
@@ -101,6 +111,8 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions): AgentJob
   // --- State ---
   const jobs = new Map<string, { info: AgentJobInfo; proc: ReturnType<typeof Bun.spawn> | null }>();
   const jobOutputPaths = new Map<string, string>();
+  // Launch-time changed-file lists, keyed by job id — read once in onJobComplete.
+  const jobChangedFiles = new Map<string, string[]>();
   const subscribers = new Set<ReadableStreamDefaultController>();
   const encoder = new TextEncoder();
   let version = 0;
@@ -136,7 +148,7 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions): AgentJob
     command: string[],
     label: string,
     outputPath?: string,
-    spawnOptions?: { captureStdout?: boolean; stdinPrompt?: string; cwd?: string; prompt?: string; engine?: string; model?: string; effort?: string; reasoningEffort?: string; fastMode?: boolean; prUrl?: string; diffScope?: string; diffContext?: AgentJobInfo["diffContext"] },
+    spawnOptions?: { captureStdout?: boolean; stdinPrompt?: string; cwd?: string; prompt?: string; engine?: string; model?: string; effort?: string; reasoningEffort?: string; fastMode?: boolean; prUrl?: string; diffScope?: string; diffContext?: AgentJobInfo["diffContext"]; reviewProfileId?: string; reviewProfileLabel?: string; reviewChangedFiles?: string[] },
   ): AgentJobInfo {
     const id = crypto.randomUUID();
     const source = jobSource(id);
@@ -158,6 +170,8 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions): AgentJob
       ...(spawnOptions?.prUrl && { prUrl: spawnOptions.prUrl }),
       ...(spawnOptions?.diffScope && { diffScope: spawnOptions.diffScope }),
       ...(spawnOptions?.diffContext && { diffContext: spawnOptions.diffContext }),
+      ...(spawnOptions?.reviewProfileId && { reviewProfileId: spawnOptions.reviewProfileId }),
+      ...(spawnOptions?.reviewProfileLabel && { reviewProfileLabel: spawnOptions.reviewProfileLabel }),
     };
 
     let proc: ReturnType<typeof Bun.spawn> | null = null;
@@ -193,6 +207,7 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions): AgentJob
       jobs.set(id, { info, proc });
       if (outputPath) jobOutputPaths.set(id, outputPath);
       if (spawnOptions?.cwd) jobOutputPaths.set(`${id}:cwd`, spawnOptions.cwd);
+      if (spawnOptions?.reviewChangedFiles) jobChangedFiles.set(id, spawnOptions.reviewChangedFiles);
       broadcast({ type: "job:started", job: { ...info } });
 
       // Drain stderr: capture tail for error reporting + broadcast live log deltas
@@ -292,6 +307,7 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions): AgentJob
               outputPath,
               stdout: captureStdout ? stdoutBuf : undefined,
               cwd: jobCwd,
+              reviewChangedFiles: jobChangedFiles.get(id),
             });
           } catch {
             // Result ingestion failure shouldn't prevent job completion broadcast
@@ -299,6 +315,7 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions): AgentJob
         }
         jobOutputPaths.delete(id);
         jobOutputPaths.delete(`${id}:cwd`);
+        jobChangedFiles.delete(id);
 
         broadcast({ type: "job:completed", job: { ...entry.info } });
       }).catch(() => {
@@ -335,6 +352,7 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions): AgentJob
     entry.info.endedAt = Date.now();
     jobOutputPaths.delete(id);
     jobOutputPaths.delete(`${id}:cwd`);
+    jobChangedFiles.delete(id);
     broadcast({ type: "job:completed", job: { ...entry.info } });
     return true;
   }
@@ -429,6 +447,24 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions): AgentJob
       if (url.pathname === JOBS && req.method === "POST") {
         try {
           const body = await req.json();
+
+          // Reject unknown fields rather than silently ignoring them (per the
+          // custom-reviews spec — a typo'd field should fail loud, not no-op).
+          const KNOWN_JOB_FIELDS = new Set([
+            "provider", "command", "label",
+            "engine", "model", "reasoningEffort", "effort", "fastMode",
+            "reviewProfileId",
+          ]);
+          if (body && typeof body === "object") {
+            const unknown = Object.keys(body).filter((k) => !KNOWN_JOB_FIELDS.has(k));
+            if (unknown.length > 0) {
+              return Response.json(
+                { error: `Unknown field(s): ${unknown.join(", ")}` },
+                { status: 400 },
+              );
+            }
+          }
+
           const provider = typeof body.provider === "string" ? body.provider : "";
           let rawCommand = Array.isArray(body.command) ? body.command : [];
           let command = rawCommand.filter((c: unknown): c is string => typeof c === "string");
@@ -457,6 +493,9 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions): AgentJob
           let jobPrUrl: string | undefined;
           let jobDiffScope: string | undefined;
           let jobDiffContext: AgentJobInfo["diffContext"] | undefined;
+          let jobReviewProfileId: string | undefined;
+          let jobReviewProfileLabel: string | undefined;
+          let jobReviewChangedFiles: string[] | undefined;
           if (options.buildCommand) {
             // Thread config from POST body to buildCommand
             const config: Record<string, unknown> = {};
@@ -465,6 +504,7 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions): AgentJob
             if (typeof body.reasoningEffort === "string") config.reasoningEffort = body.reasoningEffort;
             if (typeof body.effort === "string") config.effort = body.effort;
             if (body.fastMode === true) config.fastMode = true;
+            if (typeof body.reviewProfileId === "string") config.reviewProfileId = body.reviewProfileId;
             const built = await options.buildCommand(provider, Object.keys(config).length > 0 ? config : undefined);
             if (built) {
               command = built.command;
@@ -482,6 +522,9 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions): AgentJob
               jobPrUrl = built.prUrl;
               jobDiffScope = built.diffScope;
               jobDiffContext = built.diffContext;
+              jobReviewProfileId = built.reviewProfileId;
+              jobReviewProfileLabel = built.reviewProfileLabel;
+              jobReviewChangedFiles = built.reviewChangedFiles;
             }
           }
 
@@ -505,6 +548,9 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions): AgentJob
             prUrl: jobPrUrl,
             diffScope: jobDiffScope,
             diffContext: jobDiffContext,
+            reviewProfileId: jobReviewProfileId,
+            reviewProfileLabel: jobReviewProfileLabel,
+            reviewChangedFiles: jobReviewChangedFiles,
           });
           return Response.json({ job }, { status: 201 });
         } catch (err) {

--- a/packages/server/claude-review.ts
+++ b/packages/server/claude-review.ts
@@ -1,4 +1,8 @@
 import { toRelativePath } from "./path-utils";
+import {
+  composeReviewPrompt,
+  type ResolvedReviewProfile,
+} from "@plannotator/shared/review-profiles";
 
 /**
  * Claude Code Review Agent — prompt, command builder, and JSONL output parser.
@@ -176,6 +180,23 @@ Step 6: Return structured JSON output matching the schema.
 - Your only output is the structured JSON findings`;
 
 // ---------------------------------------------------------------------------
+// Prompt composition
+// ---------------------------------------------------------------------------
+
+/**
+ * Compose Claude's review prompt: the immutable system prompt, the resolved
+ * profile's Custom Review Profile section (omitted for builtin:default), then
+ * the user review message. For builtin:default / no profile the output is
+ * byte-identical to today's `CLAUDE_REVIEW_PROMPT + "\n\n---\n\n" + userMessage`.
+ */
+export function composeClaudeReviewPrompt(
+  userMessage: string,
+  reviewProfile?: ResolvedReviewProfile,
+): string {
+  return composeReviewPrompt(CLAUDE_REVIEW_PROMPT, reviewProfile, userMessage);
+}
+
+// ---------------------------------------------------------------------------
 // Command builder
 // ---------------------------------------------------------------------------
 
@@ -189,7 +210,15 @@ export interface ClaudeCommandResult {
  * Build the `claude -p` command. Prompt is passed via stdin, not as a
  * positional arg — avoids quoting issues, argv limits, and variadic flag conflicts.
  */
-export function buildClaudeCommand(prompt: string, model: string = "claude-opus-4-7", effort?: string): ClaudeCommandResult {
+export function buildClaudeCommand(
+  prompt: string,
+  model: string = "claude-opus-4-7",
+  effort?: string,
+  // Resolved review profile this command runs under. Accepted so the launch
+  // path threads it to one place; prompt composition off it lands in a later
+  // phase. Unused today — output stays byte-identical.
+  reviewProfile?: ResolvedReviewProfile,
+): ClaudeCommandResult {
   const allowedTools = [
     "Agent", "Read", "Glob", "Grep",
     // GitHub CLI

--- a/packages/server/claude-review.ts
+++ b/packages/server/claude-review.ts
@@ -214,10 +214,6 @@ export function buildClaudeCommand(
   prompt: string,
   model: string = "claude-opus-4-7",
   effort?: string,
-  // Resolved review profile this command runs under. Accepted so the launch
-  // path threads it to one place; prompt composition off it lands in a later
-  // phase. Unused today — output stays byte-identical.
-  reviewProfile?: ResolvedReviewProfile,
 ): ClaudeCommandResult {
   const allowedTools = [
     "Agent", "Read", "Glob", "Grep",

--- a/packages/server/codex-review.ts
+++ b/packages/server/codex-review.ts
@@ -191,12 +191,6 @@ export interface CodexCommandOptions {
   model?: string;
   reasoningEffort?: string;
   fastMode?: boolean;
-  /**
-   * Resolved review profile this command runs under. Accepted here so the
-   * launch path can thread it through to one place; prompt composition off it
-   * lands in a later phase. Unused today — output stays byte-identical.
-   */
-  reviewProfile?: ResolvedReviewProfile;
 }
 
 /** Build the `codex exec` argv array. Materializes the schema file on first call. */
@@ -362,7 +356,7 @@ export function transformReviewFindings(
       severity: codexPriorityToSeverity(f.priority),
     }));
 
-  debugLog("TRANSFORM_FINDINGS", {
+  void debugLog("TRANSFORM_FINDINGS", {
     inputCount: findings.length,
     outputCount: annotations.length,
     annotations: annotations.map((a) => ({

--- a/packages/server/codex-review.ts
+++ b/packages/server/codex-review.ts
@@ -11,6 +11,10 @@ import { appendFile, mkdir, unlink, writeFile, readFile } from "node:fs/promises
 import { existsSync } from "node:fs";
 import { toRelativePath } from "./path-utils";
 import { getPlannotatorDataDir } from "@plannotator/shared/data-dir";
+import {
+  composeReviewPrompt,
+  type ResolvedReviewProfile,
+} from "@plannotator/shared/review-profiles";
 
 // ---------------------------------------------------------------------------
 // Debug log — only active when PLANNOTATOR_DEBUG is set
@@ -159,6 +163,24 @@ FORMATTING GUIDELINES:
 The finding description should be one paragraph.`;
 
 // ---------------------------------------------------------------------------
+// Prompt composition
+// ---------------------------------------------------------------------------
+
+/**
+ * Compose Codex's review prompt: the immutable system prompt, the resolved
+ * profile's Custom Review Profile section (omitted for builtin:default), then
+ * the user review message. For builtin:default / no profile the output is
+ * byte-identical to today's
+ * `CODEX_REVIEW_SYSTEM_PROMPT + "\n\n---\n\n" + userMessage`.
+ */
+export function composeCodexReviewPrompt(
+  userMessage: string,
+  reviewProfile?: ResolvedReviewProfile,
+): string {
+  return composeReviewPrompt(CODEX_REVIEW_SYSTEM_PROMPT, reviewProfile, userMessage);
+}
+
+// ---------------------------------------------------------------------------
 // Command builder
 // ---------------------------------------------------------------------------
 
@@ -169,6 +191,12 @@ export interface CodexCommandOptions {
   model?: string;
   reasoningEffort?: string;
   fastMode?: boolean;
+  /**
+   * Resolved review profile this command runs under. Accepted here so the
+   * launch path can thread it through to one place; prompt composition off it
+   * lands in a later phase. Unused today — output stays byte-identical.
+   */
+  reviewProfile?: ResolvedReviewProfile;
 }
 
 /** Build the `codex exec` argv array. Materializes the schema file on first call. */
@@ -272,6 +300,23 @@ export async function parseCodexOutput(outputPath: string): Promise<CodexReviewO
 }
 
 // ---------------------------------------------------------------------------
+// Severity normalization — Codex priority → shared scale
+// ---------------------------------------------------------------------------
+
+export type ReviewSeverity = "important" | "nit" | "pre_existing";
+
+/**
+ * Map Codex's 0–3 (or null) priority onto the shared severity scale Claude
+ * already emits, so the UI can show one set of badges regardless of engine.
+ * The single source of truth for this mapping — do not duplicate it.
+ */
+export function codexPriorityToSeverity(priority: number | null): ReviewSeverity {
+  if (priority === 0 || priority === 1) return "important";
+  if (priority === 2) return "nit";
+  return "pre_existing"; // 3 or null
+}
+
+// ---------------------------------------------------------------------------
 // Finding → external annotation transform
 // ---------------------------------------------------------------------------
 
@@ -285,6 +330,7 @@ export interface ReviewAnnotationInput {
   scope: string;
   text: string;
   author: string;
+  severity: ReviewSeverity;
 }
 
 /** Transform review findings (provider-agnostic) into the external annotation format. */
@@ -313,6 +359,7 @@ export function transformReviewFindings(
       scope: "line",
       text: `${f.title}\n\n${f.body}`.trim(),
       author: author ?? "Review Agent",
+      severity: codexPriorityToSeverity(f.priority),
     }));
 
   debugLog("TRANSFORM_FINDINGS", {

--- a/packages/server/review-ingestion.test.ts
+++ b/packages/server/review-ingestion.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Ingestion-phase tests for custom reviews:
+ *  - Codex priority normalizes onto the shared important|nit|pre_existing scale
+ *    at the boundary values (the single map lives in codex-review.ts).
+ *  - The in-diff guard drops findings whose file is not in the reviewed diff and
+ *    counts the drops, while staying a no-op when the changed-file list is
+ *    unavailable.
+ *  - Completion semantics: when every finding is out-of-diff the job is flipped
+ *    to "failed" (a green run cannot hide behind "0 findings"); the post-ingest
+ *    summary surfaces a calm "N findings · M skipped" one-liner without leaking
+ *    provider internals.
+ *
+ * The filter / fail-marker / summary helpers are the exact functions
+ * onJobComplete calls, so these tests exercise real ingestion logic rather than
+ * a re-implementation.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  codexPriorityToSeverity,
+  transformReviewFindings,
+  type CodexFinding,
+} from "./codex-review";
+import {
+  filterToReviewedDiff,
+  markJobReviewFailed,
+  applyReviewFindingsSummary,
+  REVIEW_ALL_OUT_OF_DIFF,
+} from "./review";
+import type { AgentJobInfo } from "@plannotator/shared/agent-jobs";
+
+function codexFinding(priority: number | null, file: string): CodexFinding {
+  return {
+    title: "title",
+    body: "body",
+    confidence_score: 0.9,
+    priority,
+    code_location: {
+      absolute_file_path: file,
+      line_range: { start: 1, end: 2 },
+    },
+  };
+}
+
+describe("codexPriorityToSeverity — boundary mapping", () => {
+  test("0 and 1 map to important", () => {
+    expect(codexPriorityToSeverity(0)).toBe("important");
+    expect(codexPriorityToSeverity(1)).toBe("important");
+  });
+  test("2 maps to nit", () => {
+    expect(codexPriorityToSeverity(2)).toBe("nit");
+  });
+  test("3 and null map to pre_existing", () => {
+    expect(codexPriorityToSeverity(3)).toBe("pre_existing");
+    expect(codexPriorityToSeverity(null)).toBe("pre_existing");
+  });
+});
+
+describe("transformReviewFindings — stamps shared severity", () => {
+  test("each finding carries the normalized severity", () => {
+    const out = transformReviewFindings(
+      [codexFinding(0, "a.ts"), codexFinding(2, "b.ts"), codexFinding(null, "c.ts")],
+      "codex:1",
+      undefined,
+      "Codex",
+    );
+    expect(out.map((a) => a.severity)).toEqual(["important", "nit", "pre_existing"]);
+  });
+});
+
+describe("filterToReviewedDiff — in-diff guard", () => {
+  const ann = (filePath: string) => ({ filePath });
+
+  test("drops findings whose file is not in the reviewed diff and counts them", () => {
+    const { kept, dropped } = filterToReviewedDiff(
+      [ann("src/a.ts"), ann("src/ghost.ts"), ann("src/b.ts")],
+      ["src/a.ts", "src/b.ts"],
+    );
+    expect(kept.map((a) => a.filePath)).toEqual(["src/a.ts", "src/b.ts"]);
+    expect(dropped).toBe(1);
+  });
+
+  test("keeps everything when the changed-file list is unavailable", () => {
+    const items = [ann("src/a.ts"), ann("src/x.ts")];
+    expect(filterToReviewedDiff(items, undefined).kept).toHaveLength(2);
+    expect(filterToReviewedDiff(items, []).dropped).toBe(0);
+  });
+
+  test("all findings out of diff yields empty kept (the fail precondition)", () => {
+    const { kept, dropped } = filterToReviewedDiff(
+      [ann("ghost1.ts"), ann("ghost2.ts")],
+      ["src/real.ts"],
+    );
+    expect(kept).toHaveLength(0);
+    expect(dropped).toBe(2);
+  });
+});
+
+describe("completion semantics", () => {
+  function job(): AgentJobInfo {
+    return {
+      id: "j1",
+      source: "codex:1",
+      provider: "codex",
+      label: "Code Review",
+      status: "done",
+      startedAt: 0,
+      command: ["codex"],
+    };
+  }
+
+  test("all-dropped flips the job to failed with a calm reason", () => {
+    const transformed = [{ filePath: "ghost.ts" }];
+    const { kept } = filterToReviewedDiff(transformed, ["src/real.ts"]);
+
+    const j = job();
+    // Mirrors onJobComplete's branch exactly.
+    if (kept.length === 0 && transformed.length > 0) {
+      markJobReviewFailed(j, REVIEW_ALL_OUT_OF_DIFF);
+    }
+
+    expect(j.status).toBe("failed");
+    expect(j.error).toBe(REVIEW_ALL_OUT_OF_DIFF);
+    // Calm one-liner — no schema/provider internals.
+    expect(j.error).not.toMatch(/json|schema|parse|codex|claude|priority/i);
+  });
+
+  test("partial drop keeps the job complete and notes the skip count", () => {
+    const j = job();
+    j.summary = { correctness: "Issues Found", explanation: "2 findings", confidence: 0.8 };
+    applyReviewFindingsSummary(j, 2, 1);
+
+    expect(j.status).toBe("done");
+    expect(j.summary?.explanation).toContain("1 skipped (not in the reviewed diff)");
+  });
+
+  test("no drops leaves the summary untouched", () => {
+    const j = job();
+    j.summary = { correctness: "Correct", explanation: "clean", confidence: 1 };
+    applyReviewFindingsSummary(j, 3, 0);
+    expect(j.summary?.explanation).toBe("clean");
+  });
+});

--- a/packages/server/review-ingestion.test.ts
+++ b/packages/server/review-ingestion.test.ts
@@ -2,6 +2,8 @@
  * Ingestion-phase tests for custom reviews:
  *  - Codex priority normalizes onto the shared important|nit|pre_existing scale
  *    at the boundary values (the single map lives in codex-review.ts).
+ *  - Completion semantics: a provider that exits 0 but returns empty/garbage
+ *    output fails the job instead of silently showing "done".
  */
 import { describe, expect, test } from "bun:test";
 import {
@@ -9,6 +11,12 @@ import {
   transformReviewFindings,
   type CodexFinding,
 } from "./codex-review";
+import { parseClaudeStreamOutput } from "./claude-review";
+import {
+  markJobReviewFailed,
+  REVIEW_OUTPUT_FAILED,
+  type AgentJobInfo,
+} from "@plannotator/shared/agent-jobs";
 
 function codexFinding(priority: number | null, file: string): CodexFinding {
   return {
@@ -46,5 +54,28 @@ describe("transformReviewFindings — stamps shared severity", () => {
       "Codex",
     );
     expect(out.map((a) => a.severity)).toEqual(["important", "nit", "pre_existing"]);
+  });
+});
+
+describe("completion semantics — empty/unparseable output fails the job", () => {
+  // Guards the fix: a provider that exits 0 with nothing/garbage must fail the
+  // job (REVIEW_OUTPUT_FAILED), not silently leave it "done" with no findings.
+  test("parseClaudeStreamOutput returns null for empty/whitespace stdout", () => {
+    expect(parseClaudeStreamOutput("")).toBeNull();
+    expect(parseClaudeStreamOutput("   \n  ")).toBeNull();
+  });
+
+  test("parseClaudeStreamOutput returns null for unparseable stdout", () => {
+    expect(parseClaudeStreamOutput("not json\n{ broken")).toBeNull();
+  });
+
+  test("markJobReviewFailed flips the job to failed with a calm, leak-free reason", () => {
+    const job = { status: "running" } as unknown as AgentJobInfo;
+    markJobReviewFailed(job, REVIEW_OUTPUT_FAILED);
+    expect(job.status).toBe("failed");
+    expect(job.error).toBe(REVIEW_OUTPUT_FAILED);
+    // No schema/CLI internals leaked in the user-facing reason.
+    expect(REVIEW_OUTPUT_FAILED).not.toContain("stdout");
+    expect(REVIEW_OUTPUT_FAILED).not.toContain("JSON");
   });
 });

--- a/packages/server/review-ingestion.test.ts
+++ b/packages/server/review-ingestion.test.ts
@@ -2,17 +2,6 @@
  * Ingestion-phase tests for custom reviews:
  *  - Codex priority normalizes onto the shared important|nit|pre_existing scale
  *    at the boundary values (the single map lives in codex-review.ts).
- *  - The in-diff guard drops findings whose file is not in the reviewed diff and
- *    counts the drops, while staying a no-op when the changed-file list is
- *    unavailable.
- *  - Completion semantics: when every finding is out-of-diff the job is flipped
- *    to "failed" (a green run cannot hide behind "0 findings"); the post-ingest
- *    summary surfaces a calm "N findings · M skipped" one-liner without leaking
- *    provider internals.
- *
- * The filter / fail-marker / summary helpers are the exact functions
- * onJobComplete calls, so these tests exercise real ingestion logic rather than
- * a re-implementation.
  */
 import { describe, expect, test } from "bun:test";
 import {
@@ -20,13 +9,6 @@ import {
   transformReviewFindings,
   type CodexFinding,
 } from "./codex-review";
-import {
-  filterToReviewedDiff,
-  markJobReviewFailed,
-  applyReviewFindingsSummary,
-  REVIEW_ALL_OUT_OF_DIFF,
-} from "./review";
-import type { AgentJobInfo } from "@plannotator/shared/agent-jobs";
 
 function codexFinding(priority: number | null, file: string): CodexFinding {
   return {
@@ -64,79 +46,5 @@ describe("transformReviewFindings — stamps shared severity", () => {
       "Codex",
     );
     expect(out.map((a) => a.severity)).toEqual(["important", "nit", "pre_existing"]);
-  });
-});
-
-describe("filterToReviewedDiff — in-diff guard", () => {
-  const ann = (filePath: string) => ({ filePath });
-
-  test("drops findings whose file is not in the reviewed diff and counts them", () => {
-    const { kept, dropped } = filterToReviewedDiff(
-      [ann("src/a.ts"), ann("src/ghost.ts"), ann("src/b.ts")],
-      ["src/a.ts", "src/b.ts"],
-    );
-    expect(kept.map((a) => a.filePath)).toEqual(["src/a.ts", "src/b.ts"]);
-    expect(dropped).toBe(1);
-  });
-
-  test("keeps everything when the changed-file list is unavailable", () => {
-    const items = [ann("src/a.ts"), ann("src/x.ts")];
-    expect(filterToReviewedDiff(items, undefined).kept).toHaveLength(2);
-    expect(filterToReviewedDiff(items, []).dropped).toBe(0);
-  });
-
-  test("all findings out of diff yields empty kept (the fail precondition)", () => {
-    const { kept, dropped } = filterToReviewedDiff(
-      [ann("ghost1.ts"), ann("ghost2.ts")],
-      ["src/real.ts"],
-    );
-    expect(kept).toHaveLength(0);
-    expect(dropped).toBe(2);
-  });
-});
-
-describe("completion semantics", () => {
-  function job(): AgentJobInfo {
-    return {
-      id: "j1",
-      source: "codex:1",
-      provider: "codex",
-      label: "Code Review",
-      status: "done",
-      startedAt: 0,
-      command: ["codex"],
-    };
-  }
-
-  test("all-dropped flips the job to failed with a calm reason", () => {
-    const transformed = [{ filePath: "ghost.ts" }];
-    const { kept } = filterToReviewedDiff(transformed, ["src/real.ts"]);
-
-    const j = job();
-    // Mirrors onJobComplete's branch exactly.
-    if (kept.length === 0 && transformed.length > 0) {
-      markJobReviewFailed(j, REVIEW_ALL_OUT_OF_DIFF);
-    }
-
-    expect(j.status).toBe("failed");
-    expect(j.error).toBe(REVIEW_ALL_OUT_OF_DIFF);
-    // Calm one-liner — no schema/provider internals.
-    expect(j.error).not.toMatch(/json|schema|parse|codex|claude|priority/i);
-  });
-
-  test("partial drop keeps the job complete and notes the skip count", () => {
-    const j = job();
-    j.summary = { correctness: "Issues Found", explanation: "2 findings", confidence: 0.8 };
-    applyReviewFindingsSummary(j, 2, 1);
-
-    expect(j.status).toBe("done");
-    expect(j.summary?.explanation).toContain("1 skipped (not in the reviewed diff)");
-  });
-
-  test("no drops leaves the summary untouched", () => {
-    const j = job();
-    j.summary = { correctness: "Correct", explanation: "clean", confidence: 1 };
-    applyReviewFindingsSummary(j, 3, 0);
-    expect(j.summary?.explanation).toBe("clean");
   });
 });

--- a/packages/server/review-profile-loader.test.ts
+++ b/packages/server/review-profile-loader.test.ts
@@ -6,7 +6,6 @@ import { BUILTIN_DEFAULT_ID } from "@plannotator/shared/review-profiles";
 import { loadReviewProfiles } from "./review-profile-loader";
 
 let dataDir: string;
-let repoDir: string;
 let prevDataDir: string | undefined;
 
 function writeUserProfile(name: string, contents: string) {
@@ -15,15 +14,8 @@ function writeUserProfile(name: string, contents: string) {
   writeFileSync(join(dir, name), contents);
 }
 
-function writeRepoProfile(name: string, contents: string) {
-  const dir = join(repoDir, ".plannotator", "reviews");
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(join(dir, name), contents);
-}
-
 beforeEach(() => {
   dataDir = mkdtempSync(join(tmpdir(), "plannotator-data-"));
-  repoDir = mkdtempSync(join(tmpdir(), "plannotator-repo-"));
   prevDataDir = process.env.PLANNOTATOR_DATA_DIR;
   process.env.PLANNOTATOR_DATA_DIR = dataDir;
 });
@@ -32,7 +24,6 @@ afterEach(() => {
   if (prevDataDir === undefined) delete process.env.PLANNOTATOR_DATA_DIR;
   else process.env.PLANNOTATOR_DATA_DIR = prevDataDir;
   rmSync(dataDir, { recursive: true, force: true });
-  rmSync(repoDir, { recursive: true, force: true });
 });
 
 describe("loadReviewProfiles", () => {
@@ -43,27 +34,15 @@ describe("loadReviewProfiles", () => {
     expect(profiles[0].default).toBe(true);
   });
 
-  test("infers id/label/engines end-to-end from a bare user file", () => {
+  test("infers id/label end-to-end from a bare user file", () => {
     writeUserProfile("api-contracts.json", JSON.stringify({ instructions: "Check API contracts." }));
 
     const profiles = loadReviewProfiles();
     const profile = profiles.find((p) => p.id === "user:api-contracts");
     expect(profile).toBeDefined();
     expect(profile!.label).toBe("API Contracts");
-    expect(profile!.engines).toEqual(["claude", "codex"]);
     expect(profile!.source).toBe("user");
     expect(profile!.sourcePath).toBe(join(dataDir, "reviews", "api-contracts.json"));
-  });
-
-  test("user profile beats a repo profile on a bare-name clash", () => {
-    writeUserProfile("security.json", JSON.stringify({ instructions: "user security" }));
-    writeRepoProfile("security.json", JSON.stringify({ instructions: "repo security" }));
-
-    const profiles = loadReviewProfiles({ repoCwd: repoDir });
-    const security = profiles.filter((p) => p.label === "Security");
-    expect(security).toHaveLength(1);
-    expect(security[0].source).toBe("user");
-    expect(security[0].instructions).toBe("user security");
   });
 
   test("malformed JSON is skipped; valid siblings survive", () => {
@@ -76,17 +55,5 @@ describe("loadReviewProfiles", () => {
     expect(ids).not.toContain("user:broken");
     // builtin + the one good profile
     expect(profiles).toHaveLength(2);
-  });
-
-  test("repo profiles are absent when no repoCwd is provided", () => {
-    writeRepoProfile("security.json", JSON.stringify({ instructions: "repo only" }));
-
-    // No repoCwd → ambiguous/remote session → repo profiles excluded.
-    const profiles = loadReviewProfiles();
-    expect(profiles.map((p) => p.id)).not.toContain("repo:security");
-
-    // With repoCwd → the repo profile is loaded.
-    const withRepo = loadReviewProfiles({ repoCwd: repoDir });
-    expect(withRepo.map((p) => p.id)).toContain("repo:security");
   });
 });

--- a/packages/server/review-profile-loader.test.ts
+++ b/packages/server/review-profile-loader.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { BUILTIN_DEFAULT_ID } from "@plannotator/shared/review-profiles";
+import { loadReviewProfiles } from "./review-profile-loader";
+
+let dataDir: string;
+let repoDir: string;
+let prevDataDir: string | undefined;
+
+function writeUserProfile(name: string, contents: string) {
+  const dir = join(dataDir, "reviews");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, name), contents);
+}
+
+function writeRepoProfile(name: string, contents: string) {
+  const dir = join(repoDir, ".plannotator", "reviews");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, name), contents);
+}
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "plannotator-data-"));
+  repoDir = mkdtempSync(join(tmpdir(), "plannotator-repo-"));
+  prevDataDir = process.env.PLANNOTATOR_DATA_DIR;
+  process.env.PLANNOTATOR_DATA_DIR = dataDir;
+});
+
+afterEach(() => {
+  if (prevDataDir === undefined) delete process.env.PLANNOTATOR_DATA_DIR;
+  else process.env.PLANNOTATOR_DATA_DIR = prevDataDir;
+  rmSync(dataDir, { recursive: true, force: true });
+  rmSync(repoDir, { recursive: true, force: true });
+});
+
+describe("loadReviewProfiles", () => {
+  test("always returns builtin:default, even with no profile dirs", () => {
+    const profiles = loadReviewProfiles();
+    expect(profiles).toHaveLength(1);
+    expect(profiles[0].id).toBe(BUILTIN_DEFAULT_ID);
+    expect(profiles[0].default).toBe(true);
+  });
+
+  test("infers id/label/engines end-to-end from a bare user file", () => {
+    writeUserProfile("api-contracts.json", JSON.stringify({ instructions: "Check API contracts." }));
+
+    const profiles = loadReviewProfiles();
+    const profile = profiles.find((p) => p.id === "user:api-contracts");
+    expect(profile).toBeDefined();
+    expect(profile!.label).toBe("API Contracts");
+    expect(profile!.engines).toEqual(["claude", "codex"]);
+    expect(profile!.source).toBe("user");
+    expect(profile!.sourcePath).toBe(join(dataDir, "reviews", "api-contracts.json"));
+  });
+
+  test("user profile beats a repo profile on a bare-name clash", () => {
+    writeUserProfile("security.json", JSON.stringify({ instructions: "user security" }));
+    writeRepoProfile("security.json", JSON.stringify({ instructions: "repo security" }));
+
+    const profiles = loadReviewProfiles({ repoCwd: repoDir });
+    const security = profiles.filter((p) => p.label === "Security");
+    expect(security).toHaveLength(1);
+    expect(security[0].source).toBe("user");
+    expect(security[0].instructions).toBe("user security");
+  });
+
+  test("malformed JSON is skipped; valid siblings survive", () => {
+    writeUserProfile("broken.json", "{ not valid json");
+    writeUserProfile("good.json", JSON.stringify({ instructions: "valid" }));
+
+    const profiles = loadReviewProfiles();
+    const ids = profiles.map((p) => p.id);
+    expect(ids).toContain("user:good");
+    expect(ids).not.toContain("user:broken");
+    // builtin + the one good profile
+    expect(profiles).toHaveLength(2);
+  });
+
+  test("repo profiles are absent when no repoCwd is provided", () => {
+    writeRepoProfile("security.json", JSON.stringify({ instructions: "repo only" }));
+
+    // No repoCwd → ambiguous/remote session → repo profiles excluded.
+    const profiles = loadReviewProfiles();
+    expect(profiles.map((p) => p.id)).not.toContain("repo:security");
+
+    // With repoCwd → the repo profile is loaded.
+    const withRepo = loadReviewProfiles({ repoCwd: repoDir });
+    expect(withRepo.map((p) => p.id)).toContain("repo:security");
+  });
+});

--- a/packages/server/review-profile-loader.ts
+++ b/packages/server/review-profile-loader.ts
@@ -2,21 +2,14 @@
  * Review Profile Loader
  *
  * Reads review profiles from disk and resolves them into a flat, launchable
- * list. Three sources, loaded in spec order:
+ * list. Two sources, loaded in spec order:
  *
  *   - builtin: in code (BUILTIN_PROFILES) — `builtin:default` is today's review.
  *   - user:    `${PLANNOTATOR_DATA_DIR}/reviews/*.json` — personal, every repo.
- *   - repo:    `<repoCwd>/.plannotator/reviews/*.json` — checked in, shared.
  *
  * Malformed files are skipped with one log line and never throw. Inference and
  * name-clash resolution come from the runtime-agnostic shared module; this file
  * only does the disk I/O. Reload on each request — no file watching.
- *
- * Repo-profile scoping (per spec): repo profiles are only loaded when there is
- * one unambiguous local review repo. The caller decides that by passing
- * `repoCwd` only when the session has a single local repo (i.e. not remote-only
- * PR mode and not ambiguous workspace mode); otherwise it omits `repoCwd` and
- * repo profiles are simply absent.
  */
 
 import { existsSync, readdirSync, readFileSync } from "node:fs";
@@ -28,20 +21,8 @@ import {
   type ResolvedReviewProfile,
 } from "@plannotator/shared/review-profiles";
 
-export interface LoadReviewProfilesOptions {
-  /**
-   * Working directory of the single, unambiguous local review repo. Repo
-   * profiles are read from `<repoCwd>/.plannotator/reviews`. Omit in
-   * remote-only PR mode or ambiguous workspace mode to exclude repo profiles.
-   */
-  repoCwd?: string;
-}
-
 /** Read every `*.json` file in a reviews dir into raw entries (no validation). */
-function readReviewDir(
-  dir: string,
-  source: "user" | "repo",
-): RawReviewProfileEntry[] {
+function readReviewDir(dir: string): RawReviewProfileEntry[] {
   if (!existsSync(dir)) return [];
 
   let filenames: string[];
@@ -62,7 +43,7 @@ function readReviewDir(
     const path = join(dir, filename);
     try {
       const raw = readFileSync(path, "utf-8");
-      entries.push({ source, path, json: JSON.parse(raw) });
+      entries.push({ source: "user", path, json: JSON.parse(raw) });
     } catch (err) {
       // Skip-and-log: one line, never throw. A broken file does not break
       // discovery for its valid siblings.
@@ -77,19 +58,12 @@ function readReviewDir(
 }
 
 /**
- * Load and resolve review profiles from builtin + user + (optionally) repo
- * sources. Always returns at least `builtin:default`.
+ * Load and resolve review profiles from builtin + user sources. Always returns
+ * at least `builtin:default`.
  */
-export function loadReviewProfiles(
-  options: LoadReviewProfilesOptions = {},
-): ResolvedReviewProfile[] {
+export function loadReviewProfiles(): ResolvedReviewProfile[] {
   const userDir = join(getPlannotatorDataDir(), "reviews");
-  const entries: RawReviewProfileEntry[] = readReviewDir(userDir, "user");
-
-  if (options.repoCwd) {
-    const repoDir = join(options.repoCwd, ".plannotator", "reviews");
-    entries.push(...readReviewDir(repoDir, "repo"));
-  }
+  const entries: RawReviewProfileEntry[] = readReviewDir(userDir);
 
   return resolveReviewProfiles(entries);
 }

--- a/packages/server/review-profile-loader.ts
+++ b/packages/server/review-profile-loader.ts
@@ -38,7 +38,9 @@ function readReviewDir(dir: string): RawReviewProfileEntry[] {
   }
 
   const entries: RawReviewProfileEntry[] = [];
-  for (const filename of filenames) {
+  // Sort so a bare-name clash resolves deterministically (first-seen wins) rather
+  // than by filesystem readdir order, which varies across machines.
+  for (const filename of filenames.sort()) {
     if (!filename.toLowerCase().endsWith(".json")) continue;
     const path = join(dir, filename);
     try {

--- a/packages/server/review-profile-loader.ts
+++ b/packages/server/review-profile-loader.ts
@@ -1,0 +1,95 @@
+/**
+ * Review Profile Loader
+ *
+ * Reads review profiles from disk and resolves them into a flat, launchable
+ * list. Three sources, loaded in spec order:
+ *
+ *   - builtin: in code (BUILTIN_PROFILES) — `builtin:default` is today's review.
+ *   - user:    `${PLANNOTATOR_DATA_DIR}/reviews/*.json` — personal, every repo.
+ *   - repo:    `<repoCwd>/.plannotator/reviews/*.json` — checked in, shared.
+ *
+ * Malformed files are skipped with one log line and never throw. Inference and
+ * name-clash resolution come from the runtime-agnostic shared module; this file
+ * only does the disk I/O. Reload on each request — no file watching.
+ *
+ * Repo-profile scoping (per spec): repo profiles are only loaded when there is
+ * one unambiguous local review repo. The caller decides that by passing
+ * `repoCwd` only when the session has a single local repo (i.e. not remote-only
+ * PR mode and not ambiguous workspace mode); otherwise it omits `repoCwd` and
+ * repo profiles are simply absent.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { getPlannotatorDataDir } from "@plannotator/shared/data-dir";
+import {
+  resolveReviewProfiles,
+  type RawReviewProfileEntry,
+  type ResolvedReviewProfile,
+} from "@plannotator/shared/review-profiles";
+
+export interface LoadReviewProfilesOptions {
+  /**
+   * Working directory of the single, unambiguous local review repo. Repo
+   * profiles are read from `<repoCwd>/.plannotator/reviews`. Omit in
+   * remote-only PR mode or ambiguous workspace mode to exclude repo profiles.
+   */
+  repoCwd?: string;
+}
+
+/** Read every `*.json` file in a reviews dir into raw entries (no validation). */
+function readReviewDir(
+  dir: string,
+  source: "user" | "repo",
+): RawReviewProfileEntry[] {
+  if (!existsSync(dir)) return [];
+
+  let filenames: string[];
+  try {
+    filenames = readdirSync(dir);
+  } catch (err) {
+    console.error(
+      `[plannotator] Could not read review profiles dir ${dir}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return [];
+  }
+
+  const entries: RawReviewProfileEntry[] = [];
+  for (const filename of filenames) {
+    if (!filename.toLowerCase().endsWith(".json")) continue;
+    const path = join(dir, filename);
+    try {
+      const raw = readFileSync(path, "utf-8");
+      entries.push({ source, path, json: JSON.parse(raw) });
+    } catch (err) {
+      // Skip-and-log: one line, never throw. A broken file does not break
+      // discovery for its valid siblings.
+      console.error(
+        `[plannotator] Skipping malformed review profile ${path}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+  return entries;
+}
+
+/**
+ * Load and resolve review profiles from builtin + user + (optionally) repo
+ * sources. Always returns at least `builtin:default`.
+ */
+export function loadReviewProfiles(
+  options: LoadReviewProfilesOptions = {},
+): ResolvedReviewProfile[] {
+  const userDir = join(getPlannotatorDataDir(), "reviews");
+  const entries: RawReviewProfileEntry[] = readReviewDir(userDir, "user");
+
+  if (options.repoCwd) {
+    const repoDir = join(options.repoCwd, ".plannotator", "reviews");
+    entries.push(...readReviewDir(repoDir, "repo"));
+  }
+
+  return resolveReviewProfiles(entries);
+}

--- a/packages/server/review-prompt-composition.test.ts
+++ b/packages/server/review-prompt-composition.test.ts
@@ -15,7 +15,6 @@ const security: ResolvedReviewProfile = {
   label: "Security",
   instructions: "Focus only on security-impacting issues.",
   source: "user",
-  engines: ["claude", "codex"],
 };
 
 // The exact prompt today, before this phase, for the default path.
@@ -81,14 +80,13 @@ describe("review prompt composition — custom section placement", () => {
   });
 
   test("section carries the profile's label and source verbatim", () => {
-    const repo: ResolvedReviewProfile = {
-      id: "repo:perf",
+    const profile: ResolvedReviewProfile = {
+      id: "user:perf",
       label: "Performance",
       instructions: "Flag N+1 queries.",
-      source: "repo",
-      engines: ["claude"],
+      source: "user",
     };
-    const prompt = composeClaudeReviewPrompt(userMessage, repo);
-    expect(prompt).toContain("Profile: Performance\nSource: repo\n\nFlag N+1 queries.");
+    const prompt = composeClaudeReviewPrompt(userMessage, profile);
+    expect(prompt).toContain("Profile: Performance\nSource: user\n\nFlag N+1 queries.");
   });
 });

--- a/packages/server/review-prompt-composition.test.ts
+++ b/packages/server/review-prompt-composition.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { composeClaudeReviewPrompt, CLAUDE_REVIEW_PROMPT } from "./claude-review";
+import { composeCodexReviewPrompt, CODEX_REVIEW_SYSTEM_PROMPT } from "./codex-review";
+import {
+  BUILTIN_DEFAULT_PROFILE,
+  type ResolvedReviewProfile,
+} from "@plannotator/shared/review-profiles";
+
+// Stand-in for buildAgentReviewUserMessage(...) output. The composer treats it
+// as opaque text, so a literal is enough to pin placement and byte-equality.
+const userMessage = "Review of the current code changes.\n\n```diff\n+const x = 1;\n```";
+
+const security: ResolvedReviewProfile = {
+  id: "user:security",
+  label: "Security",
+  instructions: "Focus only on security-impacting issues.",
+  source: "user",
+  engines: ["claude", "codex"],
+};
+
+// The exact prompt today, before this phase, for the default path.
+const claudeDefault = CLAUDE_REVIEW_PROMPT + "\n\n---\n\n" + userMessage;
+const codexDefault = CODEX_REVIEW_SYSTEM_PROMPT + "\n\n---\n\n" + userMessage;
+
+describe("review prompt composition — default is byte-identical", () => {
+  test("Claude: absent profile matches today's prompt exactly", () => {
+    expect(composeClaudeReviewPrompt(userMessage)).toBe(claudeDefault);
+  });
+
+  test("Claude: builtin:default matches today's prompt exactly", () => {
+    expect(composeClaudeReviewPrompt(userMessage, BUILTIN_DEFAULT_PROFILE)).toBe(claudeDefault);
+  });
+
+  test("Codex: absent profile matches today's prompt exactly", () => {
+    expect(composeCodexReviewPrompt(userMessage)).toBe(codexDefault);
+  });
+
+  test("Codex: builtin:default matches today's prompt exactly", () => {
+    expect(composeCodexReviewPrompt(userMessage, BUILTIN_DEFAULT_PROFILE)).toBe(codexDefault);
+  });
+
+  test("a custom profile with empty instructions still yields the default prompt", () => {
+    const blank: ResolvedReviewProfile = { ...security, instructions: "   " };
+    expect(composeClaudeReviewPrompt(userMessage, blank)).toBe(claudeDefault);
+    expect(composeCodexReviewPrompt(userMessage, blank)).toBe(codexDefault);
+  });
+});
+
+describe("review prompt composition — custom section placement", () => {
+  test("Claude: section sits between system prompt and user message", () => {
+    const prompt = composeClaudeReviewPrompt(userMessage, security);
+
+    const expected =
+      CLAUDE_REVIEW_PROMPT +
+      "\n\n" +
+      "## Custom Review Profile\n\nProfile: Security\nSource: user\n\nFocus only on security-impacting issues." +
+      "\n\n---\n\n" +
+      userMessage;
+
+    expect(prompt).toBe(expected);
+    // Ordering invariant: system prompt → section → separator → user message.
+    expect(prompt.indexOf("## Custom Review Profile")).toBeGreaterThan(
+      prompt.indexOf(CLAUDE_REVIEW_PROMPT),
+    );
+    expect(prompt.indexOf(userMessage)).toBeGreaterThan(
+      prompt.indexOf("## Custom Review Profile"),
+    );
+  });
+
+  test("Codex: section sits between system prompt and user message", () => {
+    const prompt = composeCodexReviewPrompt(userMessage, security);
+
+    const expected =
+      CODEX_REVIEW_SYSTEM_PROMPT +
+      "\n\n" +
+      "## Custom Review Profile\n\nProfile: Security\nSource: user\n\nFocus only on security-impacting issues." +
+      "\n\n---\n\n" +
+      userMessage;
+
+    expect(prompt).toBe(expected);
+  });
+
+  test("section carries the profile's label and source verbatim", () => {
+    const repo: ResolvedReviewProfile = {
+      id: "repo:perf",
+      label: "Performance",
+      instructions: "Flag N+1 queries.",
+      source: "repo",
+      engines: ["claude"],
+    };
+    const prompt = composeClaudeReviewPrompt(userMessage, repo);
+    expect(prompt).toContain("Profile: Performance\nSource: repo\n\nFlag N+1 queries.");
+  });
+});

--- a/packages/server/review.ts
+++ b/packages/server/review.ts
@@ -561,11 +561,29 @@ export async function startReviewServer(
         prRepo: getDisplayRepo(jobPrMeta),
       } : jobPrUrl ? { prUrl: jobPrUrl } : {};
 
-      const profileLabel = job.reviewProfileLabel;
+      // Only tag annotations with a *custom* profile — the default review needs no tag.
+      const profileLabel =
+        job.reviewProfileId && job.reviewProfileId !== BUILTIN_DEFAULT_PROFILE.id
+          ? job.reviewProfileLabel
+          : undefined;
+
+      // Map findings onto annotations and ingest. Shared by both engine branches;
+      // no-ops on an empty set so a clean (zero-finding) review stays "done".
+      const ingest = <T extends object>(transformed: readonly T[], logTag: string) => {
+        if (transformed.length === 0) return;
+        const annotations = transformed.map((a) => ({
+          ...a,
+          ...jobPrContext,
+          ...(jobDiffScope && { diffScope: jobDiffScope }),
+          ...(profileLabel && { reviewProfileLabel: profileLabel }),
+        }));
+        const result = externalAnnotations.addAnnotations({ annotations });
+        if ("error" in result) console.error(`[${logTag}] addAnnotations error:`, result.error);
+      };
 
       // --- Codex path ---
-      if (job.provider === "codex" && meta.outputPath) {
-        const output = await parseCodexOutput(meta.outputPath);
+      if (job.provider === "codex") {
+        const output = meta.outputPath ? await parseCodexOutput(meta.outputPath) : null;
         if (!output) {
           // Process exited 0 but output is missing/unparseable — not a green run.
           markJobReviewFailed(job, REVIEW_OUTPUT_FAILED);
@@ -581,23 +599,16 @@ export async function startReviewServer(
           confidence: output.overall_confidence_score,
         };
 
-        if (output.findings.length > 0) {
-          const transformed = transformReviewFindings(
+        ingest(
+          transformReviewFindings(
             output.findings,
             job.source,
             cwd,
             "Codex",
             workspace ? (filePath) => workspace.normalizeAnnotationPath(filePath) : undefined,
-          );
-          const annotations = transformed.map(a => ({
-            ...a,
-            ...jobPrContext,
-            ...(jobDiffScope && { diffScope: jobDiffScope }),
-            ...(profileLabel && { reviewProfileLabel: profileLabel }),
-          }));
-          const result = externalAnnotations.addAnnotations({ annotations });
-          if ("error" in result) console.error(`[codex-review] addAnnotations error:`, result.error);
-        }
+          ),
+          "codex-review",
+        );
         return;
       }
 
@@ -618,22 +629,15 @@ export async function startReviewServer(
           confidence: total === 0 ? 1.0 : Math.max(0, 1.0 - (output.summary.important * 0.2)),
         };
 
-        if (output.findings.length > 0) {
-          const transformed = transformClaudeFindings(
+        ingest(
+          transformClaudeFindings(
             output.findings,
             job.source,
             cwd,
             workspace ? (filePath) => workspace.normalizeAnnotationPath(filePath) : undefined,
-          );
-          const annotations = transformed.map(a => ({
-            ...a,
-            ...jobPrContext,
-            ...(jobDiffScope && { diffScope: jobDiffScope }),
-            ...(profileLabel && { reviewProfileLabel: profileLabel }),
-          }));
-          const result = externalAnnotations.addAnnotations({ annotations });
-          if ("error" in result) console.error(`[claude-review] addAnnotations error:`, result.error);
-        }
+          ),
+          "claude-review",
+        );
         return;
       }
 

--- a/packages/server/review.ts
+++ b/packages/server/review.ts
@@ -36,7 +36,7 @@ import {
   checkoutPRHead,
   type PRDiffScope,
 } from "@plannotator/shared/pr-stack";
-import type { AgentJobInfo } from "@plannotator/shared/agent-jobs";
+import { type AgentJobInfo, REVIEW_OUTPUT_FAILED, markJobReviewFailed } from "@plannotator/shared/agent-jobs";
 import { getRepoInfo } from "./repo";
 import { handleImage, handleUpload, handleAgents, handleServerReady, handleDraftSave, handleDraftLoad, handleDraftDelete, handleFavicon, type OpencodeClient } from "./shared-handlers";
 import { contentHash, deleteDraft } from "./draft";
@@ -72,48 +72,8 @@ import {
   type ReviewProfilesResponse,
 } from "@plannotator/shared/review-profiles";
 
-// --- Review ingestion helpers (shared shape with Pi serverReview.ts) ---
-
-// Calm, provider-neutral failure reasons. Never leak schema/CLI internals.
-export const REVIEW_OUTPUT_FAILED = "Review finished but produced no usable findings.";
-export const REVIEW_ALL_OUT_OF_DIFF = "Review findings were all outside the reviewed diff.";
-
-/**
- * Drop findings whose file is not in the reviewed diff. Cheap guard, not a
- * diff-anchoring module: a plain set-membership check against the launch
- * patch's changed files. When the changed-file list is unavailable (e.g.
- * unfingerprintable mode), keep everything rather than silently dropping.
- */
-export function filterToReviewedDiff<T extends { filePath: string }>(
-  annotations: T[],
-  changedFiles: string[] | undefined,
-): { kept: T[]; dropped: number } {
-  if (!changedFiles || changedFiles.length === 0) {
-    return { kept: annotations, dropped: 0 };
-  }
-  const allowed = new Set(changedFiles);
-  const kept = annotations.filter((a) => allowed.has(a.filePath));
-  return { kept, dropped: annotations.length - kept.length };
-}
-
-/** Flip a job to failed with a calm one-liner (Code Tour precedent). */
-export function markJobReviewFailed(job: AgentJobInfo, error: string): void {
-  job.status = "failed";
-  job.error = error;
-}
-
-/**
- * Reflect post-ingestion counts on the job summary so the detail panel can
- * surface "N findings · M skipped (not in the reviewed diff)".
- */
-export function applyReviewFindingsSummary(job: AgentJobInfo, kept: number, dropped: number): void {
-  if (dropped <= 0 || !job.summary) return;
-  const note = `${kept} findings · ${dropped} skipped (not in the reviewed diff)`;
-  job.summary = {
-    ...job.summary,
-    explanation: job.summary.explanation ? `${job.summary.explanation} — ${note}` : note,
-  };
-}
+// Review ingestion completion semantics (REVIEW_OUTPUT_FAILED,
+// markJobReviewFailed) now live in @plannotator/shared/agent-jobs.
 
 // Re-export utilities
 export { isRemoteSession, getServerPort } from "./remote";
@@ -482,25 +442,17 @@ export async function startReviewServer(
       // the job's cwd, prompt, and PR attribution must describe the same PR.
       const launchMetadata = prMetadata;
       const launchPatch = currentPatch;
-      // Files in the diff the agent will actually review. Threaded to
-      // onJobComplete so out-of-diff findings can be dropped against this
-      // snapshot, not whatever diff happens to be current at completion.
-      const launchChangedFiles = extractChangedFiles(launchPatch);
       const launchDiffType = currentDiffType;
       const launchBase = currentBase;
       const launchScope = currentPRDiffScope;
 
-      // Resolve the requested review profile against the same target the agent
-      // will review. Repo profiles are scoped to a single unambiguous local
-      // repo (excluded in remote-only PR mode and ambiguous workspace mode),
-      // matching the discovery endpoint. Absent or unknown id → builtin:default,
-      // so today's "Run Review" stays byte-identical.
+      // Resolve the requested review profile. Profiles come from the user dir
+      // plus builtins. Absent or unknown id → builtin:default, so today's
+      // "Run Review" stays byte-identical.
       const requestedProfileId =
         typeof config?.reviewProfileId === "string" ? config.reviewProfileId : undefined;
-      const profileRepoCwd =
-        !isPRMode && !isWorkspaceMode && gitContext ? gitContext.cwd : undefined;
       const reviewProfile: ResolvedReviewProfile = requestedProfileId
-        ? loadReviewProfiles({ repoCwd: profileRepoCwd }).find((p) => p.id === requestedProfileId) ??
+        ? loadReviewProfiles().find((p) => p.id === requestedProfileId) ??
           BUILTIN_DEFAULT_PROFILE
         : BUILTIN_DEFAULT_PROFILE;
 
@@ -582,16 +534,16 @@ export async function startReviewServer(
         const fastMode = config?.fastMode === true;
         const outputPath = generateOutputPath();
         const prompt = composeCodexReviewPrompt(userMessage, reviewProfile);
-        const command = await buildCodexCommand({ cwd, outputPath, prompt, model, reasoningEffort, fastMode, reviewProfile });
-        return { command, outputPath, prompt, cwd, label: jobLabel, model, reasoningEffort, fastMode: fastMode || undefined, prUrl: launchPrUrl, diffScope: launchDiffScope, diffContext, reviewProfileId: reviewProfile.id, reviewProfileLabel: reviewProfile.label, reviewChangedFiles: launchChangedFiles };
+        const command = await buildCodexCommand({ cwd, outputPath, prompt, model, reasoningEffort, fastMode });
+        return { command, outputPath, prompt, cwd, label: jobLabel, model, reasoningEffort, fastMode: fastMode || undefined, prUrl: launchPrUrl, diffScope: launchDiffScope, diffContext, reviewProfileId: reviewProfile.id, reviewProfileLabel: reviewProfile.label };
       }
 
       if (provider === "claude") {
         const model = typeof config?.model === "string" && config.model ? config.model : undefined;
         const effort = typeof config?.effort === "string" && config.effort ? config.effort : undefined;
         const prompt = composeClaudeReviewPrompt(userMessage, reviewProfile);
-        const { command, stdinPrompt } = buildClaudeCommand(prompt, model, effort, reviewProfile);
-        return { command, stdinPrompt, prompt, cwd, label: jobLabel, captureStdout: true, model, effort, prUrl: launchPrUrl, diffScope: launchDiffScope, diffContext, reviewProfileId: reviewProfile.id, reviewProfileLabel: reviewProfile.label, reviewChangedFiles: launchChangedFiles };
+        const { command, stdinPrompt } = buildClaudeCommand(prompt, model, effort);
+        return { command, stdinPrompt, prompt, cwd, label: jobLabel, captureStdout: true, model, effort, prUrl: launchPrUrl, diffScope: launchDiffScope, diffContext, reviewProfileId: reviewProfile.id, reviewProfileLabel: reviewProfile.label };
       }
 
       return null;
@@ -637,12 +589,7 @@ export async function startReviewServer(
             "Codex",
             workspace ? (filePath) => workspace.normalizeAnnotationPath(filePath) : undefined,
           );
-          const { kept, dropped } = filterToReviewedDiff(transformed, meta.reviewChangedFiles);
-          if (kept.length === 0 && transformed.length > 0) {
-            markJobReviewFailed(job, REVIEW_ALL_OUT_OF_DIFF);
-            return;
-          }
-          const annotations = kept.map(a => ({
+          const annotations = transformed.map(a => ({
             ...a,
             ...jobPrContext,
             ...(jobDiffScope && { diffScope: jobDiffScope }),
@@ -650,16 +597,16 @@ export async function startReviewServer(
           }));
           const result = externalAnnotations.addAnnotations({ annotations });
           if ("error" in result) console.error(`[codex-review] addAnnotations error:`, result.error);
-          else applyReviewFindingsSummary(job, kept.length, dropped);
         }
         return;
       }
 
       // --- Claude path ---
-      if (job.provider === "claude" && meta.stdout) {
-        const output = parseClaudeStreamOutput(meta.stdout);
+      if (job.provider === "claude") {
+        const stdout = meta.stdout ?? "";
+        const output = parseClaudeStreamOutput(stdout);
         if (!output) {
-          console.error(`[claude-review] Failed to parse output (${meta.stdout.length} bytes, last 200: ${meta.stdout.slice(-200)})`);
+          console.error(`[claude-review] Failed to parse output (${stdout.length} bytes, last 200: ${stdout.slice(-200)})`);
           markJobReviewFailed(job, REVIEW_OUTPUT_FAILED);
           return;
         }
@@ -678,12 +625,7 @@ export async function startReviewServer(
             cwd,
             workspace ? (filePath) => workspace.normalizeAnnotationPath(filePath) : undefined,
           );
-          const { kept, dropped } = filterToReviewedDiff(transformed, meta.reviewChangedFiles);
-          if (kept.length === 0 && transformed.length > 0) {
-            markJobReviewFailed(job, REVIEW_ALL_OUT_OF_DIFF);
-            return;
-          }
-          const annotations = kept.map(a => ({
+          const annotations = transformed.map(a => ({
             ...a,
             ...jobPrContext,
             ...(jobDiffScope && { diffScope: jobDiffScope }),
@@ -691,7 +633,6 @@ export async function startReviewServer(
           }));
           const result = externalAnnotations.addAnnotations({ annotations });
           if ("error" in result) console.error(`[claude-review] addAnnotations error:`, result.error);
-          else applyReviewFindingsSummary(job, kept.length, dropped);
         }
         return;
       }
@@ -1470,19 +1411,15 @@ export async function startReviewServer(
           }
 
           // API: Review profiles (custom reviews discovery). Reloaded per
-          // request, no file watching. Repo profiles are scoped to a single
-          // unambiguous local repo: excluded in remote-only PR mode and
-          // ambiguous workspace mode.
+          // request, no file watching. Profiles come from the user dir plus
+          // builtins.
           if (url.pathname === "/api/agents/review-profiles" && req.method === "GET") {
-            const repoCwd =
-              !isPRMode && !isWorkspaceMode && gitContext ? gitContext.cwd : undefined;
-            const profiles = loadReviewProfiles({ repoCwd });
+            const profiles = loadReviewProfiles();
             const body: ReviewProfilesResponse = {
               profiles: profiles.map((p) => ({
                 id: p.id,
                 label: p.label,
                 description: p.description,
-                engines: p.engines,
                 source: p.source,
                 sourcePath: p.sourcePath,
                 default: p.default,

--- a/packages/server/review.ts
+++ b/packages/server/review.ts
@@ -44,7 +44,7 @@ import { createEditorAnnotationHandler } from "./editor-annotations";
 import { createExternalAnnotationHandler } from "./external-annotations";
 import { createAgentJobHandler } from "./agent-jobs";
 import {
-  CODEX_REVIEW_SYSTEM_PROMPT,
+  composeCodexReviewPrompt,
   buildCodexCommand,
   generateOutputPath,
   parseCodexOutput,
@@ -52,7 +52,7 @@ import {
 } from "./codex-review";
 import { buildAgentReviewUserMessage, buildAgentReviewUserMessageForTarget, type WorkspaceReviewPromptContext } from "./agent-review-message";
 import {
-  CLAUDE_REVIEW_PROMPT,
+  composeClaudeReviewPrompt,
   buildClaudeCommand,
   parseClaudeStreamOutput,
   transformClaudeFindings,
@@ -65,6 +65,55 @@ import type { AIEndpoints } from "@plannotator/ai";
 import { isWSL } from "./browser";
 import type { LocalWorkspaceReview, WorkspaceDiffType } from "./review-workspace";
 import { handleCodeNavResolve, extractChangedFiles } from "./code-nav";
+import { loadReviewProfiles } from "./review-profile-loader";
+import {
+  BUILTIN_DEFAULT_PROFILE,
+  type ResolvedReviewProfile,
+  type ReviewProfilesResponse,
+} from "@plannotator/shared/review-profiles";
+
+// --- Review ingestion helpers (shared shape with Pi serverReview.ts) ---
+
+// Calm, provider-neutral failure reasons. Never leak schema/CLI internals.
+export const REVIEW_OUTPUT_FAILED = "Review finished but produced no usable findings.";
+export const REVIEW_ALL_OUT_OF_DIFF = "Review findings were all outside the reviewed diff.";
+
+/**
+ * Drop findings whose file is not in the reviewed diff. Cheap guard, not a
+ * diff-anchoring module: a plain set-membership check against the launch
+ * patch's changed files. When the changed-file list is unavailable (e.g.
+ * unfingerprintable mode), keep everything rather than silently dropping.
+ */
+export function filterToReviewedDiff<T extends { filePath: string }>(
+  annotations: T[],
+  changedFiles: string[] | undefined,
+): { kept: T[]; dropped: number } {
+  if (!changedFiles || changedFiles.length === 0) {
+    return { kept: annotations, dropped: 0 };
+  }
+  const allowed = new Set(changedFiles);
+  const kept = annotations.filter((a) => allowed.has(a.filePath));
+  return { kept, dropped: annotations.length - kept.length };
+}
+
+/** Flip a job to failed with a calm one-liner (Code Tour precedent). */
+export function markJobReviewFailed(job: AgentJobInfo, error: string): void {
+  job.status = "failed";
+  job.error = error;
+}
+
+/**
+ * Reflect post-ingestion counts on the job summary so the detail panel can
+ * surface "N findings · M skipped (not in the reviewed diff)".
+ */
+export function applyReviewFindingsSummary(job: AgentJobInfo, kept: number, dropped: number): void {
+  if (dropped <= 0 || !job.summary) return;
+  const note = `${kept} findings · ${dropped} skipped (not in the reviewed diff)`;
+  job.summary = {
+    ...job.summary,
+    explanation: job.summary.explanation ? `${job.summary.explanation} — ${note}` : note,
+  };
+}
 
 // Re-export utilities
 export { isRemoteSession, getServerPort } from "./remote";
@@ -433,9 +482,27 @@ export async function startReviewServer(
       // the job's cwd, prompt, and PR attribution must describe the same PR.
       const launchMetadata = prMetadata;
       const launchPatch = currentPatch;
+      // Files in the diff the agent will actually review. Threaded to
+      // onJobComplete so out-of-diff findings can be dropped against this
+      // snapshot, not whatever diff happens to be current at completion.
+      const launchChangedFiles = extractChangedFiles(launchPatch);
       const launchDiffType = currentDiffType;
       const launchBase = currentBase;
       const launchScope = currentPRDiffScope;
+
+      // Resolve the requested review profile against the same target the agent
+      // will review. Repo profiles are scoped to a single unambiguous local
+      // repo (excluded in remote-only PR mode and ambiguous workspace mode),
+      // matching the discovery endpoint. Absent or unknown id → builtin:default,
+      // so today's "Run Review" stays byte-identical.
+      const requestedProfileId =
+        typeof config?.reviewProfileId === "string" ? config.reviewProfileId : undefined;
+      const profileRepoCwd =
+        !isPRMode && !isWorkspaceMode && gitContext ? gitContext.cwd : undefined;
+      const reviewProfile: ResolvedReviewProfile = requestedProfileId
+        ? loadReviewProfiles({ repoCwd: profileRepoCwd }).find((p) => p.id === requestedProfileId) ??
+          BUILTIN_DEFAULT_PROFILE
+        : BUILTIN_DEFAULT_PROFILE;
 
       // Agents run inside the PR checkout — wait out the background warmup so
       // the spawn-time getCwd() below resolves to a path that exists.
@@ -497,7 +564,7 @@ export async function startReviewServer(
           prMetadata: launchMetadata,
           config,
         });
-        return built ? { ...built, prUrl: launchPrUrl, diffScope: launchDiffScope, diffContext } : built;
+        return built ? { ...built, prUrl: launchPrUrl, diffScope: launchDiffScope, diffContext, reviewProfileId: reviewProfile.id, reviewProfileLabel: reviewProfile.label } : built;
       }
 
       const userMessage = workspacePrompt
@@ -514,17 +581,17 @@ export async function startReviewServer(
         const reasoningEffort = typeof config?.reasoningEffort === "string" && config.reasoningEffort ? config.reasoningEffort : undefined;
         const fastMode = config?.fastMode === true;
         const outputPath = generateOutputPath();
-        const prompt = CODEX_REVIEW_SYSTEM_PROMPT + "\n\n---\n\n" + userMessage;
-        const command = await buildCodexCommand({ cwd, outputPath, prompt, model, reasoningEffort, fastMode });
-        return { command, outputPath, prompt, cwd, label: jobLabel, model, reasoningEffort, fastMode: fastMode || undefined, prUrl: launchPrUrl, diffScope: launchDiffScope, diffContext };
+        const prompt = composeCodexReviewPrompt(userMessage, reviewProfile);
+        const command = await buildCodexCommand({ cwd, outputPath, prompt, model, reasoningEffort, fastMode, reviewProfile });
+        return { command, outputPath, prompt, cwd, label: jobLabel, model, reasoningEffort, fastMode: fastMode || undefined, prUrl: launchPrUrl, diffScope: launchDiffScope, diffContext, reviewProfileId: reviewProfile.id, reviewProfileLabel: reviewProfile.label, reviewChangedFiles: launchChangedFiles };
       }
 
       if (provider === "claude") {
         const model = typeof config?.model === "string" && config.model ? config.model : undefined;
         const effort = typeof config?.effort === "string" && config.effort ? config.effort : undefined;
-        const prompt = CLAUDE_REVIEW_PROMPT + "\n\n---\n\n" + userMessage;
-        const { command, stdinPrompt } = buildClaudeCommand(prompt, model, effort);
-        return { command, stdinPrompt, prompt, cwd, label: jobLabel, captureStdout: true, model, effort, prUrl: launchPrUrl, diffScope: launchDiffScope, diffContext };
+        const prompt = composeClaudeReviewPrompt(userMessage, reviewProfile);
+        const { command, stdinPrompt } = buildClaudeCommand(prompt, model, effort, reviewProfile);
+        return { command, stdinPrompt, prompt, cwd, label: jobLabel, captureStdout: true, model, effort, prUrl: launchPrUrl, diffScope: launchDiffScope, diffContext, reviewProfileId: reviewProfile.id, reviewProfileLabel: reviewProfile.label, reviewChangedFiles: launchChangedFiles };
       }
 
       return null;
@@ -542,10 +609,16 @@ export async function startReviewServer(
         prRepo: getDisplayRepo(jobPrMeta),
       } : jobPrUrl ? { prUrl: jobPrUrl } : {};
 
+      const profileLabel = job.reviewProfileLabel;
+
       // --- Codex path ---
       if (job.provider === "codex" && meta.outputPath) {
         const output = await parseCodexOutput(meta.outputPath);
-        if (!output) return;
+        if (!output) {
+          // Process exited 0 but output is missing/unparseable — not a green run.
+          markJobReviewFailed(job, REVIEW_OUTPUT_FAILED);
+          return;
+        }
 
         // Override verdict if there are blocking findings (P0/P1) — Codex's
         // freeform correctness string can say "mostly correct" with real bugs.
@@ -557,16 +630,27 @@ export async function startReviewServer(
         };
 
         if (output.findings.length > 0) {
-          const annotations = transformReviewFindings(
+          const transformed = transformReviewFindings(
             output.findings,
             job.source,
             cwd,
             "Codex",
             workspace ? (filePath) => workspace.normalizeAnnotationPath(filePath) : undefined,
-          )
-            .map(a => ({ ...a, ...jobPrContext, ...(jobDiffScope && { diffScope: jobDiffScope }) }));
+          );
+          const { kept, dropped } = filterToReviewedDiff(transformed, meta.reviewChangedFiles);
+          if (kept.length === 0 && transformed.length > 0) {
+            markJobReviewFailed(job, REVIEW_ALL_OUT_OF_DIFF);
+            return;
+          }
+          const annotations = kept.map(a => ({
+            ...a,
+            ...jobPrContext,
+            ...(jobDiffScope && { diffScope: jobDiffScope }),
+            ...(profileLabel && { reviewProfileLabel: profileLabel }),
+          }));
           const result = externalAnnotations.addAnnotations({ annotations });
           if ("error" in result) console.error(`[codex-review] addAnnotations error:`, result.error);
+          else applyReviewFindingsSummary(job, kept.length, dropped);
         }
         return;
       }
@@ -576,6 +660,7 @@ export async function startReviewServer(
         const output = parseClaudeStreamOutput(meta.stdout);
         if (!output) {
           console.error(`[claude-review] Failed to parse output (${meta.stdout.length} bytes, last 200: ${meta.stdout.slice(-200)})`);
+          markJobReviewFailed(job, REVIEW_OUTPUT_FAILED);
           return;
         }
 
@@ -587,15 +672,26 @@ export async function startReviewServer(
         };
 
         if (output.findings.length > 0) {
-          const annotations = transformClaudeFindings(
+          const transformed = transformClaudeFindings(
             output.findings,
             job.source,
             cwd,
             workspace ? (filePath) => workspace.normalizeAnnotationPath(filePath) : undefined,
-          )
-            .map(a => ({ ...a, ...jobPrContext, ...(jobDiffScope && { diffScope: jobDiffScope }) }));
+          );
+          const { kept, dropped } = filterToReviewedDiff(transformed, meta.reviewChangedFiles);
+          if (kept.length === 0 && transformed.length > 0) {
+            markJobReviewFailed(job, REVIEW_ALL_OUT_OF_DIFF);
+            return;
+          }
+          const annotations = kept.map(a => ({
+            ...a,
+            ...jobPrContext,
+            ...(jobDiffScope && { diffScope: jobDiffScope }),
+            ...(profileLabel && { reviewProfileLabel: profileLabel }),
+          }));
           const result = externalAnnotations.addAnnotations({ annotations });
           if ("error" in result) console.error(`[claude-review] addAnnotations error:`, result.error);
+          else applyReviewFindingsSummary(job, kept.length, dropped);
         }
         return;
       }
@@ -1371,6 +1467,28 @@ export async function startReviewServer(
           // API: Get available agents (OpenCode only)
           if (url.pathname === "/api/agents") {
             return handleAgents(options.opencodeClient);
+          }
+
+          // API: Review profiles (custom reviews discovery). Reloaded per
+          // request, no file watching. Repo profiles are scoped to a single
+          // unambiguous local repo: excluded in remote-only PR mode and
+          // ambiguous workspace mode.
+          if (url.pathname === "/api/agents/review-profiles" && req.method === "GET") {
+            const repoCwd =
+              !isPRMode && !isWorkspaceMode && gitContext ? gitContext.cwd : undefined;
+            const profiles = loadReviewProfiles({ repoCwd });
+            const body: ReviewProfilesResponse = {
+              profiles: profiles.map((p) => ({
+                id: p.id,
+                label: p.label,
+                description: p.description,
+                engines: p.engines,
+                source: p.source,
+                sourcePath: p.sourcePath,
+                default: p.default,
+              })),
+            };
+            return Response.json(body);
           }
 
           // API: Annotation draft persistence

--- a/packages/shared/agent-jobs.ts
+++ b/packages/shared/agent-jobs.ts
@@ -134,3 +134,16 @@ export function isTerminalStatus(status: AgentJobStatus): boolean {
 export function jobSource(id: string): string {
   return "agent-" + id.slice(0, 8);
 }
+
+// ---------------------------------------------------------------------------
+// Review ingestion completion semantics
+// ---------------------------------------------------------------------------
+
+/** Calm, provider-neutral failure reason. Never leak schema/CLI internals. */
+export const REVIEW_OUTPUT_FAILED = "Review finished but produced no usable findings.";
+
+/** Flip a job to failed with a calm one-liner (Code Tour precedent). */
+export function markJobReviewFailed(job: AgentJobInfo, error: string): void {
+  job.status = "failed";
+  job.error = error;
+}

--- a/packages/shared/agent-jobs.ts
+++ b/packages/shared/agent-jobs.ts
@@ -75,6 +75,10 @@ export interface AgentJobInfo {
   diffScope?: string;
   /** Diff context at launch time (see AgentJobDiffContext). */
   diffContext?: AgentJobDiffContext;
+  /** Resolved review profile id at launch time (e.g. "builtin:default", "user:security"). */
+  reviewProfileId?: string;
+  /** Resolved review profile label — rides on findings so the UI can show a profile tag. */
+  reviewProfileLabel?: string;
 }
 
 export interface AgentCapability {

--- a/packages/shared/external-annotation.ts
+++ b/packages/shared/external-annotation.ts
@@ -190,9 +190,10 @@ interface ReviewAnnotation {
   createdAt: number;
   author?: string;
   source?: string;
-  // Agent review metadata (optional — only set by Claude review findings)
+  // Agent review metadata (optional — only set by agent review findings)
   severity?: string; // "important" | "nit" | "pre_existing"
   reasoning?: string; // Validation chain explaining how the issue was confirmed
+  reviewProfileLabel?: string; // Custom review profile that produced this finding
 }
 
 const VALID_REVIEW_TYPES = ["comment", "suggestion", "concern"];
@@ -267,9 +268,10 @@ export function transformReviewInput(
       createdAt: Date.now(),
       author: typeof obj.author === "string" ? obj.author : undefined,
       source,
-      // Agent review metadata (optional — only set by Claude review findings)
+      // Agent review metadata (optional — only set by agent review findings)
       ...(typeof obj.severity === "string" && { severity: obj.severity }),
       ...(typeof obj.reasoning === "string" && { reasoning: obj.reasoning }),
+      ...(typeof obj.reviewProfileLabel === "string" && { reviewProfileLabel: obj.reviewProfileLabel }),
     });
   }
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -46,7 +46,8 @@
     "./code-nav": "./code-nav.ts",
     "./goal-setup": "./goal-setup.ts",
     "./semantic-diff": "./semantic-diff.ts",
-    "./semantic-diff-types": "./semantic-diff-types.ts"
+    "./semantic-diff-types": "./semantic-diff-types.ts",
+    "./review-profiles": "./review-profiles.ts"
   },
   "dependencies": {
     "@joplin/turndown-plugin-gfm": "^1.0.64",

--- a/packages/shared/review-profiles.test.ts
+++ b/packages/shared/review-profiles.test.ts
@@ -14,17 +14,11 @@ const userEntry = (path: string, json: unknown): RawReviewProfileEntry => ({
   path,
   json,
 });
-const repoEntry = (path: string, json: unknown): RawReviewProfileEntry => ({
-  source: "repo",
-  path,
-  json,
-});
 
 describe("inference", () => {
   test("id ← filename stem namespaced by source", () => {
     expect(filenameStem("/home/me/.plannotator/reviews/security.json")).toBe("security");
     expect(inferId("security", "user")).toBe("user:security");
-    expect(inferId("security", "repo")).toBe("repo:security");
   });
 
   test("label ← title-cased id", () => {
@@ -33,13 +27,12 @@ describe("inference", () => {
     expect(inferLabel("data_flow")).toBe("Data Flow");
   });
 
-  test("a bare instructions-only file resolves with inferred id/label/engines", () => {
+  test("a bare instructions-only file resolves with inferred id/label", () => {
     const [, profile] = resolveReviewProfiles([
       userEntry("/data/reviews/security.json", { instructions: "Focus on security." }),
     ]);
     expect(profile.id).toBe("user:security");
     expect(profile.label).toBe("Security");
-    expect(profile.engines).toEqual(["claude", "codex"]);
     expect(profile.source).toBe("user");
     expect(profile.sourcePath).toBe("/data/reviews/security.json");
   });
@@ -55,15 +48,6 @@ describe("validateProfileShape", () => {
     expect(validateProfileShape([{ instructions: "ok" }])).toBeNull();
   });
 
-  test("engines must be a non-empty subset of supported", () => {
-    expect(validateProfileShape({ instructions: "x", engines: ["claude"] })).toMatchObject({
-      engines: ["claude"],
-    });
-    expect(validateProfileShape({ instructions: "x", engines: [] })).toBeNull();
-    expect(validateProfileShape({ instructions: "x", engines: ["gemini"] })).toBeNull();
-    expect(validateProfileShape({ instructions: "x", engines: "claude" })).toBeNull();
-  });
-
   test("rejects oversized instructions", () => {
     expect(validateProfileShape({ instructions: "a".repeat(20_001) })).toBeNull();
   });
@@ -77,18 +61,16 @@ describe("resolution + name clashes", () => {
     expect(resolved[0].default).toBe(true);
   });
 
-  test("user beats repo on a bare-name clash", () => {
+  test("first-seen user profile wins on a bare-name clash", () => {
     const resolved = resolveReviewProfiles([
-      repoEntry("/repo/.plannotator/reviews/security.json", {
-        instructions: "repo version",
-      }),
-      userEntry("/data/reviews/security.json", { instructions: "user version" }),
+      userEntry("/data/reviews/security.json", { instructions: "first version" }),
+      userEntry("/data/reviews/security.json", { instructions: "second version" }),
     ]);
     const security = resolved.filter((p) => p.label === "Security");
     expect(security).toHaveLength(1);
     expect(security[0].source).toBe("user");
     expect(security[0].id).toBe("user:security");
-    expect(security[0].instructions).toBe("user version");
+    expect(security[0].instructions).toBe("first version");
   });
 
   test("malformed entries are dropped, valid siblings survive", () => {

--- a/packages/shared/review-profiles.test.ts
+++ b/packages/shared/review-profiles.test.ts
@@ -1,0 +1,118 @@
+import { describe, test, expect } from "bun:test";
+import {
+  BUILTIN_DEFAULT_ID,
+  filenameStem,
+  inferId,
+  inferLabel,
+  resolveReviewProfiles,
+  validateProfileShape,
+  type RawReviewProfileEntry,
+} from "./review-profiles";
+
+const userEntry = (path: string, json: unknown): RawReviewProfileEntry => ({
+  source: "user",
+  path,
+  json,
+});
+const repoEntry = (path: string, json: unknown): RawReviewProfileEntry => ({
+  source: "repo",
+  path,
+  json,
+});
+
+describe("inference", () => {
+  test("id ← filename stem namespaced by source", () => {
+    expect(filenameStem("/home/me/.plannotator/reviews/security.json")).toBe("security");
+    expect(inferId("security", "user")).toBe("user:security");
+    expect(inferId("security", "repo")).toBe("repo:security");
+  });
+
+  test("label ← title-cased id", () => {
+    expect(inferLabel("api-contracts")).toBe("API Contracts");
+    expect(inferLabel("performance")).toBe("Performance");
+    expect(inferLabel("data_flow")).toBe("Data Flow");
+  });
+
+  test("a bare instructions-only file resolves with inferred id/label/engines", () => {
+    const [, profile] = resolveReviewProfiles([
+      userEntry("/data/reviews/security.json", { instructions: "Focus on security." }),
+    ]);
+    expect(profile.id).toBe("user:security");
+    expect(profile.label).toBe("Security");
+    expect(profile.engines).toEqual(["claude", "codex"]);
+    expect(profile.source).toBe("user");
+    expect(profile.sourcePath).toBe("/data/reviews/security.json");
+  });
+});
+
+describe("validateProfileShape", () => {
+  test("requires non-empty instructions string", () => {
+    expect(validateProfileShape({ instructions: "ok" })).not.toBeNull();
+    expect(validateProfileShape({ instructions: "   " })).toBeNull();
+    expect(validateProfileShape({ instructions: 42 })).toBeNull();
+    expect(validateProfileShape({})).toBeNull();
+    expect(validateProfileShape(null)).toBeNull();
+    expect(validateProfileShape([{ instructions: "ok" }])).toBeNull();
+  });
+
+  test("engines must be a non-empty subset of supported", () => {
+    expect(validateProfileShape({ instructions: "x", engines: ["claude"] })).toMatchObject({
+      engines: ["claude"],
+    });
+    expect(validateProfileShape({ instructions: "x", engines: [] })).toBeNull();
+    expect(validateProfileShape({ instructions: "x", engines: ["gemini"] })).toBeNull();
+    expect(validateProfileShape({ instructions: "x", engines: "claude" })).toBeNull();
+  });
+
+  test("rejects oversized instructions", () => {
+    expect(validateProfileShape({ instructions: "a".repeat(20_001) })).toBeNull();
+  });
+});
+
+describe("resolution + name clashes", () => {
+  test("builtin:default is always present", () => {
+    const resolved = resolveReviewProfiles([]);
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0].id).toBe(BUILTIN_DEFAULT_ID);
+    expect(resolved[0].default).toBe(true);
+  });
+
+  test("user beats repo on a bare-name clash", () => {
+    const resolved = resolveReviewProfiles([
+      repoEntry("/repo/.plannotator/reviews/security.json", {
+        instructions: "repo version",
+      }),
+      userEntry("/data/reviews/security.json", { instructions: "user version" }),
+    ]);
+    const security = resolved.filter((p) => p.label === "Security");
+    expect(security).toHaveLength(1);
+    expect(security[0].source).toBe("user");
+    expect(security[0].id).toBe("user:security");
+    expect(security[0].instructions).toBe("user version");
+  });
+
+  test("malformed entries are dropped, valid siblings survive", () => {
+    const resolved = resolveReviewProfiles([
+      userEntry("/data/reviews/broken.json", { notInstructions: true }),
+      userEntry("/data/reviews/good.json", { instructions: "valid" }),
+    ]);
+    const ids = resolved.map((p) => p.id);
+    expect(ids).toContain("user:good");
+    expect(ids).not.toContain("user:broken");
+    // discovery still works — builtin + the one good profile
+    expect(resolved).toHaveLength(2);
+  });
+
+  test("a custom file cannot claim the reserved builtin:default name", () => {
+    const resolved = resolveReviewProfiles([
+      userEntry("/data/reviews/whatever.json", {
+        id: "builtin:default",
+        instructions: "hijack attempt",
+      }),
+    ]);
+    const defaults = resolved.filter((p) => p.id === BUILTIN_DEFAULT_ID);
+    expect(defaults).toHaveLength(1);
+    expect(defaults[0].source).toBe("builtin");
+    expect(defaults[0].instructions).toBe("");
+  });
+});

--- a/packages/shared/review-profiles.ts
+++ b/packages/shared/review-profiles.ts
@@ -1,0 +1,334 @@
+/**
+ * Review Profiles — shared types, shape validation, inference, and resolution.
+ *
+ * Runtime-agnostic: no node:fs, no node:http, no Bun APIs. The loader that
+ * reads files from disk lives in packages/server/review-profile-loader.ts and
+ * calls into this module. Vendored to Pi.
+ *
+ * A review profile is a named bundle of review intent. The only field a human
+ * must write is `instructions`; everything else (`id`, `label`, `engines`) is
+ * inferred. See docs/custom-reviews.md for the authoritative spec.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Engines a profile can target. */
+export type ReviewEngine = "claude" | "codex";
+
+/** Where a resolved profile came from. */
+export type ReviewProfileSource = "builtin" | "user" | "repo";
+
+export interface ReviewProfile {
+  /** Inferred from filename if omitted. */
+  id: string;
+  /** Inferred from id if omitted. */
+  label: string;
+  /** The only field a human must write. */
+  instructions: string;
+  description?: string;
+  /** Defaults to all supported engines. */
+  engines?: ReviewEngine[];
+}
+
+export interface ResolvedReviewProfile extends ReviewProfile {
+  source: ReviewProfileSource;
+  sourcePath?: string;
+  /** True for builtin:default — surfaced to the picker as the pre-selected option. */
+  default?: boolean;
+  /** Always resolved to a concrete list (never undefined after resolution). */
+  engines: ReviewEngine[];
+}
+
+/** Response shape for `GET /api/agents/review-profiles`. */
+export interface ReviewProfilesResponse {
+  profiles: Array<{
+    id: string;
+    label: string;
+    description?: string;
+    engines: ReviewEngine[];
+    source: ReviewProfileSource;
+    sourcePath?: string;
+    default?: boolean;
+  }>;
+}
+
+/** All engines a profile may target. Inference default. */
+export const SUPPORTED_ENGINES: ReadonlyArray<ReviewEngine> = ["claude", "codex"];
+
+/** Reserved id for the built-in default review. */
+export const BUILTIN_DEFAULT_ID = "builtin:default";
+
+// ---------------------------------------------------------------------------
+// Bounds — reject obviously malformed/abusive profiles without a schema engine.
+// ---------------------------------------------------------------------------
+
+const MAX_INSTRUCTIONS_LEN = 20_000;
+const MAX_LABEL_LEN = 200;
+const MAX_DESCRIPTION_LEN = 2_000;
+const MAX_BARE_ID_LEN = 200;
+
+// ---------------------------------------------------------------------------
+// Built-in profiles
+// ---------------------------------------------------------------------------
+
+/**
+ * The built-in default review — today's review, preserved. It carries no
+ * custom instructions; the prompt composer omits the Custom Review Profile
+ * section entirely for this id, so the default prompt stays byte-for-byte
+ * today's prompt.
+ */
+export const BUILTIN_DEFAULT_PROFILE: ResolvedReviewProfile = {
+  id: BUILTIN_DEFAULT_ID,
+  label: "Default",
+  instructions: "",
+  source: "builtin",
+  engines: [...SUPPORTED_ENGINES],
+  default: true,
+};
+
+export const BUILTIN_PROFILES: ReadonlyArray<ResolvedReviewProfile> = [
+  BUILTIN_DEFAULT_PROFILE,
+];
+
+// ---------------------------------------------------------------------------
+// Shape validation
+// ---------------------------------------------------------------------------
+
+/** A raw profile entry as discovered on disk, before validation/inference. */
+export interface RawReviewProfileEntry {
+  source: "user" | "repo";
+  /** Absolute path to the JSON file. */
+  path: string;
+  /** Parsed JSON contents (already JSON.parse'd by the loader). */
+  json: unknown;
+}
+
+export interface ParsedReviewProfileShape {
+  instructions: string;
+  id?: string;
+  label?: string;
+  description?: string;
+  engines?: ReviewEngine[];
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isEngine(value: unknown): value is ReviewEngine {
+  return value === "claude" || value === "codex";
+}
+
+/**
+ * Validate the shape of a parsed profile JSON. Returns the well-typed fields on
+ * success, or `null` when the entry is malformed and should be dropped.
+ *
+ * Rules:
+ *  - `instructions` is required and must be a non-empty (after trim) string.
+ *  - `id`, `label`, `description` if present must be strings within bounds.
+ *  - `engines` if present must be a non-empty array that is a subset of the
+ *    supported engines.
+ *  - Bounded sizes guard against obviously abusive input.
+ */
+export function validateProfileShape(json: unknown): ParsedReviewProfileShape | null {
+  if (!isPlainObject(json)) return null;
+
+  const { instructions, id, label, description, engines } = json;
+
+  if (typeof instructions !== "string") return null;
+  if (instructions.trim().length === 0) return null;
+  if (instructions.length > MAX_INSTRUCTIONS_LEN) return null;
+
+  const out: ParsedReviewProfileShape = { instructions };
+
+  if (id !== undefined) {
+    if (typeof id !== "string") return null;
+    const trimmed = id.trim();
+    if (trimmed.length === 0 || trimmed.length > MAX_BARE_ID_LEN) return null;
+    // A separator-only id (e.g. "___") would infer to an empty label,
+    // violating the non-empty `label` contract. Require at least one word.
+    if (inferLabel(trimmed).length === 0) return null;
+    out.id = trimmed;
+  }
+
+  if (label !== undefined) {
+    if (typeof label !== "string") return null;
+    const trimmed = label.trim();
+    if (trimmed.length === 0 || trimmed.length > MAX_LABEL_LEN) return null;
+    out.label = trimmed;
+  }
+
+  if (description !== undefined) {
+    if (typeof description !== "string") return null;
+    if (description.length > MAX_DESCRIPTION_LEN) return null;
+    out.description = description;
+  }
+
+  if (engines !== undefined) {
+    if (!Array.isArray(engines) || engines.length === 0) return null;
+    if (!engines.every(isEngine)) return null;
+    // Dedupe while preserving order.
+    out.engines = [...new Set(engines as ReviewEngine[])];
+  }
+
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Inference
+// ---------------------------------------------------------------------------
+
+/** Strip a `.json` suffix and return the filename stem. */
+export function filenameStem(filename: string): string {
+  const base = filename.replace(/^.*[\\/]/, "");
+  return base.replace(/\.json$/i, "");
+}
+
+/**
+ * Infer the namespaced id from a source + bare id (e.g. a filename stem).
+ * `security` + `user` → `user:security`.
+ */
+export function inferId(bareId: string, source: "user" | "repo"): string {
+  return `${source}:${bareId}`;
+}
+
+/**
+ * Title-case a bare id into a label. `api-contracts` → `API Contracts`.
+ * Splits on `-` and `_`; known acronyms are upper-cased.
+ */
+export function inferLabel(bareId: string): string {
+  const ACRONYMS = new Set(["api", "ui", "ux", "sql", "css", "html", "id", "url"]);
+  return bareId
+    .split(/[-_]+/)
+    .filter((w) => w.length > 0)
+    .map((word) => {
+      const lower = word.toLowerCase();
+      if (ACRONYMS.has(lower)) return word.toUpperCase();
+      return lower.charAt(0).toUpperCase() + lower.slice(1);
+    })
+    .join(" ");
+}
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve raw discovered entries plus builtins into a deduped, fully-inferred
+ * list of launchable profiles.
+ *
+ * Name-clash story (deliberately trivial — see spec):
+ *  - `builtin:default` is special-cased and always wins its name; no user/repo
+ *    entry can shadow it.
+ *  - On a bare-name clash between a user and a repo profile, the user wins.
+ *  - Malformed entries are dropped. The caller logs them — resolution stays
+ *    pure and silent.
+ */
+export function resolveReviewProfiles(
+  entries: RawReviewProfileEntry[],
+  builtins: ReadonlyArray<ResolvedReviewProfile> = BUILTIN_PROFILES,
+): ResolvedReviewProfile[] {
+  // Bare name → resolved profile. user wins over repo.
+  const byBareName = new Map<string, ResolvedReviewProfile>();
+
+  for (const entry of entries) {
+    const shape = validateProfileShape(entry.json);
+    if (!shape) continue; // malformed — dropped (caller logs)
+
+    const bareId = shape.id ?? filenameStem(entry.path);
+    if (bareId.length === 0) continue;
+
+    // Guard the inferred-label contract: a separator-only bareId (e.g. an
+    // "___.json" filename) infers to an empty label. Drop it unless an
+    // explicit non-empty label was supplied.
+    const label = shape.label ?? inferLabel(bareId);
+    if (label.length === 0) continue;
+
+    // builtin:default is reserved; a custom file cannot claim it.
+    const namespacedId = inferId(bareId, entry.source);
+    if (namespacedId === BUILTIN_DEFAULT_ID) continue;
+
+    const resolved: ResolvedReviewProfile = {
+      id: namespacedId,
+      label,
+      instructions: shape.instructions,
+      description: shape.description,
+      engines: shape.engines ?? [...SUPPORTED_ENGINES],
+      source: entry.source,
+      sourcePath: entry.path,
+    };
+
+    const existing = byBareName.get(bareId);
+    if (!existing) {
+      byBareName.set(bareId, resolved);
+      continue;
+    }
+    // user beats repo on a bare-name clash. Otherwise keep first-seen.
+    if (existing.source === "repo" && resolved.source === "user") {
+      byBareName.set(bareId, resolved);
+    }
+  }
+
+  return [...builtins, ...byBareName.values()];
+}
+
+// ---------------------------------------------------------------------------
+// Prompt composition
+// ---------------------------------------------------------------------------
+
+/**
+ * A profile contributes a custom section only when it carries instructions and
+ * isn't the reserved built-in default. The default (or any instruction-less
+ * profile) yields no section, keeping the prompt byte-for-byte today's prompt.
+ */
+function profileHasCustomSection(profile: ResolvedReviewProfile | undefined): boolean {
+  return (
+    !!profile &&
+    profile.id !== BUILTIN_DEFAULT_ID &&
+    profile.instructions.trim().length > 0
+  );
+}
+
+/**
+ * Render the "## Custom Review Profile" section for a profile, or `null` when
+ * the profile contributes none (built-in default / no instructions).
+ */
+export function renderReviewProfileSection(
+  profile: ResolvedReviewProfile | undefined,
+): string | null {
+  if (!profileHasCustomSection(profile)) return null;
+  const p = profile as ResolvedReviewProfile;
+  return [
+    "## Custom Review Profile",
+    "",
+    `Profile: ${p.label}`,
+    `Source: ${p.source}`,
+    "",
+    p.instructions.trim(),
+  ].join("\n");
+}
+
+/**
+ * Compose the full review prompt deterministically:
+ *
+ *   <provider immutable instructions>
+ *   [## Custom Review Profile … ---]   (omitted for builtin:default)
+ *   <user message>
+ *
+ * For the built-in default (or any instruction-less profile) the section is
+ * omitted and the output is byte-identical to
+ * `systemPrompt + "\n\n---\n\n" + userMessage` — today's prompt.
+ */
+export function composeReviewPrompt(
+  systemPrompt: string,
+  profile: ResolvedReviewProfile | undefined,
+  userMessage: string,
+): string {
+  const section = renderReviewProfileSection(profile);
+  if (section === null) {
+    return systemPrompt + "\n\n---\n\n" + userMessage;
+  }
+  return systemPrompt + "\n\n" + section + "\n\n---\n\n" + userMessage;
+}

--- a/packages/shared/review-profiles.ts
+++ b/packages/shared/review-profiles.ts
@@ -6,19 +6,16 @@
  * calls into this module. Vendored to Pi.
  *
  * A review profile is a named bundle of review intent. The only field a human
- * must write is `instructions`; everything else (`id`, `label`, `engines`) is
- * inferred. See docs/custom-reviews.md for the authoritative spec.
+ * must write is `instructions`; everything else (`id`, `label`) is inferred.
+ * See docs/custom-reviews.md for the authoritative spec.
  */
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-/** Engines a profile can target. */
-export type ReviewEngine = "claude" | "codex";
-
 /** Where a resolved profile came from. */
-export type ReviewProfileSource = "builtin" | "user" | "repo";
+export type ReviewProfileSource = "builtin" | "user";
 
 export interface ReviewProfile {
   /** Inferred from filename if omitted. */
@@ -28,8 +25,6 @@ export interface ReviewProfile {
   /** The only field a human must write. */
   instructions: string;
   description?: string;
-  /** Defaults to all supported engines. */
-  engines?: ReviewEngine[];
 }
 
 export interface ResolvedReviewProfile extends ReviewProfile {
@@ -37,8 +32,6 @@ export interface ResolvedReviewProfile extends ReviewProfile {
   sourcePath?: string;
   /** True for builtin:default — surfaced to the picker as the pre-selected option. */
   default?: boolean;
-  /** Always resolved to a concrete list (never undefined after resolution). */
-  engines: ReviewEngine[];
 }
 
 /** Response shape for `GET /api/agents/review-profiles`. */
@@ -47,15 +40,11 @@ export interface ReviewProfilesResponse {
     id: string;
     label: string;
     description?: string;
-    engines: ReviewEngine[];
     source: ReviewProfileSource;
     sourcePath?: string;
     default?: boolean;
   }>;
 }
-
-/** All engines a profile may target. Inference default. */
-export const SUPPORTED_ENGINES: ReadonlyArray<ReviewEngine> = ["claude", "codex"];
 
 /** Reserved id for the built-in default review. */
 export const BUILTIN_DEFAULT_ID = "builtin:default";
@@ -84,7 +73,6 @@ export const BUILTIN_DEFAULT_PROFILE: ResolvedReviewProfile = {
   label: "Default",
   instructions: "",
   source: "builtin",
-  engines: [...SUPPORTED_ENGINES],
   default: true,
 };
 
@@ -98,7 +86,7 @@ export const BUILTIN_PROFILES: ReadonlyArray<ResolvedReviewProfile> = [
 
 /** A raw profile entry as discovered on disk, before validation/inference. */
 export interface RawReviewProfileEntry {
-  source: "user" | "repo";
+  source: "user";
   /** Absolute path to the JSON file. */
   path: string;
   /** Parsed JSON contents (already JSON.parse'd by the loader). */
@@ -110,15 +98,10 @@ export interface ParsedReviewProfileShape {
   id?: string;
   label?: string;
   description?: string;
-  engines?: ReviewEngine[];
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function isEngine(value: unknown): value is ReviewEngine {
-  return value === "claude" || value === "codex";
 }
 
 /**
@@ -128,14 +111,12 @@ function isEngine(value: unknown): value is ReviewEngine {
  * Rules:
  *  - `instructions` is required and must be a non-empty (after trim) string.
  *  - `id`, `label`, `description` if present must be strings within bounds.
- *  - `engines` if present must be a non-empty array that is a subset of the
- *    supported engines.
  *  - Bounded sizes guard against obviously abusive input.
  */
 export function validateProfileShape(json: unknown): ParsedReviewProfileShape | null {
   if (!isPlainObject(json)) return null;
 
-  const { instructions, id, label, description, engines } = json;
+  const { instructions, id, label, description } = json;
 
   if (typeof instructions !== "string") return null;
   if (instructions.trim().length === 0) return null;
@@ -166,13 +147,6 @@ export function validateProfileShape(json: unknown): ParsedReviewProfileShape | 
     out.description = description;
   }
 
-  if (engines !== undefined) {
-    if (!Array.isArray(engines) || engines.length === 0) return null;
-    if (!engines.every(isEngine)) return null;
-    // Dedupe while preserving order.
-    out.engines = [...new Set(engines as ReviewEngine[])];
-  }
-
   return out;
 }
 
@@ -190,7 +164,7 @@ export function filenameStem(filename: string): string {
  * Infer the namespaced id from a source + bare id (e.g. a filename stem).
  * `security` + `user` → `user:security`.
  */
-export function inferId(bareId: string, source: "user" | "repo"): string {
+export function inferId(bareId: string, source: "user"): string {
   return `${source}:${bareId}`;
 }
 
@@ -220,9 +194,9 @@ export function inferLabel(bareId: string): string {
  * list of launchable profiles.
  *
  * Name-clash story (deliberately trivial — see spec):
- *  - `builtin:default` is special-cased and always wins its name; no user/repo
+ *  - `builtin:default` is special-cased and always wins its name; no user
  *    entry can shadow it.
- *  - On a bare-name clash between a user and a repo profile, the user wins.
+ *  - On a bare-name clash between two user profiles, the first-seen wins.
  *  - Malformed entries are dropped. The caller logs them — resolution stays
  *    pure and silent.
  */
@@ -230,7 +204,7 @@ export function resolveReviewProfiles(
   entries: RawReviewProfileEntry[],
   builtins: ReadonlyArray<ResolvedReviewProfile> = BUILTIN_PROFILES,
 ): ResolvedReviewProfile[] {
-  // Bare name → resolved profile. user wins over repo.
+  // Bare name → resolved profile. First-seen wins.
   const byBareName = new Map<string, ResolvedReviewProfile>();
 
   for (const entry of entries) {
@@ -246,29 +220,20 @@ export function resolveReviewProfiles(
     const label = shape.label ?? inferLabel(bareId);
     if (label.length === 0) continue;
 
-    // builtin:default is reserved; a custom file cannot claim it.
+    // The namespace prefix (e.g. "user:") reserves builtin:default — an
+    // inferred user id can never collide with it, so no explicit guard needed.
     const namespacedId = inferId(bareId, entry.source);
-    if (namespacedId === BUILTIN_DEFAULT_ID) continue;
 
-    const resolved: ResolvedReviewProfile = {
+    if (byBareName.has(bareId)) continue; // first-seen wins on a bare-name clash
+
+    byBareName.set(bareId, {
       id: namespacedId,
       label,
       instructions: shape.instructions,
       description: shape.description,
-      engines: shape.engines ?? [...SUPPORTED_ENGINES],
       source: entry.source,
       sourcePath: entry.path,
-    };
-
-    const existing = byBareName.get(bareId);
-    if (!existing) {
-      byBareName.set(bareId, resolved);
-      continue;
-    }
-    // user beats repo on a bare-name clash. Otherwise keep first-seen.
-    if (existing.source === "repo" && resolved.source === "user") {
-      byBareName.set(bareId, resolved);
-    }
+    });
   }
 
   return [...builtins, ...byBareName.values()];


### PR DESCRIPTION
## What

Named, reusable **review profiles** — "Security", "Performance", "API Contract" — that run through the **existing** Claude/Codex background review pipeline. A developer drops a JSON file, picks it at launch, and findings come back as the same external diff annotations as today.

```json
{ "instructions": "Focus only on security-impacting issues." }
```

That one-line file is a complete, valid profile.

**This PR is backend only — no UI yet.** It's fully drivable over HTTP, and the existing **"Run Review" path is unchanged**: an absent `reviewProfileId` resolves to `builtin:default` and produces a **byte-identical** prompt. Nothing regresses while this lands.

> Authoritative spec: [`docs/custom-reviews.md`](docs/custom-reviews.md). Current-pipeline reference map it builds on: [`docs/agent-jobs-code-review-handoff.md`](docs/agent-jobs-code-review-handoff.md).

## How it works

```
pick profile → resolve (builtin/user/repo) → sectioned prompt → Claude/Codex
  → parse → severity-normalize → in-diff filter → external annotations
```

- **`packages/shared/review-profiles.ts`** (new, runtime-agnostic) — types, shape validation, `filename → id` inference, label inference, trivial name-clash resolution, and the sectioned prompt composer.
- **`packages/server/review-profile-loader.ts`** (new) — discovery across built-in + user dir (`${PLANNOTATOR_DATA_DIR}/reviews/`) + repo dir (`.plannotator/reviews/`), skip-and-log on malformed files.
- **`GET /api/agents/review-profiles`** — discovery endpoint (Bun + Pi).
- **`reviewProfileId` on `POST /api/agents/jobs`** — parsed and forwarded; **rejects unknown fields**; no inline prompt text accepted. `reviewProfileId`/`reviewProfileLabel` added to `AgentJobInfo`.
- **Launch-time resolution** at the existing launch-state snapshot boundary; repo profiles scoped to one unambiguous local repo (absent in remote-only PR / ambiguous workspace mode).
- **Severity normalization** — Codex `priority 0-3` → the shared `important | nit | pre_existing` scale, in one place, so badges read the same regardless of engine.
- **In-diff filter + completion semantics** — drop findings not in the reviewed patch; fail the job if *all* findings are out-of-diff or output is missing/unparseable (the Code Tour precedent). Calm one-liner: `8 findings · 2 skipped (not in the reviewed diff)`.
- **Profile label as annotation metadata** — `author` stays the engine name (`Claude Code` / `Codex`); the profile rides alongside.
- **Bun/Pi parity** maintained via `vendor.sh`.

## Scope discipline

The spec has an explicit **"Deliberately not building"** section, honored here: no precedence engine, no content hashing, no diagnostics channel, no `ReviewEngineAdapter` interface, no anchoring module, no inline `reviewPrompt`, no temp-profile machinery. Two new modules, the rest small edits.

## Deferred (not in this PR)

Frontend: the engine/review picker in `AgentsTab.tsx`, sending `reviewProfileId` from `useAgentJobs.ts`, the repo-source tag, and the profile tag on annotations.

## Verification

- **Typecheck**: clean (`packages/shared` + `packages/server` tsconfigs)
- **New suites**: review-profiles, loader, launch, prompt composition, ingestion — all green
- **Regression**: full server + AI suites pass, 0 fail
- **Vendor**: `vendor.sh` idempotent (no Pi drift on re-run)

Built via a phased pipeline with per-phase perspective-diverse adversarial review (correctness / spec-fidelity / Bun-Pi parity) and a final whole-feature audit. Verification re-run independently after handoff.

## Review notes

The two-engine prompt/severity seams (`claude-review.ts`, `codex-review.ts`, and `onJobComplete` in `review.ts`) and the Bun↔Pi mirror in `serverReview.ts` / `apps/pi-extension/server/agent-jobs.ts` are the highest-value places to scrutinize. The byte-identical-default-prompt invariant has a dedicated test but is worth a human eye.

🤖 Implemented with Claude Code via a multi-agent workflow; verified before PR.