### PR TITLE
fix(opencode): preserve planning handoff

### DIFF
--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -44,6 +44,7 @@ import {
   shouldModifyPrompts,
   shouldRegisterSubmitPlan,
   shouldRejectSubmitPlanForAgent,
+  shouldStartImplementationForAgent,
   type RuntimeMode,
   type PlannotatorOpenCodeOptions,
 } from "./workflow";
@@ -659,6 +660,8 @@ Use /plannotator-last or /plannotator-annotate for manual review, or set workflo
 
             const shouldSwitchAgent = result.agentSwitch && result.agentSwitch !== 'disabled';
             const targetAgent = result.agentSwitch || 'build';
+            const shouldStartImplementation = shouldSwitchAgent
+              && shouldStartImplementationForAgent(targetAgent, workflowOptions);
 
             if (shouldSwitchAgent) {
               try {
@@ -667,7 +670,12 @@ Use /plannotator-last or /plannotator-annotate for manual review, or set workflo
                   body: {
                     agent: targetAgent,
                     noReply: true,
-                    parts: [{ type: "text", text: "Proceed with implementation" }],
+                    parts: [{
+                      type: "text",
+                      text: shouldStartImplementation
+                        ? "Proceed with implementation"
+                        : "Plan approved. Plan mode remains active; no implementation has been requested.",
+                    }],
                   },
                 });
               } catch {
@@ -680,7 +688,7 @@ Use /plannotator-last or /plannotator-annotate for manual review, or set workflo
                 planFilePath: backingPath,
                 doneMsg: result.savedPath ? `Saved to: ${result.savedPath}` : "",
                 feedback: result.feedback,
-                proceedSuffix: shouldSwitchAgent
+                proceedSuffix: shouldStartImplementation
                   ? "\n\nProceed with implementation, incorporating these notes where applicable."
                   : "",
               });

--- a/apps/opencode-plugin/workflow.test.ts
+++ b/apps/opencode-plugin/workflow.test.ts
@@ -8,6 +8,7 @@ import {
   shouldModifyPrompts,
   shouldRegisterSubmitPlan,
   shouldRejectSubmitPlanForAgent,
+  shouldStartImplementationForAgent,
 } from "./workflow";
 
 describe("normalizeWorkflowOptions", () => {
@@ -102,6 +103,19 @@ describe("workflow gates", () => {
     expect(shouldRejectSubmitPlanForAgent("build", planAgent)).toBe(true);
     expect(shouldRejectSubmitPlanForAgent(undefined, planAgent)).toBe(true);
     expect(shouldRejectSubmitPlanForAgent("build", allAgents)).toBe(false);
+  });
+
+  test("starts implementation only for non-planning handoff targets", () => {
+    const defaultOptions = normalizeWorkflowOptions({ workflow: "plan-agent" });
+    const customPlannerOptions = normalizeWorkflowOptions({
+      workflow: "plan-agent",
+      planningAgents: ["planner"],
+    });
+
+    expect(shouldStartImplementationForAgent("build", defaultOptions)).toBe(true);
+    expect(shouldStartImplementationForAgent("reviewer", defaultOptions)).toBe(true);
+    expect(shouldStartImplementationForAgent("plan", defaultOptions)).toBe(false);
+    expect(shouldStartImplementationForAgent("planner", customPlannerOptions)).toBe(false);
   });
 });
 

--- a/apps/opencode-plugin/workflow.ts
+++ b/apps/opencode-plugin/workflow.ts
@@ -106,6 +106,14 @@ export function isPlanningAgent(
   return !!agentName && options.planningAgentSet.has(agentName);
 }
 
+/** A planning agent reviews plans; only non-planning agents receive an implementation handoff. */
+export function shouldStartImplementationForAgent(
+  agentName: string | undefined,
+  options: NormalizedWorkflowOptions,
+): boolean {
+  return !!agentName && !isPlanningAgent(agentName, options);
+}
+
 export function shouldRegisterSubmitPlan(options: NormalizedWorkflowOptions): boolean {
   return options.workflow !== "manual";
 }


### PR DESCRIPTION
## Summary

- Prevent the OpenCode `plan` agent and configured planning agents from receiving the `Proceed with implementation` handoff after plan approval.
- Keep the implementation handoff unchanged for `build` and other non-planning agents.
- Emit a visible status message when approval targets a planning agent:

  `Plan approved. Plan mode remains active; no implementation has been requested.`

## Related issues

Regression from #648: the agent picker correctly removed the implementation directive for `No switch`, but selecting `plan` still injected `Proceed with implementation`.

#648 also addressed #159, which requested approval without automatically starting implementation. This change preserves that behavior when the selected target is a planning agent.

## Changes

| File | Change |
| --- | --- |
| `apps/opencode-plugin/workflow.ts` | Adds a planning-target predicate for implementation handoffs. |
| `apps/opencode-plugin/index.ts` | Sends the implementation prompt only to non-planning agents; planning agents receive a non-executing status message instead. |
| `apps/opencode-plugin/workflow.test.ts` | Covers `build`, `plan`, custom planning agents, and regular non-planning agents. |

## Test plan

- [x] `bun test apps/opencode-plugin`
- [x] `bun run build:opencode`
- [x] Manual: selecting `plan` keeps plan mode active and displays the status message.
- [x] Manual: selecting `build` still sends `Proceed with implementation`.