### PR TITLE
fix(annotate): make Ask AI announcement provider cards clickable (#972)

### DIFF
--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -4655,6 +4655,8 @@ const App: React.FC = () => {
           isOpen={shouldShowPlanAIAnnouncement}
           origin={origin}
           providerName={selectedAIProvider?.name ?? null}
+          providers={aiProviders}
+          onSelectProvider={(providerId) => handleAIConfigChange({ providerId })}
           onOpenAI={handleOpenAIAnnouncement}
           onDismiss={dismissPlanAIAnnouncement}
         />

--- a/packages/ui/components/PlanAIAnnouncementDialog.tsx
+++ b/packages/ui/components/PlanAIAnnouncementDialog.tsx
@@ -5,10 +5,18 @@ import { AGENT_CONFIG, getAgentAIProviderTypes, getAgentName } from '@plannotato
 import { SparklesIcon } from './SparklesIcon';
 import { getProviderMeta } from './ProviderIcons';
 
+interface PlanAIAnnouncementProvider {
+  id: string;
+  name: string;
+}
+
 interface PlanAIAnnouncementDialogProps {
   isOpen: boolean;
   origin?: Origin | null;
   providerName?: string | null;
+  /** Actually-detected providers (installed + authenticated). Cards matching one of these are selectable. */
+  providers?: PlanAIAnnouncementProvider[];
+  onSelectProvider?: (providerId: string) => void;
   onOpenAI: () => void;
   onDismiss: () => void;
 }
@@ -27,6 +35,8 @@ export const PlanAIAnnouncementDialog: React.FC<PlanAIAnnouncementDialogProps> =
   isOpen,
   origin,
   providerName,
+  providers = [],
+  onSelectProvider,
   onOpenAI,
   onDismiss,
 }) => {
@@ -67,25 +77,55 @@ export const PlanAIAnnouncementDialog: React.FC<PlanAIAnnouncementDialogProps> =
                   const meta = getProviderMeta(providerType);
                   const Icon = meta.icon;
                   const isSelected = providerType === providerName;
-                  return (
-                    <div
-                      key={providerType}
-                      className={`flex min-h-16 items-center gap-2 rounded-lg border p-2.5 ${
-                        isSelected
-                          ? 'border-primary bg-primary/5'
-                          : 'border-border bg-muted/35'
-                      }`}
-                    >
+                  // A card is selectable only if the provider is actually detected on this machine.
+                  const detected = providers.find(p => p.name === providerType) ?? null;
+                  const isSelectable = Boolean(detected && onSelectProvider);
+
+                  const inner = (
+                    <>
                       <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-md bg-background/70 text-muted-foreground">
                         <Icon className="h-[18px] w-[18px]" />
                       </div>
                       <div className="min-w-0">
                         <div className="truncate text-sm font-medium">{meta.label}</div>
-                        {isSelected && (
+                        {isSelected ? (
                           <div className="text-[10px] uppercase tracking-wide text-primary">selected</div>
-                        )}
+                        ) : !detected ? (
+                          <div className="text-[10px] text-muted-foreground/60">not installed</div>
+                        ) : null}
                       </div>
-                    </div>
+                    </>
+                  );
+
+                  if (!isSelectable) {
+                    return (
+                      <div
+                        key={providerType}
+                        className={`flex min-h-16 items-center gap-2 rounded-lg border p-2.5 ${
+                          isSelected
+                            ? 'border-primary bg-primary/5'
+                            : 'border-border bg-muted/35 opacity-60'
+                        }`}
+                      >
+                        {inner}
+                      </div>
+                    );
+                  }
+
+                  return (
+                    <button
+                      key={providerType}
+                      type="button"
+                      onClick={() => onSelectProvider?.(detected!.id)}
+                      aria-pressed={isSelected}
+                      className={`flex min-h-16 items-center gap-2 rounded-lg border p-2.5 text-left transition-colors ${
+                        isSelected
+                          ? 'border-primary bg-primary/5'
+                          : 'border-border bg-muted/35 hover:border-muted-foreground/30 hover:bg-muted/60'
+                      }`}
+                    >
+                      {inner}
+                    </button>
                   );
                 })}
               </div>


### PR DESCRIPTION
Fixes #972

## Problem

The `PlanAIAnnouncementDialog` (the one-time "New: Ask AI for annotated documents" popup) shows provider cards — Claude, OpenCode, Pi, Codex — with clear selection styling: one card reads "SELECTED" while the others look unselected. This strongly implies the cards are clickable to switch the active AI provider.

They weren't. Each card was a plain `<div>` with no `onClick`, so clicking did nothing. A user with both Claude Code and OpenCode installed (Plannotator auto-detects `claude-code` as origin) would see OpenCode sitting right there, click it to switch, and get no response — the affordance lied.

## Fix

- Provider cards now render as `<button>`s for **actually-detected** providers and call the existing AI config change handler — the same path used by the Settings provider selector (`handleAIConfigChange` → `saveAIProviderSelection`).
- Selection state was already lifted in `App.tsx`, so the "SELECTED" badge updates live on click — no new state needed.
- Providers that aren't installed are shown greyed out with a "not installed" label instead of looking selectable, since the dialog's card list is the full set of *supported* provider types, not just the detected ones.
- The dialog is fed the raw detected provider list (`aiProviders`) rather than `visibleAIProviders`, so the agent-terminal substitution doesn't collapse the list to a single pseudo-provider and make every card read "not installed".

## Note on the report's "additional issue" (buttons unresponsive in `--render-html`)

The report also claimed that in `--render-html` mode the embedded iframe captured pointer events, making *all* dialog buttons (including Dismiss) unresponsive.

I could not reproduce this. The dialog renders as a portal overlay above the iframe at `z-[100]`, which receives clicks normally — and manual testing (`annotate <file.html> --render-html --gate`, fresh incognito session) confirmed Dismiss, Open AI Chat, and the cards all work. The reported symptom was the dead-cards bug above: clicking the cards did nothing, which read as "the whole dialog is frozen." This change resolves it; no iframe/layering change was needed.

## Testing

- `tsc --noEmit` clean for `packages/ui`
- `build:hook` and review app build succeed
- Manually verified in `annotate --render-html --gate` (incognito): cards switch provider, badge updates, uninstalled providers greyed, Dismiss / Open AI Chat responsive