### PR TITLE
Disambiguate OpenCode model dropdown labels by provider

### DIFF
--- a/packages/ai/providers/opencode-sdk.ts
+++ b/packages/ai/providers/opencode-sdk.ts
@@ -228,7 +228,11 @@ export class OpenCodeProvider implements AIProvider {
 				for (const model of Object.values(provider.models)) {
 					models.push({
 						id: `${provider.id}/${model.id}`,
-						label: model.name ?? model.id,
+						// include the provider name: different providers can expose
+						// models with the same name (e.g. deepseek-v4-pro via
+						// DeepSeek and via OpenRouter), which would otherwise be
+						// indistinguishable in the dropdown
+						label: `${model.name ?? model.id} (${provider.name})`,
 					});
 				}
 			}


### PR DESCRIPTION
## Summary
- `fetchModels()` in `packages/ai/providers/opencode-sdk.ts` built each model's dropdown `label` from `model.name ?? model.id` alone.
- OpenCode lets multiple providers expose models with the same name (e.g. `deepseek-v4-pro` via both DeepSeek and OpenRouter). The `id` field already disambiguates them (`${provider.id}/${model.id}`), but the `label` shown in the dropdown did not, so identical entries appeared side by side with no way to tell them apart.
- Fix: append the provider's display name to the label, e.g. `deepseek-v4-pro (DeepSeek)` vs. `deepseek-v4-pro (OpenRouter)`.

## Test plan
- [x] `bun x tsc --noEmit -p packages/ai/tsconfig.json` — clean.
- [x] `bun test packages/ai/ai.test.ts` — 102/102 pass.
- [x] `bun test` (full suite) — same pass/fail counts as `main` (5 pre-existing failures unrelated to this change, caused by missing generated codegen files, reproduced identically on `main` without this diff).

Fixes #988