### PR TITLE
Render arbitrary HTML in HtmlViewer without altering it

### DIFF
--- a/apps/skills/extra/plannotator-visual-explainer/references/theme-override.md
+++ b/apps/skills/extra/plannotator-visual-explainer/references/theme-override.md
@@ -2,9 +2,19 @@
 
 When visual-explainer's workflow says to pick a palette and font pairing, use these Plannotator tokens instead. Everything else — layout, structure, components, anti-slop rules — stays as visual-explainer prescribes.
 
+## Host theme opt-in (required)
+
+Plannotator's HTML viewer renders arbitrary documents untouched — it never injects bare theme tokens into a document unless the document asks for them. For the generated file to follow the active Plannotator theme when embedded in raw HTML annotation mode, it MUST declare the opt-in in its `<head>`:
+
+```html
+<meta name="plannotator-theme" content="host">
+```
+
+With this tag present, the viewer overrides the document's bare tokens (`--background`, `--muted`, …) with the host theme's values and mirrors the host's light/dark mode. Without it, the `:root` defaults below are all the document ever sees.
+
 ## CSS Custom Properties
 
-Replace visual-explainer's `--bg`, `--surface`, `--border`, `--text`, `--accent` variables with Plannotator's semantic tokens. Include these as `:root` defaults so the file works standalone. When embedded in Plannotator's raw HTML annotation mode, these get overridden by the active theme.
+Replace visual-explainer's `--bg`, `--surface`, `--border`, `--text`, `--accent` variables with Plannotator's semantic tokens. Include these as `:root` defaults so the file works standalone. When embedded in Plannotator's raw HTML annotation mode (with the meta opt-in above), these get overridden by the active theme.
 
 ```css
 :root {
@@ -91,7 +101,7 @@ mermaid.initialize({
 
 ## Dark mode
 
-Plannotator handles dark/light via theme classes, not `prefers-color-scheme`. The standalone defaults above are the light theme. When embedded in raw HTML annotation mode, the active theme's tokens override automatically — no media query needed in the generated HTML.
+Plannotator handles dark/light via theme classes, not `prefers-color-scheme`. The standalone defaults above are the light theme. When embedded in raw HTML annotation mode (with the `plannotator-theme` meta opt-in), the active theme's tokens override automatically — no media query needed in the generated HTML.
 
 For standalone viewing, you may optionally add a `prefers-color-scheme: dark` block with the Plannotator dark theme values:
 

--- a/packages/shared/html-diff.test.ts
+++ b/packages/shared/html-diff.test.ts
@@ -12,20 +12,25 @@ function count(haystack: string, needle: string): number {
   return n;
 }
 
+// Diff-generated wrappers carry this class so viewers can style them without
+// touching author-written <ins>/<del> markup.
+const INS = '<ins class="plannotator-diff">';
+const DEL = '<del class="plannotator-diff">';
+
 describe("htmlDiff", () => {
   test("pure text addition inside a <p> wraps the added word in <ins>", () => {
     const out = htmlDiff("<p>hello world</p>", "<p>hello brave world</p>");
-    // The added word is wrapped in <ins>.
-    expect(out).toContain("<ins>");
+    // The added word is wrapped in a class-tagged <ins>.
+    expect(out).toContain(INS);
     expect(out).toContain("brave");
-    expect(out.indexOf("brave")).toBeGreaterThan(out.indexOf("<ins>"));
+    expect(out.indexOf("brave")).toBeGreaterThan(out.indexOf(INS));
     // Structure intact: exactly one opening <p and one closing </p>.
     expect(count(out, "<p")).toBe(1);
     expect(count(out, "</p>")).toBe(1);
     // No <del> for a pure addition.
-    expect(out).not.toContain("<del>");
+    expect(out).not.toContain("<del");
     // <ins>/</ins> are balanced.
-    expect(count(out, "<ins>")).toBe(count(out, "</ins>"));
+    expect(count(out, INS)).toBe(count(out, "</ins>"));
   });
 
   test("replaced word produces <del>Manual</del> and <ins>Scheduled</ins> inside <li>", () => {
@@ -34,23 +39,23 @@ describe("htmlDiff", () => {
       "<li>Scheduled transmission</li>",
     );
     expect(out).toContain("Manual");
-    expect(out).toContain("<del>");
+    expect(out).toContain(DEL);
     expect(out).toContain("</del>");
     expect(out).toContain("Scheduled");
-    expect(out).toContain("<ins>");
+    expect(out).toContain(INS);
     expect(out).toContain("</ins>");
     // Both ins and del sit inside the <li>...</li>.
     const liOpen = out.indexOf("<li>");
     const liClose = out.indexOf("</li>");
     expect(liOpen).toBeGreaterThanOrEqual(0);
     expect(liClose).toBeGreaterThan(liOpen);
-    expect(out.indexOf("<del>")).toBeGreaterThan(liOpen);
+    expect(out.indexOf(DEL)).toBeGreaterThan(liOpen);
     expect(out.indexOf("</del>")).toBeLessThan(liClose);
-    expect(out.indexOf("<ins>")).toBeGreaterThan(liOpen);
+    expect(out.indexOf(INS)).toBeGreaterThan(liOpen);
     expect(out.indexOf("</ins>")).toBeLessThan(liClose);
     // "Manual" appears only inside the del; "Scheduled" only inside the ins.
-    expect(out).toContain("<del>Manual</del>");
-    expect(out).toContain("<ins>Scheduled</ins>");
+    expect(out).toContain(`${DEL}Manual</del>`);
+    expect(out).toContain(`${INS}Scheduled</ins>`);
   });
 
   test("added element shows its text in <ins> with tags intact", () => {
@@ -61,11 +66,11 @@ describe("htmlDiff", () => {
     expect(count(out, "<li>")).toBe(2);
     expect(count(out, "</li>")).toBe(2);
     // The added text is wrapped in <ins> but the <li> tags are NOT inside it.
-    expect(out).toContain("<ins>");
+    expect(out).toContain(INS);
     expect(out).toContain("Audit log");
-    expect(out).not.toContain("<ins><li>");
+    expect(out).not.toContain(`${INS}<li>`);
     expect(out).not.toContain("</li></ins>");
-    expect(count(out, "<ins>")).toBe(count(out, "</ins>"));
+    expect(count(out, INS)).toBe(count(out, "</ins>"));
   });
 
   test("<script> contents are NOT wrapped with ins/del even if changed", () => {
@@ -74,8 +79,8 @@ describe("htmlDiff", () => {
     const out = htmlDiff(oldHtml, newHtml);
     // The new script content is present verbatim, opaque (no ins/del inside it).
     expect(out).toContain("<script>var a = 2;</script>");
-    expect(out).not.toContain("<ins>");
-    expect(out).not.toContain("<del>");
+    expect(out).not.toContain("<ins");
+    expect(out).not.toContain("<del");
   });
 
   test("<style> contents are NOT wrapped with ins/del even if changed", () => {
@@ -83,8 +88,8 @@ describe("htmlDiff", () => {
     const newHtml = "<head><style>.a{color:blue}</style></head>";
     const out = htmlDiff(oldHtml, newHtml);
     expect(out).toContain("<style>.a{color:blue}</style>");
-    expect(out).not.toContain("<ins>");
-    expect(out).not.toContain("<del>");
+    expect(out).not.toContain("<ins");
+    expect(out).not.toContain("<del");
   });
 
   test("identical input yields the new HTML verbatim with no ins/del", () => {
@@ -92,14 +97,21 @@ describe("htmlDiff", () => {
       "<!doctype html><html><head><title>T</title></head><body><p>Same text here</p></body></html>";
     const out = htmlDiff(html, html);
     expect(out).toBe(html);
-    expect(out).not.toContain("<ins>");
-    expect(out).not.toContain("<del>");
+    expect(out).not.toContain("<ins");
+    expect(out).not.toContain("<del");
+  });
+
+  test("author-written <ins>/<del> pass through untagged (no plannotator-diff class)", () => {
+    const html = "<p>legal text with <ins>inserted</ins> and <del>struck</del> words</p>";
+    const out = htmlDiff(html, html);
+    expect(out).toBe(html);
+    expect(out).not.toContain("plannotator-diff");
   });
 
   test("whitespace-only changes do not produce noisy ins/del", () => {
     const out = htmlDiff("<p>a b</p>", "<p>a  b</p>");
-    expect(out).not.toContain("<ins>");
-    expect(out).not.toContain("<del>");
+    expect(out).not.toContain("<ins");
+    expect(out).not.toContain("<del");
     expect(out).toContain("<p>");
     expect(out).toContain("</p>");
   });
@@ -116,8 +128,8 @@ describe("htmlDiff", () => {
     expect(count(out, "<body>")).toBe(1);
     expect(count(out, "</body>")).toBe(1);
     // ins/del balanced.
-    expect(count(out, "<ins>")).toBe(count(out, "</ins>"));
-    expect(count(out, "<del>")).toBe(count(out, "</del>"));
+    expect(count(out, INS)).toBe(count(out, "</ins>"));
+    expect(count(out, DEL)).toBe(count(out, "</del>"));
   });
 
   test("tags with > inside quoted attributes are tokenized whole (attr-only change)", () => {
@@ -136,7 +148,7 @@ describe("htmlDiff", () => {
       '<td title="a > b">cat</td>',
       '<td title="a > b">dog</td>',
     );
-    expect(out).toBe('<td title="a > b"><del>cat</del><ins>dog</ins></td>');
+    expect(out).toBe(`<td title="a > b">${DEL}cat</del>${INS}dog</ins></td>`);
   });
 
   test("script opener with > in an attribute keeps contents opaque", () => {
@@ -144,8 +156,8 @@ describe("htmlDiff", () => {
     const newHtml = '<script data-x="a>b">var a = 2;</script><p>hi</p>';
     const out = htmlDiff(oldHtml, newHtml);
     expect(out).toContain('<script data-x="a>b">var a = 2;</script>');
-    expect(out).not.toContain("<ins>");
-    expect(out).not.toContain("<del>");
+    expect(out).not.toContain("<ins");
+    expect(out).not.toContain("<del");
   });
 
   test("removed element drops its tags (no unbalanced tags) and dels its text", () => {
@@ -156,11 +168,11 @@ describe("htmlDiff", () => {
     expect(count(out, "<li>")).toBe(1);
     expect(count(out, "</li>")).toBe(1);
     // Removed text "Two" appears inside a <del>.
-    expect(out).toContain("<del>");
+    expect(out).toContain(DEL);
     expect(out).toContain("Two");
     // Never wrap a tag in del.
-    expect(out).not.toContain("<del><li>");
+    expect(out).not.toContain(`${DEL}<li>`);
     expect(out).not.toContain("</li></del>");
-    expect(count(out, "<del>")).toBe(count(out, "</del>"));
+    expect(count(out, DEL)).toBe(count(out, "</del>"));
   });
 });

--- a/packages/shared/html-diff.ts
+++ b/packages/shared/html-diff.ts
@@ -6,7 +6,9 @@ import { diffArrays } from "diff";
  * Given two versions of an HTML document, {@link htmlDiff} returns a single merged
  * HTML string: the NEW document with changed TEXT wrapped in `<ins>...</ins>`
  * (added) and removed TEXT wrapped in `<del>...</del>` (deleted), so it can be
- * rendered to visually show what changed.
+ * rendered to visually show what changed. Generated wrappers carry
+ * `class="plannotator-diff"` so viewers can style diff output without touching
+ * author-written `<ins>`/`<del>` markup (which passes through untagged).
  *
  * This is the classic "htmldiff" approach (à la the Ruby htmldiff / DaisyDiff
  * family): it diffs an ordered token stream where tokens are either complete
@@ -125,7 +127,7 @@ export function htmlDiff(oldHtml: string, newHtml: string): string {
       const flush = () => {
         if (buffer.length === 0) return;
         if (!isAllWhitespace(buffer)) {
-          out.push("<del>");
+          out.push('<del class="plannotator-diff">');
           for (const t of buffer) out.push(t.value);
           out.push("</del>");
         }
@@ -154,7 +156,7 @@ export function htmlDiff(oldHtml: string, newHtml: string): string {
         // Added whitespace-only run: emit verbatim, no <ins> noise.
         for (const t of buffer) out.push(t.value);
       } else {
-        out.push("<ins>");
+        out.push('<ins class="plannotator-diff">');
         for (const t of buffer) out.push(t.value);
         out.push("</ins>");
       }

--- a/packages/ui/components/html-viewer/HtmlViewer.tsx
+++ b/packages/ui/components/html-viewer/HtmlViewer.tsx
@@ -17,38 +17,15 @@ import { CommentPopover, type CommentAskAIHandler } from "../CommentPopover";
 import { FloatingQuickLabelPicker } from "../FloatingQuickLabelPicker";
 import type { ViewerHandle } from "../Viewer";
 import { useHtmlAnnotation } from "./useHtmlAnnotation";
-import { ANNOTATION_HIGHLIGHT_CSS, BRIDGE_SCRIPT } from "./bridge-script";
+import {
+  THEME_TOKENS,
+  buildSrcdocInjection,
+  buildThemeTokenPayload,
+  hasHostThemeOptIn,
+  injectIntoHead,
+} from "./srcdoc";
 
 const PREFIX = "plannotator-bridge-";
-
-const THEME_TOKENS = [
-  "--background",
-  "--foreground",
-  "--card",
-  "--card-foreground",
-  "--primary",
-  "--primary-foreground",
-  "--secondary",
-  "--secondary-foreground",
-  "--muted",
-  "--muted-foreground",
-  "--accent",
-  "--accent-foreground",
-  "--destructive",
-  "--destructive-foreground",
-  "--success",
-  "--success-foreground",
-  "--warning",
-  "--warning-foreground",
-  "--border",
-  "--input",
-  "--ring",
-  "--code-bg",
-  "--focus-highlight",
-  "--font-sans",
-  "--font-mono",
-  "--radius",
-] as const;
 
 function readThemeTokens(): Record<string, string> {
   const style = getComputedStyle(document.documentElement);
@@ -124,26 +101,19 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
       contextText: string;
     } | null>(null);
 
-    const srcdoc = useMemo(() => {
-      const tokens = readThemeTokens();
-      let themeCSS = ":root {\n";
-      for (const [key, val] of Object.entries(tokens)) {
-        themeCSS += `  ${key}: ${val};\n`;
-      }
-      themeCSS += "}\n";
-      if (isLightTheme()) themeCSS += ":root { color-scheme: light; }\n:root.light, :root { }\n";
+    // Host theming is opt-in per document (Plannotator-generated artifacts tag
+    // themselves); arbitrary HTML renders untouched, like a standalone tab.
+    const hostTheme = useMemo(() => hasHostThemeOptIn(rawHtml), [rawHtml]);
 
-      // Version-diff highlights: htmlDiff wraps changed text in <ins>/<del>.
-      const diffCSS =
-        "ins{background:#e6ffec;color:#0a7d33;text-decoration:none;border-radius:2px;box-shadow:0 0 0 1px #abf2bc inset}" +
-        "del{background:#ffebe9;color:#b31d28;text-decoration:line-through;border-radius:2px;box-shadow:0 0 0 1px #ffc1bc inset}";
-      const injection = `<style>${themeCSS}${ANNOTATION_HIGHLIGHT_CSS}${diffCSS}</style><script>${BRIDGE_SCRIPT}</script>`;
-      const headClose = rawHtml.indexOf("</head>");
-      if (headClose !== -1) {
-        return rawHtml.slice(0, headClose) + injection + rawHtml.slice(headClose);
-      }
-      return injection + rawHtml;
-    }, [rawHtml]);
+    const srcdoc = useMemo(() => {
+      const injection = buildSrcdocInjection({
+        tokens: readThemeTokens(),
+        isLight: isLightTheme(),
+        hostTheme,
+        diffActive: !!diffActive,
+      });
+      return injectIntoHead(rawHtml, injection);
+    }, [rawHtml, hostTheme, diffActive]);
 
     const handleResize = useCallback((height: number) => {
       setIframeHeight(height);
@@ -189,9 +159,13 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
     useEffect(() => {
       if (!iframeReady) return;
       function sendTheme() {
-        const tokens = readThemeTokens();
         iframeRef.current?.contentWindow?.postMessage(
-          { type: `${PREFIX}theme`, tokens, isLight: isLightTheme() },
+          {
+            type: `${PREFIX}theme`,
+            tokens: buildThemeTokenPayload(readThemeTokens(), hostTheme),
+            isLight: isLightTheme(),
+            hostTheme,
+          },
           "*",
         );
       }
@@ -202,7 +176,7 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
         attributeFilter: ["class", "style"],
       });
       return () => observer.disconnect();
-    }, [iframeReady]);
+    }, [iframeReady, hostTheme]);
 
     useImperativeHandle(ref, () => ({
       removeHighlight: hook.removeHighlight,

--- a/packages/ui/components/html-viewer/bridge-script.ts
+++ b/packages/ui/components/html-viewer/bridge-script.ts
@@ -9,6 +9,11 @@
  * No external dependencies.
  */
 
+/**
+ * Reads only viewer-namespaced \`--pn-*\` variables (with fallbacks): arbitrary
+ * documents may define bare token names like \`--accent\` for themselves, and the
+ * viewer must never depend on — or collide with — the author's namespace.
+ */
 export const ANNOTATION_HIGHLIGHT_CSS = `
 .annotation-highlight {
   border-radius: 2px;
@@ -17,33 +22,33 @@ export const ANNOTATION_HIGHLIGHT_CSS = `
   cursor: pointer;
 }
 .annotation-highlight.deletion {
-  background: oklch(from var(--destructive, #c0392b) l c h / 0.35);
+  background: oklch(from var(--pn-destructive, #c0392b) l c h / 0.35);
   text-decoration: line-through;
-  text-decoration-color: var(--destructive, #c0392b);
+  text-decoration-color: var(--pn-destructive, #c0392b);
   text-decoration-thickness: 2px;
 }
 .annotation-highlight.comment {
   background: oklch(0.70 0.18 60 / 0.3);
-  border-bottom: 2px solid var(--accent, #d97757);
+  border-bottom: 2px solid var(--pn-accent, #d97757);
 }
 .annotation-highlight.focused {
-  background: oklch(from var(--focus-highlight, #4493f8) l c h / 0.45) !important;
-  box-shadow: 0 0 8px oklch(from var(--focus-highlight, #4493f8) l c h / 0.4);
-  border-bottom: 2px solid var(--focus-highlight, #4493f8);
+  background: oklch(from var(--pn-focus-highlight, #4493f8) l c h / 0.45) !important;
+  box-shadow: 0 0 8px oklch(from var(--pn-focus-highlight, #4493f8) l c h / 0.4);
+  border-bottom: 2px solid var(--pn-focus-highlight, #4493f8);
   filter: none;
 }
 .annotation-highlight:hover {
   filter: brightness(1.2);
 }
 .plannotator-pinpoint-hover {
-  outline: 2px solid var(--focus-highlight, #4493f8) !important;
+  outline: 2px solid var(--pn-focus-highlight, #4493f8) !important;
   outline-offset: 1px;
   cursor: crosshair !important;
 }
 /* SVG nodes can't take a CSS outline — stroke their shapes instead. */
 .plannotator-pinpoint-hover rect, .plannotator-pinpoint-hover path,
 .plannotator-pinpoint-hover circle, .plannotator-pinpoint-hover ellipse, .plannotator-pinpoint-hover polygon {
-  stroke: var(--focus-highlight, #4493f8) !important; stroke-width: 2.5px !important;
+  stroke: var(--pn-focus-highlight, #4493f8) !important; stroke-width: 2.5px !important;
 }
 `;
 
@@ -51,15 +56,23 @@ export const BRIDGE_SCRIPT = `(function() {
   var PREFIX = 'plannotator-bridge-';
 
   // --- Theme ---
+  // The author owns this document. Unless it opted in to host theming
+  // (hostTheme), only viewer-namespaced --pn-* properties may be written to its
+  // root, and its class list is never touched.
   window.addEventListener('message', function(e) {
     if (!e.data || e.data.type !== PREFIX + 'theme') return;
     var root = document.documentElement;
-    var tokens = e.data.tokens;
+    var tokens = e.data.tokens || {};
+    var hostTheme = !!e.data.hostTheme;
     for (var key in tokens) {
-      if (tokens.hasOwnProperty(key)) root.style.setProperty(key, tokens[key]);
+      if (!tokens.hasOwnProperty(key)) continue;
+      if (!hostTheme && key.indexOf('--pn-') !== 0) continue;
+      root.style.setProperty(key, tokens[key]);
     }
-    root.classList.remove('light');
-    if (e.data.isLight) root.classList.add('light');
+    if (hostTheme) {
+      root.classList.remove('light');
+      if (e.data.isLight) root.classList.add('light');
+    }
   });
 
   // --- Resize ---
@@ -244,7 +257,7 @@ export const BRIDGE_SCRIPT = `(function() {
     if (!pinpointLabelEl) {
       pinpointLabelEl = document.createElement('div');
       pinpointLabelEl.setAttribute('data-plannotator-pinpoint-label', '');
-      pinpointLabelEl.style.cssText = 'position:fixed;z-index:2147483647;pointer-events:none;display:none;font:600 11px/1.3 system-ui,-apple-system,sans-serif;padding:2px 7px;border-radius:5px;background:var(--focus-highlight,#4493f8);color:#fff;white-space:nowrap;box-shadow:0 1px 5px rgba(0,0,0,.35);';
+      pinpointLabelEl.style.cssText = 'position:fixed;z-index:2147483647;pointer-events:none;display:none;font:600 11px/1.3 system-ui,-apple-system,sans-serif;padding:2px 7px;border-radius:5px;background:var(--pn-focus-highlight,#4493f8);color:#fff;white-space:nowrap;box-shadow:0 1px 5px rgba(0,0,0,.35);';
       document.body.appendChild(pinpointLabelEl);
     }
     return pinpointLabelEl;

--- a/packages/ui/components/html-viewer/srcdoc.test.ts
+++ b/packages/ui/components/html-viewer/srcdoc.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Rendering-neutrality contract for the HTML viewer (see srcdoc.ts).
+ *
+ * Arbitrary customer HTML must render exactly as in a plain browser tab: the
+ * viewer writes NOTHING into the document's namespace — no bare CSS custom
+ * properties (a host `--muted` clobbering an author `--muted` visibly corrupts
+ * documents), no `color-scheme`, no root classes, no styling of author
+ * elements. Host tokens travel only under the viewer-owned `--pn-*` prefix
+ * unless the document opts in via <meta name="plannotator-theme" content="host">.
+ *
+ * These tests are the mutation guard: reintroducing any bare-token injection
+ * for non-opted-in documents must go red here.
+ */
+import { describe, expect, test } from "bun:test";
+import { ANNOTATION_HIGHLIGHT_CSS, BRIDGE_SCRIPT } from "./bridge-script";
+import {
+  DIFF_HIGHLIGHT_CSS,
+  buildSrcdocInjection,
+  buildThemeTokenPayload,
+  hasHostThemeOptIn,
+  injectIntoHead,
+} from "./srcdoc";
+
+const HOST_TOKENS = {
+  "--background": "oklch(0.15 0.02 260)",
+  "--muted": "oklch(0.26 0.02 260)",
+  "--border": "oklch(0.35 0.02 260)",
+  "--destructive": "oklch(0.65 0.20 25)",
+  "--focus-highlight": "#4493f8",
+};
+
+/** Matches a bare (non --pn-) custom-property declaration like `--muted:`. */
+const BARE_TOKEN_DECL = /(^|[^-\w])--(?!pn-)[\w-]+\s*:/m;
+
+describe("buildThemeTokenPayload", () => {
+  test("default (arbitrary document): every pushed property is --pn- prefixed", () => {
+    const payload = buildThemeTokenPayload(HOST_TOKENS, false);
+    expect(Object.keys(payload).length).toBe(Object.keys(HOST_TOKENS).length);
+    for (const key of Object.keys(payload)) {
+      expect(key.startsWith("--pn-")).toBe(true);
+    }
+    expect(payload["--pn-muted"]).toBe(HOST_TOKENS["--muted"]);
+    expect(payload["--muted"]).toBeUndefined();
+  });
+
+  test("host-theme opt-in: bare tokens ride along with the --pn- set", () => {
+    const payload = buildThemeTokenPayload(HOST_TOKENS, true);
+    expect(payload["--muted"]).toBe(HOST_TOKENS["--muted"]);
+    expect(payload["--pn-muted"]).toBe(HOST_TOKENS["--muted"]);
+  });
+});
+
+describe("buildSrcdocInjection", () => {
+  const base = { tokens: HOST_TOKENS, isLight: true, hostTheme: false, diffActive: false };
+
+  test("arbitrary document: no bare custom-property declarations reach the doc", () => {
+    const injection = buildSrcdocInjection(base);
+    const [themeBlock] = injection.split(ANNOTATION_HIGHLIGHT_CSS);
+    expect(themeBlock).toContain("--pn-muted:");
+    expect(BARE_TOKEN_DECL.test(themeBlock!.replace(/--pn-[\w-]+\s*:/g, ""))).toBe(false);
+  });
+
+  test("arbitrary document: no color-scheme injection in either host theme", () => {
+    expect(buildSrcdocInjection({ ...base, isLight: true })).not.toContain("color-scheme");
+    expect(buildSrcdocInjection({ ...base, isLight: false })).not.toContain("color-scheme");
+  });
+
+  test("host-theme opt-in: bare tokens and symmetric color-scheme are injected", () => {
+    const light = buildSrcdocInjection({ ...base, hostTheme: true, isLight: true });
+    expect(light).toContain("--muted:");
+    expect(light).toContain("color-scheme: light");
+    const dark = buildSrcdocInjection({ ...base, hostTheme: true, isLight: false });
+    expect(dark).toContain("color-scheme: dark");
+  });
+
+  test("diff CSS is absent on plain renders and scoped when active", () => {
+    expect(buildSrcdocInjection(base)).not.toContain("plannotator-diff");
+    const active = buildSrcdocInjection({ ...base, diffActive: true });
+    expect(active).toContain(DIFF_HIGHLIGHT_CSS);
+    // Scoped to diff-generated markup only — never bare ins/del selectors that
+    // would restyle author elements.
+    expect(DIFF_HIGHLIGHT_CSS).toContain("ins.plannotator-diff");
+    expect(DIFF_HIGHLIGHT_CSS).toContain("del.plannotator-diff");
+    expect(/(^|[}\s;])(ins|del)\s*\{/.test(DIFF_HIGHLIGHT_CSS)).toBe(false);
+  });
+});
+
+describe("viewer CSS/script namespace", () => {
+  test("annotation CSS reads only --pn- variables", () => {
+    expect(ANNOTATION_HIGHLIGHT_CSS).toContain("var(--pn-");
+    expect(/var\(--(?!pn-)/.test(ANNOTATION_HIGHLIGHT_CSS)).toBe(false);
+  });
+
+  test("bridge script reads only --pn- variables and guards bare writes", () => {
+    expect(/var\(--(?!pn-)/.test(BRIDGE_SCRIPT)).toBe(false);
+    // The theme handler's non-opt-in guard: only --pn-* may be set on the root.
+    expect(BRIDGE_SCRIPT).toContain("key.indexOf('--pn-') !== 0");
+  });
+});
+
+describe("hasHostThemeOptIn", () => {
+  test("detects the meta tag across attribute order and quoting", () => {
+    expect(
+      hasHostThemeOptIn('<head><meta name="plannotator-theme" content="host"></head>'),
+    ).toBe(true);
+    expect(
+      hasHostThemeOptIn("<head><meta content='host' name='plannotator-theme'/></head>"),
+    ).toBe(true);
+    expect(hasHostThemeOptIn("<head><meta name=plannotator-theme content=host></head>")).toBe(
+      true,
+    );
+  });
+
+  test("does not trigger on absent, foreign, or mismatched metas", () => {
+    expect(hasHostThemeOptIn("<html><body><p>hi</p></body></html>")).toBe(false);
+    expect(hasHostThemeOptIn('<meta name="viewport" content="host">')).toBe(false);
+    expect(hasHostThemeOptIn('<meta name="plannotator-theme" content="self">')).toBe(false);
+  });
+});
+
+// Exercises the real bridge theme handler (the inline-setProperty site): on a
+// host theme flip, nothing may land on the author's documentElement except
+// --pn-* properties — no bare tokens, no `light` class — unless the document
+// opted in to host theming. Requires DOM_TESTS=1 (happy-dom preload).
+const hasDom = typeof document !== "undefined";
+describe.if(hasDom)("bridge theme handler (DOM)", () => {
+  function postTheme(data: Record<string, unknown>) {
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: { type: "plannotator-bridge-theme", ...data },
+      }),
+    );
+  }
+
+  test("author root only receives --pn-* on theme flip; opt-in restores bare push", () => {
+    new Function(BRIDGE_SCRIPT)();
+    const root = document.documentElement;
+
+    postTheme({
+      tokens: { "--pn-muted": "red", "--muted": "blue" },
+      isLight: true,
+      hostTheme: false,
+    });
+    expect(root.style.getPropertyValue("--pn-muted")).toBe("red");
+    expect(root.style.getPropertyValue("--muted")).toBe("");
+    expect(root.classList.contains("light")).toBe(false);
+
+    postTheme({
+      tokens: { "--pn-muted": "red", "--muted": "blue" },
+      isLight: true,
+      hostTheme: true,
+    });
+    expect(root.style.getPropertyValue("--muted")).toBe("blue");
+    expect(root.classList.contains("light")).toBe(true);
+
+    root.style.removeProperty("--pn-muted");
+    root.style.removeProperty("--muted");
+    root.classList.remove("light");
+  });
+});
+
+describe("injectIntoHead", () => {
+  test("splices before </head> when present, else prepends", () => {
+    expect(injectIntoHead("<html><head><title>t</title></head><body/></html>", "[X]")).toBe(
+      "<html><head><title>t</title>[X]</head><body/></html>",
+    );
+    expect(injectIntoHead("<p>no head</p>", "[X]")).toBe("[X]<p>no head</p>");
+  });
+});

--- a/packages/ui/components/html-viewer/srcdoc.ts
+++ b/packages/ui/components/html-viewer/srcdoc.ts
@@ -1,0 +1,130 @@
+/**
+ * Srcdoc injection builder for the HTML viewer.
+ *
+ * Product rule: arbitrary HTML must render exactly as it would in a plain
+ * browser tab. The viewer never writes into the document's namespace — no bare
+ * CSS custom properties, no classes on the author's root, no `color-scheme`,
+ * no styling of author elements. Host theme tokens are pushed under the
+ * viewer-owned `--pn-*` prefix, which the annotation CSS reads.
+ *
+ * Documents that WANT to follow the host theme (e.g. Plannotator-generated
+ * artifacts) opt in with `<meta name="plannotator-theme" content="host">`,
+ * which re-enables the bare-token push, the `light` class on their root, and
+ * `color-scheme` sync — for that document only.
+ *
+ * Pure string logic (no DOM) so the rendering-neutrality contract is unit-testable.
+ */
+import { ANNOTATION_HIGHLIGHT_CSS, BRIDGE_SCRIPT } from "./bridge-script";
+
+export const THEME_TOKENS = [
+  "--background",
+  "--foreground",
+  "--card",
+  "--card-foreground",
+  "--primary",
+  "--primary-foreground",
+  "--secondary",
+  "--secondary-foreground",
+  "--muted",
+  "--muted-foreground",
+  "--accent",
+  "--accent-foreground",
+  "--destructive",
+  "--destructive-foreground",
+  "--success",
+  "--success-foreground",
+  "--warning",
+  "--warning-foreground",
+  "--border",
+  "--input",
+  "--ring",
+  "--code-bg",
+  "--focus-highlight",
+  "--font-sans",
+  "--font-mono",
+  "--radius",
+] as const;
+
+/** Viewer-owned namespace for properties injected into the document. */
+export const PN_TOKEN_PREFIX = "--pn-";
+
+/**
+ * Version-diff highlights. htmlDiff tags the <ins>/<del> it generates with
+ * this class so author-written <ins>/<del> markup is never restyled.
+ */
+export const DIFF_HIGHLIGHT_CSS =
+  "ins.plannotator-diff{background:#e6ffec;color:#0a7d33;text-decoration:none;border-radius:2px;box-shadow:0 0 0 1px #abf2bc inset}" +
+  "del.plannotator-diff{background:#ffebe9;color:#b31d28;text-decoration:line-through;border-radius:2px;box-shadow:0 0 0 1px #ffc1bc inset}";
+
+/**
+ * True when the document opts in to following the host theme via
+ * `<meta name="plannotator-theme" content="host">` (attribute order/quoting agnostic).
+ */
+export function hasHostThemeOptIn(rawHtml: string): boolean {
+  const metas = rawHtml.match(/<meta\b[^>]*>/gi);
+  if (!metas) return false;
+  return metas.some(
+    (tag) =>
+      /\bname\s*=\s*["']?plannotator-theme["']?/i.test(tag) &&
+      /\bcontent\s*=\s*["']?host["']?/i.test(tag),
+  );
+}
+
+/**
+ * Build the theme properties to write into the document. Bare host token names
+ * (`--muted`, `--background`, …) collide with author variables, so they are
+ * remapped to `--pn-*`; the originals ride along only for host-theme documents.
+ */
+export function buildThemeTokenPayload(
+  tokens: Record<string, string>,
+  hostTheme: boolean,
+): Record<string, string> {
+  const payload: Record<string, string> = {};
+  for (const [key, val] of Object.entries(tokens)) {
+    payload[PN_TOKEN_PREFIX + key.slice(2)] = val;
+    if (hostTheme) payload[key] = val;
+  }
+  return payload;
+}
+
+export interface SrcdocInjectionOptions {
+  /** Host theme tokens, keyed by bare name (as read from the host root). */
+  tokens: Record<string, string>;
+  /** Whether the host is currently in its light theme. */
+  isLight: boolean;
+  /** Document opted in to host theming (see {@link hasHostThemeOptIn}). */
+  hostTheme: boolean;
+  /** The version-diff view is showing (rawHtml is htmlDiff output). */
+  diffActive: boolean;
+}
+
+/** The `<style>` + `<script>` block spliced into the document's head. */
+export function buildSrcdocInjection({
+  tokens,
+  isLight,
+  hostTheme,
+  diffActive,
+}: SrcdocInjectionOptions): string {
+  const payload = buildThemeTokenPayload(tokens, hostTheme);
+  let themeCSS = ":root {\n";
+  for (const [key, val] of Object.entries(payload)) {
+    themeCSS += `  ${key}: ${val};\n`;
+  }
+  themeCSS += "}\n";
+  // Host-theme documents mirror the host's light/dark; arbitrary documents keep
+  // their own color-scheme resolution (document + OS), like a standalone tab.
+  if (hostTheme) {
+    themeCSS += `:root { color-scheme: ${isLight ? "light" : "dark"}; }\n`;
+  }
+  const diffCSS = diffActive ? DIFF_HIGHLIGHT_CSS : "";
+  return `<style>${themeCSS}${ANNOTATION_HIGHLIGHT_CSS}${diffCSS}</style><script>${BRIDGE_SCRIPT}</script>`;
+}
+
+/** Splice the injection just before `</head>`, or prepend when there is none. */
+export function injectIntoHead(rawHtml: string, injection: string): string {
+  const headClose = rawHtml.indexOf("</head>");
+  if (headClose !== -1) {
+    return rawHtml.slice(0, headClose) + injection + rawHtml.slice(headClose);
+  }
+  return injection + rawHtml;
+}


### PR DESCRIPTION
## The bug

`HtmlViewer` injected host-app state into rendered documents and clobbered author CSS. A document defining common token names (`--muted`, `--background`, `--border`, …) rendered with wrong colors — e.g. body text set via the author's `--muted` turned near-invisible in a dark host because the host's `--muted` (a background color) overwrote the author's (a text gray). Reproduced in Plannotator and in Workspaces (which consumes `@plannotator/ui`); root-caused to three injection sites:

1. **srcdoc build** — ~26 bare host tokens copied into a `:root` block inside the document.
2. **bridge theme handler** — on every host theme flip, tokens re-applied **inline** on the author's `documentElement` (beats any author stylesheet), plus a `light` class toggled on their root.
3. **asymmetric `color-scheme:light`** injection, and `ins`/`del` diff styles injected unconditionally, restyling legitimate author markup.

## The fix

Arbitrary documents now render exactly as in a standalone browser tab — the viewer writes nothing into the document's namespace:

- Host tokens are pushed only under the viewer-owned **`--pn-*`** prefix (`packages/ui/components/html-viewer/srcdoc.ts`, new pure module). `ANNOTATION_HIGHLIGHT_CSS` and the bridge read only `var(--pn-…, fallback)`.
- The bridge theme handler **refuses non-`--pn-` writes** and never touches the author root's class list unless the document opts in. No `color-scheme` injection — light/dark resolves from the document + OS.
- **Host theme-following is opt-in** via `<meta name="plannotator-theme" content="host">`, which restores the bare-token push, the `light` class, and a now-symmetric `color-scheme` sync. Plannotator's own artifact generator (visual-explainer skill) emits the tag, so generated artifacts keep following the host theme.
- **Diff CSS is gated and scoped**: injected only while the version-diff view is active, and scoped to `ins.plannotator-diff` / `del.plannotator-diff`, which `htmlDiff` now emits on its generated wrappers. Author `<ins>`/`<del>` markup is never restyled, even in diff view.

## Acceptance tests (pinned)

`packages/ui/components/html-viewer/srcdoc.test.ts`:
- No bare custom-property declarations reach a non-opted-in document (mutation guard — reintroducing one goes red).
- No `color-scheme` injection in either host theme; opt-in restores bare tokens + symmetric color-scheme.
- Diff CSS absent on plain renders; no bare `ins`/`del` selectors ever.
- Viewer CSS and bridge script reference only `--pn-*` variables.
- DOM test runs the **actual bridge script**, fires a theme-flip message, and asserts nothing lands on the author's `documentElement` except `--pn-*` properties (and that the opt-in restores the old behavior).

`packages/shared/html-diff.test.ts`: updated for the class-tagged wrappers + new case pinning that author-written `<ins>`/`<del>` pass through untagged.

## Notes

- Artifacts generated **before** this change lack the meta tag and will stop live-following the host theme (they fall back to their own `:root` defaults + `prefers-color-scheme`) — intended: arbitrary documents get zero unprefixed injection by default.
- Workspaces will pick this up via an `@plannotator/ui` version bump (supersedes their 2-line patch / H-ask-1).

## Test plan

- `bun test` — 1980 pass, 0 fail (incl. `DOM_TESTS=1` for the bridge DOM test)
- `bun run typecheck` — clean, including the strict-consumer tsconfig
- `bun run --cwd apps/review build && bun run build:hook` — bundles build

https://claude.ai/code/session_01MDqD8jdgTbdjiXcVVigzV2