### PR TITLE
fix(server): surface session URL in local mode when the browser can't open

### DIFF
--- a/packages/server/agent-terminal-node-sidecar.mjs
+++ b/packages/server/agent-terminal-node-sidecar.mjs
@@ -1,3 +1,5 @@
+// Runs under Node.js, not Bun: it hosts node-pty, a native addon Bun can't
+// load. The parent Bun server spawns this sidecar (see agent-terminal-runtime.ts).
 import { createServer } from "node:http";
 
 const webtuiCoreUrl = process.env.PLANNOTATOR_AGENT_WEBTUI_CORE_URL || "@plannotator/webtui/core";

--- a/packages/server/agent-terminal-runtime.ts
+++ b/packages/server/agent-terminal-runtime.ts
@@ -1,3 +1,21 @@
+/**
+ * Agent-terminal runtime resolution.
+ *
+ * Why this exists: Bun cannot dlopen the native `node-pty` addon, so the PTY
+ * can't run in-process. Instead it runs in a spawned **Node.js (>=20)** sidecar
+ * (`agent-terminal-node-sidecar.mjs`), which imports `@plannotator/webtui`'s
+ * server (the package that owns node-pty). This module's job is to locate a
+ * usable Node + sidecar + webtui runtime, in one of two modes:
+ *
+ *   - **bundled (dev):** the sidecar `.mjs` is on real disk next to this source,
+ *     so Node resolves webtui/node-pty straight from the repo's node_modules.
+ *   - **managed (compiled release binary):** the sidecar is a Bun *virtual*
+ *     path (not real disk), so we materialize it to the data dir and rely on a
+ *     webtui runtime `npm install`-ed there ahead of time by
+ *     `plannotator install-runtime agent-terminal` (run by scripts/install.sh).
+ *
+ * See ADR adr/implementation/annotate-agent-terminal.md for the full design.
+ */
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -76,6 +94,12 @@ export async function resolveAgentTerminalRuntime(): Promise<ResolvedAgentTermin
   const nodeCheck = await checkNodeVersion(nodePath);
   if (!nodeCheck.ok) return nodeCheck;
 
+  // Prefer the bundled (dev) sidecar when it's on real disk; fall back to the
+  // managed runtime otherwise. `resolveBundledAgentTerminalSidecarPath` returns
+  // null when the path is a Bun *virtual* path — i.e. we're running from the
+  // compiled binary — which is exactly how we distinguish dev from a release
+  // build. Bundled resolution can also fail its preflight (e.g. webtui not in
+  // the repo node_modules), in which case we still try the managed runtime.
   const bundledSidecarPath = resolveBundledAgentTerminalSidecarPath();
   if (bundledSidecarPath) {
     const bundledRuntime = await resolveBundledAgentTerminalRuntime(nodePath, bundledSidecarPath);

--- a/packages/server/shared-handlers.test.ts
+++ b/packages/server/shared-handlers.test.ts
@@ -137,7 +137,7 @@ describe("handleServerReady", () => {
     expect(writes.join("")).toContain("http://localhost:19432");
   });
 
-  test("does not print the URL for a local session (browser opens instead)", async () => {
+  test("does not print the URL for a local session when the browser opens", async () => {
     const writes: string[] = [];
     let opened = "";
     const original = process.stderr.write.bind(process.stderr);
@@ -149,6 +149,7 @@ describe("handleServerReady", () => {
       await handleServerReady("http://localhost:3000", false, 3000, {
         openBrowser: async (u: string) => {
           opened = u;
+          return true;
         },
       });
     } finally {
@@ -156,5 +157,25 @@ describe("handleServerReady", () => {
     }
     expect(writes.join("")).not.toContain("http://localhost:3000");
     expect(opened).toBe("http://localhost:3000");
+  });
+
+  // Regression: a local session whose browser can't be opened (headless box,
+  // devcontainer with no display) must still surface the URL, or the agent
+  // hangs at waitForDecision with the user having no link to visit.
+  test("prints the URL for a local session when the browser fails to open", async () => {
+    const writes: string[] = [];
+    const original = process.stderr.write.bind(process.stderr);
+    (process.stderr as { write: unknown }).write = (chunk: unknown) => {
+      writes.push(String(chunk));
+      return true;
+    };
+    try {
+      await handleServerReady("http://localhost:4000", false, 4000, {
+        openBrowser: async () => false,
+      });
+    } finally {
+      (process.stderr as { write: unknown }).write = original;
+    }
+    expect(writes.join("")).toContain("http://localhost:4000");
   });
 });

--- a/packages/server/shared-handlers.ts
+++ b/packages/server/shared-handlers.ts
@@ -208,7 +208,15 @@ export async function handleServerReady(
   const skipBrowserOpen = options.skipBrowserOpen ?? process.env.PLANNOTATOR_SKIP_BROWSER_OPEN === "1";
   if (skipBrowserOpen) return;
 
-  await (options.openBrowser ?? openBrowserImpl)(url, { isRemote, useGlimpse: true });
+  const opened = await (options.openBrowser ?? openBrowserImpl)(url, { isRemote, useGlimpse: true });
+
+  // Local fallback lifeline: if the browser couldn't be opened (headless box,
+  // devcontainer with no display, broken open/xdg-open), the user otherwise has
+  // no URL and the agent hangs at waitForDecision. Remote already printed the
+  // URL above; only cover the local case here to avoid a double print.
+  if (!opened && !isRemote) {
+    process.stderr.write(`\n  Plannotator session ready — open in your browser:\n  ${url}\n\n`);
+  }
 }
 
 /** Save to external note apps (Obsidian, Bear, Octarine). Used by plan + annotate servers. */


### PR DESCRIPTION
## What
`handleServerReady` only printed the reachable URL for **remote** sessions. In **local** mode, if `openBrowser()` failed (headless box, devcontainer with no display, broken `open`/`xdg-open`), nothing surfaced the URL and the agent hung at `waitForDecision` with the user having no link to visit.

## Fix
- Capture `openBrowser()`'s boolean result; on a **local** failure, print the URL to stderr.
- Gated on `!isRemote` (remote already prints above) — no double print.
- Writes to **stderr**, never stdout, so it can't touch the approve/deny decision channel.
- Skips entirely in host-plugin mode (`skipBrowserOpen` early-returns before this).
- Single chokepoint: covers **plan, review, and annotate**. Mirrors the Pi extension's existing `!opened -> notify(url)` behavior.

## Tests
- Updated the local-open test to return a successful open (no print).
- Added a regression test: local + browser fails ⇒ URL is printed.
- `shared-handlers.test.ts`: 9/9 pass · typecheck clean · build:hook OK.

## Also
Adds explanatory comments to the agent-terminal sidecar/runtime (why the Node sidecar exists; dev vs release resolution) — docs only.

## Not covered
Some headless setups where `open` reports success even when nothing renders — `openBrowser` returns true there, so the fallback won't fire. Strictly better than today (which never prints locally) and never prints spuriously.