### PR TITLE
fix(review): render tables + inline video in PR comments, descriptions, and commit messages

### DIFF
--- a/packages/review-editor/components/CommitDescriptionHeader.tsx
+++ b/packages/review-editor/components/CommitDescriptionHeader.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import type { CommitDiffInfo } from '@plannotator/shared/types';
 import { Avatar } from './Avatar';
-import { MarkdownBody } from './PRSummaryTab';
+import { MarkdownBody } from './MarkdownBody';
 import { formatRelativeTime } from '@plannotator/ui/utils/aiChatFormat';
 
 /**

--- a/packages/review-editor/components/MarkdownBody.tsx
+++ b/packages/review-editor/components/MarkdownBody.tsx
@@ -1,0 +1,160 @@
+/**
+ * Lightweight block-level markdown renderer for GitHub-sourced text
+ * (PR descriptions, PR comments, commit messages). No annotation
+ * infrastructure — the full document surface is Viewer/BlockRenderer.
+ */
+import React, { useMemo, useRef, useEffect } from 'react';
+import { parseMarkdownToBlocks } from '@plannotator/ui/utils/parser';
+import { parseTableContent } from '@plannotator/ui/components/blocks/TableBlock';
+import { sanitizeInlineHtml } from '@plannotator/ui/utils/sanitizeHtml';
+import { renderInlineMarkdown } from '../utils/renderInlineMarkdown';
+
+
+
+/** Check if content contains HTML tags that should be rendered natively. */
+const HTML_TAG_RE = /<[a-z][a-z0-9]*[\s/>]/i;
+const containsHtml = (text: string) => HTML_TAG_RE.test(text);
+
+/** Renders sanitized HTML and hides broken images via ref (no inline event handlers). */
+function SafeHtml({ html, as: Tag = 'div' }: { html: string; as?: 'div' | 'span' }) {
+  const ref = useRef<HTMLElement>(null);
+  useEffect(() => {
+    if (!ref.current) return;
+    const imgs = ref.current.querySelectorAll('img');
+    imgs.forEach((img) => {
+      img.onerror = () => { img.style.display = 'none'; img.onerror = null; };
+    });
+  }, [html]);
+  return <Tag ref={ref as any} dangerouslySetInnerHTML={{ __html: html }} />;
+}
+
+/**
+ * Render inline content — if it contains HTML tags, sanitize and render.
+ * Otherwise use our markdown renderer.
+ */
+function renderContent(content: string): React.ReactNode {
+  if (containsHtml(content)) {
+    return <SafeHtml html={sanitizeInlineHtml(content)} as="span" />;
+  }
+  return renderInlineMarkdown(content);
+}
+
+/** Video file links (GitHub can't inline-play these either, but we can). */
+const VIDEO_EXT_RE = /\.(webm|mp4|mov|m4v|ogg)(\?[^\s)]*)?$/i;
+
+/** A paragraph that is exactly one markdown link (or bare URL) to a video file. */
+function parseLoneVideoLink(content: string): { url: string; label: string } | null {
+  const t = content.trim();
+  const md = t.match(/^\[([^\]]*)\]\(([^)\s]+)\)$/);
+  if (md && VIDEO_EXT_RE.test(md[2])) return { url: md[2], label: md[1] || md[2] };
+  if (/^https?:\/\/\S+$/.test(t) && VIDEO_EXT_RE.test(t)) return { url: t, label: t };
+  return null;
+}
+
+/** Render a simplified block-level markdown view (no annotation infrastructure). */
+export function MarkdownBody({ markdown, textClassName = 'text-xs' }: { markdown: string; textClassName?: string }) {
+  const blocks = useMemo(() => parseMarkdownToBlocks(markdown), [markdown]);
+
+  return (
+    <div className={`space-y-2.5 ${textClassName} text-foreground/90 leading-relaxed`}>
+      {blocks.map((block) => {
+        switch (block.type) {
+          case 'heading': {
+            const Tag = `h${Math.min(block.level ?? 1, 6)}` as keyof JSX.IntrinsicElements;
+            const sizes: Record<number, string> = {
+              1: 'text-base font-bold',
+              2: 'text-sm font-semibold',
+              3: 'text-xs font-semibold',
+            };
+            return (
+              <Tag key={block.id} className={`${sizes[block.level ?? 1] ?? 'text-xs font-medium'} text-foreground`}>
+                {renderContent(block.content)}
+              </Tag>
+            );
+          }
+          case 'code':
+            return (
+              <pre key={block.id} className="bg-muted/50 rounded-md p-2 text-[11px] font-mono overflow-x-auto whitespace-pre-wrap">
+                <code>{block.content}</code>
+              </pre>
+            );
+          case 'list-item':
+            return (
+              <div key={block.id} className="flex gap-1.5" style={{ paddingLeft: (block.level ?? 0) * 12 }}>
+                <span className="text-muted-foreground shrink-0">{block.checked !== undefined ? (block.checked ? '☑' : '☐') : '•'}</span>
+                <span>{renderContent(block.content)}</span>
+              </div>
+            );
+          case 'blockquote':
+            return (
+              <blockquote key={block.id} className="border-l-2 border-border pl-2 text-muted-foreground italic">
+                {renderContent(block.content)}
+              </blockquote>
+            );
+          case 'hr':
+            return <hr key={block.id} className="border-border/50" />;
+          case 'table': {
+            const { headers, rows } = parseTableContent(block.content);
+            if (!headers.length) return null;
+            return (
+              <div key={block.id} className="overflow-x-auto">
+                <table className="min-w-full border-collapse">
+                  <thead>
+                    <tr className="border-b border-border">
+                      {headers.map((header, i) => (
+                        <th key={i} className="px-2 py-1 text-left font-semibold text-foreground/90 bg-muted/30">
+                          {renderContent(header)}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {rows.map((row, ri) => (
+                      <tr key={ri} className="border-b border-border/50">
+                        {row.map((cell, ci) => (
+                          <td key={ci} className="px-2 py-1 align-top">
+                            {renderContent(cell)}
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            );
+          }
+          default: {
+            if (!block.content) return null;
+            // A paragraph that is just a link to a video file → inline player
+            const video = parseLoneVideoLink(block.content);
+            if (video) {
+              return (
+                <div key={block.id} className="my-1">
+                  <video
+                    controls
+                    preload="metadata"
+                    src={video.url}
+                    className="max-w-full rounded-md border border-border bg-black"
+                  />
+                  <a
+                    href={video.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mt-1 block text-[11px] text-muted-foreground hover:text-foreground truncate"
+                  >
+                    {video.label}
+                  </a>
+                </div>
+              );
+            }
+            // If the entire paragraph is HTML, sanitize and render
+            if (containsHtml(block.content)) {
+              return <SafeHtml key={block.id} html={sanitizeInlineHtml(block.content)} />;
+            }
+            return <p key={block.id}>{renderInlineMarkdown(block.content)}</p>;
+          }
+        }
+      })}
+    </div>
+  );
+}

--- a/packages/review-editor/components/PRCommentsTab.tsx
+++ b/packages/review-editor/components/PRCommentsTab.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState, useEffect, useRef, useCallback } from 'react';
 import type { PRContext, PRComment, PRReview, PRReviewThread } from '@plannotator/shared/pr-types';
-import { MarkdownBody } from './PRSummaryTab';
+import { MarkdownBody } from './MarkdownBody';
 import { CopyButton } from './CopyButton';
 import { DiffHunkPreview } from './DiffHunkPreview';
 import { OverlayScrollArea } from '@plannotator/ui/components/OverlayScrollArea';

--- a/packages/review-editor/components/PRSummaryTab.tsx
+++ b/packages/review-editor/components/PRSummaryTab.tsx
@@ -1,98 +1,12 @@
-import React, { useMemo, useRef, useEffect } from 'react';
-import { parseMarkdownToBlocks } from '@plannotator/ui/utils/parser';
-import { sanitizeInlineHtml } from '@plannotator/ui/utils/sanitizeHtml';
+import React from 'react';
 import { AnnotatableDescription } from './AnnotatableDescription';
-import { renderInlineMarkdown } from '../utils/renderInlineMarkdown';
+import { MarkdownBody } from './MarkdownBody';
 import type { PRContext, PRMetadata } from '@plannotator/shared/pr-types';
 
 interface PRSummaryTabProps {
   context: PRContext;
   metadata: PRMetadata;
 }
-
-/** Check if content contains HTML tags that should be rendered natively. */
-const HTML_TAG_RE = /<[a-z][a-z0-9]*[\s/>]/i;
-const containsHtml = (text: string) => HTML_TAG_RE.test(text);
-
-/** Renders sanitized HTML and hides broken images via ref (no inline event handlers). */
-function SafeHtml({ html, as: Tag = 'div' }: { html: string; as?: 'div' | 'span' }) {
-  const ref = useRef<HTMLElement>(null);
-  useEffect(() => {
-    if (!ref.current) return;
-    const imgs = ref.current.querySelectorAll('img');
-    imgs.forEach((img) => {
-      img.onerror = () => { img.style.display = 'none'; img.onerror = null; };
-    });
-  }, [html]);
-  return <Tag ref={ref as any} dangerouslySetInnerHTML={{ __html: html }} />;
-}
-
-/**
- * Render inline content — if it contains HTML tags, sanitize and render.
- * Otherwise use our markdown renderer.
- */
-function renderContent(content: string): React.ReactNode {
-  if (containsHtml(content)) {
-    return <SafeHtml html={sanitizeInlineHtml(content)} as="span" />;
-  }
-  return renderInlineMarkdown(content);
-}
-
-/** Render a simplified block-level markdown view (no annotation infrastructure). */
-export function MarkdownBody({ markdown, textClassName = 'text-xs' }: { markdown: string; textClassName?: string }) {
-  const blocks = useMemo(() => parseMarkdownToBlocks(markdown), [markdown]);
-
-  return (
-    <div className={`space-y-2.5 ${textClassName} text-foreground/90 leading-relaxed`}>
-      {blocks.map((block) => {
-        switch (block.type) {
-          case 'heading': {
-            const Tag = `h${Math.min(block.level ?? 1, 6)}` as keyof JSX.IntrinsicElements;
-            const sizes: Record<number, string> = {
-              1: 'text-base font-bold',
-              2: 'text-sm font-semibold',
-              3: 'text-xs font-semibold',
-            };
-            return (
-              <Tag key={block.id} className={`${sizes[block.level ?? 1] ?? 'text-xs font-medium'} text-foreground`}>
-                {renderContent(block.content)}
-              </Tag>
-            );
-          }
-          case 'code':
-            return (
-              <pre key={block.id} className="bg-muted/50 rounded-md p-2 text-[11px] font-mono overflow-x-auto whitespace-pre-wrap">
-                <code>{block.content}</code>
-              </pre>
-            );
-          case 'list-item':
-            return (
-              <div key={block.id} className="flex gap-1.5" style={{ paddingLeft: (block.level ?? 0) * 12 }}>
-                <span className="text-muted-foreground shrink-0">{block.checked !== undefined ? (block.checked ? '☑' : '☐') : '•'}</span>
-                <span>{renderContent(block.content)}</span>
-              </div>
-            );
-          case 'blockquote':
-            return (
-              <blockquote key={block.id} className="border-l-2 border-border pl-2 text-muted-foreground italic">
-                {renderContent(block.content)}
-              </blockquote>
-            );
-          case 'hr':
-            return <hr key={block.id} className="border-border/50" />;
-          default:
-            if (!block.content) return null;
-            // If the entire paragraph is HTML, sanitize and render
-            if (containsHtml(block.content)) {
-              return <SafeHtml key={block.id} html={sanitizeInlineHtml(block.content)} />;
-            }
-            return <p key={block.id}>{renderInlineMarkdown(block.content)}</p>;
-        }
-      })}
-    </div>
-  );
-}
-
 export const PRSummaryTab: React.FC<PRSummaryTabProps> = React.memo(({ context, metadata }) => {
   return (
     <div className="px-8 py-4 space-y-4 max-w-2xl">
@@ -189,3 +103,4 @@ export const PRSummaryTab: React.FC<PRSummaryTabProps> = React.memo(({ context, 
     </div>
   );
 });
+

--- a/packages/review-editor/components/markdownBody.test.tsx
+++ b/packages/review-editor/components/markdownBody.test.tsx
@@ -1,0 +1,53 @@
+import { describe, test, expect } from 'bun:test';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { MarkdownBody } from './MarkdownBody';
+
+describe('MarkdownBody', () => {
+  test('renders pipe tables as real tables (PR comments previously collapsed them to one line)', () => {
+    const md = `Results:
+
+| Scenario | Result |
+|----------|--------|
+| Render | PASS |
+| Approve | PASS |
+`;
+    const html = renderToString(<MarkdownBody markdown={md} />);
+    expect(html).toContain('<table');
+    expect(html).toContain('<th');
+    expect(html).toContain('Scenario');
+    expect(html).toContain('Approve');
+    // The old behavior inlined the raw pipes into a paragraph
+    expect(html).not.toContain('| Scenario |');
+  });
+
+  test('renders escaped pipes inside cells via the shared parser', () => {
+    const md = `| Name | Expr |
+|------|------|
+| or | a \\| b |
+`;
+    const html = renderToString(<MarkdownBody markdown={md} />);
+    expect(html).toContain('a | b');
+  });
+
+  test('renders a lone video link as an inline player with a fallback link', () => {
+    const md = '[02-annotate-approve.webm](https://github.com/o/r/releases/download/t/02.webm)';
+    const html = renderToString(<MarkdownBody markdown={md} />);
+    expect(html).toContain('<video');
+    expect(html).toContain('controls');
+    expect(html).toContain('src="https://github.com/o/r/releases/download/t/02.webm"');
+    expect(html).toContain('02-annotate-approve.webm');
+  });
+
+  test('renders a bare video URL as a player too', () => {
+    const html = renderToString(<MarkdownBody markdown={'https://cdn.example/demo.mp4?sig=abc'} />);
+    expect(html).toContain('<video');
+  });
+
+  test('leaves non-video links and mixed paragraphs alone', () => {
+    const html = renderToString(
+      <MarkdownBody markdown={'See [the docs](https://example.com/page) and https://x.test/a.webm plus text'} />
+    );
+    expect(html).not.toContain('<video');
+  });
+});


### PR DESCRIPTION
Found while dogfooding: reviewing PR #957 inside Plannotator, a PR comment containing a markdown table rendered as one collapsed line of pipes, and links to test-recording videos were plain links.

**Root cause:** the lightweight `MarkdownBody` renderer (used by the PR-comments panel, PR description tab, and commit-description header — NOT the main document viewer, which has a full `TableBlock`) had no `table` case, so table blocks fell through to the paragraph branch.

**Changes:**
- `table` case reusing `parseTableContent` from `@plannotator/ui`'s TableBlock (single pipe parser), compact styling, inline markdown in cells
- A paragraph that is exactly one link/bare URL to a video file now renders an inline `<video controls>` player with a fallback link
- `MarkdownBody` extracted to its own module (it served three components from inside `PRSummaryTab`); importers re-pointed
- New `markdownBody.test.tsx` (5 tests, renderToString — runs in plain CI)

**Verification:** typecheck clean · full suite 1897 pass / 0 fail · `apps/review` builds.