### PR TITLE
fix(vscode): enable clipboard in webview iframe

### DIFF
--- a/apps/vscode-extension/src/panel-manager.test.ts
+++ b/apps/vscode-extension/src/panel-manager.test.ts
@@ -42,6 +42,31 @@ describe("PanelManager", () => {
     );
   });
 
+  it("grants clipboard permission to the iframe", async () => {
+    let capturedHtml = "";
+    const spy = spyOn(vscode.window, "createWebviewPanel");
+    spy.mockImplementation((() => {
+      let disposeListener: (() => void) | null = null;
+      return {
+        webview: {
+          get html() { return capturedHtml; },
+          set html(v: string) { capturedHtml = v; },
+        },
+        reveal() {},
+        dispose() { disposeListener?.(); },
+        onDidDispose(listener: () => void) {
+          disposeListener = listener;
+          return { dispose() {} };
+        },
+      } as unknown as vscode.WebviewPanel;
+    }) as typeof vscode.window.createWebviewPanel);
+    spies.push(spy);
+
+    await manager.open("http://127.0.0.1:9999/review?id=42");
+
+    expect(capturedHtml).toContain('allow="clipboard-read; clipboard-write"');
+  });
+
   it("uses asExternalUri resolved URL in iframe and CSP", async () => {
     const envSpy = spyOn(vscode.env, "asExternalUri");
     envSpy.mockImplementation(async (_uri: vscode.Uri) => {

--- a/apps/vscode-extension/src/panel-manager.ts
+++ b/apps/vscode-extension/src/panel-manager.ts
@@ -54,7 +54,7 @@ function getHtml(url: string, origin: string): string {
   </style>
 </head>
 <body>
-  <iframe id="pn-frame" src="${url}"></iframe>
+  <iframe id="pn-frame" src="${url}" allow="clipboard-read; clipboard-write"></iframe>
   ${themeScript}
   <script>
     (function() {


### PR DESCRIPTION
## Problem

Closes #864.

In the VS Code extension, copying text from the Plannotator tab and pasting into a comment both silently fail.

## Root cause

`PanelManager` renders the Plannotator app inside an `<iframe>` within the VS Code webview (`apps/vscode-extension/src/panel-manager.ts`). A VS Code webview is itself a sandboxed iframe, so a *nested* iframe is gated by Permissions Policy. The iframe had no `allow` attribute, which blocks `navigator.clipboard` reads/writes and `paste` events in the embedded app.

The app relies on `navigator.clipboard.writeText` for every copy action (code blocks, tables, export, annotations, …) and on `clipboardData` for paste — all of these are blocked under the default permissions policy of a nested iframe.

## Fix

Grant clipboard access to the iframe:

```html
<iframe id="pn-frame" src="${url}" allow="clipboard-read; clipboard-write"></iframe>
```

## Testing

- Added a `panel-manager.test.ts` case asserting the iframe HTML carries `allow="clipboard-read; clipboard-write"`.
- `bun test src/panel-manager.test.ts` → 3 pass.
- `bun run build:vscode` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)