### PR TITLE
Keep annotation panel closed when adding annotations

### DIFF
--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -1570,9 +1570,6 @@ const App: React.FC = () => {
     setAnnotations(prev => [...prev, ann]);
     setSelectedAnnotationId(ann.id);
     setSelectedCodeAnnotationId(null);
-    if (wideModeType === null) {
-      setIsPanelOpen(true);
-    }
   };
 
   // Keep selection behavior explicit across mobile/wide-mode transitions.
@@ -1600,10 +1597,7 @@ const App: React.FC = () => {
     setCodeAnnotations(prev => [...prev, annotation]);
     setSelectedAnnotationId(null);
     setSelectedCodeAnnotationId(annotation.id);
-    if (wideModeType === null) {
-      setIsPanelOpen(true);
-    }
-  }, [wideModeType]);
+  }, []);
 
   // The code popout is full-viewport modal — the annotation panel is behind it.
   // This handler only fires when the popout is closed (sidebar visible), so

--- a/packages/ui/components/CommentPopover.tsx
+++ b/packages/ui/components/CommentPopover.tsx
@@ -5,6 +5,7 @@ import { AttachmentsButton } from './AttachmentsButton';
 import { submitHint } from '../utils/platform';
 import { useDraggable } from '../hooks/useDraggable';
 import { SparklesIcon } from './SparklesIcon';
+import { hasUnsavedCommentContent } from '../utils/commentContent';
 
 export interface CommentAskAIContext {
   kind: 'general' | 'selection';
@@ -52,7 +53,7 @@ const draftStore = new Map<string, { text: string; images: ImageAttachment[] }>(
 function useCommentDraftSync(draftKey: string | undefined, text: string, images: ImageAttachment[]) {
   useEffect(() => {
     if (!draftKey) return;
-    if (text.trim() || images.length > 0) {
+    if (hasUnsavedCommentContent(text, images)) {
       draftStore.set(draftKey, { text, images });
     } else {
       draftStore.delete(draftKey);
@@ -98,6 +99,9 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
   const [position, setPosition] = useState<{ top: number; left: number; flipAbove: boolean; width: number } | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
+  const hasUnsavedContent = hasUnsavedCommentContent(text, allowImages ? images : []);
+  const hasUnsavedContentRef = useRef(hasUnsavedContent);
+  hasUnsavedContentRef.current = hasUnsavedContent;
   const { dragPosition, dragHandleProps, wasDragged, reset: resetDrag } = useDraggable(popoverRef);
 
   useEffect(() => {
@@ -157,6 +161,7 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
       // Don't close if clicking inside a child portal (AttachmentsButton, ImageAnnotator, etc.)
       const el = target as HTMLElement;
       if (el.closest?.('[data-popover-layer]')) return;
+      if (hasUnsavedContentRef.current) return;
       onClose();
     };
 
@@ -166,11 +171,11 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
 
   const handleSubmit = useCallback(() => {
     const canSubmitEmpty = allowEmptySubmit && initialText.trim().length > 0;
-    if (text.trim() || (allowImages && images.length > 0) || canSubmitEmpty) {
+    if (hasUnsavedContent || canSubmitEmpty) {
       if (draftKey) draftStore.delete(draftKey);
       onSubmit(text, allowImages && images.length > 0 ? images : undefined);
     }
-  }, [text, images, onSubmit, draftKey, allowImages, allowEmptySubmit, initialText]);
+  }, [text, images, onSubmit, draftKey, allowImages, allowEmptySubmit, initialText, hasUnsavedContent]);
 
   const handleAskAI = useCallback(() => {
     const question = text.trim();
@@ -207,8 +212,7 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
       : 'Comment';
 
   const canSubmit =
-    text.trim().length > 0 ||
-    (allowImages && images.length > 0) ||
+    hasUnsavedContent ||
     (allowEmptySubmit && initialText.trim().length > 0);
   const canAskAI = !!onAskAI && !askAIDisabled && text.trim().length > 0;
 

--- a/packages/ui/utils/commentContent.test.ts
+++ b/packages/ui/utils/commentContent.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { hasUnsavedCommentContent } from "./commentContent";
+import type { ImageAttachment } from "../types";
+
+const image: ImageAttachment = {
+  path: "/tmp/mock.png",
+  name: "mock",
+};
+
+describe("hasUnsavedCommentContent", () => {
+  test("returns false for empty text and no images", () => {
+    expect(hasUnsavedCommentContent("")).toBe(false);
+  });
+
+  test("returns false for whitespace-only text and no images", () => {
+    expect(hasUnsavedCommentContent(" \n\t ")).toBe(false);
+  });
+
+  test("returns true for non-whitespace text", () => {
+    expect(hasUnsavedCommentContent("note")).toBe(true);
+  });
+
+  test("returns true for images without text", () => {
+    expect(hasUnsavedCommentContent("", [image])).toBe(true);
+  });
+});

--- a/packages/ui/utils/commentContent.ts
+++ b/packages/ui/utils/commentContent.ts
@@ -1,0 +1,8 @@
+import type { ImageAttachment } from "../types";
+
+export function hasUnsavedCommentContent(
+  text: string,
+  images: readonly ImageAttachment[] = [],
+): boolean {
+  return text.trim().length > 0 || images.length > 0;
+}


### PR DESCRIPTION
## Summary
- Stop plan/annotate annotations from forcing the right annotation panel open.
- Stop code-file popout annotations in the plan app from forcing the panel open.
- Keep dirty shared comment popovers open on outside click so in-progress annotation text/images are not lost. Empty popovers still close on outside click; Escape and X still explicitly cancel.

## Issues
- Fixes #821.
- Fixes #888.

## Validation
- bun install --frozen-lockfile
- bun run --cwd packages/ui typecheck
- bun test packages/ui
- git diff --check