### PR TITLE
feat(review): [optional] Add opt-out for platform review attribution

### DIFF
--- a/apps/pi-extension/server/serverAnnotate.ts
+++ b/apps/pi-extension/server/serverAnnotate.ts
@@ -462,11 +462,12 @@ export async function startAnnotateServer(options: {
 			handleShareHtml(res, url);
 		} else if (url.pathname === "/api/config" && req.method === "POST") {
 			try {
-				const body = (await parseBody(req)) as { displayName?: string; diffOptions?: Record<string, unknown>; conventionalComments?: boolean };
+				const body = (await parseBody(req)) as { displayName?: string; diffOptions?: Record<string, unknown>; conventionalComments?: boolean; platformReviewAttribution?: boolean };
 				const toSave: Record<string, unknown> = {};
 				if (body.displayName !== undefined) toSave.displayName = body.displayName;
 				if (body.diffOptions !== undefined) toSave.diffOptions = body.diffOptions;
 				if (body.conventionalComments !== undefined) toSave.conventionalComments = body.conventionalComments;
+				if (body.platformReviewAttribution !== undefined) toSave.platformReviewAttribution = body.platformReviewAttribution;
 				if (Object.keys(toSave).length > 0) saveConfig(toSave as Parameters<typeof saveConfig>[0]);
 				json(res, { ok: true });
 			} catch {

--- a/apps/pi-extension/server/serverPlan.ts
+++ b/apps/pi-extension/server/serverPlan.ts
@@ -251,11 +251,12 @@ export async function startPlanReviewServer(options: {
 			});
 		} else if (url.pathname === "/api/config" && req.method === "POST") {
 			try {
-				const body = (await parseBody(req)) as { displayName?: string; diffOptions?: Record<string, unknown>; conventionalComments?: boolean; pfmReminder?: boolean };
+				const body = (await parseBody(req)) as { displayName?: string; diffOptions?: Record<string, unknown>; conventionalComments?: boolean; platformReviewAttribution?: boolean; pfmReminder?: boolean };
 				const toSave: Record<string, unknown> = {};
 				if (body.displayName !== undefined) toSave.displayName = body.displayName;
 				if (body.diffOptions !== undefined) toSave.diffOptions = body.diffOptions;
 				if (body.conventionalComments !== undefined) toSave.conventionalComments = body.conventionalComments;
+				if (body.platformReviewAttribution !== undefined) toSave.platformReviewAttribution = body.platformReviewAttribution;
 				if (body.pfmReminder !== undefined) toSave.pfmReminder = body.pfmReminder;
 				if (Object.keys(toSave).length > 0) saveConfig(toSave as Parameters<typeof saveConfig>[0]);
 				json(res, { ok: true });

--- a/apps/pi-extension/server/serverReview.ts
+++ b/apps/pi-extension/server/serverReview.ts
@@ -2153,11 +2153,12 @@ export async function startReviewServer(options: {
 			}
 		} else if (url.pathname === "/api/config" && req.method === "POST") {
 			try {
-				const body = (await parseBody(req)) as { displayName?: string; diffOptions?: Record<string, unknown>; conventionalComments?: boolean };
+				const body = (await parseBody(req)) as { displayName?: string; diffOptions?: Record<string, unknown>; conventionalComments?: boolean; platformReviewAttribution?: boolean };
 				const toSave: Record<string, unknown> = {};
 				if (body.displayName !== undefined) toSave.displayName = body.displayName;
 				if (body.diffOptions !== undefined) toSave.diffOptions = body.diffOptions;
 				if (body.conventionalComments !== undefined) toSave.conventionalComments = body.conventionalComments;
+				if (body.platformReviewAttribution !== undefined) toSave.platformReviewAttribution = body.platformReviewAttribution;
 				if (Object.keys(toSave).length > 0) saveConfig(toSave as Parameters<typeof saveConfig>[0]);
 				json(res, { ok: true });
 			} catch {

--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -207,6 +207,7 @@ const ReviewApp: React.FC = () => {
   const diffFontFamily = useConfigValue('diffFontFamily');
   const diffFontSize = useConfigValue('diffFontSize');
   const diffTabSize = useConfigValue('diffTabSize');
+  const platformReviewAttribution = useConfigValue('platformReviewAttribution');
   // Global plan-look preference; surfaced here only by the shared 0.20.0
   // look-and-feel announcement (the grid/clean chooser applies to plan review).
   const gridEnabled = useConfigValue('gridEnabled');
@@ -2443,7 +2444,7 @@ const ReviewApp: React.FC = () => {
       const bodyForTarget = (target: SubmissionTarget) => {
         const parts: string[] = [];
         if (generalComment) parts.push(generalComment);
-        parts.push('Review from Plannotator');
+        if (platformReviewAttribution) parts.push('Review from Plannotator');
         if (target.fileScopedBody) parts.push(target.fileScopedBody);
         return parts.join('\n\n');
       };
@@ -2529,7 +2530,7 @@ const ReviewApp: React.FC = () => {
     } finally {
       setIsPlatformActioning(false);
     }
-  }, [platformOpenPR, platformLabel, mrLabel, prMetadata]);
+  }, [platformOpenPR, platformLabel, mrLabel, prMetadata, platformReviewAttribution]);
 
   const openPlatformDialog = useCallback((action: 'approve' | 'comment') => {
     const diffPaths = new Set(files.map(f => f.path));

--- a/packages/server/annotate.ts
+++ b/packages/server/annotate.ts
@@ -472,11 +472,12 @@ export async function startAnnotateServer(
           // API: Update user config (write-back to ~/.plannotator/config.json)
           if (url.pathname === "/api/config" && req.method === "POST") {
             try {
-              const body = (await req.json()) as { displayName?: string; diffOptions?: Record<string, unknown>; conventionalComments?: boolean; conventionalLabels?: unknown[] | null };
+              const body = (await req.json()) as { displayName?: string; diffOptions?: Record<string, unknown>; conventionalComments?: boolean; platformReviewAttribution?: boolean; conventionalLabels?: unknown[] | null };
               const toSave: Record<string, unknown> = {};
               if (body.displayName !== undefined) toSave.displayName = body.displayName;
               if (body.diffOptions !== undefined) toSave.diffOptions = body.diffOptions;
               if (body.conventionalComments !== undefined) toSave.conventionalComments = body.conventionalComments;
+              if (body.platformReviewAttribution !== undefined) toSave.platformReviewAttribution = body.platformReviewAttribution;
               if (body.conventionalLabels !== undefined) toSave.conventionalLabels = body.conventionalLabels;
               if (Object.keys(toSave).length > 0) saveConfig(toSave as Parameters<typeof saveConfig>[0]);
               return Response.json({ ok: true });

--- a/packages/server/goal-setup.ts
+++ b/packages/server/goal-setup.ts
@@ -140,6 +140,7 @@ export async function startGoalSetupServer(
                 displayName?: string;
                 diffOptions?: Record<string, unknown>;
                 conventionalComments?: boolean;
+                platformReviewAttribution?: boolean;
                 conventionalLabels?: unknown[] | null;
               };
               const toSave: Record<string, unknown> = {};
@@ -151,6 +152,9 @@ export async function startGoalSetupServer(
               }
               if (body.conventionalComments !== undefined) {
                 toSave.conventionalComments = body.conventionalComments;
+              }
+              if (body.platformReviewAttribution !== undefined) {
+                toSave.platformReviewAttribution = body.platformReviewAttribution;
               }
               if (body.conventionalLabels !== undefined) {
                 toSave.conventionalLabels = body.conventionalLabels;

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -328,11 +328,12 @@ export async function startPlannotatorServer(
           // API: Update user config (write-back to ~/.plannotator/config.json)
           if (url.pathname === "/api/config" && req.method === "POST") {
             try {
-              const body = (await req.json()) as { displayName?: string; diffOptions?: Record<string, unknown>; conventionalComments?: boolean; conventionalLabels?: unknown[] | null; pfmReminder?: boolean };
+              const body = (await req.json()) as { displayName?: string; diffOptions?: Record<string, unknown>; conventionalComments?: boolean; platformReviewAttribution?: boolean; conventionalLabels?: unknown[] | null; pfmReminder?: boolean };
               const toSave: Record<string, unknown> = {};
               if (body.displayName !== undefined) toSave.displayName = body.displayName;
               if (body.diffOptions !== undefined) toSave.diffOptions = body.diffOptions;
               if (body.conventionalComments !== undefined) toSave.conventionalComments = body.conventionalComments;
+              if (body.platformReviewAttribution !== undefined) toSave.platformReviewAttribution = body.platformReviewAttribution;
               if (body.conventionalLabels !== undefined) toSave.conventionalLabels = body.conventionalLabels;
               if (body.pfmReminder !== undefined) toSave.pfmReminder = body.pfmReminder;
               if (Object.keys(toSave).length > 0) saveConfig(toSave as Parameters<typeof saveConfig>[0]);

--- a/packages/server/review.ts
+++ b/packages/server/review.ts
@@ -2216,11 +2216,12 @@ export async function startReviewServer(
           // API: Update user config (write-back to ~/.plannotator/config.json)
           if (url.pathname === "/api/config" && req.method === "POST") {
             try {
-              const body = (await req.json()) as { displayName?: string; diffOptions?: Record<string, unknown>; conventionalComments?: boolean; conventionalLabels?: unknown[] | null };
+              const body = (await req.json()) as { displayName?: string; diffOptions?: Record<string, unknown>; conventionalComments?: boolean; platformReviewAttribution?: boolean; conventionalLabels?: unknown[] | null };
               const toSave: Record<string, unknown> = {};
               if (body.displayName !== undefined) toSave.displayName = body.displayName;
               if (body.diffOptions !== undefined) toSave.diffOptions = body.diffOptions;
               if (body.conventionalComments !== undefined) toSave.conventionalComments = body.conventionalComments;
+              if (body.platformReviewAttribution !== undefined) toSave.platformReviewAttribution = body.platformReviewAttribution;
               if (body.conventionalLabels !== undefined) toSave.conventionalLabels = body.conventionalLabels;
               if (Object.keys(toSave).length > 0) saveConfig(toSave as Parameters<typeof saveConfig>[0]);
               return Response.json({ ok: true });

--- a/packages/shared/config.ts
+++ b/packages/shared/config.ts
@@ -88,6 +88,7 @@ export interface PlannotatorConfig {
   diffOptions?: DiffOptions;
   prompts?: PromptConfig;
   conventionalComments?: boolean;
+  platformReviewAttribution?: boolean;
   /** null = explicitly cleared (use defaults), undefined = not set */
   conventionalLabels?: CCLabelConfig[] | null;
   /**
@@ -201,6 +202,7 @@ export function getServerConfig(gitUser: string | null): {
   diffOptions?: DiffOptions;
   gitUser?: string;
   conventionalComments?: boolean;
+  platformReviewAttribution?: boolean;
   conventionalLabels?: CCLabelConfig[] | null;
 } {
   const cfg = loadConfig();
@@ -209,6 +211,7 @@ export function getServerConfig(gitUser: string | null): {
     diffOptions: cfg.diffOptions,
     gitUser: gitUser ?? undefined,
     ...(cfg.conventionalComments !== undefined && { conventionalComments: cfg.conventionalComments }),
+    ...(cfg.platformReviewAttribution !== undefined && { platformReviewAttribution: cfg.platformReviewAttribution }),
     ...(cfg.conventionalLabels !== undefined && { conventionalLabels: cfg.conventionalLabels }),
   };
 }

--- a/packages/ui/components/Settings.tsx
+++ b/packages/ui/components/Settings.tsx
@@ -487,6 +487,7 @@ function parseCCLabels(json: string | null): CCLabelConfig[] {
 
 const CommentsTab: React.FC = () => {
   const conventionalComments = useConfigValue('conventionalComments');
+  const platformReviewAttribution = useConfigValue('platformReviewAttribution');
   const labelsJson = useConfigValue('conventionalLabels');
   const [labels, setLabels] = useState(() => parseCCLabels(labelsJson));
 
@@ -522,6 +523,15 @@ const CommentsTab: React.FC = () => {
 
   return (
     <>
+      <ToggleSwitch
+        checked={platformReviewAttribution}
+        onChange={(v) => configStore.set('platformReviewAttribution', v)}
+        label="Plannotator Attribution"
+        description="Include “Review from Plannotator” in GitHub and GitLab review bodies"
+      />
+
+      <div className="border-t border-border" />
+
       <ToggleSwitch
         checked={conventionalComments}
         onChange={(v) => configStore.set('conventionalComments', v)}

--- a/packages/ui/config/settings.ts
+++ b/packages/ui/config/settings.ts
@@ -276,6 +276,20 @@ export const SETTINGS = {
     },
     toServer: (v: boolean) => ({ conventionalComments: v }),
   },
+  platformReviewAttribution: {
+    defaultValue: true as boolean,
+    fromCookie: () => {
+      const v = storage.getItem('plannotator-platform-review-attribution');
+      return v === 'true' ? true : v === 'false' ? false : undefined;
+    },
+    toCookie: (v: boolean) => storage.setItem('plannotator-platform-review-attribution', String(v)),
+    serverKey: 'platformReviewAttribution',
+    fromServer: (sc: Record<string, unknown>) => {
+      const v = sc.platformReviewAttribution;
+      return typeof v === 'boolean' ? v : undefined;
+    },
+    toServer: (v: boolean) => ({ platformReviewAttribution: v }),
+  },
   /** JSON-serialized array of label configs, or null for defaults.
    *  Synced to ~/.plannotator/config.json as a parsed array (not a string). */
   conventionalLabels: {


### PR DESCRIPTION
## Context

Plannotator currently adds `Review from Plannotator` to GitHub and GitLab review bodies whenever a review is submitted from the code-review UI. That attribution is useful as a consistent product signal, but some users may prefer PR/MR comments to read as plain review text without the tool signature.

This PR keeps the current behavior as the default and adds a small review-mode preference for opting out.

> If Plannotator wants to keep its presence consistent in platform comments and not offer an opt-out, this PR is totally fine to ignore. I can see the product argument either way; this is just the quieter-comments version.

## What Changed

- Added a persisted `platformReviewAttribution` config setting, defaulting to `true`.
- Added a Review mode Settings -> Comments toggle labeled "Plannotator Attribution".
- Changed the GitHub/GitLab review body builder to include `Review from Plannotator` only when that setting is enabled.
- Threaded the setting through the Bun and Pi config endpoints so it persists via `~/.plannotator/config.json` across runtimes.

## Screenshot

<img width="633" height="286" alt="image" src="https://github.com/user-attachments/assets/e065fb8c-dcec-4c3f-b375-2e3d34fe9cef" />

## Review Focus

The main behavior to check is that the default remains unchanged: existing users should still get `Review from Plannotator` unless they explicitly disable the new setting.

The config plumbing is intentionally broad because the shared settings UI can be hosted by plan, annotate, review, and Pi runtime servers. Review the `/api/config` handlers if you want to make sure the setting persists consistently across those surfaces.

## Test Plan

- Ran the repo TypeScript project checks via `bunx --package typescript tsc` for core, shared, ai, server, ui, strict consumer, and Pi projects.
- Ran `bun run build:review && bun run build:hook` so the local CLI served the updated review UI.
- Ran `plannotator review` on this worktree; review completed with no changes requested.
- Ran `./bin/plannotator.js review https://github.com/Lexamica/lexamica-refer/pull/1167` to exercise the local CLI PR review flow; it opened the PR review UI and successfully approved the PR on GitHub.
