### PR TITLE
feat(review): Add expanded review comment editor

### DIFF
--- a/packages/review-editor/components/AnnotationToolbar.tsx
+++ b/packages/review-editor/components/AnnotationToolbar.tsx
@@ -22,6 +22,7 @@ interface AnnotationToolbarProps {
   selectedOriginalCode?: string;
   isEditing?: boolean;
   setShowCodeModal: (show: boolean) => void;
+  setShowCommentModal: (show: boolean) => void;
   onSubmit: () => void;
   onDismiss: () => void;
   onCancel: () => void;
@@ -54,6 +55,7 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
   selectedOriginalCode,
   isEditing = false,
   setShowCodeModal,
+  setShowCommentModal,
   onSubmit,
   onDismiss,
   onCancel,
@@ -128,7 +130,7 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
           dragHandleProps={dragHandleProps}
         />
       ) : (
-        <div className="w-80">
+        <div className="w-80 max-w-[calc(100vw-2rem)] flex flex-col">
           <div className="flex items-center justify-between mb-2" {...dragHandleProps}>
             <span className="text-xs text-muted-foreground">
               {isEditing
@@ -137,15 +139,25 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
                   ? formatTokenContext(toolbarState.tokenSelection)
                   : formatLineRange(toolbarState.range.start, toolbarState.range.end)}
             </span>
-            <button
-              onClick={onCancel}
-              className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
-              title="Cancel"
-            >
-              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
+            <div className="flex items-center gap-1">
+              <button
+                onClick={() => setShowCommentModal(true)}
+                className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                title="Expand comment"
+                aria-label="Expand comment"
+              >
+                <ExpandIcon />
+              </button>
+              <button
+                onClick={onCancel}
+                className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                title="Cancel"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
           </div>
 
           {conventionalCommentsEnabled && (
@@ -162,7 +174,7 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
             value={commentText}
             onChange={(e) => setCommentText(e.target.value)}
             placeholder="Leave feedback..."
-            className="w-full px-3 py-2 bg-muted rounded-lg text-xs resize-none focus:outline-none focus:ring-1 focus:ring-primary/50"
+            className="w-full min-h-[4.5rem] max-h-[calc(100vh-16rem)] px-3 py-2 bg-muted rounded-lg text-xs leading-6 resize-y border-0 focus:outline-none focus:ring-1 focus:ring-primary/50 placeholder:text-muted-foreground"
             rows={3}
             autoFocus
             onKeyDown={(e) => {
@@ -272,3 +284,9 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
 
   return createPortal(content, document.body);
 };
+
+const ExpandIcon = () => (
+  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5v-4m0 4h-4m4 0l-5-5" />
+  </svg>
+);

--- a/packages/review-editor/components/AnnotationToolbar.tsx
+++ b/packages/review-editor/components/AnnotationToolbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { ToolbarState } from '../hooks/useAnnotationToolbar';
 import { useTabIndent } from '../hooks/useTabIndent';
@@ -21,6 +21,8 @@ interface AnnotationToolbarProps {
   setShowSuggestedCode: (show: boolean) => void;
   selectedOriginalCode?: string;
   isEditing?: boolean;
+  askAIMode: boolean;
+  setAskAIMode: (show: boolean) => void;
   setShowCodeModal: (show: boolean) => void;
   setShowCommentModal: (show: boolean) => void;
   onSubmit: () => void;
@@ -54,6 +56,8 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
   setShowSuggestedCode,
   selectedOriginalCode,
   isEditing = false,
+  askAIMode,
+  setAskAIMode,
   setShowCodeModal,
   setShowCommentModal,
   onSubmit,
@@ -73,7 +77,6 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
 }) => {
   const suggestedCodeRef = useRef<HTMLTextAreaElement>(null);
   const handleTabIndent = useTabIndent(setSuggestedCode);
-  const [askAIMode, setAskAIMode] = useState(false);
   const { dragPosition, dragHandleProps, wasDragged, reset: resetDrag } = useDraggable(toolbarRef);
 
   // Reset drag when toolbar reopens for a new selection

--- a/packages/review-editor/components/ExpandedCommentDialog.tsx
+++ b/packages/review-editor/components/ExpandedCommentDialog.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useRef } from 'react';
-import { createPortal } from 'react-dom';
+import React, { useRef } from 'react';
+import { Dialog } from '@base-ui/react/dialog';
 import { SparklesIcon } from '@plannotator/ui/components/SparklesIcon';
+import { useReviewAnnotationToolbarShortcuts } from '@plannotator/ui/shortcuts';
 
 interface ExpandedCommentDialogProps {
   title: string;
@@ -27,112 +28,130 @@ export const ExpandedCommentDialog: React.FC<ExpandedCommentDialogProps> = ({
   onCollapse,
   onCancel,
 }) => {
+  const dialogRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const askAIEnabled = aiAvailable && !!onAskAI && commentText.trim().length > 0;
   const submitLabel = isEditing ? 'Update' : 'Add Comment';
 
-  useEffect(() => {
-    const id = window.setTimeout(() => {
-      const textarea = textareaRef.current;
-      if (!textarea) return;
-      textarea.focus();
-      textarea.selectionStart = textarea.selectionEnd = textarea.value.length;
-    }, 0);
-
-    return () => window.clearTimeout(id);
-  }, []);
+  useReviewAnnotationToolbarShortcuts({
+    target: 'document',
+    handlers: {
+      submitComment: {
+        when: (event) => canSubmit && !event.isComposing && event.target instanceof Node && !!dialogRef.current?.contains(event.target),
+        handle: (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onSubmit();
+        },
+      },
+      cancel: {
+        when: (event) => event.target instanceof Node && !!dialogRef.current?.contains(event.target),
+        handle: (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onCollapse();
+        },
+      },
+    },
+  });
 
   const handleAskAI = () => {
     if (!askAIEnabled) return;
     onAskAI?.(commentText.trim());
   };
 
-  return createPortal(
-    <div className="fixed inset-0 z-[2000] flex items-center justify-center p-4">
-      <div className="absolute inset-0 bg-background/80 backdrop-blur-sm" onClick={onCollapse} />
-      <div className="relative w-full max-w-2xl max-h-[85vh] bg-popover border border-border rounded-xl shadow-2xl flex flex-col">
-        <div className="flex items-center justify-between px-4 py-3 border-b border-border/50">
-          <span className="text-xs text-muted-foreground truncate">{title}</span>
-          <div className="flex items-center gap-1">
-            <button
-              type="button"
-              onClick={onCollapse}
-              className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
-              title="Collapse"
-              aria-label="Collapse expanded comment"
-            >
-              <CollapseIcon />
-            </button>
-            <button
-              type="button"
-              onClick={onCancel}
-              className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
-              title="Close"
-              aria-label="Close expanded comment"
-            >
-              <CloseIcon />
-            </button>
-          </div>
-        </div>
-
-        <div className="px-4 py-3 min-h-0 flex-1">
-          <textarea
-            ref={textareaRef}
-            value={commentText}
-            onChange={(event) => setCommentText(event.target.value)}
-            placeholder="Leave feedback..."
-            className="w-full min-h-72 max-h-[56vh] bg-muted text-sm leading-relaxed placeholder:text-muted-foreground resize-y focus:outline-none rounded-lg border-0 px-3 py-2"
-            onKeyDown={(event) => {
-              if (event.key === 'Escape') {
-                event.stopPropagation();
-                onCollapse();
-                return;
-              }
-
-              if (event.key === 'Enter' && (event.metaKey || event.ctrlKey) && !event.nativeEvent.isComposing) {
-                event.preventDefault();
-                onSubmit();
-              }
-            }}
-          />
-        </div>
-
-        <div className="flex items-center justify-between gap-3 px-4 py-3 border-t border-border/50">
-          <div>
-            {aiAvailable && (
+  return (
+    <Dialog.Root
+      open
+      onOpenChange={(open) => {
+        if (!open) onCollapse();
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Backdrop className="fixed inset-0 z-[1999] bg-background/80 backdrop-blur-sm" />
+        <Dialog.Popup
+          ref={dialogRef}
+          aria-modal="true"
+          initialFocus={() => {
+            const textarea = textareaRef.current;
+            if (textarea) {
+              textarea.selectionStart = textarea.selectionEnd = textarea.value.length;
+            }
+            return textarea;
+          }}
+          finalFocus={false}
+          className="fixed left-1/2 top-1/2 z-[2000] w-[calc(100vw-2rem)] max-w-2xl h-[min(36rem,85dvh)] max-h-[calc(100dvh-2rem)] -translate-x-1/2 -translate-y-1/2 overflow-hidden bg-popover border border-border rounded-xl shadow-2xl flex flex-col"
+        >
+          <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border/50">
+            <Dialog.Title className="text-xs font-normal text-muted-foreground truncate">{title}</Dialog.Title>
+            <div className="flex items-center gap-1">
               <button
                 type="button"
-                onClick={handleAskAI}
-                disabled={!askAIEnabled}
-                className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-primary disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                title={askAIEnabled ? 'Ask AI this question' : 'Type a question to ask AI'}
+                onClick={onCollapse}
+                className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                title="Collapse"
+                aria-label="Collapse expanded comment"
               >
-                <SparklesIcon className="w-3 h-3" />
-                Ask AI
+                <CollapseIcon />
               </button>
-            )}
+              <button
+                type="button"
+                onClick={onCancel}
+                className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                title="Close"
+                aria-label="Close expanded comment"
+              >
+                <CloseIcon />
+              </button>
+            </div>
           </div>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={onCollapse}
-              className="review-toolbar-btn"
-            >
-              Collapse
-            </button>
-            <button
-              type="button"
-              onClick={onSubmit}
-              disabled={!canSubmit}
-              className="review-toolbar-btn primary disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {submitLabel}
-            </button>
+
+          <div className="px-4 py-3 min-h-0 flex-1 flex">
+            <textarea
+              ref={textareaRef}
+              value={commentText}
+              onChange={(event) => setCommentText(event.target.value)}
+              placeholder="Leave feedback..."
+              className="w-full h-full min-h-0 max-h-full bg-muted text-sm leading-relaxed placeholder:text-muted-foreground resize-y focus:outline-none rounded-lg border-0 px-3 py-2"
+            />
           </div>
-        </div>
-      </div>
-    </div>,
-    document.body,
+
+          <div className="shrink-0 flex items-center justify-between gap-3 px-4 py-3 border-t border-border/50">
+            <div>
+              {aiAvailable && (
+                <button
+                  type="button"
+                  onClick={handleAskAI}
+                  disabled={!askAIEnabled}
+                  className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-primary disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  title={askAIEnabled ? 'Ask AI this question' : 'Type a question to ask AI'}
+                >
+                  <SparklesIcon className="w-3 h-3" />
+                  Ask AI
+                </button>
+              )}
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={onCollapse}
+                className="review-toolbar-btn"
+              >
+                Collapse
+              </button>
+              <button
+                type="button"
+                onClick={onSubmit}
+                disabled={!canSubmit}
+                className="review-toolbar-btn primary disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {submitLabel}
+              </button>
+            </div>
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 };
 

--- a/packages/review-editor/components/ExpandedCommentDialog.tsx
+++ b/packages/review-editor/components/ExpandedCommentDialog.tsx
@@ -1,0 +1,149 @@
+import React, { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { SparklesIcon } from '@plannotator/ui/components/SparklesIcon';
+
+interface ExpandedCommentDialogProps {
+  title: string;
+  commentText: string;
+  setCommentText: (text: string) => void;
+  isEditing: boolean;
+  canSubmit: boolean;
+  aiAvailable?: boolean;
+  onAskAI?: (question: string) => void;
+  onSubmit: () => void;
+  onCollapse: () => void;
+  onCancel: () => void;
+}
+
+export const ExpandedCommentDialog: React.FC<ExpandedCommentDialogProps> = ({
+  title,
+  commentText,
+  setCommentText,
+  isEditing,
+  canSubmit,
+  aiAvailable = false,
+  onAskAI,
+  onSubmit,
+  onCollapse,
+  onCancel,
+}) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const askAIEnabled = aiAvailable && !!onAskAI && commentText.trim().length > 0;
+  const submitLabel = isEditing ? 'Update' : 'Add Comment';
+
+  useEffect(() => {
+    const id = window.setTimeout(() => {
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+      textarea.focus();
+      textarea.selectionStart = textarea.selectionEnd = textarea.value.length;
+    }, 0);
+
+    return () => window.clearTimeout(id);
+  }, []);
+
+  const handleAskAI = () => {
+    if (!askAIEnabled) return;
+    onAskAI?.(commentText.trim());
+  };
+
+  return createPortal(
+    <div className="fixed inset-0 z-[2000] flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-background/80 backdrop-blur-sm" onClick={onCollapse} />
+      <div className="relative w-full max-w-2xl max-h-[85vh] bg-popover border border-border rounded-xl shadow-2xl flex flex-col">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-border/50">
+          <span className="text-xs text-muted-foreground truncate">{title}</span>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={onCollapse}
+              className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+              title="Collapse"
+              aria-label="Collapse expanded comment"
+            >
+              <CollapseIcon />
+            </button>
+            <button
+              type="button"
+              onClick={onCancel}
+              className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+              title="Close"
+              aria-label="Close expanded comment"
+            >
+              <CloseIcon />
+            </button>
+          </div>
+        </div>
+
+        <div className="px-4 py-3 min-h-0 flex-1">
+          <textarea
+            ref={textareaRef}
+            value={commentText}
+            onChange={(event) => setCommentText(event.target.value)}
+            placeholder="Leave feedback..."
+            className="w-full min-h-72 max-h-[56vh] bg-muted text-sm leading-relaxed placeholder:text-muted-foreground resize-y focus:outline-none rounded-lg border-0 px-3 py-2"
+            onKeyDown={(event) => {
+              if (event.key === 'Escape') {
+                event.stopPropagation();
+                onCollapse();
+                return;
+              }
+
+              if (event.key === 'Enter' && (event.metaKey || event.ctrlKey) && !event.nativeEvent.isComposing) {
+                event.preventDefault();
+                onSubmit();
+              }
+            }}
+          />
+        </div>
+
+        <div className="flex items-center justify-between gap-3 px-4 py-3 border-t border-border/50">
+          <div>
+            {aiAvailable && (
+              <button
+                type="button"
+                onClick={handleAskAI}
+                disabled={!askAIEnabled}
+                className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-primary disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                title={askAIEnabled ? 'Ask AI this question' : 'Type a question to ask AI'}
+              >
+                <SparklesIcon className="w-3 h-3" />
+                Ask AI
+              </button>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onCollapse}
+              className="review-toolbar-btn"
+            >
+              Collapse
+            </button>
+            <button
+              type="button"
+              onClick={onSubmit}
+              disabled={!canSubmit}
+              className="review-toolbar-btn primary disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {submitLabel}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+};
+
+const CollapseIcon = () => (
+  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M9 9V4.5M9 9H4.5M9 9L3.75 3.75M9 15v4.5M9 15H4.5M9 15l-5.25 5.25M15 9h4.5M15 9V4.5M15 9l5.25-5.25M15 15h4.5M15 15v4.5m0-4.5l5.25 5.25" />
+  </svg>
+);
+
+const CloseIcon = () => (
+  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+  </svg>
+);

--- a/packages/review-editor/components/ToolbarHost.tsx
+++ b/packages/review-editor/components/ToolbarHost.tsx
@@ -111,6 +111,13 @@ export const ToolbarHost = forwardRef<ToolbarHostHandle, ToolbarHostProps>(funct
     toolbar.setShowCommentModal(false);
     toolbar.handleCancel();
   }, [toolbar.handleCancel, toolbar.setShowCommentModal]);
+  const handleExpandedAskAI = useCallback((question: string) => {
+    if (!onAskAI) return;
+    onAskAI(question);
+    toolbar.setCommentText('');
+    toolbar.setAskAIMode(true);
+    toolbar.setShowCommentModal(false);
+  }, [onAskAI, toolbar.setAskAIMode, toolbar.setCommentText, toolbar.setShowCommentModal]);
 
   const expandedCommentTitle = useMemo(() => {
     const toolbarState = toolbar.toolbarState;
@@ -135,6 +142,8 @@ export const ToolbarHost = forwardRef<ToolbarHostHandle, ToolbarHostProps>(funct
           showSuggestedCode={toolbar.showSuggestedCode}
           setShowSuggestedCode={toolbar.setShowSuggestedCode}
           selectedOriginalCode={toolbar.selectedOriginalCode}
+          askAIMode={toolbar.askAIMode}
+          setAskAIMode={toolbar.setAskAIMode}
           setShowCodeModal={toolbar.setShowCodeModal}
           setShowCommentModal={toolbar.setShowCommentModal}
           isEditing={!!toolbar.editingAnnotationId}
@@ -163,7 +172,7 @@ export const ToolbarHost = forwardRef<ToolbarHostHandle, ToolbarHostProps>(funct
           isEditing={!!toolbar.editingAnnotationId}
           canSubmit={canSubmitAnnotation}
           aiAvailable={aiAvailable && !toolbar.editingAnnotationId}
-          onAskAI={onAskAI}
+          onAskAI={handleExpandedAskAI}
           onSubmit={toolbar.handleSubmitAnnotation}
           onCollapse={handleCollapseCommentModal}
           onCancel={handleCancelCommentModal}

--- a/packages/review-editor/components/ToolbarHost.tsx
+++ b/packages/review-editor/components/ToolbarHost.tsx
@@ -12,8 +12,10 @@ import { useConfigValue } from '@plannotator/ui/config';
 import { useAnnotationToolbar } from '../hooks/useAnnotationToolbar';
 import { AnnotationToolbar } from './AnnotationToolbar';
 import { SuggestionModal } from './SuggestionModal';
+import { ExpandedCommentDialog } from './ExpandedCommentDialog';
 import { getEnabledLabels } from './ConventionalLabelPicker';
 import type { AIChatEntry } from '../hooks/useAIChat';
+import { formatLineRange, formatTokenContext } from '../utils/formatLineRange';
 
 export interface ToolbarHostHandle {
   handleLineSelectionEnd: (range: SelectedLineRange | null) => void;
@@ -104,10 +106,25 @@ export const ToolbarHost = forwardRef<ToolbarHostHandle, ToolbarHostProps>(funct
   );
 
   const handleCloseCodeModal = useCallback(() => toolbar.setShowCodeModal(false), [toolbar.setShowCodeModal]);
+  const handleCollapseCommentModal = useCallback(() => toolbar.setShowCommentModal(false), [toolbar.setShowCommentModal]);
+  const handleCancelCommentModal = useCallback(() => {
+    toolbar.setShowCommentModal(false);
+    toolbar.handleCancel();
+  }, [toolbar.handleCancel, toolbar.setShowCommentModal]);
+
+  const expandedCommentTitle = useMemo(() => {
+    const toolbarState = toolbar.toolbarState;
+    if (!toolbarState) return 'Comment';
+    if (toolbar.editingAnnotationId) return 'Edit annotation';
+    if (toolbarState.tokenSelection) return formatTokenContext(toolbarState.tokenSelection);
+    return formatLineRange(toolbarState.range.start, toolbarState.range.end);
+  }, [toolbar.editingAnnotationId, toolbar.toolbarState]);
+
+  const canSubmitAnnotation = toolbar.commentText.trim().length > 0 || toolbar.suggestedCode.trim().length > 0;
 
   return (
     <>
-      {toolbar.toolbarState && !toolbar.showCodeModal && (
+      {toolbar.toolbarState && !toolbar.showCodeModal && !toolbar.showCommentModal && (
         <AnnotationToolbar
           toolbarState={toolbar.toolbarState}
           toolbarRef={toolbar.toolbarRef}
@@ -119,6 +136,7 @@ export const ToolbarHost = forwardRef<ToolbarHostHandle, ToolbarHostProps>(funct
           setShowSuggestedCode={toolbar.setShowSuggestedCode}
           selectedOriginalCode={toolbar.selectedOriginalCode}
           setShowCodeModal={toolbar.setShowCodeModal}
+          setShowCommentModal={toolbar.setShowCommentModal}
           isEditing={!!toolbar.editingAnnotationId}
           onSubmit={toolbar.handleSubmitAnnotation}
           onDismiss={toolbar.handleDismiss}
@@ -134,6 +152,21 @@ export const ToolbarHost = forwardRef<ToolbarHostHandle, ToolbarHostProps>(funct
           isAILoading={isAILoading}
           onViewAIResponse={onViewAIResponse}
           aiHistoryMessages={aiHistoryMessages}
+        />
+      )}
+
+      {toolbar.toolbarState && toolbar.showCommentModal && (
+        <ExpandedCommentDialog
+          title={expandedCommentTitle}
+          commentText={toolbar.commentText}
+          setCommentText={toolbar.setCommentText}
+          isEditing={!!toolbar.editingAnnotationId}
+          canSubmit={canSubmitAnnotation}
+          aiAvailable={aiAvailable && !toolbar.editingAnnotationId}
+          onAskAI={onAskAI}
+          onSubmit={toolbar.handleSubmitAnnotation}
+          onCollapse={handleCollapseCommentModal}
+          onCancel={handleCancelCommentModal}
         />
       )}
 

--- a/packages/review-editor/hooks/useAnnotationToolbar.ts
+++ b/packages/review-editor/hooks/useAnnotationToolbar.ts
@@ -63,6 +63,7 @@ export function useAnnotationToolbar({ patch, filePath, isFocused, onLineSelecti
   const [suggestedCode, setSuggestedCode] = useState('');
   const [showSuggestedCode, setShowSuggestedCode] = useState(false);
   const [selectedOriginalCode, setSelectedOriginalCode] = useState('');
+  const [askAIMode, setAskAIMode] = useState(false);
   const [showCodeModal, setShowCodeModal] = useState(false);
   const [showCommentModal, setShowCommentModal] = useState(false);
   const [modalLayout, setModalLayout] = useState<'horizontal' | 'vertical'>('horizontal');
@@ -128,6 +129,7 @@ export function useAnnotationToolbar({ patch, filePath, isFocused, onLineSelecti
     setSuggestedCode('');
     setSelectedOriginalCode('');
     setShowSuggestedCode(false);
+    setAskAIMode(false);
     setShowCodeModal(false);
     setShowCommentModal(false);
     setEditingAnnotationId(null);
@@ -150,6 +152,7 @@ export function useAnnotationToolbar({ patch, filePath, isFocused, onLineSelecti
   ) => {
     saveDraft();
     setEditingAnnotationId(null);
+    setAskAIMode(false);
     setShowCodeModal(false);
     setShowCommentModal(false);
 
@@ -236,6 +239,7 @@ export function useAnnotationToolbar({ patch, filePath, isFocused, onLineSelecti
     setSuggestedCode(annotation.suggestedCode || '');
     setSelectedOriginalCode(annotation.originalCode || '');
     setShowSuggestedCode(!!annotation.suggestedCode);
+    setAskAIMode(false);
     setShowCodeModal(false);
     setShowCommentModal(false);
     setConventionalLabel(annotation.conventionalLabel || null);
@@ -296,6 +300,7 @@ export function useAnnotationToolbar({ patch, filePath, isFocused, onLineSelecti
       setConventionalLabel(draft.conventionalLabel);
       setDecorations(draft.decorations);
       setEditingAnnotationId(null);
+      setAskAIMode(false);
       setShowCodeModal(false);
       setShowCommentModal(false);
       setToolbarState({
@@ -353,6 +358,8 @@ export function useAnnotationToolbar({ patch, filePath, isFocused, onLineSelecti
     showSuggestedCode,
     setShowSuggestedCode,
     selectedOriginalCode,
+    askAIMode,
+    setAskAIMode,
     showCodeModal,
     setShowCodeModal,
     showCommentModal,

--- a/packages/review-editor/hooks/useAnnotationToolbar.ts
+++ b/packages/review-editor/hooks/useAnnotationToolbar.ts
@@ -64,6 +64,7 @@ export function useAnnotationToolbar({ patch, filePath, isFocused, onLineSelecti
   const [showSuggestedCode, setShowSuggestedCode] = useState(false);
   const [selectedOriginalCode, setSelectedOriginalCode] = useState('');
   const [showCodeModal, setShowCodeModal] = useState(false);
+  const [showCommentModal, setShowCommentModal] = useState(false);
   const [modalLayout, setModalLayout] = useState<'horizontal' | 'vertical'>('horizontal');
   const [editingAnnotationId, setEditingAnnotationId] = useState<string | null>(null);
   const [conventionalLabel, setConventionalLabel] = useState<ConventionalLabel | null>(null);
@@ -128,6 +129,7 @@ export function useAnnotationToolbar({ patch, filePath, isFocused, onLineSelecti
     setSelectedOriginalCode('');
     setShowSuggestedCode(false);
     setShowCodeModal(false);
+    setShowCommentModal(false);
     setEditingAnnotationId(null);
     setConventionalLabel(null);
     setDecorations([]);
@@ -148,6 +150,8 @@ export function useAnnotationToolbar({ patch, filePath, isFocused, onLineSelecti
   ) => {
     saveDraft();
     setEditingAnnotationId(null);
+    setShowCodeModal(false);
+    setShowCommentModal(false);
 
     const draft = draftStore.get(draftKey(filePath, range));
     if (draft) {
@@ -233,6 +237,7 @@ export function useAnnotationToolbar({ patch, filePath, isFocused, onLineSelecti
     setSelectedOriginalCode(annotation.originalCode || '');
     setShowSuggestedCode(!!annotation.suggestedCode);
     setShowCodeModal(false);
+    setShowCommentModal(false);
     setConventionalLabel(annotation.conventionalLabel || null);
     setDecorations(annotation.decorations || []);
 
@@ -263,7 +268,7 @@ export function useAnnotationToolbar({ patch, filePath, isFocused, onLineSelecti
   }, [onLineSelection, clearDraft, resetForm]);
 
   useDismissOnOutsideAndEscape({
-    enabled: !!toolbarState && !showCodeModal,
+    enabled: !!toolbarState && !showCodeModal && !showCommentModal,
     ref: toolbarRef,
     onDismiss: handleDismiss,
   });
@@ -292,6 +297,7 @@ export function useAnnotationToolbar({ patch, filePath, isFocused, onLineSelecti
       setDecorations(draft.decorations);
       setEditingAnnotationId(null);
       setShowCodeModal(false);
+      setShowCommentModal(false);
       setToolbarState({
         position: draft.position,
         range: draft.range,
@@ -349,6 +355,8 @@ export function useAnnotationToolbar({ patch, filePath, isFocused, onLineSelecti
     selectedOriginalCode,
     showCodeModal,
     setShowCodeModal,
+    showCommentModal,
+    setShowCommentModal,
     modalLayout,
     setModalLayout,
     editingAnnotationId,


### PR DESCRIPTION
## Context

Long agent-generated review comments can be awkward to read or edit in the compact inline review annotation toolbar. The compact composer is still useful for quick comments, but larger findings need a first-class expanded writing space.

## What Changed

- Added an expand control to the code-review annotation toolbar.
- Added a review-specific expanded comment dialog that edits the same existing toolbar comment state.
- Preserved the compact toolbar as the default surface, including the original `w-80` starting width.
- Kept textarea vertical resize in the compact composer for a lightweight inline improvement.
- Left suggested-code expansion on the existing suggestion modal path.

## GIF
<img width="1654" height="840" alt="Jul-09-2026 14-54-08" src="https://github.com/user-attachments/assets/27f522b1-3f60-4280-85e2-9fdd4acb60ca" />

## Review Focus

- Confirm the expanded dialog uses the existing review annotation state correctly for both add and edit flows.
- Check the collapse vs close behavior: collapse returns to the compact toolbar, close cancels the annotation like the existing compact close button.
- Verify the modal does not interfere with the existing suggested-code modal or outside-dismiss behavior.

## Test Plan

- [x] `env PATH=/Users/leonardo/.codex/worktrees/91ae/plannotator/node_modules/.bun/typescript@5.8.3/node_modules/.bin:$PATH bun run typecheck`
- [x] `bun run build:review`
- [x] `bun run build:hook`
- [x] Opened a local `plannotator review` session and exercised the new expanded comment editor path.