### PR TITLE
fix(ui): correct light-mode contrast in code hover preview

### DIFF
--- a/packages/editor/index.css
+++ b/packages/editor/index.css
@@ -41,6 +41,13 @@ pre code.hljs .hljs-code {
   color: oklch(0.25 0.02 260) !important;
 }
 
+/* The code-file hover preview is a <div class="hljs">, so the pre code.hljs
+   rule above misses it. The unscoped .hljs-* token rules below already color
+   its tokens; this just supplies the matching default text color. */
+.light .code-snippet-preview {
+  color: oklch(0.25 0.02 260) !important;
+}
+
 .light .hljs-keyword,
 .light .hljs-selector-tag,
 .light .hljs-built_in,

--- a/packages/ui/components/InlineMarkdown.tsx
+++ b/packages/ui/components/InlineMarkdown.tsx
@@ -94,7 +94,7 @@ const CodeSnippetPreview: React.FC<{
         <span>{filepath.split('/').pop()}</span>
         <span className="opacity-60">{lineEnd && lineEnd !== line ? `lines ${line}–${lineEnd}` : `line ${line}`}</span>
       </div>
-      <div className="hljs overflow-auto text-[12px] leading-5 min-h-0" style={{ padding: 0, background: 'var(--color-muted, #1e293b)' }}>
+      <div className="hljs code-snippet-preview overflow-auto text-[12px] leading-5 min-h-0" style={{ padding: 0, background: 'var(--code-bg, #1e293b)' }}>
         <table className="border-collapse w-full">
           <tbody>
             {snippet.split('\n').map((_, i) => (


### PR DESCRIPTION
## Problem
The code hover preview is a great feature, I noticed there was a tiny but kinda really glaring visual bug (excuse the pun)

In **light mode**, the code-file hover preview - the syntax-highlighted snippet popover shown when hovering an inline `file.ts:10-20` reference (added in #692)  - renders with very low contrast. The snippet text washes out against the popover background. Dark mode is unaffected, this doesn't affect that case.

<img width="1000" height="445" alt="plannotator-hover-contrast-BEFORE-light-mode" src="https://github.com/user-attachments/assets/c76cb5a8-8816-468d-aee8-4edd4dea2ce6" />

## Root Cause

The preview body is a `<div class="hljs">` colored by the github-dark highlight.js theme, whose default text color is tuned for a dark background. But the popover hardcoded a generic `--color-muted` background, which resolves *light* in light themes, so you get light-gray default text on a light surface.

`packages/editor/index.css` already handles this class of issue for code blocks in #234: it has unscoped `.light .hljs-*` token rules **and** a light-mode default-text override. The token rules already reach the preview, but the default-text override is scoped to `pre code.hljs`, so the `div`-based popover never receives it and we get that washed out text :( 

(Note, the preview only renders in the plan and annotate apps, both of which load `editor/index.css`)

## Changes

- **`packages/ui/components/InlineMarkdown.tsx`** : give the preview body a `code-snippet-preview` class and switch its background from `--color-muted` to the theme-aware `--code-bg` (light in light themes, dark in dark themes, matching the app's other code surfaces).
- **`packages/editor/index.css`**: add a light-mode default-text color for `.code-snippet-preview`, right next to the existing `pre code.hljs` override. The existing unscoped `.light .hljs-*` token rules keep coloring the tokens.

## Testing

- `bun test packages/ui/components/InlineMarkdown.test.ts` , all 13 tests pass
- UI package typecheck clean
- Verified the preview in both light and dark modes via a local annotate session.

**After: light mode**
<img width="396" height="168" alt="Screenshot 2026-06-17 at 8 55 34 PM" src="https://github.com/user-attachments/assets/a166d9d4-11f0-459f-89b3-0d02e93e7c70" />

**After: dark mode (unchanged):**
<img width="412" height="211" alt="Screenshot 2026-06-17 at 8 56 34 PM" src="https://github.com/user-attachments/assets/03b82b95-ca56-427c-99e9-c10840d1fa31" />


Let me know if there's anything else I need to do, and feel free to contribute to the PR as well