### PR TITLE
fix(ai): swallow async EPIPE on codex app-server stdin (crashes host)

### DIFF
--- a/packages/ai/providers/codex-app-server.ts
+++ b/packages/ai/providers/codex-app-server.ts
@@ -332,6 +332,10 @@ class CodexAppServerProcess {
     }
 
     this.proc = proc;
+    // Swallow async EPIPE on stdin — codex may close the pipe mid-write
+    // (e.g. incompatible app-server version). Without this listener the
+    // 'error' event escalates to uncaughtException and kills the host process.
+    proc.stdin?.on("error", () => {});
     proc.once("exit", () => {
       this.handleProcessEnd(new Error("Codex app-server exited unexpectedly"));
     });


### PR DESCRIPTION
Fixes #1039.

## Problem

Opening the plan-review page crashes the entire host process (`pi`) with an unhandled `write EPIPE` from the Codex app-server provider's `stdin`. The session dies mid tool-call.

```
Error: write EPIPE
    at CodexAppServerProcess.send (packages/ai/providers/codex-app-server.ts)
    at CodexAppServerProcess.sendAndWait
    at CodexAppServerProcess.doStart
    at CodexAppServerProvider.fetchModels
```

## Root cause

`createPiAIRuntime()` registers the Codex provider whenever `codex` is on `PATH` and eagerly calls `fetchModels()`, which spawns the app-server and writes `initialize` to its stdin. With an incompatible codex version (reproduced with codex-cli 0.22.0) the child closes its pipe end, so the write fails **asynchronously** with `EPIPE`. The spawned `stdin` has no `error` listener, so Node escalates the stream error to `uncaughtException` and kills the host.

The existing `.catch(() => {})` on `fetchModels()` does not cover this — the failure is an `'error'` event on the stdin stream, not a promise rejection.

## Fix

Attach a no-op `error` listener to the child's stdin right after spawn — a single choke point for every `send()` caller. The process still ends via the existing `exit`/timeout paths, `fetchModels()` rejects into the existing `.catch()`, and the host keeps running.

Verified locally: the same repro that produced the uncaught EPIPE now completes cleanly (all plan-review endpoints return 200).

## Note

`generated/` copies are build artifacts; this changes the `packages/` source only.