### PR TITLE
fix visual-explainer Mermaid theme colors

### DIFF
--- a/apps/skills/extra/plannotator-visual-explainer/SKILL.md
+++ b/apps/skills/extra/plannotator-visual-explainer/SKILL.md
@@ -24,6 +24,12 @@ Three paths depending on content type. Each has its own references and structure
 
 Always deliver via Plannotator's annotation UI. Do NOT use `open` or `xdg-open`.
 
+For any deliverable that uses Mermaid, render every diagram with Mermaid 11 in both the light
+and dark palettes before opening the annotation UI. Rendering is a hard gate: an exception,
+empty SVG, or error output such as `aria-roledescription="error"` or `Syntax error in text`
+means the explainer is not deliverable. Fix the diagram or theme configuration and rerun both
+palettes until every SVG passes.
+
 **Plans/proposals** (user should approve/deny):
 ```bash
 plannotator annotate <file> --gate

--- a/apps/skills/extra/plannotator-visual-explainer/SKILL.test.ts
+++ b/apps/skills/extra/plannotator-visual-explainer/SKILL.test.ts
@@ -1,0 +1,45 @@
+/// <reference types="bun-types" />
+/// <reference types="node" />
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const themeOverride = readFileSync(
+  join(import.meta.dir, "references/theme-override.md"),
+  "utf-8",
+);
+const mermaidStart = themeOverride.indexOf("## Mermaid theming");
+const mermaidEnd = themeOverride.indexOf("\n## ", mermaidStart + 1);
+const mermaidSection = themeOverride.slice(mermaidStart, mermaidEnd);
+const exampleStart = mermaidSection.indexOf("```javascript");
+const exampleEnd = mermaidSection.indexOf("```", exampleStart + 3);
+const mermaidExample = mermaidSection.slice(exampleStart, exampleEnd);
+
+describe("plannotator-visual-explainer Mermaid theming", () => {
+  test("keeps the Mermaid theming section", () => {
+    expect(mermaidStart).toBeGreaterThan(-1);
+    expect(mermaidEnd).toBeGreaterThan(mermaidStart);
+    expect(exampleStart).toBeGreaterThan(-1);
+    expect(exampleEnd).toBeGreaterThan(exampleStart);
+  });
+
+  test("uses Mermaid-compatible literal colors", () => {
+    const literalColors = mermaidExample.match(/#[0-9a-f]{6}\b/gi) ?? [];
+    expect(mermaidExample).toContain("themeVariables");
+    expect(literalColors.length).toBeGreaterThanOrEqual(10);
+  });
+
+  test("keeps CSS color processing outside Mermaid themeVariables", () => {
+    expect(mermaidSection).not.toMatch(/\boklch\(\s*[^)]/i);
+    expect(mermaidSection).not.toMatch(/\bvar\(\s*[^)]/i);
+    expect(mermaidSection).not.toMatch(/\bcolor-mix\(\s*[^)]/i);
+  });
+
+  test("preserves OKLCH for ordinary page CSS", () => {
+    expect(themeOverride).toMatch(/--background:\s+oklch\(/);
+    expect(themeOverride).toMatch(
+      /@media \(prefers-color-scheme: dark\)[\s\S]*--background:\s+oklch\(/,
+    );
+  });
+});

--- a/apps/skills/extra/plannotator-visual-explainer/SKILL.test.ts
+++ b/apps/skills/extra/plannotator-visual-explainer/SKILL.test.ts
@@ -15,6 +15,43 @@ const mermaidSection = themeOverride.slice(mermaidStart, mermaidEnd);
 const exampleStart = mermaidSection.indexOf("```javascript");
 const exampleEnd = mermaidSection.indexOf("```", exampleStart + 3);
 const mermaidExample = mermaidSection.slice(exampleStart, exampleEnd);
+const mermaidExampleCode = mermaidExample.slice(
+  mermaidExample.indexOf("\n") + 1,
+);
+const skill = readFileSync(join(import.meta.dir, "SKILL.md"), "utf-8");
+
+interface CapturedMermaidConfig {
+  theme?: string;
+  themeVariables?: Record<string, unknown>;
+}
+
+function captureMermaidConfig(colorScheme: "light" | "dark") {
+  let captured: CapturedMermaidConfig | undefined;
+  const runExample = new Function(
+    "mermaid",
+    "getComputedStyle",
+    "window",
+    "document",
+    mermaidExampleCode,
+  );
+
+  runExample(
+    {
+      initialize: (config: CapturedMermaidConfig) => {
+        captured = config;
+      },
+    },
+    () => ({ colorScheme }),
+    { matchMedia: () => ({ matches: colorScheme === "dark" }) },
+    { documentElement: {} },
+  );
+
+  if (!captured?.themeVariables) {
+    throw new Error(`Mermaid example did not initialize the ${colorScheme} palette`);
+  }
+
+  return { name: colorScheme, config: captured };
+}
 
 describe("plannotator-visual-explainer Mermaid theming", () => {
   test("keeps the Mermaid theming section", () => {
@@ -41,5 +78,120 @@ describe("plannotator-visual-explainer Mermaid theming", () => {
     expect(themeOverride).toMatch(
       /@media \(prefers-color-scheme: dark\)[\s\S]*--background:\s+oklch\(/,
     );
+  });
+
+  test("renders representative Mermaid 11 diagrams in both palettes", async () => {
+    const palettes = [captureMermaidConfig("light"), captureMermaidConfig("dark")];
+    const uiPackageDir = join(import.meta.dir, "../../../../packages/ui");
+    const renderProbe = String.raw`
+      import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+      GlobalRegistrator.register();
+      const [{ default: mermaid }, { default: mermaidPackage }] = await Promise.all([
+        import("mermaid"),
+        import("mermaid/package.json", { with: { type: "json" } }),
+      ]);
+
+      if (!String(mermaidPackage.version).startsWith("11.")) {
+        throw new Error("Expected Mermaid 11, received " + mermaidPackage.version);
+      }
+
+      const palettes = JSON.parse(process.env.PLANNOTATOR_MERMAID_PALETTES ?? "[]");
+      const diagrams = [
+        {
+          name: "architecture",
+          source: "flowchart TD\n  A[Provider] --> B[Database]",
+          labels: ["Provider", "Database"],
+        },
+        {
+          name: "review-flow",
+          source: "flowchart LR\n  U([Reviewer]) --> D{Approve?}\n  D -->|Yes| M[(Merge)]\n  D -->|No| R[Revise]",
+          labels: ["Reviewer", "Approve?", "Merge", "Revise"],
+        },
+      ];
+      const errorSignature = /aria-roledescription\s*=\s*["']error["']|Syntax error in text/i;
+      const knownErrorOutputs = [
+        '<svg aria-roledescription="error"></svg>',
+        '<svg><text>Syntax error in text</text></svg>',
+      ];
+
+      if (knownErrorOutputs.some((output) => !errorSignature.test(output))) {
+        throw new Error("Mermaid error-output guard does not recognize its required signatures");
+      }
+
+      for (const palette of palettes) {
+        for (const diagram of diagrams) {
+          mermaid.initialize({
+            ...palette.config,
+            startOnLoad: false,
+            // Happy DOM cannot run DOMPurify's strict-mode serialization, but Mermaid's
+            // parser, theme derivation, layout, and SVG renderer all execute in loose mode.
+            securityLevel: "loose",
+          });
+          const { diagramType, svg } = await mermaid.render(
+            "probe-" + palette.name + "-" + diagram.name,
+            diagram.source,
+          );
+
+          if (!svg || !/<svg\b/i.test(svg)) {
+            throw new Error(palette.name + "/" + diagram.name + " produced an empty SVG");
+          }
+          if (diagramType === "error" || errorSignature.test(svg)) {
+            throw new Error(palette.name + "/" + diagram.name + " produced Mermaid error output");
+          }
+          if (!/aria-roledescription=["']flowchart-v2["']/.test(svg)) {
+            throw new Error(palette.name + "/" + diagram.name + " was not rendered as a flowchart");
+          }
+          for (const colorKey of ["primaryColor", "primaryTextColor"]) {
+            const color = String(palette.config.themeVariables?.[colorKey] ?? "").toLowerCase();
+            if (!color || !svg.toLowerCase().includes(color)) {
+              throw new Error(
+                palette.name + "/" + diagram.name + " did not apply " + colorKey,
+              );
+            }
+          }
+          for (const label of diagram.labels) {
+            if (!svg.includes(label)) {
+              throw new Error(palette.name + "/" + diagram.name + " omitted label " + label);
+            }
+          }
+        }
+      }
+
+      console.log(
+        "Rendered " + (palettes.length * diagrams.length) +
+          " Mermaid " + mermaidPackage.version + " SVGs without error signatures",
+      );
+    `;
+    const child = Bun.spawn(
+      [process.execPath, "--cwd", uiPackageDir, "-e", renderProbe],
+      {
+        env: {
+          ...process.env,
+          PLANNOTATOR_MERMAID_PALETTES: JSON.stringify(palettes),
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+    const [exitCode, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ]);
+
+    if (exitCode !== 0) {
+      throw new Error(`Mermaid render probe failed:\n${stderr || stdout}`);
+    }
+    expect(stdout).toMatch(
+      /Rendered 4 Mermaid 11\.[0-9.]+\.[0-9]+ SVGs without error signatures/,
+    );
+  }, 20_000);
+
+  test("keeps Mermaid rendering as a pre-delivery gate", () => {
+    expect(skill).toContain("render every diagram with Mermaid 11");
+    expect(skill).toContain('aria-roledescription="error"');
+    expect(skill).toContain("Syntax error in text");
+    expect(skill).toContain("the explainer is not deliverable");
   });
 });

--- a/apps/skills/extra/plannotator-visual-explainer/references/theme-override.md
+++ b/apps/skills/extra/plannotator-visual-explainer/references/theme-override.md
@@ -81,18 +81,47 @@ The `--font-display` (serif) is still used for headings to create visual contras
 
 ## Mermaid theming
 
-When visual-explainer instructs you to set `themeVariables` in Mermaid config, use Plannotator tokens:
+Mermaid processes `themeVariables` itself and derives additional colors from them. That color-processing boundary does not accept every color syntax that browsers accept in CSS. Use Mermaid-compatible literal hex colors here instead of copying the semantic CSS token declarations above.
+
+Do not pass OKLCH color functions, CSS custom-property references such as `var()`, or `color-mix()` values directly into `themeVariables`. This restriction applies only to Mermaid's color-processing boundary. Continue using Plannotator's OKLCH custom properties and other modern color functions for ordinary page CSS.
+
+Use the same light/dark state as the page, but keep both Mermaid palettes literal. With the host-theme opt-in, Plannotator synchronizes `color-scheme`; standalone documents fall back to the operating-system preference:
 
 ```javascript
+const colorScheme = getComputedStyle(document.documentElement).colorScheme;
+const isDark = colorScheme === 'dark'
+  || (colorScheme === 'normal'
+    && window.matchMedia('(prefers-color-scheme: dark)').matches);
+
+const mermaidThemeVariables = isDark
+  ? {
+      darkMode: true,
+      primaryColor: '#9a9dff',
+      primaryTextColor: '#070b14',
+      primaryBorderColor: '#343b45',
+      lineColor: '#9da5b2',
+      secondaryColor: '#1e242e',
+      secondaryTextColor: '#dadee5',
+      tertiaryColor: '#1e242e',
+      tertiaryTextColor: '#dadee5',
+      background: '#070b14',
+    }
+  : {
+      primaryColor: '#5537eb',
+      primaryTextColor: '#ffffff',
+      primaryBorderColor: '#d4d8de',
+      lineColor: '#414853',
+      secondaryColor: '#e1e5eb',
+      secondaryTextColor: '#414853',
+      tertiaryColor: '#e1e5eb',
+      tertiaryTextColor: '#414853',
+      background: '#f3f5f9',
+    };
+
 mermaid.initialize({
   theme: 'base',
   themeVariables: {
-    primaryColor: 'oklch(0.50 0.25 280)',         // --primary
-    primaryTextColor: 'oklch(1 0 0)',              // --primary-foreground
-    primaryBorderColor: 'oklch(0.88 0.01 260)',    // --border
-    lineColor: 'oklch(0.40 0.02 260)',             // --muted-foreground
-    secondaryColor: 'oklch(0.92 0.01 260)',        // --muted
-    tertiaryColor: 'oklch(0.92 0.01 260)',         // --muted
+    ...mermaidThemeVariables,
     fontFamily: "'Inter', system-ui, sans-serif",
     fontSize: '14px',
   }


### PR DESCRIPTION
Fixes #1043

## Root cause

The delegated `nicobailon/visual-explainer` Mermaid template uses compatible literal hex colors, but Plannotator's authoritative theme override replaced those values with `oklch(...)` strings.

OKLCH remains valid for normal page CSS in modern browsers. Mermaid is a separate color-processing boundary: with `theme: "base"`, it parses the supplied `themeVariables` and derives additional colors itself. Mermaid 11 rejects the OKLCH strings during that calculation.

## Minimal reproduction

The diagram source is unchanged between both runs:

```mermaid
flowchart TD
  A["Provider"] --> B["Database"]
```

With the six original OKLCH values, Mermaid 11 fails during theme initialization with `Unsupported color format`. Replacing only the Mermaid theme colors with the literal palette in this PR renders a normal `aria-roledescription="flowchart-v2"` SVG containing `Provider` and `Database`.

## What changed

- Replaced only the Mermaid-specific palette guidance with literal light and dark hex palettes that preserve Plannotator's purple/neutral identity.
- Explicitly prohibited OKLCH functions, CSS custom-property references such as `var()`, and `color-mix()` values inside Mermaid `themeVariables` while retaining OKLCH for ordinary page CSS.
- Added a reusable light/dark example that follows Plannotator's synchronized `color-scheme`.
- Made Mermaid 11 light/dark rendering a hard pre-delivery gate for explainers, rejecting exceptions, empty SVGs, `aria-roledescription="error"`, and `Syntax error in text`.
- Added a colocated Bun regression test that executes the exact documented example, captures both palettes, and uses the repository's existing Mermaid 11 + Happy DOM toolchain to render two representative flowcharts per palette. It verifies non-empty flowchart SVGs, labels, applied palette colors, and the absence of error signatures without adding a dependency.

The light and dark foreground/background pairs were browser-checked at contrast ratios from 6.70:1 to 12.09:1. Ordinary Plannotator CSS custom properties, including the existing OKLCH light and dark tokens, remain unchanged.

## Verification

- `bun install --frozen-lockfile` — passed; no lockfile change.
- `bun test apps/skills/extra/plannotator-visual-explainer/SKILL.test.ts` — 6 passed, including four real Mermaid 11.15.0 SVG renders.
- `bun test apps/skills` — 9 passed.
- `bun test scripts/install.test.ts` — 85 passed; includes skill/frontmatter and installer package contracts.
- `bun test` — 1,950 passed, 84 expected skips, 0 failed.
- `bun run typecheck` — passed.
- `bun run build:review && bun run build` — passed with no generated artifact drift.
- `git diff --check` — passed.
- `git merge-tree --write-tree origin/main HEAD` — passed against current `main` (`4f1ae8ee`).
