### PR TITLE
fix(server): always show remote URL + close share-html symlink gap

### DIFF
--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -86,6 +86,7 @@ import {
 	type Phase,
 	stripPlanningOnlyTools,
 } from "./tool-scope.ts";
+import { isRemoteSession } from "./server/network.js";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -126,6 +127,17 @@ function safeNotify(
 		if (notifyCurrentPiSession(message, type, origin)) return;
 		console.error(`Plannotator notification failed: ${err instanceof Error ? err.message : String(err)}`);
 	}
+}
+
+/**
+ * Foreground "session opened" notice. For a remote session the auto-opened
+ * browser is unreachable, so the URL must ride in THIS in-turn message — the
+ * after-turn notify inside openBrowserForServer fires too late to render.
+ */
+function sessionOpenedMessage(label: string, url: string): string {
+	return isRemoteSession()
+		? `${label} — open ${url} on your local machine (forward the port if needed). You can keep chatting while it runs.`
+		: `${label}. You can keep chatting while it runs.`;
 }
 
 function reportBackgroundError(ctx: ExtensionContext, message: string, err: unknown, origin?: PiSessionIdentity): void {
@@ -427,7 +439,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 					vcsType: reviewArgs.vcsType,
 					useLocal: reviewArgs.useLocal,
 				});
-				ctx.ui.notify("Code review opened. You can keep chatting while it runs.", "info");
+				ctx.ui.notify(sessionOpenedMessage("Code review opened", session.url), "info");
 				void session
 					.waitForDecision()
 					.then((result) => {
@@ -597,7 +609,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 					!!rawHtml,
 					renderMarkdownFlag,
 				);
-				ctx.ui.notify("Annotation opened. You can keep chatting while it runs.", "info");
+				ctx.ui.notify(sessionOpenedMessage("Annotation opened", session.url), "info");
 				void session
 					.waitForDecision()
 					.then((result) => {
@@ -671,7 +683,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 
 			try {
 				const session = await startLastMessageAnnotationSession(ctx, snapshot.text, gate, pickerMessages);
-				ctx.ui.notify("Last-message annotation opened. You can keep chatting while it runs.", "info");
+				ctx.ui.notify(sessionOpenedMessage("Last-message annotation opened", session.url), "info");
 				void session
 					.waitForDecision()
 					.then((result) => {

--- a/apps/pi-extension/server/serverAnnotate.ts
+++ b/apps/pi-extension/server/serverAnnotate.ts
@@ -1,6 +1,6 @@
 import { createServer } from "node:http";
-import { dirname, isAbsolute, relative, resolve as resolvePath } from "node:path";
-import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { dirname, resolve as resolvePath } from "node:path";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 
 import { contentHash, deleteDraft } from "../generated/draft.js";
@@ -43,7 +43,7 @@ import {
 	normalizeHtmlAssetRoutePath,
 	rewriteHtmlAssetReferences,
 } from "../generated/html-assets.js";
-import { inlineHtmlLocalAssets, MAX_HTML_ASSET_BYTES } from "../generated/html-assets-node.js";
+import { inlineHtmlLocalAssets, isWithinDirectory, MAX_HTML_ASSET_BYTES } from "../generated/html-assets-node.js";
 
 export interface AnnotateServerResult {
 	port: number;
@@ -143,26 +143,6 @@ function createHtmlAssetRegistry() {
 	}
 
 	return { rewriteHtml, inlineHtml, handle };
-}
-
-function isWithinDirectory(filePath: string, root: string): boolean {
-	let resolvedRoot: string;
-	try {
-		resolvedRoot = realpathSync(resolvePath(root));
-	} catch {
-		return false;
-	}
-	// Resolve symlinks on the asset so an in-directory symlink pointing outside
-	// the root (e.g. evil.css -> ~/.ssh/id_rsa) is rejected, not followed. A
-	// nonexistent target keeps the lexical path; the later read simply fails.
-	let resolved = resolvePath(filePath);
-	try {
-		resolved = realpathSync(resolved);
-	} catch {
-		// asset does not exist yet — fall through with the lexical path
-	}
-	const rel = relative(resolvedRoot, resolved);
-	return rel === "" || (!!rel && !rel.startsWith("..") && !isAbsolute(rel));
 }
 
 export async function startAnnotateServer(options: {

--- a/packages/server/annotate.test.ts
+++ b/packages/server/annotate.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { startAnnotateServer } from "./annotate";
@@ -79,6 +80,57 @@ describe("annotate server: /api/save-notes wiring", () => {
       const response = await fetch(`${server.url}/not-a-real-route`);
       expect(response.headers.get("content-type")).toContain("text/html");
       expect(await response.text()).toContain("Plannotator");
+    } finally {
+      server.stop();
+    }
+  });
+});
+
+describe("annotate server: /api/share-html symlink containment", () => {
+  let savedPort: string | undefined;
+  let savedRemote: string | undefined;
+
+  beforeEach(() => {
+    savedPort = process.env.PLANNOTATOR_PORT;
+    savedRemote = process.env.PLANNOTATOR_REMOTE;
+    delete process.env.PLANNOTATOR_PORT;
+    process.env.PLANNOTATOR_REMOTE = "0";
+  });
+
+  afterEach(() => {
+    if (savedPort === undefined) delete process.env.PLANNOTATOR_PORT;
+    else process.env.PLANNOTATOR_PORT = savedPort;
+    if (savedRemote === undefined) delete process.env.PLANNOTATOR_REMOTE;
+    else process.env.PLANNOTATOR_REMOTE = savedRemote;
+  });
+
+  // Regression: /api/share-html read the requested file through a lexical-only
+  // containment check, so a symlinked *.html inside the doc directory pointing
+  // outside it leaked the target's contents into the share payload. (Completes
+  // the #927 symlink fix, which hardened the asset sinks but missed this one.)
+  test("rejects a symlinked .html that escapes the document directory", async () => {
+    const docDir = mkdtempSync(join(tmpdir(), "plannotator-sharehtml-"));
+    const secretDir = mkdtempSync(join(tmpdir(), "plannotator-secret-"));
+    const secretPath = join(secretDir, "secret.html");
+    writeFileSync(secretPath, "SECRET_OUTSIDE_CONTENT", "utf-8");
+    symlinkSync(secretPath, join(docDir, "evil.html"));
+    const pagePath = join(docDir, "page.html");
+    writeFileSync(pagePath, MINIMAL_HTML, "utf-8");
+
+    const server = await startAnnotateServer({
+      markdown: "",
+      filePath: pagePath,
+      htmlContent: MINIMAL_HTML,
+      rawHtml: MINIMAL_HTML,
+      renderHtml: true,
+    });
+
+    try {
+      const response = await fetch(
+        `${server.url}/api/share-html?path=${encodeURIComponent(join(docDir, "evil.html"))}`,
+      );
+      expect(response.status).toBe(403);
+      expect(await response.text()).not.toContain("SECRET_OUTSIDE_CONTENT");
     } finally {
       server.stop();
     }

--- a/packages/server/annotate.ts
+++ b/packages/server/annotate.ts
@@ -27,8 +27,8 @@ import {
 } from "@plannotator/shared/source-save-node";
 import { createExternalAnnotationHandler } from "./external-annotations";
 import { saveConfig, detectGitUser, getServerConfig } from "./config";
-import { dirname, isAbsolute, relative, resolve as resolvePath } from "path";
-import { realpathSync } from "node:fs";
+import { dirname, resolve as resolvePath } from "path";
+import { isWithinDirectory } from "@plannotator/shared/html-assets-node";
 import { isWSL } from "./browser";
 import { AI_QUERY_ENDPOINT, createAIRuntime } from "./ai-runtime";
 import type { AIEndpoints } from "@plannotator/ai";
@@ -566,24 +566,4 @@ export async function startAnnotateServer(
       server.stop();
     },
   };
-}
-
-function isWithinDirectory(filePath: string, root: string): boolean {
-  let resolvedRoot: string;
-  try {
-    resolvedRoot = realpathSync(resolvePath(root));
-  } catch {
-    return false;
-  }
-  // Resolve symlinks on the target so an in-directory symlink pointing outside
-  // the root (e.g. evil.html -> ~/.ssh/id_rsa) is rejected, not followed. A
-  // nonexistent target keeps the lexical path; the later read simply fails.
-  let resolved = resolvePath(filePath);
-  try {
-    resolved = realpathSync(resolved);
-  } catch {
-    // target does not exist yet — fall through with the lexical path
-  }
-  const rel = relative(resolvedRoot, resolved);
-  return rel === "" || (!!rel && !rel.startsWith("..") && !isAbsolute(rel));
 }

--- a/packages/server/annotate.ts
+++ b/packages/server/annotate.ts
@@ -28,6 +28,7 @@ import {
 import { createExternalAnnotationHandler } from "./external-annotations";
 import { saveConfig, detectGitUser, getServerConfig } from "./config";
 import { dirname, isAbsolute, relative, resolve as resolvePath } from "path";
+import { realpathSync } from "node:fs";
 import { isWSL } from "./browser";
 import { AI_QUERY_ENDPOINT, createAIRuntime } from "./ai-runtime";
 import type { AIEndpoints } from "@plannotator/ai";
@@ -568,8 +569,21 @@ export async function startAnnotateServer(
 }
 
 function isWithinDirectory(filePath: string, root: string): boolean {
-  const resolved = resolvePath(filePath);
-  const resolvedRoot = resolvePath(root);
+  let resolvedRoot: string;
+  try {
+    resolvedRoot = realpathSync(resolvePath(root));
+  } catch {
+    return false;
+  }
+  // Resolve symlinks on the target so an in-directory symlink pointing outside
+  // the root (e.g. evil.html -> ~/.ssh/id_rsa) is rejected, not followed. A
+  // nonexistent target keeps the lexical path; the later read simply fails.
+  let resolved = resolvePath(filePath);
+  try {
+    resolved = realpathSync(resolved);
+  } catch {
+    // target does not exist yet — fall through with the lexical path
+  }
   const rel = relative(resolvedRoot, resolved);
   return rel === "" || (!!rel && !rel.startsWith("..") && !isAbsolute(rel));
 }

--- a/packages/server/html-assets.ts
+++ b/packages/server/html-assets.ts
@@ -1,5 +1,4 @@
-import { dirname, isAbsolute, relative, resolve as resolvePath } from "path";
-import { realpathSync } from "node:fs";
+import { dirname, resolve as resolvePath } from "path";
 import {
   HTML_ASSET_ROUTE_PREFIX,
   encodeHtmlAssetPath,
@@ -9,6 +8,7 @@ import {
 } from "@plannotator/shared/html-assets";
 import {
   inlineHtmlLocalAssets,
+  isWithinDirectory,
   MAX_HTML_ASSET_BYTES,
 } from "@plannotator/shared/html-assets-node";
 
@@ -99,22 +99,3 @@ export function createHtmlAssetRegistry() {
   return { rewriteHtml, inlineHtml, handle };
 }
 
-function isWithinDirectory(filePath: string, root: string): boolean {
-  let resolvedRoot: string;
-  try {
-    resolvedRoot = realpathSync(resolvePath(root));
-  } catch {
-    return false;
-  }
-  // Resolve symlinks on the asset so an in-directory symlink pointing outside
-  // the root (e.g. evil.css -> ~/.ssh/id_rsa) is rejected, not followed. A
-  // nonexistent target keeps the lexical path; the later read simply 404s.
-  let resolved = resolvePath(filePath);
-  try {
-    resolved = realpathSync(resolved);
-  } catch {
-    // asset does not exist yet — fall through with the lexical path
-  }
-  const rel = relative(resolvedRoot, resolved);
-  return rel === "" || (!!rel && !rel.startsWith("..") && !isAbsolute(rel));
-}

--- a/packages/server/shared-handlers.test.ts
+++ b/packages/server/shared-handlers.test.ts
@@ -116,4 +116,45 @@ describe("handleServerReady", () => {
 
     expect(opened).toBe(false);
   });
+
+  // Regression: a remote session must surface a reachable URL in the terminal
+  // regardless of URL sharing — otherwise a sharing-disabled remote user is left
+  // with no URL and the agent hangs waiting on the review.
+  test("prints the reachable URL to stderr for a remote session", async () => {
+    const writes: string[] = [];
+    const original = process.stderr.write.bind(process.stderr);
+    (process.stderr as { write: unknown }).write = (chunk: unknown) => {
+      writes.push(String(chunk));
+      return true;
+    };
+    try {
+      await handleServerReady("http://localhost:19432", true, 19432, {
+        skipBrowserOpen: true,
+      });
+    } finally {
+      (process.stderr as { write: unknown }).write = original;
+    }
+    expect(writes.join("")).toContain("http://localhost:19432");
+  });
+
+  test("does not print the URL for a local session (browser opens instead)", async () => {
+    const writes: string[] = [];
+    let opened = "";
+    const original = process.stderr.write.bind(process.stderr);
+    (process.stderr as { write: unknown }).write = (chunk: unknown) => {
+      writes.push(String(chunk));
+      return true;
+    };
+    try {
+      await handleServerReady("http://localhost:3000", false, 3000, {
+        openBrowser: async (u: string) => {
+          opened = u;
+        },
+      });
+    } finally {
+      (process.stderr as { write: unknown }).write = original;
+    }
+    expect(writes.join("")).not.toContain("http://localhost:3000");
+    expect(opened).toBe("http://localhost:3000");
+  });
 });

--- a/packages/server/shared-handlers.ts
+++ b/packages/server/shared-handlers.ts
@@ -172,6 +172,17 @@ export async function handleServerReady(
     }
   }
 
+  // A remote/SSH session can't pop a browser on the user's machine, so the
+  // session URL must be visible in the terminal — independently of whether URL
+  // sharing is enabled. The share link (gated on sharing) is an extra; this
+  // reachable URL is the lifeline. Without it, a sharing-disabled remote user
+  // saw no URL at all and the agent hung waiting on the review.
+  if (isRemote) {
+    process.stderr.write(
+      `\n  Plannotator session ready — open on your local machine (forward port ${port} if needed):\n  ${url}\n\n`,
+    );
+  }
+
   const skipBrowserOpen = options.skipBrowserOpen ?? process.env.PLANNOTATOR_SKIP_BROWSER_OPEN === "1";
   if (skipBrowserOpen) return;
 

--- a/packages/shared/html-assets-node.ts
+++ b/packages/shared/html-assets-node.ts
@@ -55,7 +55,15 @@ export function inlineHtmlLocalAssets(html: string, htmlFilePath: string): strin
   }
 }
 
-function isWithinDirectory(filePath: string, root: string): boolean {
+/**
+ * Single source of truth for "is this file inside this root?" containment used
+ * by every HTML asset / share-html sink (Bun route handler, share inliner, and
+ * the Pi server via the vendored copy). Resolves symlinks on BOTH the root and
+ * the target so an in-directory symlink pointing outside the root cannot escape.
+ * Keep all sinks importing this — duplicating it is how the escape was missed in
+ * one runtime before (#927/#929).
+ */
+export function isWithinDirectory(filePath: string, root: string): boolean {
   let resolvedRoot: string;
   try {
     resolvedRoot = realpathSync(resolvePath(root));


### PR DESCRIPTION
Makes the session URL reliably visible to remote users across runtimes, closes a symlink-containment gap, and de-duplicates the containment helper. Surfaced by the pre-release QA sweep + real Pi user reports.

## 1. 🔴 Remote URL visibility — Claude Code hook
On a headless remote box the browser can't open, and the hook's only user-visible URL came from `writeRemoteShareLink`, gated on `sharingEnabled`. With sharing disabled (`PLANNOTATOR_SHARE=disabled` or `config.json {"share":"disabled"}`, widened by #921) the user saw **no URL** and the agent hung on `waitForDecision()`. `handleServerReady` now prints the reachable `localhost:<port>` whenever remote, independent of sharing.

## 2. 🔴 Remote URL visibility — Pi (review / annotate / last)
Remote Pi users never saw a URL for these slash commands. Root cause: the URL was emitted from `openBrowserForServer` **after the command's turn ended** (fire-and-forget), and Pi only renders a `notify` during an active turn — so it silently dropped. (The "X opened. You can keep chatting" notice fires *in-turn* and shows fine.) Fix: fold the URL into that in-turn message for remote sessions, single-line per the notify convention. Local sessions unchanged.

## 3. 🟠 `/api/share-html` symlink containment (completes #927)
#927 hardened the `/api/html-assets` asset sinks with `realpathSync` but missed `annotate.ts`'s `/api/share-html` containment, which stayed lexical — a symlinked `*.html` in the doc dir leaked its target. Now realpath-resolved. Bun-only (Pi was already hardened).

## 4. ♻️ Consolidate the containment helper
The four byte-identical `isWithinDirectory` copies (the reason a sink kept getting missed) are now one exported function in `packages/shared/html-assets-node.ts`, imported by all sinks (Bun + the Pi vendored copy). A new sink can't silently diverge.

## Tests / verification
- `shared-handlers.test.ts`: remote session prints URL; local doesn't.
- `annotate.test.ts`: `/api/share-html` returns 403 (no leak) on symlink escape.
- Full `packages/server` + `packages/shared`: 690 pass, 0 fail. typecheck clean; `build:pi` clean; hook binary rebuilt.

## Known follow-ups (non-blocking)
- OpenCode CLI-bridge double-logs the bare URL (the hook print's header is stripped by the stderr allowlist while the URL line is forwarded, duplicating the ready-file log). Fix is to gate the hook print on `!readyFile`; not yet included.
- The `/api/doc` route (`handleDoc`) uses the same lexical containment as the share-html sink did — a likely pre-existing symlink class, out of scope here, worth a separate follow-up.