### PR TITLE
feat(server): support bounded port ranges

### DIFF
--- a/apps/marketing/src/content/docs/reference/environment-variables.md
+++ b/apps/marketing/src/content/docs/reference/environment-variables.md
@@ -13,7 +13,7 @@ All Plannotator environment variables and their defaults.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PLANNOTATOR_REMOTE` | auto-detect | Set to `1` or `true` to force remote mode, `0` or `false` to force local mode, or leave unset to auto-detect via `SSH_TTY` / `SSH_CONNECTION`. Uses a fixed port in remote mode; browser-opening behavior depends on the environment. |
-| `PLANNOTATOR_PORT` | random (local) / `19432` (remote) | Fixed server port. When not set, local sessions use a random port; remote sessions default to `19432`. |
+| `PLANNOTATOR_PORT` | random (local) / `19432` (remote) | Fixed server port or inclusive range such as `19432-19463`. A range uses the first available port. When not set, local sessions use a random port; remote sessions default to `19432`. |
 | `PLANNOTATOR_BROWSER` | system default | Custom browser to open the UI in. macOS: app name or path. Linux/Windows: executable path. Can also be a script. Takes priority over `BROWSER`. Also settable per-invocation with `--browser`. |
 | `BROWSER` | (none) | Standard env var for specifying a browser. VS Code sets this automatically in devcontainers. Used as fallback when `PLANNOTATOR_BROWSER` is not set. |
 | `PLANNOTATOR_ORIGIN` | auto-detect | Explicit agent-origin override. Valid values: `claude-code`, `amp`, `droid`, `opencode`, `codex`, `copilot-cli`, `pi`, `gemini-cli`, `kiro-cli`. Invalid values silently fall through to env-based detection. |
@@ -89,9 +89,11 @@ If either is present, Plannotator enables remote mode automatically when `PLANNO
 
 ## Port resolution order
 
-1. `PLANNOTATOR_PORT` environment variable (if valid integer 0-65535; `0` means random)
+1. `PLANNOTATOR_PORT` environment variable: one integer from `0` to `65535` (`0` means random), or an inclusive range such as `19432-19463`
 2. `19432` if in remote mode
 3. `0` (random) if in local mode
+
+For a range, Plannotator tries each port from lowest to highest and binds the first available one.
 
 ## Custom browser examples
 

--- a/apps/pi-extension/server/network.test.ts
+++ b/apps/pi-extension/server/network.test.ts
@@ -90,14 +90,14 @@ describe("pi remote detection", () => {
 });
 
 describe("pi port selection", () => {
-	test("uses random local port when false overrides SSH", () => {
+	test("PLANNOTATOR_PORT unset preserves the random local default", () => {
 		clearEnv();
 		process.env.PLANNOTATOR_REMOTE = "false";
 		process.env.SSH_TTY = "/dev/pts/0";
 		expect(getServerPort()).toEqual({ port: 0, portSource: "random" });
 	});
 
-	test("uses default remote port when SSH is detected", () => {
+	test("PLANNOTATOR_PORT unset preserves the 19432 remote default", () => {
 		clearEnv();
 		process.env.SSH_CONNECTION = "192.168.1.1 12345 192.168.1.2 22";
 		expect(getServerPort()).toEqual({ port: 19432, portSource: "remote-default" });
@@ -140,6 +140,16 @@ describe("pi port selection", () => {
 		}
 	});
 
+	test("a malformed range follows the existing remote default path", () => {
+		clearEnv();
+		process.env.PLANNOTATOR_REMOTE = "1";
+		process.env.PLANNOTATOR_PORT = "19432-19435garbage";
+		expect(getServerPorts()).toEqual({
+			ports: [19432],
+			portSource: "remote-default",
+		});
+	});
+
 	test("binds the next port when the range start is occupied", async () => {
 		clearEnv();
 		const { start, servers } = await occupyConsecutivePorts(2);
@@ -167,10 +177,25 @@ describe("pi port selection", () => {
 
 		try {
 			await expect(listenOnPort(server)).rejects.toThrow(
-				`Port selection ${start}-${start + 1} exhausted`,
+				new RegExp(`^Port selection ${start}-${start + 1} exhausted$`),
 			);
 		} finally {
 			await Promise.all(servers.map(closeServer));
+		}
+	});
+
+	test("treats a valid one-port range as range syntax", async () => {
+		clearEnv();
+		const { start, servers } = await occupyConsecutivePorts(1);
+		process.env.PLANNOTATOR_PORT = `${start}-${start}`;
+		const server = createServer();
+
+		try {
+			await expect(listenOnPort(server)).rejects.toThrow(
+				new RegExp(`^Port selection ${start}-${start} exhausted$`),
+			);
+		} finally {
+			await closeServer(servers[0]);
 		}
 	});
 
@@ -186,6 +211,25 @@ describe("pi port selection", () => {
 			expect(server.listenerCount("listening")).toBe(0);
 		} finally {
 			await Promise.all(servers.map(closeServer));
+		}
+	});
+});
+
+describe("pi non-range port compatibility", () => {
+	test("an occupied fixed port preserves the existing retry error", async () => {
+		clearEnv();
+		const { start, servers } = await occupyConsecutivePorts(1);
+		process.env.PLANNOTATOR_PORT = String(start);
+		const server = createServer();
+
+		try {
+			await expect(listenOnPort(server)).rejects.toThrow(
+				new RegExp(`^Port ${start} in use after 5 retries$`),
+			);
+			expect(server.listenerCount("error")).toBe(0);
+			expect(server.listenerCount("listening")).toBe(0);
+		} finally {
+			await closeServer(servers[0]);
 		}
 	});
 });

--- a/apps/pi-extension/server/network.test.ts
+++ b/apps/pi-extension/server/network.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { createServer } from "node:http";
 import {
 	getServerHostname,
 	getServerPort,
+	getServerPorts,
 	isNoOpBrowserSentinel,
 	isRemoteSession,
+	listenOnPort,
 	openBrowser,
 } from "./network";
 
@@ -105,6 +108,42 @@ describe("pi port selection", () => {
 		process.env.SSH_TTY = "/dev/pts/0";
 		process.env.PLANNOTATOR_PORT = "9999";
 		expect(getServerPort()).toEqual({ port: 9999, portSource: "env" });
+	});
+
+	test("expands an inclusive port range", () => {
+		clearEnv();
+		process.env.PLANNOTATOR_PORT = "19432-19435";
+		expect(getServerPorts()).toEqual({
+			ports: [19432, 19433, 19434, 19435],
+			portSource: "env",
+		});
+		expect(getServerPort()).toEqual({ port: 19432, portSource: "env" });
+	});
+
+	test("ignores reversed port ranges", () => {
+		clearEnv();
+		process.env.PLANNOTATOR_PORT = "19435-19432";
+		expect(getServerPorts()).toEqual({ ports: [0], portSource: "random" });
+	});
+
+	test("binds the next port when the range start is occupied", async () => {
+		clearEnv();
+		const blocker = createServer();
+		await new Promise<void>((resolve) => blocker.listen(0, "127.0.0.1", resolve));
+		const blockedPort = (blocker.address() as { port: number }).port;
+		expect(blockedPort).toBeLessThan(65535);
+
+		process.env.PLANNOTATOR_PORT = `${blockedPort}-${blockedPort + 1}`;
+		const server = createServer();
+		try {
+			expect(await listenOnPort(server)).toEqual({
+				port: blockedPort + 1,
+				portSource: "env",
+			});
+		} finally {
+			server.close();
+			blocker.close();
+		}
 	});
 });
 

--- a/apps/pi-extension/server/network.test.ts
+++ b/apps/pi-extension/server/network.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { createServer } from "node:http";
+import { closeServer, occupyConsecutivePorts } from "../../../tests/helpers/ports";
 import {
 	getServerHostname,
 	getServerPort,
@@ -126,23 +127,65 @@ describe("pi port selection", () => {
 		expect(getServerPorts()).toEqual({ ports: [0], portSource: "random" });
 	});
 
+	test("rejects malformed fixed ports and ranges without accepting numeric prefixes", () => {
+		clearEnv();
+		for (const value of [
+			"19432garbage",
+			"19432.5",
+			"19432-19435garbage",
+			"19432-19435-19436",
+		]) {
+			process.env.PLANNOTATOR_PORT = value;
+			expect(getServerPorts()).toEqual({ ports: [0], portSource: "random" });
+		}
+	});
+
 	test("binds the next port when the range start is occupied", async () => {
 		clearEnv();
-		const blocker = createServer();
-		await new Promise<void>((resolve) => blocker.listen(0, "127.0.0.1", resolve));
-		const blockedPort = (blocker.address() as { port: number }).port;
-		expect(blockedPort).toBeLessThan(65535);
-
-		process.env.PLANNOTATOR_PORT = `${blockedPort}-${blockedPort + 1}`;
+		const { start, servers } = await occupyConsecutivePorts(2);
+		await closeServer(servers[1]);
+		process.env.PLANNOTATOR_PORT = `${start}-${start + 1}`;
 		const server = createServer();
 		try {
 			expect(await listenOnPort(server)).toEqual({
-				port: blockedPort + 1,
+				port: start + 1,
 				portSource: "env",
 			});
+			expect(server.listenerCount("error")).toBe(0);
+			expect(server.listenerCount("listening")).toBe(0);
 		} finally {
-			server.close();
-			blocker.close();
+			await closeServer(server);
+			await closeServer(servers[0]);
+		}
+	});
+
+	test("reports an exhausted occupied range", async () => {
+		clearEnv();
+		const { start, servers } = await occupyConsecutivePorts(2);
+		process.env.PLANNOTATOR_PORT = `${start}-${start + 1}`;
+		const server = createServer();
+
+		try {
+			await expect(listenOnPort(server)).rejects.toThrow(
+				`Port selection ${start}-${start + 1} exhausted`,
+			);
+		} finally {
+			await Promise.all(servers.map(closeServer));
+		}
+	});
+
+	test("removes failed-attempt listeners across a long occupied range", async () => {
+		clearEnv();
+		const { start, servers } = await occupyConsecutivePorts(12);
+		process.env.PLANNOTATOR_PORT = `${start}-${start + servers.length - 1}`;
+		const server = createServer();
+
+		try {
+			await expect(listenOnPort(server)).rejects.toThrow("exhausted");
+			expect(server.listenerCount("error")).toBe(0);
+			expect(server.listenerCount("listening")).toBe(0);
+		} finally {
+			await Promise.all(servers.map(closeServer));
 		}
 	});
 });

--- a/apps/pi-extension/server/network.ts
+++ b/apps/pi-extension/server/network.ts
@@ -14,6 +14,13 @@ const DEFAULT_REMOTE_PORT = 19432;
 const LOOPBACK_HOST = "127.0.0.1";
 const NOOP_BROWSER_VALUES = new Set(["true", "false", "none", ":", "0", "1"]);
 
+function isAddressInUseError(err: unknown): boolean {
+	return err instanceof Error && (
+		(err as NodeJS.ErrnoException).code === "EADDRINUSE" ||
+		err.message.includes("EADDRINUSE")
+	);
+}
+
 export function isNoOpBrowserSentinel(value: string | undefined): boolean {
 	if (!value) return false;
 	return NOOP_BROWSER_VALUES.has(value.trim().toLowerCase());
@@ -53,28 +60,48 @@ export function isRemoteSession(): boolean {
 }
 
 /**
- * Get the server port to use.
- * - PLANNOTATOR_PORT env var takes precedence
+ * Get the server ports to try, in order.
+ * - PLANNOTATOR_PORT accepts a fixed port or inclusive range
  * - Remote sessions default to 19432 (for port forwarding)
- * - Local sessions use random port
- * Returns { port, portSource } so caller can notify user if needed.
+ * - Local sessions use a random port
  */
-export function getServerPort(): {
-	port: number;
+export function getServerPorts(): {
+	ports: number[];
 	portSource: "env" | "remote-default" | "random";
 } {
 	const envPort = process.env.PLANNOTATOR_PORT;
 	if (envPort) {
-		const parsed = parseInt(envPort, 10);
-		if (!Number.isNaN(parsed) && parsed >= 0 && parsed < 65536) {
-			return { port: parsed, portSource: "env" };
+		const value = envPort.trim();
+		const range = /^(\d+)-(\d+)$/.exec(value);
+		if (range) {
+			const start = Number(range[1]);
+			const end = Number(range[2]);
+			if (start >= 1 && end < 65536 && start <= end) {
+				return {
+					ports: Array.from({ length: end - start + 1 }, (_, index) => start + index),
+					portSource: "env",
+				};
+			}
+		} else {
+			const parsed = parseInt(value, 10);
+			if (!Number.isNaN(parsed) && parsed >= 0 && parsed < 65536) {
+				return { ports: [parsed], portSource: "env" };
+			}
 		}
 		// Invalid port - fall back silently, caller can check env var themselves
 	}
 	if (isRemoteSession()) {
-		return { port: DEFAULT_REMOTE_PORT, portSource: "remote-default" };
+		return { ports: [DEFAULT_REMOTE_PORT], portSource: "remote-default" };
 	}
-	return { port: 0, portSource: "random" };
+	return { ports: [0], portSource: "random" };
+}
+
+export function getServerPort(): {
+	port: number;
+	portSource: "env" | "remote-default" | "random";
+} {
+	const { ports, portSource } = getServerPorts();
+	return { port: ports[0], portSource };
 }
 
 export function getServerHostname(): string {
@@ -87,14 +114,15 @@ const RETRY_DELAY_MS = 500;
 export async function listenOnPort(
 	server: Server,
 ): Promise<{ port: number; portSource: "env" | "remote-default" | "random" }> {
-	const result = getServerPort();
+	const { ports, portSource } = getServerPorts();
+	const portsToTry = ports.length > 1 ? ports : Array(MAX_RETRIES).fill(ports[0]);
 
-	for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+	for (const [index, port] of portsToTry.entries()) {
 		try {
 			await new Promise<void>((resolve, reject) => {
 				server.once("error", reject);
 				server.listen(
-					result.port,
+					port,
 					getServerHostname(),
 					() => {
 						server.removeListener("error", reject);
@@ -103,21 +131,21 @@ export async function listenOnPort(
 				);
 			});
 			const addr = server.address() as { port: number };
-			return { port: addr.port, portSource: result.portSource };
+			return { port: addr.port, portSource };
 		} catch (err: unknown) {
-			const isAddressInUse =
-				err instanceof Error && err.message.includes("EADDRINUSE");
-			if (isAddressInUse && attempt < MAX_RETRIES) {
-				await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
+			const isAddressInUse = isAddressInUseError(err);
+			if (isAddressInUse && index < portsToTry.length - 1) {
+				if (ports.length === 1) {
+					await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
+				}
 				continue;
 			}
 			if (isAddressInUse) {
+				const configured = ports.length > 1 ? `${ports[0]}-${ports.at(-1)}` : String(port);
 				const hint = isRemoteSession()
-					? " (set PLANNOTATOR_PORT to use a different port)"
+					? " (set PLANNOTATOR_PORT to use a different port or range)"
 					: "";
-				throw new Error(
-					`Port ${result.port} in use after ${MAX_RETRIES} retries${hint}`,
-				);
+				throw new Error(`Port selection ${configured} exhausted${hint}`);
 			}
 			throw err;
 		}

--- a/apps/pi-extension/server/network.ts
+++ b/apps/pi-extension/server/network.ts
@@ -9,6 +9,7 @@ import type { Server } from "node:http";
 import { release } from "node:os";
 import { delimiter, join } from "node:path";
 import { loadConfig, resolveUseGlimpse } from "../generated/config.js";
+import { parsePortSelection } from "../generated/port-range.js";
 
 const DEFAULT_REMOTE_PORT = 19432;
 const LOOPBACK_HOST = "127.0.0.1";
@@ -71,22 +72,9 @@ export function getServerPorts(): {
 } {
 	const envPort = process.env.PLANNOTATOR_PORT;
 	if (envPort) {
-		const value = envPort.trim();
-		const range = /^(\d+)-(\d+)$/.exec(value);
-		if (range) {
-			const start = Number(range[1]);
-			const end = Number(range[2]);
-			if (start >= 1 && end < 65536 && start <= end) {
-				return {
-					ports: Array.from({ length: end - start + 1 }, (_, index) => start + index),
-					portSource: "env",
-				};
-			}
-		} else {
-			const parsed = parseInt(value, 10);
-			if (!Number.isNaN(parsed) && parsed >= 0 && parsed < 65536) {
-				return { ports: [parsed], portSource: "env" };
-			}
+		const parsed = parsePortSelection(envPort);
+		if (parsed) {
+			return { ports: parsed, portSource: "env" };
 		}
 		// Invalid port - fall back silently, caller can check env var themselves
 	}
@@ -120,15 +108,27 @@ export async function listenOnPort(
 	for (const [index, port] of portsToTry.entries()) {
 		try {
 			await new Promise<void>((resolve, reject) => {
-				server.once("error", reject);
-				server.listen(
-					port,
-					getServerHostname(),
-					() => {
-						server.removeListener("error", reject);
-						resolve();
-					},
-				);
+				const onError = (error: Error) => {
+					cleanup();
+					reject(error);
+				};
+				const onListening = () => {
+					cleanup();
+					resolve();
+				};
+				const cleanup = () => {
+					server.removeListener("error", onError);
+					server.removeListener("listening", onListening);
+				};
+
+				server.once("error", onError);
+				server.once("listening", onListening);
+				try {
+					server.listen(port, getServerHostname());
+				} catch (error: unknown) {
+					cleanup();
+					reject(error);
+				}
 			});
 			const addr = server.address() as { port: number };
 			return { port: addr.port, portSource };

--- a/apps/pi-extension/server/network.ts
+++ b/apps/pi-extension/server/network.ts
@@ -70,18 +70,38 @@ export function getServerPorts(): {
 	ports: number[];
 	portSource: "env" | "remote-default" | "random";
 } {
+	const configuration = getServerPortConfiguration();
+	return {
+		ports: configuration.ports,
+		portSource: configuration.portSource,
+	};
+}
+
+function getServerPortConfiguration(): {
+	ports: number[];
+	portSource: "env" | "remote-default" | "random";
+	isRange: boolean;
+} {
 	const envPort = process.env.PLANNOTATOR_PORT;
 	if (envPort) {
 		const parsed = parsePortSelection(envPort);
 		if (parsed) {
-			return { ports: parsed, portSource: "env" };
+			return {
+				ports: parsed.ports,
+				portSource: "env",
+				isRange: parsed.kind === "range",
+			};
 		}
 		// Invalid port - fall back silently, caller can check env var themselves
 	}
 	if (isRemoteSession()) {
-		return { ports: [DEFAULT_REMOTE_PORT], portSource: "remote-default" };
+		return {
+			ports: [DEFAULT_REMOTE_PORT],
+			portSource: "remote-default",
+			isRange: false,
+		};
 	}
-	return { ports: [0], portSource: "random" };
+	return { ports: [0], portSource: "random", isRange: false };
 }
 
 export function getServerPort(): {
@@ -102,8 +122,8 @@ const RETRY_DELAY_MS = 500;
 export async function listenOnPort(
 	server: Server,
 ): Promise<{ port: number; portSource: "env" | "remote-default" | "random" }> {
-	const { ports, portSource } = getServerPorts();
-	const portsToTry = ports.length > 1 ? ports : Array(MAX_RETRIES).fill(ports[0]);
+	const { ports, portSource, isRange } = getServerPortConfiguration();
+	const portsToTry = isRange ? ports : Array(MAX_RETRIES).fill(ports[0]);
 
 	for (const [index, port] of portsToTry.entries()) {
 		try {
@@ -135,13 +155,20 @@ export async function listenOnPort(
 		} catch (err: unknown) {
 			const isAddressInUse = isAddressInUseError(err);
 			if (isAddressInUse && index < portsToTry.length - 1) {
-				if (ports.length === 1) {
+				if (!isRange) {
 					await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
 				}
 				continue;
 			}
 			if (isAddressInUse) {
-				const configured = ports.length > 1 ? `${ports[0]}-${ports.at(-1)}` : String(port);
+				if (!isRange) {
+					const hint = isRemoteSession()
+						? " (set PLANNOTATOR_PORT to use a different port)"
+						: "";
+					throw new Error(`Port ${port} in use after ${MAX_RETRIES} retries${hint}`);
+				}
+
+				const configured = `${ports[0]}-${ports.at(-1)}`;
 				const hint = isRemoteSession()
 					? " (set PLANNOTATOR_PORT to use a different port or range)"
 					: "";

--- a/apps/pi-extension/server/port-startup-compat.test.ts
+++ b/apps/pi-extension/server/port-startup-compat.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createTestEnvironment } from "../../../tests/helpers/environment";
+import { closeServer, occupyConsecutivePorts } from "../../../tests/helpers/ports";
+import { openBrowser } from "./network";
+import { startPlanReviewServer } from "./serverPlan";
+
+const envKeys = [
+	"PLANNOTATOR_PORT",
+	"PLANNOTATOR_REMOTE",
+	"PLANNOTATOR_DATA_DIR",
+	"PLANNOTATOR_BROWSER",
+	"BROWSER",
+] as const;
+const environment = createTestEnvironment(envKeys, "plannotator-pi-port-compat-");
+
+afterEach(() => environment.restore());
+
+describe("Pi startup port compatibility", () => {
+	test("unset local startup keeps its random URL for browser handoff", async () => {
+		environment.reset();
+		process.env.PLANNOTATOR_REMOTE = "0";
+		process.env.PLANNOTATOR_DATA_DIR = environment.makeTempDir();
+
+		const server = await startPlanReviewServer({
+			plan: "# Port compatibility",
+			origin: "pi",
+			htmlContent: "<!doctype html><html><body>plan</body></html>",
+		});
+
+		try {
+			expect(server.port).toBeGreaterThan(0);
+			expect(server.portSource).toBe("random");
+			expect(server.url).toBe(`http://localhost:${server.port}`);
+
+			process.env.PLANNOTATOR_REMOTE = "1";
+			process.env.BROWSER = "true";
+			expect(await openBrowser(server.url)).toEqual({
+				opened: false,
+				isRemote: true,
+				url: server.url,
+			});
+		} finally {
+			server.stop();
+		}
+	});
+
+	test("a fixed numeric port keeps the same server URL", async () => {
+		environment.reset();
+		const { start, servers } = await occupyConsecutivePorts(1);
+		await closeServer(servers[0]);
+		process.env.PLANNOTATOR_REMOTE = "0";
+		process.env.PLANNOTATOR_PORT = String(start);
+		process.env.PLANNOTATOR_DATA_DIR = environment.makeTempDir();
+
+		const server = await startPlanReviewServer({
+			plan: "# Fixed port compatibility",
+			origin: "pi",
+			htmlContent: "<!doctype html><html><body>plan</body></html>",
+		});
+
+		try {
+			expect(server.port).toBe(start);
+			expect(server.portSource).toBe("env");
+			expect(server.url).toBe(`http://localhost:${start}`);
+		} finally {
+			server.stop();
+		}
+	});
+});

--- a/apps/pi-extension/vendor.sh
+++ b/apps/pi-extension/vendor.sh
@@ -29,7 +29,7 @@ for f in config-types storage-types workspace-status-types; do
 done
 
 # Everything else in the original flat list stays sourced from packages/shared.
-for f in prompts review-core diff-paths cli-pagination jj-core vcs-core review-args draft pr-types pr-context-live pr-provider pr-stack pr-github pr-gitlab checklist integrations-common repo reference-common resolve-file annotate-reference-roots-node worktree worktree-pool html-to-markdown html-diff html-assets html-assets-node url-to-markdown tour annotate-args at-reference review-workspace-node review-workspace pfm-reminder improvement-hooks code-nav data-dir semantic-diff-types semantic-diff source-save-node review-profiles guide commit-avatars commit-history; do
+for f in prompts review-core diff-paths cli-pagination jj-core vcs-core review-args draft pr-types pr-context-live pr-provider pr-stack pr-github pr-gitlab checklist integrations-common repo reference-common resolve-file annotate-reference-roots-node worktree worktree-pool html-to-markdown html-diff html-assets html-assets-node url-to-markdown tour annotate-args at-reference review-workspace-node review-workspace pfm-reminder improvement-hooks code-nav data-dir semantic-diff-types semantic-diff source-save-node review-profiles guide commit-avatars commit-history port-range; do
   src="../../packages/shared/$f.ts"
   printf '// @generated — DO NOT EDIT. Source: packages/shared/%s.ts\n' "$f" | cat - "$src" > "generated/$f.ts"
 done

--- a/packages/server/annotate.ts
+++ b/packages/server/annotate.ts
@@ -11,7 +11,7 @@
  *   PLANNOTATOR_PORT   - Fixed port or inclusive range (default: random locally, 19432 for remote)
  */
 
-import { isAddressInUseError, isRemoteSession, getServerHostname, getServerPorts } from "./remote";
+import { isRemoteSession, getServerHostname, startBunServerOnAvailablePort } from "./remote";
 import { getRepoInfo } from "./repo";
 import type { Origin } from "@plannotator/shared/agents";
 import { handleImage, handleUpload, handleServerReady, handleDraftSave, handleDraftLoad, handleDraftDelete, handleFavicon, handleSaveNotes, readDraftGenerationFromBody, readDraftGenerationFromUrl } from "./shared-handlers";
@@ -121,9 +121,6 @@ export interface AnnotateServerResult {
 
 // --- Server Implementation ---
 
-const MAX_RETRIES = 5;
-const RETRY_DELAY_MS = 500;
-
 /**
  * Start the Annotate server
  *
@@ -158,10 +155,6 @@ export async function startAnnotateServer(
   } = options;
 
   const isRemote = isRemoteSession();
-  const configuredPorts = getServerPorts();
-  const portsToTry = configuredPorts.length > 1
-    ? configuredPorts
-    : Array(MAX_RETRIES).fill(configuredPorts[0]);
   const wslFlag = await isWSL();
   const gitUser = detectGitUser();
 
@@ -353,13 +346,8 @@ export async function startAnnotateServer(
     resolveDecision = resolve;
   });
 
-  // Start server with retry logic
-  let server: ReturnType<typeof Bun.serve> | null = null;
-
-  for (let attempt = 1; attempt <= portsToTry.length; attempt++) {
-    const port = portsToTry[attempt - 1];
-    try {
-      server = Bun.serve({
+  const server = await startBunServerOnAvailablePort((port) =>
+    Bun.serve({
         hostname: getServerHostname(),
         port,
         // Bun's default 10s idleTimeout kills AI SSE streams that stall
@@ -716,34 +704,8 @@ export async function startAnnotateServer(
             { status: 500, headers: { "Content-Type": "text/plain" } },
           );
         },
-      });
-
-      break; // Success, exit retry loop
-    } catch (err: unknown) {
-      const isAddressInUse = isAddressInUseError(err);
-
-      if (isAddressInUse && attempt < portsToTry.length) {
-        if (configuredPorts.length === 1) await Bun.sleep(RETRY_DELAY_MS);
-        continue;
-      }
-
-      if (isAddressInUse) {
-        const configured = configuredPorts.length > 1
-          ? `${configuredPorts[0]}-${configuredPorts.at(-1)}`
-          : String(port);
-        const hint = isRemote
-          ? " (set PLANNOTATOR_PORT to use a different port or range)"
-          : "";
-        throw new Error(`Port selection ${configured} exhausted${hint}`);
-      }
-
-      throw err;
-    }
-  }
-
-  if (!server) {
-    throw new Error("Failed to start server");
-  }
+    }),
+  );
 
   const port = server.port!;
   const serverUrl = `http://localhost:${port}`;

--- a/packages/server/annotate.ts
+++ b/packages/server/annotate.ts
@@ -8,10 +8,10 @@
  *
  * Environment variables:
  *   PLANNOTATOR_REMOTE - Set to "1"/"true" for remote, "0"/"false" for local
- *   PLANNOTATOR_PORT   - Fixed port to use (default: random locally, 19432 for remote)
+ *   PLANNOTATOR_PORT   - Fixed port or inclusive range (default: random locally, 19432 for remote)
  */
 
-import { isRemoteSession, getServerHostname, getServerPort } from "./remote";
+import { isAddressInUseError, isRemoteSession, getServerHostname, getServerPorts } from "./remote";
 import { getRepoInfo } from "./repo";
 import type { Origin } from "@plannotator/shared/agents";
 import { handleImage, handleUpload, handleServerReady, handleDraftSave, handleDraftLoad, handleDraftDelete, handleFavicon, handleSaveNotes, readDraftGenerationFromBody, readDraftGenerationFromUrl } from "./shared-handlers";
@@ -158,7 +158,10 @@ export async function startAnnotateServer(
   } = options;
 
   const isRemote = isRemoteSession();
-  const configuredPort = getServerPort();
+  const configuredPorts = getServerPorts();
+  const portsToTry = configuredPorts.length > 1
+    ? configuredPorts
+    : Array(MAX_RETRIES).fill(configuredPorts[0]);
   const wslFlag = await isWSL();
   const gitUser = detectGitUser();
 
@@ -353,11 +356,12 @@ export async function startAnnotateServer(
   // Start server with retry logic
   let server: ReturnType<typeof Bun.serve> | null = null;
 
-  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+  for (let attempt = 1; attempt <= portsToTry.length; attempt++) {
+    const port = portsToTry[attempt - 1];
     try {
       server = Bun.serve({
         hostname: getServerHostname(),
-        port: configuredPort,
+        port,
         // Bun's default 10s idleTimeout kills AI SSE streams that stall
         // between bytes (e.g. while a permission prompt waits on the user).
         idleTimeout: 0,
@@ -716,21 +720,21 @@ export async function startAnnotateServer(
 
       break; // Success, exit retry loop
     } catch (err: unknown) {
-      const isAddressInUse =
-        err instanceof Error && err.message.includes("EADDRINUSE");
+      const isAddressInUse = isAddressInUseError(err);
 
-      if (isAddressInUse && attempt < MAX_RETRIES) {
-        await Bun.sleep(RETRY_DELAY_MS);
+      if (isAddressInUse && attempt < portsToTry.length) {
+        if (configuredPorts.length === 1) await Bun.sleep(RETRY_DELAY_MS);
         continue;
       }
 
       if (isAddressInUse) {
+        const configured = configuredPorts.length > 1
+          ? `${configuredPorts[0]}-${configuredPorts.at(-1)}`
+          : String(port);
         const hint = isRemote
-          ? " (set PLANNOTATOR_PORT to use different port)"
+          ? " (set PLANNOTATOR_PORT to use a different port or range)"
           : "";
-        throw new Error(
-          `Port ${configuredPort} in use after ${MAX_RETRIES} retries${hint}`
-        );
+        throw new Error(`Port selection ${configured} exhausted${hint}`);
       }
 
       throw err;

--- a/packages/server/goal-setup.ts
+++ b/packages/server/goal-setup.ts
@@ -15,7 +15,7 @@ import {
   type GoalSetupQuestionAnswer,
   type GoalSetupResult,
 } from "@plannotator/shared/goal-setup";
-import { isAddressInUseError, isRemoteSession, getServerHostname, getServerPorts } from "./remote";
+import { isRemoteSession, getServerHostname, startBunServerOnAvailablePort } from "./remote";
 import { getRepoInfo } from "./repo";
 import {
   handleFavicon,
@@ -45,9 +45,6 @@ export interface GoalSetupServerResult {
   }>;
   stop: () => void;
 }
-
-const MAX_RETRIES = 5;
-const RETRY_DELAY_MS = 500;
 
 function coerceAnswers(body: unknown): GoalSetupQuestionAnswer[] {
   if (!body || typeof body !== "object") return [];
@@ -80,10 +77,6 @@ export async function startGoalSetupServer(
 ): Promise<GoalSetupServerResult> {
   const { bundle, htmlContent, origin = "claude-code", onReady } = options;
   const isRemote = isRemoteSession();
-  const configuredPorts = getServerPorts();
-  const portsToTry = configuredPorts.length > 1
-    ? configuredPorts
-    : Array(MAX_RETRIES).fill(configuredPorts[0]);
   const wslFlag = await isWSL();
   const repoInfo = await getRepoInfo();
   const gitUser = detectGitUser();
@@ -106,12 +99,8 @@ export async function startGoalSetupServer(
     resolveDecision(result);
   };
 
-  let server: ReturnType<typeof Bun.serve> | null = null;
-
-  for (let attempt = 1; attempt <= portsToTry.length; attempt++) {
-    const port = portsToTry[attempt - 1];
-    try {
-      server = Bun.serve({
+  const server = await startBunServerOnAvailablePort((port) =>
+    Bun.serve({
         hostname: getServerHostname(),
         port,
         // Bun's default 10s idleTimeout kills long-running requests.
@@ -211,34 +200,8 @@ export async function startGoalSetupServer(
             { status: 500, headers: { "Content-Type": "text/plain" } }
           );
         },
-      });
-
-      break;
-    } catch (err: unknown) {
-      const isAddressInUse = isAddressInUseError(err);
-
-      if (isAddressInUse && attempt < portsToTry.length) {
-        if (configuredPorts.length === 1) await Bun.sleep(RETRY_DELAY_MS);
-        continue;
-      }
-
-      if (isAddressInUse) {
-        const configured = configuredPorts.length > 1
-          ? `${configuredPorts[0]}-${configuredPorts.at(-1)}`
-          : String(port);
-        const hint = isRemote
-          ? " (set PLANNOTATOR_PORT to use a different port or range)"
-          : "";
-        throw new Error(`Port selection ${configured} exhausted${hint}`);
-      }
-
-      throw err;
-    }
-  }
-
-  if (!server) {
-    throw new Error("Failed to start goal setup server");
-  }
+    }),
+  );
 
   const port = server.port!;
   const serverUrl = `http://localhost:${port}`;

--- a/packages/server/goal-setup.ts
+++ b/packages/server/goal-setup.ts
@@ -15,7 +15,7 @@ import {
   type GoalSetupQuestionAnswer,
   type GoalSetupResult,
 } from "@plannotator/shared/goal-setup";
-import { isRemoteSession, getServerHostname, getServerPort } from "./remote";
+import { isAddressInUseError, isRemoteSession, getServerHostname, getServerPorts } from "./remote";
 import { getRepoInfo } from "./repo";
 import {
   handleFavicon,
@@ -80,7 +80,10 @@ export async function startGoalSetupServer(
 ): Promise<GoalSetupServerResult> {
   const { bundle, htmlContent, origin = "claude-code", onReady } = options;
   const isRemote = isRemoteSession();
-  const configuredPort = getServerPort();
+  const configuredPorts = getServerPorts();
+  const portsToTry = configuredPorts.length > 1
+    ? configuredPorts
+    : Array(MAX_RETRIES).fill(configuredPorts[0]);
   const wslFlag = await isWSL();
   const repoInfo = await getRepoInfo();
   const gitUser = detectGitUser();
@@ -105,11 +108,12 @@ export async function startGoalSetupServer(
 
   let server: ReturnType<typeof Bun.serve> | null = null;
 
-  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+  for (let attempt = 1; attempt <= portsToTry.length; attempt++) {
+    const port = portsToTry[attempt - 1];
     try {
       server = Bun.serve({
         hostname: getServerHostname(),
-        port: configuredPort,
+        port,
         // Bun's default 10s idleTimeout kills long-running requests.
         idleTimeout: 0,
 
@@ -211,21 +215,21 @@ export async function startGoalSetupServer(
 
       break;
     } catch (err: unknown) {
-      const isAddressInUse =
-        err instanceof Error && err.message.includes("EADDRINUSE");
+      const isAddressInUse = isAddressInUseError(err);
 
-      if (isAddressInUse && attempt < MAX_RETRIES) {
-        await Bun.sleep(RETRY_DELAY_MS);
+      if (isAddressInUse && attempt < portsToTry.length) {
+        if (configuredPorts.length === 1) await Bun.sleep(RETRY_DELAY_MS);
         continue;
       }
 
       if (isAddressInUse) {
+        const configured = configuredPorts.length > 1
+          ? `${configuredPorts[0]}-${configuredPorts.at(-1)}`
+          : String(port);
         const hint = isRemote
-          ? " (set PLANNOTATOR_PORT to use different port)"
+          ? " (set PLANNOTATOR_PORT to use a different port or range)"
           : "";
-        throw new Error(
-          `Port ${configuredPort} in use after ${MAX_RETRIES} retries${hint}`
-        );
+        throw new Error(`Port selection ${configured} exhausted${hint}`);
       }
 
       throw err;

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -14,7 +14,7 @@
 
 import type { Origin } from "@plannotator/shared/agents";
 import { resolve } from "path";
-import { isAddressInUseError, isRemoteSession, getServerHostname, getServerPorts } from "./remote";
+import { isRemoteSession, getServerHostname, startBunServerOnAvailablePort } from "./remote";
 import { openEditorDiff } from "./ide";
 import {
   saveToObsidian,
@@ -113,9 +113,6 @@ export interface ServerResult {
 
 // --- Server Implementation ---
 
-const MAX_RETRIES = 5;
-const RETRY_DELAY_MS = 500;
-
 /**
  * Start the Plannotator server
  *
@@ -131,10 +128,6 @@ export async function startPlannotatorServer(
   const { plan, origin, htmlContent, permissionMode, sharingEnabled = true, shareBaseUrl, pasteApiUrl, onReady, mode, customPlanPath } = options;
 
   const isRemote = isRemoteSession();
-  const configuredPorts = getServerPorts();
-  const portsToTry = configuredPorts.length > 1
-    ? configuredPorts
-    : Array(MAX_RETRIES).fill(configuredPorts[0]);
   const wslFlag = await isWSL();
   const gitUser = detectGitUser();
 
@@ -207,13 +200,8 @@ export async function startPlannotatorServer(
     decisionPromise = new Promise(() => {});
   }
 
-  // Start server with retry logic
-  let server: ReturnType<typeof Bun.serve> | null = null;
-
-  for (let attempt = 1; attempt <= portsToTry.length; attempt++) {
-    const port = portsToTry[attempt - 1];
-    try {
-      server = Bun.serve({
+  const server = await startBunServerOnAvailablePort((port) =>
+    Bun.serve({
         hostname: getServerHostname(),
         port,
         // Bun's default 10s idleTimeout kills AI SSE streams that stall
@@ -586,32 +574,8 @@ export async function startPlannotatorServer(
             { status: 500, headers: { "Content-Type": "text/plain" } },
           );
         },
-      });
-
-      break; // Success, exit retry loop
-    } catch (err: unknown) {
-      const isAddressInUse = isAddressInUseError(err);
-
-      if (isAddressInUse && attempt < portsToTry.length) {
-        if (configuredPorts.length === 1) await Bun.sleep(RETRY_DELAY_MS);
-        continue;
-      }
-
-      if (isAddressInUse) {
-        const configured = configuredPorts.length > 1
-          ? `${configuredPorts[0]}-${configuredPorts.at(-1)}`
-          : String(port);
-        const hint = isRemote ? " (set PLANNOTATOR_PORT to use a different port or range)" : "";
-        throw new Error(`Port selection ${configured} exhausted${hint}`);
-      }
-
-      throw err;
-    }
-  }
-
-  if (!server) {
-    throw new Error("Failed to start server");
-  }
+    }),
+  );
 
   const port = server.port!;
   const serverUrl = `http://localhost:${port}`;

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -5,7 +5,7 @@
  *
  * Environment variables:
  *   PLANNOTATOR_REMOTE - Set to "1"/"true" for remote, "0"/"false" for local
- *   PLANNOTATOR_PORT   - Fixed port to use (default: random locally, 19432 for remote)
+ *   PLANNOTATOR_PORT   - Fixed port or inclusive range (default: random locally, 19432 for remote)
  *   PLANNOTATOR_ORIGIN - Explicit origin override; validated against AGENT_CONFIG
  *                        in packages/shared/agents.ts. Supported values:
  *                        "claude-code", "opencode", "codex", "copilot-cli",
@@ -14,7 +14,7 @@
 
 import type { Origin } from "@plannotator/shared/agents";
 import { resolve } from "path";
-import { isRemoteSession, getServerHostname, getServerPort } from "./remote";
+import { isAddressInUseError, isRemoteSession, getServerHostname, getServerPorts } from "./remote";
 import { openEditorDiff } from "./ide";
 import {
   saveToObsidian,
@@ -131,7 +131,10 @@ export async function startPlannotatorServer(
   const { plan, origin, htmlContent, permissionMode, sharingEnabled = true, shareBaseUrl, pasteApiUrl, onReady, mode, customPlanPath } = options;
 
   const isRemote = isRemoteSession();
-  const configuredPort = getServerPort();
+  const configuredPorts = getServerPorts();
+  const portsToTry = configuredPorts.length > 1
+    ? configuredPorts
+    : Array(MAX_RETRIES).fill(configuredPorts[0]);
   const wslFlag = await isWSL();
   const gitUser = detectGitUser();
 
@@ -207,11 +210,12 @@ export async function startPlannotatorServer(
   // Start server with retry logic
   let server: ReturnType<typeof Bun.serve> | null = null;
 
-  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+  for (let attempt = 1; attempt <= portsToTry.length; attempt++) {
+    const port = portsToTry[attempt - 1];
     try {
       server = Bun.serve({
         hostname: getServerHostname(),
-        port: configuredPort,
+        port,
         // Bun's default 10s idleTimeout kills AI SSE streams that stall
         // between bytes (e.g. while a permission prompt waits on the user).
         idleTimeout: 0,
@@ -586,17 +590,19 @@ export async function startPlannotatorServer(
 
       break; // Success, exit retry loop
     } catch (err: unknown) {
-      const isAddressInUse =
-        err instanceof Error && err.message.includes("EADDRINUSE");
+      const isAddressInUse = isAddressInUseError(err);
 
-      if (isAddressInUse && attempt < MAX_RETRIES) {
-        await Bun.sleep(RETRY_DELAY_MS);
+      if (isAddressInUse && attempt < portsToTry.length) {
+        if (configuredPorts.length === 1) await Bun.sleep(RETRY_DELAY_MS);
         continue;
       }
 
       if (isAddressInUse) {
-        const hint = isRemote ? " (set PLANNOTATOR_PORT to use different port)" : "";
-        throw new Error(`Port ${configuredPort} in use after ${MAX_RETRIES} retries${hint}`);
+        const configured = configuredPorts.length > 1
+          ? `${configuredPorts[0]}-${configuredPorts.at(-1)}`
+          : String(port);
+        const hint = isRemote ? " (set PLANNOTATOR_PORT to use a different port or range)" : "";
+        throw new Error(`Port selection ${configured} exhausted${hint}`);
       }
 
       throw err;

--- a/packages/server/port-startup-compat.test.ts
+++ b/packages/server/port-startup-compat.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createTestEnvironment } from "../../tests/helpers/environment";
+import { closeServer, occupyConsecutivePorts } from "../../tests/helpers/ports";
+import { startPlannotatorServer } from "./index";
+import { handleServerReady } from "./shared-handlers";
+
+const envKeys = [
+  "PLANNOTATOR_PORT",
+  "PLANNOTATOR_REMOTE",
+  "PLANNOTATOR_DATA_DIR",
+  "PLANNOTATOR_SKIP_BROWSER_OPEN",
+  "__CFBundleIdentifier",
+] as const;
+const environment = createTestEnvironment(envKeys, "plannotator-port-compat-");
+
+afterEach(() => environment.restore());
+
+describe("Bun startup port compatibility", () => {
+  test("unset local startup keeps its random URL and browser-ready handoff", async () => {
+    environment.reset();
+    process.env.PLANNOTATOR_REMOTE = "0";
+    process.env.PLANNOTATOR_DATA_DIR = environment.makeTempDir();
+    process.env.__CFBundleIdentifier = "com.apple.Terminal";
+    let ready: { url: string; isRemote: boolean; port: number } | undefined;
+
+    const server = await startPlannotatorServer({
+      plan: "# Port compatibility",
+      origin: "codex",
+      htmlContent: "<!doctype html><html><body>plan</body></html>",
+      onReady: (url, isRemote, port) => {
+        ready = { url, isRemote, port };
+      },
+    });
+
+    try {
+      expect(server.port).toBeGreaterThan(0);
+      expect(server.url).toBe(`http://localhost:${server.port}`);
+      expect(ready).toEqual({
+        url: server.url,
+        isRemote: false,
+        port: server.port,
+      });
+
+      let openedUrl: string | undefined;
+      await handleServerReady(server.url, server.isRemote, server.port, {
+        openBrowser: async (url) => {
+          openedUrl = url;
+          return true;
+        },
+      });
+      expect(openedUrl).toBe(server.url);
+    } finally {
+      server.stop();
+    }
+  });
+
+  test("a fixed numeric port keeps the same ready URL", async () => {
+    environment.reset();
+    const { start, servers } = await occupyConsecutivePorts(1);
+    await closeServer(servers[0]);
+    process.env.PLANNOTATOR_REMOTE = "0";
+    process.env.PLANNOTATOR_PORT = String(start);
+    process.env.PLANNOTATOR_DATA_DIR = environment.makeTempDir();
+    let ready: { url: string; isRemote: boolean; port: number } | undefined;
+
+    const server = await startPlannotatorServer({
+      plan: "# Fixed port compatibility",
+      origin: "codex",
+      htmlContent: "<!doctype html><html><body>plan</body></html>",
+      onReady: (url, isRemote, port) => {
+        ready = { url, isRemote, port };
+      },
+    });
+
+    try {
+      expect(server.port).toBe(start);
+      expect(server.url).toBe(`http://localhost:${start}`);
+      expect(ready).toEqual({ url: server.url, isRemote: false, port: start });
+    } finally {
+      server.stop();
+    }
+  });
+});

--- a/packages/server/remote.test.ts
+++ b/packages/server/remote.test.ts
@@ -26,6 +26,14 @@ function clearEnv() {
   }
 }
 
+function startTestBunServer(port: number): ReturnType<typeof Bun.serve> {
+  return Bun.serve({
+    hostname: "127.0.0.1",
+    port,
+    fetch: () => new Response("ok"),
+  });
+}
+
 afterEach(() => {
   for (const key of envKeys) {
     if (savedEnv[key] !== undefined) {
@@ -100,12 +108,12 @@ describe("isAddressInUseError", () => {
 });
 
 describe("getServerPort", () => {
-  test("returns 0 for local session (random port)", () => {
+  test("PLANNOTATOR_PORT unset preserves the random local default", () => {
     clearEnv();
     expect(getServerPort()).toBe(0);
   });
 
-  test("returns 19432 for remote session", () => {
+  test("PLANNOTATOR_PORT unset preserves the 19432 remote default", () => {
     clearEnv();
     process.env.PLANNOTATOR_REMOTE = "1";
     expect(getServerPort()).toBe(19432);
@@ -169,6 +177,13 @@ describe("getServerPort", () => {
     }
   });
 
+  test("a malformed range follows the existing remote default path", () => {
+    clearEnv();
+    process.env.PLANNOTATOR_REMOTE = "1";
+    process.env.PLANNOTATOR_PORT = "19432-19435garbage";
+    expect(getServerPorts()).toEqual([19432]);
+  });
+
   test("ignores out-of-range port", () => {
     clearEnv();
     process.env.PLANNOTATOR_PORT = "99999";
@@ -191,11 +206,7 @@ describe("Bun port range binding", () => {
 
     let server: ReturnType<typeof Bun.serve> | undefined;
     try {
-      server = await startBunServerOnAvailablePort((port) => Bun.serve({
-        hostname: "127.0.0.1",
-        port,
-        fetch: () => new Response("ok"),
-      }));
+      server = await startBunServerOnAvailablePort(startTestBunServer);
       expect(server.port).toBe(start + 1);
     } finally {
       server?.stop(true);
@@ -209,13 +220,44 @@ describe("Bun port range binding", () => {
     process.env.PLANNOTATOR_PORT = `${start}-${start + 1}`;
 
     try {
-      await expect(startBunServerOnAvailablePort((port) => Bun.serve({
-        hostname: "127.0.0.1",
-        port,
-        fetch: () => new Response("ok"),
-      }))).rejects.toThrow(`Port selection ${start}-${start + 1} exhausted`);
+      await expect(startBunServerOnAvailablePort(startTestBunServer)).rejects.toThrow(
+        new RegExp(`^Port selection ${start}-${start + 1} exhausted$`),
+      );
     } finally {
       await Promise.all(servers.map(closeServer));
+    }
+  });
+
+  test("treats a valid one-port range as range syntax", async () => {
+    clearEnv();
+    const { start, servers } = await occupyConsecutivePorts(1);
+    process.env.PLANNOTATOR_PORT = `${start}-${start}`;
+
+    try {
+      await expect(startBunServerOnAvailablePort(startTestBunServer)).rejects.toThrow(
+        new RegExp(`^Port selection ${start}-${start} exhausted$`),
+      );
+    } finally {
+      await closeServer(servers[0]);
+    }
+  });
+});
+
+describe("Bun non-range port compatibility", () => {
+  test("an occupied fixed port preserves the existing retry error", async () => {
+    clearEnv();
+    const { start, servers } = await occupyConsecutivePorts(1);
+    process.env.PLANNOTATOR_REMOTE = "1";
+    process.env.PLANNOTATOR_PORT = String(start);
+
+    try {
+      await expect(startBunServerOnAvailablePort(startTestBunServer)).rejects.toThrow(
+        new RegExp(
+          `^Port ${start} in use after 5 retries \\(set PLANNOTATOR_PORT to use different port\\)$`,
+        ),
+      );
+    } finally {
+      await closeServer(servers[0]);
     }
   });
 });

--- a/packages/server/remote.test.ts
+++ b/packages/server/remote.test.ts
@@ -5,7 +5,15 @@
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
-import { isAddressInUseError, isRemoteSession, getServerHostname, getServerPort, getServerPorts } from "./remote";
+import { closeServer, occupyConsecutivePorts } from "../../tests/helpers/ports";
+import {
+  isAddressInUseError,
+  isRemoteSession,
+  getServerHostname,
+  getServerPort,
+  getServerPorts,
+  startBunServerOnAvailablePort,
+} from "./remote";
 
 // Save and restore env between tests
 const savedEnv: Record<string, string | undefined> = {};
@@ -148,6 +156,19 @@ describe("getServerPort", () => {
     expect(getServerPort()).toBe(0);
   });
 
+  test("rejects malformed fixed ports and ranges without accepting numeric prefixes", () => {
+    clearEnv();
+    for (const value of [
+      "19432garbage",
+      "19432.5",
+      "19432-19435garbage",
+      "19432-19435-19436",
+    ]) {
+      process.env.PLANNOTATOR_PORT = value;
+      expect(getServerPorts()).toEqual([0]);
+    }
+  });
+
   test("ignores out-of-range port", () => {
     clearEnv();
     process.env.PLANNOTATOR_PORT = "99999";
@@ -158,6 +179,44 @@ describe("getServerPort", () => {
     clearEnv();
     process.env.PLANNOTATOR_PORT = "0";
     expect(getServerPort()).toBe(0);
+  });
+});
+
+describe("Bun port range binding", () => {
+  test("binds the next port when the range start is occupied", async () => {
+    clearEnv();
+    const { start, servers } = await occupyConsecutivePorts(2);
+    await closeServer(servers[1]);
+    process.env.PLANNOTATOR_PORT = `${start}-${start + 1}`;
+
+    let server: ReturnType<typeof Bun.serve> | undefined;
+    try {
+      server = await startBunServerOnAvailablePort((port) => Bun.serve({
+        hostname: "127.0.0.1",
+        port,
+        fetch: () => new Response("ok"),
+      }));
+      expect(server.port).toBe(start + 1);
+    } finally {
+      server?.stop(true);
+      await closeServer(servers[0]);
+    }
+  });
+
+  test("reports an exhausted occupied range", async () => {
+    clearEnv();
+    const { start, servers } = await occupyConsecutivePorts(2);
+    process.env.PLANNOTATOR_PORT = `${start}-${start + 1}`;
+
+    try {
+      await expect(startBunServerOnAvailablePort((port) => Bun.serve({
+        hostname: "127.0.0.1",
+        port,
+        fetch: () => new Response("ok"),
+      }))).rejects.toThrow(`Port selection ${start}-${start + 1} exhausted`);
+    } finally {
+      await Promise.all(servers.map(closeServer));
+    }
   });
 });
 

--- a/packages/server/remote.test.ts
+++ b/packages/server/remote.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
-import { isRemoteSession, getServerHostname, getServerPort } from "./remote";
+import { isAddressInUseError, isRemoteSession, getServerHostname, getServerPort, getServerPorts } from "./remote";
 
 // Save and restore env between tests
 const savedEnv: Record<string, string | undefined> = {};
@@ -85,6 +85,12 @@ describe("isRemoteSession", () => {
   });
 });
 
+describe("isAddressInUseError", () => {
+  test("recognizes Bun errors by code", () => {
+    expect(isAddressInUseError(Object.assign(new Error("listen failed"), { code: "EADDRINUSE" }))).toBe(true);
+  });
+});
+
 describe("getServerPort", () => {
   test("returns 0 for local session (random port)", () => {
     clearEnv();
@@ -115,6 +121,25 @@ describe("getServerPort", () => {
     process.env.PLANNOTATOR_REMOTE = "1";
     process.env.PLANNOTATOR_PORT = "3000";
     expect(getServerPort()).toBe(3000);
+  });
+
+  test("expands an inclusive port range", () => {
+    clearEnv();
+    process.env.PLANNOTATOR_PORT = "19432-19435";
+    expect(getServerPorts()).toEqual([19432, 19433, 19434, 19435]);
+    expect(getServerPort()).toBe(19432);
+  });
+
+  test("ignores reversed port ranges", () => {
+    clearEnv();
+    process.env.PLANNOTATOR_PORT = "19435-19432";
+    expect(getServerPorts()).toEqual([0]);
+  });
+
+  test("ignores ranges containing random port zero", () => {
+    clearEnv();
+    process.env.PLANNOTATOR_PORT = "0-3";
+    expect(getServerPorts()).toEqual([0]);
   });
 
   test("ignores invalid port (falls back to default)", () => {

--- a/packages/server/remote.ts
+++ b/packages/server/remote.ts
@@ -8,9 +8,14 @@
  * Legacy (still supported): SSH_TTY, SSH_CONNECTION
  */
 
+import { parsePortSelection } from "@plannotator/shared/port-range";
+
 const DEFAULT_REMOTE_PORT = 19432;
 const LOOPBACK_HOST = "127.0.0.1";
+const MAX_FIXED_PORT_RETRIES = 5;
+const PORT_RETRY_DELAY_MS = 500;
 
+/** Return whether a runtime listen failure represents an occupied address. */
 export function isAddressInUseError(err: unknown): boolean {
   return err instanceof Error && (
     (err as NodeJS.ErrnoException).code === "EADDRINUSE" ||
@@ -58,19 +63,9 @@ export function isRemoteSession(): boolean {
 export function getServerPorts(): number[] {
   const envPort = process.env.PLANNOTATOR_PORT;
   if (envPort) {
-    const value = envPort.trim();
-    const range = /^(\d+)-(\d+)$/.exec(value);
-    if (range) {
-      const start = Number(range[1]);
-      const end = Number(range[2]);
-      if (start >= 1 && end < 65536 && start <= end) {
-        return Array.from({ length: end - start + 1 }, (_, index) => start + index);
-      }
-    } else {
-      const parsed = parseInt(value, 10);
-      if (!Number.isNaN(parsed) && parsed >= 0 && parsed < 65536) {
-        return [parsed];
-      }
+    const parsed = parsePortSelection(envPort);
+    if (parsed) {
+      return parsed;
     }
     console.error(
       `[Plannotator] Warning: Invalid PLANNOTATOR_PORT "${envPort}", using default`
@@ -86,6 +81,48 @@ export function getServerPorts(): number[] {
  */
 export function getServerPort(): number {
   return getServerPorts()[0];
+}
+
+/**
+ * Start a Bun server on the first available configured port.
+ *
+ * Bounded ranges advance immediately after EADDRINUSE. A fixed port retains
+ * the existing five-attempt retry behavior for transient conflicts.
+ */
+export async function startBunServerOnAvailablePort<TServer>(
+  startServer: (port: number) => TServer,
+): Promise<TServer> {
+  const configuredPorts = getServerPorts();
+  const portsToTry = configuredPorts.length > 1
+    ? configuredPorts
+    : Array(MAX_FIXED_PORT_RETRIES).fill(configuredPorts[0]);
+
+  for (const [index, port] of portsToTry.entries()) {
+    try {
+      return startServer(port);
+    } catch (error: unknown) {
+      if (!isAddressInUseError(error)) {
+        throw error;
+      }
+
+      if (index < portsToTry.length - 1) {
+        if (configuredPorts.length === 1) {
+          await Bun.sleep(PORT_RETRY_DELAY_MS);
+        }
+        continue;
+      }
+
+      const configured = configuredPorts.length > 1
+        ? `${configuredPorts[0]}-${configuredPorts.at(-1)}`
+        : String(port);
+      const hint = isRemoteSession()
+        ? " (set PLANNOTATOR_PORT to use a different port or range)"
+        : "";
+      throw new Error(`Port selection ${configured} exhausted${hint}`);
+    }
+  }
+
+  throw new Error("Failed to start server");
 }
 
 /**

--- a/packages/server/remote.ts
+++ b/packages/server/remote.ts
@@ -61,11 +61,18 @@ export function isRemoteSession(): boolean {
  * Get the server ports to try, in order.
  */
 export function getServerPorts(): number[] {
+  return getServerPortConfiguration().ports;
+}
+
+function getServerPortConfiguration(): {
+  ports: number[];
+  isRange: boolean;
+} {
   const envPort = process.env.PLANNOTATOR_PORT;
   if (envPort) {
     const parsed = parsePortSelection(envPort);
     if (parsed) {
-      return parsed;
+      return { ports: parsed.ports, isRange: parsed.kind === "range" };
     }
     console.error(
       `[Plannotator] Warning: Invalid PLANNOTATOR_PORT "${envPort}", using default`
@@ -73,7 +80,10 @@ export function getServerPorts(): number[] {
   }
 
   // Remote sessions use fixed port for port forwarding; local uses random
-  return [isRemoteSession() ? DEFAULT_REMOTE_PORT : 0];
+  return {
+    ports: [isRemoteSession() ? DEFAULT_REMOTE_PORT : 0],
+    isRange: false,
+  };
 }
 
 /**
@@ -92,8 +102,8 @@ export function getServerPort(): number {
 export async function startBunServerOnAvailablePort<TServer>(
   startServer: (port: number) => TServer,
 ): Promise<TServer> {
-  const configuredPorts = getServerPorts();
-  const portsToTry = configuredPorts.length > 1
+  const { ports: configuredPorts, isRange } = getServerPortConfiguration();
+  const portsToTry = isRange
     ? configuredPorts
     : Array(MAX_FIXED_PORT_RETRIES).fill(configuredPorts[0]);
 
@@ -106,15 +116,22 @@ export async function startBunServerOnAvailablePort<TServer>(
       }
 
       if (index < portsToTry.length - 1) {
-        if (configuredPorts.length === 1) {
+        if (!isRange) {
           await Bun.sleep(PORT_RETRY_DELAY_MS);
         }
         continue;
       }
 
-      const configured = configuredPorts.length > 1
-        ? `${configuredPorts[0]}-${configuredPorts.at(-1)}`
-        : String(port);
+      if (!isRange) {
+        const hint = isRemoteSession()
+          ? " (set PLANNOTATOR_PORT to use different port)"
+          : "";
+        throw new Error(
+          `Port ${port} in use after ${MAX_FIXED_PORT_RETRIES} retries${hint}`,
+        );
+      }
+
+      const configured = `${configuredPorts[0]}-${configuredPorts.at(-1)}`;
       const hint = isRemoteSession()
         ? " (set PLANNOTATOR_PORT to use a different port or range)"
         : "";

--- a/packages/server/remote.ts
+++ b/packages/server/remote.ts
@@ -3,13 +3,20 @@
  *
  * Environment variables:
  *   PLANNOTATOR_REMOTE - Set to "1"/"true" to force remote, "0"/"false" to force local
- *   PLANNOTATOR_PORT   - Fixed port to use (default: random locally, 19432 for remote)
+ *   PLANNOTATOR_PORT   - Fixed port or inclusive range (default: random locally, 19432 for remote)
  *
  * Legacy (still supported): SSH_TTY, SSH_CONNECTION
  */
 
 const DEFAULT_REMOTE_PORT = 19432;
 const LOOPBACK_HOST = "127.0.0.1";
+
+export function isAddressInUseError(err: unknown): boolean {
+  return err instanceof Error && (
+    (err as NodeJS.ErrnoException).code === "EADDRINUSE" ||
+    err.message.includes("EADDRINUSE")
+  );
+}
 
 function getRemoteOverride(): boolean | null {
   const remote = process.env.PLANNOTATOR_REMOTE;
@@ -46,15 +53,24 @@ export function isRemoteSession(): boolean {
 }
 
 /**
- * Get the server port to use
+ * Get the server ports to try, in order.
  */
-export function getServerPort(): number {
-  // Explicit port from environment takes precedence
+export function getServerPorts(): number[] {
   const envPort = process.env.PLANNOTATOR_PORT;
   if (envPort) {
-    const parsed = parseInt(envPort, 10);
-    if (!isNaN(parsed) && parsed >= 0 && parsed < 65536) {
-      return parsed;
+    const value = envPort.trim();
+    const range = /^(\d+)-(\d+)$/.exec(value);
+    if (range) {
+      const start = Number(range[1]);
+      const end = Number(range[2]);
+      if (start >= 1 && end < 65536 && start <= end) {
+        return Array.from({ length: end - start + 1 }, (_, index) => start + index);
+      }
+    } else {
+      const parsed = parseInt(value, 10);
+      if (!Number.isNaN(parsed) && parsed >= 0 && parsed < 65536) {
+        return [parsed];
+      }
     }
     console.error(
       `[Plannotator] Warning: Invalid PLANNOTATOR_PORT "${envPort}", using default`
@@ -62,7 +78,14 @@ export function getServerPort(): number {
   }
 
   // Remote sessions use fixed port for port forwarding; local uses random
-  return isRemoteSession() ? DEFAULT_REMOTE_PORT : 0;
+  return [isRemoteSession() ? DEFAULT_REMOTE_PORT : 0];
+}
+
+/**
+ * Get the first configured server port.
+ */
+export function getServerPort(): number {
+  return getServerPorts()[0];
 }
 
 /**

--- a/packages/server/review.ts
+++ b/packages/server/review.ts
@@ -6,10 +6,10 @@
  *
  * Environment variables:
  *   PLANNOTATOR_REMOTE - Set to "1"/"true" for remote, "0"/"false" for local
- *   PLANNOTATOR_PORT   - Fixed port to use (default: random locally, 19432 for remote)
+ *   PLANNOTATOR_PORT   - Fixed port or inclusive range (default: random locally, 19432 for remote)
  */
 
-import { isRemoteSession, getServerHostname, getServerPort } from "./remote";
+import { isAddressInUseError, isRemoteSession, getServerHostname, getServerPorts } from "./remote";
 import type { Origin } from "@plannotator/shared/agents";
 import { type DiffType, type GitContext, runVcsDiff, getVcsFileContentsForDiff, getVcsDiffFingerprint, canStageFiles, stageFile, unstageFile, resolveVcsCwd, validateFilePath, getVcsContext, detectRemoteDefaultCompareTarget, gitRuntime } from "./vcs";
 import { basename } from "node:path";
@@ -1202,7 +1202,10 @@ export async function startReviewServer(
   const aiRuntime = await createAIRuntime({ getCwd: resolveAgentCwd });
 
   const isRemote = isRemoteSession();
-  const configuredPort = getServerPort();
+  const configuredPorts = getServerPorts();
+  const portsToTry = configuredPorts.length > 1
+    ? configuredPorts
+    : Array(MAX_RETRIES).fill(configuredPorts[0]);
   const wslFlag = await isWSL();
   const gitUser = detectGitUser();
 
@@ -1282,11 +1285,12 @@ export async function startReviewServer(
   // Start server with retry logic
   let server: ReturnType<typeof Bun.serve> | null = null;
 
-  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+  for (let attempt = 1; attempt <= portsToTry.length; attempt++) {
+    const port = portsToTry[attempt - 1];
     try {
       server = Bun.serve({
         hostname: getServerHostname(),
-        port: configuredPort,
+        port,
         // Bun's default 10s idleTimeout kills requests that legitimately park:
         // PR-mode endpoints await the background checkout warmup (a clone that
         // can take minutes) and AI SSE streams can stall between bytes.
@@ -2533,17 +2537,19 @@ export async function startReviewServer(
 
       break; // Success, exit retry loop
     } catch (err: unknown) {
-      const isAddressInUse =
-        err instanceof Error && err.message.includes("EADDRINUSE");
+      const isAddressInUse = isAddressInUseError(err);
 
-      if (isAddressInUse && attempt < MAX_RETRIES) {
-        await Bun.sleep(RETRY_DELAY_MS);
+      if (isAddressInUse && attempt < portsToTry.length) {
+        if (configuredPorts.length === 1) await Bun.sleep(RETRY_DELAY_MS);
         continue;
       }
 
       if (isAddressInUse) {
-        const hint = isRemote ? " (set PLANNOTATOR_PORT to use different port)" : "";
-        throw new Error(`Port ${configuredPort} in use after ${MAX_RETRIES} retries${hint}`);
+        const configured = configuredPorts.length > 1
+          ? `${configuredPorts[0]}-${configuredPorts.at(-1)}`
+          : String(port);
+        const hint = isRemote ? " (set PLANNOTATOR_PORT to use a different port or range)" : "";
+        throw new Error(`Port selection ${configured} exhausted${hint}`);
       }
 
       throw err;

--- a/packages/server/review.ts
+++ b/packages/server/review.ts
@@ -9,7 +9,7 @@
  *   PLANNOTATOR_PORT   - Fixed port or inclusive range (default: random locally, 19432 for remote)
  */
 
-import { isAddressInUseError, isRemoteSession, getServerHostname, getServerPorts } from "./remote";
+import { isRemoteSession, getServerHostname, startBunServerOnAvailablePort } from "./remote";
 import type { Origin } from "@plannotator/shared/agents";
 import { type DiffType, type GitContext, runVcsDiff, getVcsFileContentsForDiff, getVcsDiffFingerprint, canStageFiles, stageFile, unstageFile, resolveVcsCwd, validateFilePath, getVcsContext, detectRemoteDefaultCompareTarget, gitRuntime } from "./vcs";
 import { basename } from "node:path";
@@ -187,9 +187,6 @@ export interface ReviewServerResult {
 }
 
 // --- Server Implementation ---
-
-const MAX_RETRIES = 5;
-const RETRY_DELAY_MS = 500;
 
 /**
  * Start the Code Review server
@@ -1202,10 +1199,6 @@ export async function startReviewServer(
   const aiRuntime = await createAIRuntime({ getCwd: resolveAgentCwd });
 
   const isRemote = isRemoteSession();
-  const configuredPorts = getServerPorts();
-  const portsToTry = configuredPorts.length > 1
-    ? configuredPorts
-    : Array(MAX_RETRIES).fill(configuredPorts[0]);
   const wslFlag = await isWSL();
   const gitUser = detectGitUser();
 
@@ -1282,13 +1275,8 @@ export async function startReviewServer(
     resolveDecision = resolve;
   });
 
-  // Start server with retry logic
-  let server: ReturnType<typeof Bun.serve> | null = null;
-
-  for (let attempt = 1; attempt <= portsToTry.length; attempt++) {
-    const port = portsToTry[attempt - 1];
-    try {
-      server = Bun.serve({
+  const server = await startBunServerOnAvailablePort((port) =>
+    Bun.serve({
         hostname: getServerHostname(),
         port,
         // Bun's default 10s idleTimeout kills requests that legitimately park:
@@ -2533,32 +2521,8 @@ export async function startReviewServer(
             { status: 500, headers: { "Content-Type": "text/plain" } },
           );
         },
-      });
-
-      break; // Success, exit retry loop
-    } catch (err: unknown) {
-      const isAddressInUse = isAddressInUseError(err);
-
-      if (isAddressInUse && attempt < portsToTry.length) {
-        if (configuredPorts.length === 1) await Bun.sleep(RETRY_DELAY_MS);
-        continue;
-      }
-
-      if (isAddressInUse) {
-        const configured = configuredPorts.length > 1
-          ? `${configuredPorts[0]}-${configuredPorts.at(-1)}`
-          : String(port);
-        const hint = isRemote ? " (set PLANNOTATOR_PORT to use a different port or range)" : "";
-        throw new Error(`Port selection ${configured} exhausted${hint}`);
-      }
-
-      throw err;
-    }
-  }
-
-  if (!server) {
-    throw new Error("Failed to start server");
-  }
+    }),
+  );
 
   const port = server.port!;
   serverUrl = `http://localhost:${port}`;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -60,6 +60,7 @@
     "./browser-paths": "./browser-paths.ts",
     "./workspace-status": "./workspace-status.ts",
     "./open-in-apps": "./open-in-apps.ts",
+    "./port-range": "./port-range.ts",
     "./review-profiles": "./review-profiles.ts",
     "./commit-avatars": "./commit-avatars.ts"
   },

--- a/packages/shared/port-range.ts
+++ b/packages/shared/port-range.ts
@@ -1,3 +1,8 @@
+/** A whole-string fixed port or inclusive range parsed from configuration. */
+export type ParsedPortSelection =
+  | { readonly kind: "fixed"; readonly ports: [number] }
+  | { readonly kind: "range"; readonly ports: number[] };
+
 /**
  * Parse a fixed TCP port or an inclusive bounded port range.
  *
@@ -5,7 +10,7 @@
  * so both bounds must be between 1 and 65535. Returns null when any part of
  * the trimmed input is malformed or outside those bounds.
  */
-export function parsePortSelection(value: string): number[] | null {
+export function parsePortSelection(value: string): ParsedPortSelection | null {
   const trimmed = value.trim();
   const rangeMatch = /^(\d+)-(\d+)$/.exec(trimmed);
 
@@ -16,7 +21,10 @@ export function parsePortSelection(value: string): number[] | null {
       return null;
     }
 
-    return Array.from({ length: end - start + 1 }, (_, index) => start + index);
+    return {
+      kind: "range",
+      ports: Array.from({ length: end - start + 1 }, (_, index) => start + index),
+    };
   }
 
   if (!/^\d+$/.test(trimmed)) {
@@ -24,5 +32,5 @@ export function parsePortSelection(value: string): number[] | null {
   }
 
   const port = Number(trimmed);
-  return port <= 65535 ? [port] : null;
+  return port <= 65535 ? { kind: "fixed", ports: [port] } : null;
 }

--- a/packages/shared/port-range.ts
+++ b/packages/shared/port-range.ts
@@ -1,0 +1,28 @@
+/**
+ * Parse a fixed TCP port or an inclusive bounded port range.
+ *
+ * Fixed ports accept 0 for an ephemeral port. Ranges require concrete ports,
+ * so both bounds must be between 1 and 65535. Returns null when any part of
+ * the trimmed input is malformed or outside those bounds.
+ */
+export function parsePortSelection(value: string): number[] | null {
+  const trimmed = value.trim();
+  const rangeMatch = /^(\d+)-(\d+)$/.exec(trimmed);
+
+  if (rangeMatch) {
+    const start = Number(rangeMatch[1]);
+    const end = Number(rangeMatch[2]);
+    if (start < 1 || end > 65535 || start > end) {
+      return null;
+    }
+
+    return Array.from({ length: end - start + 1 }, (_, index) => start + index);
+  }
+
+  if (!/^\d+$/.test(trimmed)) {
+    return null;
+  }
+
+  const port = Number(trimmed);
+  return port <= 65535 ? [port] : null;
+}

--- a/tests/helpers/environment.ts
+++ b/tests/helpers/environment.ts
@@ -1,0 +1,46 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Create an environment-and-temp-directory fixture for integration tests.
+ * Call reset before each test and restore from afterEach.
+ */
+export function createTestEnvironment(
+  envKeys: readonly string[],
+  tempPrefix: string,
+): {
+  reset(): void;
+  makeTempDir(): string;
+  restore(): void;
+} {
+  const savedEnv = new Map<string, string | undefined>();
+  const tempDirs: string[] = [];
+
+  return {
+    reset() {
+      if (savedEnv.size > 0) {
+        throw new Error("Test environment is already active");
+      }
+      for (const key of envKeys) {
+        savedEnv.set(key, process.env[key]);
+        delete process.env[key];
+      }
+    },
+    makeTempDir() {
+      const dir = mkdtempSync(join(tmpdir(), tempPrefix));
+      tempDirs.push(dir);
+      return dir;
+    },
+    restore() {
+      for (const [key, value] of savedEnv) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+      savedEnv.clear();
+      for (const dir of tempDirs.splice(0)) {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  };
+}

--- a/tests/helpers/ports.ts
+++ b/tests/helpers/ports.ts
@@ -1,0 +1,75 @@
+import { createServer, type Server } from "node:http";
+
+function bindServer(server: Server, port: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      server.removeListener("error", onError);
+      server.removeListener("listening", onListening);
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onListening = () => {
+      cleanup();
+      resolve();
+    };
+
+    server.once("error", onError);
+    server.once("listening", onListening);
+    try {
+      server.listen(port, "127.0.0.1");
+    } catch (error: unknown) {
+      cleanup();
+      reject(error);
+    }
+  });
+}
+
+/** Close a listening test server, or resolve immediately if it is already closed. */
+export function closeServer(server: Server): Promise<void> {
+  if (!server.listening) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  });
+}
+
+/**
+ * Reserve a contiguous loopback port range for network fallback tests.
+ * Retries with new ephemeral starting ports when a neighboring port is busy.
+ */
+export async function occupyConsecutivePorts(count: number): Promise<{
+  start: number;
+  servers: Server[];
+}> {
+  if (!Number.isInteger(count) || count < 1) {
+    throw new Error("Test port range length must be a positive integer");
+  }
+
+  for (let attempt = 0; attempt < 25; attempt++) {
+    const servers: Server[] = [];
+    try {
+      const first = createServer();
+      servers.push(first);
+      await bindServer(first, 0);
+      const address = first.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Test server did not expose a TCP port");
+      }
+      if (address.port + count - 1 > 65535) {
+        throw new Error("Ephemeral port is too close to the upper bound");
+      }
+
+      for (let offset = 1; offset < count; offset++) {
+        const server = createServer();
+        servers.push(server);
+        await bindServer(server, address.port + offset);
+      }
+      return { start: address.port, servers };
+    } catch {
+      await Promise.all(servers.map(closeServer));
+    }
+  }
+
+  throw new Error(`Unable to reserve ${count} consecutive test ports`);
+}


### PR DESCRIPTION
## Summary

- accept inclusive `PLANNOTATOR_PORT` ranges such as `19432-19463`
- try each port in order and bind the first available one in Bun and Pi runtimes
- preserve existing fixed-port retries and random-port defaults

## Validation

- focused port tests: 42 passed, 0 failed
- syntax bundle of all changed runtime files
- `git diff --check`

Related to #899
