### PR TITLE
Polish live file tree refresh

### DIFF
--- a/apps/pi-extension/server.test.ts
+++ b/apps/pi-extension/server.test.ts
@@ -13,6 +13,7 @@ import {
   runGitDiff,
   runVcsDiff,
   stageFile,
+  startPlanReviewServer,
   startReviewServer,
   unstageFile,
 } from "./server";
@@ -30,6 +31,28 @@ function makeTempDir(prefix: string): string {
   const dir = mkdtempSync(join(tmpdir(), prefix));
   tempDirs.push(dir);
   return dir;
+}
+
+function writeTempFile(root: string, relativePath: string, content = "x"): string {
+  const full = join(root, relativePath);
+  mkdirSync(join(full, ".."), { recursive: true });
+  writeFileSync(full, content, "utf-8");
+  return full;
+}
+
+interface PiTreeNode {
+  path: string;
+  type: "file" | "folder";
+  children?: PiTreeNode[];
+}
+
+function flattenTree(nodes: PiTreeNode[]): string[] {
+  const paths: string[] = [];
+  for (const node of nodes) {
+    if (node.type === "file") paths.push(node.path);
+    else paths.push(...flattenTree(node.children ?? []));
+  }
+  return paths;
 }
 
 function childEnv(): NodeJS.ProcessEnv {
@@ -963,4 +986,49 @@ describe("pi review server", () => {
       server.stop();
     }
   }, 20_000);
+});
+
+describe("pi plan server file browser", () => {
+  test("filters excluded folders from tree and workspace status", async () => {
+    const repo = makeTempDir("plannotator-pi-files-");
+    const dataDir = makeTempDir("plannotator-pi-files-data-");
+    process.env.PLANNOTATOR_DATA_DIR = dataDir;
+    process.env.PLANNOTATOR_PORT = String(await reservePort());
+    process.chdir(repo);
+
+    git(repo, ["init"]);
+    git(repo, ["branch", "-M", "main"]);
+    git(repo, ["config", "user.email", "pi-files@example.com"]);
+    git(repo, ["config", "user.name", "Pi Files"]);
+    writeTempFile(repo, "docs/visible.md", "visible\n");
+    writeTempFile(repo, "dist/generated.md", "before\n");
+    git(repo, ["add", "-A"]);
+    git(repo, ["commit", "-m", "initial"]);
+
+    writeTempFile(repo, "dist/generated.md", "after\n");
+    writeTempFile(repo, "packages/app/node_modules/pkg/readme.md", "hidden\n");
+
+    const server = await startPlanReviewServer({
+      plan: "# Plan",
+      origin: "pi",
+      htmlContent: "<!doctype html><html><body>plan</body></html>",
+    });
+
+    try {
+      const url = new URL(`${server.url}/api/reference/files`);
+      url.searchParams.set("dirPath", repo);
+      const response = await fetch(url);
+      const payload = await response.json() as {
+        tree: PiTreeNode[];
+        workspaceStatus: { totals: { files: number }; files: Record<string, unknown> };
+      };
+
+      expect(response.status).toBe(200);
+      expect(flattenTree(payload.tree)).toEqual(["docs/visible.md"]);
+      expect(payload.workspaceStatus.totals.files).toBe(0);
+      expect(payload.workspaceStatus.files).toEqual({});
+    } finally {
+      server.stop();
+    }
+  });
 });

--- a/apps/pi-extension/server/file-browser-watch.test.ts
+++ b/apps/pi-extension/server/file-browser-watch.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { isFileBrowserWatchIgnoredPath } from "./file-browser-watch";
+
+describe("Pi file browser watcher", () => {
+	test("ignores nested excluded folders for watcher paths", () => {
+		const root = join(tmpdir(), "plannotator-pi-watch-root");
+
+		expect(isFileBrowserWatchIgnoredPath(join(root, "packages", "app", "node_modules"), root)).toBe(true);
+		expect(isFileBrowserWatchIgnoredPath(join(root, "packages", "app", "node_modules", "pkg", "readme.md"), root)).toBe(true);
+		expect(isFileBrowserWatchIgnoredPath(join(root, "docs", "dist", "generated.md"), root)).toBe(true);
+		expect(isFileBrowserWatchIgnoredPath(join(root, "docs", "plan.md"), root)).toBe(false);
+		expect(isFileBrowserWatchIgnoredPath(root, root)).toBe(false);
+		expect(isFileBrowserWatchIgnoredPath(join(dirname(root), "outside", "node_modules"), root)).toBe(false);
+	});
+});

--- a/apps/pi-extension/server/file-browser-watch.ts
+++ b/apps/pi-extension/server/file-browser-watch.ts
@@ -31,7 +31,7 @@ function serialize(event: FileBrowserChangeEvent): string {
 	return `data: ${JSON.stringify(event)}\n\n`;
 }
 
-function isExcludedPath(path: string, root: string): boolean {
+export function isFileBrowserWatchIgnoredPath(path: string, root: string): boolean {
 	const rel = relative(root, path).replace(/\\/g, "/");
 	if (!rel || rel.startsWith("..") || isAbsolute(rel)) return false;
 	return isFileBrowserExcludedPath(rel);
@@ -73,7 +73,9 @@ function closeWatcher(entry: WatchEntry): void {
 	if (entry.debounceTimer) clearTimeout(entry.debounceTimer);
 	void entry.contentWatcher?.close();
 	void entry.gitWatcher?.close();
-	watchers.delete(entry.dirPath);
+	if (watchers.get(entry.dirPath) === entry) {
+		watchers.delete(entry.dirPath);
+	}
 }
 
 function releaseSubscriber(entry: WatchEntry, res: ServerResponse): void {
@@ -96,7 +98,7 @@ function ensureWatcher(dirPath: string): WatchEntry {
 	entry.contentWatcher = chokidar.watch(dirPath, {
 		ignoreInitial: true,
 		persistent: true,
-		ignored: (path) => isExcludedPath(path, dirPath),
+		ignored: (path) => isFileBrowserWatchIgnoredPath(path, dirPath),
 		awaitWriteFinish: {
 			stabilityThreshold: 120,
 			pollInterval: 30,

--- a/apps/pi-extension/server/reference.ts
+++ b/apps/pi-extension/server/reference.ts
@@ -20,7 +20,6 @@ import type { IncomingMessage } from "node:http";
 import {
 	type VaultNode,
 	buildFileTree,
-	FILE_BROWSER_EXCLUDED,
 	isFileBrowserExcludedPath,
 } from "../generated/reference-common.js";
 import {
@@ -194,13 +193,13 @@ function walkMarkdownFiles(dir: string, root: string, results: string[], extensi
 		return;
 	}
 	for (const entry of entries) {
+		const relative = join(dir, entry.name)
+			.slice(root.length + 1)
+			.replace(/\\/g, "/");
 		if (entry.isDirectory()) {
-			if (FILE_BROWSER_EXCLUDED.includes(entry.name + "/")) continue;
+			if (isFileBrowserExcludedPath(relative)) continue;
 			walkMarkdownFiles(join(dir, entry.name), root, results, extensions);
 		} else if (entry.isFile() && extensions.test(entry.name)) {
-			const relative = join(dir, entry.name)
-				.slice(root.length + 1)
-				.replace(/\\/g, "/");
 			if (isFileBrowserExcludedPath(relative)) continue;
 			results.push(relative);
 		}
@@ -508,7 +507,7 @@ export function handleObsidianDocRequest(res: Res, url: URL): void {
 	}
 }
 
-export function handleFileBrowserRequest(res: Res, url: URL): void {
+export async function handleFileBrowserRequest(res: Res, url: URL): Promise<void> {
 	const dirPath = url.searchParams.get("dirPath");
 	if (!dirPath) {
 		json(res, { error: "Missing dirPath parameter" }, 400);
@@ -524,7 +523,7 @@ export function handleFileBrowserRequest(res: Res, url: URL): void {
 		const diskFiles: string[] = [];
 		walkMarkdownFiles(resolvedDir, resolvedDir, diskFiles);
 		for (const file of diskFiles) files.add(file);
-		const workspaceStatus = filterWorkspaceStatusForDirectory(getWorkspaceStatusForDirectory(resolvedDir), resolvedDir, includeWorkspaceFile);
+		const workspaceStatus = filterWorkspaceStatusForDirectory(await getWorkspaceStatusForDirectory(resolvedDir), resolvedDir, includeWorkspaceFile);
 		for (const file of getWorkspaceStatusRelativePaths(workspaceStatus, resolvedDir, includeWorkspaceFile)) {
 			files.add(file);
 		}

--- a/apps/pi-extension/server/serverAnnotate.ts
+++ b/apps/pi-extension/server/serverAnnotate.ts
@@ -411,7 +411,7 @@ export async function startAnnotateServer(options: {
 		} else if (url.pathname === "/api/reference/obsidian/doc" && req.method === "GET") {
 			handleObsidianDocRequest(res, url);
 		} else if (url.pathname === "/api/reference/files" && req.method === "GET") {
-			handleFileBrowserRequest(res, url);
+			await handleFileBrowserRequest(res, url);
 		} else if (url.pathname === "/api/reference/files/stream" && req.method === "GET") {
 			handleFileBrowserStreamRequest(req, res, url);
 			return;

--- a/apps/pi-extension/server/serverPlan.ts
+++ b/apps/pi-extension/server/serverPlan.ts
@@ -284,7 +284,7 @@ export async function startPlanReviewServer(options: {
 		} else if (url.pathname === "/api/reference/obsidian/doc" && req.method === "GET") {
 			handleObsidianDocRequest(res, url);
 		} else if (url.pathname === "/api/reference/files" && req.method === "GET") {
-			handleFileBrowserRequest(res, url);
+			await handleFileBrowserRequest(res, url);
 		} else if (url.pathname === "/api/reference/files/stream" && req.method === "GET") {
 			handleFileBrowserStreamRequest(req, res, url);
 			return;

--- a/packages/server/reference-handlers.test.ts
+++ b/packages/server/reference-handlers.test.ts
@@ -172,7 +172,7 @@ describe("handleFileBrowserFiles", () => {
 		git(root, "commit", "-m", "init");
 
 		writeTempFile(root, "dist/generated.md", "after\n");
-		writeTempFile(root, "node_modules/pkg/readme.md", "hidden\n");
+		writeTempFile(root, "packages/app/node_modules/pkg/readme.md", "hidden\n");
 
 		const url = new URL("http://localhost/api/reference/files");
 		url.searchParams.set("dirPath", root);

--- a/packages/server/reference-handlers.ts
+++ b/packages/server/reference-handlers.ts
@@ -6,7 +6,8 @@
  */
 
 import { existsSync, statSync } from "fs";
-import { resolve } from "path";
+import { readdir } from "fs/promises";
+import { join, relative, resolve } from "path";
 import { buildFileTree, isFileBrowserExcludedPath } from "@plannotator/shared/reference-common";
 import {
 	filterWorkspaceStatusForDirectory,
@@ -511,6 +512,27 @@ function includeWorkspaceFile(relativePath: string, _change: WorkspaceFileChange
 	return FILE_BROWSER_EXTENSIONS.test(relativePath) && !isFileBrowserExcludedPath(relativePath);
 }
 
+async function walkFileBrowserFiles(dir: string, root: string, files: Set<string>): Promise<void> {
+	let entries;
+	try {
+		entries = await readdir(dir, { withFileTypes: true });
+	} catch {
+		return;
+	}
+
+	for (const entry of entries) {
+		const fullPath = join(dir, entry.name);
+		const relativePath = relative(root, fullPath).replace(/\\/g, "/");
+		if (entry.isDirectory()) {
+			if (isFileBrowserExcludedPath(relativePath)) continue;
+			await walkFileBrowserFiles(fullPath, root, files);
+		} else if (entry.isFile() && FILE_BROWSER_EXTENSIONS.test(entry.name)) {
+			if (isFileBrowserExcludedPath(relativePath)) continue;
+			files.add(relativePath);
+		}
+	}
+}
+
 /** List markdown files in a directory as a nested tree. */
 export async function handleFileBrowserFiles(req: Request): Promise<Response> {
 	const url = new URL(req.url);
@@ -528,16 +550,9 @@ export async function handleFileBrowserFiles(req: Request): Promise<Response> {
 	}
 
 	try {
-		const glob = new Bun.Glob("**/*.{md,mdx,txt,html,htm}");
 		const files = new Set<string>();
-		for await (const match of glob.scan({
-			cwd: resolvedDir,
-			onlyFiles: true,
-		})) {
-			if (isFileBrowserExcludedPath(match)) continue;
-			files.add(match);
-		}
-		const workspaceStatus = filterWorkspaceStatusForDirectory(getWorkspaceStatusForDirectory(resolvedDir), resolvedDir, includeWorkspaceFile);
+		await walkFileBrowserFiles(resolvedDir, resolvedDir, files);
+		const workspaceStatus = filterWorkspaceStatusForDirectory(await getWorkspaceStatusForDirectory(resolvedDir), resolvedDir, includeWorkspaceFile);
 		for (const match of getWorkspaceStatusRelativePaths(workspaceStatus, resolvedDir, includeWorkspaceFile)) {
 			files.add(match);
 		}

--- a/packages/server/reference-watch.test.ts
+++ b/packages/server/reference-watch.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
-import { handleFileBrowserFilesStream } from "./reference-watch";
+import { handleFileBrowserFilesStream, isFileBrowserWatchIgnoredPath } from "./reference-watch";
 
 const tempDirs: string[] = [];
 
@@ -52,6 +52,17 @@ afterEach(() => {
 });
 
 describe("handleFileBrowserFilesStream", () => {
+	test("ignores nested excluded folders for watcher paths", () => {
+		const root = join(tmpdir(), "plannotator-watch-root");
+
+		expect(isFileBrowserWatchIgnoredPath(join(root, "packages", "app", "node_modules"), root)).toBe(true);
+		expect(isFileBrowserWatchIgnoredPath(join(root, "packages", "app", "node_modules", "pkg", "readme.md"), root)).toBe(true);
+		expect(isFileBrowserWatchIgnoredPath(join(root, "docs", "dist", "generated.md"), root)).toBe(true);
+		expect(isFileBrowserWatchIgnoredPath(join(root, "docs", "plan.md"), root)).toBe(false);
+		expect(isFileBrowserWatchIgnoredPath(root, root)).toBe(false);
+		expect(isFileBrowserWatchIgnoredPath(join(dirname(root), "outside", "node_modules"), root)).toBe(false);
+	});
+
 	test("opens one SSE stream for multiple roots", async () => {
 		const first = makeTempDir("plannotator-watch-a-");
 		const second = makeTempDir("plannotator-watch-b-");

--- a/packages/server/reference-watch.ts
+++ b/packages/server/reference-watch.ts
@@ -29,7 +29,7 @@ function serialize(event: FileBrowserChangeEvent): Uint8Array {
 	return encoder.encode(`data: ${JSON.stringify(event)}\n\n`);
 }
 
-function isExcludedPath(path: string, root: string): boolean {
+export function isFileBrowserWatchIgnoredPath(path: string, root: string): boolean {
 	const rel = relative(root, path).replace(/\\/g, "/");
 	if (!rel || rel.startsWith("..") || isAbsolute(rel)) return false;
 	return isFileBrowserExcludedPath(rel);
@@ -71,7 +71,9 @@ function closeWatcher(entry: WatchEntry): void {
 	if (entry.debounceTimer) clearTimeout(entry.debounceTimer);
 	void entry.contentWatcher?.close();
 	void entry.gitWatcher?.close();
-	watchers.delete(entry.dirPath);
+	if (watchers.get(entry.dirPath) === entry) {
+		watchers.delete(entry.dirPath);
+	}
 }
 
 function releaseSubscriber(entry: WatchEntry, controller: ReadableStreamDefaultController): void {
@@ -94,7 +96,7 @@ function ensureWatcher(dirPath: string): WatchEntry {
 	entry.contentWatcher = chokidar.watch(dirPath, {
 		ignoreInitial: true,
 		persistent: true,
-		ignored: (path) => isExcludedPath(path, dirPath),
+		ignored: (path) => isFileBrowserWatchIgnoredPath(path, dirPath),
 		awaitWriteFinish: {
 			stabilityThreshold: 120,
 			pollInterval: 30,

--- a/packages/shared/reference-common.test.ts
+++ b/packages/shared/reference-common.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { isFileBrowserExcludedPath } from "./reference-common";
+
+describe("isFileBrowserExcludedPath", () => {
+	test("matches excluded folders at any path depth", () => {
+		expect(isFileBrowserExcludedPath("node_modules")).toBe(true);
+		expect(isFileBrowserExcludedPath("node_modules/pkg/readme.md")).toBe(true);
+		expect(isFileBrowserExcludedPath("docs/node_modules")).toBe(true);
+		expect(isFileBrowserExcludedPath("docs/node_modules/pkg/readme.md")).toBe(true);
+		expect(isFileBrowserExcludedPath("docs/dist")).toBe(true);
+		expect(isFileBrowserExcludedPath("docs/dist/generated.md")).toBe(true);
+	});
+
+	test("matches exact path segments only", () => {
+		expect(isFileBrowserExcludedPath("docs/node_modules_backup/readme.md")).toBe(false);
+		expect(isFileBrowserExcludedPath("docs/build-notes/plan.md")).toBe(false);
+		expect(isFileBrowserExcludedPath("docs/plan.md")).toBe(false);
+	});
+
+	test("normalizes windows separators and leading slashes", () => {
+		expect(isFileBrowserExcludedPath("\\repo\\docs\\node_modules")).toBe(true);
+		expect(isFileBrowserExcludedPath("/repo/docs/node_modules/pkg/readme.md")).toBe(true);
+	});
+});

--- a/packages/shared/reference-common.ts
+++ b/packages/shared/reference-common.ts
@@ -29,12 +29,17 @@ export const FILE_BROWSER_EXCLUDED = [
 	"storybook-static/",
 ];
 
+const FILE_BROWSER_EXCLUDED_NAMES = new Set(
+	FILE_BROWSER_EXCLUDED.map((entry) => entry.replace(/\/+$/, "")),
+);
+
 export function isFileBrowserExcludedPath(relativePath: string): boolean {
 	const normalized = relativePath.replace(/\\/g, "/").replace(/^\/+/, "");
-	return FILE_BROWSER_EXCLUDED.some((entry) => {
-		const name = entry.replace(/\/+$/, "");
-		return normalized === name || normalized.startsWith(`${name}/`) || normalized.includes(`/${name}/`);
-	});
+	if (!normalized) return false;
+	return normalized
+		.split("/")
+		.filter(Boolean)
+		.some((part) => FILE_BROWSER_EXCLUDED_NAMES.has(part));
 }
 
 export interface VaultNode {

--- a/packages/shared/workspace-status.test.ts
+++ b/packages/shared/workspace-status.test.ts
@@ -1,15 +1,22 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { getGitMetadataWatchPaths, getWorkspaceStatusForDirectory, getWorkspaceStatusRelativePaths } from "./workspace-status";
 
 const tempDirs: string[] = [];
+const originalPath = process.env.PATH;
+const originalGitTimeout = process.env.PLANNOTATOR_GIT_TIMEOUT_MS;
+
+function makeTempDir(prefix: string): string {
+	const dir = mkdtempSync(join(tmpdir(), prefix));
+	tempDirs.push(dir);
+	return dir;
+}
 
 function tempRepo(): string {
-	const dir = mkdtempSync(join(tmpdir(), "plannotator-workspace-status-"));
-	tempDirs.push(dir);
+	const dir = makeTempDir("plannotator-workspace-status-");
 	git(dir, "init", "-b", "main");
 	git(dir, "config", "user.email", "test@test");
 	git(dir, "config", "user.name", "Test");
@@ -23,14 +30,112 @@ function git(cwd: string, ...args: string[]): void {
 	}
 }
 
+function findGit(): string {
+	const command = process.platform === "win32" ? "where.exe" : "which";
+	const result = spawnSync(command, ["git"], { encoding: "utf8" });
+	if (result.status !== 0) {
+		throw new Error(result.stderr || "Unable to find git");
+	}
+	return result.stdout.split(/\r?\n/).find(Boolean)?.trim() ?? "";
+}
+
+async function waitForFile(path: string): Promise<void> {
+	for (let i = 0; i < 50; i++) {
+		if (existsSync(path)) return;
+		await new Promise((resolve) => setTimeout(resolve, 20));
+	}
+	throw new Error(`Timed out waiting for ${path}`);
+}
+
+function installDelayedStatusGitWrapper(wrapperDir: string, signalPath: string): void {
+	const realGit = findGit();
+	const scriptPath = join(wrapperDir, "git-wrapper.mjs");
+	const releasePath = `${signalPath}.release`;
+	writeFileSync(
+		scriptPath,
+		[
+			'import { spawnSync } from "node:child_process";',
+			'import { existsSync, writeFileSync } from "node:fs";',
+			`const realGit = ${JSON.stringify(realGit)};`,
+			`const signal = ${JSON.stringify(signalPath)};`,
+			`const release = ${JSON.stringify(releasePath)};`,
+			"const args = process.argv.slice(2);",
+			"const result = spawnSync(realGit, args, { encoding: 'utf8', maxBuffer: 20 * 1024 * 1024 });",
+			"if (result.error) {",
+			"  process.stderr.write(result.error.message);",
+			"  process.exit(1);",
+			"}",
+			"if (args.includes('status')) {",
+			"  writeFileSync(signal, 'done');",
+			"  const started = Date.now();",
+			"  while (!existsSync(release) && Date.now() - started < 2000) {",
+			"    await Bun.sleep(10);",
+			"  }",
+			"}",
+			"process.stdout.write(result.stdout ?? '');",
+			"process.stderr.write(result.stderr ?? '');",
+			"process.exit(result.status ?? 1);",
+			"",
+		].join("\n"),
+	);
+	const gitPath = join(wrapperDir, "git");
+	writeFileSync(gitPath, ["#!/usr/bin/env sh", `exec ${JSON.stringify(process.execPath)} ${JSON.stringify(scriptPath)} "$@"`, ""].join("\n"));
+	chmodSync(gitPath, 0o755);
+	writeFileSync(join(wrapperDir, "git.cmd"), [`@echo off`, `"${process.execPath}" "${scriptPath}" %*`, ""].join("\r\n"));
+	process.env.PATH = [wrapperDir, originalPath].filter(Boolean).join(delimiter);
+}
+
+function installHangingOnceStatusGitWrapper(wrapperDir: string, markerPath: string): void {
+	const realGit = findGit();
+	const scriptPath = join(wrapperDir, "git-wrapper.mjs");
+	writeFileSync(
+		scriptPath,
+		[
+			'import { spawnSync } from "node:child_process";',
+			'import { existsSync, writeFileSync } from "node:fs";',
+			`const realGit = ${JSON.stringify(realGit)};`,
+			`const marker = ${JSON.stringify(markerPath)};`,
+			"const args = process.argv.slice(2);",
+			"if (args.includes('status') && !existsSync(marker)) {",
+			"  writeFileSync(marker, 'hung');",
+			"  await new Promise(() => {});",
+			"}",
+			"const result = spawnSync(realGit, args, { encoding: 'utf8', maxBuffer: 20 * 1024 * 1024 });",
+			"if (result.error) {",
+			"  process.stderr.write(result.error.message);",
+			"  process.exit(1);",
+			"}",
+			"process.stdout.write(result.stdout ?? '');",
+			"process.stderr.write(result.stderr ?? '');",
+			"process.exit(result.status ?? 1);",
+			"",
+		].join("\n"),
+	);
+	const gitPath = join(wrapperDir, "git");
+	writeFileSync(gitPath, ["#!/usr/bin/env sh", `exec ${JSON.stringify(process.execPath)} ${JSON.stringify(scriptPath)} "$@"`, ""].join("\n"));
+	chmodSync(gitPath, 0o755);
+	writeFileSync(join(wrapperDir, "git.cmd"), [`@echo off`, `"${process.execPath}" "${scriptPath}" %*`, ""].join("\r\n"));
+	process.env.PATH = [wrapperDir, originalPath].filter(Boolean).join(delimiter);
+}
+
 afterEach(() => {
+	if (originalPath === undefined) {
+		delete process.env.PATH;
+	} else {
+		process.env.PATH = originalPath;
+	}
+	if (originalGitTimeout === undefined) {
+		delete process.env.PLANNOTATOR_GIT_TIMEOUT_MS;
+	} else {
+		process.env.PLANNOTATOR_GIT_TIMEOUT_MS = originalGitTimeout;
+	}
 	for (const dir of tempDirs.splice(0)) {
 		rmSync(dir, { recursive: true, force: true });
 	}
 });
 
 describe("workspace status", () => {
-	test("reports git changes under the requested directory and clears after commit", () => {
+	test("reports git changes under the requested directory and clears after commit", async () => {
 		const repo = tempRepo();
 		const docs = join(repo, "docs");
 		mkdirSync(docs);
@@ -45,7 +150,7 @@ describe("workspace status", () => {
 		writeFileSync(join(docs, "new.md"), "alpha\nbeta\n");
 		writeFileSync(join(repo, "outside.md"), "outside changed\n");
 
-		const status = getWorkspaceStatusForDirectory(docs);
+		const status = await getWorkspaceStatusForDirectory(docs);
 		const realDocs = realpathSync(docs);
 
 		expect(status.available).toBe(true);
@@ -70,13 +175,13 @@ describe("workspace status", () => {
 		git(repo, "add", "-A");
 		git(repo, "commit", "-m", "changes");
 
-		const afterCommit = getWorkspaceStatusForDirectory(docs);
+		const afterCommit = await getWorkspaceStatusForDirectory(docs);
 		expect(afterCommit.available).toBe(true);
 		expect(afterCommit.totals.files).toBe(0);
 		expect(afterCommit.files).toEqual({});
 	});
 
-	test("keeps line counts for renamed files with edits", () => {
+	test("keeps line counts for renamed files with edits", async () => {
 		const repo = tempRepo();
 		const docs = join(repo, "docs");
 		mkdirSync(docs);
@@ -87,7 +192,7 @@ describe("workspace status", () => {
 		git(repo, "mv", join("docs", "old.md"), join("docs", "new.md"));
 		writeFileSync(join(docs, "new.md"), "one\nTWO\nthree\nfour\n");
 
-		const status = getWorkspaceStatusForDirectory(docs);
+		const status = await getWorkspaceStatusForDirectory(docs);
 		const realDocs = realpathSync(docs);
 		const change = status.files[join(realDocs, "new.md")];
 
@@ -114,7 +219,7 @@ describe("workspace status", () => {
 		expect(paths).toContain(join(realRepo, ".git", "refs"));
 	});
 
-	test("counts staged and unstaged changes when the net diff against HEAD is empty", () => {
+	test("counts staged and unstaged changes when the net diff against HEAD is empty", async () => {
 		const repo = tempRepo();
 		const docs = join(repo, "docs");
 		mkdirSync(docs);
@@ -126,7 +231,7 @@ describe("workspace status", () => {
 		git(repo, "add", join("docs", "plan.md"));
 		writeFileSync(join(docs, "plan.md"), "one\ntwo\n");
 
-		const status = getWorkspaceStatusForDirectory(docs);
+		const status = await getWorkspaceStatusForDirectory(docs);
 		const realDocs = realpathSync(docs);
 		const change = status.files[join(realDocs, "plan.md")];
 
@@ -138,5 +243,52 @@ describe("workspace status", () => {
 		expect(change?.deletions).toBe(2);
 		expect(status.totals.additions).toBe(2);
 		expect(status.totals.deletions).toBe(2);
+	});
+
+	test("runs a trailing status when a request arrives during an active status", async () => {
+		const repo = tempRepo();
+		const docs = join(repo, "docs");
+		mkdirSync(docs);
+		writeFileSync(join(docs, "plan.md"), "one\n");
+		git(repo, "add", "-A");
+		git(repo, "commit", "-m", "init");
+
+		const wrapperDir = makeTempDir("plannotator-git-wrapper-");
+		const signalPath = join(wrapperDir, "status-started");
+		installDelayedStatusGitWrapper(wrapperDir, signalPath);
+
+		const first = getWorkspaceStatusForDirectory(docs);
+		await waitForFile(signalPath);
+		writeFileSync(join(docs, "new.md"), "new\n");
+		const second = getWorkspaceStatusForDirectory(docs);
+		writeFileSync(`${signalPath}.release`, "go");
+
+		const status = await second;
+		const realDocs = realpathSync(docs);
+
+		expect(status.files[join(realDocs, "new.md")]?.status).toBe("untracked");
+		expect(await first).toBe(status);
+	});
+
+	test("clears the in-flight status after git times out", async () => {
+		const repo = tempRepo();
+		const docs = join(repo, "docs");
+		mkdirSync(docs);
+		writeFileSync(join(docs, "plan.md"), "one\n");
+		git(repo, "add", "-A");
+		git(repo, "commit", "-m", "init");
+
+		const wrapperDir = makeTempDir("plannotator-git-timeout-");
+		const markerPath = join(wrapperDir, "status-hung");
+		installHangingOnceStatusGitWrapper(wrapperDir, markerPath);
+		process.env.PLANNOTATOR_GIT_TIMEOUT_MS = "1000";
+
+		const timedOut = await getWorkspaceStatusForDirectory(docs);
+		expect(timedOut.available).toBe(false);
+		expect(timedOut.error).toContain("git timed out");
+
+		const retried = await getWorkspaceStatusForDirectory(docs);
+		expect(retried.available).toBe(true);
+		expect(retried.totals.files).toBe(0);
 	});
 });

--- a/packages/shared/workspace-status.ts
+++ b/packages/shared/workspace-status.ts
@@ -1,5 +1,6 @@
-import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, realpathSync } from "node:fs";
+import { readFile, realpath, stat } from "node:fs/promises";
 import { isAbsolute, relative, resolve } from "node:path";
 
 export type WorkspaceFileStatus =
@@ -43,11 +44,24 @@ export interface GitRepositoryInfo {
 }
 
 const TEXT_FILE_MAX_BYTES = 2 * 1024 * 1024;
+const GIT_MAX_BUFFER = 20 * 1024 * 1024;
+const DEFAULT_GIT_TIMEOUT_MS = 30_000;
+type GitResult = { ok: true; stdout: string } | { ok: false; error: string };
+interface WorkspaceStatusFlight {
+	promise?: Promise<WorkspaceStatusPayload>;
+	rerunRequested: boolean;
+}
+const workspaceStatusFlights = new Map<string, WorkspaceStatusFlight>();
 
-function runGit(cwd: string, args: string[]): { ok: true; stdout: string } | { ok: false; error: string } {
+function getGitTimeoutMs(): number {
+	const timeout = Number.parseInt(process.env.PLANNOTATOR_GIT_TIMEOUT_MS ?? "", 10);
+	return Number.isFinite(timeout) && timeout > 0 ? timeout : DEFAULT_GIT_TIMEOUT_MS;
+}
+
+function runGit(cwd: string, args: string[]): GitResult {
 	const result = spawnSync("git", ["--no-optional-locks", "-C", cwd, ...args], {
 		encoding: "utf8",
-		maxBuffer: 20 * 1024 * 1024,
+		maxBuffer: GIT_MAX_BUFFER,
 	});
 	if (result.error) return { ok: false, error: result.error.message };
 	if (result.status !== 0) {
@@ -55,6 +69,58 @@ function runGit(cwd: string, args: string[]): { ok: true; stdout: string } | { o
 		return { ok: false, error: stderr || `git exited with status ${result.status ?? "unknown"}` };
 	}
 	return { ok: true, stdout: result.stdout ?? "" };
+}
+
+function runGitAsync(cwd: string, args: string[]): Promise<GitResult> {
+	return new Promise((resolveResult) => {
+		const child = spawn("git", ["--no-optional-locks", "-C", cwd, ...args], {
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		let stdout = "";
+		let stderr = "";
+		let stdoutBytes = 0;
+		let stderrBytes = 0;
+		let settled = false;
+		let timeout: ReturnType<typeof setTimeout> | null = null;
+
+		const finish = (result: GitResult) => {
+			if (settled) return;
+			settled = true;
+			if (timeout) clearTimeout(timeout);
+			resolveResult(result);
+		};
+
+		const timeoutMs = getGitTimeoutMs();
+		timeout = setTimeout(() => {
+			child.kill("SIGKILL");
+			finish({ ok: false, error: `git timed out after ${timeoutMs}ms` });
+		}, timeoutMs);
+
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stdout.on("data", (chunk: string) => {
+			stdoutBytes += Buffer.byteLength(chunk);
+			if (stdoutBytes > GIT_MAX_BUFFER) {
+				child.kill();
+				finish({ ok: false, error: `git stdout exceeded ${GIT_MAX_BUFFER} bytes` });
+				return;
+			}
+			stdout += chunk;
+		});
+		child.stderr.on("data", (chunk: string) => {
+			stderrBytes += Buffer.byteLength(chunk);
+			if (stderrBytes <= GIT_MAX_BUFFER) stderr += chunk;
+		});
+		child.on("error", (error) => finish({ ok: false, error: error.message }));
+		child.on("close", (status) => {
+			if (status === 0) {
+				finish({ ok: true, stdout });
+				return;
+			}
+			const message = stderr.trim() || `git exited with status ${status ?? "unknown"}`;
+			finish({ ok: false, error: message });
+		});
+	});
 }
 
 function resolveGitPath(cwd: string, value: string): string {
@@ -97,6 +163,40 @@ export function getGitRepositoryInfo(cwd: string): GitRepositoryInfo | null {
 
 	const gitDir = runGit(cwd, ["rev-parse", "--git-dir"]);
 	const gitCommonDir = runGit(cwd, ["rev-parse", "--git-common-dir"]);
+
+	return {
+		repoRoot,
+		gitDir: gitDir.ok && gitDir.stdout.trim() ? resolveGitPath(gitCwd, gitDir.stdout.trim()) : resolve(repoRoot, ".git"),
+		gitCommonDir: gitCommonDir.ok && gitCommonDir.stdout.trim()
+			? resolveGitPath(gitCwd, gitCommonDir.stdout.trim())
+			: gitDir.ok && gitDir.stdout.trim()
+				? resolveGitPath(gitCwd, gitDir.stdout.trim())
+				: resolve(repoRoot, ".git"),
+	};
+}
+
+async function getGitRepositoryInfoAsync(cwd: string): Promise<GitRepositoryInfo | null> {
+	const topLevel = await runGitAsync(cwd, ["rev-parse", "--show-toplevel"]);
+	if (!topLevel.ok) return null;
+	const rawRepoRoot = topLevel.stdout.trim();
+	if (!rawRepoRoot) return null;
+	let gitCwd: string;
+	try {
+		gitCwd = await realpath(resolve(cwd));
+	} catch {
+		return null;
+	}
+	let repoRoot: string;
+	try {
+		repoRoot = await realpath(rawRepoRoot);
+	} catch {
+		return null;
+	}
+
+	const [gitDir, gitCommonDir] = await Promise.all([
+		runGitAsync(cwd, ["rev-parse", "--git-dir"]),
+		runGitAsync(cwd, ["rev-parse", "--git-common-dir"]),
+	]);
 
 	return {
 		repoRoot,
@@ -188,11 +288,11 @@ function parseNumstat(output: string): Map<string, { additions: number; deletion
 	return counts;
 }
 
-function countTextFileLines(path: string): number {
+async function countTextFileLines(path: string): Promise<number> {
 	try {
-		const stat = statSync(path);
-		if (!stat.isFile() || stat.size > TEXT_FILE_MAX_BYTES) return 0;
-		const text = readFileSync(path, "utf8").replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+		const fileStat = await stat(path);
+		if (!fileStat.isFile() || fileStat.size > TEXT_FILE_MAX_BYTES) return 0;
+		const text = (await readFile(path, "utf8")).replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 		if (text.length === 0) return 0;
 		const trimmed = text.endsWith("\n") ? text.slice(0, -1) : text;
 		return trimmed.length === 0 ? 1 : trimmed.split("\n").length;
@@ -201,50 +301,38 @@ function countTextFileLines(path: string): number {
 	}
 }
 
-export function getWorkspaceStatusForDirectory(dirPath: string): WorkspaceStatusPayload {
-	let rootPath: string;
-	try {
-		rootPath = realpathSync(resolve(dirPath));
-	} catch {
-		return {
-			available: false,
-			rootPath: resolve(dirPath),
-			files: {},
-			totals: { files: 0, additions: 0, deletions: 0 },
-			error: "invalid-directory",
-		};
-	}
-	const repo = getGitRepositoryInfo(rootPath);
-	if (!repo) {
-		return {
-			available: false,
-			rootPath,
-			files: {},
-			totals: { files: 0, additions: 0, deletions: 0 },
-			error: "not-a-git-repo",
-		};
-	}
+function unavailableWorkspaceStatus(
+	rootPath: string,
+	error: string,
+	repoRoot?: string,
+): WorkspaceStatusPayload {
+	return {
+		available: false,
+		rootPath,
+		repoRoot,
+		files: {},
+		totals: { files: 0, additions: 0, deletions: 0 },
+		error,
+	};
+}
+
+async function computeWorkspaceStatusForDirectory(rootPath: string): Promise<WorkspaceStatusPayload> {
+	const repo = await getGitRepositoryInfoAsync(rootPath);
+	if (!repo) return unavailableWorkspaceStatus(rootPath, "not-a-git-repo");
 
 	const rootPathspec = relative(repo.repoRoot, rootPath).replace(/\\/g, "/") || ".";
-	const status = runGit(repo.repoRoot, ["status", "--porcelain=v1", "-z", "--untracked-files=all", "--", rootPathspec]);
-	if ("error" in status) {
-		return {
-			available: false,
-			rootPath,
-			repoRoot: repo.repoRoot,
-			files: {},
-			totals: { files: 0, additions: 0, deletions: 0 },
-			error: status.error,
-		};
-	}
+	const status = await runGitAsync(repo.repoRoot, ["status", "--porcelain=v1", "-z", "--untracked-files=all", "--", rootPathspec]);
+	if ("error" in status) return unavailableWorkspaceStatus(rootPath, status.error, repo.repoRoot);
 
 	const entries = parsePorcelain(status.stdout);
-	const numstat = runGit(repo.repoRoot, ["diff", "--numstat", "-z", "HEAD", "--", rootPathspec]);
+	const numstat = await runGitAsync(repo.repoRoot, ["diff", "--numstat", "-z", "HEAD", "--", rootPathspec]);
 	const headLineCounts = numstat.ok ? parseNumstat(numstat.stdout) : new Map<string, { additions: number; deletions: number }>();
 	let splitLineCounts: Map<string, { additions: number; deletions: number }> | null = null;
 	if (entries.some((entry) => entry.staged && entry.unstaged)) {
-		const cached = runGit(repo.repoRoot, ["diff", "--cached", "--numstat", "-z", "--", rootPathspec]);
-		const unstaged = runGit(repo.repoRoot, ["diff", "--numstat", "-z", "--", rootPathspec]);
+		const [cached, unstaged] = await Promise.all([
+			runGitAsync(repo.repoRoot, ["diff", "--cached", "--numstat", "-z", "--", rootPathspec]),
+			runGitAsync(repo.repoRoot, ["diff", "--numstat", "-z", "--", rootPathspec]),
+		]);
 		splitLineCounts = combinedLineCounts(
 			cached.ok ? parseNumstat(cached.stdout) : new Map<string, { additions: number; deletions: number }>(),
 			unstaged.ok ? parseNumstat(unstaged.stdout) : new Map<string, { additions: number; deletions: number }>(),
@@ -266,7 +354,7 @@ export function getWorkspaceStatusForDirectory(dirPath: string): WorkspaceStatus
 			: { additions: 0, deletions: 0 };
 		const countedAdditions = counts.additions + oldCounts.additions;
 		const additions = (entry.status === "untracked" || entry.status === "added") && countedAdditions === 0
-			? countTextFileLines(absolutePath)
+			? await countTextFileLines(absolutePath)
 			: countedAdditions;
 		const deletions = counts.deletions + oldCounts.deletions;
 		const oldPath = entry.oldRepoRelativePath
@@ -298,6 +386,42 @@ export function getWorkspaceStatusForDirectory(dirPath: string): WorkspaceStatus
 			deletions: totalDeletions,
 		},
 	};
+}
+
+async function runWorkspaceStatusFlight(rootPath: string, flight: WorkspaceStatusFlight): Promise<WorkspaceStatusPayload> {
+	try {
+		let status: WorkspaceStatusPayload;
+		do {
+			flight.rerunRequested = false;
+			status = await computeWorkspaceStatusForDirectory(rootPath);
+		} while (flight.rerunRequested);
+		return status;
+	} finally {
+		if (workspaceStatusFlights.get(rootPath) === flight) {
+			workspaceStatusFlights.delete(rootPath);
+		}
+	}
+}
+
+export async function getWorkspaceStatusForDirectory(dirPath: string): Promise<WorkspaceStatusPayload> {
+	let rootPath: string;
+	try {
+		rootPath = await realpath(resolve(dirPath));
+	} catch {
+		return unavailableWorkspaceStatus(resolve(dirPath), "invalid-directory");
+	}
+
+	const existing = workspaceStatusFlights.get(rootPath);
+	if (existing?.promise) {
+		existing.rerunRequested = true;
+		return existing.promise;
+	}
+
+	const flight: WorkspaceStatusFlight = { rerunRequested: false };
+	const status = runWorkspaceStatusFlight(rootPath, flight);
+	flight.promise = status;
+	workspaceStatusFlights.set(rootPath, flight);
+	return status;
 }
 
 export function getWorkspaceStatusRelativePaths(


### PR DESCRIPTION
## Summary
- prune excluded file-browser folders by path segment, including nested `node_modules`
- make live file-tree watcher teardown identity-safe in Bun and Pi
- move workspace git status reads to async subprocesses and coalesce in-flight requests
- add Bun/Pi coverage for excluded folders and workspace status filtering

## Verification
- `bun run typecheck`
- `bun test`
- `bun run build:hook`
- `git diff --check`