### PR TITLE
feat(ui): handle-wide click-to-collapse + suppressible hover on resize handles

### DIFF
--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -250,6 +250,9 @@ const feedbackLossDescription = (annotationCount: number, hasDirectEdits: boolea
 
 type SourceFileEditWarningAction = 'send-feedback' | 'approve' | 'close';
 
+/** Hint shown following the cursor while hovering a sidebar/panel resize handle. */
+const RESIZE_HANDLE_TOOLTIP = 'Click to close · Drag to resize';
+
 const App: React.FC = () => {
   const [markdown, setMarkdown] = useState(DEMO_PLAN_CONTENT);
   const [annotations, setAnnotations] = useState<Annotation[]>([]);
@@ -3969,7 +3972,7 @@ const App: React.FC = () => {
                   className="hidden lg:block z-[55]"
                   side="left"
                   hideHoverTrack
-                  tooltip="Click to close · Drag to resize"
+                  tooltip={RESIZE_HANDLE_TOOLTIP}
                   onCollapse={hideAgentTerminal}
                 />
               )}
@@ -4068,7 +4071,7 @@ const App: React.FC = () => {
                 onSelectMessage={handleSelectMessage}
                 messageAnnotationCounts={activeMessageAnnotationCounts}
               />
-              <ResizeHandle {...tocResize.handleProps} className="hidden lg:block z-[55]" side="left" hideHoverTrack tooltip="Click to close · Drag to resize" onCollapse={sidebar.close} />
+              <ResizeHandle {...tocResize.handleProps} className="hidden lg:block z-[55]" side="left" hideHoverTrack tooltip={RESIZE_HANDLE_TOOLTIP} onCollapse={sidebar.close} />
             </div>
           )}
 
@@ -4403,7 +4406,7 @@ const App: React.FC = () => {
               ancestor (`contents` = no layout box). */}
           <div className="contents group/sidebar">
           {/* Resize Handle */}
-          {isPanelOpen && wideModeType === null && !goalSetupMode && (rightSidebarTab === 'annotations' || canUseAskAI) && <ResizeHandle {...panelResize.handleProps} className="hidden md:block z-[55]" side="right" hideHoverTrack tooltip="Click to close · Drag to resize" onCollapse={() => setIsPanelOpen(false)} />}
+          {isPanelOpen && wideModeType === null && !goalSetupMode && (rightSidebarTab === 'annotations' || canUseAskAI) && <ResizeHandle {...panelResize.handleProps} className="hidden md:block z-[55]" side="right" hideHoverTrack tooltip={RESIZE_HANDLE_TOOLTIP} onCollapse={() => setIsPanelOpen(false)} />}
 
           {/* Annotation Panel */}
           <AnnotationPanel

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -453,6 +453,8 @@ const App: React.FC = () => {
     storageKey: 'plannotator-panel-width',
     // Drag the right panel skinny → snap it shut (matches the contents sidebar).
     onSnapClose: () => setIsPanelOpen(false),
+    // Single click on the handle (no drag) collapses it.
+    onClick: () => setIsPanelOpen(false),
     // Render-free drag: write the live width to a :root var the panel reads,
     // so dragging never re-renders this (heavy) App.
     apply: (w) => document.documentElement.style.setProperty('--rpanel-w', `${w}px`),
@@ -462,6 +464,8 @@ const App: React.FC = () => {
     defaultWidth: 240, minWidth: 160, maxWidth: 400, side: 'left',
     // Drag the contents panel skinny → snap it shut (prototype behavior).
     onSnapClose: sidebar.close,
+    // Single click on the handle (no drag) collapses it.
+    onClick: sidebar.close,
     // Render-free drag: write the live width to a :root var the panel reads.
     apply: (w) => document.documentElement.style.setProperty('--toc-w', `${w}px`),
   });
@@ -472,6 +476,8 @@ const App: React.FC = () => {
     maxWidth: 640,
     side: 'left',
     onSnapClose: () => setIsAgentTerminalOpen(false),
+    // Single click on the handle (no drag) collapses it.
+    onClick: () => hideAgentTerminal(),
     apply: (w) => document.documentElement.style.setProperty('--agent-terminal-w', `${w}px`),
   });
   const isResizing = panelResize.isDragging || tocResize.isDragging || agentTerminalResize.isDragging;
@@ -3962,6 +3968,8 @@ const App: React.FC = () => {
                   {...agentTerminalResize.handleProps}
                   className="hidden lg:block z-[55]"
                   side="left"
+                  hideHoverTrack
+                  tooltip="Click to close · Drag to resize"
                   onCollapse={hideAgentTerminal}
                 />
               )}
@@ -4060,7 +4068,7 @@ const App: React.FC = () => {
                 onSelectMessage={handleSelectMessage}
                 messageAnnotationCounts={activeMessageAnnotationCounts}
               />
-              <ResizeHandle {...tocResize.handleProps} className="hidden lg:block z-[55]" side="left" onCollapse={sidebar.close} />
+              <ResizeHandle {...tocResize.handleProps} className="hidden lg:block z-[55]" side="left" hideHoverTrack tooltip="Click to close · Drag to resize" onCollapse={sidebar.close} />
             </div>
           )}
 
@@ -4395,7 +4403,7 @@ const App: React.FC = () => {
               ancestor (`contents` = no layout box). */}
           <div className="contents group/sidebar">
           {/* Resize Handle */}
-          {isPanelOpen && wideModeType === null && !goalSetupMode && (rightSidebarTab === 'annotations' || canUseAskAI) && <ResizeHandle {...panelResize.handleProps} className="hidden md:block z-[55]" side="right" onCollapse={() => setIsPanelOpen(false)} />}
+          {isPanelOpen && wideModeType === null && !goalSetupMode && (rightSidebarTab === 'annotations' || canUseAskAI) && <ResizeHandle {...panelResize.handleProps} className="hidden md:block z-[55]" side="right" hideHoverTrack tooltip="Click to close · Drag to resize" onCollapse={() => setIsPanelOpen(false)} />}
 
           {/* Annotation Panel */}
           <AnnotationPanel

--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -148,6 +148,9 @@ function orderFilesBySections(files: DiffFile[], sections?: SinceBaseSections | 
     .map((entry) => entry.file);
 }
 
+/** Hint shown following the cursor while hovering a sidebar/panel resize handle. */
+const RESIZE_HANDLE_TOOLTIP = 'Click to close · Drag to resize';
+
 const ReviewApp: React.FC = () => {
   const { resolvedMode } = useTheme();
   const [diffData, setDiffData] = useState<DiffData | null>(null);
@@ -3150,7 +3153,7 @@ const ReviewApp: React.FC = () => {
                 onSelectSearchMatch={hasSearchableFiles ? handleSelectSearchMatch : undefined}
                 onStepSearchMatch={hasSearchableFiles ? stepSearchMatch : undefined}
               />
-              <ResizeHandle {...fileTreeResize.handleProps} className="z-10" side="left" hideHoverTrack tooltip="Click to close · Drag to resize" onCollapse={() => setIsFileTreeOpen(false)} />
+              <ResizeHandle {...fileTreeResize.handleProps} className="z-10" side="left" hideHoverTrack tooltip={RESIZE_HANDLE_TOOLTIP} onCollapse={() => setIsFileTreeOpen(false)} />
             </div>
           )}
           {!guideOpen && shouldShowFileTree && isFileTreeOpen && showCommitsPanel && (
@@ -3170,7 +3173,7 @@ const ReviewApp: React.FC = () => {
                 onSelectPanelView={handlePanelViewSelect}
                 showSectionsOption={sectionsCapable}
               />
-              <ResizeHandle {...fileTreeResize.handleProps} className="z-10" side="left" hideHoverTrack tooltip="Click to close · Drag to resize" onCollapse={() => setIsFileTreeOpen(false)} />
+              <ResizeHandle {...fileTreeResize.handleProps} className="z-10" side="left" hideHoverTrack tooltip={RESIZE_HANDLE_TOOLTIP} onCollapse={() => setIsFileTreeOpen(false)} />
             </div>
           )}
           {!guideOpen && shouldShowFileTree && isFileTreeOpen && !(sectionsAvailable && panelView === 'sections') && !showCommitsPanel && (
@@ -3237,7 +3240,7 @@ const ReviewApp: React.FC = () => {
                 onStageFile={canStageFiles ? stageFile : undefined}
                 stagingFile={stagingFile}
               />
-              <ResizeHandle {...fileTreeResize.handleProps} className="z-10" side="left" hideHoverTrack tooltip="Click to close · Drag to resize" onCollapse={() => setIsFileTreeOpen(false)} />
+              <ResizeHandle {...fileTreeResize.handleProps} className="z-10" side="left" hideHoverTrack tooltip={RESIZE_HANDLE_TOOLTIP} onCollapse={() => setIsFileTreeOpen(false)} />
             </div>
           )}
 
@@ -3361,7 +3364,7 @@ const ReviewApp: React.FC = () => {
           {/* Resize Handle + Sidebar */}
           {reviewSidebar.isOpen && (
             <div className="contents group/sidebar">
-              <ResizeHandle {...panelResize.handleProps} className="z-10" side="right" hideHoverTrack tooltip="Click to close · Drag to resize" onCollapse={() => reviewSidebar.close()} />
+              <ResizeHandle {...panelResize.handleProps} className="z-10" side="right" hideHoverTrack tooltip={RESIZE_HANDLE_TOOLTIP} onCollapse={() => reviewSidebar.close()} />
               <ReviewSidebar
                 isOpen
                 onClose={reviewSidebar.close}

--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -788,11 +788,15 @@ const ReviewApp: React.FC = () => {
   const panelResize = useResizablePanel({
     storageKey: 'plannotator-review-panel-width',
     onSnapClose: () => reviewSidebar.close(),
+    // Single click on the handle (no drag) collapses it.
+    onClick: () => reviewSidebar.close(),
   });
   const fileTreeResize = useResizablePanel({
     storageKey: 'plannotator-filetree-width',
     defaultWidth: 256, minWidth: 160, maxWidth: 400, side: 'left',
     onSnapClose: () => setIsFileTreeOpen(false),
+    // Single click on the handle (no drag) collapses it.
+    onClick: () => setIsFileTreeOpen(false),
   });
   const isResizing = panelResize.isDragging || fileTreeResize.isDragging;
 
@@ -3146,7 +3150,7 @@ const ReviewApp: React.FC = () => {
                 onSelectSearchMatch={hasSearchableFiles ? handleSelectSearchMatch : undefined}
                 onStepSearchMatch={hasSearchableFiles ? stepSearchMatch : undefined}
               />
-              <ResizeHandle {...fileTreeResize.handleProps} className="z-10" side="left" onCollapse={() => setIsFileTreeOpen(false)} />
+              <ResizeHandle {...fileTreeResize.handleProps} className="z-10" side="left" hideHoverTrack tooltip="Click to close · Drag to resize" onCollapse={() => setIsFileTreeOpen(false)} />
             </div>
           )}
           {!guideOpen && shouldShowFileTree && isFileTreeOpen && showCommitsPanel && (
@@ -3166,7 +3170,7 @@ const ReviewApp: React.FC = () => {
                 onSelectPanelView={handlePanelViewSelect}
                 showSectionsOption={sectionsCapable}
               />
-              <ResizeHandle {...fileTreeResize.handleProps} className="z-10" side="left" onCollapse={() => setIsFileTreeOpen(false)} />
+              <ResizeHandle {...fileTreeResize.handleProps} className="z-10" side="left" hideHoverTrack tooltip="Click to close · Drag to resize" onCollapse={() => setIsFileTreeOpen(false)} />
             </div>
           )}
           {!guideOpen && shouldShowFileTree && isFileTreeOpen && !(sectionsAvailable && panelView === 'sections') && !showCommitsPanel && (
@@ -3233,7 +3237,7 @@ const ReviewApp: React.FC = () => {
                 onStageFile={canStageFiles ? stageFile : undefined}
                 stagingFile={stagingFile}
               />
-              <ResizeHandle {...fileTreeResize.handleProps} className="z-10" side="left" onCollapse={() => setIsFileTreeOpen(false)} />
+              <ResizeHandle {...fileTreeResize.handleProps} className="z-10" side="left" hideHoverTrack tooltip="Click to close · Drag to resize" onCollapse={() => setIsFileTreeOpen(false)} />
             </div>
           )}
 
@@ -3357,7 +3361,7 @@ const ReviewApp: React.FC = () => {
           {/* Resize Handle + Sidebar */}
           {reviewSidebar.isOpen && (
             <div className="contents group/sidebar">
-              <ResizeHandle {...panelResize.handleProps} className="z-10" side="right" onCollapse={() => reviewSidebar.close()} />
+              <ResizeHandle {...panelResize.handleProps} className="z-10" side="right" hideHoverTrack tooltip="Click to close · Drag to resize" onCollapse={() => reviewSidebar.close()} />
               <ReviewSidebar
                 isOpen
                 onClose={reviewSidebar.close}

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -30,6 +30,21 @@ configurePlannotatorUI({
 
 Anything you don't pass keeps Plannotator's default. A few component-specific overrides (e.g. an "open in editor" diff action) are passed as props where you render that component.
 
+### Resize-handle seams (`ResizeHandle` / `useResizablePanel`)
+
+The sidebar/panel resize handle exposes seams for hosts that want different edge interactions (e.g. no hover reveal, click-to-collapse). All default to today's behavior — pass nothing and it's unchanged.
+
+- **Suppress / restyle the hover reveal.** The inner visible track carries a `[data-resize-track]` attribute (same host-CSS pattern as the collapse button's `[data-collapse]`), and `ResizeHandle` takes a `trackClassName` prop. To kill the pop-in from host CSS:
+  ```css
+  [data-resize-track] { background: none !important; }
+  ```
+- **Click-to-collapse anywhere on the handle.** The handle can't tell a click from a drag-start on its own — the hook owns the pointer state machine. Pass `onClick` to `useResizablePanel`; it fires on pointer-up only when the pointer never traveled past `clickThreshold` (default 4px), so a genuine click on the full-width handle can collapse the panel while drags still resize:
+  ```ts
+  const resize = useResizablePanel({ storageKey, side: "left", onSnapClose: collapse, onClick: collapse });
+  ```
+
+Building your own tooltip and removing the built-in double-click reset are host-side concerns (override `onDoubleClick` where you render the handle).
+
 ## Consuming it (e.g. from Workspaces)
 
 ```bash

--- a/packages/ui/components/ResizeHandle.tsx
+++ b/packages/ui/components/ResizeHandle.tsx
@@ -82,7 +82,7 @@ export const ResizeHandle: React.FC<Props> = ({
         style={style}
         onPointerDown={onPointerDown}
         onDoubleClick={onDoubleClick}
-        onPointerMove={tooltip != null ? (e) => setTip({ x: e.clientX, y: e.clientY }) : undefined}
+        onPointerMove={tooltip != null && !isDragging ? (e) => setTip({ x: e.clientX, y: e.clientY }) : undefined}
         onPointerLeave={tooltip != null ? () => setTip(null) : undefined}
       />
       {/* Cursor-following hint. pointer-events-none so it never blocks the drag;

--- a/packages/ui/components/ResizeHandle.tsx
+++ b/packages/ui/components/ResizeHandle.tsx
@@ -1,8 +1,22 @@
 import React from 'react';
+import { createPortal } from 'react-dom';
 import type { ResizeHandleProps as BaseProps } from '../hooks/useResizablePanel';
 
 interface Props extends BaseProps {
   className?: string;
+  /**
+   * Extra classes for the inner visible track (the 4px bar that reveals on
+   * hover). `className` only reaches the outer wrapper, so this is the seam for
+   * restyling or suppressing the hover affordance. The track also carries a
+   * `[data-resize-track]` attribute (same pattern as `[data-collapse]`) so a
+   * host can target it from plain CSS — e.g. to kill the hover reveal:
+   * `[data-resize-track] { background: none !important; }`.
+   */
+  trackClassName?: string;
+  /** Suppress the hover color-change on the track entirely (no pop-in). */
+  hideHoverTrack?: boolean;
+  /** Cursor-following hint shown while hovering the handle (hidden mid-drag). */
+  tooltip?: React.ReactNode;
   /** When provided, renders a hover-reveal collapse button centered on the
    *  handle (prototype's gutter affordance). Chevron direction follows `side`:
    *  a left sidebar collapses leftward, a right sidebar rightward. */
@@ -34,53 +48,78 @@ export const ResizeHandle: React.FC<Props> = ({
   onDoubleClick,
   style,
   className,
+  trackClassName,
+  hideHoverTrack,
+  tooltip,
   side,
   onCollapse,
-}) => (
-  <div
-    className={`relative w-0 cursor-col-resize flex-shrink-0 group${className ? ` ${className}` : ''}`}
-  >
-    {/* Visible track — 4px wide, centered on the zero-width layout box,
-        invisible until hover/drag. */}
-    <div className={`absolute inset-y-0 -left-0.5 -right-0.5 transition-colors ${
-      isDragging ? 'bg-transparent' : 'group-hover:bg-border'
-    }`} />
-    {/* Wider grab/touch zone — must never have zero width (see `side` docs).
-        Pointer events + setPointerCapture live here; touch-action:none (from
-        style) stops touch drags from scroll-hijacking. */}
+}) => {
+  const [tip, setTip] = React.useState<{ x: number; y: number } | null>(null);
+  const showTip = tooltip != null && tip != null && !isDragging;
+
+  return (
     <div
-      className={`absolute inset-y-0 ${
-        side === 'left' ? '-right-2 -left-1' :
-        side === 'right' ? '-right-3 left-0' :
-        '-inset-x-2'
-      }`}
-      style={style}
-      onPointerDown={onPointerDown}
-      onDoubleClick={onDoubleClick}
-    />
-    {/* Hover-reveal collapse button, centered on the handle. stopPropagation on
-        pointerdown so clicking it never starts a drag. Hidden mid-drag. */}
-    {onCollapse && !isDragging && (
-      <button
-        type="button"
-        onPointerDown={(e) => e.stopPropagation()}
-        onClick={(e) => {
-          e.stopPropagation();
-          onCollapse();
-        }}
-        title="Collapse sidebar"
-        aria-label="Collapse sidebar"
-        data-collapse={side}
-        className="absolute top-1/2 left-1/2 z-20 flex h-6 w-4 -translate-x-1/2 -translate-y-1/2 items-center justify-center before:absolute before:-inset-2 before:content-[''] rounded-sm bg-surface-1 text-muted-foreground/60 opacity-0 ring-1 ring-border/40 transition-opacity hover:text-foreground group-hover:opacity-100 group-hover/sidebar:opacity-100"
-      >
-        <svg className="size-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d={side === 'right' ? 'M9 5l7 7-7 7' : 'M15 19l-7-7 7-7'}
-          />
-        </svg>
-      </button>
-    )}
-  </div>
-);
+      className={`relative w-0 cursor-col-resize flex-shrink-0 group${className ? ` ${className}` : ''}`}
+    >
+      {/* Visible track — 4px wide, centered on the zero-width layout box,
+          invisible until hover/drag. `data-resize-track` + `trackClassName` are
+          host seams for restyling/suppressing the hover reveal. */}
+      <div
+        data-resize-track={side ?? ''}
+        className={`absolute inset-y-0 -left-0.5 -right-0.5 transition-colors ${
+          isDragging || hideHoverTrack ? 'bg-transparent' : 'group-hover:bg-border'
+        }${trackClassName ? ` ${trackClassName}` : ''}`}
+      />
+      {/* Wider grab/touch zone — must never have zero width (see `side` docs).
+          Pointer events + setPointerCapture live here; touch-action:none (from
+          style) stops touch drags from scroll-hijacking. */}
+      <div
+        className={`absolute inset-y-0 ${
+          side === 'left' ? '-right-2 -left-1' :
+          side === 'right' ? '-right-3 left-0' :
+          '-inset-x-2'
+        }`}
+        style={style}
+        onPointerDown={onPointerDown}
+        onDoubleClick={onDoubleClick}
+        onPointerMove={tooltip != null ? (e) => setTip({ x: e.clientX, y: e.clientY }) : undefined}
+        onPointerLeave={tooltip != null ? () => setTip(null) : undefined}
+      />
+      {/* Cursor-following hint. pointer-events-none so it never blocks the drag;
+          portaled to body so the zero-width parent doesn't clip it. */}
+      {showTip && typeof document !== 'undefined' && createPortal(
+        <div
+          style={{ position: 'fixed', left: tip.x + 14, top: tip.y + 16, zIndex: 100 }}
+          className="pointer-events-none whitespace-nowrap rounded-md bg-surface-1 px-2 py-1 text-xs text-foreground shadow-md ring-1 ring-border/60"
+        >
+          {tooltip}
+        </div>,
+        document.body,
+      )}
+      {/* Hover-reveal collapse button, centered on the handle. stopPropagation on
+          pointerdown so clicking it never starts a drag. Hidden mid-drag. */}
+      {onCollapse && !isDragging && (
+        <button
+          type="button"
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => {
+            e.stopPropagation();
+            onCollapse();
+          }}
+          title="Collapse sidebar"
+          aria-label="Collapse sidebar"
+          data-collapse={side}
+          className="absolute top-1/2 left-1/2 z-20 flex h-6 w-4 -translate-x-1/2 -translate-y-1/2 items-center justify-center before:absolute before:-inset-2 before:content-[''] rounded-sm bg-surface-1 text-muted-foreground/60 opacity-0 ring-1 ring-border/40 transition-opacity hover:text-foreground group-hover:opacity-100 group-hover/sidebar:opacity-100"
+        >
+          <svg className="size-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d={side === 'right' ? 'M9 5l7 7-7 7' : 'M15 19l-7-7 7-7'}
+            />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+};

--- a/packages/ui/hooks/useResizablePanel.ts
+++ b/packages/ui/hooks/useResizablePanel.ts
@@ -23,6 +23,16 @@ interface UseResizablePanelOptions {
    * (still rAF-coalesced).
    */
   apply?: (width: number) => void;
+  /**
+   * Fires on pointer-up when the pointer never moved beyond `clickThreshold` —
+   * i.e. a genuine click on the handle, not a drag. The hook owns the pointer
+   * state machine, so this is the only reliable way to tell a click from a
+   * drag-start. Lets a host make the whole handle a click target (e.g. click
+   * anywhere on the handle to collapse the panel). Not fired on a snap-close.
+   */
+  onClick?: () => void;
+  /** Max pointer travel (px) still counted as a click for `onClick`. Default 4. */
+  clickThreshold?: number;
 }
 
 export interface ResizeHandleProps {
@@ -43,6 +53,8 @@ export function useResizablePanel({
   onSnapClose,
   snapCloseRatio = 0.6,
   apply,
+  onClick,
+  clickThreshold = 4,
 }: UseResizablePanelOptions) {
   const [width, setWidth] = useState(() => {
     const saved = storage.getItem(storageKey);
@@ -61,6 +73,9 @@ export function useResizablePanel({
   const startWidthRef = useRef(0);
   const draggingRef = useRef(false);
   const snappedRef = useRef(false);
+  // Latches true once the pointer travels past clickThreshold — distinguishes a
+  // click from a drag. Reset on each pointerdown.
+  const movedRef = useRef(false);
   const latestXRef = useRef(0);
   const rafRef = useRef<number | null>(null);
 
@@ -69,6 +84,8 @@ export function useResizablePanel({
   applyRef.current = apply;
   const onSnapCloseRef = useRef(onSnapClose);
   onSnapCloseRef.current = onSnapClose;
+  const onClickRef = useRef(onClick);
+  onClickRef.current = onClick;
 
   // rAF tick: compute the width from the most recent pointer position and apply
   // it. At most one DOM/state write per frame regardless of pointer-event rate.
@@ -110,6 +127,7 @@ export function useResizablePanel({
       startWidthRef.current = widthRef.current;
       latestXRef.current = pos;
       snappedRef.current = false;
+      movedRef.current = false;
       draggingRef.current = true;
       setIsDragging(true);
 
@@ -120,6 +138,8 @@ export function useResizablePanel({
       const onMove = (ev: PointerEvent) => {
         if (!draggingRef.current) return;
         latestXRef.current = axis === 'y' ? ev.clientY : ev.clientX;
+        if (Math.abs(latestXRef.current - startXRef.current) > clickThreshold)
+          movedRef.current = true;
         if (rafRef.current == null) rafRef.current = requestAnimationFrame(flush);
       };
       const cleanup = () => {
@@ -137,9 +157,16 @@ export function useResizablePanel({
         }
         setIsDragging(false);
         if (!wasSnapped) {
-          // Commit the live width to React state + persist.
-          setWidth(widthRef.current);
-          storage.setItem(storageKey, String(widthRef.current));
+          if (onClickRef.current && !movedRef.current) {
+            // A pointerdown+up that never crossed the threshold is a click, not
+            // a resize — fire onClick and leave the width untouched. Only when a
+            // host opts in via onClick; otherwise commit exactly as before.
+            onClickRef.current();
+          } else {
+            // Commit the live width to React state + persist.
+            setWidth(widthRef.current);
+            storage.setItem(storageKey, String(widthRef.current));
+          }
         }
         cleanup();
       }
@@ -148,7 +175,7 @@ export function useResizablePanel({
       window.addEventListener('pointerup', onUp);
       window.addEventListener('pointercancel', onUp);
     },
-    [flush, storageKey, axis],
+    [flush, storageKey, axis, clickThreshold],
   );
 
   const resetWidth = useCallback(() => {

--- a/packages/ui/hooks/useResizablePanel.ts
+++ b/packages/ui/hooks/useResizablePanel.ts
@@ -147,7 +147,11 @@ export function useResizablePanel({
         window.removeEventListener('pointerup', onUp);
         window.removeEventListener('pointercancel', onUp);
       };
-      function onUp() {
+      function onUp(e: PointerEvent) {
+        // pointercancel = the browser aborted the gesture (palm rejection, a
+        // system gesture, focus loss). It is NOT a completed click — only clean
+        // up drag state, never treat it as a click-to-collapse.
+        const cancelled = e?.type === 'pointercancel';
         const wasSnapped = snappedRef.current;
         draggingRef.current = false;
         snappedRef.current = false;
@@ -157,7 +161,7 @@ export function useResizablePanel({
         }
         setIsDragging(false);
         if (!wasSnapped) {
-          if (onClickRef.current && !movedRef.current) {
+          if (onClickRef.current && !movedRef.current && !cancelled) {
             // A pointerdown+up that never crossed the threshold is a click, not
             // a resize — fire onClick and leave the width untouched. Only when a
             // host opts in via onClick; otherwise commit exactly as before.


### PR DESCRIPTION
## What

Reworks the sidebar/panel resize-handle interaction across the plan editor and review editor, and adds host-facing seams to `@plannotator/ui` so the commercial Workspaces app can drive its own edge UX.

### New UX (Plannotator, all handles)
- **No hover highlight** on the track bar.
- **Cursor-following tooltip**: "Click to close · Drag to resize".
- **Single click anywhere on the handle collapses** the panel (drag still resizes).
- **Double-click reset** is now unreachable (the single click collapses first).
- **Collapse chevron retained** on hover.

### New seams in `@plannotator/ui` (default-off, Plannotator opt-in)
- `useResizablePanel({ onClick, clickThreshold })` — the hook owns the pointer-capture drag state machine, so this is the only reliable way to distinguish a click from a drag-start. `onClick` fires on pointer-up only when travel stayed under `clickThreshold` (default 4px). Not fired on snap-close.
- `ResizeHandle` props: `hideHoverTrack`, `tooltip`, `trackClassName`, plus a `[data-resize-track]` attribute (same host-CSS pattern as `[data-collapse]`).

## Why
Workspaces is reworking sidebar-edge interactions (no hover reveal, tooltip, click-to-collapse). Two capabilities couldn't be done cleanly from the host side — targeting/suppressing the hardcoded hover track, and telling a click apart from a drag. Both now have seams; Workspaces builds its own tooltip and double-click removal on top.

## Compatibility
- New options/props are all optional and default to today's behavior. When nothing is passed, existing consumers are unchanged (the click-vs-commit branch is gated on `onClick` being present).
- No version bump — that happens at release time.

## Test
- Plan editor + review editor dev servers: hover a divider (no highlight, tooltip follows cursor), single-click (collapses), drag (resizes), chevron on hover.
- `packages/ui` typecheck + strict-consumer typecheck pass; ui test suite green (349 pass / 0 fail).