### PR TITLE
fix(pi-extension): hoist @earendil-works/pi-* runtime deps

### DIFF
--- a/apps/pi-extension/package.json
+++ b/apps/pi-extension/package.json
@@ -14,9 +14,17 @@
   "bugs": {
     "url": "https://github.com/backnotprop/plannotator/issues"
   },
-  "keywords": ["pi-package", "plannotator", "plan-review", "ai-agent", "coding-agent"],
+  "keywords": [
+    "pi-package",
+    "plannotator",
+    "plan-review",
+    "ai-agent",
+    "coding-agent"
+  ],
   "pi": {
-    "extensions": ["./"]
+    "extensions": [
+      "./"
+    ]
   },
   "files": [
     "index.ts",
@@ -44,16 +52,16 @@
     "@plannotator/webtui": "0.1.0",
     "chokidar": "^5.0.0",
     "parse5": "^7.3.0",
-    "turndown": "^7.2.4"
+    "turndown": "^7.2.4",
+    "@earendil-works/pi-agent-core": ">=0.74.0",
+    "@earendil-works/pi-ai": ">=0.74.0",
+    "@earendil-works/pi-tui": ">=0.74.0"
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": ">=0.74.0"
   },
   "devDependencies": {
     "glimpseui": "^0.8.0",
-    "@earendil-works/pi-coding-agent": ">=0.74.0",
-    "@earendil-works/pi-agent-core": ">=0.74.0",
-    "@earendil-works/pi-ai": ">=0.74.0",
-    "@earendil-works/pi-tui": ">=0.74.0"
+    "@earendil-works/pi-coding-agent": ">=0.74.0"
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -63,7 +63,7 @@
     },
     "apps/opencode-plugin": {
       "name": "@plannotator/opencode",
-      "version": "0.21.2",
+      "version": "0.21.3",
       "dependencies": {
         "@opencode-ai/plugin": "^1.1.10",
       },
@@ -85,8 +85,11 @@
     },
     "apps/pi-extension": {
       "name": "@plannotator/pi-extension",
-      "version": "0.21.2",
+      "version": "0.21.3",
       "dependencies": {
+        "@earendil-works/pi-agent-core": ">=0.74.0",
+        "@earendil-works/pi-ai": ">=0.74.0",
+        "@earendil-works/pi-tui": ">=0.74.0",
         "@joplin/turndown-plugin-gfm": "^1.0.64",
         "@pierre/diffs": "1.2.8",
         "@plannotator/webtui": "0.1.0",
@@ -95,10 +98,7 @@
         "turndown": "^7.2.4",
       },
       "devDependencies": {
-        "@earendil-works/pi-agent-core": ">=0.74.0",
-        "@earendil-works/pi-ai": ">=0.74.0",
         "@earendil-works/pi-coding-agent": ">=0.74.0",
-        "@earendil-works/pi-tui": ">=0.74.0",
         "glimpseui": "^0.8.0",
       },
       "peerDependencies": {
@@ -147,7 +147,7 @@
     },
     "apps/vscode-extension": {
       "name": "plannotator-webview",
-      "version": "0.16.5",
+      "version": "0.16.7",
       "devDependencies": {
         "@types/bun": "latest",
         "@types/vscode": "^1.85.0",
@@ -214,7 +214,7 @@
     },
     "packages/server": {
       "name": "@plannotator/server",
-      "version": "0.21.2",
+      "version": "0.21.3",
       "dependencies": {
         "@pierre/diffs": "1.2.8",
         "@plannotator/ai": "workspace:*",


### PR DESCRIPTION
Move `@earendil-works/pi-ai`, `pi-agent-core`, and `pi-tui` from devDependencies to dependencies so they are installed and hoisted alongside @`plannotator/pi-extension`.

These packages are imported at runtime by `index.ts` (e.g. `import { Type } from "@earendil-works/pi-ai"`), but were only listed as devDependencies/peerDependencies. pi installs extensions with peer-dep resolution disabled (--omit=peer / --legacy-peer-deps), so on a clean install or `pi update` the modules never land in the extension's node_modules and pi fails to open with:

```
  Failed to load extension: Cannot find module '@earendil-works/pi-ai'
  Require stack:
  - @plannotator/pi-extension/index.ts
```

The namespace was migrated from `@mariozechner/*` to `@earendil-works/*` in #729, which swapped the imports and devDependency pins but kept them as devDependencies, leaving no guaranteed install path for the runtime imports.



MIT & Apache 2.0 dual-licensing is fine.
