### PR TITLE
Disable bunfig autoload for release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,46 +76,46 @@ jobs:
           VERSION=$(jq -r .version package.json)
 
           # macOS ARM64
-          bun build apps/hook/server/index.ts --compile --target=bun-darwin-arm64 --define "__CLI_VERSION__=\"$VERSION\"" --outfile plannotator-darwin-arm64
+          bun build apps/hook/server/index.ts --compile --no-compile-autoload-bunfig --target=bun-darwin-arm64 --define "__CLI_VERSION__=\"$VERSION\"" --outfile plannotator-darwin-arm64
           sha256sum plannotator-darwin-arm64 > plannotator-darwin-arm64.sha256
 
           # macOS x64
-          bun build apps/hook/server/index.ts --compile --target=bun-darwin-x64 --define "__CLI_VERSION__=\"$VERSION\"" --outfile plannotator-darwin-x64
+          bun build apps/hook/server/index.ts --compile --no-compile-autoload-bunfig --target=bun-darwin-x64 --define "__CLI_VERSION__=\"$VERSION\"" --outfile plannotator-darwin-x64
           sha256sum plannotator-darwin-x64 > plannotator-darwin-x64.sha256
 
           # Linux x64
-          bun build apps/hook/server/index.ts --compile --target=bun-linux-x64 --define "__CLI_VERSION__=\"$VERSION\"" --outfile plannotator-linux-x64
+          bun build apps/hook/server/index.ts --compile --no-compile-autoload-bunfig --target=bun-linux-x64 --define "__CLI_VERSION__=\"$VERSION\"" --outfile plannotator-linux-x64
           sha256sum plannotator-linux-x64 > plannotator-linux-x64.sha256
 
           # Linux ARM64
-          bun build apps/hook/server/index.ts --compile --target=bun-linux-arm64 --define "__CLI_VERSION__=\"$VERSION\"" --outfile plannotator-linux-arm64
+          bun build apps/hook/server/index.ts --compile --no-compile-autoload-bunfig --target=bun-linux-arm64 --define "__CLI_VERSION__=\"$VERSION\"" --outfile plannotator-linux-arm64
           sha256sum plannotator-linux-arm64 > plannotator-linux-arm64.sha256
 
           # Windows x64
-          bun build apps/hook/server/index.ts --compile --target=bun-windows-x64 --define "__CLI_VERSION__=\"$VERSION\"" --outfile plannotator-win32-x64.exe
+          bun build apps/hook/server/index.ts --compile --no-compile-autoload-bunfig --target=bun-windows-x64 --define "__CLI_VERSION__=\"$VERSION\"" --outfile plannotator-win32-x64.exe
           sha256sum plannotator-win32-x64.exe > plannotator-win32-x64.exe.sha256
 
           # Windows ARM64 (native, via bun-windows-arm64 — stable since Bun v1.3.10)
-          bun build apps/hook/server/index.ts --compile --target=bun-windows-arm64 --define "__CLI_VERSION__=\"$VERSION\"" --outfile plannotator-win32-arm64.exe
+          bun build apps/hook/server/index.ts --compile --no-compile-autoload-bunfig --target=bun-windows-arm64 --define "__CLI_VERSION__=\"$VERSION\"" --outfile plannotator-win32-arm64.exe
           sha256sum plannotator-win32-arm64.exe > plannotator-win32-arm64.exe.sha256
 
           # Paste service binaries
-          bun build apps/paste-service/targets/bun.ts --compile --target=bun-darwin-arm64 --outfile plannotator-paste-darwin-arm64
+          bun build apps/paste-service/targets/bun.ts --compile --no-compile-autoload-bunfig --target=bun-darwin-arm64 --outfile plannotator-paste-darwin-arm64
           sha256sum plannotator-paste-darwin-arm64 > plannotator-paste-darwin-arm64.sha256
 
-          bun build apps/paste-service/targets/bun.ts --compile --target=bun-darwin-x64 --outfile plannotator-paste-darwin-x64
+          bun build apps/paste-service/targets/bun.ts --compile --no-compile-autoload-bunfig --target=bun-darwin-x64 --outfile plannotator-paste-darwin-x64
           sha256sum plannotator-paste-darwin-x64 > plannotator-paste-darwin-x64.sha256
 
-          bun build apps/paste-service/targets/bun.ts --compile --target=bun-linux-x64 --outfile plannotator-paste-linux-x64
+          bun build apps/paste-service/targets/bun.ts --compile --no-compile-autoload-bunfig --target=bun-linux-x64 --outfile plannotator-paste-linux-x64
           sha256sum plannotator-paste-linux-x64 > plannotator-paste-linux-x64.sha256
 
-          bun build apps/paste-service/targets/bun.ts --compile --target=bun-linux-arm64 --outfile plannotator-paste-linux-arm64
+          bun build apps/paste-service/targets/bun.ts --compile --no-compile-autoload-bunfig --target=bun-linux-arm64 --outfile plannotator-paste-linux-arm64
           sha256sum plannotator-paste-linux-arm64 > plannotator-paste-linux-arm64.sha256
 
-          bun build apps/paste-service/targets/bun.ts --compile --target=bun-windows-x64 --outfile plannotator-paste-win32-x64.exe
+          bun build apps/paste-service/targets/bun.ts --compile --no-compile-autoload-bunfig --target=bun-windows-x64 --outfile plannotator-paste-win32-x64.exe
           sha256sum plannotator-paste-win32-x64.exe > plannotator-paste-win32-x64.exe.sha256
 
-          bun build apps/paste-service/targets/bun.ts --compile --target=bun-windows-arm64 --outfile plannotator-paste-win32-arm64.exe
+          bun build apps/paste-service/targets/bun.ts --compile --no-compile-autoload-bunfig --target=bun-windows-arm64 --outfile plannotator-paste-win32-arm64.exe
           sha256sum plannotator-paste-win32-arm64.exe > plannotator-paste-win32-arm64.exe.sha256
 
       - name: Upload artifacts
@@ -158,8 +158,14 @@ jobs:
           set -euo pipefail
           chmod +x "$BINARY"
 
-          # 1. --help: proves binary loads and arg parsing works.
-          "$BINARY" --help
+          # 1. --help from a hostile caller cwd proves the binary loads,
+          # arg parsing works, and Bun did not autoload caller bunfig.toml.
+          hostile_cwd="$(mktemp -d)"
+          printf 'preload = ["./does-not-exist.ts"]\n' > "$hostile_cwd/bunfig.toml"
+          (
+            cd "$hostile_cwd"
+            "$GITHUB_WORKSPACE/$BINARY" --help
+          )
 
           smoke_test_server() {
             local label="$1" port="$2" endpoint="$3"
@@ -206,8 +212,16 @@ jobs:
           $ErrorActionPreference = "Stop"
           $binary = (Resolve-Path $env:BINARY).Path
 
-          # 1. --help: proves binary loads and arg parsing works.
-          & $binary --help
+          # 1. --help from a hostile caller cwd proves the binary loads,
+          # arg parsing works, and Bun did not autoload caller bunfig.toml.
+          $hostileCwd = New-Item -ItemType Directory -Path (Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString()))
+          Set-Content -Path (Join-Path $hostileCwd.FullName "bunfig.toml") -Value 'preload = ["./does-not-exist.ts"]'
+          Push-Location $hostileCwd.FullName
+          try {
+            & $binary --help
+          } finally {
+            Pop-Location
+          }
 
           function Test-PlannotatorServer {
             param(

--- a/tests/manual/local/sandbox-codex.sh
+++ b/tests/manual/local/sandbox-codex.sh
@@ -50,7 +50,7 @@ echo "Compiling plannotator binary..."
 cd "$PROJECT_ROOT"
 bun run build:hook > /dev/null 2>&1
 bun run build:review > /dev/null 2>&1
-bun build apps/hook/server/index.ts --compile --outfile ~/.local/bin/plannotator 2>&1
+bun build apps/hook/server/index.ts --compile --no-compile-autoload-bunfig --outfile ~/.local/bin/plannotator 2>&1
 echo "Binary compiled to ~/.local/bin/plannotator"
 echo ""
 


### PR DESCRIPTION
Add Bun's compile autoload guard to every release binary build so distributed executables do not inherit bunfig.toml from the caller's current directory.

Extend the binary smoke test to launch --help from a temporary directory with an invalid preload entry, matching the crash reproduction.

Update the Codex sandbox manual compile path so locally rebuilt binaries use the same guard.