### PR TITLE
fix(ui): comment editor textarea not focused on open in WebKit hosts

### DIFF
--- a/packages/ui/components/CommentPopover.tsx
+++ b/packages/ui/components/CommentPopover.tsx
@@ -167,17 +167,20 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
     anchorEl?.scrollIntoView({ block: 'center', behavior: 'smooth' });
   }, [anchorEl]);
 
-  // Focus textarea on mount and mode changes
-  useEffect(() => {
-    const id = setTimeout(() => {
-      const el = textareaRef.current;
-      if (el) {
-        el.focus();
-        el.selectionStart = el.selectionEnd = el.value.length;
-      }
+  // Focus the textarea when it mounts (initial open and popover/dialog switches).
+  // A ref callback rather than a mount effect: in popover mode the textarea only
+  // renders after `position` is measured, and WebKit fires 0ms timers ahead of
+  // that commit, so an effect keyed on mode alone can run before the textarea
+  // exists and never focus it (e.g. in WKWebView hosts like Glimpse).
+  const focusOnMountRef = useCallback((el: HTMLTextAreaElement | null) => {
+    textareaRef.current = el;
+    if (!el) return;
+    setTimeout(() => {
+      if (!el.isConnected) return;
+      el.focus();
+      el.selectionStart = el.selectionEnd = el.value.length;
     }, 0);
-    return () => clearTimeout(id);
-  }, [mode]);
+  }, []);
 
   // Click-outside for popover mode
   useEffect(() => {
@@ -307,7 +310,7 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
           {/* Textarea */}
           <div className="px-4 py-3 flex-1">
             <textarea
-              ref={textareaRef}
+              ref={focusOnMountRef}
               value={text}
               onChange={(e) => setText(e.target.value)}
               onKeyDown={handleKeyDown}
@@ -429,7 +432,7 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
       {/* Textarea */}
       <div className="px-3 py-2">
         <textarea
-          ref={textareaRef}
+          ref={focusOnMountRef}
           value={text}
           onChange={(e) => setText(e.target.value)}
           onKeyDown={handleKeyDown}


### PR DESCRIPTION
## Problem

In Comment mode, selecting text (or double-clicking a word) opens the comment editor, but the textarea isn't focused — you have to tab several times or reach for the mouse before you can type. This happens consistently in WKWebView hosts (observed with the `glimpseui` integration on macOS); Chromium-based browsers are unaffected.

## Root cause

`CommentPopover` focused the textarea from a mount effect keyed on `[mode]` that scheduled a `setTimeout(0)`:

- In popover mode, the component renders `null` until `position` is computed by a later effect, so the textarea only mounts in the **next** commit.
- Whether the 0ms timer fires before or after that commit is engine-dependent task ordering. Chromium happens to commit the re-render first, so `textareaRef.current` is set when the timer fires. WebKit fires the timer first — the ref is still `null`, the effect never re-runs (`mode` doesn't change), and the editor opens unfocused.

Traced by instrumenting the page inside a real glimpse (WKWebView) window:

```
SCHED focus-timer d=0
FIRE focus-timer
DONE focus-timer active=BODY   ← callback ran, ref was null, focus() never called
```

Manually calling `focus()` on the same textarea afterwards worked fine, confirming the engine wasn't refusing focus — the app just never asked.

## Fix

Focus from a **ref callback** on the textarea instead of a mount effect. The callback runs exactly when the element mounts, so there's no commit/timer race in either engine:

- Deferred (`setTimeout(0)`) focus and caret-to-end behavior are preserved.
- Popover ⇄ dialog switches still refocus, because the textarea remounts (this is what the old `[mode]` dep provided).
- `isConnected` guards the case where the popover unmounts before the deferred focus runs (also makes the StrictMode double-attach harmless).

## Verification

- **WKWebView (glimpse)**: instrumented driver over glimpse's JSON-lines protocol now logs `focus(): TEXTAREA active=true` and `document.activeElement` is the textarea as soon as the popover opens.
- **Chromium**: double-click-to-comment, drag-select-to-comment, and Expand (popover → dialog) all focus the textarea and accept typing immediately.
- `tsc --noEmit` on `packages/ui/tsconfig.json` and `tsconfig.strict-consumer.json` — clean.
- `bun test packages/ui` — 352 pass, 0 fail.
