### PR TITLE
fix(review): remove automatic platform attribution

### DIFF
--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -60,7 +60,13 @@ import { useAnnotationFactory } from './hooks/useAnnotationFactory';
 import { DEMO_DIFF } from './demoData';
 import { exportReviewFeedback, buildProseFeedback, commitShaFromMode } from './utils/exportFeedback';
 import { parseDiffToFiles } from './utils/diffParser';
-import { ReviewSubmissionDialog, buildReviewSubmission, type ReviewSubmission, type SubmissionTarget } from './components/ReviewSubmissionDialog';
+import {
+  ReviewSubmissionDialog,
+  buildPlatformReviewBody,
+  buildReviewSubmission,
+  type ReviewSubmission,
+  type SubmissionTarget,
+} from './components/ReviewSubmissionDialog';
 import { ReviewStateProvider, type ReviewState } from './dock/ReviewStateContext';
 import { JobLogsProvider } from './dock/JobLogsContext';
 import { reviewPanelComponents } from './dock/reviewPanelComponents';
@@ -2458,13 +2464,14 @@ const ReviewApp: React.FC = () => {
     setPlatformActionError(null);
 
     try {
-      const bodyForTarget = (target: SubmissionTarget) => {
-        const parts: string[] = [];
-        if (generalComment) parts.push(generalComment);
-        parts.push('Review from Plannotator');
-        if (target.fileScopedBody) parts.push(target.fileScopedBody);
-        return parts.join('\n\n');
-      };
+      if (!prMetadata) throw new Error('PR metadata unavailable');
+
+      const bodyForTarget = (target: SubmissionTarget) => buildPlatformReviewBody(
+        action,
+        prMetadata.platform,
+        generalComment,
+        target,
+      );
 
       // For approve, only post to the currently viewed PR.
       // For comment with no targets but a general comment, create a minimal target.

--- a/packages/review-editor/components/ReviewSubmissionDialog.test.ts
+++ b/packages/review-editor/components/ReviewSubmissionDialog.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  buildPlatformReviewBody,
+  type SubmissionTarget,
+} from './ReviewSubmissionDialog';
+
+const inlineComment: SubmissionTarget['fileComments'][number] = {
+  path: 'src/example.ts',
+  line: 12,
+  side: 'RIGHT',
+  body: 'Handle the error here.',
+};
+
+describe('buildPlatformReviewBody', () => {
+  test('contains only user-authored top-level feedback when present', () => {
+    expect(buildPlatformReviewBody('comment', 'github', 'Overall feedback', {
+      fileComments: [inlineComment],
+      fileScopedBody: '**src/example.ts:** File-level feedback',
+    })).toBe('Overall feedback\n\n**src/example.ts:** File-level feedback');
+  });
+
+  test('uses a neutral GitHub body for an inline-only comment review', () => {
+    expect(buildPlatformReviewBody('comment', 'github', '   ', {
+      fileComments: [inlineComment],
+      fileScopedBody: '',
+    })).toBe('See inline comments.');
+  });
+
+  test('does not manufacture a GitLab note for inline-only comments', () => {
+    expect(buildPlatformReviewBody('comment', 'gitlab', undefined, {
+      fileComments: [inlineComment],
+      fileScopedBody: '',
+    })).toBe('');
+  });
+
+  test('does not manufacture an approval body', () => {
+    expect(buildPlatformReviewBody('approve', 'github', undefined, {
+      fileComments: [inlineComment],
+      fileScopedBody: '',
+    })).toBe('');
+  });
+});

--- a/packages/review-editor/components/ReviewSubmissionDialog.tsx
+++ b/packages/review-editor/components/ReviewSubmissionDialog.tsx
@@ -38,6 +38,8 @@ export interface ReviewSubmission {
   orphans: OrphanedFindings[];
 }
 
+type ReviewPlatform = 'github' | 'gitlab';
+
 interface ReviewSubmissionDialogProps {
   isOpen: boolean;
   action: 'approve' | 'comment';
@@ -92,6 +94,28 @@ function buildFileScopedBody(annotations: CodeAnnotation[]): string {
     else if (scope === 'general' && a.text) parts.push(a.text);
   }
   return parts.join('\n\n');
+}
+
+/**
+ * Build the top-level review body without adding product attribution.
+ * GitHub requires a body for COMMENT reviews, so an inline-only review gets a
+ * neutral pointer. Approvals and GitLab discussions can remain bodyless.
+ */
+export function buildPlatformReviewBody(
+  action: 'approve' | 'comment',
+  platform: ReviewPlatform,
+  generalComment: string | undefined,
+  target: Pick<SubmissionTarget, 'fileComments' | 'fileScopedBody'>,
+): string {
+  const parts: string[] = [];
+  if (generalComment?.trim()) parts.push(generalComment);
+  if (target.fileScopedBody.trim()) parts.push(target.fileScopedBody);
+
+  if (parts.length > 0) return parts.join('\n\n');
+  if (action === 'comment' && platform === 'github' && target.fileComments.length > 0) {
+    return 'See inline comments.';
+  }
+  return '';
 }
 
 export function buildReviewSubmission(


### PR DESCRIPTION
## Summary

- Remove the automatic “Review from Plannotator” text from GitHub and GitLab reviews.
- Preserve user-authored general and file-scoped feedback unchanged.
- Use the neutral “See inline comments.” only when GitHub requires a top-level body for an inline-only COMMENT review.
- Keep bodyless approvals and GitLab inline-only discussions silent.

This supersedes #1026 with the simpler product direction discussed there. Thank you @leoreisdias for raising the behavior; the implementation commit includes Leonardo as a co-author.

## Validation

- bun test packages/review-editor
- bun run typecheck
- bun run build:review
- bun run build:hook