### PR TITLE
feat: add Notion notes integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,8 @@ You run /plannotator-review
 
 **Bear**: Save plans as Bear notes with nested tags and project metadata.
 
+**Notion**: Save plans as Markdown child pages under a shared Notion page. Set `NOTION_TOKEN` in the environment that starts Plannotator, then configure the parent page in Settings.
+
 **GitHub / GitLab**: Pass any PR or MR URL to `/plannotator-review` and review it with the full diff viewer, annotations, and file tree.
 
 ---

--- a/apps/marketing/src/content/docs/guides/notion-integration.md
+++ b/apps/marketing/src/content/docs/guides/notion-integration.md
@@ -1,0 +1,36 @@
+---
+title: "Notion Integration"
+description: "Save Plannotator plans as child pages in Notion."
+sidebar:
+  order: 23
+section: "Guides"
+---
+
+Plannotator can save plans to Notion as child pages of a page you choose. The integration uses your local Notion integration token; Plannotator never stores the token in browser settings.
+
+## Setup
+
+1. Create an internal integration or personal access token in the [Notion developer portal](https://www.notion.com/developers).
+2. Copy its token into the environment that starts Plannotator:
+
+   ```bash
+   export NOTION_TOKEN="ntn_..."
+   ```
+
+3. In Notion, open the page under which plans should be created and share it with your integration.
+4. Open **Settings > Notion** in Plannotator, enable Notion, and paste the parent page URL or ID.
+
+The token persists through future sessions wherever you keep your environment secrets. It is read only by the local Plannotator server and is never sent from the browser.
+
+## Exporting
+
+Use **Export > Notes**, **Save to Notion** in the header menu, or set Notion as the default `Cmd/Ctrl+S` destination. You can also enable **Auto-save on Plan Arrival**.
+
+Each export creates a child page whose title is the plan's first H1. The plan body is sent as Notion-flavored Markdown.
+
+## Troubleshooting
+
+- `Set NOTION_TOKEN`: start Plannotator with `NOTION_TOKEN` defined.
+- `token is invalid or revoked`: create or restore a valid Notion token.
+- `Share the parent page`: add your Notion integration to the parent page's connections before exporting.
+- Markdown extensions unique to Plannotator may not render exactly as they do in Plannotator.

--- a/apps/marketing/src/content/docs/reference/api-endpoints.md
+++ b/apps/marketing/src/content/docs/reference/api-endpoints.md
@@ -22,7 +22,7 @@ Used during plan review (`ExitPlanMode` hook).
 | `/api/image` | GET | Serve a local image by path query param |
 | `/api/upload` | POST | Upload an image, returns `{ path, originalName }` |
 | `/api/obsidian/vaults` | GET | Detect available Obsidian vaults |
-| `/api/save-notes` | POST | Save plan to Obsidian/Bear on demand |
+| `/api/save-notes` | POST | Save plan to Obsidian/Bear/Octarine/Notion on demand |
 | `/api/external-annotations/stream` | GET | SSE stream for real-time external annotations |
 | `/api/external-annotations` | GET | Snapshot of external annotations (`?since=N` for version gating) |
 | `/api/external-annotations` | POST | Add external annotations (single or batch) |
@@ -54,6 +54,7 @@ Body:
   "planSave": { "enabled": true, "customPath": null },
   "obsidian": { "vaultPath": "/path/to/vault", "folder": "plannotator", "plan": "..." },
   "bear": { "plan": "..." },
+  "notion": { "parentPageId": "01234567-89ab-cdef-0123-456789abcdef", "plan": "..." },
   "feedback": "optional annotations if present"
 }
 ```

--- a/apps/pi-extension/server/handlers.ts
+++ b/apps/pi-extension/server/handlers.ts
@@ -17,9 +17,11 @@ import {
 	type IntegrationResult,
 	type ObsidianConfig,
 	type OctarineConfig,
+	type NotionConfig,
 	saveToBear,
 	saveToObsidian,
 	saveToOctarine,
+	saveToNotion,
 } from "./integrations.js";
 
 type Res = import("node:http").ServerResponse;
@@ -244,6 +246,7 @@ export async function handleSaveNotesRequest(
 		obsidian?: IntegrationResult;
 		bear?: IntegrationResult;
 		octarine?: IntegrationResult;
+		notion?: IntegrationResult;
 	} = {};
 	try {
 		const body = await parseBody(req);
@@ -251,6 +254,7 @@ export async function handleSaveNotesRequest(
 		const obsConfig = body.obsidian as ObsidianConfig | undefined;
 		const bearConfig = body.bear as BearConfig | undefined;
 		const octConfig = body.octarine as OctarineConfig | undefined;
+		const notionConfig = body.notion as NotionConfig | undefined;
 		if (obsConfig?.vaultPath && obsConfig?.plan) {
 			promises.push(
 				saveToObsidian(obsConfig).then((r) => {
@@ -269,6 +273,13 @@ export async function handleSaveNotesRequest(
 			promises.push(
 				saveToOctarine(octConfig).then((r) => {
 					results.octarine = r;
+				}),
+			);
+		}
+		if (notionConfig?.plan && notionConfig?.parentPageId) {
+			promises.push(
+				saveToNotion(notionConfig).then((r) => {
+					results.notion = r;
 				}),
 			);
 		}

--- a/apps/pi-extension/server/integrations.ts
+++ b/apps/pi-extension/server/integrations.ts
@@ -1,5 +1,5 @@
 /**
- * Note-taking app integrations (Obsidian, Bear, Octarine).
+ * Note-taking app integrations (Obsidian, Bear, Octarine, Notion).
  * Node.js equivalents of packages/server/integrations.ts.
  * Config types, save functions, tag extraction, filename generation
  */
@@ -12,6 +12,7 @@ import {
 	type ObsidianConfig,
 	type BearConfig,
 	type OctarineConfig,
+	type NotionConfig,
 	type IntegrationResult,
 	extractTitle,
 	generateFrontmatter,
@@ -25,7 +26,7 @@ import {
 import { sanitizeTag } from "../generated/project.js";
 import { resolveUserPath } from "../generated/resolve-file.js";
 
-export type { ObsidianConfig, BearConfig, OctarineConfig, IntegrationResult };
+export type { ObsidianConfig, BearConfig, OctarineConfig, NotionConfig, IntegrationResult };
 export {
 	extractTitle,
 	generateFrontmatter,
@@ -191,5 +192,47 @@ export async function saveToOctarine(
 			success: false,
 			error: err instanceof Error ? err.message : "Unknown error",
 		};
+	}
+}
+
+const NOTION_API_VERSION = "2026-03-11";
+
+export async function saveToNotion(
+	config: NotionConfig,
+): Promise<IntegrationResult> {
+	const token = process.env.NOTION_TOKEN?.trim();
+	if (!token) {
+		return { success: false, error: "Notion is not configured. Set NOTION_TOKEN." };
+	}
+	const parentPageId = config.parentPageId.trim();
+	if (!parentPageId) {
+		return { success: false, error: "Notion parent page is required." };
+	}
+
+	try {
+		const response = await fetch("https://api.notion.com/v1/pages", {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "application/json",
+				"Notion-Version": NOTION_API_VERSION,
+			},
+			body: JSON.stringify({
+				parent: { page_id: parentPageId },
+				properties: { title: { title: [{ text: { content: extractTitle(config.plan) } }] } },
+				markdown: config.plan,
+			}),
+		});
+		const data = await response.json().catch(() => null) as { message?: unknown; url?: unknown } | null;
+		if (!response.ok) {
+			const detail = typeof data?.message === "string" ? ` ${data.message}` : "";
+			if (response.status === 401) return { success: false, error: `Notion token is invalid or revoked.${detail}` };
+			if (response.status === 403) return { success: false, error: `Notion cannot access this page. Share the parent page with your Notion integration.${detail}` };
+			if (response.status === 429) return { success: false, error: `Notion rate limit exceeded.${detail}` };
+			return { success: false, error: `Notion export failed (${response.status}).${detail}` };
+		}
+		return { success: true, ...(typeof data?.url === "string" ? { url: data.url } : {}) };
+	} catch (err) {
+		return { success: false, error: err instanceof Error ? `Notion export failed: ${err.message}` : "Notion export failed." };
 	}
 }

--- a/apps/pi-extension/server/serverPlan.ts
+++ b/apps/pi-extension/server/serverPlan.ts
@@ -33,9 +33,11 @@ import {
 	type IntegrationResult,
 	type ObsidianConfig,
 	type OctarineConfig,
+	type NotionConfig,
 	saveToBear,
 	saveToObsidian,
 	saveToOctarine,
+	saveToNotion,
 } from "./integrations.js";
 import { listenOnPort } from "./network.js";
 
@@ -357,6 +359,7 @@ export async function startPlanReviewServer(options: {
 				const obsConfig = body.obsidian as ObsidianConfig | undefined;
 				const bearConfig = body.bear as BearConfig | undefined;
 				const octConfig = body.octarine as OctarineConfig | undefined;
+				const notionConfig = body.notion as NotionConfig | undefined;
 				if (obsConfig?.vaultPath && obsConfig?.plan) {
 					integrationPromises.push(
 						saveToObsidian(obsConfig).then((r) => {
@@ -375,6 +378,13 @@ export async function startPlanReviewServer(options: {
 					integrationPromises.push(
 						saveToOctarine(octConfig).then((r) => {
 							integrationResults.octarine = r;
+						}),
+					);
+				}
+				if (notionConfig?.plan && notionConfig?.parentPageId) {
+					integrationPromises.push(
+						saveToNotion(notionConfig).then((r) => {
+							integrationResults.notion = r;
 						}),
 					);
 				}

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -32,6 +32,7 @@ import { LookAndFeelAnnouncementDialog } from '@plannotator/ui/components/LookAn
 import { getObsidianSettings, getEffectiveVaultPath, isObsidianConfigured, CUSTOM_PATH_SENTINEL } from '@plannotator/ui/utils/obsidian';
 import { getBearSettings } from '@plannotator/ui/utils/bear';
 import { getOctarineSettings, isOctarineConfigured } from '@plannotator/ui/utils/octarine';
+import { getNotionSettings, isNotionConfigured, normalizeNotionPageId } from '@plannotator/ui/utils/notion';
 import { getDefaultNotesApp } from '@plannotator/ui/utils/defaultNotesApp';
 import { getAgentSwitchSettings, getEffectiveAgentName } from '@plannotator/ui/utils/agentSwitch';
 import { getPlanSaveSettings } from '@plannotator/ui/utils/planSave';
@@ -154,6 +155,7 @@ type NoteAutoSaveResults = {
   obsidian?: boolean;
   bear?: boolean;
   octarine?: boolean;
+  notion?: boolean;
 };
 
 type MessageAnnotationState = {
@@ -2382,7 +2384,7 @@ const App: React.FC = () => {
     if (!isApiMode || !markdown || isSharedSession || annotateMode || archive.archiveMode) return;
     if (autoSaveAttempted.current) return;
 
-    const body: { obsidian?: object; bear?: object; octarine?: object } = {};
+    const body: { obsidian?: object; bear?: object; octarine?: object; notion?: object } = {};
     const targets: string[] = [];
 
     const obsSettings = getObsidianSettings();
@@ -2420,6 +2422,13 @@ const App: React.FC = () => {
       targets.push('Octarine');
     }
 
+    const notionSettings = getNotionSettings();
+    const parentPageId = normalizeNotionPageId(notionSettings.parentPageId);
+    if (notionSettings.autoSave && notionSettings.enabled && parentPageId) {
+      body.notion = { plan: markdown, parentPageId };
+      targets.push('Notion');
+    }
+
     if (targets.length === 0) return;
     autoSaveAttempted.current = true;
 
@@ -2434,6 +2443,7 @@ const App: React.FC = () => {
           ...(body.obsidian ? { obsidian: Boolean(data.results?.obsidian?.success) } : {}),
           ...(body.bear ? { bear: Boolean(data.results?.bear?.success) } : {}),
           ...(body.octarine ? { octarine: Boolean(data.results?.octarine?.success) } : {}),
+          ...(body.notion ? { notion: Boolean(data.results?.notion?.success) } : {}),
         };
         autoSaveResultsRef.current = results;
 
@@ -2597,13 +2607,14 @@ const App: React.FC = () => {
       const obsidianSettings = getObsidianSettings();
       const bearSettings = getBearSettings();
       const octarineSettings = getOctarineSettings();
+      const notionSettings = getNotionSettings();
       const planSaveSettings = getPlanSaveSettings();
-      const autoSaveResults = bearSettings.autoSave && autoSavePromiseRef.current
+      const autoSaveResults = (bearSettings.autoSave || notionSettings.autoSave) && autoSavePromiseRef.current
         ? await autoSavePromiseRef.current
         : autoSaveResultsRef.current;
 
       // Build request body - include integrations if enabled
-      const body: { draftGeneration: number; obsidian?: object; bear?: object; octarine?: object; feedback?: string; agentSwitch?: string; planSave?: { enabled: boolean; customPath?: string }; permissionMode?: string } = {
+      const body: { draftGeneration: number; obsidian?: object; bear?: object; octarine?: object; notion?: object; feedback?: string; agentSwitch?: string; planSave?: { enabled: boolean; customPath?: string }; permissionMode?: string } = {
         draftGeneration: getDraftGeneration(),
       };
 
@@ -2650,6 +2661,11 @@ const App: React.FC = () => {
           workspace: octarineSettings.workspace,
           folder: octarineSettings.folder || 'plannotator',
         };
+      }
+
+      const parentPageId = normalizeNotionPageId(notionSettings.parentPageId);
+      if (notionSettings.enabled && parentPageId && !(notionSettings.autoSave && autoSaveResults.notion)) {
+        body.notion = { plan: currentMarkdown, parentPageId };
       }
 
       // Include annotations as feedback if any exist (for OpenCode "approve with notes").
@@ -3315,8 +3331,8 @@ const App: React.FC = () => {
     toast.success('Downloaded annotations');
   };
 
-  const handleQuickSaveToNotes = async (target: 'obsidian' | 'bear' | 'octarine') => {
-    const body: { obsidian?: object; bear?: object; octarine?: object } = {};
+  const handleQuickSaveToNotes = async (target: 'obsidian' | 'bear' | 'octarine' | 'notion') => {
+    const body: { obsidian?: object; bear?: object; octarine?: object; notion?: object } = {};
     // Mid-edit saves describe the live buffer, matching handleApprove.
     const quickSaveMarkdown = isEditingMarkdown
       ? markdownEditorHandleRef.current?.getMarkdown() ?? displayedMarkdown
@@ -3352,7 +3368,13 @@ const App: React.FC = () => {
       };
     }
 
-    const targetName = target === 'obsidian' ? 'Obsidian' : target === 'bear' ? 'Bear' : 'Octarine';
+    if (target === 'notion') {
+      const ns = getNotionSettings();
+      const parentPageId = normalizeNotionPageId(ns.parentPageId);
+      if (parentPageId) body.notion = { plan: quickSaveMarkdown, parentPageId };
+    }
+
+    const targetName = target === 'obsidian' ? 'Obsidian' : target === 'bear' ? 'Bear' : target === 'octarine' ? 'Octarine' : 'Notion';
     try {
       const res = await fetch('/api/save-notes', {
         method: 'POST',
@@ -3606,6 +3628,7 @@ const App: React.FC = () => {
       const obsOk = isObsidianConfigured();
       const bearOk = getBearSettings().enabled;
       const octOk = isOctarineConfigured();
+      const notionOk = isNotionConfigured();
 
       if (defaultApp === 'download') {
         handleDownloadAnnotations();
@@ -3615,6 +3638,8 @@ const App: React.FC = () => {
         handleQuickSaveToNotes('bear');
       } else if (defaultApp === 'octarine' && octOk) {
         handleQuickSaveToNotes('octarine');
+      } else if (defaultApp === 'notion' && notionOk) {
+        handleQuickSaveToNotes('notion');
       } else {
         setInitialExportTab('notes');
         setShowExport(true);
@@ -3765,6 +3790,7 @@ const App: React.FC = () => {
   const handleOpenImport = useCallback(() => setShowImport(true), []);
   const handleSaveToObsidian = useCallback(() => headerHandlersRef.current.handleQuickSaveToNotes('obsidian'), []);
   const handleSaveToOctarine = useCallback(() => headerHandlersRef.current.handleQuickSaveToNotes('octarine'), []);
+  const handleSaveToNotion = useCallback(() => headerHandlersRef.current.handleQuickSaveToNotes('notion'), []);
   const handleSaveToBear = useCallback(() => headerHandlersRef.current.handleQuickSaveToNotes('bear'), []);
 
   const planMaxWidth = useMemo(() => {
@@ -3875,6 +3901,7 @@ const App: React.FC = () => {
           onSaveToObsidian={handleSaveToObsidian}
           onSaveToBear={handleSaveToBear}
           onSaveToOctarine={handleSaveToOctarine}
+          onSaveToNotion={handleSaveToNotion}
           appVersion={typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : '0.0.0'}
           updateInfo={updateInfo}
           isWSL={isWSL}
@@ -3882,6 +3909,7 @@ const App: React.FC = () => {
           obsidianConfigured={isObsidianConfigured()}
           bearConfigured={getBearSettings().enabled}
           octarineConfigured={isOctarineConfigured()}
+          notionConfigured={isNotionConfigured()}
         />
 
         {/* Linked document error banner */}

--- a/packages/editor/components/AppHeader.tsx
+++ b/packages/editor/components/AppHeader.tsx
@@ -80,6 +80,7 @@ interface AppHeaderProps {
   onSaveToObsidian: () => void;
   onSaveToBear: () => void;
   onSaveToOctarine: () => void;
+  onSaveToNotion: () => void;
 
   // PlanHeaderMenu config
   appVersion: string;
@@ -89,6 +90,7 @@ interface AppHeaderProps {
   obsidianConfigured: boolean;
   bearConfigured: boolean;
   octarineConfigured: boolean;
+  notionConfigured: boolean;
 }
 
 export const AppHeader = React.memo<AppHeaderProps>(({
@@ -150,6 +152,7 @@ export const AppHeader = React.memo<AppHeaderProps>(({
   onSaveToObsidian,
   onSaveToBear,
   onSaveToOctarine,
+  onSaveToNotion,
   appVersion,
   updateInfo,
   isWSL,
@@ -157,6 +160,7 @@ export const AppHeader = React.memo<AppHeaderProps>(({
   obsidianConfigured,
   bearConfigured,
   octarineConfigured,
+  notionConfigured,
 }) => {
   return (
     <header data-app-header="true" className="h-12 flex items-center justify-between px-2 md:px-4 border-b border-border/50 bg-card/50 backdrop-blur-xl sticky top-0 z-[50]">
@@ -367,12 +371,14 @@ export const AppHeader = React.memo<AppHeaderProps>(({
           onSaveToObsidian={onSaveToObsidian}
           onSaveToBear={onSaveToBear}
           onSaveToOctarine={onSaveToOctarine}
+          onSaveToNotion={onSaveToNotion}
           sharingEnabled={canShareCurrentSession}
           isApiMode={isApiMode}
           agentInstructionsEnabled={agentInstructionsEnabled}
           obsidianConfigured={!goalSetupMode && obsidianConfigured}
           bearConfigured={!goalSetupMode && bearConfigured}
           octarineConfigured={!goalSetupMode && octarineConfigured}
+          notionConfigured={!goalSetupMode && notionConfigured}
         />
       </div>
     </header>

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -20,9 +20,11 @@ import {
   saveToObsidian,
   saveToBear,
   saveToOctarine,
+  saveToNotion,
   type ObsidianConfig,
   type BearConfig,
   type OctarineConfig,
+  type NotionConfig,
   type IntegrationResult,
 } from "./integrations";
 import {
@@ -453,6 +455,7 @@ export async function startPlannotatorServer(
                 obsidian?: ObsidianConfig;
                 bear?: BearConfig;
                 octarine?: OctarineConfig;
+                notion?: NotionConfig;
                 feedback?: string;
                 agentSwitch?: string;
                 planSave?: { enabled: boolean; customPath?: string };
@@ -493,6 +496,9 @@ export async function startPlannotatorServer(
               }
               if (body.octarine?.plan && body.octarine?.workspace) {
                 integrationPromises.push(saveToOctarine(body.octarine).then(r => { integrationResults.octarine = r; }));
+              }
+              if (body.notion?.plan && body.notion?.parentPageId) {
+                integrationPromises.push(saveToNotion(body.notion).then(r => { integrationResults.notion = r; }));
               }
               await Promise.allSettled(integrationPromises);
 

--- a/packages/server/integrations.test.ts
+++ b/packages/server/integrations.test.ts
@@ -13,6 +13,8 @@ import {
   buildHashtags,
   buildBearContent,
   saveToObsidian,
+  saveToNotion,
+  NOTION_API_VERSION,
 } from "./integrations";
 
 describe("extractTitle", () => {
@@ -207,5 +209,71 @@ describe("saveToObsidian", () => {
     });
     expect(result.success).toBe(false);
     expect(result.error).toBeString();
+  });
+});
+
+describe("saveToNotion", () => {
+  const originalToken = process.env.NOTION_TOKEN;
+  const originalFetch = globalThis.fetch;
+
+  function restore(): void {
+    if (originalToken === undefined) delete process.env.NOTION_TOKEN;
+    else process.env.NOTION_TOKEN = originalToken;
+    globalThis.fetch = originalFetch;
+  }
+
+  test("requires a token without making a request", async () => {
+    delete process.env.NOTION_TOKEN;
+    try {
+      const result = await saveToNotion({ plan: "# Test Plan", parentPageId: "page-id" });
+      expect(result).toEqual({ success: false, error: "Notion is not configured. Set NOTION_TOKEN." });
+    } finally {
+      restore();
+    }
+  });
+
+  test("creates a markdown child page without exposing the token", async () => {
+    process.env.NOTION_TOKEN = "secret-token";
+    let request: Request | undefined;
+    globalThis.fetch = async (input, init) => {
+      request = new Request(input, init);
+      return Response.json({ url: "https://www.notion.so/test-page" });
+    };
+
+    try {
+      const result = await saveToNotion({
+        plan: "# Implementation Plan: Test Export\n\nContent",
+        parentPageId: "parent-page-id",
+      });
+
+      expect(result).toEqual({ success: true, url: "https://www.notion.so/test-page" });
+      expect(request?.url).toBe("https://api.notion.com/v1/pages");
+      expect(request?.headers.get("Authorization")).toBe("Bearer secret-token");
+      expect(request?.headers.get("Notion-Version")).toBe(NOTION_API_VERSION);
+      expect(await request?.json()).toEqual({
+        parent: { page_id: "parent-page-id" },
+        properties: { title: { title: [{ text: { content: "Test Export" } }] } },
+        markdown: "# Implementation Plan: Test Export\n\nContent",
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  test("explains a page access failure without leaking the token", async () => {
+    process.env.NOTION_TOKEN = "secret-token";
+    globalThis.fetch = async () => Response.json(
+      { message: "Could not find page" },
+      { status: 403 },
+    );
+
+    try {
+      const result = await saveToNotion({ plan: "# Test Plan", parentPageId: "page-id" });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Share the parent page");
+      expect(result.error).not.toContain("secret-token");
+    } finally {
+      restore();
+    }
   });
 });

--- a/packages/server/integrations.ts
+++ b/packages/server/integrations.ts
@@ -1,5 +1,5 @@
 /**
- * Note-taking app integrations (Obsidian, Bear)
+ * Note-taking app integrations (Obsidian, Bear, Octarine, Notion)
  */
 
 import { $ } from "bun";
@@ -11,6 +11,7 @@ import {
 	type ObsidianConfig,
 	type BearConfig,
 	type OctarineConfig,
+	type NotionConfig,
 	type IntegrationResult,
 	extractTitle,
 	generateFrontmatter,
@@ -23,7 +24,7 @@ import {
 } from "@plannotator/shared/integrations-common";
 import { resolveUserPath } from "@plannotator/shared/resolve-file";
 
-export type { ObsidianConfig, BearConfig, OctarineConfig, IntegrationResult };
+export type { ObsidianConfig, BearConfig, OctarineConfig, NotionConfig, IntegrationResult };
 export { detectObsidianVaults, extractTitle, generateFrontmatter, generateFilename, generateOctarineFrontmatter, stripH1, buildHashtags, buildBearContent };
 
 /**
@@ -210,5 +211,56 @@ export async function saveToOctarine(
 	} catch (err) {
 		const message = err instanceof Error ? err.message : "Unknown error";
 		return { success: false, error: message };
+	}
+}
+
+export const NOTION_API_VERSION = "2026-03-11";
+
+/** Save a plan as a child page of a Notion page using the user's local token. */
+export async function saveToNotion(
+	config: NotionConfig,
+): Promise<IntegrationResult> {
+	const token = process.env.NOTION_TOKEN?.trim();
+	if (!token) {
+		return { success: false, error: "Notion is not configured. Set NOTION_TOKEN." };
+	}
+
+	const parentPageId = config.parentPageId.trim();
+	if (!parentPageId) {
+		return { success: false, error: "Notion parent page is required." };
+	}
+
+	try {
+		const response = await fetch("https://api.notion.com/v1/pages", {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "application/json",
+				"Notion-Version": NOTION_API_VERSION,
+			},
+			body: JSON.stringify({
+				parent: { page_id: parentPageId },
+				properties: {
+					title: { title: [{ text: { content: extractTitle(config.plan) } }] },
+				},
+				markdown: config.plan,
+			}),
+		});
+
+		const data = await response.json().catch(() => null) as { message?: unknown; url?: unknown } | null;
+		if (!response.ok) {
+			const detail = typeof data?.message === "string" ? ` ${data.message}` : "";
+			if (response.status === 401) return { success: false, error: `Notion token is invalid or revoked.${detail}` };
+			if (response.status === 403) return { success: false, error: `Notion cannot access this page. Share the parent page with your Notion integration.${detail}` };
+			if (response.status === 429) return { success: false, error: `Notion rate limit exceeded.${detail}` };
+			return { success: false, error: `Notion export failed (${response.status}).${detail}` };
+		}
+
+		return { success: true, ...(typeof data?.url === "string" ? { url: data.url } : {}) };
+	} catch (err) {
+		return {
+			success: false,
+			error: err instanceof Error ? `Notion export failed: ${err.message}` : "Notion export failed.",
+		};
 	}
 }

--- a/packages/server/shared-handlers.test.ts
+++ b/packages/server/shared-handlers.test.ts
@@ -69,6 +69,30 @@ describe("handleSaveNotes", () => {
     expect(json.results.obsidian).toHaveProperty("error");
   });
 
+  test("dispatches a Notion export without exposing its token", async () => {
+    const originalToken = process.env.NOTION_TOKEN;
+    const originalFetch = globalThis.fetch;
+    process.env.NOTION_TOKEN = "secret-token";
+    globalThis.fetch = async () => Response.json({ url: "https://www.notion.so/saved-plan" });
+
+    try {
+      const response = await handleSaveNotes(
+        saveNotesRequest({
+          notion: { plan: "# Test Plan", parentPageId: "parent-page-id" },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const json = await response.json();
+      expect(json.results.notion).toEqual({ success: true, url: "https://www.notion.so/saved-plan" });
+      expect(JSON.stringify(json)).not.toContain("secret-token");
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalToken === undefined) delete process.env.NOTION_TOKEN;
+      else process.env.NOTION_TOKEN = originalToken;
+    }
+  });
+
   test("an unparseable body returns a 500 JSON error (not SPA HTML)", async () => {
     const badRequest = new Request("http://localhost/api/save-notes", {
       method: "POST",

--- a/packages/server/shared-handlers.ts
+++ b/packages/server/shared-handlers.ts
@@ -12,8 +12,8 @@ import { openBrowser as openBrowserImpl } from "./browser";
 import { validateImagePath, validateUploadExtension, UPLOAD_DIR } from "./image";
 import { saveDraft, loadDraft, deleteDraft, getDraftGeneration } from "./draft";
 import { FAVICON_PNG_BYTES } from "@plannotator/shared/favicon";
-import { saveToObsidian, saveToBear, saveToOctarine } from "./integrations";
-import type { ObsidianConfig, BearConfig, OctarineConfig, IntegrationResult } from "./integrations";
+import { saveToObsidian, saveToBear, saveToOctarine, saveToNotion } from "./integrations";
+import type { ObsidianConfig, BearConfig, OctarineConfig, NotionConfig, IntegrationResult } from "./integrations";
 
 function normalizeDraftGeneration(value: unknown): number | undefined {
   if (typeof value !== "number") return undefined;
@@ -228,15 +228,16 @@ export async function handleServerReady(
   }
 }
 
-/** Save to external note apps (Obsidian, Bear, Octarine). Used by plan + annotate servers. */
+/** Save to external note apps. Used by plan + annotate servers. */
 export async function handleSaveNotes(req: Request): Promise<Response> {
-  const results: { obsidian?: IntegrationResult; bear?: IntegrationResult; octarine?: IntegrationResult } = {};
+  const results: { obsidian?: IntegrationResult; bear?: IntegrationResult; octarine?: IntegrationResult; notion?: IntegrationResult } = {};
 
   try {
     const body = (await req.json()) as {
       obsidian?: ObsidianConfig;
       bear?: BearConfig;
       octarine?: OctarineConfig;
+      notion?: NotionConfig;
     };
 
     const promises: Promise<void>[] = [];
@@ -248,6 +249,9 @@ export async function handleSaveNotes(req: Request): Promise<Response> {
     }
     if (body.octarine?.plan && body.octarine?.workspace) {
       promises.push(saveToOctarine(body.octarine).then(r => { results.octarine = r; }));
+    }
+    if (body.notion?.plan && body.notion?.parentPageId) {
+      promises.push(saveToNotion(body.notion).then(r => { results.notion = r; }));
     }
     await Promise.allSettled(promises);
 

--- a/packages/shared/integrations-common.ts
+++ b/packages/shared/integrations-common.ts
@@ -23,10 +23,16 @@ export interface OctarineConfig {
 	folder: string;
 }
 
+export interface NotionConfig {
+	plan: string;
+	parentPageId: string;
+}
+
 export interface IntegrationResult {
 	success: boolean;
 	error?: string;
 	path?: string;
+	url?: string;
 }
 
 /**

--- a/packages/ui/components/ExportModal.tsx
+++ b/packages/ui/components/ExportModal.tsx
@@ -10,6 +10,7 @@ import React, { useState, useEffect } from 'react';
 import { getObsidianSettings, getEffectiveVaultPath } from '../utils/obsidian';
 import { getBearSettings } from '../utils/bear';
 import { getOctarineSettings } from '../utils/octarine';
+import { getNotionSettings, normalizeNotionPageId } from '../utils/notion';
 import { wrapFeedbackForAgent } from '../utils/parser';
 import { OverlayScrollArea } from './OverlayScrollArea';
 
@@ -18,11 +19,12 @@ interface SaveToNotesPayload {
   obsidian?: object;
   bear?: object;
   octarine?: object;
+  notion?: object;
 }
 
 /** Parsed response from the notes endpoint. */
 interface SaveToNotesResult {
-  results?: Record<string, { success?: boolean; error?: string }>;
+  results?: Record<string, { success?: boolean; error?: string; url?: string }>;
 }
 
 /** Default save-to-notes wire: today's literal POST to /api/save-notes. */
@@ -61,7 +63,7 @@ interface ExportModalProps {
 
 type Tab = 'share' | 'annotations' | 'notes';
 
-type SaveTarget = 'obsidian' | 'bear' | 'octarine';
+type SaveTarget = 'obsidian' | 'bear' | 'octarine' | 'notion';
 type SaveStatus = 'idle' | 'saving' | 'success' | 'error';
 
 export const ExportModal: React.FC<ExportModalProps> = ({
@@ -85,8 +87,9 @@ export const ExportModal: React.FC<ExportModalProps> = ({
   const defaultTab = initialTab || (sharingEnabled ? 'share' : 'annotations');
   const [activeTab, setActiveTab] = useState<Tab>(defaultTab);
   const [copied, setCopied] = useState<'short' | 'full' | 'annotations' | false>(false);
-  const [saveStatus, setSaveStatus] = useState<Record<SaveTarget, SaveStatus>>({ obsidian: 'idle', bear: 'idle', octarine: 'idle' });
+  const [saveStatus, setSaveStatus] = useState<Record<SaveTarget, SaveStatus>>({ obsidian: 'idle', bear: 'idle', octarine: 'idle', notion: 'idle' });
   const [saveErrors, setSaveErrors] = useState<Record<string, string>>({});
+  const [savedUrls, setSavedUrls] = useState<Partial<Record<SaveTarget, string>>>({});
 
   // Reset tab when modal opens
   useEffect(() => {
@@ -98,8 +101,9 @@ export const ExportModal: React.FC<ExportModalProps> = ({
   // Reset save status when modal opens
   useEffect(() => {
     if (isOpen) {
-      setSaveStatus({ obsidian: 'idle', bear: 'idle', octarine: 'idle' });
+      setSaveStatus({ obsidian: 'idle', bear: 'idle', octarine: 'idle', notion: 'idle' });
       setSaveErrors({});
+      setSavedUrls({});
     }
   }, [isOpen]);
 
@@ -109,10 +113,13 @@ export const ExportModal: React.FC<ExportModalProps> = ({
   const obsidianSettings = getObsidianSettings();
   const bearSettings = getBearSettings();
   const octarineSettings = getOctarineSettings();
+  const notionSettings = getNotionSettings();
   const effectiveVaultPath = getEffectiveVaultPath(obsidianSettings);
   const isObsidianReady = obsidianSettings.enabled && effectiveVaultPath.trim().length > 0;
   const isBearReady = bearSettings.enabled;
   const isOctarineReady = octarineSettings.enabled && octarineSettings.workspace.trim().length > 0;
+  const notionParentPageId = normalizeNotionPageId(notionSettings.parentPageId);
+  const isNotionReady = notionSettings.enabled && notionParentPageId !== null;
 
   const handleCopy = async (text: string, which: 'short' | 'full' | 'annotations') => {
     try {
@@ -149,7 +156,7 @@ export const ExportModal: React.FC<ExportModalProps> = ({
     setSaveStatus(prev => ({ ...prev, [target]: 'saving' }));
     setSaveErrors(prev => { const next = { ...prev }; delete next[target]; return next; });
 
-    const body: { obsidian?: object; bear?: object; octarine?: object } = {};
+    const body: { obsidian?: object; bear?: object; octarine?: object; notion?: object } = {};
 
     if (target === 'obsidian') {
       body.obsidian = {
@@ -170,6 +177,9 @@ export const ExportModal: React.FC<ExportModalProps> = ({
         folder: octarineSettings.folder || 'plannotator',
       };
     }
+    if (target === 'notion' && notionParentPageId) {
+      body.notion = { plan: markdown, parentPageId: notionParentPageId };
+    }
 
     try {
       const data = await onSaveToNotes(body);
@@ -177,6 +187,7 @@ export const ExportModal: React.FC<ExportModalProps> = ({
 
       if (result?.success) {
         setSaveStatus(prev => ({ ...prev, [target]: 'success' }));
+        if (result.url) setSavedUrls(prev => ({ ...prev, [target]: result.url! }));
       } else {
         setSaveStatus(prev => ({ ...prev, [target]: 'error' }));
         setSaveErrors(prev => ({ ...prev, [target]: result?.error || 'Save failed' }));
@@ -192,10 +203,11 @@ export const ExportModal: React.FC<ExportModalProps> = ({
     if (isObsidianReady) targets.push('obsidian');
     if (isBearReady) targets.push('bear');
     if (isOctarineReady) targets.push('octarine');
+    if (isNotionReady) targets.push('notion');
     await Promise.all(targets.map(t => handleSaveToNotes(t)));
   };
 
-  const readyCount = [isObsidianReady, isBearReady, isOctarineReady].filter(Boolean).length;
+  const readyCount = [isObsidianReady, isBearReady, isOctarineReady, isNotionReady].filter(Boolean).length;
 
   // Determine which tabs to show
   const showTabs = sharingEnabled || showNotesTab;
@@ -521,12 +533,67 @@ export const ExportModal: React.FC<ExportModalProps> = ({
                 )}
               </div>
 
+              {/* Notion */}
+              <div className="border border-border rounded-lg p-3 space-y-2">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className={`w-2 h-2 rounded-full ${isNotionReady ? 'bg-success' : 'bg-muted-foreground/30'}`} />
+                    <span className="text-sm font-medium">Notion</span>
+                  </div>
+                  {isNotionReady ? (
+                    <button
+                      onClick={() => handleSaveToNotes('notion')}
+                      disabled={saveStatus.notion === 'saving'}
+                      className={`px-3 py-1 rounded-md text-xs font-medium transition-all ${
+                        saveStatus.notion === 'success'
+                          ? 'bg-success/15 text-success'
+                          : saveStatus.notion === 'error'
+                            ? 'bg-destructive/15 text-destructive'
+                            : saveStatus.notion === 'saving'
+                              ? 'bg-muted text-muted-foreground opacity-50'
+                              : 'bg-primary text-primary-foreground hover:opacity-90'
+                      }`}
+                    >
+                      {saveStatus.notion === 'saving' ? 'Saving...'
+                        : saveStatus.notion === 'success' ? 'Saved'
+                        : saveStatus.notion === 'error' ? 'Failed'
+                        : 'Save'}
+                    </button>
+                  ) : (
+                    <span className="text-xs text-muted-foreground">Not configured</span>
+                  )}
+                </div>
+                {isNotionReady && (
+                  <div className="text-[10px] text-muted-foreground/70">
+                    Parent page: {notionParentPageId}
+                  </div>
+                )}
+                {savedUrls.notion && (
+                  <a
+                    href={savedUrls.notion}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="block text-[10px] text-primary hover:underline truncate"
+                  >
+                    Open saved page
+                  </a>
+                )}
+                {!isNotionReady && (
+                  <div className="text-[10px] text-muted-foreground/70">
+                    Enable in Settings &gt; Saving &gt; Notion
+                  </div>
+                )}
+                {saveErrors.notion && (
+                  <div className="text-[10px] text-destructive">{saveErrors.notion}</div>
+                )}
+              </div>
+
               {/* Save All button */}
               {readyCount >= 2 && (
                 <div className="flex justify-end">
                   <button
                     onClick={handleSaveAll}
-                    disabled={saveStatus.obsidian === 'saving' || saveStatus.bear === 'saving' || saveStatus.octarine === 'saving'}
+                    disabled={saveStatus.obsidian === 'saving' || saveStatus.bear === 'saving' || saveStatus.octarine === 'saving' || saveStatus.notion === 'saving'}
                     className="px-3 py-1.5 rounded-md text-xs font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity disabled:opacity-50"
                   >
                     Save All

--- a/packages/ui/components/PlanHeaderMenu.tsx
+++ b/packages/ui/components/PlanHeaderMenu.tsx
@@ -29,12 +29,14 @@ interface PlanHeaderMenuProps {
   onSaveToObsidian: () => void;
   onSaveToBear: () => void;
   onSaveToOctarine: () => void;
+  onSaveToNotion: () => void;
   sharingEnabled: boolean;
   isApiMode: boolean;
   agentInstructionsEnabled: boolean;
   obsidianConfigured: boolean;
   bearConfigured: boolean;
   octarineConfigured: boolean;
+  notionConfigured: boolean;
 }
 
 export const PlanHeaderMenu: React.FC<PlanHeaderMenuProps> = ({
@@ -52,19 +54,21 @@ export const PlanHeaderMenu: React.FC<PlanHeaderMenuProps> = ({
   onSaveToObsidian,
   onSaveToBear,
   onSaveToOctarine,
+  onSaveToNotion,
   sharingEnabled,
   isApiMode,
   agentInstructionsEnabled,
   obsidianConfigured,
   bearConfigured,
   octarineConfigured,
+  notionConfigured,
 }) => {
   const { theme, setTheme, colorTheme } = useTheme();
 
   const showUpdateDot = !!updateInfo?.updateAvailable && !updateInfo.dismissed;
 
   const anyNotesAppConfigured =
-    isApiMode && (obsidianConfigured || bearConfigured || octarineConfigured);
+    isApiMode && (obsidianConfigured || bearConfigured || octarineConfigured || notionConfigured);
 
   return (
     <ActionMenu
@@ -231,6 +235,16 @@ export const PlanHeaderMenu: React.FC<PlanHeaderMenuProps> = ({
                   }}
                   icon={<NoteIcon />}
                   label="Save to Octarine"
+                />
+              )}
+              {notionConfigured && (
+                <ActionMenuItem
+                  onClick={() => {
+                    closeMenu();
+                    onSaveToNotion();
+                  }}
+                  icon={<NoteIcon />}
+                  label="Save to Notion"
                 />
               )}
             </>

--- a/packages/ui/components/Settings.tsx
+++ b/packages/ui/components/Settings.tsx
@@ -27,6 +27,12 @@ import {
   type OctarineSettings,
 } from '../utils/octarine';
 import {
+  getNotionSettings,
+  saveNotionSettings,
+  normalizeNotionPageId,
+  type NotionSettings,
+} from '../utils/notion';
+import {
   getAgentSwitchSettings,
   saveAgentSwitchSettings,
   AGENT_OPTIONS,
@@ -71,7 +77,7 @@ import {
   type FileBrowserSettings,
 } from '../utils/fileBrowser';
 
-type SettingsTab = 'general' | 'theme' | 'git' | 'display' | 'saving' | 'labels' | 'shortcuts' | 'ai' | 'files' | 'obsidian' | 'bear' | 'octarine' | 'comments' | 'hooks';
+type SettingsTab = 'general' | 'theme' | 'git' | 'display' | 'saving' | 'labels' | 'shortcuts' | 'ai' | 'files' | 'obsidian' | 'bear' | 'octarine' | 'notion' | 'comments' | 'hooks';
 
 interface SettingsProps {
   taterMode: boolean;
@@ -678,6 +684,7 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
   const [vaultsLoading, setVaultsLoading] = useState(false);
   const [bear, setBear] = useState<BearSettings>({ enabled: false, customTags: '', tagPosition: 'append', autoSave: false });
   const [octarine, setOctarine] = useState<OctarineSettings>({ enabled: false, workspace: '', folder: 'plannotator', autoSave: false });
+  const [notion, setNotion] = useState<NotionSettings>({ enabled: false, parentPageId: '', autoSave: false });
   const [agent, setAgent] = useState<AgentSwitchSettings>({ switchTo: 'build' });
   const [planSave, setPlanSave] = useState<PlanSaveSettings>({ enabled: true, customPath: null });
   const [uiPrefs, setUiPrefs] = useState<UIPreferences>({ tocEnabled: true, stickyActionsEnabled: true, planWidth: 'compact' });
@@ -721,12 +728,13 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
   const integrationTabs: { id: SettingsTab; label: string }[] = [
     { id: 'files', label: 'Files' },
     ...(mode === 'plan'
-      ? [{ id: 'obsidian' as SettingsTab, label: 'Obsidian' }, { id: 'bear' as SettingsTab, label: 'Bear' }, { id: 'octarine' as SettingsTab, label: 'Octarine' }]
+      ? [{ id: 'obsidian' as SettingsTab, label: 'Obsidian' }, { id: 'bear' as SettingsTab, label: 'Bear' }, { id: 'octarine' as SettingsTab, label: 'Octarine' }, { id: 'notion' as SettingsTab, label: 'Notion' }]
       : []),
   ];
   const obsidianDefaultSaveAvailable = obsidian.enabled && getEffectiveVaultPath(obsidian).trim().length > 0;
   const bearDefaultSaveAvailable = bear.enabled;
   const octarineDefaultSaveAvailable = octarine.enabled && octarine.workspace.trim().length > 0;
+  const notionDefaultSaveAvailable = notion.enabled && normalizeNotionPageId(notion.parentPageId) !== null;
 
   // Sync external open state
   useEffect(() => {
@@ -742,6 +750,7 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
       setObsidian(getObsidianSettings());
       setBear(getBearSettings());
       setOctarine(getOctarineSettings());
+      setNotion(getNotionSettings());
       setAgent(getAgentSwitchSettings());
       setPlanSave(getPlanSaveSettings());
       setUiPrefs(getUIPreferences());
@@ -768,7 +777,8 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
       defaultNotesApp === 'download' ||
       (defaultNotesApp === 'obsidian' && obsidianDefaultSaveAvailable) ||
       (defaultNotesApp === 'bear' && bearDefaultSaveAvailable) ||
-      (defaultNotesApp === 'octarine' && octarineDefaultSaveAvailable);
+      (defaultNotesApp === 'octarine' && octarineDefaultSaveAvailable) ||
+      (defaultNotesApp === 'notion' && notionDefaultSaveAvailable);
 
     if (!defaultSaveAvailable) {
       setDefaultNotesApp('ask');
@@ -780,6 +790,7 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
     obsidianDefaultSaveAvailable,
     bearDefaultSaveAvailable,
     octarineDefaultSaveAvailable,
+    notionDefaultSaveAvailable,
   ]);
 
   // Fetch detected vaults when Obsidian is enabled
@@ -834,6 +845,12 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
     const newSettings = { ...octarine, ...updates };
     setOctarine(newSettings);
     saveOctarineSettings(newSettings);
+  };
+
+  const handleNotionChange = (updates: Partial<NotionSettings>) => {
+    const newSettings = { ...notion, ...updates };
+    setNotion(newSettings);
+    saveNotionSettings(newSettings);
   };
 
   const handleAgentChange = (switchTo: AgentSwitchSettings['switchTo'], customName?: string) => {
@@ -1463,13 +1480,14 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
                         {obsidianDefaultSaveAvailable && <option value="obsidian">Obsidian</option>}
                         {bearDefaultSaveAvailable && <option value="bear">Bear</option>}
                         {octarineDefaultSaveAvailable && <option value="octarine">Octarine</option>}
+                        {notionDefaultSaveAvailable && <option value="notion">Notion</option>}
                       </select>
                       <div className="text-[10px] text-muted-foreground/70">
                         {defaultNotesApp === 'ask'
                           ? 'Opens Export dialog with Notes tab'
                           : defaultNotesApp === 'download'
                             ? `${modKey}+S downloads the annotations file`
-                            : `${modKey}+S saves directly to ${{ obsidian: 'Obsidian', bear: 'Bear', octarine: 'Octarine' }[defaultNotesApp] ?? defaultNotesApp}`}
+                            : `${modKey}+S saves directly to ${{ obsidian: 'Obsidian', bear: 'Bear', octarine: 'Octarine', notion: 'Notion' }[defaultNotesApp] ?? defaultNotesApp}`}
                       </div>
                     </div>
 
@@ -2177,6 +2195,66 @@ tags: [plan, ...]
                             <span className={`inline-block h-4 w-4 transform rounded-full bg-white shadow-sm transition-transform ${
                               octarine.autoSave ? 'translate-x-6' : 'translate-x-1'
                             }`} />
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </>
+                )}
+
+                {/* === NOTION TAB === */}
+                {activeTab === 'notion' && (
+                  <>
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <div className="text-sm font-medium">Notion</div>
+                        <div className="text-xs text-muted-foreground">Save plans as child pages in Notion</div>
+                      </div>
+                      <button
+                        role="switch"
+                        aria-checked={notion.enabled}
+                        onClick={() => handleNotionChange({ enabled: !notion.enabled })}
+                        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${notion.enabled ? 'bg-primary' : 'bg-muted'}`}
+                      >
+                        <span className={`inline-block h-4 w-4 transform rounded-full bg-white shadow-sm transition-transform ${notion.enabled ? 'translate-x-6' : 'translate-x-1'}`} />
+                      </button>
+                    </div>
+                    {notion.enabled && (
+                      <div className="mt-3 space-y-3">
+                        <div className="space-y-1.5">
+                          <label className="text-xs text-muted-foreground">Parent Page URL or ID</label>
+                          <input
+                            type="text"
+                            value={notion.parentPageId}
+                            onChange={(e) => handleNotionChange({ parentPageId: e.target.value })}
+                            onBlur={(e) => {
+                              const parentPageId = normalizeNotionPageId(e.target.value);
+                              if (parentPageId) handleNotionChange({ parentPageId });
+                            }}
+                            placeholder="https://www.notion.so/..."
+                            className="w-full px-3 py-2 bg-muted rounded-lg text-xs font-mono placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-primary/50"
+                          />
+                          <div className="text-[10px] text-muted-foreground">
+                            Share this parent page with your Notion integration before exporting.
+                          </div>
+                        </div>
+                        <div className="rounded-lg bg-muted/50 p-3 text-[10px] text-muted-foreground space-y-1">
+                          <div>Set <code>NOTION_TOKEN</code> in the environment that starts Plannotator.</div>
+                          <div>The token is never stored in Plannotator settings or sent by your browser.</div>
+                        </div>
+                        <div className="border-t border-border/30" />
+                        <div className="flex items-center justify-between">
+                          <div>
+                            <div className="text-xs font-medium">Auto-save on Plan Arrival</div>
+                            <div className="text-[10px] text-muted-foreground">Automatically create a Notion page when a plan loads, before you approve or deny.</div>
+                          </div>
+                          <button
+                            role="switch"
+                            aria-checked={notion.autoSave}
+                            onClick={() => handleNotionChange({ autoSave: !notion.autoSave })}
+                            className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${notion.autoSave ? 'bg-primary' : 'bg-muted'}`}
+                          >
+                            <span className={`inline-block h-4 w-4 transform rounded-full bg-white shadow-sm transition-transform ${notion.autoSave ? 'translate-x-6' : 'translate-x-1'}`} />
                           </button>
                         </div>
                       </div>

--- a/packages/ui/utils/defaultNotesApp.ts
+++ b/packages/ui/utils/defaultNotesApp.ts
@@ -9,7 +9,7 @@ import { storage } from './storage';
 
 const STORAGE_KEY = 'plannotator-default-notes-app';
 
-export type DefaultNotesApp = 'obsidian' | 'bear' | 'octarine' | 'download' | 'ask';
+export type DefaultNotesApp = 'obsidian' | 'bear' | 'octarine' | 'notion' | 'download' | 'ask';
 
 export function getDefaultNotesApp(): DefaultNotesApp {
   return (storage.getItem(STORAGE_KEY) as DefaultNotesApp) || 'ask';

--- a/packages/ui/utils/notion.test.ts
+++ b/packages/ui/utils/notion.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'bun:test';
+import { normalizeNotionPageId } from './notion';
+
+describe('normalizeNotionPageId', () => {
+  test('normalizes a compact page ID', () => {
+    expect(normalizeNotionPageId('0123456789abcdef0123456789abcdef')).toBe('01234567-89ab-cdef-0123-456789abcdef');
+  });
+
+  test('extracts a page ID from a Notion URL', () => {
+    expect(normalizeNotionPageId('https://www.notion.so/My-page-0123456789abcdef0123456789abcdef')).toBe('01234567-89ab-cdef-0123-456789abcdef');
+  });
+
+  test('rejects values without a Notion page ID', () => {
+    expect(normalizeNotionPageId('not a page')).toBeNull();
+  });
+});

--- a/packages/ui/utils/notion.ts
+++ b/packages/ui/utils/notion.ts
@@ -1,0 +1,38 @@
+import { storage } from './storage';
+
+const STORAGE_KEY_ENABLED = 'plannotator-notion-enabled';
+const STORAGE_KEY_PARENT_PAGE_ID = 'plannotator-notion-parent-page-id';
+const STORAGE_KEY_AUTOSAVE = 'plannotator-notion-autosave';
+
+export interface NotionSettings {
+  enabled: boolean;
+  parentPageId: string;
+  autoSave: boolean;
+}
+
+/** Extract and normalize a Notion page UUID from either an ID or a page URL. */
+export function normalizeNotionPageId(value: string): string | null {
+  const match = value.trim().match(/[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}/i);
+  if (!match) return null;
+  const compact = match[0].replace(/-/g, '').toLowerCase();
+  return `${compact.slice(0, 8)}-${compact.slice(8, 12)}-${compact.slice(12, 16)}-${compact.slice(16, 20)}-${compact.slice(20)}`;
+}
+
+export function getNotionSettings(): NotionSettings {
+  return {
+    enabled: storage.getItem(STORAGE_KEY_ENABLED) === 'true',
+    parentPageId: storage.getItem(STORAGE_KEY_PARENT_PAGE_ID) ?? '',
+    autoSave: storage.getItem(STORAGE_KEY_AUTOSAVE) === 'true',
+  };
+}
+
+export function saveNotionSettings(settings: NotionSettings): void {
+  storage.setItem(STORAGE_KEY_ENABLED, String(settings.enabled));
+  storage.setItem(STORAGE_KEY_PARENT_PAGE_ID, settings.parentPageId);
+  storage.setItem(STORAGE_KEY_AUTOSAVE, String(settings.autoSave));
+}
+
+export function isNotionConfigured(): boolean {
+  const settings = getNotionSettings();
+  return settings.enabled && normalizeNotionPageId(settings.parentPageId) !== null;
+}


### PR DESCRIPTION
## Summary

Closes #434.

Adds Notion as a fourth note destination alongside Obsidian, Bear, and Octarine. A plan can be saved to Notion on approval, on arrival (auto-save), from the Export > Notes modal, from the header menu, and via the `Cmd/Ctrl+S` default action.

Each export creates a child page under a chosen parent page (`POST /v1/pages`), using the plan's first H1 as the title and the plan body as Notion-flavored Markdown.

## Authentication

Notion differs from the existing integrations: Obsidian writes a local file, Bear/Octarine open a URI scheme, but Notion needs an authenticated HTTPS API.

To keep this a self-hostable, single-PR feature with no new infrastructure, the integration uses a **local Notion integration token** read only from `NOTION_TOKEN` in the server process environment:

- The token is never stored in cookies, sent from the browser, or included in any API response, snapshot, or log.
- The UI persists only non-secret settings (enable flag, parent page id/URL, auto-save).
- It works the same across Claude Code, OpenCode, and Pi as long as the process inherits `NOTION_TOKEN`.

A public OAuth flow would require a hosted callback, encrypted refresh-token storage, and a client secret that can't ship in a local plugin — that's a separate follow-up, not this PR.

## Setup

1. Create an internal integration (or PAT) in the Notion developer portal, with Insert Content capability.
2. Share the parent page with that integration.
3. Start Plannotator with `NOTION_TOKEN` set.
4. In Settings > Notion, enable it and paste the parent page URL or ID.

## Changes

- **shared**: `NotionConfig` type + optional `url` on `IntegrationResult`.
- **server (Bun + Pi)**: `saveToNotion`, wired into `/api/save-notes` and the approve path with the same `Promise.allSettled` isolation (an integration failure never blocks approval). Both runtimes updated per AGENTS.md.
- **ui**: `notion` settings util, Settings tab, ExportModal card, header menu action, and the three `App.tsx` export triggers. Duplicate-page gating on approve mirrors Bear (Notion creates a new page per call).
- **tests**: Notion request shape + token-safety, dispatcher isolation, and page-id/URL parsing.
- **docs**: Notion integration guide + README and API-endpoint updates.

## Testing

- `bun test packages/server/integrations.test.ts packages/server/shared-handlers.test.ts packages/ui/utils/notion.test.ts` (49 pass)
- `bun run typecheck` (all packages, incl. Pi vendoring)
- `bun run --cwd apps/review build` and `bun run build:hook`
- `git diff --check`

## Notes

- Scope is a child page under an existing page. Creating rows in a Notion database (data source) has its own schema/field-mapping concerns and is intentionally left as a follow-up.
- Plannotator-specific Markdown extensions may render with reduced fidelity in Notion; documented in the guide.