### PR TITLE
fix(hook): echo tool_input as updatedInput so plan approval survives Claude Code 2.1.199+

### DIFF
--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -1981,6 +1981,11 @@ if (args[0] === "sessions") {
             hookEventName: "PermissionRequest",
             decision: {
               behavior: "allow",
+              // Echo the original tool_input as updatedInput. Claude Code
+              // >= 2.1.199 silently drops an allow decision for ExitPlanMode
+              // (a tool requiring user interaction) when updatedInput is
+              // absent, falling back to the built-in approval dialog.
+              updatedInput: event.tool_input,
               ...(updatedPermissions.length > 0 && { updatedPermissions }),
             },
           },


### PR DESCRIPTION
## Problem

Since **Claude Code 2.1.199**, clicking **Approve** in the plan review UI no longer returns control to the CLI — the page closes but the built-in plan-approval dialog reappears in the terminal. **Deny is unaffected.** Reproduced on 2.1.199–2.1.202.

## Cause

2.1.199 added a guard that **discards a `PermissionRequest` `allow` for `ExitPlanMode` when `updatedInput` is absent** (ExitPlanMode requires user interaction and isn't an MCP tool). The hook emitted a bare `allow`, so it was dropped — along with `updatedPermissions`. The deny path skips this guard, matching the symptom.

## Fix

Echo the original `tool_input` (in scope as `event.tool_input`) back as `decision.updatedInput`. Backward compatible — a verified no-op on 2.1.198, so safe to ship unconditionally.

## Verification

Built the hook binary with this change, ran it against a mock `ExitPlanMode` event, and drove `/api/approve`; the decision now carries `updatedInput` plus `updatedPermissions`. Independently confirmed on 2.1.201 in #995 and anthropics/claude-code#74256.

Fixes #995