### PR TITLE
fix(editor): stop setState-during-render loop in multi-message annotate (#949)

### DIFF
--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -896,7 +896,14 @@ const App: React.FC = () => {
 
   const buildMessageAnnotationEntries = React.useCallback((): MessageAnnotationEntry[] => {
     if (annotateSource !== 'message' || recentMessages.length === 0) return [];
-    const states = saveCurrentMessageState();
+    // Must be a PURE read: this runs on the render path via
+    // currentFeedbackPayload (useMemo) -> getCurrentFeedbackPayload ->
+    // buildFullAnnotationsOutput. saveCurrentMessageState() writes React state
+    // (setCachedMessageAnnotationCounts), which during render is an infinite
+    // re-render loop in multi-message mode (#949). getMessageStatesWithCurrent
+    // returns the same merged data without the setState side effect; the cache
+    // persistence happens in event handlers (handleSelectMessage) instead.
+    const states = getMessageStatesWithCurrent();
     return recentMessages.map((msg) => {
       const state = states.get(msg.messageId) ?? createEmptyMessageState(msg);
       const linkedDocs: Map<string, LinkedDocAnnotationEntry> = new Map();
@@ -917,7 +924,7 @@ const App: React.FC = () => {
         codeAnnotations: state.codeAnnotations,
       };
     });
-  }, [annotateSource, recentMessages, saveCurrentMessageState]);
+  }, [annotateSource, recentMessages, getMessageStatesWithCurrent]);
 
   const activeMessageAnnotationCounts = React.useMemo(() => {
     const counts = new Map(cachedMessageAnnotationCounts);


### PR DESCRIPTION
## What

`/plannotator-last` renders a **blank page on Pi** whenever the session has **2+ assistant messages**. React throws `#301` ("Too many re-renders") before the UI draws.

## Root cause (verified in our code)

`buildMessageAnnotationEntries()` runs on the **render path**:

```
currentFeedbackPayload = useMemo(() => getCurrentFeedbackPayload(), […])   // App.tsx:2482, render
  └ getCurrentFeedbackPayload()        // 1957 — if messageMultiSelectMode →
     └ buildFullAnnotationsOutput()    // 1200 →
        └ buildMessageAnnotationEntries()  // 899 →
           └ saveCurrentMessageState()     // 893 →
              └ setCachedMessageAnnotationCounts(buildMessageAnnotationCounts(states))  // setState during render
```

`buildMessageAnnotationCounts` returns a **fresh `Map`** each call, so `Object.is` never bails → infinite re-render. The branch only runs when `messageMultiSelectMode = annotateSource === 'message' && recentMessages.length > 1` — which is why **1 message works, 2+ crashes**.

Introduced by `1fa60522` (predates v0.21.0; present since v0.20.3).

## Fix (2 lines)

Switch the render-path read from `saveCurrentMessageState()` (writes state) to `getMessageStatesWithCurrent()` (pure read of the same merged data). Cache persistence still happens where it belongs — in event handlers (`handleSelectMessage`). Exported feedback output is byte-identical.

## Verification

- `bun run typecheck` clean
- `bun run build:hook` clean

## Credit

Reported, root-caused, and fixed by @emmaneugene in #949 (diagnosis confirmed independently against current main; their suggested change applied).

Closes #949