### PR TITLE
fix(annotate): block symlink escape in HTML asset serving + cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Requires `gh` installed and authenticated. Can also be set persistently in `~/.p
 { "verifyAttestation": true }
 ```
 
-See the [verification docs](https://plannotator.ai/docs/getting-started/installation/#verifying-your-install) for details.
+See the [verification docs](https://plannotator.ai/docs/reference/verifying-your-install/) for details.
 
 ---
 

--- a/apps/hook/README.md
+++ b/apps/hook/README.md
@@ -21,7 +21,7 @@ irm https://plannotator.ai/install.ps1 | iex
 curl -fsSL https://plannotator.ai/install.cmd -o install.cmd && install.cmd && del install.cmd
 ```
 
-Released binaries ship with SHA256 sidecars and [SLSA build provenance](https://slsa.dev/) attestations from v0.17.2 onwards. See the [installation docs](https://plannotator.ai/docs/getting-started/installation/#verifying-your-install) for version pinning and verification commands.
+Released binaries ship with SHA256 sidecars and [SLSA build provenance](https://slsa.dev/) attestations from v0.17.2 onwards. See the [installation docs](https://plannotator.ai/docs/getting-started/installation/) for version pinning and the [verification docs](https://plannotator.ai/docs/reference/verifying-your-install/) for verification commands.
 
 ---
 

--- a/apps/pi-extension/server/serverAnnotate.ts
+++ b/apps/pi-extension/server/serverAnnotate.ts
@@ -1,6 +1,6 @@
 import { createServer } from "node:http";
 import { dirname, isAbsolute, relative, resolve as resolvePath } from "node:path";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 
 import { contentHash, deleteDraft } from "../generated/draft.js";
@@ -145,8 +145,21 @@ function createHtmlAssetRegistry() {
 }
 
 function isWithinDirectory(filePath: string, root: string): boolean {
-	const resolved = resolvePath(filePath);
-	const resolvedRoot = resolvePath(root);
+	let resolvedRoot: string;
+	try {
+		resolvedRoot = realpathSync(resolvePath(root));
+	} catch {
+		return false;
+	}
+	// Resolve symlinks on the asset so an in-directory symlink pointing outside
+	// the root (e.g. evil.css -> ~/.ssh/id_rsa) is rejected, not followed. A
+	// nonexistent target keeps the lexical path; the later read simply fails.
+	let resolved = resolvePath(filePath);
+	try {
+		resolved = realpathSync(resolved);
+	} catch {
+		// asset does not exist yet — fall through with the lexical path
+	}
 	const rel = relative(resolvedRoot, resolved);
 	return rel === "" || (!!rel && !rel.startsWith("..") && !isAbsolute(rel));
 }

--- a/packages/server/annotate-html-assets.test.ts
+++ b/packages/server/annotate-html-assets.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createHtmlAssetRegistry, inlineHtmlLocalAssets } from "./html-assets";
@@ -62,5 +62,46 @@ describe("annotate raw HTML assets", () => {
     expect(cssBase64).toBeTruthy();
     const css = Buffer.from(cssBase64!, "base64").toString("utf-8");
     expect(css).toContain('url("data:image/png;base64,AQID")');
+  });
+
+  test("does not serve a symlinked asset that escapes the source directory", async () => {
+    // Attacker bundle: a symlink inside the HTML's dir pointing at a secret outside it.
+    const base = mkdtempSync(join(tmpdir(), "plannotator-html-symlink-"));
+    const htmlDir = join(base, "site");
+    mkdirSync(htmlDir);
+    const secretPath = join(base, "secret.css");
+    writeFileSync(secretPath, "SECRET_OUTSIDE_CONTENT", "utf-8");
+    symlinkSync(secretPath, join(htmlDir, "evil.css"));
+    const htmlPath = join(htmlDir, "page.html");
+    const html = '<!doctype html><html><head><link rel="stylesheet" href="./evil.css"></head><body></body></html>';
+    writeFileSync(htmlPath, html, "utf-8");
+
+    const assets = createHtmlAssetRegistry();
+    const rawHtml = assets.rewriteHtml(html, htmlPath);
+    const cssUrl = rawHtml.match(/href="([^"]+evil\.css)"/)?.[1];
+    expect(cssUrl).toBeTruthy();
+
+    const requestUrl = new URL(cssUrl!, "http://localhost");
+    const response = await assets.handle(new Request(String(requestUrl)), requestUrl);
+    expect(response?.status).toBe(403);
+    expect(await response?.text()).not.toContain("SECRET_OUTSIDE_CONTENT");
+  });
+
+  test("does not inline a symlinked asset that escapes the source directory", () => {
+    const base = mkdtempSync(join(tmpdir(), "plannotator-html-symlink-inline-"));
+    const htmlDir = join(base, "site");
+    mkdirSync(htmlDir);
+    const secretPath = join(base, "secret.css");
+    writeFileSync(secretPath, "SECRET_OUTSIDE_CONTENT", "utf-8");
+    symlinkSync(secretPath, join(htmlDir, "evil.css"));
+    const htmlPath = join(htmlDir, "page.html");
+    const html = '<!doctype html><html><head><link rel="stylesheet" href="./evil.css"></head><body></body></html>';
+    writeFileSync(htmlPath, html, "utf-8");
+
+    const shareHtml = inlineHtmlLocalAssets(html, htmlPath);
+    // The symlinked secret must not be base64-embedded into the portable share.
+    expect(shareHtml).not.toContain("base64");
+    expect(Buffer.from(shareHtml).toString("utf-8")).not.toContain("SECRET_OUTSIDE_CONTENT");
+    expect(shareHtml).not.toContain(Buffer.from("SECRET_OUTSIDE_CONTENT").toString("base64"));
   });
 });

--- a/packages/server/html-assets.ts
+++ b/packages/server/html-assets.ts
@@ -1,4 +1,5 @@
 import { dirname, isAbsolute, relative, resolve as resolvePath } from "path";
+import { realpathSync } from "node:fs";
 import {
   HTML_ASSET_ROUTE_PREFIX,
   encodeHtmlAssetPath,
@@ -99,8 +100,21 @@ export function createHtmlAssetRegistry() {
 }
 
 function isWithinDirectory(filePath: string, root: string): boolean {
-  const resolved = resolvePath(filePath);
-  const resolvedRoot = resolvePath(root);
+  let resolvedRoot: string;
+  try {
+    resolvedRoot = realpathSync(resolvePath(root));
+  } catch {
+    return false;
+  }
+  // Resolve symlinks on the asset so an in-directory symlink pointing outside
+  // the root (e.g. evil.css -> ~/.ssh/id_rsa) is rejected, not followed. A
+  // nonexistent target keeps the lexical path; the later read simply 404s.
+  let resolved = resolvePath(filePath);
+  try {
+    resolved = realpathSync(resolved);
+  } catch {
+    // asset does not exist yet — fall through with the lexical path
+  }
   const rel = relative(resolvedRoot, resolved);
   return rel === "" || (!!rel && !rel.startsWith("..") && !isAbsolute(rel));
 }

--- a/packages/shared/html-assets-node.ts
+++ b/packages/shared/html-assets-node.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { dirname, isAbsolute, relative, resolve as resolvePath, posix as pathPosix } from "node:path";
 import {
   htmlAssetContentType,
@@ -56,8 +56,21 @@ export function inlineHtmlLocalAssets(html: string, htmlFilePath: string): strin
 }
 
 function isWithinDirectory(filePath: string, root: string): boolean {
-  const resolved = resolvePath(filePath);
-  const resolvedRoot = resolvePath(root);
+  let resolvedRoot: string;
+  try {
+    resolvedRoot = realpathSync(resolvePath(root));
+  } catch {
+    return false;
+  }
+  // Resolve symlinks on the asset so an in-directory symlink pointing outside
+  // the root (e.g. evil.css -> ~/.ssh/id_rsa) is rejected, not followed. A
+  // nonexistent target keeps the lexical path; the later read simply fails.
+  let resolved = resolvePath(filePath);
+  try {
+    resolved = realpathSync(resolved);
+  } catch {
+    // asset does not exist yet — fall through with the lexical path
+  }
   const rel = relative(resolvedRoot, resolved);
   return rel === "" || (!!rel && !rel.startsWith("..") && !isAbsolute(rel));
 }

--- a/tests/manual/local/sandbox-pi.sh
+++ b/tests/manual/local/sandbox-pi.sh
@@ -82,7 +82,7 @@ if [ "$NO_GIT" = false ]; then
   git config user.name "Test User"
 fi
 
-# Create sample project
+# Create sample project (base files — committed history lives on `main`)
 cat > README.md << 'EOF'
 # Sample Project
 
@@ -95,27 +95,100 @@ This is a sandbox for testing the Plannotator Pi extension.
 - Last message annotation
 EOF
 
+cat > package.json << 'EOF'
+{
+  "name": "sandbox",
+  "version": "1.0.0",
+  "type": "module"
+}
+EOF
+
 mkdir -p src
 cat > src/index.ts << 'EOF'
 export function greet(name: string): string {
   return `Hello, ${name}!`;
 }
 
-// TODO: Add more features
 console.log(greet("World"));
 EOF
 
-# Commit initial files
+cat > src/utils.ts << 'EOF'
+export function clamp(n: number, lo: number, hi: number): number {
+  return Math.min(Math.max(n, lo), hi);
+}
+EOF
+
+cat > src/legacy.ts << 'EOF'
+// Deprecated helper kept only for backwards compatibility.
+export function oldGreet(name: string): string {
+  return "Hi " + name;
+}
+EOF
+
+# Build rich git state so /plannotator-review can exercise every diff mode:
+# uncommitted, staged, unstaged, last-commit, branch, and merge-base.
 if [ "$NO_GIT" = false ]; then
+  # ── main: two commits of history ──
   git add -A
   git commit -q -m "Initial commit"
+  git branch -M main
 
-  # Add uncommitted changes (for /plannotator-review)
-  cat >> src/index.ts << 'EOF'
-
-export function farewell(name: string): string {
-  return `Goodbye, ${name}!`;
+  cat > src/math.ts << 'EOF'
+export function add(a: number, b: number): number {
+  return a + b;
 }
+EOF
+  printf '\n## Status\nActive.\n' >> README.md
+  git add -A
+  git commit -q -m "Add math utilities"
+
+  # ── feature branch: diverges from main (powers branch / merge-base diff) ──
+  git checkout -q -b feature/widgets
+
+  cat > src/widget.ts << 'EOF'
+export interface Widget {
+  id: string;
+  label: string;
+}
+
+export function renderWidget(w: Widget): string {
+  return `[${w.id}] ${w.label}`;
+}
+EOF
+  printf '\nexport const VERSION = "1.0";\n' >> src/index.ts
+  git add -A
+  git commit -q -m "Add widget module"
+
+  # last commit: a rename + a delete + a modify (rich single-commit diff)
+  git mv src/utils.ts src/helpers.ts
+  git rm -q src/legacy.ts
+  printf '\nexport const PI = 3.14159;\n' >> src/math.ts
+  git add -A
+  git commit -q -m "Refactor: rename utils -> helpers, drop legacy, extend math"
+
+  # ── working tree: staged + unstaged + untracked, all at once ──
+  # staged (modify + brand-new file, both git-added)
+  printf '\nexport const WIDGET_LIMIT = 100;\n' >> src/widget.ts
+  cat > src/staged-feature.ts << 'EOF'
+export function staged(): string {
+  return "this change is staged";
+}
+EOF
+  git add src/widget.ts src/staged-feature.ts
+
+  # unstaged (modify tracked files, NOT added)
+  printf '\n// FIXME: handle empty input\n' >> src/index.ts
+  printf '\n## Notes\nWork in progress.\n' >> README.md
+
+  # untracked (new files, never added)
+  cat > src/scratch.ts << 'EOF'
+// Scratch experiment, not yet tracked.
+export const scratch = true;
+EOF
+  cat > notes.md << 'EOF'
+# Scratch notes
+
+Untracked working-tree file.
 EOF
 fi
 
@@ -126,13 +199,20 @@ echo "Directory: $SANDBOX_DIR"
 if [ "$NO_GIT" = true ]; then
   echo "Git: DISABLED"
 else
-  echo "Git: enabled (with uncommitted changes)"
+  echo "Git: branch 'feature/widgets' off 'main' (2 commits each)"
+  echo "     staged:    src/widget.ts (mod), src/staged-feature.ts (new)"
+  echo "     unstaged:  src/index.ts, README.md"
+  echo "     untracked: src/scratch.ts, notes.md"
+  echo "     last commit: rename utils->helpers, delete legacy, modify math"
+  echo "     vs main: widget add + index/math changes (branch / merge-base)"
 fi
 echo ""
 echo "To test:"
 echo "  1. Plan mode: Ask the agent to plan something"
 if [ "$NO_GIT" = false ]; then
   echo "  2. Code review: Run /plannotator-review"
+  echo "     Switch diff mode in the UI to exercise uncommitted / staged /"
+  echo "     unstaged / last-commit / branch / merge-base."
 fi
 echo "  3. Annotate file: Run /plannotator-annotate README.md"
 echo "  4. Annotate last: Run /plannotator-last"


### PR DESCRIPTION
## Security fix (the main one)

The raw-HTML annotate feature (#924) serves local support assets via `/api/html-assets/<token>/<path>` and inlines them into share payloads. Both checked path containment **lexically**, so a symlink *inside* the HTML's directory pointing outside it (e.g. `evil.css -> ~/.ssh/id_rsa`) passed the check and was served / base64-inlined. In remote mode the inliner auto-fires at server startup, so a malicious HTML bundle could exfiltrate symlinked local files to the paste service with no user action.

**Fix:** resolve symlinks with `realpathSync` on **both** the asset and the root before the relative-path containment check, in all three runtime copies:
- `packages/server/html-assets.ts` (Bun route handler)
- `packages/shared/html-assets-node.ts` (shared share-inliner; Pi gets it via `vendor.sh`)
- `apps/pi-extension/server/serverAnnotate.ts` (Pi route handler)

Non-existent assets fall back to the lexical path and 404 on read; the root is realpath'd too so macOS `/tmp`→`/private/tmp` symlinking doesn't cause false rejections. Adds regression tests for both sinks (route returns 403, inliner doesn't embed the secret).

Found via an adversarial multi-agent QA pass over the two unreleased PRs (#890, #924); confirmed and reproduced by two independent reviewers.

## Also in this PR (unrelated, bundled to keep it moving)

- **test(pi):** expand `tests/manual/local/sandbox-pi.sh` to build rich git state (multiple commits, a feature branch, rename+delete+modify) so `/plannotator-review` can exercise every diff mode.
- **docs:** fix a broken verification link in `README.md` and `apps/hook/README.md` — they pointed at a non-existent `installation/#verifying-your-install` anchor; now point to the standalone `/docs/reference/verifying-your-install/` page.

## Test
- `bun test packages/server/annotate-html-assets.test.ts packages/shared/html-assets.test.ts` — 11 pass (incl. 2 new symlink regressions)
- `bun run typecheck` — clean
- route-parity test green