### PR TITLE
fix(opencode): honor cli runtime for command routing

### DIFF
--- a/apps/opencode-plugin/index.test.ts
+++ b/apps/opencode-plugin/index.test.ts
@@ -1,0 +1,254 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import PlannotatorPlugin from "./index";
+
+const tempDirs: string[] = [];
+const originalPlannotatorBin = process.env.PLANNOTATOR_BIN;
+const originalShareUrl = process.env.PLANNOTATOR_SHARE_URL;
+const originalPasteUrl = process.env.PLANNOTATOR_PASTE_URL;
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "plannotator-opencode-index-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function installFakeCli(tempDir: string): {
+  argsFile: string;
+  stdinFile: string;
+} {
+  const argsFile = path.join(tempDir, "args.txt");
+  const stdinFile = path.join(tempDir, "stdin.json");
+  const fakeCli = path.join(tempDir, "plannotator-cli");
+  writeFileSync(fakeCli, `#!/bin/sh
+printf '%s\\n' "$@" > "$PLANNOTATOR_TEST_ARGS_FILE"
+cat > "$PLANNOTATOR_TEST_STDIN_FILE"
+printf '%s\\n' '{"decision":"dismissed"}'
+`);
+  chmodSync(fakeCli, 0o755);
+
+  process.env.PLANNOTATOR_BIN = fakeCli;
+  process.env.PLANNOTATOR_TEST_ARGS_FILE = argsFile;
+  process.env.PLANNOTATOR_TEST_STDIN_FILE = stdinFile;
+  process.env.PLANNOTATOR_SHARE_URL = "https://share.example.test";
+  process.env.PLANNOTATOR_PASTE_URL = "https://paste.example.test";
+
+  return { argsFile, stdinFile };
+}
+
+function makeClient(messages: any[] = []) {
+  return {
+    app: {
+      log: mock((_entry: unknown) => {}),
+      agents: mock(async (_input: unknown) => ({ data: [{ name: "build" }] })),
+    },
+    config: {
+      get: mock(async (_input: unknown) => ({ data: { share: "disabled" } })),
+    },
+    session: {
+      messages: mock(async (_input: unknown) => ({ data: messages })),
+      prompt: mock(async (_input: unknown) => {}),
+    },
+  };
+}
+
+function hideBundledHtml(): () => void {
+  const pluginDir = path.dirname(fileURLToPath(import.meta.url));
+  const restorePairs: Array<{ hiddenPath: string; originalPath: string }> = [];
+
+  for (const filename of ["plannotator.html", "review-editor.html"]) {
+    for (const originalPath of [
+      path.join(pluginDir, filename),
+      path.join(pluginDir, "..", filename),
+    ]) {
+      if (!existsSync(originalPath)) continue;
+      const hiddenPath = path.join(makeTempDir(), filename);
+      renameSync(originalPath, hiddenPath);
+      restorePairs.push({ hiddenPath, originalPath });
+    }
+  }
+
+  return () => {
+    for (const { hiddenPath, originalPath } of restorePairs.reverse()) {
+      if (!existsSync(hiddenPath) || existsSync(originalPath)) continue;
+      renameSync(hiddenPath, originalPath);
+    }
+  };
+}
+
+afterEach(() => {
+  if (originalPlannotatorBin === undefined) {
+    delete process.env.PLANNOTATOR_BIN;
+  } else {
+    process.env.PLANNOTATOR_BIN = originalPlannotatorBin;
+  }
+  if (originalShareUrl === undefined) {
+    delete process.env.PLANNOTATOR_SHARE_URL;
+  } else {
+    process.env.PLANNOTATOR_SHARE_URL = originalShareUrl;
+  }
+  if (originalPasteUrl === undefined) {
+    delete process.env.PLANNOTATOR_PASTE_URL;
+  } else {
+    process.env.PLANNOTATOR_PASTE_URL = originalPasteUrl;
+  }
+  delete process.env.PLANNOTATOR_TEST_ARGS_FILE;
+  delete process.env.PLANNOTATOR_TEST_STDIN_FILE;
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("OpenCode plugin command hook", () => {
+  test("runtime cli routes plannotator-last through the CLI bridge even when embedded is available", async () => {
+    const tempDir = makeTempDir();
+    const { argsFile, stdinFile } = installFakeCli(tempDir);
+    const client = makeClient([
+      {
+        info: { role: "assistant", id: "older", time: { created: 1_700_000_000_000 } },
+        parts: [{ type: "text", text: "Older assistant message" }],
+      },
+      {
+        info: { role: "assistant", id: "latest", time: { created: 1_700_000_001_000 } },
+        parts: [{ type: "text", text: "Latest assistant message" }],
+      },
+    ]);
+
+    const plugin = await PlannotatorPlugin(
+      { client, directory: tempDir } as any,
+      { workflow: "manual", runtime: "cli" },
+    ) as any;
+    const output = { parts: [{ type: "text", text: "command body" }] };
+
+    await plugin["command.execute.before"](
+      {
+        command: "plannotator-last",
+        sessionID: "session-123",
+        arguments: "--gate",
+      },
+      output,
+    );
+
+    expect(output.parts).toEqual([]);
+    expect(readFileSync(argsFile, "utf-8").trim()).toBe("opencode-annotate-last");
+
+    const payload = JSON.parse(readFileSync(stdinFile, "utf-8"));
+    expect(payload.gate).toBe(true);
+    expect(payload.sharingEnabled).toBe(false);
+    expect(payload.shareBaseUrl).toBe("https://share.example.test");
+    expect(payload.pasteApiUrl).toBe("https://paste.example.test");
+    expect(payload.recentMessages).toEqual([
+      {
+        messageId: "latest",
+        text: "Latest assistant message",
+        timestamp: new Date(1_700_000_001_000).toISOString(),
+      },
+      {
+        messageId: "older",
+        text: "Older assistant message",
+        timestamp: new Date(1_700_000_000_000).toISOString(),
+      },
+    ]);
+    expect(client.session.prompt).not.toHaveBeenCalled();
+  });
+
+  test("runtime cli routes plannotator-annotate through the CLI bridge", async () => {
+    const tempDir = makeTempDir();
+    const { argsFile, stdinFile } = installFakeCli(tempDir);
+    const client = makeClient();
+
+    const plugin = await PlannotatorPlugin(
+      { client, directory: tempDir } as any,
+      { workflow: "manual", runtime: "cli" },
+    ) as any;
+    const output = { parts: [{ type: "text", text: "command body" }] };
+
+    await plugin["command.execute.before"](
+      {
+        command: "plannotator-annotate",
+        sessionID: "session-123",
+        arguments: "notes.md --gate",
+      },
+      output,
+    );
+
+    expect(output.parts).toEqual([]);
+    expect(readFileSync(argsFile, "utf-8").trim().split("\n")).toEqual([
+      "annotate",
+      "notes.md",
+      "--json",
+      "--gate",
+    ]);
+    expect(readFileSync(stdinFile, "utf-8")).toBe("");
+    expect(client.session.prompt).not.toHaveBeenCalled();
+  });
+
+  test("runtime cli routes plannotator-review through the CLI bridge", async () => {
+    const tempDir = makeTempDir();
+    const { argsFile, stdinFile } = installFakeCli(tempDir);
+    const client = makeClient();
+
+    const plugin = await PlannotatorPlugin(
+      { client, directory: tempDir } as any,
+      { workflow: "manual", runtime: "cli" },
+    ) as any;
+    const output = { parts: [{ type: "text", text: "command body" }] };
+
+    await plugin["command.execute.before"](
+      {
+        command: "plannotator-review",
+        sessionID: "session-123",
+        arguments: "--base main",
+      },
+      output,
+    );
+
+    expect(output.parts).toEqual([]);
+    expect(readFileSync(argsFile, "utf-8").trim()).toBe("opencode-review");
+
+    const payload = JSON.parse(readFileSync(stdinFile, "utf-8"));
+    expect(payload.arguments).toBe("--base main");
+    expect(payload.sharingEnabled).toBe(false);
+    expect(payload.shareBaseUrl).toBe("https://share.example.test");
+    expect(payload.pasteApiUrl).toBe("https://paste.example.test");
+    expect(client.session.prompt).not.toHaveBeenCalled();
+  });
+
+  test("runtime cli submit_plan does not require bundled HTML assets", async () => {
+    const restoreBundledHtml = hideBundledHtml();
+    try {
+      const tempDir = makeTempDir();
+      const { argsFile, stdinFile } = installFakeCli(tempDir);
+      const client = makeClient();
+
+      const plugin = await PlannotatorPlugin(
+        { client, directory: tempDir } as any,
+        { runtime: "cli" },
+      ) as any;
+
+      const result = await plugin.tool.submit_plan.execute(
+        {
+          edits: [{
+            start: 1,
+            content: "# Plan\n\nUse the CLI bridge.",
+          }],
+        },
+        { agent: "plan", sessionID: "session-123" },
+      );
+
+      expect(result).toContain("Plan changes requested");
+      expect(readFileSync(argsFile, "utf-8").trim()).toBe("opencode-plan");
+
+      const payload = JSON.parse(readFileSync(stdinFile, "utf-8"));
+      expect(payload.plan).toBe("# Plan\n\nUse the CLI bridge.");
+      expect(payload.sharingEnabled).toBe(false);
+      expect(payload.shareBaseUrl).toBe("https://share.example.test");
+      expect(payload.pasteApiUrl).toBe("https://paste.example.test");
+    } finally {
+      restoreBundledHtml();
+    }
+  });
+});

--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -38,6 +38,7 @@ import {
   applyWorkflowConfig,
   isPlanningAgent,
   normalizeWorkflowOptions,
+  resolveRuntimeExecutionMode,
   shouldApplyToolDefinitionRewrites,
   shouldInjectFullPlanningPrompt,
   shouldInjectGenericPlanReminder,
@@ -94,6 +95,18 @@ function getPlanHtml(): string {
 function getReviewHtml(): string {
   if (!_reviewHtml) _reviewHtml = readBundledHtml("review-editor.html");
   return _reviewHtml;
+}
+
+function preloadBundledHtml(filename: string, cache: (html: string) => void): void {
+  // CLI runtime paths do not need packaged HTML. Keep startup tolerant in
+  // source checkouts; embedded paths still fail at first get*Html() use.
+  let htmlPath: string;
+  try {
+    htmlPath = resolveBundledHtmlPath(filename);
+  } catch {
+    return;
+  }
+  readFile(htmlPath, "utf-8").then(cache).catch(() => {});
 }
 
 const DEFAULT_PLAN_TIMEOUT_SECONDS = 345_600; // 96 hours
@@ -177,10 +190,6 @@ function hasEmbeddedRuntime(): boolean {
   return typeof getBunRuntime()?.serve === "function";
 }
 
-function shouldUseEmbeddedRuntime(runtime: RuntimeMode): boolean {
-  return runtime !== "cli" && hasEmbeddedRuntime();
-}
-
 function getEmbeddedRuntimeError(): string {
   return "runtime \"embedded\" requires a Bun-hosted OpenCode plugin runtime. Use runtime \"auto\" or \"cli\" with this OpenCode host.";
 }
@@ -240,11 +249,12 @@ async function runPlanReview(input: {
   cwd?: string;
   bridge: OpenCodeBridgeContext;
 }): Promise<OpenCodePlanReviewResult> {
-  if (input.runtime === "embedded" && !hasEmbeddedRuntime()) {
+  const runtimeMode = resolveRuntimeExecutionMode(input.runtime, hasEmbeddedRuntime());
+  if (runtimeMode === "embedded-unavailable") {
     throw new Error(getEmbeddedRuntimeError());
   }
 
-  if (shouldUseEmbeddedRuntime(input.runtime)) {
+  if (runtimeMode === "embedded") {
     try {
       const embedded = await importEmbeddedRuntime();
       return await embedded.runEmbeddedPlanReview({
@@ -281,8 +291,8 @@ const PlannotatorPlugin: Plugin = async (ctx, rawOptions?: PlannotatorOpenCodeOp
   const workflowOptions = normalizeWorkflowOptions(rawOptions);
 
   // Preload HTML in background — populates the sync cache before first use
-  readFile(resolveBundledHtmlPath("plannotator.html"), "utf-8").then(h => { _planHtml = h; }).catch(() => {});
-  readFile(resolveBundledHtmlPath("review-editor.html"), "utf-8").then(h => { _reviewHtml = h; }).catch(() => {});
+  preloadBundledHtml("plannotator.html", h => { _planHtml = h; });
+  preloadBundledHtml("review-editor.html", h => { _reviewHtml = h; });
 
   let cachedAgents: any[] | null = null;
 
@@ -507,7 +517,12 @@ Do NOT proceed with implementation until your plan is approved.`);
         properties: { sessionID: input.sessionID, arguments: input.arguments },
       };
 
-      if (shouldUseEmbeddedRuntime(workflowOptions.runtime)) {
+      const runtimeMode = resolveRuntimeExecutionMode(
+        workflowOptions.runtime,
+        hasEmbeddedRuntime(),
+      );
+
+      if (runtimeMode === "embedded") {
         try {
           const embedded = await importEmbeddedRuntime();
           const deps = {
@@ -547,7 +562,7 @@ Do NOT proceed with implementation until your plan is approved.`);
         }
       }
 
-      if (workflowOptions.runtime === "embedded" && !hasEmbeddedRuntime()) {
+      if (runtimeMode === "embedded-unavailable") {
         try {
           void ctx.client.app.log({
             level: "error",
@@ -635,6 +650,10 @@ Use /plannotator-last or /plannotator-annotate for manual review, or set workflo
           writeFileSync(backingPath, planContent, "utf-8");
 
           const timeoutSeconds = getPlanTimeoutSeconds();
+          const runtimeMode = resolveRuntimeExecutionMode(
+            workflowOptions.runtime,
+            hasEmbeddedRuntime(),
+          );
           let result: OpenCodePlanReviewResult;
           try {
             result = await runPlanReview({
@@ -644,7 +663,7 @@ Use /plannotator-last or /plannotator-annotate for manual review, or set workflo
               sharingEnabled: await getSharingEnabled(),
               shareBaseUrl: getShareBaseUrl(),
               pasteApiUrl: getPasteApiUrl(),
-              htmlContent: getPlanHtml(),
+              htmlContent: runtimeMode === "embedded" ? getPlanHtml() : "",
               timeoutSeconds,
               cwd: ctx.directory,
               bridge: await getBridgeContext(),

--- a/apps/opencode-plugin/workflow.test.ts
+++ b/apps/opencode-plugin/workflow.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   applyWorkflowConfig,
   normalizeWorkflowOptions,
+  resolveRuntimeExecutionMode,
   shouldApplyToolDefinitionRewrites,
   shouldInjectFullPlanningPrompt,
   shouldInjectGenericPlanReminder,
@@ -48,6 +49,23 @@ describe("normalizeWorkflowOptions", () => {
     });
 
     expect(options.planningAgents).toEqual(["plan"]);
+  });
+});
+
+describe("resolveRuntimeExecutionMode", () => {
+  test("runtime cli always selects the CLI bridge", () => {
+    expect(resolveRuntimeExecutionMode("cli", true)).toBe("cli");
+    expect(resolveRuntimeExecutionMode("cli", false)).toBe("cli");
+  });
+
+  test("runtime auto uses embedded only when available", () => {
+    expect(resolveRuntimeExecutionMode("auto", true)).toBe("embedded");
+    expect(resolveRuntimeExecutionMode("auto", false)).toBe("cli");
+  });
+
+  test("runtime embedded stays strict when unavailable", () => {
+    expect(resolveRuntimeExecutionMode("embedded", true)).toBe("embedded");
+    expect(resolveRuntimeExecutionMode("embedded", false)).toBe("embedded-unavailable");
   });
 });
 

--- a/apps/opencode-plugin/workflow.ts
+++ b/apps/opencode-plugin/workflow.ts
@@ -16,6 +16,8 @@ export interface NormalizedWorkflowOptions {
   runtime: RuntimeMode;
 }
 
+export type RuntimeExecutionMode = "embedded" | "cli" | "embedded-unavailable";
+
 const WORKFLOWS = new Set<WorkflowMode>(["manual", "user-managed", "plan-agent", "all-agents"]);
 const RUNTIMES = new Set<RuntimeMode>(["auto", "embedded", "cli"]);
 const DEFAULT_WORKFLOW: WorkflowMode = "plan-agent";
@@ -63,6 +65,17 @@ function normalizeRuntime(value: unknown): RuntimeMode {
   return RUNTIMES.has(rawRuntime as RuntimeMode)
     ? rawRuntime as RuntimeMode
     : DEFAULT_RUNTIME;
+}
+
+export function resolveRuntimeExecutionMode(
+  runtime: RuntimeMode,
+  embeddedAvailable: boolean,
+): RuntimeExecutionMode {
+  if (runtime === "cli") return "cli";
+  if (runtime === "embedded") {
+    return embeddedAvailable ? "embedded" : "embedded-unavailable";
+  }
+  return embeddedAvailable ? "embedded" : "cli";
 }
 
 function normalizePlanningAgents(value: unknown): string[] {


### PR DESCRIPTION
## Summary
- route OpenCode runtime selection through a shared helper so `runtime: "cli"` is an explicit first-class CLI path
- avoid reading bundled HTML for CLI `submit_plan`, keeping source checkouts and CLI-only workflows independent of embedded assets
- add OpenCode plugin hook coverage for `/plannotator-last`, `/plannotator-annotate`, `/plannotator-review`, and CLI `submit_plan` without bundled HTML

## Issue
Fixes #947

## Verification
- `bun test apps/opencode-plugin/*.test.ts`
- `PATH="$PWD/apps/hook/node_modules/.bin:$PWD/packages/ui/node_modules/.bin:$PATH" BUN_INSTALL_CACHE_DIR="$PWD/../bun-cache" bun run typecheck`
- `bun test`
- `git diff --check`
- `bun build embedded.ts --outfile dist/embedded.js --target bun --external @opencode-ai/plugin && bun build index.ts --outfile dist/index.js --target node` (run from `apps/opencode-plugin` with the system Bun binary)