### PR TITLE
chore(ui): move to the plannotator/atomic-editor fork (markdown-editor 0.2.0)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -63,7 +63,7 @@
     },
     "apps/opencode-plugin": {
       "name": "@plannotator/opencode",
-      "version": "0.21.4",
+      "version": "0.22.0",
       "dependencies": {
         "@opencode-ai/plugin": "^1.1.10",
       },
@@ -85,7 +85,7 @@
     },
     "apps/pi-extension": {
       "name": "@plannotator/pi-extension",
-      "version": "0.21.4",
+      "version": "0.22.0",
       "dependencies": {
         "@joplin/turndown-plugin-gfm": "^1.0.64",
         "@pierre/diffs": "1.2.8",
@@ -214,7 +214,7 @@
     },
     "packages/server": {
       "name": "@plannotator/server",
-      "version": "0.21.4",
+      "version": "0.22.0",
       "dependencies": {
         "@pierre/diffs": "1.2.8",
         "@plannotator/ai": "workspace:*",
@@ -242,7 +242,6 @@
       "name": "@plannotator/ui",
       "version": "0.0.1",
       "dependencies": {
-        "@atomic-editor/editor": "^0.4.3",
         "@codemirror/autocomplete": "^6.20.3",
         "@codemirror/commands": "^6.10.3",
         "@codemirror/lang-javascript": "^6.2.5",
@@ -261,7 +260,8 @@
         "@lezer/highlight": "^1.2.3",
         "@pierre/diffs": "1.2.8",
         "@plannotator/ai": "workspace:*",
-        "@plannotator/markdown-editor": "0.1.0",
+        "@plannotator/atomic-editor": "^0.5.0",
+        "@plannotator/markdown-editor": "^0.2.0",
         "@plannotator/shared": "workspace:*",
         "@plannotator/web-highlighter": "^0.8.1",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -338,8 +338,6 @@
     "@astrojs/sitemap": ["@astrojs/sitemap@3.7.3", "", { "dependencies": { "sitemap": "^9.0.0", "stream-replace-string": "^2.0.0", "zod": "^4.3.6" } }, "sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA=="],
 
     "@astrojs/telemetry": ["@astrojs/telemetry@3.3.0", "", { "dependencies": { "ci-info": "^4.2.0", "debug": "^4.4.0", "dlv": "^1.1.3", "dset": "^3.1.4", "is-docker": "^3.0.0", "is-wsl": "^3.1.0", "which-pm-runs": "^1.1.0" } }, "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ=="],
-
-    "@atomic-editor/editor": ["@atomic-editor/editor@0.4.3", "", { "peerDependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/commands": "^6.0.0", "@codemirror/lang-cpp": "^6.0.0", "@codemirror/lang-css": "^6.0.0", "@codemirror/lang-go": "^6.0.0", "@codemirror/lang-html": "^6.0.0", "@codemirror/lang-java": "^6.0.0", "@codemirror/lang-javascript": "^6.0.0", "@codemirror/lang-json": "^6.0.0", "@codemirror/lang-markdown": "^6.0.0", "@codemirror/lang-php": "^6.0.0", "@codemirror/lang-python": "^6.0.0", "@codemirror/lang-rust": "^6.0.0", "@codemirror/lang-sql": "^6.0.0", "@codemirror/lang-xml": "^6.0.0", "@codemirror/lang-yaml": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/legacy-modes": "^6.0.0", "@codemirror/search": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/common": "^1.0.0", "@lezer/highlight": "^1.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@codemirror/lang-cpp", "@codemirror/lang-css", "@codemirror/lang-go", "@codemirror/lang-html", "@codemirror/lang-java", "@codemirror/lang-javascript", "@codemirror/lang-json", "@codemirror/lang-php", "@codemirror/lang-python", "@codemirror/lang-rust", "@codemirror/lang-sql", "@codemirror/lang-xml", "@codemirror/lang-yaml", "@codemirror/legacy-modes"] }, "sha512-91+Gztr+Jxut0VSQ1ncUHNurM+NmQdBo8kXQ+EKck+P75cUuKMYMTwhhJk6Fg0Bxe+t57I70p4ipiRHzlFKdLQ=="],
 
     "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
 
@@ -781,11 +779,13 @@
 
     "@plannotator/ai": ["@plannotator/ai@workspace:packages/ai"],
 
+    "@plannotator/atomic-editor": ["@plannotator/atomic-editor@0.5.0", "", { "peerDependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/commands": "^6.0.0", "@codemirror/lang-cpp": "^6.0.0", "@codemirror/lang-css": "^6.0.0", "@codemirror/lang-go": "^6.0.0", "@codemirror/lang-html": "^6.0.0", "@codemirror/lang-java": "^6.0.0", "@codemirror/lang-javascript": "^6.0.0", "@codemirror/lang-json": "^6.0.0", "@codemirror/lang-markdown": "^6.0.0", "@codemirror/lang-php": "^6.0.0", "@codemirror/lang-python": "^6.0.0", "@codemirror/lang-rust": "^6.0.0", "@codemirror/lang-sql": "^6.0.0", "@codemirror/lang-xml": "^6.0.0", "@codemirror/lang-yaml": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/legacy-modes": "^6.0.0", "@codemirror/search": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/common": "^1.0.0", "@lezer/highlight": "^1.0.0", "@lezer/markdown": "^1.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@codemirror/lang-cpp", "@codemirror/lang-css", "@codemirror/lang-go", "@codemirror/lang-html", "@codemirror/lang-java", "@codemirror/lang-javascript", "@codemirror/lang-json", "@codemirror/lang-php", "@codemirror/lang-python", "@codemirror/lang-rust", "@codemirror/lang-sql", "@codemirror/lang-xml", "@codemirror/lang-yaml", "@codemirror/legacy-modes"] }, "sha512-nJfa6CZ3S0Ywg++HxJLZ9AqPrruhrurVAisFFvCIQmyUnyEt270CfNnVoVyUZBGYHPy47mtybtMZJaN9LXpnCg=="],
+
     "@plannotator/editor": ["@plannotator/editor@workspace:packages/editor"],
 
     "@plannotator/hooks": ["@plannotator/hooks@workspace:apps/hook"],
 
-    "@plannotator/markdown-editor": ["@plannotator/markdown-editor@0.1.0", "", { "peerDependencies": { "@atomic-editor/editor": "^0.4.0", "@codemirror/lang-javascript": "^6.0.0", "@codemirror/lang-json": "^6.0.0", "@codemirror/lang-python": "^6.0.0", "@codemirror/lang-yaml": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/legacy-modes": "^6.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@codemirror/lang-javascript", "@codemirror/lang-json", "@codemirror/lang-python", "@codemirror/lang-yaml", "@codemirror/legacy-modes"] }, "sha512-tLc7ZeUcnsJCxvS3HNa+R0cP/ZikjGuP8nD1+4JeDUUd/5IB0upygcJRCC0OHZ4V6CJ5C9PdKGwnTp88Y72sog=="],
+    "@plannotator/markdown-editor": ["@plannotator/markdown-editor@0.2.0", "", { "peerDependencies": { "@codemirror/lang-javascript": "^6.0.0", "@codemirror/lang-json": "^6.0.0", "@codemirror/lang-python": "^6.0.0", "@codemirror/lang-yaml": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/legacy-modes": "^6.0.0", "@plannotator/atomic-editor": "^0.5.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@codemirror/lang-javascript", "@codemirror/lang-json", "@codemirror/lang-python", "@codemirror/lang-yaml", "@codemirror/legacy-modes"] }, "sha512-ENy6mMZSJWU6NnEsG/15Ia/oZLMSUfwd0skdmDyJcY4HGFESAZ2CTApHfgO2fGTQAaoOafSQ6Dh28QxWxY9duA=="],
 
     "@plannotator/marketing": ["@plannotator/marketing@workspace:apps/marketing"],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,7 +1,7 @@
 [install]
 linker = "isolated"
 minimumReleaseAge = 604800  # 7 days in seconds
-minimumReleaseAgeExcludes = ["@pierre/diffs", "@plannotator/markdown-editor", "@plannotator/webtui"]
+minimumReleaseAgeExcludes = ["@pierre/diffs", "@plannotator/atomic-editor", "@plannotator/markdown-editor", "@plannotator/webtui"]
 
 [test]
 preload = ["./packages/ui/test-setup/happy-dom.ts"]

--- a/packages/ui/markdownEditorFidelity.test.tsx
+++ b/packages/ui/markdownEditorFidelity.test.tsx
@@ -25,7 +25,7 @@ import { homedir } from 'node:os';
 import {
   AtomicCodeMirrorEditor,
   type AtomicCodeMirrorEditorHandle,
-} from '@atomic-editor/editor';
+} from '@plannotator/atomic-editor';
 
 const hasDom = typeof document !== 'undefined';
 const CORPUS_DIR = join(homedir(), '.plannotator', 'history');

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -20,7 +20,7 @@
     "./theme": "./theme.css"
   },
   "dependencies": {
-    "@atomic-editor/editor": "^0.4.3",
+    "@plannotator/atomic-editor": "^0.5.0",
     "@codemirror/autocomplete": "^6.20.3",
     "@codemirror/commands": "^6.10.3",
     "@codemirror/lang-javascript": "^6.2.5",
@@ -39,7 +39,7 @@
     "@lezer/common": "^1.5.2",
     "@lezer/highlight": "^1.2.3",
     "@plannotator/ai": "workspace:*",
-    "@plannotator/markdown-editor": "0.1.0",
+    "@plannotator/markdown-editor": "^0.2.0",
     "@plannotator/shared": "workspace:*",
     "@plannotator/web-highlighter": "^0.8.1",
     "@radix-ui/react-dialog": "^1.1.15",


### PR DESCRIPTION
Swaps the upstream editor for the org fork and picks up the rewired wrapper:

- `@atomic-editor/editor@^0.4.3` → `@plannotator/atomic-editor@^0.5.0` (the wrapper's peer dependency was renamed to the fork)
- `@plannotator/markdown-editor` `0.1.0` → `^0.2.0`
- `bunfig.toml`: exempt `@plannotator/atomic-editor` from the minimum-release-age gate (same first-party trust as `@plannotator/markdown-editor`)
- `markdownEditorFidelity.test.tsx`: import re-pointed to the fork

**What users get** (from the fork, `github.com/plannotator/atomic-editor`):
- Frontmatter parses properly — a leading `---` block no longer misrenders as a horizontal rule + giant heading
- The Obsidian-style **Properties widget** (key/value grid, tag chips, edit-as-source), with single-line dispatches so edits never rewrite neighboring bytes

**Verification:** typecheck clean · `DOM_TESTS=1` byte-fidelity suite 4/4 · full suite 1892 pass / 0 fail · `apps/review` + `build:hook` both build.

Note: PR #957 pins the same two lines and will pick this up on its next rebase.