### PR TITLE
fix(review): show pending agent job launches

### DIFF
--- a/packages/review-editor/components/ReviewSidebar.tsx
+++ b/packages/review-editor/components/ReviewSidebar.tsx
@@ -9,7 +9,7 @@ import { detectLanguage } from '../utils/detectLanguage';
 import { renderInlineMarkdown } from '../utils/renderInlineMarkdown';
 import { FileNameChip } from './FileNameChip';
 import { AITab } from './AITab';
-import { AgentsTab } from '@plannotator/ui/components/AgentsTab';
+import { AgentsTab, type AgentLaunchParams, type AgentLaunchResult } from '@plannotator/ui/components/AgentsTab';
 import type { PRMetadata } from '@plannotator/shared/pr-types';
 import { OverlayScrollArea } from '@plannotator/ui/components/OverlayScrollArea';
 import type { AIChatEntry } from '../hooks/useAIChat';
@@ -55,7 +55,7 @@ interface ReviewSidebarProps {
   // Agent props
   agentJobs?: AgentJobInfo[];
   agentCapabilities?: AgentCapabilities | null;
-  onAgentLaunch?: (params: { provider?: string; command?: string[]; label?: string; engine?: string; model?: string; reasoningEffort?: string; effort?: string; fastMode?: boolean; reviewProfileId?: string }) => void;
+  onAgentLaunch?: (params: AgentLaunchParams) => AgentLaunchResult | Promise<AgentLaunchResult>;
   onAgentKillJob?: (id: string) => void;
   onAgentKillAll?: () => void;
   externalAnnotations?: Array<{ source?: string }>;
@@ -411,7 +411,7 @@ export const ReviewSidebar: React.FC<ReviewSidebarProps> = /* React.memo */({
             <AgentsTab
               jobs={agentJobs ?? []}
               capabilities={agentCapabilities ?? null}
-              onLaunch={onAgentLaunch ?? (() => {})}
+              onLaunch={onAgentLaunch ?? (() => null)}
               onKillJob={onAgentKillJob ?? (() => {})}
               onKillAll={onAgentKillAll ?? (() => {})}
               externalAnnotations={externalAnnotations ?? []}

--- a/packages/ui/components/AgentsTab.tsx
+++ b/packages/ui/components/AgentsTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import {
   Bot,
   Play,
@@ -21,6 +21,9 @@ import { ReviewAgentsIcon } from './ReviewAgentsIcon';
 import { ClaudeIcon, CodexIcon, CursorIcon, OpenCodeIcon } from './icons/AgentIcons';
 import { useAgentSettings } from '../hooks/useAgentSettings';
 import type { AgentEngine, AgentMode, ReviewEngine } from '../hooks/useAgentSettings';
+import type { AgentLaunchParams } from '../hooks/useAgentJobs';
+
+export type { AgentLaunchParams } from '../hooks/useAgentJobs';
 
 // --- Agent option catalogs (shared across review + tour engine dropdowns) ---
 
@@ -119,10 +122,12 @@ const REVIEW_ENGINE_ICON: Record<ReviewEngine, React.FC<{ className?: string }>>
   opencode: OpenCodeIcon,
 };
 
+export type AgentLaunchResult = AgentJobInfo | null | void;
+
 interface AgentsTabProps {
   jobs: AgentJobInfo[];
   capabilities: AgentCapabilities | null;
-  onLaunch: (params: { provider?: string; command?: string[]; label?: string; engine?: string; model?: string; reasoningEffort?: string; effort?: string; fastMode?: boolean; reviewProfileId?: string }) => void;
+  onLaunch: (params: AgentLaunchParams) => AgentLaunchResult | Promise<AgentLaunchResult>;
   onKillJob: (id: string) => void;
   onKillAll: () => void;
   externalAnnotations: Array<{ source?: string }>;
@@ -532,6 +537,35 @@ function JobCard({
   );
 }
 
+function PendingLaunchCard({
+  label,
+  provider,
+  startedAt,
+}: {
+  label: string;
+  provider?: string;
+  startedAt: number;
+}) {
+  return (
+    <div className="rounded-lg bg-primary/5 px-2.5 py-2 ring-1 ring-primary/10">
+      <div className="flex items-start gap-2.5">
+        <StatusSquare status="starting" />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            <span className="truncate font-medium text-[12px] text-foreground">{label}</span>
+          </div>
+          <div className="mt-0.5 flex flex-wrap items-center gap-1 text-[9px] text-muted-foreground/50">
+            {provider && <span className="rounded bg-surface-1 px-1 py-px">{provider}</span>}
+            <span>requesting launch</span>
+            <span className="text-muted-foreground/30">·</span>
+            <span className="tabular-nums"><ElapsedTime startedAt={startedAt} /></span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // --- Main component ---
 
 export const AgentsTab: React.FC<AgentsTabProps> = ({
@@ -544,6 +578,9 @@ export const AgentsTab: React.FC<AgentsTabProps> = ({
   onOpenJobDetail,
 }) => {
   const [expandedJobId, setExpandedJobId] = useState<string | null>(null);
+  const [pendingLaunch, setPendingLaunch] = useState<{ label: string; provider?: string; startedAt: number } | null>(null);
+  const [launchError, setLaunchError] = useState<string | null>(null);
+  const launchingRef = useRef(false);
   const settings = useAgentSettings();
   const {
     selectedMode,
@@ -738,7 +775,7 @@ export const AgentsTab: React.FC<AgentsTabProps> = ({
     ? reviewProfileId
     : 'builtin:default';
 
-  type LaunchParams = Parameters<typeof onLaunch>[0];
+  type LaunchParams = AgentLaunchParams;
   const buildReviewLaunch = (engine: ReviewEngine): LaunchParams => {
     // Carry the chosen review only when it is a custom one. Absent → the server
     // resolves to the built-in default.
@@ -794,9 +831,28 @@ export const AgentsTab: React.FC<AgentsTabProps> = ({
       ? tourAvailable && engineAvailable(tourEngine)
       : false;
 
-  const handleLaunch = () => {
-    if (!canLaunch) return;
-    onLaunch(selectedMode === 'review' ? buildReviewLaunch(reviewEngine) : buildTourLaunch());
+  const handleLaunch = async () => {
+    if (!canLaunch || launchingRef.current) return;
+    const params = selectedMode === 'review' ? buildReviewLaunch(reviewEngine) : buildTourLaunch();
+    launchingRef.current = true;
+    setPendingLaunch({
+      label: params.label ?? 'Agent job',
+      ...(params.provider && { provider: params.provider }),
+      startedAt: Date.now(),
+    });
+    setLaunchError(null);
+
+    try {
+      const result = await onLaunch(params);
+      if (result === null) {
+        setLaunchError('Could not start agent job.');
+      }
+    } catch (error) {
+      setLaunchError(error instanceof Error ? error.message : 'Could not start agent job.');
+    } finally {
+      launchingRef.current = false;
+      setPendingLaunch(null);
+    }
   };
 
   const modeOptions = availableModes.map((mode) => ({ value: mode, label: MODE_LABEL[mode] }));
@@ -985,18 +1041,31 @@ export const AgentsTab: React.FC<AgentsTabProps> = ({
 
           <button
             onClick={handleLaunch}
-            disabled={!canLaunch}
+            disabled={!canLaunch || pendingLaunch !== null}
+            aria-busy={pendingLaunch !== null}
             className="mt-3 flex w-full items-center justify-center gap-1.5 rounded-lg bg-primary py-2 font-medium text-[12px] text-primary-foreground transition-colors hover:bg-primary/90 active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            <Play size={11} />
-            Run
+            {pendingLaunch ? <Loader2 className="animate-spin" size={11} /> : <Play size={11} />}
+            {pendingLaunch ? 'Starting...' : 'Run'}
           </button>
+          {launchError && (
+            <p className="mt-2 text-[10px] leading-snug text-destructive/80">
+              {launchError}
+            </p>
+          )}
         </div>
       )}
 
       {/* Job list (scrolls; launch controls are pinned above) */}
       <div className="flex-1 overflow-y-auto p-2 space-y-1">
-        {sortedJobs.length === 0 ? (
+        {pendingLaunch && (
+          <PendingLaunchCard
+            label={pendingLaunch.label}
+            provider={pendingLaunch.provider}
+            startedAt={pendingLaunch.startedAt}
+          />
+        )}
+        {sortedJobs.length === 0 && !pendingLaunch ? (
           <div className="flex flex-col items-center py-10 text-center">
             <div className="mb-2 flex h-8 w-8 items-center justify-center rounded-full bg-surface-1/50">
               <ReviewAgentsIcon className="h-4 w-4 text-muted-foreground/40" />

--- a/packages/ui/hooks/useAgentJobs.ts
+++ b/packages/ui/hooks/useAgentJobs.ts
@@ -17,12 +17,76 @@ const POLL_INTERVAL_MS = 500;
 const STREAM_URL = '/api/agents/jobs/stream';
 const JOBS_URL = '/api/agents/jobs';
 const CAPABILITIES_URL = '/api/agents/capabilities';
+const DEFAULT_LAUNCH_ERROR = 'Could not start agent job.';
+const AGENT_JOB_STATUSES = new Set(['starting', 'running', 'done', 'failed', 'killed']);
+
+export type AgentLaunchParams = {
+  provider?: string;
+  command?: string[];
+  label?: string;
+  engine?: string;
+  model?: string;
+  reasoningEffort?: string;
+  effort?: string;
+  fastMode?: boolean;
+  reviewProfileId?: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+function isAgentJobInfo(value: unknown): value is AgentJobInfo {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.id === 'string' &&
+    typeof value.source === 'string' &&
+    typeof value.provider === 'string' &&
+    typeof value.label === 'string' &&
+    typeof value.status === 'string' &&
+    AGENT_JOB_STATUSES.has(value.status) &&
+    typeof value.startedAt === 'number' &&
+    isStringArray(value.command)
+  );
+}
+
+function upsertJob(jobs: AgentJobInfo[], job: AgentJobInfo): AgentJobInfo[] {
+  const existing = jobs.findIndex((current) => current.id === job.id);
+  if (existing === -1) return [...jobs, job];
+  const next = [...jobs];
+  next[existing] = job;
+  return next;
+}
+
+async function readResponseError(response: Response): Promise<string> {
+  try {
+    const body: unknown = await response.json();
+    if (body && typeof body === 'object' && 'error' in body) {
+      const error = (body as { readonly error?: unknown }).error;
+      if (typeof error === 'string' && error.trim()) return error;
+    }
+  } catch {
+    // Fall through to the generic launch message.
+  }
+  return DEFAULT_LAUNCH_ERROR;
+}
+
+function parseLaunchJob(body: unknown): AgentJobInfo | null {
+  if (!isRecord(body)) return null;
+  const job = body.job;
+  return isAgentJobInfo(job) ? job : null;
+}
 
 interface UseAgentJobsReturn {
   jobs: AgentJobInfo[];
   jobLogs: Map<string, string>;
   capabilities: AgentCapabilities | null;
-  launchJob: (params: { provider?: string; command?: string[]; label?: string; engine?: string; model?: string; reasoningEffort?: string; effort?: string; fastMode?: boolean; reviewProfileId?: string }) => Promise<AgentJobInfo | null>;
+  /** Rejects with a user-facing message when the server refuses the launch. */
+  launchJob: (params: AgentLaunchParams) => Promise<AgentJobInfo | null>;
   killJob: (id: string) => Promise<void>;
   killAll: () => Promise<void>;
 }
@@ -77,7 +141,7 @@ export function useAgentJobs(
             setJobs(parsed.jobs);
             break;
           case 'job:started':
-            setJobs((prev) => [...prev, parsed.job]);
+            setJobs((prev) => upsertJob(prev, parsed.job));
             break;
           case 'job:updated':
           case 'job:completed':
@@ -159,29 +223,20 @@ export function useAgentJobs(
   }, [enabled]);
 
   const launchJob = useCallback(
-    async (params: {
-      provider?: string;
-      command?: string[];
-      label?: string;
-      engine?: string;
-      model?: string;
-      reasoningEffort?: string;
-      effort?: string;
-      fastMode?: boolean;
-      reviewProfileId?: string;
-    }): Promise<AgentJobInfo | null> => {
-      try {
-        const res = await fetch(JOBS_URL, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(params),
-        });
-        if (!res.ok) return null;
-        const data = await res.json();
-        return data.job ?? null;
-      } catch {
-        return null;
+    async (params: AgentLaunchParams): Promise<AgentJobInfo | null> => {
+      const res = await fetch(JOBS_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(params),
+      });
+      if (!res.ok) {
+        throw new Error(await readResponseError(res));
       }
+
+      const data: unknown = await res.json();
+      const job = parseLaunchJob(data);
+      if (job) setJobs((prev) => upsertJob(prev, job));
+      return job;
     },
     [],
   );


### PR DESCRIPTION
## Summary

- show an immediate pending launch row and Starting state when Review Agents starts a job
- surface server launch failures instead of silently clearing the request
- upsert the POST-returned job and dedupe later SSE job:started events so the pending row hands off cleanly

## Self-review

- traced the click -> POST /api/agents/jobs -> buildCommand -> spawnJob -> SSE flow and confirmed the lag was before any real server job exists
- kept the server lifecycle unchanged; the placeholder is client-only until the launch request resolves
- hardened duplicate-click handling with an in-flight ref guard and added minimal response parsing before inserting the POST-returned job

## Verification

- bun run typecheck
- bun test
- git diff --check