### PR TITLE
fix(ai): resolve Bedrock/Vertex model ids for Ask AI

### DIFF
--- a/packages/ai/ai.test.ts
+++ b/packages/ai/ai.test.ts
@@ -802,6 +802,79 @@ describe("AI endpoints", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Claude Agent SDK — Bedrock/Vertex model resolution
+// ---------------------------------------------------------------------------
+
+import { resolveSDKModel } from "./providers/claude-agent-sdk.ts";
+
+describe("resolveSDKModel", () => {
+  const SONNET_ARN =
+    "arn:aws:bedrock:us-east-1:123456789012:inference-profile/global.anthropic.claude-sonnet-4-6";
+  const OPUS_ARN =
+    "arn:aws:bedrock:us-east-1:123456789012:inference-profile/global.anthropic.claude-opus-4-8[1m]";
+  const HAIKU_ARN =
+    "arn:aws:bedrock:us-east-1:123456789012:inference-profile/global.anthropic.claude-haiku-4-5-20251001-v1:0";
+
+  const bedrockEnv = {
+    CLAUDE_CODE_USE_BEDROCK: "1",
+    ANTHROPIC_MODEL: OPUS_ARN,
+    ANTHROPIC_DEFAULT_SONNET_MODEL: SONNET_ARN,
+    ANTHROPIC_DEFAULT_OPUS_MODEL: OPUS_ARN,
+    ANTHROPIC_DEFAULT_HAIKU_MODEL: HAIKU_ARN,
+  };
+
+  test("off Bedrock/Vertex: returns the requested alias unchanged", () => {
+    expect(resolveSDKModel("claude-sonnet-4-6", {})).toBe("claude-sonnet-4-6");
+  });
+
+  test("maps a bare sonnet alias to the configured Sonnet ARN on Bedrock", () => {
+    expect(resolveSDKModel("claude-sonnet-4-6", bedrockEnv)).toBe(SONNET_ARN);
+  });
+
+  test("maps bare opus / haiku aliases to their ARNs", () => {
+    expect(resolveSDKModel("claude-opus-4-8", bedrockEnv)).toBe(OPUS_ARN);
+    expect(resolveSDKModel("claude-haiku-4-5", bedrockEnv)).toBe(HAIKU_ARN);
+  });
+
+  test("maps the [1m] context variant by family", () => {
+    expect(resolveSDKModel("claude-sonnet-4-6[1m]", bedrockEnv)).toBe(SONNET_ARN);
+  });
+
+  test("passes through an identifier that is already an ARN", () => {
+    expect(resolveSDKModel(SONNET_ARN, bedrockEnv)).toBe(SONNET_ARN);
+  });
+
+  test("passes through a bare inference-profile id", () => {
+    const profile = "us.anthropic.claude-sonnet-4-5-20250929-v1:0";
+    expect(resolveSDKModel(profile, bedrockEnv)).toBe(profile);
+  });
+
+  test("falls back to ANTHROPIC_MODEL when no family default is set", () => {
+    expect(
+      resolveSDKModel("claude-sonnet-4-6", {
+        CLAUDE_CODE_USE_BEDROCK: "1",
+        ANTHROPIC_MODEL: OPUS_ARN,
+      }),
+    ).toBe(OPUS_ARN);
+  });
+
+  test("returns undefined so the SDK inherits env when nothing else resolves", () => {
+    expect(
+      resolveSDKModel("claude-sonnet-4-6", { CLAUDE_CODE_USE_BEDROCK: "1" }),
+    ).toBeUndefined();
+  });
+
+  test("also applies on Vertex", () => {
+    expect(
+      resolveSDKModel("claude-opus-4-8", {
+        CLAUDE_CODE_USE_VERTEX: "true",
+        ANTHROPIC_DEFAULT_OPUS_MODEL: OPUS_ARN,
+      }),
+    ).toBe(OPUS_ARN);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Codex SDK event mapping
 // ---------------------------------------------------------------------------
 

--- a/packages/ai/providers/claude-agent-sdk.ts
+++ b/packages/ai/providers/claude-agent-sdk.ts
@@ -35,11 +35,83 @@ const DEFAULT_MAX_TURNS = 99;
 const DEFAULT_MODEL = "claude-sonnet-4-6";
 
 // ---------------------------------------------------------------------------
+// Bedrock / Vertex model resolution
+// ---------------------------------------------------------------------------
+
+/** Env-var truthiness, matching Claude Code's own `1`/`true` convention. */
+function isTruthyEnv(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
+/**
+ * A model string that already names a Bedrock/Vertex target — a full ARN
+ * (`arn:aws:bedrock:...`) or any inference-profile / publisher id containing
+ * `anthropic.` (e.g. `us.anthropic.claude-...`). Bare aliases like
+ * `claude-sonnet-4-6` deliberately do NOT match.
+ */
+function isCloudModelId(model: string): boolean {
+  return model.startsWith("arn:") || model.includes("anthropic.");
+}
+
+/**
+ * Resolve the model identifier to hand the Claude Agent SDK.
+ *
+ * Plannotator's model picker uses bare aliases (`claude-sonnet-4-6`). Those
+ * are valid against the first-party Anthropic API but are rejected by Bedrock
+ * and Vertex, which require a full inference-profile id / ARN — producing
+ * `400 The provided model identifier is invalid`. Claude Code itself reads
+ * those identifiers from `ANTHROPIC_MODEL` and the
+ * `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL` env vars; we mirror that here:
+ *
+ *   - Off Bedrock/Vertex: return the requested model unchanged.
+ *   - Already a cloud identifier (ARN / `anthropic.` profile): pass through.
+ *   - A bare family alias (opus/sonnet/haiku): map to the matching
+ *     `ANTHROPIC_DEFAULT_*_MODEL` env var when set.
+ *   - Anything else: fall back to `ANTHROPIC_MODEL`, or `undefined` so the SDK
+ *     inherits the environment's default model.
+ *
+ * Returning `undefined` is meaningful: the caller omits `--model` entirely,
+ * letting the spawned `claude` resolve the model from its own env config.
+ */
+export function resolveSDKModel(
+  requestedModel: string | undefined,
+  env: Record<string, string | undefined> = process.env,
+): string | undefined {
+  const onCloud =
+    isTruthyEnv(env.CLAUDE_CODE_USE_BEDROCK) ||
+    isTruthyEnv(env.CLAUDE_CODE_USE_VERTEX);
+  if (!onCloud) return requestedModel;
+
+  // Already a Bedrock/Vertex identifier — trust it as-is.
+  if (requestedModel && isCloudModelId(requestedModel)) return requestedModel;
+
+  // Map a bare family alias to the user's configured default ARN.
+  if (requestedModel) {
+    const family = requestedModel.toLowerCase();
+    if (family.includes("opus") && env.ANTHROPIC_DEFAULT_OPUS_MODEL) {
+      return env.ANTHROPIC_DEFAULT_OPUS_MODEL;
+    }
+    if (family.includes("sonnet") && env.ANTHROPIC_DEFAULT_SONNET_MODEL) {
+      return env.ANTHROPIC_DEFAULT_SONNET_MODEL;
+    }
+    if (family.includes("haiku") && env.ANTHROPIC_DEFAULT_HAIKU_MODEL) {
+      return env.ANTHROPIC_DEFAULT_HAIKU_MODEL;
+    }
+  }
+
+  // Fall back to the env default model, or let the SDK inherit from the env.
+  return env.ANTHROPIC_MODEL || undefined;
+}
+
+// ---------------------------------------------------------------------------
 // SDK query options — typed to catch typos at compile time
 // ---------------------------------------------------------------------------
 
 interface ClaudeSDKQueryOptions {
-  model: string;
+  /** Omitted when undefined so the SDK inherits the env's default model (Bedrock/Vertex). */
+  model?: string;
   maxTurns: number;
   allowedTools: string[];
   cwd: string;
@@ -264,8 +336,12 @@ class ClaudeAgentSDKSession extends BaseSession {
   // -------------------------------------------------------------------------
 
   private buildQueryOptions(): ClaudeSDKQueryOptions {
+    // On Bedrock/Vertex, bare aliases (e.g. "claude-sonnet-4-6") are rejected
+    // with a 400; resolveSDKModel() maps them to the configured ARN or returns
+    // undefined so the SDK inherits the environment's default model.
+    const resolvedModel = resolveSDKModel(this.config.model);
     const opts: ClaudeSDKQueryOptions = {
-      model: this.config.model,
+      ...(resolvedModel !== undefined && { model: resolvedModel }),
       maxTurns: this.config.maxTurns,
       allowedTools: this.config.allowedTools,
       cwd: this.config.cwd,


### PR DESCRIPTION
Closes #938

## Problem

The Ask AI feature is unusable on Amazon Bedrock (and, by the same mechanism, Vertex AI). Every query fails with:

> API Error (claude-sonnet-4-6): 400 The provided model identifier is invalid.

### Root cause

`ClaudeAgentSDKProvider` hardcodes a bare model alias and force-passes it to the spawned `claude` binary as `--model`:

- `packages/ai/providers/claude-agent-sdk.ts` — `DEFAULT_MODEL = "claude-sonnet-4-6"`, used whenever no model is explicitly selected (`baseConfig()`), and the model picker only offers bare aliases too.

Bare aliases like `claude-sonnet-4-6` resolve fine against the first-party Anthropic API, but Bedrock/Vertex require a full inference-profile id / ARN (e.g. `arn:aws:bedrock:...:inference-profile/global.anthropic.claude-sonnet-4-6`). A normal Claude Code session works because it reads that ARN from `ANTHROPIC_MODEL` / `ANTHROPIC_DEFAULT_*_MODEL`; Ask AI overrides it with the bare alias, so Bedrock 400s.

## Fix

Add `resolveSDKModel()` in the Claude provider. When `CLAUDE_CODE_USE_BEDROCK` or `CLAUDE_CODE_USE_VERTEX` is set:

- pass through identifiers that are already ARNs / `anthropic.` inference profiles
- map the picker's family aliases (opus / sonnet / haiku) to the matching `ANTHROPIC_DEFAULT_*_MODEL` env var
- otherwise fall back to `ANTHROPIC_MODEL`, or omit `--model` so the SDK inherits the environment's default

Off Bedrock/Vertex, behavior is unchanged (alias returned as-is).

## Verification

- `bun test packages/ai/ai.test.ts` → 97 pass (9 new `resolveSDKModel` cases: alias→ARN mapping, ARN/profile pass-through, `[1m]` variant, env fallback, Vertex).
- Drove the real provider via the production factory on a live Bedrock account with **no model set** (the failing path): it resolved to the configured ARN and returned a successful reply — no 400.

Happy to adjust the approach (env-var name, mapping strategy, etc.) if you'd prefer something different.
