### PR TITLE
feat(config): support share toggle via config.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ claude --plugin-dir ./apps/hook
 | `PLANNOTATOR_REMOTE` | Set to `1` / `true` for remote mode, `0` / `false` for local mode, or leave unset for SSH auto-detection. Uses a fixed port in remote mode; browser-opening behavior depends on the environment. |
 | `PLANNOTATOR_PORT` | Fixed port to use. Default: random locally, `19432` for remote sessions. |
 | `PLANNOTATOR_BROWSER` | Custom browser to open plans in. macOS: app name or path. Linux/Windows: executable path. |
-| `PLANNOTATOR_SHARE` | Set to `disabled` to turn off URL sharing entirely. Default: enabled. |
+| `PLANNOTATOR_SHARE` | Set to `disabled` to turn off URL sharing entirely. Default: enabled. Can also be set via `~/.plannotator/config.json` (`{ "share": "disabled" }`); the env var takes precedence. |
 | `PLANNOTATOR_SHARE_URL` | Custom base URL for share links (self-hosted portal). Default: `https://share.plannotator.ai`. |
 | `PLANNOTATOR_PASTE_URL` | Base URL of the paste service API for short URL sharing. Default: `https://plannotator-paste.plannotator.workers.dev`. |
 | `PLANNOTATOR_ORIGIN` | Explicit agent-origin override at the top of the detection chain. Valid values: `claude-code`, `amp`, `droid`, `opencode`, `codex`, `copilot-cli`, `gemini-cli`, `kiro-cli`, `pi`. Invalid values silently fall through to env-based detection. Unset by default. |

--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -84,7 +84,7 @@ import {
   handleGoalSetupServerReady,
 } from "@plannotator/server/goal-setup";
 import { type DiffType, detectManagedVcs, prepareLocalReviewDiff, gitRuntime } from "@plannotator/server/vcs";
-import { loadConfig, resolveDefaultDiffType, resolveUseJina } from "@plannotator/shared/config";
+import { loadConfig, resolveDefaultDiffType, resolveUseJina, resolveSharingEnabled } from "@plannotator/shared/config";
 import { parseReviewArgs } from "@plannotator/shared/review-args";
 import {
   normalizeGoalSetupBundle,
@@ -272,7 +272,7 @@ process.once("SIGINT", () => process.exit(130));
 process.once("SIGTERM", () => process.exit(143));
 
 // Check if URL sharing is enabled (default: true)
-const sharingEnabled = process.env.PLANNOTATOR_SHARE !== "disabled";
+const sharingEnabled = resolveSharingEnabled(loadConfig());
 
 // Custom share portal URL for self-hosting
 const shareBaseUrl = process.env.PLANNOTATOR_SHARE_URL || undefined;

--- a/apps/marketing/src/content/docs/getting-started/configuration.md
+++ b/apps/marketing/src/content/docs/getting-started/configuration.md
@@ -15,7 +15,7 @@ Plannotator is configured through environment variables, hook/plugin configurati
 | `PLANNOTATOR_REMOTE` | auto-detect | Set to `1` or `true` to force remote mode, `0` or `false` to force local mode, or leave unset to auto-detect via `SSH_TTY` / `SSH_CONNECTION`. Uses a fixed port in remote mode; browser-opening behavior depends on the environment. |
 | `PLANNOTATOR_PORT` | random (local) / `19432` (remote) | Fixed server port. Useful for port forwarding in remote environments. |
 | `PLANNOTATOR_BROWSER` | system default | Custom browser or script to open the UI. |
-| `PLANNOTATOR_SHARE` | enabled | Set to `disabled` to turn off URL sharing entirely. |
+| `PLANNOTATOR_SHARE` | enabled | Set to `disabled` to turn off URL sharing entirely. Can also be set via `~/.plannotator/config.json` (`{ "share": "disabled" }`). |
 | `PLANNOTATOR_SHARE_URL` | `https://share.plannotator.ai` | Point share links at a self-hosted portal. |
 | `CLAUDE_CONFIG_DIR` | `~/.claude` | Respected by the install script when placing hooks. |
 
@@ -144,6 +144,6 @@ Sessions are tracked automatically. Stale entries from crashed processes are cle
 
 ## Disabling sharing
 
-Set `PLANNOTATOR_SHARE=disabled` to remove all sharing UI — the Share tab, copy link action, and import review option are all hidden. Useful for teams working with sensitive plans.
+Set `PLANNOTATOR_SHARE=disabled` to remove all sharing UI — the Share tab, copy link action, and import review option are all hidden. Useful for teams working with sensitive plans. To make this persistent without an environment variable, add `"share": "disabled"` to `~/.plannotator/config.json`. The environment variable takes precedence over the config file.
 
 To self-host the share portal instead, see the [self-hosting guide](/docs/guides/self-hosting/).

--- a/apps/marketing/src/content/docs/guides/sharing-and-collaboration.md
+++ b/apps/marketing/src/content/docs/guides/sharing-and-collaboration.md
@@ -52,6 +52,14 @@ If you want to prevent sharing (e.g., for sensitive plans), set:
 export PLANNOTATOR_SHARE=disabled
 ```
 
+Or set it persistently in `~/.plannotator/config.json`:
+
+```json
+{ "share": "disabled" }
+```
+
+The environment variable takes precedence over the config file.
+
 When sharing is disabled:
 - The Share tab is hidden from the Export modal
 - The "Copy Share Link" quick action is removed

--- a/apps/marketing/src/content/docs/reference/environment-variables.md
+++ b/apps/marketing/src/content/docs/reference/environment-variables.md
@@ -19,7 +19,7 @@ All Plannotator environment variables and their defaults.
 | `PLANNOTATOR_ORIGIN` | auto-detect | Explicit agent-origin override. Valid values: `claude-code`, `amp`, `droid`, `opencode`, `codex`, `copilot-cli`, `pi`, `gemini-cli`, `kiro-cli`. Invalid values silently fall through to env-based detection. |
 | `PLANNOTATOR_READY_FILE` | (none) | Internal host-plugin side channel. When set, Plannotator appends server-ready JSON lines containing the local UI URL. |
 | `PLANNOTATOR_SKIP_BROWSER_OPEN` | unset | Internal host-plugin flag. Set to `1` to prevent Plannotator from opening the browser itself when the host will open the URL. |
-| `PLANNOTATOR_SHARE` | enabled | Set to `disabled` to turn off sharing. Hides share UI and import options. |
+| `PLANNOTATOR_SHARE` | enabled | Set to `disabled` to turn off sharing. Hides share UI and import options. Can also be set via `~/.plannotator/config.json` (`{ "share": "disabled" }`); the env var takes precedence. |
 | `PLANNOTATOR_SHARE_URL` | `https://share.plannotator.ai` | Base URL for share links. Set this when self-hosting the share portal. |
 | `PLANNOTATOR_DATA_DIR` | `~/.plannotator` | Override the base data directory. Supports `~` expansion. All data (plans, history, drafts, config, hooks, sessions) is stored under this directory.* |
 | `PLANNOTATOR_PLAN_TIMEOUT_SECONDS` | `345600` | OpenCode only. `submit_plan` wait timeout in seconds. Set `0` to disable timeout. |

--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -27,7 +27,7 @@ import {
   getPlanToolName,
   getAnnotateMessageFeedbackPrompt,
 } from "@plannotator/shared/prompts";
-import { loadConfig } from "@plannotator/shared/config";
+import { loadConfig, resolveSharingEnabled } from "@plannotator/shared/config";
 import { readImprovementHook } from "@plannotator/shared/improvement-hooks";
 import { composeImproveContext } from "@plannotator/shared/pfm-reminder";
 import {
@@ -295,9 +295,9 @@ const PlannotatorPlugin: Plugin = async (ctx, rawOptions?: PlannotatorOpenCodeOp
         return share !== "disabled";
       }
     } catch {
-      // Config read failed, fall through to env var
+      // Config read failed, fall through to env var / plannotator config
     }
-    return process.env.PLANNOTATOR_SHARE !== "disabled";
+    return resolveSharingEnabled(loadConfig());
   }
 
   function getShareBaseUrl(): string | undefined {

--- a/apps/pi-extension/plannotator-browser.ts
+++ b/apps/pi-extension/plannotator-browser.ts
@@ -33,7 +33,7 @@ import {
 } from "./generated/pr-provider.js";
 import { parseRemoteUrl } from "./generated/repo.js";
 import { fetchRef, createWorktree, removeWorktree, ensureObjectAvailable } from "./generated/worktree.js";
-import { loadConfig, resolveDefaultDiffType } from "./generated/config.js";
+import { loadConfig, resolveDefaultDiffType, resolveSharingEnabled } from "./generated/config.js";
 import {
 	WorkspaceReviewSession,
 	type WorkspaceDiffType,
@@ -192,7 +192,7 @@ export async function startPlanReviewBrowserSession(
 		plan: planContent,
 		htmlContent: planHtmlContent,
 		origin: "pi",
-		sharingEnabled: process.env.PLANNOTATOR_SHARE !== "disabled",
+		sharingEnabled: resolveSharingEnabled(loadConfig()),
 		shareBaseUrl: process.env.PLANNOTATOR_SHARE_URL || undefined,
 		pasteApiUrl: process.env.PLANNOTATOR_PASTE_URL || undefined,
 	});
@@ -480,7 +480,7 @@ export async function startCodeReviewBrowserSession(
 		agentCwd,
 		worktreePool,
 		htmlContent: reviewHtmlContent,
-		sharingEnabled: process.env.PLANNOTATOR_SHARE !== "disabled",
+		sharingEnabled: resolveSharingEnabled(loadConfig()),
 		shareBaseUrl: process.env.PLANNOTATOR_SHARE_URL || undefined,
 		pasteApiUrl: process.env.PLANNOTATOR_PASTE_URL || undefined,
 		onCleanup: worktreeCleanup,
@@ -556,7 +556,7 @@ export async function startMarkdownAnnotationSession(
 		renderHtml,
 		convertHtml,
 		htmlContent: planHtmlContent,
-		sharingEnabled: process.env.PLANNOTATOR_SHARE !== "disabled",
+		sharingEnabled: resolveSharingEnabled(loadConfig()),
 		shareBaseUrl: process.env.PLANNOTATOR_SHARE_URL || undefined,
 		pasteApiUrl: process.env.PLANNOTATOR_PASTE_URL || undefined,
 	});
@@ -610,7 +610,7 @@ export async function openArchiveBrowserAction(
 		origin: "pi",
 		mode: "archive",
 		customPlanPath,
-		sharingEnabled: process.env.PLANNOTATOR_SHARE !== "disabled",
+		sharingEnabled: resolveSharingEnabled(loadConfig()),
 		shareBaseUrl: process.env.PLANNOTATOR_SHARE_URL || undefined,
 		pasteApiUrl: process.env.PLANNOTATOR_PASTE_URL || undefined,
 	});

--- a/apps/pi-extension/server/serverAnnotate.ts
+++ b/apps/pi-extension/server/serverAnnotate.ts
@@ -4,7 +4,7 @@ import { existsSync, readFileSync, statSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 
 import { contentHash, deleteDraft } from "../generated/draft.js";
-import { saveConfig, detectGitUser, getServerConfig } from "../generated/config.js";
+import { saveConfig, detectGitUser, getServerConfig, loadConfig, resolveSharingEnabled } from "../generated/config.js";
 import { disabledSourceSave, type SourceSaveRequest } from "../generated/source-save.js";
 import {
 	createSourceSaveCapability,
@@ -173,7 +173,7 @@ export async function startAnnotateServer(options: {
 	void warmFileListCache(process.cwd(), "code");
 	const gitUser = detectGitUser();
 	const sharingEnabled =
-		options.sharingEnabled ?? process.env.PLANNOTATOR_SHARE !== "disabled";
+		options.sharingEnabled ?? resolveSharingEnabled(loadConfig());
 	const shareBaseUrl =
 		(options.shareBaseUrl ?? process.env.PLANNOTATOR_SHARE_URL) || undefined;
 	const pasteApiUrl =

--- a/apps/pi-extension/server/serverPlan.ts
+++ b/apps/pi-extension/server/serverPlan.ts
@@ -37,7 +37,7 @@ import {
 } from "./integrations.js";
 import { listenOnPort } from "./network.js";
 
-import { loadConfig, saveConfig, detectGitUser, getServerConfig } from "../generated/config.js";
+import { loadConfig, saveConfig, detectGitUser, getServerConfig, resolveSharingEnabled } from "../generated/config.js";
 import { readImprovementHook, getImprovementHookExpectedPath } from "../generated/improvement-hooks.js";
 import { composeImproveContext } from "../generated/pfm-reminder.js";
 import { detectProjectName, getRepoInfo } from "./project.js";
@@ -85,7 +85,7 @@ export async function startPlanReviewServer(options: {
 	void warmFileListCache(process.cwd(), "code");
 	const gitUser = detectGitUser();
 	const sharingEnabled =
-		options.sharingEnabled ?? process.env.PLANNOTATOR_SHARE !== "disabled";
+		options.sharingEnabled ?? resolveSharingEnabled(loadConfig());
 	const shareBaseUrl =
 		(options.shareBaseUrl ?? process.env.PLANNOTATOR_SHARE_URL) || undefined;
 	const pasteApiUrl =

--- a/apps/pi-extension/server/serverReview.ts
+++ b/apps/pi-extension/server/serverReview.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import { basename } from "node:path";
 
 import { contentHash, deleteDraft } from "../generated/draft.js";
-import { loadConfig, saveConfig, detectGitUser, getServerConfig } from "../generated/config.js";
+import { loadConfig, saveConfig, detectGitUser, getServerConfig, resolveSharingEnabled } from "../generated/config.js";
 
 export type {
 	DiffOption,
@@ -625,7 +625,7 @@ export async function startReviewServer(options: {
 		},
 	});
 	const sharingEnabled =
-		options.sharingEnabled ?? process.env.PLANNOTATOR_SHARE !== "disabled";
+		options.sharingEnabled ?? resolveSharingEnabled(loadConfig());
 	const shareBaseUrl =
 		(options.shareBaseUrl ?? process.env.PLANNOTATOR_SHARE_URL) || undefined;
 	const pasteApiUrl =

--- a/packages/shared/config.ts
+++ b/packages/shared/config.ts
@@ -135,6 +135,13 @@ export interface PlannotatorConfig {
    * Set to false to always use the system browser even when Glimpse is installed.
    */
   glimpse?: boolean;
+  /**
+   * Control URL sharing (Share tab, copy link, short URLs, import review).
+   * Defaults to enabled. Set to "disabled" to hide all sharing UI — useful
+   * for teams working with sensitive plans. Mirrors the PLANNOTATOR_SHARE
+   * env var value, which takes precedence over this setting.
+   */
+  share?: "enabled" | "disabled";
 }
 
 const CONFIG_DIR = getPlannotatorDataDir();
@@ -258,5 +265,18 @@ export function resolveUseJina(cliNoJina: boolean, config: PlannotatorConfig): b
   if (config.jina !== undefined) return config.jina;
 
   // Default: enabled
+  return true;
+}
+
+/**
+ * Resolve whether URL sharing is enabled.
+ *
+ * Priority (highest wins):
+ *   PLANNOTATOR_SHARE env var  →  config.share  →  default true
+ */
+export function resolveSharingEnabled(config: PlannotatorConfig): boolean {
+  const envVal = process.env.PLANNOTATOR_SHARE;
+  if (envVal !== undefined) return envVal !== "disabled";
+  if (config.share !== undefined) return config.share !== "disabled";
   return true;
 }


### PR DESCRIPTION
## Summary

Adds support for toggling URL sharing via `~/.plannotator/config.json`, not just the `PLANNOTATOR_SHARE` environment variable. Teams who want sharing off persistently can now set it in config instead of exporting an env var in every shell.

```json
{ "share": "disabled" }
```

## Details

- New `share?: "enabled" | "disabled"` field on `PlannotatorConfig`, mirroring the env var's value so the two stay aligned.
- New `resolveSharingEnabled(config)` helper following the existing `resolveUseJina`/`resolveUseGlimpse` pattern. Precedence: `PLANNOTATOR_SHARE` env var → `config.share` → default enabled. The env var keeps its existing `!== "disabled"` semantics and remains highest priority, so current behavior is unchanged.
- All inline `process.env.PLANNOTATOR_SHARE !== "disabled"` checks now route through the helper: hook server, OpenCode plugin (config-aware fallback), and the Pi extension (browser + server fallbacks).
- Docs updated (configuration, environment-variables reference, sharing guide, AGENTS.md).

`typecheck` and `bun test` both pass.
