### PR TITLE
fix(review): signal-safe cleanup + triage suffix for PR feedback

### DIFF
--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -260,6 +260,14 @@ if (isInteractiveNoArgInvocation(args, process.stdin.isTTY)) {
 // Ensure session cleanup on exit
 process.on("exit", () => unregisterSession());
 
+// Route fatal signals through process.exit() so "exit" handlers run — by
+// default a SIGINT/SIGTERM death skips them, leaking background-warmup
+// children and stale `git worktree` registrations (the --local PR checkout
+// cleanup below is registered on "exit"). `once` keeps a second Ctrl-C as a
+// force-quit escape hatch if cleanup ever hangs.
+process.once("SIGINT", () => process.exit(130));
+process.once("SIGTERM", () => process.exit(143));
+
 // Check if URL sharing is enabled (default: true)
 const sharingEnabled = process.env.PLANNOTATOR_SHARE !== "disabled";
 
@@ -842,7 +850,11 @@ if (args[0] === "sessions") {
     console.log(getReviewApprovedPrompt(detectedOrigin));
   } else {
     console.log(result.feedback);
-    if (!isPRMode) {
+    // Append the triage-first suffix whenever the reviewer sent annotations to
+    // act on — in PR mode too. Platform PR actions (approve/comment posted to
+    // the host) come back with an empty annotation set and a status message;
+    // those must NOT get the "triage and don't change code" instruction.
+    if (result.annotations.length > 0) {
       console.log(getReviewDeniedSuffix(detectedOrigin));
     }
   }

--- a/apps/opencode-plugin/commands.ts
+++ b/apps/opencode-plugin/commands.ts
@@ -165,11 +165,14 @@ export async function handleReviewCommand(
       const shouldSwitchAgent = result.agentSwitch && result.agentSwitch !== "disabled";
       const targetAgent = result.agentSwitch || "build";
 
+      // Append the triage-first suffix when the reviewer sent annotations to
+      // act on (PR mode included). Platform PR actions post a status message
+      // with no annotations — those go through verbatim, no suffix.
       const message = result.approved
         ? getReviewApprovedPrompt("opencode")
-        : isPRMode
-          ? result.feedback
-          : `${result.feedback}${getReviewDeniedSuffix("opencode")}`;
+        : result.annotations.length > 0
+          ? `${result.feedback}${getReviewDeniedSuffix("opencode")}`
+          : result.feedback;
 
       try {
         await client.session.prompt({

--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -408,7 +408,6 @@ export default function plannotator(pi: ExtensionAPI): void {
 
 			try {
 				const reviewArgs = parseReviewArgs(args ?? "");
-				const isPRReview = reviewArgs.prUrl !== undefined;
 				const session = await startCodeReviewBrowserSession(ctx, {
 					prUrl: reviewArgs.prUrl,
 					vcsType: reviewArgs.vcsType,
@@ -437,21 +436,17 @@ export default function plannotator(pi: ExtensionAPI): void {
 								safeNotify(ctx, "Code review closed (no feedback).", "info", origin);
 								return;
 							}
-							if (isPRReview) {
-								// Platform PR actions (approve/comment) return approved:false with a
-								// status message — don't tell the agent to "address" a platform action.
-								sendUserMessageWithCurrentSessionFallback(
-									pi,
-									result.feedback,
-									{ deliverAs: "followUp" },
-									"Plannotator code review feedback could not be sent",
-									origin,
-								);
-								return;
-							}
+							// Append the triage-first suffix when the reviewer sent
+							// annotations to act on (PR mode included). Platform PR actions
+							// (approve/comment posted to the host) come back with an empty
+							// annotation set and a status message — don't tell the agent to
+							// "address" a platform action.
+							const reviewFeedback = (result.annotations?.length ?? 0) > 0
+								? `${result.feedback}${getReviewDeniedSuffix("pi", loadConfig())}`
+								: result.feedback;
 							sendUserMessageWithCurrentSessionFallback(
 								pi,
-								`${result.feedback}${getReviewDeniedSuffix("pi", loadConfig())}`,
+								reviewFeedback,
 								{ deliverAs: "followUp" },
 								"Plannotator code review feedback could not be sent",
 								origin,


### PR DESCRIPTION
Two QA follow-ups found while validating the release. Both are small, both touch the review feedback path, and neither belongs in the in-flight Cursor PR (#912), so they're bundled here.

## 1. Signal-safe cleanup (lifecycle)
`apps/hook/server/index.ts` registers its background-PR-checkout cleanup (kill warmup children, `git worktree remove/prune`, session unregister) on the `"exit"` event — which **does not fire** on SIGINT (Ctrl-C) or SIGTERM. So aborting a review mid-checkout leaked clone/fetch children and stale `git worktree` registrations.

Fix: route `SIGINT`/`SIGTERM` through `process.exit()` so the existing handlers run. Uses `once`, so a second signal still force-quits if cleanup ever hangs. The change is scoped to the standalone hook binary only (OpenCode/Pi run in-host and must not call `process.exit`).

## 2. Triage suffix now reaches PR-mode feedback
The review-denied suffix (`getReviewDeniedSuffix` — "triage it, verify against the code, don't change anything until we discuss") was gated behind `!isPRMode`, so **every PR review skipped it**. That gate predates the suffix-unification work — the content was unified across runtimes, but the PR-mode exclusion was never revisited.

Root cause: `isPRMode` was a blunt proxy. In PR mode there are two `approved:false` outcomes:
- **Send Feedback** → annotations go to the agent → *should* get the suffix
- **Platform PR action** (approve/comment posted to GitHub/GitLab) → status message, empty annotation set → should *not*

Fix: gate on `result.annotations.length > 0` instead of `!isPRMode`. Genuine feedback always carries annotations; platform actions always send `[]`. Now the suffix is appended for PR **and** local feedback, and never onto a platform status message. Applied consistently across **hook, OpenCode, and Pi**.

## Verification
- `bun test` — 1434 pass / 0 fail
- Pi + server typecheck clean (`bunx tsc -p ...`)
- `build:opencode` compiles
- Pi `isPRReview` local removed (now dead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)