### PR TITLE
feat(review): file comments in the diff + unified click-to-highlight comment UX

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -64,7 +64,7 @@
     },
     "apps/opencode-plugin": {
       "name": "@plannotator/opencode",
-      "version": "0.21.1",
+      "version": "0.21.2",
       "dependencies": {
         "@opencode-ai/plugin": "^1.1.10",
       },
@@ -86,7 +86,7 @@
     },
     "apps/pi-extension": {
       "name": "@plannotator/pi-extension",
-      "version": "0.21.1",
+      "version": "0.21.2",
       "dependencies": {
         "@joplin/turndown-plugin-gfm": "^1.0.64",
         "@pierre/diffs": "1.2.8",
@@ -215,7 +215,7 @@
     },
     "packages/server": {
       "name": "@plannotator/server",
-      "version": "0.21.1",
+      "version": "0.21.2",
       "dependencies": {
         "@pierre/diffs": "1.2.8",
         "@plannotator/ai": "workspace:*",

--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -1537,10 +1537,10 @@ const ReviewApp: React.FC = () => {
       return;
     }
     const annotation = allAnnotationsRef.current.find(a => a.id === id);
-    // Don't navigate to an annotation filtered out of the active PR/diff-scope —
-    // it isn't rendered in the current diff, so scroll/highlight would target
-    // nothing (e.g. a stale sidebar row after an in-place PR/scope switch).
-    if (annotation && !annotationMatchesPrScope(annotation, prMetadata?.url, prDiffScope)) {
+    // Ignore navigation to an annotation that's gone (deleted) or filtered out of
+    // the active PR/diff-scope — there's nothing in the current diff to scroll to
+    // or highlight, so don't fake a selection.
+    if (!annotation || !annotationMatchesPrScope(annotation, prMetadata?.url, prDiffScope)) {
       return;
     }
     if (annotation && !isAllFilesActiveRef.current) {

--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -85,7 +85,7 @@ import {
   REVIEW_ALL_FILES_PANEL_ID,
   REVIEW_CODE_NAV_PANEL_ID,
 } from './dock/reviewPanelTypes';
-import type { DiffFile } from './types';
+import type { DiffFile, AnnotationScrollTarget } from './types';
 import type { DiffOption, WorktreeInfo, GitContext } from '@plannotator/shared/types';
 import type { PRMetadata } from '@plannotator/shared/pr-types';
 import type { PRDiffScope, PRDiffScopeOption, PRStackInfo, PRStackTree } from '@plannotator/shared/pr-stack';
@@ -121,6 +121,11 @@ const ReviewApp: React.FC = () => {
   const [activeFileIndex, setActiveFileIndex] = useState(0);
   const [annotations, setAnnotations] = useState<CodeAnnotation[]>([]);
   const [selectedAnnotationId, setSelectedAnnotationId] = useState<string | null>(null);
+  // Sidebar-initiated "scroll to this comment" signal. The token bumps on every
+  // sidebar click so re-selecting the same comment re-navigates. Selecting a
+  // comment in the diff sets selectedAnnotationId but NOT this — so it never
+  // moves the viewport.
+  const [scrollTargetAnnotation, setScrollTargetAnnotation] = useState<AnnotationScrollTarget | null>(null);
   const [isAllFilesActive, setIsAllFilesActive] = useState(false);
   // Mirror ref: handlers captured by Pierre slot portals (which only republish
   // on item version bumps) and early-declared callbacks read the CURRENT value
@@ -1511,29 +1516,29 @@ const ReviewApp: React.FC = () => {
   // handler is baked into Pierre slot portals, which only republish on item
   // version bumps — a stale captured value would yank the user out of the
   // all-files tab into the single-file panel when they click an annotation.
+  // Inline-card selection: toggle the highlight + ring only. No scroll, no file
+  // switch — the clicked card is already on screen. Clicking the selected card
+  // again (or a null id) clears it.
   const handleSelectAnnotation = useCallback((id: string | null) => {
+    setSelectedAnnotationId(prev => (!id || prev === id ? null : id));
+  }, []);
+
+  // Sidebar navigation: select AND scroll-to the comment (DiffsHub "set +
+  // scroll"). The token bump re-fires the panels' scroll effect even when the
+  // same comment is clicked twice; in single-file mode it switches to the
+  // owning file first so the scroll target exists.
+  const handleNavigateToAnnotation = useCallback((id: string | null) => {
     if (!id) {
       setSelectedAnnotationId(null);
       return;
     }
-
-    // Find the annotation
     const annotation = allAnnotationsRef.current.find(a => a.id === id);
-    if (!annotation) {
-      setSelectedAnnotationId(id);
-      return;
-    }
-
-    // In all-files mode, just set the selection — the panel's scroll-to-annotation
-    // effect handles expanding and scrolling. In single-file mode, switch to the file.
-    if (!isAllFilesActiveRef.current) {
+    if (annotation && !isAllFilesActiveRef.current) {
       const fileIndex = files.findIndex(f => f.path === annotation.filePath);
-      if (fileIndex !== -1) {
-        handleFileSwitch(fileIndex);
-      }
+      if (fileIndex !== -1) handleFileSwitch(fileIndex);
     }
-
     setSelectedAnnotationId(id);
+    setScrollTargetAnnotation(prev => ({ id, token: (prev?.token ?? 0) + 1 }));
   }, [files, handleFileSwitch]);
 
   // Diff context bundled into local-mode feedback headers so the receiving
@@ -1596,6 +1601,7 @@ const ReviewApp: React.FC = () => {
     allAnnotations,
     externalAnnotations,
     selectedAnnotationId,
+    scrollTargetAnnotation,
     pendingSelection,
     onLineSelection: handleLineSelection,
     onAddAnnotation: handleAddAnnotation,
@@ -1604,6 +1610,7 @@ const ReviewApp: React.FC = () => {
     onAddFileCommentForFile: handleAddFileCommentForFile,
     onEditAnnotation: handleEditAnnotation,
     onSelectAnnotation: handleSelectAnnotation,
+    onNavigateToAnnotation: handleNavigateToAnnotation,
     onDeleteAnnotation: handleDeleteAnnotation,
     viewedFiles,
     onToggleViewed: handleToggleViewed,
@@ -1654,9 +1661,9 @@ const ReviewApp: React.FC = () => {
     diffLineDiffType, diffShowLineNumbers, diffShowBackground,
     diffExpandUnchanged, diffFontFamily, diffFontSize, activeDiffBase, committedBase, feedbackDiffContext, prReviewScopeLabel, prDiffScope, agentCwd,
     allAnnotations, externalAnnotations,
-    selectedAnnotationId, pendingSelection, handleLineSelection,
+    selectedAnnotationId, scrollTargetAnnotation, pendingSelection, handleLineSelection,
     handleAddAnnotation, handleAddFileComment, handleAddFileCommentForFile, handleEditAnnotation,
-    handleSelectAnnotation, handleDeleteAnnotation, viewedFiles,
+    handleSelectAnnotation, handleNavigateToAnnotation, handleDeleteAnnotation, viewedFiles,
     handleToggleViewed, stagedFiles, stagingFile, stageFile,
     canStageFiles, stageError, isSearchPending, debouncedSearchQuery,
     activeFileSearchMatches, activeSearchMatchId, activeSearchMatch, searchMatches,
@@ -2575,6 +2582,7 @@ const ReviewApp: React.FC = () => {
                 files={files}
                 selectedAnnotationId={selectedAnnotationId}
                 onSelectAnnotation={handleSelectAnnotation}
+                onNavigateToAnnotation={handleNavigateToAnnotation}
                 onDeleteAnnotation={handleDeleteAnnotation}
                 feedbackMarkdown={feedbackMarkdown}
                 width={panelResize.width}

--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -86,6 +86,7 @@ import {
   REVIEW_CODE_NAV_PANEL_ID,
 } from './dock/reviewPanelTypes';
 import type { DiffFile, AnnotationScrollTarget } from './types';
+import { annotationMatchesPrScope } from './utils/annotationScope';
 import type { DiffOption, WorktreeInfo, GitContext } from '@plannotator/shared/types';
 import type { PRMetadata } from '@plannotator/shared/pr-types';
 import type { PRDiffScope, PRDiffScopeOption, PRStackInfo, PRStackTree } from '@plannotator/shared/pr-stack';
@@ -1536,13 +1537,19 @@ const ReviewApp: React.FC = () => {
       return;
     }
     const annotation = allAnnotationsRef.current.find(a => a.id === id);
+    // Don't navigate to an annotation filtered out of the active PR/diff-scope —
+    // it isn't rendered in the current diff, so scroll/highlight would target
+    // nothing (e.g. a stale sidebar row after an in-place PR/scope switch).
+    if (annotation && !annotationMatchesPrScope(annotation, prMetadata?.url, prDiffScope)) {
+      return;
+    }
     if (annotation && !isAllFilesActiveRef.current) {
       const fileIndex = files.findIndex(f => f.path === annotation.filePath);
       if (fileIndex !== -1) handleFileSwitch(fileIndex);
     }
     setSelectedAnnotationId(id);
     setScrollTargetAnnotation(prev => ({ id, token: (prev?.token ?? 0) + 1 }));
-  }, [files, handleFileSwitch]);
+  }, [files, handleFileSwitch, prMetadata, prDiffScope]);
 
   // Diff context bundled into local-mode feedback headers so the receiving
   // agent knows which diff the annotations are anchored to. Uses committedBase

--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -1543,7 +1543,7 @@ const ReviewApp: React.FC = () => {
     if (!annotation || !annotationMatchesPrScope(annotation, prMetadata?.url, prDiffScope)) {
       return;
     }
-    if (annotation && !isAllFilesActiveRef.current) {
+    if (!isAllFilesActiveRef.current) {
       const fileIndex = files.findIndex(f => f.path === annotation.filePath);
       if (fileIndex !== -1) handleFileSwitch(fileIndex);
     }

--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -1520,6 +1520,9 @@ const ReviewApp: React.FC = () => {
   // switch — the clicked card is already on screen. Clicking the selected card
   // again (or a null id) clears it.
   const handleSelectAnnotation = useCallback((id: string | null) => {
+    // An inline selection supersedes any pending sidebar/findings navigate target,
+    // so a later remount (Refresh / base switch) doesn't re-scroll back to it.
+    setScrollTargetAnnotation(null);
     setSelectedAnnotationId(prev => (!id || prev === id ? null : id));
   }, []);
 

--- a/packages/review-editor/components/AITab.tsx
+++ b/packages/review-editor/components/AITab.tsx
@@ -3,6 +3,7 @@ import type { AIChatEntry, PendingPermission } from '../hooks/useAIChat';
 import { renderChatMarkdown } from '../utils/renderChatMarkdown';
 import { formatLineRange } from '../utils/formatLineRange';
 import { formatRelativeTime } from '../utils/formatRelativeTime';
+import { FileNameChip } from './FileNameChip';
 import { SparklesIcon } from '@plannotator/ui/components/SparklesIcon';
 import { CountBadge } from './CountBadge';
 import { CopyButton } from './CopyButton';
@@ -352,10 +353,8 @@ const QAPair = memo<{
                 {formatLineRange(question.lineStart, question.lineEnd)}
               </button>
             )}
-            {scope === 'file' && (
-              <span className="text-[9px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded bg-primary/10 text-primary">
-                file
-              </span>
+            {scope === 'file' && question.filePath && (
+              <FileNameChip path={question.filePath} />
             )}
           </div>
           <span className="text-[10px] text-muted-foreground/50">

--- a/packages/review-editor/components/AllFilesCodeView.tsx
+++ b/packages/review-editor/components/AllFilesCodeView.tsx
@@ -1427,6 +1427,16 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
   //   2. A toolbar-originated range CodeView doesn't know about (gutter-utility
   //      click on a not-yet-active file, draft restore) → paint it on the
   //      active file's item.
+  // The controlled line highlight for a selected annotation (null for file-scoped
+  // / unresolved). Shared by the compose-end restore and the selection-replay
+  // effect so the two can't diverge.
+  const lineSelectionForAnnotation = useStableCallback(
+    (ann: CodeAnnotation | null | undefined): CodeViewLineSelection | null => {
+      if (!ann || isFileScopedAnnotation(ann)) return null;
+      const itemId = filePathToItemId.get(ann.filePath);
+      return itemId != null ? { id: itemId, range: lineRangeForAnnotation(ann) } : null;
+    },
+  );
   // Mirror so the effect below can restore the selected comment's highlight when
   // a compose ends, without taking selectedAnnotationId as a dep.
   const selectedAnnotationIdRef = useRef(selectedAnnotationId);
@@ -1438,12 +1448,7 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
       const ann = selectedAnnotationIdRef.current
         ? annotationsRef.current.find((a) => a.id === selectedAnnotationIdRef.current)
         : null;
-      if (ann && !isFileScopedAnnotation(ann)) {
-        const itemId = filePathToItemId.get(ann.filePath);
-        setSelectedLines(itemId != null ? { id: itemId, range: lineRangeForAnnotation(ann) } : null);
-      } else {
-        setSelectedLines(null);
-      }
+      setSelectedLines(lineSelectionForAnnotation(ann));
       return;
     }
     const current = selectedLinesRef.current;
@@ -1612,14 +1617,9 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
     // single-file DiffViewer's `pendingSelection ?? selectedAnnotationRange`.
     if (pendingSelectionRef.current != null) return;
 
-    // Line/range comments replay their exact range as the controlled highlight
-    // (the same state a drag paints). File-scoped comments / deselection clear it.
-    const itemId = ann ? filePathToItemId.get(ann.filePath) : undefined;
-    if (!ann || isFileScopedAnnotation(ann) || itemId == null) {
-      setSelectedLines((prev) => (prev ? null : prev));
-      return;
-    }
-    setSelectedLines({ id: itemId, range: lineRangeForAnnotation(ann) });
+    // Replay the selected line comment's range as the controlled highlight (the
+    // same state a drag paints); file-scoped / deselection clears it.
+    setSelectedLines(lineSelectionForAnnotation(ann));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedAnnotationId, filePathToItemId, filePathToItemIds, refreshItem]);
 

--- a/packages/review-editor/components/AllFilesCodeView.tsx
+++ b/packages/review-editor/components/AllFilesCodeView.tsx
@@ -510,8 +510,12 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
   // file's patch CONTENT changes (diff type / base / whitespace / PR switch),
   // and is used as the CodeView `key` to force a remount + fresh seed.
   const fileSetKey = useMemo(
-    () => `${files.length}:${files.map((f, i) => `${f.path}#${patchHashes[i]}`).join('|')}`,
-    [files, patchHashes],
+    // prUrl/prDiffScope are part of the key so a pure scope switch (layer ↔
+    // full-stack, same file set) remounts and re-seeds annotations through the
+    // current scope filter — the incremental sync bails on an unchanged
+    // annotations ref and can't otherwise detect the filter change.
+    () => `${prUrl ?? ''}:${prDiffScope ?? ''}:${files.length}:${files.map((f, i) => `${f.path}#${patchHashes[i]}`).join('|')}`,
+    [files, patchHashes, prUrl, prDiffScope],
   );
 
   // Visual-order list of file paths (for [/] stepping). Derived from items so it

--- a/packages/review-editor/components/AllFilesCodeView.tsx
+++ b/packages/review-editor/components/AllFilesCodeView.tsx
@@ -23,13 +23,15 @@ import type {
 import { CommentPopover } from '@plannotator/ui/components/CommentPopover';
 import { usePierreTheme } from '../hooks/usePierreTheme';
 import { useIsWorkerPoolReadyOrDisabled, useWorkerPoolThemeSync } from '../workerPool';
-import type { DiffFile } from '../types';
+import type { DiffFile, AnnotationScrollTarget } from '../types';
 import { buildFileTree, getVisualFileOrder } from '../utils/buildFileTree';
 import { buildCodeNavRequest } from '../utils/buildCodeNavRequest';
 import { getDiffSelection, getLineNumberFromNode, getSideFromNode } from '../utils/diffSelection';
 import { isContentConsistentWithPatch } from '../utils/patchConsistency';
 import { ToolbarHost, type ToolbarHostHandle } from './ToolbarHost';
 import { FileHeader } from './FileHeader';
+import { FileCommentBanner } from './FileCommentBanner';
+import { annotationMatchesPrScope, isFileScopedAnnotation, lineRangeForAnnotation } from '../utils/annotationScope';
 import { InlineAnnotation } from './InlineAnnotation';
 import { detectLanguage } from '../utils/detectLanguage';
 import type { AIChatEntry } from '../hooks/useAIChat';
@@ -153,6 +155,7 @@ interface AllFilesCodeViewProps {
   // line annotations render through CodeView item state.
   annotations: CodeAnnotation[];
   selectedAnnotationId: string | null;
+  scrollTargetAnnotation: AnnotationScrollTarget | null;
   pendingSelection: SelectedLineRange | null;
   reviewBase?: string;
   // Annotation / toolbar wiring (P2). Mirrors AllFilesDiffView's surface so the
@@ -244,11 +247,14 @@ function hashString(value: string): string {
   return hash.toString(36);
 }
 
-// Project a file's line annotations into Pierre's DiffLineAnnotation shape. This
-// is the EXACT projection AllFilesDiffView builds (side, lineNumber = lineEnd,
-// metadata = DiffAnnotationMetadata) so the two surfaces render identically.
-// Filters to line-scoped annotations that belong to this file in the active
-// PR/diff-scope (file-scoped comments live in the header, not the gutter).
+// The first rendered line of a file's diff, used to anchor file-scoped comments.
+// Pierre suppresses the header-prefix slot whenever a custom header is present
+// (renderDiffChildren makes them mutually exclusive), so file comments can't
+// live "between header and body" — instead they ride the line-annotation slot
+// Project a file's LINE annotations into Pierre's DiffLineAnnotation shape (side,
+// lineNumber = lineEnd, metadata = DiffAnnotationMetadata). File-scoped comments
+// are deliberately excluded — they render in the file header (renderCustomHeader),
+// not the gutter (see fileCommentsByPath).
 function projectFileAnnotations(
   annotations: CodeAnnotation[],
   filePath: string,
@@ -260,8 +266,7 @@ function projectFileAnnotations(
       (a) =>
         a.filePath === filePath &&
         (a.scope ?? 'line') === 'line' &&
-        (!a.prUrl || !prUrl || a.prUrl === prUrl) &&
-        (!a.diffScope || !prDiffScope || a.diffScope === prDiffScope),
+        annotationMatchesPrScope(a, prUrl, prDiffScope),
     )
     .map((ann) => ({
       side: ann.side === 'new' ? ('additions' as const) : ('deletions' as const),
@@ -277,6 +282,9 @@ function projectFileAnnotations(
         reasoning: ann.reasoning,
         conventionalLabel: ann.conventionalLabel,
         decorations: ann.decorations,
+        createdAt: ann.createdAt,
+        reviewProfileLabel: ann.reviewProfileLabel,
+        source: ann.source,
       } as DiffAnnotationMetadata,
     }));
 }
@@ -384,6 +392,7 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
   fontSize,
   annotations,
   selectedAnnotationId,
+  scrollTargetAnnotation,
   pendingSelection,
   reviewBase,
   onLineSelection,
@@ -659,6 +668,21 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
     toolbarHostRef.current?.startEdit(ann);
   });
 
+  // Per-file file-scoped comments, namespaced to the active PR/diff-scope. These
+  // render in the file HEADER (renderCustomHeader, below the path) when the file
+  // is expanded — not in the gutter — so they read as a file-level note rather
+  // than a stray line comment.
+  const fileCommentsByPath = useMemo(() => {
+    const map = new Map<string, CodeAnnotation[]>();
+    for (const a of annotations) {
+      if (!isFileScopedAnnotation(a) || !annotationMatchesPrScope(a, prUrl, prDiffScope)) continue;
+      const arr = map.get(a.filePath);
+      if (arr) arr.push(a);
+      else map.set(a.filePath, [a]);
+    }
+    return map;
+  }, [annotations, prUrl, prDiffScope]);
+
   // Render a single annotation from item state. `renderAnnotation` receives both
   // the LineAnnotation and DiffLineAnnotation union — guard `'side' in
   // annotation && item.type === 'diff'` (the Diffshub pattern) so file-item
@@ -678,6 +702,7 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
         <InlineAnnotation
           metadata={annotation.metadata}
           language={filePath ? detectLanguage(filePath) : undefined}
+          isSelected={selectedAnnotationId === annotation.metadata.annotationId}
           onSelect={onSelectAnnotation}
           onEdit={handleEditAnnotation}
           onDelete={onDeleteAnnotation}
@@ -1256,15 +1281,22 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
     const signatures = (list: CodeAnnotation[]) => {
       const map = new Map<string, string>();
       for (const a of list) {
-        if ((a.scope ?? 'line') !== 'line') continue;
-        if (a.prUrl && prUrl && a.prUrl !== prUrl) continue;
-        if (a.diffScope && prDiffScope && a.diffScope !== prDiffScope) continue;
-        const sig = JSON.stringify([
-          a.id, a.lineEnd, a.side, a.type,
-          a.text ?? '', a.suggestedCode ?? '', a.originalCode ?? '',
-          a.conventionalLabel ?? '', (a.decorations ?? []).join(','),
-          a.severity ?? '', a.reasoning ?? '', a.author ?? '',
-        ]);
+        const scope = a.scope ?? 'line';
+        if (scope !== 'line' && scope !== 'file') continue;
+        if (!annotationMatchesPrScope(a, prUrl, prDiffScope)) continue;
+        // File comments carry different render-affecting fields than line notes
+        // (no line/side/suggestion; they DO surface source + profile badges).
+        const sig = scope === 'file'
+          ? JSON.stringify([
+              'F', a.id, a.text ?? '', a.source ?? '', a.author ?? '',
+              a.reviewProfileLabel ?? '', a.conventionalLabel ?? '',
+            ])
+          : JSON.stringify([
+              a.id, a.lineEnd, a.side, a.type,
+              a.text ?? '', a.suggestedCode ?? '', a.originalCode ?? '',
+              a.conventionalLabel ?? '', (a.decorations ?? []).join(','),
+              a.severity ?? '', a.reasoning ?? '', a.author ?? '',
+            ]);
         map.set(a.filePath, `${map.get(a.filePath) ?? ''}${sig}\n`);
       }
       return map;
@@ -1543,26 +1575,52 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
     viewer.scrollTo({ type: 'item', id: itemId, align: 'start' });
   }, []);
 
-  // --- Selected-annotation navigation (P4) -----------------------------------
+  // --- Selected-annotation highlight + navigation ----------------------------
 
-  // Selecting an annotation in the sidebar must expand its owning file (if
-  // collapsed) and scroll to it. We expand via item state (collapsed=false +
-  // version bump + updateItem — the Diffshub pattern), then scrollTo the
-  // annotation's line range so it lands in view. rAF defers the scroll one frame
-  // so the expand's layout has settled before CodeView resolves the line top.
-  // `annotations` is read through the ref, NOT the dep list: this must fire only
-  // when the SELECTION changes. With `annotations` as a dep, any annotation
-  // change while one is selected (add/edit/delete elsewhere, an external SSE
-  // annotation arriving) re-runs the effect and yanks the viewport back to the
-  // selected annotation with zero user action.
+  // SELECTION (inline card OR sidebar) paints the line highlight + repaints the
+  // card ring — but NEVER scrolls. Clicking a comment in the diff must not move
+  // the viewport. `annotations` is read through the ref so this fires only on
+  // selection change, not on any add/edit/delete while one is selected.
+  const prevSelectedFileRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!selectedAnnotationId) return;
-    const ann = annotationsRef.current.find((a) => a.id === selectedAnnotationId);
+    const ann = selectedAnnotationId
+      ? annotationsRef.current.find((a) => a.id === selectedAnnotationId)
+      : null;
+    const newFile = ann?.filePath ?? null;
+
+    // Repaint the inline card's selected ring on the previously- AND
+    // newly-selected file: renderAnnotation only re-runs on updateItem, so a bare
+    // selection-state change wouldn't otherwise reach the portal'd cards.
+    const filesToRefresh = new Set<string>();
+    if (prevSelectedFileRef.current) filesToRefresh.add(prevSelectedFileRef.current);
+    if (newFile) filesToRefresh.add(newFile);
+    prevSelectedFileRef.current = newFile;
+    for (const path of filesToRefresh) {
+      for (const itemId of filePathToItemIds.get(path) ?? []) refreshItem(itemId);
+    }
+
+    // Line/range comments replay their exact range as the controlled highlight
+    // (the same state a drag paints). File-scoped comments / deselection clear it.
+    const itemId = ann ? filePathToItemId.get(ann.filePath) : undefined;
+    if (!ann || isFileScopedAnnotation(ann) || itemId == null) {
+      setSelectedLines((prev) => (prev ? null : prev));
+      return;
+    }
+    setSelectedLines({ id: itemId, range: lineRangeForAnnotation(ann) });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedAnnotationId, filePathToItemId, filePathToItemIds, refreshItem]);
+
+  // NAVIGATION (sidebar only) — expand the owning file if collapsed and scroll
+  // to the comment. Keyed on the navigation token so it fires per sidebar click
+  // (re-clicking the same comment re-centers it) and NEVER on a bare in-diff
+  // selection. rAF defers the scroll a frame so the expand's layout has settled.
+  useEffect(() => {
+    if (!scrollTargetAnnotation) return;
+    const ann = annotationsRef.current.find((a) => a.id === scrollTargetAnnotation.id);
     if (!ann) return;
     const itemId = filePathToItemId.get(ann.filePath);
-    if (itemId == null) return;
     const handle = viewerRef.current;
-    if (handle == null) return;
+    if (itemId == null || handle == null) return;
 
     const item = handle.getItem(itemId);
     if (item != null && item.collapsed === true) {
@@ -1571,17 +1629,17 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
       handle.updateItem(item);
     }
 
-    const start = Math.min(ann.lineStart, ann.lineEnd);
-    const end = Math.max(ann.lineStart, ann.lineEnd);
-    const side = ann.side === 'new' ? ('additions' as const) : ('deletions' as const);
+    const isFile = isFileScopedAnnotation(ann);
+    const range = lineRangeForAnnotation(ann);
     const raf = requestAnimationFrame(() => {
       const viewer = viewerRef.current;
       if (viewer == null) return;
-      viewer.scrollTo({ type: 'range', id: itemId, range: { start, end, side } });
+      if (isFile) viewer.scrollTo({ type: 'item', id: itemId, align: 'start' });
+      else viewer.scrollTo({ type: 'range', id: itemId, range });
     });
     return () => cancelAnimationFrame(raf);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedAnnotationId, filePathToItemId]);
+  }, [scrollTargetAnnotation, filePathToItemId]);
 
   useEffect(() => {
     if (!isActive) return;
@@ -1699,9 +1757,11 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
     if (file == null) return null;
 
     const collapsed = item.collapsed === true;
+    const fileComments = fileCommentsByPath.get(filePath) ?? [];
 
     return (
-      <FileHeader
+      <div className="flex flex-col">
+        <FileHeader
         filePath={filePath}
         patch={file.patch}
         status={file.status}
@@ -1747,7 +1807,20 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
           </button>
         }
         onCollapseToggle={() => toggleItemCollapsed(item.id)}
-      />
+        />
+        {/* File-scoped comments live in the header (below the path), shown only
+            when the file is expanded. They ride the sticky header — fine for a
+            short guide note; long ones scroll within the banner. */}
+        {!collapsed && fileComments.length > 0 && (
+          <FileCommentBanner
+            comments={fileComments}
+            selectedAnnotationId={selectedAnnotationId}
+            onSelect={onSelectAnnotation}
+            onEdit={onEditAnnotation}
+            onDelete={onDeleteAnnotation}
+          />
+        )}
+      </div>
     );
   });
 

--- a/packages/review-editor/components/AllFilesCodeView.tsx
+++ b/packages/review-editor/components/AllFilesCodeView.tsx
@@ -1856,6 +1856,9 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
       enableGutterUtility: true,
       hunkSeparators: 'line-info',
       stickyHeaders: true,
+      // Flush files together (no inter-file gap) — file boundaries already read
+      // via the sticky header. Keep Pierre's default 8px list edge padding.
+      layout: { gap: 0, paddingTop: 8, paddingBottom: 8 },
       itemMetrics: {
         diffHeaderHeight: PANEL_HEADER_HEIGHT,
         hunkSeparatorHeight: HUNK_SEPARATOR_HEIGHT,

--- a/packages/review-editor/components/AllFilesCodeView.tsx
+++ b/packages/review-editor/components/AllFilesCodeView.tsx
@@ -32,7 +32,7 @@ import { ToolbarHost, type ToolbarHostHandle } from './ToolbarHost';
 import { FileHeader } from './FileHeader';
 import { FileCommentBanner } from './FileCommentBanner';
 import { annotationMatchesPrScope, isFileScopedAnnotation, lineRangeForAnnotation } from '../utils/annotationScope';
-import { commentCopyText } from '../utils/annotationDisplay';
+import { lineAnnotationMetadata } from '../utils/annotationDisplay';
 import { InlineAnnotation } from './InlineAnnotation';
 import { detectLanguage } from '../utils/detectLanguage';
 import type { AIChatEntry } from '../hooks/useAIChat';
@@ -272,22 +272,7 @@ function projectFileAnnotations(
     .map((ann) => ({
       side: ann.side === 'new' ? ('additions' as const) : ('deletions' as const),
       lineNumber: ann.lineEnd,
-      metadata: {
-        annotationId: ann.id,
-        type: ann.type,
-        text: ann.text,
-        suggestedCode: ann.suggestedCode,
-        originalCode: ann.originalCode,
-        author: ann.author,
-        severity: ann.severity,
-        reasoning: ann.reasoning,
-        conventionalLabel: ann.conventionalLabel,
-        decorations: ann.decorations,
-        createdAt: ann.createdAt,
-        reviewProfileLabel: ann.reviewProfileLabel,
-        source: ann.source,
-        copyText: ann.text ? commentCopyText(ann) : undefined,
-      } as DiffAnnotationMetadata,
+      metadata: lineAnnotationMetadata(ann),
     }));
 }
 
@@ -1299,6 +1284,7 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
               a.text ?? '', a.suggestedCode ?? '', a.originalCode ?? '',
               a.conventionalLabel ?? '', (a.decorations ?? []).join(','),
               a.severity ?? '', a.reasoning ?? '', a.author ?? '',
+              a.reviewProfileLabel ?? '', a.source ?? '', a.createdAt ?? 0,
             ]);
         map.set(a.filePath, `${map.get(a.filePath) ?? ''}${sig}\n`);
       }

--- a/packages/review-editor/components/AllFilesCodeView.tsx
+++ b/packages/review-editor/components/AllFilesCodeView.tsx
@@ -1277,7 +1277,7 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
           ? JSON.stringify([
               'F', a.id, a.text ?? '', a.source ?? '', a.author ?? '',
               a.reviewProfileLabel ?? '', a.conventionalLabel ?? '',
-              (a.decorations ?? []).join(','), a.createdAt ?? 0,
+              (a.decorations ?? []).join(','), a.createdAt ?? 0, a.reasoning ?? '',
             ])
           : JSON.stringify([
               a.id, a.lineEnd, a.side, a.type,
@@ -1427,9 +1427,23 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
   //   2. A toolbar-originated range CodeView doesn't know about (gutter-utility
   //      click on a not-yet-active file, draft restore) → paint it on the
   //      active file's item.
+  // Mirror so the effect below can restore the selected comment's highlight when
+  // a compose ends, without taking selectedAnnotationId as a dep.
+  const selectedAnnotationIdRef = useRef(selectedAnnotationId);
+  selectedAnnotationIdRef.current = selectedAnnotationId;
   useEffect(() => {
     if (pendingSelection == null) {
-      setSelectedLines(null);
+      // Compose ended — restore the selected line comment's highlight instead of
+      // clearing, mirroring single-file's `pendingSelection ?? annotationRange`.
+      const ann = selectedAnnotationIdRef.current
+        ? annotationsRef.current.find((a) => a.id === selectedAnnotationIdRef.current)
+        : null;
+      if (ann && !isFileScopedAnnotation(ann)) {
+        const itemId = filePathToItemId.get(ann.filePath);
+        setSelectedLines(itemId != null ? { id: itemId, range: lineRangeForAnnotation(ann) } : null);
+      } else {
+        setSelectedLines(null);
+      }
       return;
     }
     const current = selectedLinesRef.current;
@@ -1817,6 +1831,10 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
             onSelect={onSelectAnnotation}
             onEdit={onEditAnnotation}
             onDelete={onDeleteAnnotation}
+            // Re-measure the item when a comment expands/collapses/edits — the
+            // custom-header height isn't auto-observed, so without this the
+            // content below would overlap until an unrelated refresh.
+            onHeightChange={() => refreshItem(item.id)}
           />
         )}
       </div>

--- a/packages/review-editor/components/AllFilesCodeView.tsx
+++ b/packages/review-editor/components/AllFilesCodeView.tsx
@@ -32,6 +32,7 @@ import { ToolbarHost, type ToolbarHostHandle } from './ToolbarHost';
 import { FileHeader } from './FileHeader';
 import { FileCommentBanner } from './FileCommentBanner';
 import { annotationMatchesPrScope, isFileScopedAnnotation, lineRangeForAnnotation } from '../utils/annotationScope';
+import { commentCopyText } from '../utils/annotationDisplay';
 import { InlineAnnotation } from './InlineAnnotation';
 import { detectLanguage } from '../utils/detectLanguage';
 import type { AIChatEntry } from '../hooks/useAIChat';
@@ -285,6 +286,7 @@ function projectFileAnnotations(
         createdAt: ann.createdAt,
         reviewProfileLabel: ann.reviewProfileLabel,
         source: ann.source,
+        copyText: ann.text ? commentCopyText(ann) : undefined,
       } as DiffAnnotationMetadata,
     }));
 }
@@ -1290,6 +1292,7 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
           ? JSON.stringify([
               'F', a.id, a.text ?? '', a.source ?? '', a.author ?? '',
               a.reviewProfileLabel ?? '', a.conventionalLabel ?? '',
+              (a.decorations ?? []).join(','), a.createdAt ?? 0,
             ])
           : JSON.stringify([
               a.id, a.lineEnd, a.side, a.type,
@@ -1581,6 +1584,11 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
   // card ring — but NEVER scrolls. Clicking a comment in the diff must not move
   // the viewport. `annotations` is read through the ref so this fires only on
   // selection change, not on any add/edit/delete while one is selected.
+  // Read-only mirror of pendingSelection so the selection effect can yield to an
+  // active compose WITHOUT taking pendingSelection as a dep (which would re-run
+  // it on every drag delta).
+  const pendingSelectionRef = useRef(pendingSelection);
+  pendingSelectionRef.current = pendingSelection;
   const prevSelectedFileRef = useRef<string | null>(null);
   useEffect(() => {
     const ann = selectedAnnotationId
@@ -1598,6 +1606,11 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
     for (const path of filesToRefresh) {
       for (const itemId of filePathToItemIds.get(path) ?? []) refreshItem(itemId);
     }
+
+    // An active compose (toolbar open) owns selectedLines — clicking/deselecting a
+    // comment must not clobber the in-progress range highlight. Mirrors
+    // single-file DiffViewer's `pendingSelection ?? selectedAnnotationRange`.
+    if (pendingSelectionRef.current != null) return;
 
     // Line/range comments replay their exact range as the controlled highlight
     // (the same state a drag paints). File-scoped comments / deselection clear it.

--- a/packages/review-editor/components/CommentActions.tsx
+++ b/packages/review-editor/components/CommentActions.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { CopyButton } from './CopyButton';
+
+interface CommentActionsProps {
+  /** When provided, shows the edit button (left-most). */
+  onEdit?: () => void;
+  /** When provided, shows the copy button (middle). */
+  copyText?: string;
+  /** When provided, shows the delete/close button (right-most). Omitted for
+   *  read-only (e.g. externally-sourced) comments. */
+  onDelete?: () => void;
+}
+
+const ACTION_BTN = 'p-1 rounded text-muted-foreground transition-colors';
+
+/**
+ * The single hover-revealed action row shared by every comment card (inline
+ * diff, sidebar, file banner). Bottom-aligned, right-justified, order
+ * left→right: edit · copy · delete (so the close/delete sits furthest right).
+ * The parent card must carry the Tailwind `group` class for the hover reveal.
+ */
+export const CommentActions: React.FC<CommentActionsProps> = ({ onEdit, copyText, onDelete }) => {
+  if (!onEdit && !copyText && !onDelete) return null;
+  return (
+  <div
+    className="flex items-center justify-end gap-1 mt-1.5 opacity-0 group-hover:opacity-100 transition-opacity"
+    onClick={(e) => e.stopPropagation()}
+  >
+    {onEdit && (
+      <button
+        type="button"
+        onClick={(e) => { e.stopPropagation(); onEdit(); }}
+        className={`${ACTION_BTN} hover:bg-muted hover:text-foreground`}
+        title="Edit"
+      >
+        <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+        </svg>
+      </button>
+    )}
+    {copyText && <CopyButton text={copyText} variant="inline" />}
+    {onDelete && (
+      <button
+        type="button"
+        onClick={(e) => { e.stopPropagation(); onDelete(); }}
+        className={`${ACTION_BTN} hover:bg-destructive/10 hover:text-destructive`}
+        title="Delete"
+      >
+        <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    )}
+  </div>
+  );
+};

--- a/packages/review-editor/components/CommentMeta.tsx
+++ b/packages/review-editor/components/CommentMeta.tsx
@@ -14,9 +14,6 @@ interface CommentMetaProps {
   source?: string;
   author?: string;
   createdAt?: number;
-  /** Surface-specific right-aligned controls (e.g. edit/delete actions), shown
-   *  after the timestamp. */
-  trailing?: React.ReactNode;
 }
 
 /**
@@ -35,7 +32,6 @@ export const CommentMeta: React.FC<CommentMetaProps> = ({
   source,
   author,
   createdAt,
-  trailing,
 }) => (
   <div className="review-comment-header">
     <div className="flex min-w-0 items-center gap-1.5">
@@ -63,13 +59,10 @@ export const CommentMeta: React.FC<CommentMetaProps> = ({
         </span>
       )}
     </div>
-    {(createdAt != null || trailing) && (
-      <div className="ml-auto flex flex-none items-center gap-1.5">
-        {createdAt != null && (
-          <span className="text-[10px] text-muted-foreground/50">{formatRelativeTime(createdAt)}</span>
-        )}
-        {trailing}
-      </div>
+    {createdAt != null && (
+      <span className="ml-auto flex-none text-[10px] text-muted-foreground/50">
+        {formatRelativeTime(createdAt)}
+      </span>
     )}
   </div>
 );

--- a/packages/review-editor/components/CommentMeta.tsx
+++ b/packages/review-editor/components/CommentMeta.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import type { ConventionalLabel, ConventionalDecoration } from '@plannotator/ui/types';
+import { isCurrentUser } from '@plannotator/ui/utils/identity';
+import { ConventionalLabelBadge } from './ConventionalLabelPicker';
+import { formatRelativeTime } from '../utils/formatRelativeTime';
+
+interface CommentMetaProps {
+  /** Surface-specific leading element(s): severity dot, scope/file/line badge,
+   *  collapse toggle, etc. Rendered first in the left cluster. */
+  leading?: React.ReactNode;
+  conventionalLabel?: ConventionalLabel | null;
+  decorations?: ConventionalDecoration[];
+  reviewProfileLabel?: string;
+  source?: string;
+  author?: string;
+  createdAt?: number;
+  /** Surface-specific right-aligned controls (e.g. edit/delete actions), shown
+   *  after the timestamp. */
+  trailing?: React.ReactNode;
+}
+
+/**
+ * The single identity row shared by every comment surface — the inline diff
+ * card, the sidebar list, and the file-comment banner. Left cluster: leading
+ * badge(s) → conventional label → review-profile/source badge → author. Right:
+ * relative time, then any surface-specific actions. Centralizing it keeps author
+ * + timestamp + badge styling identical everywhere (they used to be hand-rolled
+ * three different ways).
+ */
+export const CommentMeta: React.FC<CommentMetaProps> = ({
+  leading,
+  conventionalLabel,
+  decorations,
+  reviewProfileLabel,
+  source,
+  author,
+  createdAt,
+  trailing,
+}) => (
+  <div className="review-comment-header">
+    <div className="flex min-w-0 items-center gap-1.5">
+      {leading}
+      {conventionalLabel && (
+        <ConventionalLabelBadge label={conventionalLabel} decorations={decorations} />
+      )}
+      {reviewProfileLabel ? (
+        <span className="text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-accent/10 text-accent/90 truncate max-w-[140px]">
+          {reviewProfileLabel}
+        </span>
+      ) : source ? (
+        <span className="text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-muted text-muted-foreground/80 truncate max-w-[140px]">
+          {source}
+        </span>
+      ) : null}
+      {author && (
+        <span
+          className={`text-[10px] truncate max-w-[120px] ${
+            isCurrentUser(author) ? 'text-muted-foreground/50' : 'text-muted-foreground/70'
+          }`}
+        >
+          {author}
+          {isCurrentUser(author) && ' (me)'}
+        </span>
+      )}
+    </div>
+    {(createdAt != null || trailing) && (
+      <div className="ml-auto flex flex-none items-center gap-1.5">
+        {createdAt != null && (
+          <span className="text-[10px] text-muted-foreground/50">{formatRelativeTime(createdAt)}</span>
+        )}
+        {trailing}
+      </div>
+    )}
+  </div>
+);

--- a/packages/review-editor/components/DiffViewer.tsx
+++ b/packages/review-editor/components/DiffViewer.tsx
@@ -13,6 +13,9 @@ import { ToolbarHost, type ToolbarHostHandle } from './ToolbarHost';
 import { OverlayScrollArea } from '@plannotator/ui/components/OverlayScrollArea';
 import { useOverlayViewport } from '@plannotator/ui/hooks/useOverlayViewport';
 import { FileHeader } from './FileHeader';
+import { FileCommentBanner } from './FileCommentBanner';
+import { isFileScopedAnnotation, lineRangeForAnnotation } from '../utils/annotationScope';
+import type { AnnotationScrollTarget } from '../types';
 import { getLineNumberFromNode, getSideFromNode, getDiffSelection } from '../utils/diffSelection';
 import { isContentConsistentWithPatch } from '../utils/patchConsistency';
 import { InlineAnnotation } from './InlineAnnotation';
@@ -152,6 +155,7 @@ interface DiffViewerProps {
   fontSize?: string;
   annotations: CodeAnnotation[];
   selectedAnnotationId: string | null;
+  scrollTargetAnnotation: AnnotationScrollTarget | null;
   pendingSelection: SelectedLineRange | null;
   onLineSelection: (range: SelectedLineRange | null) => void;
   onAddAnnotation: (type: CodeAnnotationType, text?: string, suggestedCode?: string, originalCode?: string, conventionalLabel?: ConventionalLabel, decorations?: ConventionalDecoration[], tokenMeta?: TokenAnnotationMeta) => void;
@@ -203,6 +207,7 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
   fontSize,
   annotations,
   selectedAnnotationId,
+  scrollTargetAnnotation,
   pendingSelection,
   onLineSelection,
   onAddAnnotation,
@@ -406,13 +411,16 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
     return () => viewport.removeEventListener('scroll', onScroll);
   }, [viewport, filePath]);
 
-  // Scroll to selected annotation when it changes
+  // Scroll to a comment ONLY on sidebar navigation (scrollTargetAnnotation),
+  // never on a bare in-diff selection — clicking a comment must not move the
+  // viewport. Keyed on the token so re-clicking the same sidebar row re-centers.
   useEffect(() => {
-    if (!selectedAnnotationId || !containerRef.current) return;
+    if (!scrollTargetAnnotation || !containerRef.current) return;
+    const targetId = scrollTargetAnnotation.id;
 
     const timeoutId = setTimeout(() => {
       const annotationEl = containerRef.current?.querySelector(
-        `[data-annotation-id="${selectedAnnotationId}"]`
+        `[data-annotation-id="${targetId}"]`
       );
       if (annotationEl) {
         annotationEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
@@ -420,7 +428,7 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
     }, 100);
 
     return () => clearTimeout(timeoutId);
-  }, [selectedAnnotationId, viewport]);
+  }, [scrollTargetAnnotation, viewport]);
 
   // Apply search highlights to diff lines (including inside shadow DOM).
   // The query is already debounced upstream (useReviewSearch), so this runs synchronously.
@@ -515,6 +523,9 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
           reasoning: ann.reasoning,
           conventionalLabel: ann.conventionalLabel,
           decorations: ann.decorations,
+          createdAt: ann.createdAt,
+          reviewProfileLabel: ann.reviewProfileLabel,
+          source: ann.source,
         } as DiffAnnotationMetadata,
       }));
   }, [annotations]);
@@ -570,12 +581,13 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
       <InlineAnnotation
         metadata={annotation.metadata}
         language={detectLanguage(filePath)}
+        isSelected={annotation.metadata.annotationId === selectedAnnotationId}
         onSelect={onSelectAnnotation}
         onEdit={handleEdit}
         onDelete={onDeleteAnnotation}
       />
     );
-  }, [filePath, onSelectAnnotation, handleEdit, onDeleteAnnotation, onClickAIMarker]);
+  }, [filePath, selectedAnnotationId, onSelectAnnotation, handleEdit, onDeleteAnnotation, onClickAIMarker]);
 
   const handleGutterUtilityClick = useCallback((range: SelectedLineRange) => {
     toolbarHostRef.current?.handleLineSelectionEnd(range);
@@ -638,6 +650,24 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
     } as React.CSSProperties;
   }, [diffOverflow, isSplitLayout, splitRatio]);
 
+  // File-scoped comments render below the path, above the hunks (full text, no
+  // truncation) — line-scoped annotations stay inline in the gutter.
+  const fileComments = useMemo(
+    () => annotations.filter(isFileScopedAnnotation),
+    [annotations],
+  );
+
+  // Replay a selected line/range comment's anchor as the controlled highlight so
+  // clicking it (inline card or sidebar) lights up its lines. A live compose
+  // selection (pendingSelection) wins while the toolbar is open; file-scoped
+  // comments have no meaningful line so they don't paint a highlight.
+  const selectedAnnotationRange = useMemo<SelectedLineRange | null>(() => {
+    if (!selectedAnnotationId) return null;
+    const ann = annotations.find((a) => a.id === selectedAnnotationId);
+    if (!ann || isFileScopedAnnotation(ann)) return null;
+    return lineRangeForAnnotation(ann);
+  }, [selectedAnnotationId, annotations]);
+
   return (
     <div className="h-full flex flex-col">
       <FileHeader
@@ -660,6 +690,13 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
         overflowX="scroll"
         onViewportReady={onViewportReady}
       >
+        <FileCommentBanner
+          comments={fileComments}
+          selectedAnnotationId={selectedAnnotationId}
+          onSelect={onSelectAnnotation}
+          onEdit={onEditAnnotation}
+          onDelete={onDeleteAnnotation}
+        />
         <div className="p-4" ref={diffContentRef}>
           <div ref={splitSurfaceRef} className="relative min-w-0" style={splitGridStyle}>
             {isSplitLayout && diffOverflow !== 'wrap' && (
@@ -684,7 +721,7 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
               disableBackground={disableBackground}
               expandUnchanged={expandUnchanged}
               mergedAnnotations={mergedAnnotations}
-              pendingSelection={pendingSelection}
+              pendingSelection={pendingSelection ?? selectedAnnotationRange}
               onLineSelectionEnd={handlePierreLineSelectionEnd}
               onGutterUtilityClick={handleGutterUtilityClick}
               renderAnnotation={renderAnnotation}

--- a/packages/review-editor/components/DiffViewer.tsx
+++ b/packages/review-editor/components/DiffViewer.tsx
@@ -15,7 +15,7 @@ import { useOverlayViewport } from '@plannotator/ui/hooks/useOverlayViewport';
 import { FileHeader } from './FileHeader';
 import { FileCommentBanner } from './FileCommentBanner';
 import { isFileScopedAnnotation, lineRangeForAnnotation } from '../utils/annotationScope';
-import { commentCopyText } from '../utils/annotationDisplay';
+import { lineAnnotationMetadata } from '../utils/annotationDisplay';
 import type { AnnotationScrollTarget } from '../types';
 import { getLineNumberFromNode, getSideFromNode, getDiffSelection } from '../utils/diffSelection';
 import { isContentConsistentWithPatch } from '../utils/patchConsistency';
@@ -513,22 +513,7 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
       .map(ann => ({
         side: ann.side === 'new' ? 'additions' as const : 'deletions' as const,
         lineNumber: ann.lineEnd,
-        metadata: {
-          annotationId: ann.id,
-          type: ann.type,
-          text: ann.text,
-          suggestedCode: ann.suggestedCode,
-          originalCode: ann.originalCode,
-          author: ann.author,
-          severity: ann.severity,
-          reasoning: ann.reasoning,
-          conventionalLabel: ann.conventionalLabel,
-          decorations: ann.decorations,
-          createdAt: ann.createdAt,
-          reviewProfileLabel: ann.reviewProfileLabel,
-          source: ann.source,
-          copyText: ann.text ? commentCopyText(ann) : undefined,
-        } as DiffAnnotationMetadata,
+        metadata: lineAnnotationMetadata(ann),
       }));
   }, [annotations]);
 

--- a/packages/review-editor/components/DiffViewer.tsx
+++ b/packages/review-editor/components/DiffViewer.tsx
@@ -15,6 +15,7 @@ import { useOverlayViewport } from '@plannotator/ui/hooks/useOverlayViewport';
 import { FileHeader } from './FileHeader';
 import { FileCommentBanner } from './FileCommentBanner';
 import { isFileScopedAnnotation, lineRangeForAnnotation } from '../utils/annotationScope';
+import { commentCopyText } from '../utils/annotationDisplay';
 import type { AnnotationScrollTarget } from '../types';
 import { getLineNumberFromNode, getSideFromNode, getDiffSelection } from '../utils/diffSelection';
 import { isContentConsistentWithPatch } from '../utils/patchConsistency';
@@ -526,6 +527,7 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
           createdAt: ann.createdAt,
           reviewProfileLabel: ann.reviewProfileLabel,
           source: ann.source,
+          copyText: ann.text ? commentCopyText(ann) : undefined,
         } as DiffAnnotationMetadata,
       }));
   }, [annotations]);

--- a/packages/review-editor/components/FileCommentBanner.tsx
+++ b/packages/review-editor/components/FileCommentBanner.tsx
@@ -1,0 +1,176 @@
+import React, { useMemo, useState } from 'react';
+import type { CodeAnnotation } from '@plannotator/ui/types';
+import { sanitizeBlockHtml } from '@plannotator/ui/utils/sanitizeHtml';
+import { CommentMeta } from './CommentMeta';
+import { FileNameChip } from './FileNameChip';
+
+interface FileCommentBannerProps {
+  /** File-scoped comments for ONE file (already filtered to scope === 'file'). */
+  comments: CodeAnnotation[];
+  selectedAnnotationId: string | null;
+  onSelect: (id: string | null) => void;
+  onEdit: (id: string, text: string) => void;
+  onDelete: (id: string) => void;
+}
+
+/** First non-empty line of the comment, used as the collapsed one-line preview. */
+function firstLine(text: string): string {
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed) return trimmed.replace(/^#+\s*/, '').replace(/[*_`>]/g, '');
+  }
+  return text.trim();
+}
+
+/**
+ * A single file-scoped comment card. Exported so the all-files view can render
+ * it directly inside Pierre's annotation slot (the header-prefix slot is
+ * suppressed whenever a custom header is present), while the single-file viewer
+ * renders a stack of them in {@link FileCommentBanner}.
+ */
+export const FileCommentCard: React.FC<{
+  comment: CodeAnnotation;
+  isSelected: boolean;
+  onSelect: (id: string | null) => void;
+  onEdit: (id: string, text: string) => void;
+  onDelete: (id: string) => void;
+}> = ({ comment, isSelected, onSelect, onEdit, onDelete }) => {
+  // Default expanded (the comment IS the point of a guided review); the toggle
+  // lets a reviewer collapse a long note back to one line to reach the hunks.
+  const [collapsed, setCollapsed] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState(comment.text ?? '');
+
+  // External (source-set) comments are read-only — they mirror how inline
+  // annotations treat findings imported via the External Annotations API.
+  const editable = !comment.source;
+  const html = useMemo(
+    () => (comment.text ? sanitizeBlockHtml(comment.text) : ''),
+    [comment.text],
+  );
+
+  const saveEdit = () => {
+    const trimmed = draft.trim();
+    if (trimmed && trimmed !== comment.text) onEdit(comment.id, trimmed);
+    setIsEditing(false);
+  };
+
+  return (
+    <div
+      className={`review-comment${isSelected ? ' is-selected' : ''}`}
+      data-annotation-id={comment.id}
+      onClick={() => onSelect(comment.id)}
+    >
+      <CommentMeta
+        leading={
+          <>
+            {/* Collapse toggle — always visible (primary affordance for reclaiming
+                space from a long comment), unlike the hover-revealed actions. */}
+            <button
+              className="flex-none -ml-0.5 rounded p-0.5 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+              onClick={(e) => { e.stopPropagation(); setCollapsed((c) => !c); }}
+              title={collapsed ? 'Expand comment' : 'Collapse comment'}
+            >
+              <svg className={`w-3.5 h-3.5 transition-transform ${collapsed ? '' : 'rotate-90'}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+              </svg>
+            </button>
+            <FileNameChip path={comment.filePath} />
+          </>
+        }
+        conventionalLabel={comment.conventionalLabel}
+        decorations={comment.decorations}
+        reviewProfileLabel={comment.reviewProfileLabel}
+        source={comment.source}
+        author={comment.author}
+        createdAt={comment.createdAt}
+        trailing={
+          editable ? (
+            <div className="review-comment-actions">
+              {!isEditing && (
+                <button
+                  className="review-comment-action"
+                  onClick={(e) => { e.stopPropagation(); setDraft(comment.text ?? ''); setIsEditing(true); setCollapsed(false); }}
+                  title="Edit"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                  </svg>
+                </button>
+              )}
+              <button
+                className="review-comment-action destructive"
+                onClick={(e) => { e.stopPropagation(); onDelete(comment.id); }}
+                title="Delete"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+          ) : undefined
+        }
+      />
+
+      {isEditing ? (
+        <div className="mt-1" onClick={(e) => e.stopPropagation()}>
+          <textarea
+            autoFocus
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') { e.preventDefault(); setIsEditing(false); }
+              else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); saveEdit(); }
+            }}
+            className="w-full min-h-[80px] resize-y rounded border border-border bg-background p-2 text-xs leading-relaxed focus:outline-none focus:ring-1 focus:ring-primary/40"
+            placeholder="File comment (markdown supported)…"
+          />
+          <div className="mt-1 flex items-center justify-end gap-2">
+            <button className="text-xs px-2 py-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted" onClick={() => setIsEditing(false)}>
+              Cancel
+            </button>
+            <button className="text-xs px-2 py-1 rounded bg-primary/15 text-primary hover:bg-primary/25" onClick={saveEdit}>
+              Save
+            </button>
+          </div>
+        </div>
+      ) : comment.text ? (
+        collapsed ? (
+          <div className="review-comment-body truncate text-muted-foreground/80">{firstLine(comment.text)}</div>
+        ) : (
+          <div className="review-comment-body ai-markdown" dangerouslySetInnerHTML={{ __html: html }} />
+        )
+      ) : null}
+    </div>
+  );
+};
+
+/**
+ * Renders a file's file-scoped comments directly below the file path, above the
+ * diff hunks. Long comments stay fully visible (no truncation) but can be
+ * collapsed per-comment. Used in both the single-file viewer (plain React tree)
+ * and the all-files view (Pierre's `renderHeaderPrefix` portal slot).
+ */
+export const FileCommentBanner: React.FC<FileCommentBannerProps> = ({
+  comments,
+  selectedAnnotationId,
+  onSelect,
+  onEdit,
+  onDelete,
+}) => {
+  if (comments.length === 0) return null;
+  return (
+    <div className="file-comment-banner flex flex-col px-4 pt-1 pb-1">
+      {comments.map((comment) => (
+        <FileCommentCard
+          key={comment.id}
+          comment={comment}
+          isSelected={selectedAnnotationId === comment.id}
+          onSelect={onSelect}
+          onEdit={onEdit}
+          onDelete={onDelete}
+        />
+      ))}
+    </div>
+  );
+};

--- a/packages/review-editor/components/FileCommentBanner.tsx
+++ b/packages/review-editor/components/FileCommentBanner.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { CodeAnnotation } from '@plannotator/ui/types';
 import { sanitizeBlockHtml } from '@plannotator/ui/utils/sanitizeHtml';
 import { CommentMeta } from './CommentMeta';
@@ -52,7 +52,9 @@ export const FileCommentCard: React.FC<{
   // these cards live in Pierre's custom-header portal, whose height isn't auto-
   // observed; without this, expanding/editing overlaps the content below.
   const mounted = useRef(false);
-  useEffect(() => {
+  // Layout effect (before paint) so the re-measure lands without a one-frame
+  // overlap when the card grows/shrinks.
+  useLayoutEffect(() => {
     if (mounted.current) onHeightChange?.();
     else mounted.current = true;
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/review-editor/components/FileCommentBanner.tsx
+++ b/packages/review-editor/components/FileCommentBanner.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import type { CodeAnnotation } from '@plannotator/ui/types';
 import { sanitizeBlockHtml } from '@plannotator/ui/utils/sanitizeHtml';
 import { CommentMeta } from './CommentMeta';
@@ -13,6 +13,8 @@ interface FileCommentBannerProps {
   onSelect: (id: string | null) => void;
   onEdit: (id: string, text: string) => void;
   onDelete: (id: string) => void;
+  /** Re-measure hook for the virtualized all-files host (see FileCommentCard). */
+  onHeightChange?: () => void;
 }
 
 /** First non-empty line of the comment, used as the collapsed one-line preview. */
@@ -36,15 +38,28 @@ export const FileCommentCard: React.FC<{
   onSelect: (id: string | null) => void;
   onEdit: (id: string, text: string) => void;
   onDelete: (id: string) => void;
-}> = ({ comment, isSelected, onSelect, onEdit, onDelete }) => {
+  /** Fired after our rendered height changes (expand/collapse/edit) so the
+   *  virtualized all-files host can re-measure this item. */
+  onHeightChange?: () => void;
+}> = ({ comment, isSelected, onSelect, onEdit, onDelete, onHeightChange }) => {
   // Default expanded (the comment IS the point of a guided review); the toggle
   // lets a reviewer collapse a long note back to one line to reach the hunks.
   const [collapsed, setCollapsed] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [draft, setDraft] = useState(comment.text ?? '');
 
-  // External (source-set) comments are read-only — they mirror how inline
-  // annotations treat findings imported via the External Annotations API.
+  // Tell the owner to re-measure when our height changes — in the all-files view
+  // these cards live in Pierre's custom-header portal, whose height isn't auto-
+  // observed; without this, expanding/editing overlaps the content below.
+  const mounted = useRef(false);
+  useEffect(() => {
+    if (mounted.current) onHeightChange?.();
+    else mounted.current = true;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [collapsed, isEditing]);
+
+  // Edit is gated on !source (external findings are managed elsewhere); delete is
+  // always available so findings can be dismissed from any surface.
   const editable = !comment.source;
   const html = useMemo(
     () => (comment.text ? sanitizeBlockHtml(comment.text) : ''),
@@ -114,14 +129,14 @@ export const FileCommentCard: React.FC<{
         collapsed ? (
           <div className="review-comment-body truncate text-muted-foreground/80">{firstLine(comment.text)}</div>
         ) : (
-          <div className="review-comment-body ai-markdown" dangerouslySetInnerHTML={{ __html: html }} />
+          <div className="review-comment-body ai-markdown max-h-[220px] overflow-y-auto" dangerouslySetInnerHTML={{ __html: html }} />
         )
       ) : null}
       {!isEditing && (
         <CommentActions
           onEdit={editable ? () => { setDraft(comment.text ?? ''); setIsEditing(true); setCollapsed(false); } : undefined}
           copyText={comment.text ? commentCopyText(comment) : undefined}
-          onDelete={editable ? () => onDelete(comment.id) : undefined}
+          onDelete={() => onDelete(comment.id)}
         />
       )}
     </div>
@@ -140,6 +155,7 @@ export const FileCommentBanner: React.FC<FileCommentBannerProps> = ({
   onSelect,
   onEdit,
   onDelete,
+  onHeightChange,
 }) => {
   if (comments.length === 0) return null;
   return (
@@ -152,6 +168,7 @@ export const FileCommentBanner: React.FC<FileCommentBannerProps> = ({
           onSelect={onSelect}
           onEdit={onEdit}
           onDelete={onDelete}
+          onHeightChange={onHeightChange}
         />
       ))}
     </div>

--- a/packages/review-editor/components/FileCommentBanner.tsx
+++ b/packages/review-editor/components/FileCommentBanner.tsx
@@ -2,7 +2,9 @@ import React, { useMemo, useState } from 'react';
 import type { CodeAnnotation } from '@plannotator/ui/types';
 import { sanitizeBlockHtml } from '@plannotator/ui/utils/sanitizeHtml';
 import { CommentMeta } from './CommentMeta';
+import { CommentActions } from './CommentActions';
 import { FileNameChip } from './FileNameChip';
+import { commentCopyText } from '../utils/annotationDisplay';
 
 interface FileCommentBannerProps {
   /** File-scoped comments for ONE file (already filtered to scope === 'file'). */
@@ -57,7 +59,7 @@ export const FileCommentCard: React.FC<{
 
   return (
     <div
-      className={`review-comment${isSelected ? ' is-selected' : ''}`}
+      className={`review-comment group${isSelected ? ' is-selected' : ''}`}
       data-annotation-id={comment.id}
       onClick={() => onSelect(comment.id)}
     >
@@ -84,32 +86,6 @@ export const FileCommentCard: React.FC<{
         source={comment.source}
         author={comment.author}
         createdAt={comment.createdAt}
-        trailing={
-          editable ? (
-            <div className="review-comment-actions">
-              {!isEditing && (
-                <button
-                  className="review-comment-action"
-                  onClick={(e) => { e.stopPropagation(); setDraft(comment.text ?? ''); setIsEditing(true); setCollapsed(false); }}
-                  title="Edit"
-                >
-                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                  </svg>
-                </button>
-              )}
-              <button
-                className="review-comment-action destructive"
-                onClick={(e) => { e.stopPropagation(); onDelete(comment.id); }}
-                title="Delete"
-              >
-                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </button>
-            </div>
-          ) : undefined
-        }
       />
 
       {isEditing ? (
@@ -141,6 +117,13 @@ export const FileCommentCard: React.FC<{
           <div className="review-comment-body ai-markdown" dangerouslySetInnerHTML={{ __html: html }} />
         )
       ) : null}
+      {!isEditing && (
+        <CommentActions
+          onEdit={editable ? () => { setDraft(comment.text ?? ''); setIsEditing(true); setCollapsed(false); } : undefined}
+          copyText={comment.text ? commentCopyText(comment) : undefined}
+          onDelete={editable ? () => onDelete(comment.id) : undefined}
+        />
+      )}
     </div>
   );
 };

--- a/packages/review-editor/components/FileCommentBanner.tsx
+++ b/packages/review-editor/components/FileCommentBanner.tsx
@@ -60,9 +60,6 @@ export const FileCommentCard: React.FC<{
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [collapsed, isEditing]);
 
-  // Edit is gated on !source (external findings are managed elsewhere); delete is
-  // always available so findings can be dismissed from any surface.
-  const editable = !comment.source;
   const html = useMemo(
     () => (comment.text ? sanitizeBlockHtml(comment.text) : ''),
     [comment.text],
@@ -136,7 +133,7 @@ export const FileCommentCard: React.FC<{
       ) : null}
       {!isEditing && (
         <CommentActions
-          onEdit={editable ? () => { setDraft(comment.text ?? ''); setIsEditing(true); setCollapsed(false); } : undefined}
+          onEdit={() => { setDraft(comment.text ?? ''); setIsEditing(true); setCollapsed(false); }}
           copyText={comment.text ? commentCopyText(comment) : undefined}
           onDelete={() => onDelete(comment.id)}
         />

--- a/packages/review-editor/components/FileHeader.tsx
+++ b/packages/review-editor/components/FileHeader.tsx
@@ -146,7 +146,7 @@ export const FileHeader: React.FC<FileHeaderProps> = ({
       <div className="min-w-0 flex flex-1 items-center" onClick={onCollapseToggle} style={onCollapseToggle ? { cursor: 'pointer' } : undefined}>
         {collapseToggle}
         <span
-          className="min-w-0 flex items-center text-xs font-semibold leading-none whitespace-nowrap"
+          className="min-w-0 flex items-center text-xs font-semibold leading-normal whitespace-nowrap"
           title={status === 'renamed' && oldPath ? `${oldPath} → ${filePath}` : filePath}
         >
           {/* Rename: dimmed old path → new path (diffshub treatment). Dropped

--- a/packages/review-editor/components/FileNameChip.tsx
+++ b/packages/review-editor/components/FileNameChip.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { fileBasename } from '../utils/fileName';
+
+/**
+ * Compact chip showing a file's name (basename) with the full path on hover.
+ * Shared label for file-scoped annotations across the comment banner, sidebar,
+ * and AI tab so the "which file" marker stays visually consistent everywhere.
+ */
+export const FileNameChip: React.FC<{ path: string }> = ({ path }) => (
+  <span
+    className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-primary/10 text-primary truncate max-w-[180px]"
+    title={path}
+  >
+    {fileBasename(path)}
+  </span>
+);

--- a/packages/review-editor/components/InlineAnnotation.tsx
+++ b/packages/review-editor/components/InlineAnnotation.tsx
@@ -24,6 +24,8 @@ export const InlineAnnotation: React.FC<InlineAnnotationProps> = ({
   onDelete,
 }) => {
   const severity = metadata.severity ? SEVERITY_STYLES[metadata.severity] : null;
+  // External (source-set) findings are read-only — matches the file-comment card.
+  const editable = !metadata.source;
 
   return (
     <div
@@ -58,9 +60,9 @@ export const InlineAnnotation: React.FC<InlineAnnotationProps> = ({
         </div>
       )}
       <CommentActions
-        onEdit={() => onEdit(metadata.annotationId)}
-        copyText={metadata.text ? `${metadata.text}${metadata.reasoning ? `\n\nReasoning: ${metadata.reasoning}` : ''}` : undefined}
-        onDelete={() => onDelete(metadata.annotationId)}
+        onEdit={editable ? () => onEdit(metadata.annotationId) : undefined}
+        copyText={metadata.copyText}
+        onDelete={editable ? () => onDelete(metadata.annotationId) : undefined}
       />
     </div>
   );

--- a/packages/review-editor/components/InlineAnnotation.tsx
+++ b/packages/review-editor/components/InlineAnnotation.tsx
@@ -24,7 +24,8 @@ export const InlineAnnotation: React.FC<InlineAnnotationProps> = ({
   onDelete,
 }) => {
   const severity = metadata.severity ? SEVERITY_STYLES[metadata.severity] : null;
-  // External (source-set) findings are read-only — matches the file-comment card.
+  // Edit is gated on !source (external findings are managed elsewhere); delete
+  // stays available so findings can be dismissed from any surface.
   const editable = !metadata.source;
 
   return (
@@ -62,7 +63,7 @@ export const InlineAnnotation: React.FC<InlineAnnotationProps> = ({
       <CommentActions
         onEdit={editable ? () => onEdit(metadata.annotationId) : undefined}
         copyText={metadata.copyText}
-        onDelete={editable ? () => onDelete(metadata.annotationId) : undefined}
+        onDelete={() => onDelete(metadata.annotationId)}
       />
     </div>
   );

--- a/packages/review-editor/components/InlineAnnotation.tsx
+++ b/packages/review-editor/components/InlineAnnotation.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { SEVERITY_STYLES, DiffAnnotationMetadata } from '@plannotator/ui/types';
 import { SuggestionBlock } from './SuggestionBlock';
 import { CommentMeta } from './CommentMeta';
+import { CommentActions } from './CommentActions';
 import { renderInlineMarkdown } from '../utils/renderInlineMarkdown';
 
 interface InlineAnnotationProps {
@@ -26,7 +27,7 @@ export const InlineAnnotation: React.FC<InlineAnnotationProps> = ({
 
   return (
     <div
-      className={`review-comment${isSelected ? ' is-selected' : ''}`}
+      className={`review-comment group${isSelected ? ' is-selected' : ''}`}
       data-annotation-id={metadata.annotationId}
       onClick={() => onSelect(metadata.annotationId)}
     >
@@ -42,34 +43,6 @@ export const InlineAnnotation: React.FC<InlineAnnotationProps> = ({
         source={metadata.source}
         author={metadata.author}
         createdAt={metadata.createdAt}
-        trailing={
-          <div className="review-comment-actions">
-            <button
-              className="review-comment-action"
-              onClick={(e) => {
-                e.stopPropagation();
-                onEdit(metadata.annotationId);
-              }}
-              title="Edit"
-            >
-              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            </button>
-            <button
-              className="review-comment-action destructive"
-              onClick={(e) => {
-                e.stopPropagation();
-                onDelete(metadata.annotationId);
-              }}
-              title="Delete"
-            >
-              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-          </div>
-        }
       />
       {metadata.text && (
         <div className="review-comment-body">{renderInlineMarkdown(metadata.text)}</div>
@@ -84,6 +57,11 @@ export const InlineAnnotation: React.FC<InlineAnnotationProps> = ({
           <SuggestionBlock code={metadata.suggestedCode} originalCode={metadata.originalCode} language={language} />
         </div>
       )}
+      <CommentActions
+        onEdit={() => onEdit(metadata.annotationId)}
+        copyText={metadata.text ? `${metadata.text}${metadata.reasoning ? `\n\nReasoning: ${metadata.reasoning}` : ''}` : undefined}
+        onDelete={() => onDelete(metadata.annotationId)}
+      />
     </div>
   );
 };

--- a/packages/review-editor/components/InlineAnnotation.tsx
+++ b/packages/review-editor/components/InlineAnnotation.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { SEVERITY_STYLES, DiffAnnotationMetadata } from '@plannotator/ui/types';
 import { SuggestionBlock } from './SuggestionBlock';
-import { ConventionalLabelBadge } from './ConventionalLabelPicker';
+import { CommentMeta } from './CommentMeta';
 import { renderInlineMarkdown } from '../utils/renderInlineMarkdown';
 
 interface InlineAnnotationProps {
   metadata: DiffAnnotationMetadata;
   language?: string;
+  isSelected?: boolean;
   onSelect: (id: string) => void;
   onEdit: (id: string) => void;
   onDelete: (id: string) => void;
@@ -16,6 +17,7 @@ interface InlineAnnotationProps {
 export const InlineAnnotation: React.FC<InlineAnnotationProps> = ({
   metadata,
   language,
+  isSelected = false,
   onSelect,
   onEdit,
   onDelete,
@@ -24,47 +26,51 @@ export const InlineAnnotation: React.FC<InlineAnnotationProps> = ({
 
   return (
     <div
-      className="review-comment"
+      className={`review-comment${isSelected ? ' is-selected' : ''}`}
       data-annotation-id={metadata.annotationId}
       onClick={() => onSelect(metadata.annotationId)}
     >
-      <div className="review-comment-header">
-        <div className="flex items-center gap-1.5">
-          {severity && (
+      <CommentMeta
+        leading={
+          severity && (
             <span className={`w-2 h-2 rounded-full flex-shrink-0 ${severity.dot}`} title={severity.label} />
-          )}
-          {metadata.conventionalLabel && (
-            <ConventionalLabelBadge label={metadata.conventionalLabel} decorations={metadata.decorations} />
-          )}
-          {metadata.author && <span className="text-xs text-muted-foreground">{metadata.author}</span>}
-        </div>
-        <div className="review-comment-actions">
-          <button
-            className="review-comment-action"
-            onClick={(e) => {
-              e.stopPropagation();
-              onEdit(metadata.annotationId);
-            }}
-            title="Edit"
-          >
-            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-            </svg>
-          </button>
-          <button
-            className="review-comment-action destructive"
-            onClick={(e) => {
-              e.stopPropagation();
-              onDelete(metadata.annotationId);
-            }}
-            title="Delete"
-          >
-            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
-      </div>
+          )
+        }
+        conventionalLabel={metadata.conventionalLabel}
+        decorations={metadata.decorations}
+        reviewProfileLabel={metadata.reviewProfileLabel}
+        source={metadata.source}
+        author={metadata.author}
+        createdAt={metadata.createdAt}
+        trailing={
+          <div className="review-comment-actions">
+            <button
+              className="review-comment-action"
+              onClick={(e) => {
+                e.stopPropagation();
+                onEdit(metadata.annotationId);
+              }}
+              title="Edit"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+              </svg>
+            </button>
+            <button
+              className="review-comment-action destructive"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete(metadata.annotationId);
+              }}
+              title="Delete"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        }
+      />
       {metadata.text && (
         <div className="review-comment-body">{renderInlineMarkdown(metadata.text)}</div>
       )}

--- a/packages/review-editor/components/InlineAnnotation.tsx
+++ b/packages/review-editor/components/InlineAnnotation.tsx
@@ -24,9 +24,6 @@ export const InlineAnnotation: React.FC<InlineAnnotationProps> = ({
   onDelete,
 }) => {
   const severity = metadata.severity ? SEVERITY_STYLES[metadata.severity] : null;
-  // Edit is gated on !source (external findings are managed elsewhere); delete
-  // stays available so findings can be dismissed from any surface.
-  const editable = !metadata.source;
 
   return (
     <div
@@ -61,7 +58,7 @@ export const InlineAnnotation: React.FC<InlineAnnotationProps> = ({
         </div>
       )}
       <CommentActions
-        onEdit={editable ? () => onEdit(metadata.annotationId) : undefined}
+        onEdit={() => onEdit(metadata.annotationId)}
         copyText={metadata.copyText}
         onDelete={() => onDelete(metadata.annotationId)}
       />

--- a/packages/review-editor/components/PRCommentsTab.tsx
+++ b/packages/review-editor/components/PRCommentsTab.tsx
@@ -387,7 +387,7 @@ export const PRCommentsTab: React.FC<PRCommentsTabProps> = React.memo(({ context
                 )}
 
                 {!isCollapsed && (
-                  <CommentActions
+                  <PRCommentLinkActions
                     url={entry.kind === 'comment' ? (entry.data as PRComment).url : (entry.data as PRReview).url}
                     body={entry.data.body}
                   />
@@ -525,14 +525,14 @@ function ThreadCard({ thread, isSelected, isCollapsed, onSelect, onToggleCollaps
           )}
 
           {/* Actions */}
-          <CommentActions url={first.url} body={first.body} />
+          <PRCommentLinkActions url={first.url} body={first.body} />
         </>
       )}
     </div>
   );
 }
 
-function CommentActions({ url, body }: { url?: string; body: string }) {
+function PRCommentLinkActions({ url, body }: { url?: string; body: string }) {
   if (!url && !body) return null;
 
   return (

--- a/packages/review-editor/components/ReviewSidebar.tsx
+++ b/packages/review-editor/components/ReviewSidebar.tsx
@@ -1,14 +1,13 @@
 import React, { useState } from 'react';
 import { CodeAnnotation, type CodeAnnotationScope, type EditorAnnotation } from '@plannotator/ui/types';
-import { isCurrentUser } from '@plannotator/ui/utils/identity';
+import { CommentMeta } from './CommentMeta';
 import { EditorAnnotationCard } from '@plannotator/ui/components/EditorAnnotationCard';
 import { CopyButton } from './CopyButton';
 import { copyLocationPrefix } from '../utils/annotationDisplay';
-import { ConventionalLabelBadge } from './ConventionalLabelPicker';
 import { HighlightedCode } from './HighlightedCode';
 import { detectLanguage } from '../utils/detectLanguage';
 import { renderInlineMarkdown } from '../utils/renderInlineMarkdown';
-import { formatRelativeTime } from '../utils/formatRelativeTime';
+import { FileNameChip } from './FileNameChip';
 import { AITab } from './AITab';
 import { AgentsTab } from '@plannotator/ui/components/AgentsTab';
 import type { PRMetadata } from '@plannotator/shared/pr-types';
@@ -29,6 +28,8 @@ interface ReviewSidebarProps {
   files: DiffFile[];
   selectedAnnotationId: string | null;
   onSelectAnnotation: (id: string | null) => void;
+  /** Sidebar row click → select AND scroll the diff to the comment. */
+  onNavigateToAnnotation: (id: string | null) => void;
   onDeleteAnnotation: (id: string) => void;
   feedbackMarkdown?: string;
   width?: number;
@@ -115,6 +116,7 @@ export const ReviewSidebar: React.FC<ReviewSidebarProps> = /* React.memo */({
   files,
   selectedAnnotationId,
   onSelectAnnotation,
+  onNavigateToAnnotation,
   onDeleteAnnotation,
   feedbackMarkdown,
   width,
@@ -213,23 +215,21 @@ export const ReviewSidebar: React.FC<ReviewSidebarProps> = /* React.memo */({
     return (
       <div
         key={annotation.id}
-        onClick={() => onSelectAnnotation(annotation.id)}
+        onClick={() => onNavigateToAnnotation(annotation.id)}
         className={`group relative p-2.5 rounded border cursor-pointer transition-colors duration-150 ${
           isSelected
             ? 'bg-primary/5 border-primary/30'
             : 'border-transparent hover:bg-muted/30'
         }`}
       >
-        <div className="flex items-center justify-between mb-1.5">
-          <div className="flex items-center gap-2">
-            {isGeneralScope ? (
+        <CommentMeta
+          leading={
+            isGeneralScope ? (
               <span className="text-[9px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded bg-primary/10 text-primary">
                 general
               </span>
             ) : isFileScope ? (
-              <span className="text-[9px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded bg-primary/10 text-primary">
-                file
-              </span>
+              <FileNameChip path={annotation.filePath} />
             ) : (
               <span className="text-[10px] font-mono text-muted-foreground">
                 {annotation.lineStart === annotation.lineEnd
@@ -239,25 +239,15 @@ export const ReviewSidebar: React.FC<ReviewSidebarProps> = /* React.memo */({
                   <span className="ml-1 text-primary/70">{`\`${annotation.tokenText.length > 30 ? annotation.tokenText.slice(0, 27) + '...' : annotation.tokenText}\``}</span>
                 )}
               </span>
-            )}
-            {annotation.conventionalLabel && (
-              <ConventionalLabelBadge label={annotation.conventionalLabel} decorations={annotation.decorations} />
-            )}
-            {annotation.reviewProfileLabel && (
-              <span className="text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-accent/10 text-accent/90">
-                {annotation.reviewProfileLabel}
-              </span>
-            )}
-            {annotation.author && (
-              <span className={`text-[10px] truncate max-w-[100px] ${isCurrentUser(annotation.author) ? 'text-muted-foreground/50' : 'text-muted-foreground/70'}`}>
-                {annotation.author}{isCurrentUser(annotation.author) && ' (me)'}
-              </span>
-            )}
-          </div>
-          <span className="text-[10px] text-muted-foreground/50">
-            {formatRelativeTime(annotation.createdAt)}
-          </span>
-        </div>
+            )
+          }
+          conventionalLabel={annotation.conventionalLabel}
+          decorations={annotation.decorations}
+          reviewProfileLabel={annotation.reviewProfileLabel}
+          source={annotation.source}
+          author={annotation.author}
+          createdAt={annotation.createdAt}
+        />
         {annotation.text && (
           <div className="text-xs text-foreground/80 line-clamp-2 review-comment-markdown">
             {renderInlineMarkdown(annotation.text)}

--- a/packages/review-editor/components/ReviewSidebar.tsx
+++ b/packages/review-editor/components/ReviewSidebar.tsx
@@ -2,8 +2,8 @@ import React, { useState } from 'react';
 import { CodeAnnotation, type CodeAnnotationScope, type EditorAnnotation } from '@plannotator/ui/types';
 import { CommentMeta } from './CommentMeta';
 import { EditorAnnotationCard } from '@plannotator/ui/components/EditorAnnotationCard';
-import { CopyButton } from './CopyButton';
-import { copyLocationPrefix } from '../utils/annotationDisplay';
+import { CommentActions } from './CommentActions';
+import { commentCopyText } from '../utils/annotationDisplay';
 import { HighlightedCode } from './HighlightedCode';
 import { detectLanguage } from '../utils/detectLanguage';
 import { renderInlineMarkdown } from '../utils/renderInlineMarkdown';
@@ -258,23 +258,10 @@ export const ReviewSidebar: React.FC<ReviewSidebarProps> = /* React.memo */({
             <SuggestionPreview code={annotation.suggestedCode} originalCode={annotation.originalCode} language={detectLanguage(annotation.filePath)} />
           </div>
         )}
-        <div className="flex items-center justify-end gap-1 mt-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
-          {annotation.text && (
-            <CopyButton text={`${copyLocationPrefix(annotation, scope)}${annotation.text}${annotation.reasoning ? `\n\nReasoning: ${annotation.reasoning}` : ''}`} variant="inline" />
-          )}
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              onDeleteAnnotation(annotation.id);
-            }}
-            className="p-1 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors"
-            title="Delete annotation"
-          >
-            <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
+        <CommentActions
+          copyText={annotation.text ? commentCopyText(annotation, scope) : undefined}
+          onDelete={() => onDeleteAnnotation(annotation.id)}
+        />
       </div>
     );
   }

--- a/packages/review-editor/dock/ReviewStateContext.tsx
+++ b/packages/review-editor/dock/ReviewStateContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext } from 'react';
 import type { CodeAnnotation, CodeAnnotationType, SelectedLineRange, TokenAnnotationMeta, ConventionalLabel, ConventionalDecoration } from '@plannotator/ui/types';
 import type { AgentJobInfo } from '@plannotator/ui/types';
-import type { DiffFile } from '../types';
+import type { DiffFile, AnnotationScrollTarget } from '../types';
 import type { AIChatEntry } from '../hooks/useAIChat';
 import type { ReviewSearchMatch } from '../utils/reviewSearch';
 import type { PRMetadata, PRContext } from '@plannotator/shared/pr-types';
@@ -50,6 +50,9 @@ export interface ReviewState {
   allAnnotations: CodeAnnotation[];
   externalAnnotations: CodeAnnotation[];
   selectedAnnotationId: string | null;
+  /** Sidebar-initiated scroll-to-comment signal; the token re-fires per click.
+   *  Selecting a comment in the diff does NOT set this, so it never scrolls. */
+  scrollTargetAnnotation: AnnotationScrollTarget | null;
   pendingSelection: SelectedLineRange | null;
   onLineSelection: (range: SelectedLineRange | null) => void;
   onAddAnnotation: (type: CodeAnnotationType, text?: string, suggestedCode?: string, originalCode?: string, conventionalLabel?: ConventionalLabel, decorations?: ConventionalDecoration[], tokenMeta?: TokenAnnotationMeta) => void;
@@ -57,7 +60,10 @@ export interface ReviewState {
   onAddFileComment: (text: string) => void;
   onAddFileCommentForFile: (filePath: string, text: string) => void;
   onEditAnnotation: (id: string, text?: string, suggestedCode?: string, originalCode?: string, conventionalLabel?: ConventionalLabel | null, decorations?: ConventionalDecoration[]) => void;
+  /** Highlight a comment without moving the viewport (in-diff click). */
   onSelectAnnotation: (id: string | null) => void;
+  /** Select AND scroll the diff to a comment (sidebar / findings-list click). */
+  onNavigateToAnnotation: (id: string | null) => void;
   onDeleteAnnotation: (id: string) => void;
 
   // Viewed / staged

--- a/packages/review-editor/dock/panels/ReviewAgentJobDetailPanel.tsx
+++ b/packages/review-editor/dock/panels/ReviewAgentJobDetailPanel.tsx
@@ -86,8 +86,10 @@ export const ReviewAgentJobDetailPanel: React.FC<IDockviewPanelProps> = (props) 
   const handleAnnotationClick = useCallback((ann: CodeAnnotation) => {
     // General comments belong to no file — nothing to open in the diff.
     if (ann.filePath) state.openDiffFile(ann.filePath);
-    state.onSelectAnnotation(ann.id);
-  }, [state.openDiffFile, state.onSelectAnnotation]);
+    // Navigate (select + scroll): clicking a finding should jump the diff to it,
+    // not merely toggle its highlight.
+    state.onNavigateToAnnotation(ann.id);
+  }, [state.openDiffFile, state.onNavigateToAnnotation]);
 
   // Copy All uses the diff context snapshotted on the JOB at launch, not the
   // current UI state — so if the reviewer switches modes/bases after the job

--- a/packages/review-editor/dock/panels/ReviewAgentJobDetailPanel.tsx
+++ b/packages/review-editor/dock/panels/ReviewAgentJobDetailPanel.tsx
@@ -459,12 +459,12 @@ function AnnotationRow({ annotation: ann, dismissed, onClick }: {
         )}
       </div>
       {ann.text && (
-        <p className={`text-xs mt-1 leading-relaxed ${dismissed ? 'text-muted-foreground/40' : 'text-foreground/80'}`}>
+        <p className={`text-xs mt-1 leading-relaxed break-words [overflow-wrap:anywhere] ${dismissed ? 'text-muted-foreground/40' : 'text-foreground/80'}`}>
           {ann.text}
         </p>
       )}
       {ann.reasoning && (
-        <p className="text-[11px] text-muted-foreground/60 leading-relaxed mt-1.5">
+        <p className="text-[11px] text-muted-foreground/60 leading-relaxed mt-1.5 break-words [overflow-wrap:anywhere]">
           {ann.reasoning}
         </p>
       )}

--- a/packages/review-editor/dock/panels/ReviewAgentJobDetailPanel.tsx
+++ b/packages/review-editor/dock/panels/ReviewAgentJobDetailPanel.tsx
@@ -8,7 +8,7 @@ import { CopyButton } from '../../components/CopyButton';
 import { LiveLogViewer } from '../../components/LiveLogViewer';
 import { ScrollFade } from '../../components/ScrollFade';
 import { exportReviewFeedback } from '../../utils/exportFeedback';
-import { annotationScope, copyLocationPrefix } from '../../utils/annotationDisplay';
+import { annotationScope, commentCopyText } from '../../utils/annotationDisplay';
 
 // ---------------------------------------------------------------------------
 // Panel
@@ -413,7 +413,7 @@ function AnnotationRow({ annotation: ann, dismissed, onClick }: {
   onClick: (ann: CodeAnnotation) => void;
 }) {
   const scope = annotationScope(ann);
-  const copyText = ann.text ? `${copyLocationPrefix(ann, scope)}${ann.text}${ann.reasoning ? `\n\nReasoning: ${ann.reasoning}` : ''}` : '';
+  const copyText = ann.text ? commentCopyText(ann, scope) : '';
   const severity = ann.severity ? SEVERITY_STYLES[ann.severity] : null;
   return (
     <div

--- a/packages/review-editor/dock/panels/ReviewAllFilesDiffPanel.tsx
+++ b/packages/review-editor/dock/panels/ReviewAllFilesDiffPanel.tsx
@@ -20,6 +20,7 @@ export const ReviewAllFilesDiffPanel: React.FC<IDockviewPanelProps> = () => {
       fontSize={state.fontSize}
       annotations={state.allAnnotations}
       selectedAnnotationId={state.selectedAnnotationId}
+      scrollTargetAnnotation={state.scrollTargetAnnotation}
       pendingSelection={state.pendingSelection}
       reviewBase={state.reviewBase}
       onLineSelection={state.onLineSelection}

--- a/packages/review-editor/dock/panels/ReviewDiffPanel.tsx
+++ b/packages/review-editor/dock/panels/ReviewDiffPanel.tsx
@@ -3,6 +3,7 @@ import type { IDockviewPanelProps } from 'dockview-react';
 import { DiffViewer } from '../../components/DiffViewer';
 import { useReviewState } from '../ReviewStateContext';
 import { getReviewDiffPanelFilePath, type ReviewDiffPanelParams } from '../reviewPanelTypes';
+import { annotationMatchesPrScope } from '../../utils/annotationScope';
 
 /**
  * Thin adapter between dockview's panel API and the existing DiffViewer.
@@ -27,8 +28,7 @@ export const ReviewDiffPanel: React.FC<IDockviewPanelProps> = (props) => {
       const currentDiffScope = state.prDiffScope;
       return state.allAnnotations.filter((a) =>
         a.filePath === file.path &&
-        (!a.prUrl || !currentPrUrl || a.prUrl === currentPrUrl) &&
-        (!a.diffScope || !currentDiffScope || a.diffScope === currentDiffScope)
+        annotationMatchesPrScope(a, currentPrUrl, currentDiffScope)
       );
     },
     [state.allAnnotations, file, state.prMetadata, state.prDiffScope]
@@ -86,6 +86,7 @@ export const ReviewDiffPanel: React.FC<IDockviewPanelProps> = (props) => {
         fontSize={state.fontSize}
         annotations={fileAnnotations}
         selectedAnnotationId={state.selectedAnnotationId}
+        scrollTargetAnnotation={state.scrollTargetAnnotation}
         pendingSelection={state.pendingSelection}
         onLineSelection={state.onLineSelection}
         onAddAnnotation={state.onAddAnnotation}

--- a/packages/review-editor/index.css
+++ b/packages/review-editor/index.css
@@ -167,43 +167,6 @@ diffs-container {
   color: var(--muted-foreground);
 }
 
-.review-comment-actions {
-  /* Float in the card's top-right corner instead of taking inline space — an
-     opacity:0 in-flow row would reserve width and shove the timestamp left,
-     misaligning it vs. surfaces without actions (the sidebar). Absolute keeps the
-     timestamp flush-right everywhere; actions fade in over the corner on hover. */
-  position: absolute;
-  top: 0.5rem;
-  right: 0.6rem;
-  display: flex;
-  gap: 0.125rem;
-  opacity: 0;
-  transform: scale(0.95);
-  transition: opacity 100ms, transform 100ms;
-}
-
-.review-comment:hover .review-comment-actions {
-  opacity: 1;
-  transform: scale(1);
-}
-
-.review-comment-action {
-  padding: 0.25rem;
-  border-radius: 4px;
-  color: var(--muted-foreground);
-  transition: color 100ms, background 100ms;
-}
-
-.review-comment-action:hover {
-  color: var(--foreground);
-  background: var(--muted);
-}
-
-.review-comment-action.destructive:hover {
-  color: var(--destructive);
-  background: oklch(from var(--destructive) l c h / 0.1);
-}
-
 .review-comment > .review-comment-body {
   min-width: 0;
   color: var(--foreground);

--- a/packages/review-editor/index.css
+++ b/packages/review-editor/index.css
@@ -120,23 +120,41 @@ diffs-container {
 .review-comment {
   position: relative;
   box-sizing: border-box;
-  width: 100%;
-  max-width: 100%;
+  /* Subtract the horizontal margins: box-sizing can't account for margin, so a
+     plain width:100% + side margins would overflow the slot (right edge touches
+     the container). Keep this in sync with the horizontal margin below. */
+  width: calc(100% - 0.5rem);
+  max-width: calc(100% - 0.5rem);
   min-width: 0;
   background: var(--popover);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: 8px;
   padding: 0.625rem 0.75rem;
   font-size: 0.8125rem;
-  margin: 0.5rem 0;
+  /* Force the app's sans font — without this the card inherits its surroundings,
+     which inside the diff is MONOSPACE, making inline comment prose hard to read
+     and inconsistent with the sidebar. Code spans opt back into mono explicitly. */
+  font-family: var(--font-sans);
+  margin: 0.5rem 0.25rem;
   cursor: pointer;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+  /* Soft two-layer shadow (close contact + ambient lift) for a card that reads
+     as elevated above the diff without a heavy border. */
+  box-shadow: 0 1px 2px rgb(0 0 0 / 0.04), 0 4px 10px rgb(0 0 0 / 0.04);
   transition: border-color 150ms, box-shadow 150ms, background 150ms;
 }
 
 .review-comment:hover {
   border-color: var(--muted-foreground);
-  box-shadow: 0 2px 6px rgba(0,0,0,0.06);
+  box-shadow: 0 1px 2px rgb(0 0 0 / 0.05), 0 6px 16px rgb(0 0 0 / 0.07);
+}
+
+/* Selected state — shared by inline annotations and file-comment cards. A
+   primary-colored border + 1px ring mirrors the sidebar's selected row so the
+   clicked card and its highlighted diff lines read as one selection. */
+.review-comment.is-selected,
+.review-comment.is-selected:hover {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 1px var(--primary), 0 4px 12px rgb(0 0 0 / 0.06);
 }
 
 .review-comment-header {
@@ -150,7 +168,13 @@ diffs-container {
 }
 
 .review-comment-actions {
-  margin-left: auto;
+  /* Float in the card's top-right corner instead of taking inline space — an
+     opacity:0 in-flow row would reserve width and shove the timestamp left,
+     misaligning it vs. surfaces without actions (the sidebar). Absolute keeps the
+     timestamp flush-right everywhere; actions fade in over the corner on hover. */
+  position: absolute;
+  top: 0.5rem;
+  right: 0.6rem;
   display: flex;
   gap: 0.125rem;
   opacity: 0;
@@ -187,6 +211,12 @@ diffs-container {
   white-space: pre-wrap;
   overflow-wrap: anywhere;
   word-break: break-word;
+}
+
+/* Block markdown in the file-comment banner: cancel the pre-wrap used for the
+   inline-markdown body so rendered paragraphs/lists don't gain blank lines. */
+.review-comment > .review-comment-body.ai-markdown {
+  white-space: normal;
 }
 
 /* Inline markdown in review comments */

--- a/packages/review-editor/index.css
+++ b/packages/review-editor/index.css
@@ -182,6 +182,14 @@ diffs-container {
   white-space: normal;
 }
 
+/* Finding reasoning — wrap long unbroken tokens (file:line refs, identifiers) so
+   they don't bleed past the card's right edge, same as the comment body. */
+.review-comment-reasoning {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 /* Inline markdown in review comments */
 .review-comment-body .inline-code,
 .review-comment-markdown .inline-code {

--- a/packages/review-editor/types.ts
+++ b/packages/review-editor/types.ts
@@ -13,3 +13,14 @@ export interface DiffFile {
   deletions: number;
   status: DiffFileStatus;
 }
+
+/**
+ * A "scroll the diff to this comment" request, distinct from mere selection so
+ * that clicking a comment in the diff (select/highlight) never moves the
+ * viewport while a sidebar / findings-list click (navigate) does. The `token`
+ * bumps on every navigate so re-selecting the same comment re-fires the scroll.
+ */
+export interface AnnotationScrollTarget {
+  id: string;
+  token: number;
+}

--- a/packages/review-editor/utils/annotationDisplay.ts
+++ b/packages/review-editor/utils/annotationDisplay.ts
@@ -1,4 +1,4 @@
-import type { CodeAnnotation, CodeAnnotationScope } from '@plannotator/ui/types';
+import type { CodeAnnotation, CodeAnnotationScope, DiffAnnotationMetadata } from '@plannotator/ui/types';
 
 /** A code annotation's scope, defaulting to 'line' for older/external data. */
 export function annotationScope(a: CodeAnnotation): CodeAnnotationScope {
@@ -30,4 +30,30 @@ export function commentCopyText(
   scope: CodeAnnotationScope = annotationScope(a),
 ): string {
   return `${copyLocationPrefix(a, scope)}${a.text ?? ''}${a.reasoning ? `\n\nReasoning: ${a.reasoning}` : ''}`;
+}
+
+/**
+ * Project a line-scoped CodeAnnotation into the @pierre/diffs line-annotation
+ * metadata the inline card renders. Single source of truth so the all-files and
+ * single-file diff surfaces stay in lockstep (and so the per-file refresh
+ * signature can't drift from what's actually rendered). Whenever a field is
+ * added here, mirror it into the signature builders that gate updateItem().
+ */
+export function lineAnnotationMetadata(ann: CodeAnnotation): DiffAnnotationMetadata {
+  return {
+    annotationId: ann.id,
+    type: ann.type,
+    text: ann.text,
+    suggestedCode: ann.suggestedCode,
+    originalCode: ann.originalCode,
+    author: ann.author,
+    severity: ann.severity,
+    reasoning: ann.reasoning,
+    conventionalLabel: ann.conventionalLabel,
+    decorations: ann.decorations,
+    createdAt: ann.createdAt,
+    reviewProfileLabel: ann.reviewProfileLabel,
+    source: ann.source,
+    copyText: ann.text ? commentCopyText(ann) : undefined,
+  };
 }

--- a/packages/review-editor/utils/annotationDisplay.ts
+++ b/packages/review-editor/utils/annotationDisplay.ts
@@ -19,3 +19,15 @@ export function copyLocationPrefix(
   if (scope === 'file') return `${a.filePath}\n`;
   return `${a.filePath}:${a.lineStart}${a.lineEnd !== a.lineStart ? `-${a.lineEnd}` : ''}\n`;
 }
+
+/**
+ * The full clipboard text for a comment: location prefix + body + reasoning.
+ * Shared by every comment card's copy action so they produce identical,
+ * self-describing text.
+ */
+export function commentCopyText(
+  a: CodeAnnotation,
+  scope: CodeAnnotationScope = annotationScope(a),
+): string {
+  return `${copyLocationPrefix(a, scope)}${a.text ?? ''}${a.reasoning ? `\n\nReasoning: ${a.reasoning}` : ''}`;
+}

--- a/packages/review-editor/utils/annotationScope.ts
+++ b/packages/review-editor/utils/annotationScope.ts
@@ -1,0 +1,39 @@
+import type { CodeAnnotation, SelectedLineRange } from '@plannotator/ui/types';
+
+/**
+ * True when an annotation belongs to the active PR + diff-scope (or carries no
+ * PR scope of its own). Centralizes the predicate that the diff surfaces use to
+ * keep annotations from one PR/diff-scope out of another after an in-place
+ * switch — previously duplicated inline across ReviewDiffPanel,
+ * projectFileAnnotations, and the file-comment projections.
+ */
+export function annotationMatchesPrScope(
+  a: CodeAnnotation,
+  prUrl: string | undefined,
+  prDiffScope: string | undefined,
+): boolean {
+  return (
+    (!a.prUrl || !prUrl || a.prUrl === prUrl) &&
+    (!a.diffScope || !prDiffScope || a.diffScope === prDiffScope)
+  );
+}
+
+/** True when an annotation is file-scoped (whole-file comment, not a line/general one). */
+export function isFileScopedAnnotation(a: CodeAnnotation): boolean {
+  return (a.scope ?? 'line') === 'file';
+}
+
+/**
+ * The diff line range an annotation anchors to, as a Pierre `SelectedLineRange`
+ * — used to replay a comment's selection as the controlled highlight when it's
+ * clicked. Normalizes endpoint order and maps our `'new'|'old'` side to Pierre's
+ * `'additions'|'deletions'`. Not meaningful for file-scoped comments (callers
+ * skip those via {@link isFileScopedAnnotation}).
+ */
+export function lineRangeForAnnotation(a: CodeAnnotation): SelectedLineRange {
+  return {
+    start: Math.min(a.lineStart, a.lineEnd),
+    end: Math.max(a.lineStart, a.lineEnd),
+    side: a.side === 'new' ? 'additions' : 'deletions',
+  };
+}

--- a/packages/review-editor/utils/fileName.ts
+++ b/packages/review-editor/utils/fileName.ts
@@ -1,0 +1,4 @@
+/** Last path segment (the file name) for display, falling back to the full path. */
+export function fileBasename(path: string): string {
+  return path.split('/').pop() || path;
+}

--- a/packages/ui/types.ts
+++ b/packages/ui/types.ts
@@ -157,6 +157,11 @@ export interface DiffAnnotationMetadata {
   reasoning?: string;
   conventionalLabel?: ConventionalLabel;
   decorations?: ConventionalDecoration[];
+  // Shared comment-meta fields (so the inline diff card shows the same identity
+  // row — author, time, badges — as the sidebar and file-banner cards).
+  createdAt?: number;
+  reviewProfileLabel?: string;
+  source?: string;
   // AI marker fields (set when kind === 'ai-marker')
   kind?: 'annotation' | 'ai-marker';
   questionId?: string;

--- a/packages/ui/types.ts
+++ b/packages/ui/types.ts
@@ -162,6 +162,10 @@ export interface DiffAnnotationMetadata {
   createdAt?: number;
   reviewProfileLabel?: string;
   source?: string;
+  /** Precomputed clipboard text (location prefix + body + reasoning) so the
+   *  inline copy action matches the sidebar/banner — the inline card only has
+   *  the projected metadata, not the full annotation. */
+  copyText?: string;
   // AI marker fields (set when kind === 'ai-marker')
   kind?: 'annotation' | 'ai-marker';
   questionId?: string;


### PR DESCRIPTION
## Summary

Renders **file-scoped comments inline** in the code review UI and overhauls the comment-card UX so the three comment surfaces (inline diff, sidebar, file banner) look and behave consistently.

### File comments
Previously file-scoped comments only showed a truncated preview in the sidebar; they now render in full in the diff:
- **Single-file view:** a full-text banner directly below the file path.
- **All-files view:** in the file header, **only when the file is expanded** (collapsed files stay compact). Pierre's virtualized custom header suppresses the body-prefix slot, but its virtualizer *measures* item heights, so a taller header is safe. This lets guided-review workflows drop the "line-1 anchor" hack with the External Annotations API.

### Click-to-highlight (DiffsHub-style)
- Each comment stores the exact line range it was created from. Clicking a comment — inline card **or** sidebar — replays that range as the controlled selection highlight; clicking again clears it.
- **Scroll/navigate is sidebar- & findings-list-only** (a token-based signal). Clicking a comment *in the diff* highlights its lines but never moves the viewport.

### Unified comment cards
- New shared **`CommentMeta`** identity row (leading badge + label + author + relative time) used by all three cards — they were three separately hand-rolled headers with different author sizes, timestamp placement, and fonts.
- New shared **`FileNameChip`** (file basename, full path on hover) replaces the literal "FILE" badge everywhere it appeared.
- Force the app **sans font** on comment cards — inline comments had been inheriting the diff's *monospace*, which made them hard to read. Code spans still opt back into mono.
- Consistent selected ring, card spacing, and **absolute hover actions** so timestamps line up across surfaces.

### Refactors / shared helpers
- `annotationScope.ts` — `annotationMatchesPrScope`, `isFileScopedAnnotation`, `lineRangeForAnnotation` (consolidates a predicate that was duplicated across the diff panels).
- `fileName.ts` — `fileBasename`.
- `createdAt` (+ `reviewProfileLabel`/`source`) plumbed through `DiffAnnotationMetadata` so inline cards show timestamps.

## Test plan
- Add a file comment (header "Comment" button) → renders below the path in single-file and in the header (expanded) in all-files; collapses with the file.
- Click a comment in the diff → its lines highlight, viewport stays put; click again → clears.
- Click a comment in the sidebar / a finding in an agent review → scrolls/expands to it.
- Inline, sidebar, and file-banner cards share one identity row (author + "Xh ago"), sans font, aligned timestamps.
- File-scope label shows the file **name** (not "FILE") in the comment, sidebar, and AI tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)