### PR TITLE
Add annotation undo/redo capability 

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "@types/node": "^25.5.2",
         "@types/turndown": "^5.0.6",
         "bun-types": "^1.3.11",
+        "typescript": "~5.8.2",
       },
     },
     "apps/hook": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@types/node": "^25.5.2",
     "@types/turndown": "^5.0.6",
-    "bun-types": "^1.3.11"
+    "bun-types": "^1.3.11",
+    "typescript": "~5.8.2"
   }
 }

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -70,19 +70,20 @@ import { useAnnotationDraft, type DraftEditedDocument, type DraftSavedFileChange
 import { useArchive } from '@plannotator/ui/hooks/useArchive';
 import { useEditorAnnotations } from '@plannotator/ui/hooks/useEditorAnnotations';
 import { useExternalAnnotations } from '@plannotator/ui/hooks/useExternalAnnotations';
+import { useAnnotationHistory, type AnnotationHistoryApi, type OverrideSnapshot, type SerializedHistory } from '@plannotator/ui/hooks/useAnnotationHistory';
+import { useHistoryShortcuts } from '@plannotator/ui/shortcuts';
 import { useExternalAnnotationHighlights } from '@plannotator/ui/hooks/useExternalAnnotationHighlights';
 import { buildPlanAgentInstructions } from '@plannotator/ui/utils/planAgentInstructions';
 import { useFileBrowser } from '@plannotator/ui/hooks/useFileBrowser';
 import { getFileEditStatus } from '@plannotator/ui/components/sidebar/FileBrowser';
 import { isVaultBrowserEnabled } from '@plannotator/ui/utils/obsidian';
 import { isFileBrowserEnabled, getFileBrowserSettings } from '@plannotator/ui/utils/fileBrowser';
-import { generateId } from '@plannotator/ui/utils/generateId';
 import { SidebarTabs } from '@plannotator/ui/components/sidebar/SidebarTabs';
 import { SidebarContainer } from '@plannotator/ui/components/sidebar/SidebarContainer';
 import type { ArchivedPlan } from '@plannotator/ui/components/sidebar/ArchiveBrowser';
 import type { PickerMessage } from '@plannotator/ui/components/sidebar/MessagesBrowser';
 import { PlanDiffViewer } from '@plannotator/ui/components/plan-diff/PlanDiffViewer';
-import { CodeFilePopout, type CodeFileAnnotationInput } from '@plannotator/ui/components/CodeFilePopout';
+import { CodeFilePopout } from '@plannotator/ui/components/CodeFilePopout';
 import type { PlanDiffMode } from '@plannotator/ui/components/plan-diff/PlanDiffModeSwitcher';
 import {
   GoalSetupSurface,
@@ -134,6 +135,7 @@ import { fetchSourceDocumentSnapshot, probeSourceSave } from './sourceDocumentCl
 import { reconcileSourceDocuments, type SourceDocumentReconcileEvent } from './sourceDocumentReconciliation';
 import { dirnameBrowserPath, normalizeBrowserPath, pathIsInsideDir } from './sourceDocumentPaths';
 import { pickRestoredSingleFileDraftToDisplay } from './draftRestoreSelection';
+import { useAnnotationCommands } from './hooks/useAnnotationCommands';
 
 type NoteAutoSaveResults = {
   obsidian?: boolean;
@@ -146,6 +148,8 @@ type MessageAnnotationState = {
   text: string;
   timestamp?: string;
   linkedDocSession: LinkedDocSessionState;
+  /** Root message undo/redo stack. Duplicates linkedDocSession.root.history for explicit message cache ownership. */
+  history?: SerializedHistory;
   codeAnnotations: CodeAnnotation[];
   selectedCodeAnnotationId: string | null;
 };
@@ -180,6 +184,7 @@ const createEmptyMessageState = (message: PickerMessage): MessageAnnotationState
     },
     docs: new Map(),
   },
+  history: undefined,
   codeAnnotations: [],
   selectedCodeAnnotationId: null,
 });
@@ -204,6 +209,7 @@ const normalizeMessageState = (
     },
     docs: new Map(state.linkedDocSession.docs),
   },
+  history: state.history ?? state.linkedDocSession.root.history,
 });
 
 const buildMessageAnnotationCounts = (
@@ -245,6 +251,15 @@ const App: React.FC = () => {
   const [codeAnnotations, setCodeAnnotations] = useState<CodeAnnotation[]>([]);
   const [selectedAnnotationId, setSelectedAnnotationId] = useState<string | null>(null);
   const [selectedCodeAnnotationId, setSelectedCodeAnnotationId] = useState<string | null>(null);
+
+  // Refs mirror live state so stable useCallback handlers and the history
+  // hook can read fresh selection/annotation values without re-creating.
+  const selectedAnnotationIdRef = useRef(selectedAnnotationId);
+  selectedAnnotationIdRef.current = selectedAnnotationId;
+  const selectedCodeAnnotationIdRef = useRef(selectedCodeAnnotationId);
+  selectedCodeAnnotationIdRef.current = selectedCodeAnnotationId;
+  const codeAnnotationsRef = useRef(codeAnnotations);
+  codeAnnotationsRef.current = codeAnnotations;
   const editableDocuments = useEditableDocuments();
   const activeEditableDocument = editableDocuments.activeDocument;
   const displayedMarkdown = activeEditableDocument?.currentText ?? markdown;
@@ -409,6 +424,17 @@ const App: React.FC = () => {
   const isMobile = useIsMobile();
 
   const viewerRef = useRef<ViewerHandle>(null);
+
+  // Undo/redo API ref — assigned after `useAnnotationHistory` is instantiated
+  // below. Handlers/effects declared earlier in the component (draft restore,
+  // share import, terminal decision, linked-doc navigation, keyboard) read it
+  // via this ref to avoid TDZ and stale-closure issues.
+  const historyApiRef = useRef<AnnotationHistoryApi | null>(null);
+  // `applyOverrides` is owned by `useCheckboxOverrides`, which is instantiated
+  // after the history hook; the history hook reads it through this ref.
+  const historyApplyOverridesRef = useRef<(next: OverrideSnapshot) => void>(() => {});
+  const checkboxOverridesSnapshotRef = useRef<() => OverrideSnapshot>(() => []);
+  const checkboxRevertOverrideRef = useRef<(blockId: string) => void>(() => {});
   // containerRef + scrollViewport both point at the OverlayScrollbars
   // viewport element (the node that actually scrolls), not the <main>
   // host. Consumers: useActiveSection (IntersectionObserver root) and
@@ -657,6 +683,8 @@ const App: React.FC = () => {
   }, [activeEditableDocument, annotateSource, editableDocuments, isEditingMarkdown]);
 
   // Linked document navigation
+  const serializeHistory = useCallback((): SerializedHistory | undefined => historyApiRef.current?.serialize(), []);
+  const restoreHistory = useCallback((snapshot: SerializedHistory | undefined) => historyApiRef.current?.restore(snapshot), []);
   const linkedDocHook = useLinkedDoc({
     markdown, annotations, selectedAnnotationId, globalAttachments,
     setMarkdown, setAnnotations, setSelectedAnnotationId, setGlobalAttachments,
@@ -666,6 +694,8 @@ const App: React.FC = () => {
     onDocumentLoaded: handleLinkedDocumentLoaded,
     getDocumentMarkdown: getLinkedDocumentMarkdown,
     onAfterBack: restoreLinkedDocumentEditableKey,
+    serializeHistory,
+    restoreHistory,
   });
 
   // Active document's directory — feeds both click-time popout fetches and
@@ -781,6 +811,7 @@ const App: React.FC = () => {
       text: msg.text,
       timestamp: msg.timestamp,
       linkedDocSession: snapshot,
+      history: snapshot.root.history,
       codeAnnotations: [...codeAnnotations],
       selectedCodeAnnotationId,
     }, msg);
@@ -867,6 +898,7 @@ const App: React.FC = () => {
 
     setSelectedMessageId(messageId);
     linkedDocHook.restoreSession(targetState.linkedDocSession);
+    historyApiRef.current?.restore(targetState.history ?? targetState.linkedDocSession.root.history);
     setCodeAnnotations([...targetState.codeAnnotations]);
     setSelectedCodeAnnotationId(targetState.selectedCodeAnnotationId);
   }, [
@@ -1271,6 +1303,9 @@ const App: React.FC = () => {
         viewerRef.current?.clearAllHighlights();
         viewerRef.current?.applySharedAnnotations(pendingSharedAnnotations.filter(a => !a.diffContext));
         clearPendingSharedAnnotations();
+        // Share import establishes a fresh annotation baseline — drop any
+        // undo/redo history so prior actions can't reverse the import.
+        historyApiRef.current?.clear();
         // `clearAllHighlights` wiped live external SSE highlights too;
         // tell the external-highlight bookkeeper to re-apply them.
         resetExternalHighlights();
@@ -1319,6 +1354,10 @@ const App: React.FC = () => {
     setEditGeneration((g) => g + 1);
     annotationsRef.current = remapped;
     setAnnotations(remapped);
+    // Stored history actions carry full annotation snapshots. Once markdown
+    // edits remap anchors, those snapshots are stale unless transformed too.
+    // Direct markdown edits are non-undoable for v1, so drop the stack here.
+    historyApiRef.current?.clear();
     return remapped;
   }, []);
 
@@ -1482,6 +1521,9 @@ const App: React.FC = () => {
   }, [resolveSavedFileChangeSource]);
 
   const handleRestoreDraft = React.useCallback(async () => {
+    // Draft restore is a bulk baseline load — drop undo/redo history so prior
+    // actions can't reverse the restored snapshot.
+    historyApiRef.current?.clear();
     const {
       annotations: restored,
       codeAnnotations: restoredCode,
@@ -2261,7 +2303,7 @@ const App: React.FC = () => {
       const res = await fetch('/api/upload', { method: 'POST', body: formData });
       if (res.ok) {
         const data = await res.json();
-        setGlobalAttachments(prev => [...prev, { path: data.path, name }]);
+        handleAddGlobalAttachment({ path: data.path, name });
       }
     } catch {
       // Upload failed silently
@@ -2365,6 +2407,8 @@ const App: React.FC = () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
       });
+      // Terminal decision succeeded: clear history so undo can't fight a published result.
+      historyApiRef.current?.clear();
       setSubmitted('approved');
     } catch {
       setIsSubmitting(false);
@@ -2391,6 +2435,8 @@ const App: React.FC = () => {
           },
         })
       });
+      // Terminal decision succeeded: clear history so undo can't fight a published result.
+      historyApiRef.current?.clear();
       setSubmitted('denied');
     } catch {
       setIsSubmitting(false);
@@ -2422,6 +2468,8 @@ const App: React.FC = () => {
           ...(messageMultiSelectMode && annotatedMessageIds.length > 1 ? { feedbackScope: 'messages' } : {}),
         }),
       });
+      // Terminal decision succeeded: clear history so undo can't fight a published result.
+      historyApiRef.current?.clear();
       setSubmitted('denied'); // reuse 'denied' state for "feedback sent" overlay
     } catch {
       setIsSubmitting(false);
@@ -2433,6 +2481,8 @@ const App: React.FC = () => {
     setIsSubmitting(true);
     try {
       await fetch('/api/approve', { method: 'POST' });
+      // Terminal decision succeeded: clear history so undo can't fight a published result.
+      historyApiRef.current?.clear();
       setSubmitted('approved');
     } catch {
       setIsSubmitting(false);
@@ -2445,6 +2495,7 @@ const App: React.FC = () => {
     try {
       const res = await fetch('/api/exit', { method: 'POST' });
       if (res.ok) {
+        historyApiRef.current?.clear();
         setSubmitted('exited');
       } else {
         throw new Error('Failed to exit');
@@ -2595,11 +2646,95 @@ const App: React.FC = () => {
     maybeConfirmUnsavedSourceFileEdits,
   ]);
 
-  const handleAddAnnotation = (ann: Annotation) => {
-    setAnnotations(prev => [...prev, ann]);
-    setSelectedAnnotationId(ann.id);
-    setSelectedCodeAnnotationId(null);
-  };
+  // ─── Undo / Redo ──────────────────────────────────────────────────────
+  // Bounded command-pattern stack (see apps/pi-extension/UNDO_SPEC.md §5).
+  // Inverses reuse the existing ViewerHandle + the same setters the draft
+  // auto-save watches, so no persistence/protocol changes are needed.
+  const history = useAnnotationHistory({
+    setAnnotations,
+    setCodeAnnotations,
+    setGlobalAttachments,
+    viewerRef,
+    applyOverrides: (next) => historyApplyOverridesRef.current(next),
+    getSelectedAnnotationId: () => selectedAnnotationIdRef.current,
+    setSelectedAnnotationId,
+    getSelectedCodeAnnotationId: () => selectedCodeAnnotationIdRef.current,
+    setSelectedCodeAnnotationId,
+  });
+  historyApiRef.current = history;
+
+  const canHandleHistoryShortcut = useCallback((e: KeyboardEvent): boolean => {
+    // Terminal / editing / modal owners take precedence.
+    if (submitted || isSubmitting || isExiting) return false;
+    if (isEditingMarkdown) return false;
+    if (
+      showExport || showImport || showFeedbackPrompt || showClaudeCodeWarning ||
+      showSourceFileEditWarning || showExitWarning || showAgentWarning ||
+      showPermissionModeSetup || pendingPasteImage
+    ) return false;
+    if (document.querySelector('[data-plannotator-confirm-dialog="true"]')) return false;
+    if (document.querySelector('[data-comment-popover="true"]')) return false;
+    if (document.querySelector('[data-quick-label-picker]')) return false;
+    if (goalSetupMode) return false;
+
+    // Let text fields (comment popover editor, panel edit, AI input, CM6)
+    // keep native undo.
+    const target = e.target as HTMLElement | null;
+    const tag = target?.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || Boolean(target?.isContentEditable)) return false;
+
+    return true;
+  }, [
+    submitted, isSubmitting, isExiting, isEditingMarkdown,
+    showExport, showImport, showFeedbackPrompt, showClaudeCodeWarning,
+    showSourceFileEditWarning, showExitWarning, showAgentWarning,
+    showPermissionModeSetup, pendingPasteImage, goalSetupMode,
+  ]);
+
+  // Mod+Z / Mod+Shift+Z / Mod+Y are registered through the shortcut runtime so
+  // registry docs, validation, and behavior stay tied to one scope.
+  useHistoryShortcuts({
+    handlers: {
+      undo: {
+        when: (e) => canHandleHistoryShortcut(e) && Boolean(historyApiRef.current?.canUndo),
+        handle: () => historyApiRef.current?.undo(),
+      },
+      redo: {
+        when: (e) => canHandleHistoryShortcut(e) && Boolean(historyApiRef.current?.canRedo),
+        handle: () => historyApiRef.current?.redo(),
+      },
+    },
+  });
+
+  const annotationCommands = useAnnotationCommands({
+    history,
+    viewerRef,
+    allAnnotations,
+    externalAnnotations,
+    codeAnnotationsRef,
+    annotationsRef,
+    selectedAnnotationIdRef,
+    selectedCodeAnnotationIdRef,
+    globalAttachments,
+    setAnnotations,
+    setCodeAnnotations,
+    setGlobalAttachments,
+    setSelectedAnnotationId,
+    setSelectedCodeAnnotationId,
+    deleteExternalAnnotation,
+    updateExternalAnnotation,
+    getCheckboxOverrides: () => checkboxOverridesSnapshotRef.current(),
+    revertCheckboxOverride: (blockId) => checkboxRevertOverrideRef.current(blockId),
+  });
+  const handleAddAnnotation = annotationCommands.addAnnotation;
+  const handleDeleteAnnotation = annotationCommands.deleteAnnotation;
+  const handleEditAnnotation = annotationCommands.editAnnotation;
+  const handleIdentityChange = annotationCommands.changeIdentity;
+  const handleAddGlobalAttachment = annotationCommands.addGlobalAttachment;
+  const handleRemoveGlobalAttachment = annotationCommands.removeGlobalAttachment;
+  const handleAddCodeAnnotation = annotationCommands.addCodeAnnotation;
+  const handleDeleteCodeAnnotation = annotationCommands.deleteCodeAnnotation;
+  const handleEditCodeAnnotation = annotationCommands.editCodeAnnotation;
 
   // Keep selection behavior explicit across mobile/wide-mode transitions.
   const handleSelectAnnotation = React.useCallback((id: string | null) => {
@@ -2607,26 +2742,6 @@ const App: React.FC = () => {
     if (id) setSelectedCodeAnnotationId(null);
     if (id && isMobile && wideModeType === null) setIsPanelOpen(true);
   }, [isMobile, wideModeType]);
-
-  const handleAddCodeAnnotation = React.useCallback((input: CodeFileAnnotationInput) => {
-    const annotation: CodeAnnotation = {
-      id: generateId('code-ann'),
-      type: 'comment',
-      scope: 'line',
-      filePath: input.filePath,
-      lineStart: input.lineStart,
-      lineEnd: input.lineEnd,
-      side: 'new',
-      text: input.text,
-      images: input.images,
-      originalCode: input.originalCode,
-      createdAt: Date.now(),
-      author: configStore.get('displayName') || undefined,
-    };
-    setCodeAnnotations(prev => [...prev, annotation]);
-    setSelectedAnnotationId(null);
-    setSelectedCodeAnnotationId(annotation.id);
-  }, []);
 
   // The code popout is full-viewport modal — the annotation panel is behind it.
   // This handler only fires when the popout is closed (sidebar visible), so
@@ -2640,76 +2755,19 @@ const App: React.FC = () => {
     if (isMobile && wideModeType === null) setIsPanelOpen(true);
   }, [codeAnnotations, codeFilePopout.open, isMobile, wideModeType]);
 
-  const handleDeleteCodeAnnotation = React.useCallback((id: string) => {
-    setCodeAnnotations(prev => prev.filter(a => a.id !== id));
-    if (selectedCodeAnnotationId === id) setSelectedCodeAnnotationId(null);
-  }, [selectedCodeAnnotationId]);
-
-  const handleEditCodeAnnotation = React.useCallback((id: string, updates: Partial<CodeAnnotation>) => {
-    setCodeAnnotations(prev => prev.map(a => a.id === id ? { ...a, ...updates } : a));
-  }, []);
-
-  // Core annotation removal — highlight cleanup + state filter + selection clear
-  const removeAnnotation = (id: string) => {
-    viewerRef.current?.removeHighlight(id);
-    setAnnotations(prev => prev.filter(a => a.id !== id));
-    if (selectedAnnotationId === id) setSelectedAnnotationId(null);
-  };
-
-  // Interactive checkbox toggling with annotation tracking
+  // Interactive checkbox toggling with annotation tracking. addAnnotation /
+  // removeAnnotation are the raw (non-recording) variants; a single toggle
+  // records one composite checkbox-toggle action via onRecordToggle.
   const checkbox = useCheckboxOverrides({
     blocks,
     annotations,
-    addAnnotation: handleAddAnnotation,
-    removeAnnotation,
+    addAnnotation: annotationCommands.addAnnotationRaw,
+    removeAnnotation: annotationCommands.removeAnnotationRaw,
+    onRecordToggle: annotationCommands.recordCheckboxToggle,
   });
-
-  const handleDeleteAnnotation = (id: string) => {
-    const ann = allAnnotations.find(a => a.id === id);
-    // External annotations (live in SSE hook) route to the SSE hook, not local state.
-    // Check membership by ID — source alone is insufficient because share-imported
-    // and draft-restored annotations also carry source but live in local state.
-    if (ann?.source && externalAnnotations.some(e => e.id === id)) {
-      deleteExternalAnnotation(id);
-      if (selectedAnnotationId === id) setSelectedAnnotationId(null);
-      return;
-    }
-    // If this is a checkbox annotation, revert the visual override
-    if (id.startsWith('ann-checkbox-')) {
-      if (ann) {
-        checkbox.revertOverride(ann.blockId);
-      }
-    }
-    removeAnnotation(id);
-  };
-
-  const handleEditAnnotation = (id: string, updates: Partial<Annotation>) => {
-    const ann = allAnnotations.find(a => a.id === id);
-    if (ann?.source && externalAnnotations.some(e => e.id === id)) {
-      updateExternalAnnotation(id, updates);
-      return;
-    }
-    setAnnotations(prev => prev.map(a =>
-      a.id === id ? { ...a, ...updates } : a
-    ));
-  };
-
-  const handleIdentityChange = useCallback((oldIdentity: string, newIdentity: string) => {
-    setAnnotations(prev => prev.map(ann =>
-      ann.author === oldIdentity ? { ...ann, author: newIdentity } : ann
-    ));
-    setCodeAnnotations(prev => prev.map(ann =>
-      ann.author === oldIdentity ? { ...ann, author: newIdentity } : ann
-    ));
-  }, []);
-
-  const handleAddGlobalAttachment = (image: ImageAttachment) => {
-    setGlobalAttachments(prev => [...prev, image]);
-  };
-
-  const handleRemoveGlobalAttachment = (path: string) => {
-    setGlobalAttachments(prev => prev.filter(p => p.path !== path));
-  };
+  historyApplyOverridesRef.current = checkbox.applyOverrides;
+  checkboxOverridesSnapshotRef.current = () => [...checkbox.overrides.entries()];
+  checkboxRevertOverrideRef.current = checkbox.revertOverride;
 
 
   const handleTocNavigate = (blockId: string) => {
@@ -2952,6 +3010,7 @@ const App: React.FC = () => {
       if (result) {
         if (result.type === 'success') {
           toast.success(result.message);
+          historyApiRef.current?.clear();
           setSubmitted(action === CallbackAction.Approve ? 'approved' : 'denied');
         } else {
           toast.error(result.message);
@@ -4041,6 +4100,10 @@ const App: React.FC = () => {
               onDiscard: item.id === 'plan' ? () => handleDiscardEdits() : undefined,
             })) ?? null}
             onOtherFileAnnotationsClick={handleFlashAnnotatedFiles}
+            canUndo={history.canUndo}
+            canRedo={history.canRedo}
+            onUndo={history.undo}
+            onRedo={history.redo}
           />
           {isPanelOpen && rightSidebarTab === 'ai' && wideModeType === null && !goalSetupMode && canUseAI && (
             <aside

--- a/packages/editor/hooks/useAnnotationCommands.ts
+++ b/packages/editor/hooks/useAnnotationCommands.ts
@@ -1,0 +1,230 @@
+import { useCallback } from 'react';
+import type { Dispatch, RefObject, SetStateAction } from 'react';
+import { configStore } from '@plannotator/ui/config';
+import type { ViewerHandle } from '@plannotator/ui/components/Viewer';
+import type { CodeFileAnnotationInput } from '@plannotator/ui/components/CodeFilePopout';
+import type { AnnotationHistoryApi, OverrideSnapshot } from '@plannotator/ui/hooks/useAnnotationHistory';
+import type { Annotation, CodeAnnotation, ImageAttachment } from '@plannotator/ui/types';
+import { generateId } from '@plannotator/ui/utils/generateId';
+import type { CheckboxToggleRecord } from './useCheckboxOverrides';
+
+interface UseAnnotationCommandsOptions {
+  history: Pick<AnnotationHistoryApi, 'push'>;
+  viewerRef: RefObject<ViewerHandle | null>;
+  allAnnotations: Annotation[];
+  externalAnnotations: Annotation[];
+  codeAnnotationsRef: RefObject<CodeAnnotation[]>;
+  annotationsRef: RefObject<Annotation[]>;
+  selectedAnnotationIdRef: RefObject<string | null>;
+  selectedCodeAnnotationIdRef: RefObject<string | null>;
+  globalAttachments: ImageAttachment[];
+  setAnnotations: Dispatch<SetStateAction<Annotation[]>>;
+  setCodeAnnotations: Dispatch<SetStateAction<CodeAnnotation[]>>;
+  setGlobalAttachments: Dispatch<SetStateAction<ImageAttachment[]>>;
+  setSelectedAnnotationId: (id: string | null) => void;
+  setSelectedCodeAnnotationId: (id: string | null) => void;
+  deleteExternalAnnotation: (id: string) => void;
+  updateExternalAnnotation: (id: string, updates: Partial<Annotation>) => void;
+  getCheckboxOverrides: () => OverrideSnapshot;
+  revertCheckboxOverride: (blockId: string) => void;
+}
+
+export interface AnnotationCommands {
+  addAnnotationRaw: (ann: Annotation) => void;
+  removeAnnotationRaw: (id: string) => void;
+  recordCheckboxToggle: (record: CheckboxToggleRecord) => void;
+  addAnnotation: (ann: Annotation) => void;
+  deleteAnnotation: (id: string) => void;
+  editAnnotation: (id: string, updates: Partial<Annotation>) => void;
+  addCodeAnnotation: (input: CodeFileAnnotationInput) => void;
+  deleteCodeAnnotation: (id: string) => void;
+  editCodeAnnotation: (id: string, updates: Partial<CodeAnnotation>) => void;
+  addGlobalAttachment: (image: ImageAttachment) => void;
+  removeGlobalAttachment: (path: string) => void;
+  changeIdentity: (oldIdentity: string, newIdentity: string) => void;
+}
+
+export function useAnnotationCommands({
+  history,
+  viewerRef,
+  allAnnotations,
+  externalAnnotations,
+  codeAnnotationsRef,
+  annotationsRef,
+  selectedAnnotationIdRef,
+  selectedCodeAnnotationIdRef,
+  globalAttachments,
+  setAnnotations,
+  setCodeAnnotations,
+  setGlobalAttachments,
+  setSelectedAnnotationId,
+  setSelectedCodeAnnotationId,
+  deleteExternalAnnotation,
+  updateExternalAnnotation,
+  getCheckboxOverrides,
+  revertCheckboxOverride,
+}: UseAnnotationCommandsOptions): AnnotationCommands {
+  const addAnnotationRaw = useCallback((ann: Annotation) => {
+    setAnnotations(prev => [...prev, ann]);
+    setSelectedAnnotationId(ann.id);
+    setSelectedCodeAnnotationId(null);
+  }, [setAnnotations, setSelectedAnnotationId, setSelectedCodeAnnotationId]);
+
+  const removeAnnotationRaw = useCallback((id: string) => {
+    viewerRef.current?.removeHighlight(id);
+    setAnnotations(prev => prev.filter(a => a.id !== id));
+    if (selectedAnnotationIdRef.current === id) setSelectedAnnotationId(null);
+  }, [selectedAnnotationIdRef, setAnnotations, setSelectedAnnotationId, viewerRef]);
+
+  const recordCheckboxToggle = useCallback((record: CheckboxToggleRecord) => {
+    history.push({ kind: 'checkbox-toggle', ...record });
+  }, [history]);
+
+  const addAnnotation = useCallback((ann: Annotation) => {
+    const prevSelectedId = selectedAnnotationIdRef.current;
+    const prevSelectedCodeId = selectedCodeAnnotationIdRef.current;
+    addAnnotationRaw(ann);
+    history.push({ kind: 'add-annotation', ann, prevSelectedId, prevSelectedCodeId });
+  }, [addAnnotationRaw, history, selectedAnnotationIdRef, selectedCodeAnnotationIdRef]);
+
+  const addCodeAnnotation = useCallback((input: CodeFileAnnotationInput) => {
+    const prevSelectedId = selectedAnnotationIdRef.current;
+    const prevSelectedCodeId = selectedCodeAnnotationIdRef.current;
+    const annotation: CodeAnnotation = {
+      id: generateId('code-ann'),
+      type: 'comment',
+      scope: 'line',
+      filePath: input.filePath,
+      lineStart: input.lineStart,
+      lineEnd: input.lineEnd,
+      side: 'new',
+      text: input.text,
+      images: input.images,
+      originalCode: input.originalCode,
+      createdAt: Date.now(),
+      author: configStore.get('displayName') || undefined,
+    };
+
+    setCodeAnnotations(prev => [...prev, annotation]);
+    setSelectedAnnotationId(null);
+    setSelectedCodeAnnotationId(annotation.id);
+    history.push({ kind: 'add-code-annotation', ann: annotation, prevSelectedId, prevSelectedCodeId });
+  }, [
+    history,
+    selectedAnnotationIdRef,
+    selectedCodeAnnotationIdRef,
+    setCodeAnnotations,
+    setSelectedAnnotationId,
+    setSelectedCodeAnnotationId,
+  ]);
+
+  const deleteCodeAnnotation = useCallback((id: string) => {
+    const ann = codeAnnotationsRef.current.find(a => a.id === id);
+    const prevSelectedCodeId = selectedCodeAnnotationIdRef.current;
+    setCodeAnnotations(prev => prev.filter(a => a.id !== id));
+    if (prevSelectedCodeId === id) setSelectedCodeAnnotationId(null);
+    if (ann) history.push({ kind: 'delete-code-annotation', ann, prevSelectedCodeId });
+  }, [codeAnnotationsRef, history, selectedCodeAnnotationIdRef, setCodeAnnotations, setSelectedCodeAnnotationId]);
+
+  const editCodeAnnotation = useCallback((id: string, updates: Partial<CodeAnnotation>) => {
+    const prevAnn = codeAnnotationsRef.current.find(a => a.id === id);
+    setCodeAnnotations(prev => prev.map(a => a.id === id ? { ...a, ...updates } : a));
+    if (prevAnn) history.push({ kind: 'update-code-annotation', prevAnn, nextAnn: { ...prevAnn, ...updates } });
+  }, [codeAnnotationsRef, history, setCodeAnnotations]);
+
+  const deleteAnnotation = useCallback((id: string) => {
+    const ann = allAnnotations.find(a => a.id === id);
+    // External annotations live in the SSE hook, not local annotation state.
+    if (ann?.source && externalAnnotations.some(e => e.id === id)) {
+      deleteExternalAnnotation(id);
+      if (selectedAnnotationIdRef.current === id) setSelectedAnnotationId(null);
+      return;
+    }
+
+    if (id.startsWith('ann-checkbox-') && ann) {
+      const prevOverrides = getCheckboxOverrides();
+      const nextOverrides = prevOverrides.filter(([bid]) => bid !== ann.blockId);
+      revertCheckboxOverride(ann.blockId);
+      removeAnnotationRaw(id);
+      history.push({
+        kind: 'checkbox-toggle',
+        blockId: ann.blockId,
+        prevOverrides,
+        nextOverrides,
+        prevCheckboxAnns: [ann],
+        nextCheckboxAnns: [],
+      });
+      return;
+    }
+
+    const prevSelectedId = selectedAnnotationIdRef.current;
+    removeAnnotationRaw(id);
+    if (ann) history.push({ kind: 'delete-annotation', ann, prevSelectedId });
+  }, [
+    allAnnotations,
+    deleteExternalAnnotation,
+    externalAnnotations,
+    getCheckboxOverrides,
+    history,
+    removeAnnotationRaw,
+    revertCheckboxOverride,
+    selectedAnnotationIdRef,
+    setSelectedAnnotationId,
+  ]);
+
+  const editAnnotation = useCallback((id: string, updates: Partial<Annotation>) => {
+    const ann = allAnnotations.find(a => a.id === id);
+    if (ann?.source && externalAnnotations.some(e => e.id === id)) {
+      updateExternalAnnotation(id, updates);
+      return;
+    }
+
+    if (ann) {
+      const nextAnn: Annotation = { ...ann, ...updates };
+      setAnnotations(prev => prev.map(a => a.id === id ? nextAnn : a));
+      history.push({ kind: 'update-annotation', prevAnn: ann, nextAnn });
+    } else {
+      setAnnotations(prev => prev.map(a => a.id === id ? { ...a, ...updates } : a));
+    }
+  }, [allAnnotations, externalAnnotations, history, setAnnotations, updateExternalAnnotation]);
+
+  const changeIdentity = useCallback((oldIdentity: string, newIdentity: string) => {
+    const affectedAnnIds = annotationsRef.current.filter(a => a.author === oldIdentity).map(a => a.id);
+    const affectedCodeAnnIds = codeAnnotationsRef.current.filter(a => a.author === oldIdentity).map(a => a.id);
+    setAnnotations(prev => prev.map(ann =>
+      ann.author === oldIdentity ? { ...ann, author: newIdentity } : ann
+    ));
+    setCodeAnnotations(prev => prev.map(ann =>
+      ann.author === oldIdentity ? { ...ann, author: newIdentity } : ann
+    ));
+    if (affectedAnnIds.length > 0 || affectedCodeAnnIds.length > 0) {
+      history.push({ kind: 'identity-change', oldIdentity, newIdentity, affectedAnnIds, affectedCodeAnnIds });
+    }
+  }, [annotationsRef, codeAnnotationsRef, history, setAnnotations, setCodeAnnotations]);
+
+  const addGlobalAttachment = useCallback((image: ImageAttachment) => {
+    setGlobalAttachments(prev => [...prev, image]);
+    history.push({ kind: 'add-global-attachment', img: image });
+  }, [history, setGlobalAttachments]);
+
+  const removeGlobalAttachment = useCallback((path: string) => {
+    const img = globalAttachments.find(p => p.path === path);
+    setGlobalAttachments(prev => prev.filter(p => p.path !== path));
+    if (img) history.push({ kind: 'remove-global-attachment', img });
+  }, [globalAttachments, history, setGlobalAttachments]);
+
+  return {
+    addAnnotationRaw,
+    removeAnnotationRaw,
+    recordCheckboxToggle,
+    addAnnotation,
+    deleteAnnotation,
+    editAnnotation,
+    addCodeAnnotation,
+    deleteCodeAnnotation,
+    editCodeAnnotation,
+    addGlobalAttachment,
+    removeGlobalAttachment,
+    changeIdentity,
+  };
+}

--- a/packages/editor/hooks/useCheckboxOverrides.ts
+++ b/packages/editor/hooks/useCheckboxOverrides.ts
@@ -4,16 +4,36 @@
  * Manages interactive checkbox toggling in the plan viewer. Each toggle creates
  * a COMMENT annotation capturing the action and section context; toggling back
  * to the original state removes the override and deletes the annotation.
+ *
+ * Undo integration: the hook records each toggle as a single composite action
+ * via `onRecordToggle` (capturing before/after override maps and checkbox
+ * annotations) so the history stack can reverse it as one step. `applyOverrides`
+ * restores a prior override map during undo/redo. The `addAnnotation` /
+ * `removeAnnotation` callbacks passed in are expected to be the *raw*
+ * (non-history-recording) variants so the toggle's internal add/remove do not
+ * each push their own history entry.
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Annotation, AnnotationType, Block } from '@plannotator/ui/types';
+import type { OverrideSnapshot } from '@plannotator/ui/hooks/useAnnotationHistory';
+
+/** Payload recorded for the history stack on each interactive toggle. */
+export interface CheckboxToggleRecord {
+  blockId: string;
+  prevOverrides: OverrideSnapshot;
+  nextOverrides: OverrideSnapshot;
+  prevCheckboxAnns: Annotation[];
+  nextCheckboxAnns: Annotation[];
+}
 
 export interface UseCheckboxOverridesOptions {
   blocks: Block[];
   annotations: Annotation[];
   addAnnotation: (ann: Annotation) => void;
   removeAnnotation: (id: string) => void;
+  /** Record a composite toggle action for undo/redo. */
+  onRecordToggle?: (record: CheckboxToggleRecord) => void;
 }
 
 export interface UseCheckboxOverridesReturn {
@@ -23,6 +43,8 @@ export interface UseCheckboxOverridesReturn {
   toggle: (blockId: string, checked: boolean) => void;
   /** Revert an override when a checkbox annotation is deleted from the panel */
   revertOverride: (blockId: string) => void;
+  /** Replace the entire override map (undo/redo). Accepts a serializable snapshot. */
+  applyOverrides: (next: OverrideSnapshot) => void;
 }
 
 export function useCheckboxOverrides({
@@ -30,14 +52,19 @@ export function useCheckboxOverrides({
   annotations,
   addAnnotation,
   removeAnnotation,
+  onRecordToggle,
 }: UseCheckboxOverridesOptions): UseCheckboxOverridesReturn {
   const [overrides, setOverrides] = useState<Map<string, boolean>>(new Map());
 
-  // Refs so callbacks don't need annotations/blocks in their dep arrays
+  // Refs so callbacks don't need annotations/blocks/overrides in their dep arrays
   const blocksRef = useRef(blocks);
   blocksRef.current = blocks;
   const annotationsRef = useRef(annotations);
   annotationsRef.current = annotations;
+  const overridesRef = useRef(overrides);
+  overridesRef.current = overrides;
+  const onRecordToggleRef = useRef(onRecordToggle);
+  onRecordToggleRef.current = onRecordToggle;
 
   // Clean up stale overrides when blocks change (e.g. markdown reloaded)
   useEffect(() => {
@@ -59,6 +86,12 @@ export function useCheckboxOverrides({
     const block = blocks.find(b => b.id === blockId);
     const isRevertingToOriginal = block && checked === block.checked;
 
+    // Snapshot before-state for the composite undo record.
+    const prevOverrides: OverrideSnapshot = [...overridesRef.current.entries()];
+    const prevCheckboxAnns = annotations.filter(
+      a => a.blockId === blockId && a.id.startsWith('ann-checkbox-'),
+    );
+
     if (isRevertingToOriginal) {
       // Undo: remove the override and delete ALL checkbox annotations for this block
       setOverrides(prev => {
@@ -68,6 +101,15 @@ export function useCheckboxOverrides({
       });
       const toDelete = annotations.filter(a => a.blockId === blockId && a.id.startsWith('ann-checkbox-'));
       toDelete.forEach(a => removeAnnotation(a.id));
+
+      const nextOverrides = prevOverrides.filter(([id]) => id !== blockId);
+      onRecordToggleRef.current?.({
+        blockId,
+        prevOverrides,
+        nextOverrides,
+        prevCheckboxAnns,
+        nextCheckboxAnns: [],
+      });
     } else {
       // Toggle: remove any existing checkbox annotations for this block first (prevents duplicates from rapid clicks)
       const existing = annotations.filter(a => a.blockId === blockId && a.id.startsWith('ann-checkbox-'));
@@ -78,6 +120,8 @@ export function useCheckboxOverrides({
         next.set(blockId, checked);
         return next;
       });
+
+      let nextCheckboxAnns: Annotation[] = [];
       if (block) {
         // Find the nearest heading above this block for section context
         const blockIdx = blocks.indexOf(block);
@@ -102,7 +146,17 @@ export function useCheckboxOverrides({
           createdA: Date.now(),
         };
         addAnnotation(ann);
+        nextCheckboxAnns = [ann];
       }
+
+      const nextOverrides: OverrideSnapshot = [...prevOverrides.filter(([id]) => id !== blockId), [blockId, checked]];
+      onRecordToggleRef.current?.({
+        blockId,
+        prevOverrides,
+        nextOverrides,
+        prevCheckboxAnns,
+        nextCheckboxAnns,
+      });
     }
   }, [addAnnotation, removeAnnotation]);
 
@@ -114,5 +168,9 @@ export function useCheckboxOverrides({
     });
   }, []);
 
-  return { overrides, toggle, revertOverride };
+  const applyOverrides = useCallback((next: OverrideSnapshot) => {
+    setOverrides(new Map(next));
+  }, []);
+
+  return { overrides, toggle, revertOverride, applyOverrides };
 }

--- a/packages/editor/shortcuts.ts
+++ b/packages/editor/shortcuts.ts
@@ -6,6 +6,7 @@ import {
   createShortcutScopeHook,
   defineShortcutScope,
   goalSetupShortcuts,
+  historyShortcuts,
   imageAnnotatorShortcuts,
   inputMethodShortcuts,
   viewerShortcuts,
@@ -83,6 +84,7 @@ const sharedPlanSurfaceShortcuts = [
   commentPopoverShortcuts,
   annotationPanelShortcuts,
   imageAnnotatorShortcuts,
+  historyShortcuts,
 ] as const;
 
 export const planReviewSettingsShortcutRegistry = createShortcutRegistry([

--- a/packages/editor/undo.test.ts
+++ b/packages/editor/undo.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Integration tests for undo → feedback-export invariant
+ * (apps/pi-extension/UNDO_SPEC.md §7.2).
+ *
+ * Combines the REAL annotation-history controller with the REAL
+ * `exportAnnotations` / `parseMarkdownToBlocks` production code to prove the
+ * v1 core promise: undoing an accidental deletion or misassigned comment
+ * removes it from the feedback text delivered to the agent.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  createAnnotationHistoryController,
+  type AnnotationHistoryApi,
+  type UseAnnotationHistoryOptions,
+} from "@plannotator/ui/hooks/useAnnotationHistory";
+import { exportAnnotations, parseMarkdownToBlocks } from "@plannotator/ui/utils/parser";
+import { AnnotationType } from "@plannotator/ui/types";
+import type { Annotation, CodeAnnotation, ImageAttachment } from "@plannotator/ui/types";
+import type { ViewerHandle } from "@plannotator/ui/components/Viewer";
+
+const PLAN = `# Plan\n\nImplement the feature.\n\n- [ ] Step one\n- [ ] Step two\n\nSome risky section to delete.\n`;
+
+interface FakeState {
+  annotations: Annotation[];
+  codeAnnotations: CodeAnnotation[];
+  globalAttachments: ImageAttachment[];
+  selectedAnnotationId: string | null;
+  selectedCodeAnnotationId: string | null;
+  overrides: Array<[string, boolean]>;
+}
+
+function makeViewer() {
+  const calls: { fn: string; arg: unknown }[] = [];
+  const viewer = {
+    removeHighlight: (id: string) => calls.push({ fn: "removeHighlight", arg: id }),
+    clearAllHighlights: () => calls.push({ fn: "clearAllHighlights", arg: null }),
+    applySharedAnnotations: (a: Annotation[]) => calls.push({ fn: "applySharedAnnotations", arg: a }),
+  } as unknown as ViewerHandle;
+  return { viewer, calls };
+}
+
+function makeOptions(state: FakeState, viewer: ViewerHandle): UseAnnotationHistoryOptions {
+  return {
+    setAnnotations: (next) => {
+      state.annotations = typeof next === "function" ? (next as (p: Annotation[]) => Annotation[])(state.annotations) : next;
+    },
+    setCodeAnnotations: (next) => {
+      state.codeAnnotations = typeof next === "function" ? (next as (p: CodeAnnotation[]) => CodeAnnotation[])(state.codeAnnotations) : next;
+    },
+    setGlobalAttachments: (next) => {
+      state.globalAttachments = typeof next === "function" ? (next as (p: ImageAttachment[]) => ImageAttachment[])(state.globalAttachments) : next;
+    },
+    viewerRef: { current: viewer },
+    applyOverrides: (next) => {
+      state.overrides = next;
+    },
+    getSelectedAnnotationId: () => state.selectedAnnotationId,
+    setSelectedAnnotationId: (id) => {
+      state.selectedAnnotationId = id;
+    },
+    getSelectedCodeAnnotationId: () => state.selectedCodeAnnotationId,
+    setSelectedCodeAnnotationId: (id) => {
+      state.selectedCodeAnnotationId = id;
+    },
+  };
+}
+
+function mount(options: UseAnnotationHistoryOptions): { api: AnnotationHistoryApi; unmount: () => void } {
+  return {
+    api: createAnnotationHistoryController(() => options),
+    unmount: () => {},
+  };
+}
+
+describe("undo → feedback export integration", () => {
+  test("undoing an accidental DELETION removes it from exported feedback", () => {
+    const blocks = parseMarkdownToBlocks(PLAN);
+    const target = blocks.find((b) => b.content.includes("risky section"))!;
+    const state: FakeState = {
+      annotations: [],
+      codeAnnotations: [],
+      globalAttachments: [],
+      selectedAnnotationId: null,
+      selectedCodeAnnotationId: null,
+      overrides: [],
+    };
+    const { viewer } = makeViewer();
+    const { api, unmount } = mount(makeOptions(state, viewer));
+
+    // User marks the section for deletion.
+    const deletion: Annotation = {
+      id: "del-1",
+      blockId: target.id,
+      startOffset: 0,
+      endOffset: target.content.length,
+      type: AnnotationType.DELETION,
+      originalText: "Some risky section to delete.",
+      createdA: 1,
+    };
+    state.annotations = [deletion];
+    state.selectedAnnotationId = "del-1";
+    api.push({ kind: "add-annotation", ann: deletion, prevSelectedId: null, prevSelectedCodeId: null });
+
+    // Before undo: feedback contains "Remove this".
+    expect(exportAnnotations(blocks, state.annotations)).toContain("Remove this");
+
+    // Undo the accidental negative feedback.
+    api.undo();
+    expect(state.annotations).toEqual([]);
+
+    // After undo: no deletion reaches the agent.
+    const after = exportAnnotations(blocks, state.annotations);
+    expect(after).not.toContain("Remove this");
+    expect(after).toContain("No changes detected.");
+
+    unmount();
+  });
+
+  test("undoing a misassigned COMMENT leaves no trace in exported feedback", () => {
+    const blocks = parseMarkdownToBlocks(PLAN);
+    const wrong = blocks.find((b) => b.content.includes("Implement the feature"))!;
+    const state: FakeState = {
+      annotations: [],
+      codeAnnotations: [],
+      globalAttachments: [],
+      selectedAnnotationId: null,
+      selectedCodeAnnotationId: null,
+      overrides: [],
+    };
+    const { viewer } = makeViewer();
+    const { api, unmount } = mount(makeOptions(state, viewer));
+
+    // User comments on the WRONG text (misassigned).
+    const misassigned: Annotation = {
+      id: "c-1",
+      blockId: wrong.id,
+      startOffset: 0,
+      endOffset: wrong.content.length,
+      type: AnnotationType.COMMENT,
+      text: "Out of scope",
+      originalText: "Implement the feature.",
+      isQuickLabel: true,
+      createdA: 1,
+    };
+    state.annotations = [misassigned];
+    api.push({ kind: "add-annotation", ann: misassigned, prevSelectedId: null, prevSelectedCodeId: null });
+
+    expect(exportAnnotations(blocks, state.annotations)).toContain("Feedback on:");
+    expect(exportAnnotations(blocks, state.annotations)).toContain("Implement the feature.");
+
+    // Undo the misassigned comment.
+    api.undo();
+    expect(state.annotations).toEqual([]);
+
+    const after = exportAnnotations(blocks, state.annotations);
+    expect(after).not.toContain("Feedback on:");
+    expect(after).not.toContain("Implement the feature.");
+    expect(after).toContain("No changes detected.");
+
+    // Redo re-applies it exactly.
+    api.redo();
+    expect(state.annotations).toEqual([misassigned]);
+    expect(exportAnnotations(blocks, state.annotations)).toContain("Feedback on:");
+
+    unmount();
+  });
+
+  test("delete-then-undo re-adds the annotation so it reappears in feedback", () => {
+    const blocks = parseMarkdownToBlocks(PLAN);
+    const target = blocks.find((b) => b.content.includes("Step one"))!;
+    const state: FakeState = {
+      annotations: [],
+      codeAnnotations: [],
+      globalAttachments: [],
+      selectedAnnotationId: "c-1",
+      selectedCodeAnnotationId: null,
+      overrides: [],
+    };
+    const { viewer, calls } = makeViewer();
+    const { api, unmount } = mount(makeOptions(state, viewer));
+
+    const comment: Annotation = {
+      id: "c-1",
+      blockId: target.id,
+      startOffset: 0,
+      endOffset: target.content.length,
+      type: AnnotationType.COMMENT,
+      text: "Clarify this",
+      originalText: "Step one",
+      createdA: 1,
+    };
+    // The annotation existed; user deletes it from the panel.
+    state.annotations = [];
+    state.selectedAnnotationId = null;
+    api.push({ kind: "delete-annotation", ann: comment, prevSelectedId: "c-1" });
+
+    expect(exportAnnotations(blocks, state.annotations)).toContain("No changes detected.");
+
+    // Undo: annotation re-added and DOM highlight re-applied.
+    api.undo();
+    expect(state.annotations).toEqual([comment]);
+    expect(calls.some((c) => c.fn === "applySharedAnnotations")).toBe(true);
+    expect(exportAnnotations(blocks, state.annotations)).toContain("Feedback on:");
+    expect(exportAnnotations(blocks, state.annotations)).toContain("Clarify this");
+
+    unmount();
+  });
+
+  test("checkbox-toggle undo restores the override and the checkbox annotation", () => {
+    const blocks = parseMarkdownToBlocks(PLAN);
+    const checkboxBlock = blocks.find((b) => b.checked !== undefined)!;
+    const state: FakeState = {
+      annotations: [],
+      codeAnnotations: [],
+      globalAttachments: [],
+      selectedAnnotationId: null,
+      selectedCodeAnnotationId: null,
+      overrides: [["blk-x", true]],
+    };
+    const { viewer } = makeViewer();
+    const { api, unmount } = mount(makeOptions(state, viewer));
+
+    const prevCheckboxAnns: Annotation[] = [];
+    const nextCheckboxAnns: Annotation[] = [
+      {
+        id: `ann-checkbox-${checkboxBlock.id}-${Date.now()}`,
+        blockId: checkboxBlock.id,
+        startOffset: 0,
+        endOffset: checkboxBlock.content.length,
+        type: AnnotationType.COMMENT,
+        text: "Mark as completed: Step one",
+        originalText: checkboxBlock.content,
+        createdA: 1,
+      },
+    ];
+    state.annotations = [...nextCheckboxAnns];
+    api.push({
+      kind: "checkbox-toggle",
+      blockId: checkboxBlock.id,
+      prevOverrides: [],
+      nextOverrides: [["blk-x", true]],
+      prevCheckboxAnns,
+      nextCheckboxAnns,
+    });
+
+    expect(exportAnnotations(blocks, state.annotations)).toContain("Mark as completed");
+
+    api.undo();
+    expect(state.overrides).toEqual([]);
+    expect(state.annotations).toEqual([]);
+    expect(exportAnnotations(blocks, state.annotations)).toContain("No changes detected.");
+
+    unmount();
+  });
+
+  test("multi-step: three annotations, undo all, redo all — feedback matches each step", () => {
+    const blocks = parseMarkdownToBlocks(PLAN);
+    const a = blocks.find((b) => b.content.includes("Implement"))!;
+    const b = blocks.find((b) => b.content.includes("risky"))!;
+    const state: FakeState = {
+      annotations: [],
+      codeAnnotations: [],
+      globalAttachments: [],
+      selectedAnnotationId: null,
+      selectedCodeAnnotationId: null,
+      overrides: [],
+    };
+    const { viewer } = makeViewer();
+    const { api, unmount } = mount(makeOptions(state, viewer));
+
+    const anns: Annotation[] = [
+      { id: "1", blockId: a.id, startOffset: 0, endOffset: a.content.length, type: AnnotationType.COMMENT, text: "q1", originalText: a.content, createdA: 1 },
+      { id: "2", blockId: b.id, startOffset: 0, endOffset: b.content.length, type: AnnotationType.DELETION, originalText: b.content, createdA: 2 },
+      { id: "3", blockId: a.id, startOffset: 0, endOffset: a.content.length, type: AnnotationType.COMMENT, text: "q2", originalText: a.content, createdA: 3 },
+    ];
+    for (const x of anns) {
+      state.annotations = [...state.annotations, x];
+      api.push({ kind: "add-annotation", ann: x, prevSelectedId: null, prevSelectedCodeId: null });
+    }
+    expect(state.annotations).toHaveLength(3);
+
+    api.undo();
+    api.undo();
+    api.undo();
+    expect(state.annotations).toEqual([]);
+    expect(exportAnnotations(blocks, state.annotations)).toContain("No changes detected.");
+
+    api.redo();
+    api.redo();
+    api.redo();
+    expect(state.annotations.map((x) => x.id)).toEqual(["1", "2", "3"]);
+    const out = exportAnnotations(blocks, state.annotations);
+    expect(out).toContain("Remove this");
+    expect(out).toContain("q1");
+    expect(out).toContain("q2");
+
+    unmount();
+  });
+});

--- a/packages/ui/components/AnnotationPanel.tsx
+++ b/packages/ui/components/AnnotationPanel.tsx
@@ -68,6 +68,11 @@ interface PanelProps {
   onClose?: () => void;
   onQuickCopy?: () => Promise<void>;
   onShare?: () => void;
+  /** Undo/redo controls surfaced in the panel header. */
+  canUndo?: boolean;
+  canRedo?: boolean;
+  onUndo?: () => void;
+  onRedo?: () => void;
   otherFileAnnotations?: { count: number; files: number };
   onOtherFileAnnotationsClick?: () => void;
   /** Committed direct edits to one or more documents. Rendered as pinned cards
@@ -94,6 +99,10 @@ export const AnnotationPanel: React.FC<PanelProps> = ({
   onClose,
   onQuickCopy,
   onShare,
+  canUndo = false,
+  canRedo = false,
+  onUndo,
+  onRedo,
   otherFileAnnotations,
   onOtherFileAnnotationsClick,
   directEdits = null,
@@ -142,18 +151,56 @@ export const AnnotationPanel: React.FC<PanelProps> = ({
               </span>
             )}
           </div>
-          {isMobile && onClose && (
-            <button
-              onClick={onClose}
-              className="relative rounded-md p-1.5 text-muted-foreground transition-colors before:absolute before:-inset-1.5 before:content-[''] hover:text-foreground md:hidden"
-              title="Close panel"
-              aria-label="Close panel"
-            >
-              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-          )}
+          <div className="flex items-center gap-0.5">
+            {onUndo && (
+              <button
+                onClick={onUndo}
+                disabled={!canUndo}
+                title="Undo (Cmd+Z)"
+                aria-label="Undo"
+                className={`rounded-md p-1.5 transition-colors ${
+                  canUndo
+                    ? 'text-muted-foreground hover:bg-surface-1 hover:text-foreground'
+                    : 'text-muted-foreground/30 cursor-not-allowed'
+                }`}
+              >
+                <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+                  <path d="M3 7v6h6" />
+                  <path d="M21 17a9 9 0 00-9-9 9 9 0 00-6 2.3L3 13" />
+                </svg>
+              </button>
+            )}
+            {onRedo && (
+              <button
+                onClick={onRedo}
+                disabled={!canRedo}
+                title="Redo (Cmd+Shift+Z)"
+                aria-label="Redo"
+                className={`rounded-md p-1.5 transition-colors ${
+                  canRedo
+                    ? 'text-muted-foreground hover:bg-surface-1 hover:text-foreground'
+                    : 'text-muted-foreground/30 cursor-not-allowed'
+                }`}
+              >
+                <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+                  <path d="M21 7v6h-6" />
+                  <path d="M3 17a9 9 0 019-9 9 9 0 016 2.3L21 13" />
+                </svg>
+              </button>
+            )}
+            {isMobile && onClose && (
+              <button
+                onClick={onClose}
+                className="relative rounded-md p-1.5 text-muted-foreground transition-colors before:absolute before:-inset-1.5 before:content-[''] hover:text-foreground md:hidden"
+                title="Close panel"
+                aria-label="Close panel"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            )}
+          </div>
         </div>
         {otherFileAnnotations && otherFileAnnotations.count > 0 && (
           <button

--- a/packages/ui/components/KeyboardShortcuts.tsx
+++ b/packages/ui/components/KeyboardShortcuts.tsx
@@ -98,6 +98,14 @@ const planShortcuts: ShortcutSection[] = [
     ],
   },
   {
+    title: 'History',
+    shortcuts: [
+      { keys: [modKey, 'Z'], desc: 'Undo', hint: 'Reverses the last annotation, comment, code annotation, attachment, checkbox toggle, or identity change. Disabled while editing markdown, the Image Annotator is open, or a modal is visible.' },
+      { keys: [modKey, 'Shift', 'Z'], desc: 'Redo', hint: 'Re-applies the most recently undone action.' },
+      { keys: [modKey, 'Y'], desc: 'Redo' },
+    ],
+  },
+  {
     title: 'Image Annotator',
     shortcuts: [
       { keys: ['1'], desc: 'Pen tool' },

--- a/packages/ui/hooks/useAnnotationHistory.test.ts
+++ b/packages/ui/hooks/useAnnotationHistory.test.ts
@@ -1,0 +1,587 @@
+/**
+ * Unit tests for useAnnotationHistory (apps/pi-extension/UNDO_SPEC.md §7.1).
+ *
+ * These drive the pure controller with fake setters and a fake ViewerHandle so we can
+ * assert both state transitions and the imperative DOM-highlight calls the
+ * inverses rely on. No DOM is required, so this runs under default `bun test`.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  createAnnotationHistoryController,
+  type AnnotationAction,
+  type AnnotationHistoryApi,
+  type OverrideSnapshot,
+  type UseAnnotationHistoryOptions,
+} from "./useAnnotationHistory";
+import { AnnotationType } from "../types";
+import type { Annotation, CodeAnnotation, ImageAttachment } from "../types";
+import type { ViewerHandle } from "../components/Viewer";
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function ann(id: string, overrides: Partial<Annotation> = {}): Annotation {
+  return {
+    id,
+    blockId: "block-1",
+    startOffset: 0,
+    endOffset: 5,
+    type: AnnotationType.COMMENT,
+    originalText: "hello",
+    createdA: 1,
+    ...overrides,
+  };
+}
+
+function codeAnn(id: string, overrides: Partial<CodeAnnotation> = {}): CodeAnnotation {
+  return {
+    id,
+    type: "comment",
+    scope: "line",
+    filePath: "a.ts",
+    lineStart: 1,
+    lineEnd: 2,
+    side: "new",
+    createdAt: 1,
+    ...overrides,
+  };
+}
+
+function img(path: string): ImageAttachment {
+  return { path, name: path };
+}
+
+interface FakeState {
+  annotations: Annotation[];
+  codeAnnotations: CodeAnnotation[];
+  globalAttachments: ImageAttachment[];
+  selectedAnnotationId: string | null;
+  selectedCodeAnnotationId: string | null;
+  overrides: OverrideSnapshot;
+}
+
+function makeFakeViewer() {
+  const calls: { fn: string; arg: unknown }[] = [];
+  const viewer = {
+    removeHighlight: (id: string) => calls.push({ fn: "removeHighlight", arg: id }),
+    clearAllHighlights: () => calls.push({ fn: "clearAllHighlights", arg: null }),
+    applySharedAnnotations: (a: Annotation[]) => calls.push({ fn: "applySharedAnnotations", arg: a }),
+  } as unknown as ViewerHandle;
+  return { viewer, calls };
+}
+
+function makeOptions(state: FakeState, viewer: ViewerHandle): UseAnnotationHistoryOptions {
+  return {
+    setAnnotations: (next) => {
+      state.annotations = typeof next === "function" ? (next as (p: Annotation[]) => Annotation[])(state.annotations) : next;
+    },
+    setCodeAnnotations: (next) => {
+      state.codeAnnotations =
+        typeof next === "function" ? (next as (p: CodeAnnotation[]) => CodeAnnotation[])(state.codeAnnotations) : next;
+    },
+    setGlobalAttachments: (next) => {
+      state.globalAttachments =
+        typeof next === "function"
+          ? (next as (p: ImageAttachment[]) => ImageAttachment[])(state.globalAttachments)
+          : next;
+    },
+    viewerRef: { current: viewer },
+    applyOverrides: (next: OverrideSnapshot) => {
+      state.overrides = next;
+    },
+    getSelectedAnnotationId: () => state.selectedAnnotationId,
+    setSelectedAnnotationId: (id) => {
+      state.selectedAnnotationId = id;
+    },
+    getSelectedCodeAnnotationId: () => state.selectedCodeAnnotationId,
+    setSelectedCodeAnnotationId: (id) => {
+      state.selectedCodeAnnotationId = id;
+    },
+  };
+}
+
+function mountHistory(options: UseAnnotationHistoryOptions): {
+  api: AnnotationHistoryApi;
+  unmount: () => void;
+} {
+  return {
+    api: createAnnotationHistoryController(() => options),
+    unmount: () => {},
+  };
+}
+
+// ─── tests ──────────────────────────────────────────────────────────────────
+
+describe("useAnnotationHistory", () => {
+  test("add-annotation: undo removes it and restores selection; redo re-adds + re-highlights", () => {
+    const state: FakeState = {
+      annotations: [],
+      codeAnnotations: [],
+      globalAttachments: [],
+      selectedAnnotationId: null,
+      selectedCodeAnnotationId: null,
+      overrides: [],
+    };
+    const { viewer, calls } = makeFakeViewer();
+    const { api, unmount } = mountHistory(makeOptions(state, viewer));
+
+    const a = ann("a1", { type: AnnotationType.DELETION });
+    state.annotations = [...state.annotations, a];
+    state.selectedAnnotationId = "a1";
+    state.selectedCodeAnnotationId = null;
+    api.push({ kind: "add-annotation", ann: a, prevSelectedId: null, prevSelectedCodeId: null });
+    expect(api.canUndo).toBe(true);
+    expect(api.canRedo).toBe(false);
+
+    api.undo();
+    expect(state.annotations).toEqual([]);
+    expect(state.selectedAnnotationId).toBe(null);
+    expect(calls.some((c) => c.fn === "removeHighlight" && c.arg === "a1")).toBe(true);
+    expect(api.canUndo).toBe(false);
+    expect(api.canRedo).toBe(true);
+
+    calls.length = 0;
+    api.redo();
+    expect(state.annotations).toEqual([a]);
+    expect(state.selectedAnnotationId).toBe("a1");
+    expect(calls.some((c) => c.fn === "applySharedAnnotations")).toBe(true);
+
+    unmount();
+  });
+
+  test("add-code-annotation: undo removes + restores selection; redo re-adds", () => {
+    const state: FakeState = {
+      annotations: [],
+      codeAnnotations: [],
+      globalAttachments: [],
+      selectedAnnotationId: null,
+      selectedCodeAnnotationId: null,
+      overrides: [],
+    };
+    const { viewer } = makeFakeViewer();
+    const { api, unmount } = mountHistory(makeOptions(state, viewer));
+
+    const ca = codeAnn("c1");
+    state.codeAnnotations = [ca];
+    state.selectedCodeAnnotationId = "c1";
+    api.push({ kind: "add-code-annotation", ann: ca, prevSelectedId: null, prevSelectedCodeId: null });
+
+    api.undo();
+    expect(state.codeAnnotations).toEqual([]);
+    expect(state.selectedCodeAnnotationId).toBe(null);
+
+    api.redo();
+    expect(state.codeAnnotations).toEqual([ca]);
+    expect(state.selectedCodeAnnotationId).toBe("c1");
+    unmount();
+  });
+
+  test("delete-annotation: undo re-adds and re-applies highlight; redo removes", () => {
+    const state: FakeState = {
+      annotations: [],
+      codeAnnotations: [],
+      globalAttachments: [],
+      selectedAnnotationId: "a1",
+      selectedCodeAnnotationId: null,
+      overrides: [],
+    };
+    const { viewer, calls } = makeFakeViewer();
+    const { api, unmount } = mountHistory(makeOptions(state, viewer));
+
+    const a = ann("a1", { originalText: "marked text" });
+    state.annotations = [];
+    state.selectedAnnotationId = null;
+    api.push({ kind: "delete-annotation", ann: a, prevSelectedId: "a1" });
+
+    api.undo();
+    expect(state.annotations).toEqual([a]);
+    expect(state.selectedAnnotationId).toBe("a1");
+    expect(calls.some((c) => c.fn === "applySharedAnnotations")).toBe(true);
+
+    calls.length = 0;
+    api.redo();
+    expect(state.annotations).toEqual([]);
+    expect(calls.some((c) => c.fn === "removeHighlight" && c.arg === "a1")).toBe(true);
+    unmount();
+  });
+
+  test("delete-code-annotation: undo re-adds; redo removes", () => {
+    const state: FakeState = {
+      annotations: [],
+      codeAnnotations: [],
+      globalAttachments: [],
+      selectedAnnotationId: null,
+      selectedCodeAnnotationId: "c1",
+      overrides: [],
+    };
+    const { viewer } = makeFakeViewer();
+    const { api, unmount } = mountHistory(makeOptions(state, viewer));
+
+    const ca = codeAnn("c1");
+    state.codeAnnotations = [];
+    state.selectedCodeAnnotationId = null;
+    api.push({ kind: "delete-code-annotation", ann: ca, prevSelectedCodeId: "c1" });
+
+    api.undo();
+    expect(state.codeAnnotations).toEqual([ca]);
+    expect(state.selectedCodeAnnotationId).toBe("c1");
+
+    api.redo();
+    expect(state.codeAnnotations).toEqual([]);
+    expect(state.selectedCodeAnnotationId).toBe(null);
+    unmount();
+  });
+
+  test("update-annotation: undo reverts fields; redo re-applies", () => {
+    const state: FakeState = {
+      annotations: [ann("a1", { text: "old" })],
+      codeAnnotations: [],
+      globalAttachments: [],
+      selectedAnnotationId: "a1",
+      selectedCodeAnnotationId: null,
+      overrides: [],
+    };
+    const { viewer } = makeFakeViewer();
+    const { api, unmount } = mountHistory(makeOptions(state, viewer));
+
+    const prevAnn = ann("a1", { text: "old" });
+    const nextAnn = ann("a1", { text: "new" });
+    state.annotations = [nextAnn];
+    api.push({ kind: "update-annotation", prevAnn, nextAnn });
+
+    api.undo();
+    expect(state.annotations[0].text).toBe("old");
+
+    api.redo();
+    expect(state.annotations[0].text).toBe("new");
+    unmount();
+  });
+
+  test("update-code-annotation: undo reverts; redo re-applies", () => {
+    const state: FakeState = {
+      annotations: [],
+      codeAnnotations: [codeAnn("c1", { text: "old" })],
+      globalAttachments: [],
+      selectedAnnotationId: null,
+      selectedCodeAnnotationId: "c1",
+      overrides: [],
+    };
+    const { viewer } = makeFakeViewer();
+    const { api, unmount } = mountHistory(makeOptions(state, viewer));
+
+    const prevAnn = codeAnn("c1", { text: "old" });
+    const nextAnn = codeAnn("c1", { text: "new" });
+    state.codeAnnotations = [nextAnn];
+    api.push({ kind: "update-code-annotation", prevAnn, nextAnn });
+
+    api.undo();
+    expect(state.codeAnnotations[0].text).toBe("old");
+    api.redo();
+    expect(state.codeAnnotations[0].text).toBe("new");
+    unmount();
+  });
+
+  test("add/remove-global-attachment round-trip", () => {
+    const state: FakeState = {
+      annotations: [],
+      codeAnnotations: [],
+      globalAttachments: [],
+      selectedAnnotationId: null,
+      selectedCodeAnnotationId: null,
+      overrides: [],
+    };
+    const { viewer } = makeFakeViewer();
+    const { api, unmount } = mountHistory(makeOptions(state, viewer));
+
+    const i = img("x.png");
+    state.globalAttachments = [i];
+    api.push({ kind: "add-global-attachment", img: i });
+    api.undo();
+    expect(state.globalAttachments).toEqual([]);
+    api.redo();
+    expect(state.globalAttachments).toEqual([i]);
+
+    state.globalAttachments = [];
+    api.push({ kind: "remove-global-attachment", img: i });
+    api.undo();
+    expect(state.globalAttachments).toEqual([i]);
+    api.redo();
+    expect(state.globalAttachments).toEqual([]);
+    unmount();
+  });
+
+  test("checkbox-toggle: undo restores overrides + checkbox annotations", () => {
+    const prevCheckboxAnns = [ann("ann-checkbox-b1-1", { blockId: "b1" })];
+    const nextCheckboxAnns = [ann("ann-checkbox-b1-2", { blockId: "b1" })];
+    const prevOverrides: OverrideSnapshot = [];
+    const nextOverrides: OverrideSnapshot = [["b1", true]];
+    const state: FakeState = {
+      annotations: [...nextCheckboxAnns],
+      codeAnnotations: [],
+      globalAttachments: [],
+      selectedAnnotationId: null,
+      selectedCodeAnnotationId: null,
+      overrides: nextOverrides,
+    };
+    const { viewer } = makeFakeViewer();
+    const { api, unmount } = mountHistory(makeOptions(state, viewer));
+
+    api.push({
+      kind: "checkbox-toggle",
+      blockId: "b1",
+      prevOverrides,
+      nextOverrides,
+      prevCheckboxAnns,
+      nextCheckboxAnns,
+    });
+
+    api.undo();
+    expect(state.overrides).toEqual(prevOverrides);
+    expect(state.annotations).toEqual(prevCheckboxAnns);
+
+    api.redo();
+    expect(state.overrides).toEqual(nextOverrides);
+    expect(state.annotations).toEqual(nextCheckboxAnns);
+    unmount();
+  });
+
+  test("identity-change: undo restores old author; redo re-applies new", () => {
+    const state: FakeState = {
+      annotations: [ann("a1", { author: "new" }), ann("a2", { author: "other" })],
+      codeAnnotations: [codeAnn("c1", { author: "new" })],
+      globalAttachments: [],
+      selectedAnnotationId: null,
+      selectedCodeAnnotationId: null,
+      overrides: [],
+    };
+    const { viewer } = makeFakeViewer();
+    const { api, unmount } = mountHistory(makeOptions(state, viewer));
+
+    api.push({
+      kind: "identity-change",
+      oldIdentity: "old",
+      newIdentity: "new",
+      affectedAnnIds: ["a1"],
+      affectedCodeAnnIds: ["c1"],
+    });
+
+    api.undo();
+    expect(state.annotations[0].author).toBe("old");
+    expect(state.annotations[1].author).toBe("other");
+    expect(state.codeAnnotations[0].author).toBe("old");
+
+    api.redo();
+    expect(state.annotations[0].author).toBe("new");
+    expect(state.codeAnnotations[0].author).toBe("new");
+    unmount();
+  });
+
+  test("push clears the redo stack", () => {
+    const state: FakeState = {
+      annotations: [],
+      codeAnnotations: [],
+      globalAttachments: [],
+      selectedAnnotationId: null,
+      selectedCodeAnnotationId: null,
+      overrides: [],
+    };
+    const { viewer } = makeFakeViewer();
+    const { api, unmount } = mountHistory(makeOptions(state, viewer));
+
+    const a = ann("a1");
+    state.annotations = [a];
+    api.push({ kind: "add-annotation", ann: a, prevSelectedId: null, prevSelectedCodeId: null });
+    api.undo();
+    expect(api.canRedo).toBe(true);
+
+    const b = ann("a2");
+    state.annotations = [b];
+    api.push({ kind: "add-annotation", ann: b, prevSelectedId: null, prevSelectedCodeId: null });
+    expect(api.canRedo).toBe(false);
+    expect(api.canUndo).toBe(true);
+    unmount();
+  });
+
+  test("bounded past cap drops oldest entries", () => {
+    const state: FakeState = {
+      annotations: [],
+      codeAnnotations: [],
+      globalAttachments: [],
+      selectedAnnotationId: null,
+      selectedCodeAnnotationId: null,
+      overrides: [],
+    };
+    const { viewer } = makeFakeViewer();
+    const { api, unmount } = mountHistory(makeOptions(state, viewer));
+
+    for (let i = 0; i < 60; i++) {
+      const a = ann(`a${i}`);
+      api.push({ kind: "add-annotation", ann: a, prevSelectedId: null, prevSelectedCodeId: null });
+    }
+    // cap is 50; undo should be possible 50 times, not 60.
+    let undos = 0;
+    while (api.canUndo) {
+      api.undo();
+      undos++;
+    }
+    expect(undos).toBe(50);
+    unmount();
+  });
+
+  test("clear empties both stacks", () => {
+    const state: FakeState = {
+      annotations: [],
+      codeAnnotations: [],
+      globalAttachments: [],
+      selectedAnnotationId: null,
+      selectedCodeAnnotationId: null,
+      overrides: [],
+    };
+    const { viewer } = makeFakeViewer();
+    const { api, unmount } = mountHistory(makeOptions(state, viewer));
+
+    const a = ann("a1");
+    api.push({ kind: "add-annotation", ann: a, prevSelectedId: null, prevSelectedCodeId: null });
+    api.undo();
+    expect(api.canUndo).toBe(false);
+    expect(api.canRedo).toBe(true);
+
+    api.clear();
+    expect(api.canUndo).toBe(false);
+    expect(api.canRedo).toBe(false);
+    unmount();
+  });
+
+  test("serialize/restore round-trip preserves past and future", () => {
+    const state: FakeState = {
+      annotations: [],
+      codeAnnotations: [],
+      globalAttachments: [],
+      selectedAnnotationId: null,
+      selectedCodeAnnotationId: null,
+      overrides: [],
+    };
+    const { viewer } = makeFakeViewer();
+    const { api, unmount } = mountHistory(makeOptions(state, viewer));
+
+    const a = ann("a1");
+    const b = ann("a2");
+    api.push({ kind: "add-annotation", ann: a, prevSelectedId: null, prevSelectedCodeId: null });
+    api.push({ kind: "add-annotation", ann: b, prevSelectedId: null, prevSelectedCodeId: null });
+    api.undo(); // past=[a], future=[b]
+    const snapshot = api.serialize();
+    expect(snapshot.past).toHaveLength(1);
+    expect(snapshot.future).toHaveLength(1);
+
+    api.clear();
+    expect(api.canUndo).toBe(false);
+
+    api.restore(snapshot);
+    expect(api.canUndo).toBe(true);
+    expect(api.canRedo).toBe(true);
+    // undo the remaining past entry -> back to empty
+    api.undo();
+    expect(api.canUndo).toBe(false);
+    unmount();
+  });
+
+  test("restore(undefined) clears", () => {
+    const state: FakeState = {
+      annotations: [],
+      codeAnnotations: [],
+      globalAttachments: [],
+      selectedAnnotationId: null,
+      selectedCodeAnnotationId: null,
+      overrides: [],
+    };
+    const { viewer } = makeFakeViewer();
+    const { api, unmount } = mountHistory(makeOptions(state, viewer));
+
+    api.push({ kind: "add-annotation", ann: ann("a1"), prevSelectedId: null, prevSelectedCodeId: null });
+    api.restore(undefined);
+    expect(api.canUndo).toBe(false);
+    expect(api.canRedo).toBe(false);
+    unmount();
+  });
+
+  test("undo/redo with empty stacks is a no-op", () => {
+    const state: FakeState = {
+      annotations: [],
+      codeAnnotations: [],
+      globalAttachments: [],
+      selectedAnnotationId: null,
+      selectedCodeAnnotationId: null,
+      overrides: [],
+    };
+    const { viewer } = makeFakeViewer();
+    const { api, unmount } = mountHistory(makeOptions(state, viewer));
+
+    expect(() => {
+      api.undo();
+      api.redo();
+    }).not.toThrow();
+    expect(api.canUndo).toBe(false);
+    expect(api.canRedo).toBe(false);
+    unmount();
+  });
+
+  test("multi-step: add three, undo all, redo all", () => {
+    const state: FakeState = {
+      annotations: [],
+      codeAnnotations: [],
+      globalAttachments: [],
+      selectedAnnotationId: null,
+      selectedCodeAnnotationId: null,
+      overrides: [],
+    };
+    const { viewer } = makeFakeViewer();
+    const { api, unmount } = mountHistory(makeOptions(state, viewer));
+
+    const ids = ["a1", "a2", "a3"];
+    for (const id of ids) {
+      const a = ann(id);
+      state.annotations = [...state.annotations, a];
+      api.push({ kind: "add-annotation", ann: a, prevSelectedId: null, prevSelectedCodeId: null });
+    }
+    expect(state.annotations.map((a) => a.id)).toEqual(ids);
+
+    api.undo();
+    api.undo();
+    api.undo();
+    expect(state.annotations).toEqual([]);
+
+    api.redo();
+    api.redo();
+    api.redo();
+    expect(state.annotations.map((a) => a.id)).toEqual(ids);
+    unmount();
+  });
+
+  test("update-annotation anchor change re-applies highlight on undo and redo", () => {
+    const state: FakeState = {
+      annotations: [ann("a1", { originalText: "old", blockId: "b1" })],
+      codeAnnotations: [],
+      globalAttachments: [],
+      selectedAnnotationId: "a1",
+      selectedCodeAnnotationId: null,
+      overrides: [],
+    };
+    const { viewer, calls } = makeFakeViewer();
+    const { api, unmount } = mountHistory(makeOptions(state, viewer));
+
+    const prevAnn = ann("a1", { originalText: "old", blockId: "b1" });
+    const nextAnn = ann("a1", { originalText: "new", blockId: "b2" });
+    state.annotations = [nextAnn];
+    api.push({ kind: "update-annotation", prevAnn, nextAnn });
+
+    calls.length = 0;
+    api.undo();
+    expect(calls.some((c) => c.fn === "applySharedAnnotations")).toBe(true);
+
+    calls.length = 0;
+    api.redo();
+    expect(calls.some((c) => c.fn === "applySharedAnnotations")).toBe(true);
+    unmount();
+  });
+});

--- a/packages/ui/hooks/useAnnotationHistory.ts
+++ b/packages/ui/hooks/useAnnotationHistory.ts
@@ -1,0 +1,376 @@
+/**
+ * Annotation History Hook — bounded undo/redo for plan-review actions.
+ *
+ * Implements the command-pattern stack described in
+ * `apps/pi-extension/UNDO_SPEC.md` §5. Each user-initiated annotation/comment
+ * action is recorded as an {@link AnnotationAction} carrying enough data to
+ * compute an inverse. `undo()` replays the inverse against the live React
+ * setters and the imperative `ViewerHandle`; `redo()` replays the original.
+ *
+ * The stack reuses the existing DOM-highlight imperative API
+ * (`removeHighlight` / `applySharedAnnotations`) — no new Viewer API is
+ * introduced. Inverse mutations flow through the same `setAnnotations` /
+ * `setCodeAnnotations` / `setGlobalAttachments` setters the app already uses,
+ * so the debounced draft auto-save (`useAnnotationDraft`) picks up undo/redo
+ * changes with no persistence-layer changes.
+ *
+ * Scope (v1): annotation add/edit/delete, code-annotation add/edit/delete,
+ * global-attachment add/remove, checkbox toggle, identity change. External
+ * (SSE) and VS Code editor annotations are non-undoable and never recorded.
+ * Direct markdown edits are non-undoable (CM6 owns native undo); the app clears
+ * this stack when committed markdown changes remap annotation anchors.
+ */
+
+import { useReducer, useRef } from "react";
+import type { Dispatch, RefObject, SetStateAction } from "react";
+import type { Annotation, CodeAnnotation, ImageAttachment } from "../types";
+import type { ViewerHandle } from "../components/Viewer";
+
+/** A serializable snapshot of the override map. */
+export type OverrideSnapshot = Array<[string, boolean]>;
+
+/**
+ * Discriminated union of every undoable v1 action. Each variant carries the
+ * data needed to compute both the undo (inverse) and redo (forward) passes.
+ *
+ * `prevAnn`/`nextAnn` (full snapshots) are used for edits rather than partial
+ * diffs so the inverse can re-apply DOM highlights when anchoring fields
+ * (`originalText` / `startMeta` / `endMeta` / `blockId`) change — see
+ * `anchorsEqual`.
+ */
+export type AnnotationAction =
+  | {
+      kind: "add-annotation";
+      ann: Annotation;
+      prevSelectedId: string | null;
+      prevSelectedCodeId: string | null;
+    }
+  | {
+      kind: "add-code-annotation";
+      ann: CodeAnnotation;
+      prevSelectedId: string | null;
+      prevSelectedCodeId: string | null;
+    }
+  | { kind: "add-global-attachment"; img: ImageAttachment }
+  | {
+      kind: "update-annotation";
+      prevAnn: Annotation;
+      nextAnn: Annotation;
+    }
+  | {
+      kind: "update-code-annotation";
+      prevAnn: CodeAnnotation;
+      nextAnn: CodeAnnotation;
+    }
+  | {
+      kind: "delete-annotation";
+      ann: Annotation;
+      prevSelectedId: string | null;
+    }
+  | {
+      kind: "delete-code-annotation";
+      ann: CodeAnnotation;
+      prevSelectedCodeId: string | null;
+    }
+  | { kind: "remove-global-attachment"; img: ImageAttachment }
+  | {
+      kind: "checkbox-toggle";
+      blockId: string;
+      prevOverrides: OverrideSnapshot;
+      nextOverrides: OverrideSnapshot;
+      prevCheckboxAnns: Annotation[];
+      nextCheckboxAnns: Annotation[];
+    }
+  | {
+      kind: "identity-change";
+      oldIdentity: string;
+      newIdentity: string;
+      affectedAnnIds: string[];
+      affectedCodeAnnIds: string[];
+    };
+
+/** JSON-serializable history snapshot for cross-surface stash/restore. */
+export interface SerializedHistory {
+  past: AnnotationAction[];
+  future: AnnotationAction[];
+}
+
+/** Live setters + selection accessors the hook drives inverses through. */
+export interface UseAnnotationHistoryOptions {
+  setAnnotations: Dispatch<SetStateAction<Annotation[]>>;
+  setCodeAnnotations: Dispatch<SetStateAction<CodeAnnotation[]>>;
+  setGlobalAttachments: Dispatch<SetStateAction<ImageAttachment[]>>;
+  viewerRef: RefObject<ViewerHandle | null>;
+  /** Replace the checkbox-override map. Accepts a serializable snapshot. */
+  applyOverrides: (next: OverrideSnapshot) => void;
+  getSelectedAnnotationId: () => string | null;
+  setSelectedAnnotationId: (id: string | null) => void;
+  getSelectedCodeAnnotationId: () => string | null;
+  setSelectedCodeAnnotationId: (id: string | null) => void;
+}
+
+export interface AnnotationHistoryApi {
+  canUndo: boolean;
+  canRedo: boolean;
+  /** Record an action's inverse onto the past stack; clears redo. */
+  push: (action: AnnotationAction) => void;
+  /** Replay the most recent action's inverse; pushes it onto the redo stack. */
+  undo: () => void;
+  /** Replay a previously undone action; pushes it back onto the past stack. */
+  redo: () => void;
+  /** Empty both stacks (bulk baseline loads, terminal decision). */
+  clear: () => void;
+  /** Snapshot both stacks for stashing across surface switches. */
+  serialize: () => SerializedHistory;
+  /** Replace both stacks from a snapshot (undefined → cleared). */
+  restore: (snapshot: SerializedHistory | undefined) => void;
+}
+
+/** Bounded past depth — oldest entries are dropped under pressure. */
+const MAX_PAST = 50;
+
+function anchorsEqual(a: Annotation, b: Annotation): boolean {
+  return (
+    a.originalText === b.originalText &&
+    a.blockId === b.blockId &&
+    a.startMeta?.parentTagName === b.startMeta?.parentTagName &&
+    a.startMeta?.parentIndex === b.startMeta?.parentIndex &&
+    a.startMeta?.textOffset === b.startMeta?.textOffset &&
+    a.endMeta?.parentTagName === b.endMeta?.parentTagName &&
+    a.endMeta?.parentIndex === b.endMeta?.parentIndex &&
+    a.endMeta?.textOffset === b.endMeta?.textOffset
+  );
+}
+
+/** True for annotations that own a DOM highlight (web-highlighter or code wrap). */
+function hasHighlight(a: Annotation): boolean {
+  return (
+    !a.diffContext &&
+    a.type !== ("GLOBAL_COMMENT" as Annotation["type"]) &&
+    !a.id.startsWith("ann-checkbox-")
+  );
+}
+
+export function useAnnotationHistory(
+  options: UseAnnotationHistoryOptions,
+): AnnotationHistoryApi {
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+  const [, forceUpdate] = useReducer((n: number) => n + 1, 0);
+  const controllerRef = useRef<AnnotationHistoryApi | null>(null);
+
+  if (!controllerRef.current) {
+    controllerRef.current = createAnnotationHistoryController(
+      () => optionsRef.current,
+      forceUpdate,
+    );
+  }
+
+  return controllerRef.current;
+}
+
+/**
+ * Pure controller behind the React hook. Tests use this directly so undo/redo
+ * semantics run in default `bun test` without requiring a DOM-backed renderer.
+ */
+export function createAnnotationHistoryController(
+  getOptions: () => UseAnnotationHistoryOptions,
+  onChange: () => void = () => {},
+): AnnotationHistoryApi {
+  let past: AnnotationAction[] = [];
+  let future: AnnotationAction[] = [];
+
+  const applyUndo = (action: AnnotationAction) => {
+    const o = getOptions();
+    switch (action.kind) {
+      case "add-annotation": {
+        o.viewerRef.current?.removeHighlight(action.ann.id);
+        o.setAnnotations((prev) => prev.filter((a) => a.id !== action.ann.id));
+        o.setSelectedAnnotationId(action.prevSelectedId);
+        o.setSelectedCodeAnnotationId(action.prevSelectedCodeId);
+        break;
+      }
+      case "add-code-annotation": {
+        o.setCodeAnnotations((prev) => prev.filter((a) => a.id !== action.ann.id));
+        o.setSelectedAnnotationId(action.prevSelectedId);
+        o.setSelectedCodeAnnotationId(action.prevSelectedCodeId);
+        break;
+      }
+      case "add-global-attachment": {
+        o.setGlobalAttachments((prev) => prev.filter((p) => p.path !== action.img.path));
+        break;
+      }
+      case "update-annotation": {
+        o.setAnnotations((prev) => prev.map((a) => (a.id === action.prevAnn.id ? action.prevAnn : a)));
+        if (hasHighlight(action.prevAnn) && !anchorsEqual(action.prevAnn, action.nextAnn)) {
+          o.viewerRef.current?.removeHighlight(action.prevAnn.id);
+          o.viewerRef.current?.applySharedAnnotations([action.prevAnn]);
+        }
+        break;
+      }
+      case "update-code-annotation": {
+        o.setCodeAnnotations((prev) => prev.map((a) => (a.id === action.prevAnn.id ? action.prevAnn : a)));
+        break;
+      }
+      case "delete-annotation": {
+        o.setAnnotations((prev) => [...prev, action.ann]);
+        if (hasHighlight(action.ann)) {
+          o.viewerRef.current?.applySharedAnnotations([action.ann]);
+        }
+        o.setSelectedAnnotationId(action.prevSelectedId);
+        break;
+      }
+      case "delete-code-annotation": {
+        o.setCodeAnnotations((prev) => [...prev, action.ann]);
+        o.setSelectedCodeAnnotationId(action.prevSelectedCodeId);
+        break;
+      }
+      case "remove-global-attachment": {
+        o.setGlobalAttachments((prev) => [...prev, action.img]);
+        break;
+      }
+      case "checkbox-toggle": {
+        o.applyOverrides(action.prevOverrides);
+        o.setAnnotations((prev) => [
+          ...prev.filter(
+            (a) => !(a.blockId === action.blockId && a.id.startsWith("ann-checkbox-")),
+          ),
+          ...action.prevCheckboxAnns,
+        ]);
+        break;
+      }
+      case "identity-change": {
+        o.setAnnotations((prev) =>
+          prev.map((a) =>
+            action.affectedAnnIds.includes(a.id) ? { ...a, author: action.oldIdentity } : a,
+          ),
+        );
+        o.setCodeAnnotations((prev) =>
+          prev.map((a) =>
+            action.affectedCodeAnnIds.includes(a.id) ? { ...a, author: action.oldIdentity } : a,
+          ),
+        );
+        break;
+      }
+    }
+  };
+
+  const applyRedo = (action: AnnotationAction) => {
+    const o = getOptions();
+    switch (action.kind) {
+      case "add-annotation": {
+        o.setAnnotations((prev) => [...prev, action.ann]);
+        if (hasHighlight(action.ann)) {
+          o.viewerRef.current?.applySharedAnnotations([action.ann]);
+        }
+        o.setSelectedAnnotationId(action.ann.id);
+        o.setSelectedCodeAnnotationId(null);
+        break;
+      }
+      case "add-code-annotation": {
+        o.setCodeAnnotations((prev) => [...prev, action.ann]);
+        o.setSelectedAnnotationId(null);
+        o.setSelectedCodeAnnotationId(action.ann.id);
+        break;
+      }
+      case "add-global-attachment": {
+        o.setGlobalAttachments((prev) => [...prev, action.img]);
+        break;
+      }
+      case "update-annotation": {
+        o.setAnnotations((prev) => prev.map((a) => (a.id === action.nextAnn.id ? action.nextAnn : a)));
+        if (hasHighlight(action.nextAnn) && !anchorsEqual(action.prevAnn, action.nextAnn)) {
+          o.viewerRef.current?.removeHighlight(action.nextAnn.id);
+          o.viewerRef.current?.applySharedAnnotations([action.nextAnn]);
+        }
+        break;
+      }
+      case "update-code-annotation": {
+        o.setCodeAnnotations((prev) => prev.map((a) => (a.id === action.nextAnn.id ? action.nextAnn : a)));
+        break;
+      }
+      case "delete-annotation": {
+        o.viewerRef.current?.removeHighlight(action.ann.id);
+        o.setAnnotations((prev) => prev.filter((a) => a.id !== action.ann.id));
+        // removeAnnotation cleared selection only when the deleted ann was selected.
+        o.setSelectedAnnotationId(action.prevSelectedId === action.ann.id ? null : action.prevSelectedId);
+        break;
+      }
+      case "delete-code-annotation": {
+        o.setCodeAnnotations((prev) => prev.filter((a) => a.id !== action.ann.id));
+        o.setSelectedCodeAnnotationId(
+          action.prevSelectedCodeId === action.ann.id ? null : action.prevSelectedCodeId,
+        );
+        break;
+      }
+      case "remove-global-attachment": {
+        o.setGlobalAttachments((prev) => prev.filter((p) => p.path !== action.img.path));
+        break;
+      }
+      case "checkbox-toggle": {
+        o.applyOverrides(action.nextOverrides);
+        o.setAnnotations((prev) => [
+          ...prev.filter(
+            (a) => !(a.blockId === action.blockId && a.id.startsWith("ann-checkbox-")),
+          ),
+          ...action.nextCheckboxAnns,
+        ]);
+        break;
+      }
+      case "identity-change": {
+        o.setAnnotations((prev) =>
+          prev.map((a) =>
+            action.affectedAnnIds.includes(a.id) ? { ...a, author: action.newIdentity } : a,
+          ),
+        );
+        o.setCodeAnnotations((prev) =>
+          prev.map((a) =>
+            action.affectedCodeAnnIds.includes(a.id) ? { ...a, author: action.newIdentity } : a,
+          ),
+        );
+        break;
+      }
+    }
+  };
+
+  return {
+    get canUndo() {
+      return past.length > 0;
+    },
+    get canRedo() {
+      return future.length > 0;
+    },
+    push(action: AnnotationAction) {
+      past = [...past, action].slice(-MAX_PAST);
+      future = [];
+      onChange();
+    },
+    undo() {
+      const action = past.pop();
+      if (!action) return;
+      applyUndo(action);
+      future = [...future, action];
+      onChange();
+    },
+    redo() {
+      const action = future.pop();
+      if (!action) return;
+      applyRedo(action);
+      past = [...past, action].slice(-MAX_PAST);
+      onChange();
+    },
+    clear() {
+      past = [];
+      future = [];
+      onChange();
+    },
+    serialize(): SerializedHistory {
+      return { past: [...past], future: [...future] };
+    },
+    restore(snapshot: SerializedHistory | undefined) {
+      past = snapshot ? [...snapshot.past] : [];
+      future = snapshot ? [...snapshot.future] : [];
+      onChange();
+    },
+  };
+}

--- a/packages/ui/hooks/useLinkedDoc.ts
+++ b/packages/ui/hooks/useLinkedDoc.ts
@@ -11,6 +11,7 @@ import type { Annotation, ImageAttachment } from "../types";
 import type { ViewerHandle } from "../components/Viewer";
 import type { SidebarTab } from "./useSidebar";
 import type { SourceSaveCapability } from "@plannotator/shared/source-save";
+import type { SerializedHistory } from "./useAnnotationHistory";
 
 export interface LinkedDocLoadData {
   markdown?: string;
@@ -56,6 +57,10 @@ export interface UseLinkedDocOptions {
   getDocumentMarkdown?: (filepath: string, fallback?: string) => string | undefined;
   /** Let the host restore any state that was suspended while a linked doc was active. */
   onAfterBack?: () => void;
+  /** Snapshot the host's undo/redo stack before a surface swap. */
+  serializeHistory?: () => SerializedHistory | undefined;
+  /** Restore the host's undo/redo stack after a surface swap (undefined = clear). */
+  restoreHistory?: (snapshot: SerializedHistory | undefined) => void;
 }
 
 interface SavedPlanState {
@@ -66,6 +71,8 @@ interface SavedPlanState {
   renderAs: 'markdown' | 'html';
   rawHtml: string;
   shareHtml: string;
+  /** Stashed undo/redo stack for this surface (cross-document navigation). */
+  history?: SerializedHistory;
 }
 
 export interface CachedDocState {
@@ -73,6 +80,8 @@ export interface CachedDocState {
   globalAttachments: ImageAttachment[];
   markdown?: string;
   isConverted?: boolean;
+  /** Stashed undo/redo stack for this linked-doc surface. */
+  history?: SerializedHistory;
 }
 
 export interface LinkedDocSessionState {
@@ -137,6 +146,8 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
     onDocumentLoaded,
     getDocumentMarkdown,
     onAfterBack,
+    serializeHistory,
+    restoreHistory,
   } = options;
 
   const [linkedDoc, setLinkedDoc] = useState<{ filepath: string; isConverted?: boolean; markdown?: string } | null>(null);
@@ -169,6 +180,7 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
         globalAttachments: [...globalAttachments],
         markdown: getDocumentMarkdown?.(linkedDoc.filepath, linkedDoc.markdown) ?? linkedDoc.markdown,
         isConverted: linkedDoc.isConverted,
+        history: serializeHistory?.(),
       });
       // Update reactive count so button labels can respond
       let total = 0;
@@ -187,6 +199,8 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
     setAnnotations(saved.annotations);
     setGlobalAttachments(saved.globalAttachments);
     setSelectedAnnotationId(saved.selectedAnnotationId);
+    // Restore the root surface's undo/redo stack.
+    restoreHistory?.(saved.history);
     setLinkedDoc(null);
     setError(null);
     savedPlanState.current = null;
@@ -214,6 +228,8 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
     onBeforeNavigate,
     getDocumentMarkdown,
     onAfterBack,
+    serializeHistory,
+    restoreHistory,
   ]);
 
   const activateDocument = useCallback((
@@ -250,6 +266,7 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
         renderAs,
         rawHtml,
         shareHtml,
+        history: serializeHistory?.(),
       };
       let total = annotations.length + globalAttachments.length;
       for (const [fp, cached] of docCache.current.entries()) {
@@ -264,6 +281,7 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
         globalAttachments: [...globalAttachments],
         markdown: getDocumentMarkdown?.(linkedDoc.filepath, linkedDoc.markdown) ?? linkedDoc.markdown,
         isConverted: linkedDoc.isConverted,
+        history: serializeHistory?.(),
       });
       let total = 0;
       for (const [fp, cached] of docCache.current.entries()) {
@@ -302,6 +320,10 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
     setError(null);
     sidebar.open(targetTab ?? "toc");
 
+    // Swap the undo/redo stack to the destination surface: restore a
+    // previously-visited doc's stashed history, or clear for a fresh doc.
+    restoreHistory?.(cached?.history);
+
     // Re-apply cached annotations after DOM settles
     if (cached?.annotations.length) {
       setTimeout(() => {
@@ -332,6 +354,8 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
     onDocumentLoaded,
     getDocumentMarkdown,
     back,
+    serializeHistory,
+    restoreHistory,
   ]);
 
   const openLoaded = useCallback((
@@ -391,6 +415,7 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
         globalAttachments: [...globalAttachments],
         markdown: getDocumentMarkdown?.(linkedDoc.filepath, linkedDoc.markdown) ?? linkedDoc.markdown,
         isConverted: linkedDoc.isConverted,
+        history: serializeHistory?.(),
       });
     }
 
@@ -403,6 +428,7 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
           annotations: [...savedPlanState.current.annotations],
           selectedAnnotationId: savedPlanState.current.selectedAnnotationId,
           globalAttachments: [...savedPlanState.current.globalAttachments],
+          history: savedPlanState.current.history,
         }
       : {
           markdown,
@@ -412,10 +438,11 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
           annotations: [...annotations],
           selectedAnnotationId,
           globalAttachments: [...globalAttachments],
+          history: serializeHistory?.(),
         };
 
     return { root, docs };
-  }, [linkedDoc, annotations, globalAttachments, markdown, renderAs, rawHtml, shareHtml, selectedAnnotationId, getDocumentMarkdown]);
+  }, [linkedDoc, annotations, globalAttachments, markdown, renderAs, rawHtml, shareHtml, selectedAnnotationId, getDocumentMarkdown, serializeHistory]);
 
   const restoreSession = useCallback((state: LinkedDocSessionState) => {
     viewerRef.current?.clearAllHighlights();
@@ -435,6 +462,8 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
     setAnnotations([...state.root.annotations]);
     setGlobalAttachments([...state.root.globalAttachments]);
     setSelectedAnnotationId(state.root.selectedAnnotationId);
+    // Restore the root surface's undo/redo stack.
+    restoreHistory?.(state.root.history);
     setLinkedDoc(null);
     setError(null);
 
@@ -453,6 +482,7 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
     setRawHtml,
     setShareHtml,
     viewerRef,
+    restoreHistory,
   ]);
 
   const getDocAnnotations = useCallback((): Map<string, CachedDocState> => {

--- a/packages/ui/shortcuts.test.ts
+++ b/packages/ui/shortcuts.test.ts
@@ -76,6 +76,7 @@ describe('shortcuts', () => {
       'Input Method',
       'Annotations',
       'Image Annotator',
+      'History',
     ]);
 
     expect(annotateSections.map(section => section.title)).toEqual([
@@ -83,6 +84,7 @@ describe('shortcuts', () => {
       'Input Method',
       'Annotations',
       'Image Annotator',
+      'History',
     ]);
 
     expect(getShortcut(planReviewSettingsShortcutRegistry, 'plan-review-editor-settings', 'submitPlan')?.description).toBe('Approve / Send feedback');

--- a/packages/ui/shortcuts/index.ts
+++ b/packages/ui/shortcuts/index.ts
@@ -9,6 +9,7 @@ export { imageAnnotatorShortcuts, useImageAnnotatorShortcuts } from './plan-revi
 export { inputMethodShortcuts } from './plan-review/inputMethod.shortcuts';
 export { viewerShortcuts, useViewerShortcuts } from './plan-review/viewer.shortcuts';
 export { goalSetupShortcuts, useGoalSetupShortcuts } from './plan-review/goalSetup.shortcuts';
+export { historyShortcuts, useHistoryShortcuts } from './plan-review/history.shortcuts';
 
 // code-review scopes
 export { reviewAnnotationToolbarShortcuts, useReviewAnnotationToolbarShortcuts } from './code-review/annotationToolbar.shortcuts';

--- a/packages/ui/shortcuts/plan-review/history.shortcuts.ts
+++ b/packages/ui/shortcuts/plan-review/history.shortcuts.ts
@@ -1,0 +1,36 @@
+import { defineShortcutScope } from '../core';
+import { createShortcutScopeHook } from '../runtime';
+
+/**
+ * Undo/redo shortcut scope for the plan-review surface.
+ *
+ * `Mod+Z` / `Mod+Shift+Z` (and `Mod+Y`) are gated in `App.tsx`'s global keydown
+ * handler so they only fire at the plan-review surface when no other owner is
+ * active (CM6 markdown editor, Image Annotator, modals, comment popover). The
+ * Image Annotator's own `undo` scope (`imageAnnotator.shortcuts.ts`) takes
+ * precedence while the image annotator modal is open.
+ */
+export const historyShortcuts = defineShortcutScope({
+  id: 'history',
+  title: 'Undo / Redo',
+  shortcuts: {
+    undo: {
+      description: 'Undo last action',
+      bindings: ['Mod+Z'],
+      section: 'History',
+      hint: 'Reverses the last annotation, comment, code annotation, attachment, checkbox toggle, or identity change. Disabled while editing markdown, the Image Annotator is open, or a modal is visible.',
+      preventDefault: true,
+      displayOrder: 10,
+    },
+    redo: {
+      description: 'Redo last undone action',
+      bindings: ['Mod+Shift+Z', 'Mod+Y'],
+      section: 'History',
+      hint: 'Re-applies the most recently undone action.',
+      preventDefault: true,
+      displayOrder: 20,
+    },
+  },
+});
+
+export const useHistoryShortcuts = createShortcutScopeHook(historyShortcuts);


### PR DESCRIPTION
 (done completely with GPT5.5)
 
 ## Summary
  - Add bounded undo/redo support for annotation actions, code annotations, attachments, checkbox toggles, and identity
  changes.
  - Wire history through linked-doc/message navigation, draft restore, direct markdown edits, submit/exit flows, and
  shortcut handling.
  - Add focused undo/redo tests plus root TypeScript dependency so `bun run typecheck` works from a fresh install.

  ## Implementation
  The core is a small command-stack controller in `useAnnotationHistory`, with each undoable action carrying enough state
  to replay its inverse and redo. `App.tsx` keeps ownership of lifecycle boundaries, while annotation mutations are routed
  through `useAnnotationCommands` so history recording stays centralized. Shortcuts use the existing shortcut registry,
  and linked-doc/message switching serializes or restores the relevant history stack with the rest of the surface state.

  ## Verification
  - `bun test`
  - `bun run typecheck`
  - `git diff --check`