### PR TITLE
feat(annotate): show annotation count badge in plan/annotate header

### DIFF
--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -3757,6 +3757,7 @@ const App: React.FC = () => {
           isAIChatOpen={isPanelOpen && rightSidebarTab === 'ai'}
           aiHasMessages={visibleAIMessages.length > 0}
           hasAnyAnnotations={hasAnyAnnotations || hasDirectEdits || hasSavedFileChanges}
+          annotationCount={feedbackAnnotationCount}
           linkedDocIsActive={linkedDocHook.isActive}
           callbackShareUrlReady={callbackConfig ? Boolean(shareUrl || shortShareUrl || (renderAs === 'html' && (shareHtml || rawHtml))) : true}
           canShareCurrentSession={canShareCurrentSession}

--- a/packages/editor/components/AppHeader.tsx
+++ b/packages/editor/components/AppHeader.tsx
@@ -36,6 +36,7 @@ interface AppHeaderProps {
   isAIChatOpen: boolean;
   aiHasMessages: boolean;
   hasAnyAnnotations: boolean;
+  annotationCount: number;
   linkedDocIsActive: boolean;
   callbackShareUrlReady: boolean;
   canShareCurrentSession: boolean;
@@ -111,6 +112,7 @@ export const AppHeader = React.memo<AppHeaderProps>(({
   isAIChatOpen,
   aiHasMessages,
   hasAnyAnnotations,
+  annotationCount,
   linkedDocIsActive,
   callbackShareUrlReady,
   canShareCurrentSession,
@@ -300,7 +302,7 @@ export const AppHeader = React.memo<AppHeaderProps>(({
         {!goalSetupMode && (
           <button
             onClick={onAnnotationPanelToggle}
-            className={`p-1.5 rounded-md text-xs font-medium transition-all ${
+            className={`relative p-1.5 rounded-md text-xs font-medium transition-all ${
               isPanelOpen
                 ? 'bg-primary/15 text-primary'
                 : 'text-muted-foreground hover:text-foreground hover:bg-muted'
@@ -310,6 +312,11 @@ export const AppHeader = React.memo<AppHeaderProps>(({
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
             </svg>
+            {annotationCount > 0 && (
+              <span className="absolute -top-1 -right-1 min-w-[14px] h-[14px] flex items-center justify-center rounded-full bg-primary text-[8px] font-bold text-primary-foreground px-0.5">
+                {annotationCount > 99 ? '99+' : annotationCount}
+              </span>
+            )}
           </button>
         )}
         {!goalSetupMode && aiAvailable && (


### PR DESCRIPTION
## What

Adds a numeric annotation-count badge to the annotations toggle button in the **plan-review** and **annotate** app header.

## Why

Both surfaces share `AppHeader`, but its annotations toggle had no count badge — unlike the code-review app's equivalent button (`packages/review-editor/App.tsx`), which shows `totalAnnotationCount`. This closes that parity gap.

## How

- `AppHeader` gains an `annotationCount: number` prop and renders the same badge style as the code-review header (capped at `99+`, hidden when `0`). The button gains `relative` so the badge anchors correctly.
- The badge is wired to the existing `feedbackAnnotationCount` in `packages/editor/App.tsx` — the app's mode-aware measure of pending feedback (covers plan annotations, code/linked-doc annotations, editor annotations, and message-multiselect mode). No new state.

Since `AppHeader` is shared, both the plan and annotate screens get the badge from one change.

## Notes

`feedbackAnnotationCount` is the "pending feedback" count, so it can differ slightly from the literal rows in the annotations panel (it counts global image attachments; it doesn't count pure direct-edit cards). This was a deliberate choice — it's the more actionable number and mirrors the spirit of the code-review badge.

## Test plan

- [x] `bun run --cwd apps/review build && bun run build:hook` succeeds
- [ ] Visual check: badge appears on the annotations toggle in plan and annotate modes, increments with annotations, hides at 0