### PR TITLE
feat(review): add System option to the theme mode toggle

### DIFF
--- a/packages/review-editor/components/ReviewHeaderMenu.tsx
+++ b/packages/review-editor/components/ReviewHeaderMenu.tsx
@@ -7,6 +7,7 @@ import {
 } from '@plannotator/ui/components/ActionMenu';
 import { useTheme } from '@plannotator/ui/components/ThemeProvider';
 import { SunIcon, MoonIcon, SystemIcon } from '@plannotator/ui/components/icons/themeIcons';
+import { getUnsupportedMode } from '@plannotator/ui/utils/themeRegistry';
 import { MenuVersionSection } from '@plannotator/ui/components/MenuVersionSection';
 import { TextShimmer } from '@plannotator/ui/components/TextShimmer';
 import { modKey } from '@plannotator/ui/utils/platform';
@@ -38,7 +39,12 @@ export const ReviewHeaderMenu: React.FC<ReviewHeaderMenuProps> = ({
   origin,
   isWSL = false,
 }) => {
-  const { theme, setTheme } = useTheme();
+  const { theme, setTheme, colorTheme } = useTheme();
+  const unsupportedMode = getUnsupportedMode(colorTheme);
+  // When the palette can't render the stored mode, the UI is forced to the
+  // opposite — highlight the mode actually shown instead of the dead one.
+  const highlightedTheme =
+    theme === unsupportedMode ? (unsupportedMode === 'light' ? 'dark' : 'light') : theme;
 
   const showUpdateDot = !!updateInfo?.updateAvailable && !updateInfo.dismissed;
 
@@ -81,14 +87,18 @@ export const ReviewHeaderMenu: React.FC<ReviewHeaderMenuProps> = ({
               {(['light', 'dark', 'system'] as const).map((mode) => (
                 <button
                   key={mode}
+                  disabled={mode === unsupportedMode}
+                  title={mode === unsupportedMode ? 'Not supported by the current color theme' : undefined}
                   onClick={() => {
                     closeMenu();
                     setTheme(mode);
                   }}
                   className={`flex flex-1 items-center justify-center gap-1.5 rounded-md px-2 py-1 text-[11px] font-medium transition-colors ${
-                    theme === mode
-                      ? 'bg-background text-foreground shadow-sm'
-                      : 'text-muted-foreground hover:text-foreground'
+                    mode === unsupportedMode
+                      ? 'text-muted-foreground opacity-40 cursor-not-allowed'
+                      : highlightedTheme === mode
+                        ? 'bg-background text-foreground shadow-sm'
+                        : 'text-muted-foreground hover:text-foreground'
                   }`}
                 >
                   {mode === 'light' ? <SunIcon /> : mode === 'dark' ? <MoonIcon /> : <SystemIcon />}

--- a/packages/review-editor/components/ReviewHeaderMenu.tsx
+++ b/packages/review-editor/components/ReviewHeaderMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import {
   ActionMenu,
   ActionMenuDivider,
@@ -6,6 +6,7 @@ import {
   ActionMenuSectionLabel,
 } from '@plannotator/ui/components/ActionMenu';
 import { useTheme } from '@plannotator/ui/components/ThemeProvider';
+import { SunIcon, MoonIcon, SystemIcon } from '@plannotator/ui/components/icons/themeIcons';
 import { MenuVersionSection } from '@plannotator/ui/components/MenuVersionSection';
 import { TextShimmer } from '@plannotator/ui/components/TextShimmer';
 import { modKey } from '@plannotator/ui/utils/platform';
@@ -37,10 +38,7 @@ export const ReviewHeaderMenu: React.FC<ReviewHeaderMenuProps> = ({
   origin,
   isWSL = false,
 }) => {
-  const { theme, resolvedMode, setTheme } = useTheme();
-  const activeTheme = useMemo<'light' | 'dark'>(() => {
-    return theme === 'system' ? resolvedMode : theme;
-  }, [resolvedMode, theme]);
+  const { theme, setTheme } = useTheme();
 
   const showUpdateDot = !!updateInfo?.updateAvailable && !updateInfo.dismissed;
 
@@ -80,7 +78,7 @@ export const ReviewHeaderMenu: React.FC<ReviewHeaderMenuProps> = ({
           <div className="px-3 py-2 space-y-1.5">
             <ActionMenuSectionLabel>Theme</ActionMenuSectionLabel>
             <div className="flex items-center gap-1 rounded-lg bg-muted/50 p-0.5">
-              {(['light', 'dark'] as const).map((mode) => (
+              {(['light', 'dark', 'system'] as const).map((mode) => (
                 <button
                   key={mode}
                   onClick={() => {
@@ -88,12 +86,12 @@ export const ReviewHeaderMenu: React.FC<ReviewHeaderMenuProps> = ({
                     setTheme(mode);
                   }}
                   className={`flex flex-1 items-center justify-center gap-1.5 rounded-md px-2 py-1 text-[11px] font-medium transition-colors ${
-                    activeTheme === mode
+                    theme === mode
                       ? 'bg-background text-foreground shadow-sm'
                       : 'text-muted-foreground hover:text-foreground'
                   }`}
                 >
-                  {mode === 'light' ? <SunIcon /> : <MoonIcon />}
+                  {mode === 'light' ? <SunIcon /> : mode === 'dark' ? <MoonIcon /> : <SystemIcon />}
                   <span className="capitalize">{mode}</span>
                 </button>
               ))}
@@ -178,19 +176,6 @@ const SettingsIcon = () => (
 const ExportIcon = () => (
   <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
     <path strokeLinecap="round" strokeLinejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
-  </svg>
-);
-
-const SunIcon = () => (
-  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v2.25M12 18.75V21M3 12h2.25M18.75 12H21M5.636 5.636l1.591 1.591M16.773 16.773l1.591 1.591M5.636 18.364l1.591-1.591M16.773 7.227l1.591-1.591" />
-    <circle cx="12" cy="12" r="3.25" />
-  </svg>
-);
-
-const MoonIcon = () => (
-  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M21 12.79A9 9 0 1111.21 3c-.18.57-.21 1.19-.21 1.82A8 8 0 0019.18 13c.63 0 1.25-.03 1.82-.21z" />
   </svg>
 );
 

--- a/packages/ui/components/ActionMenu.tsx
+++ b/packages/ui/components/ActionMenu.tsx
@@ -50,7 +50,7 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
       })}
 
       {isOpen && (
-        <div className={panelClassName ?? 'absolute top-full right-0 mt-1 w-56 rounded-lg border border-border bg-popover py-1 shadow-xl z-[70]'}>
+        <div className={panelClassName ?? 'absolute top-full right-0 mt-1 w-64 rounded-lg border border-border bg-popover py-1 shadow-xl z-[70]'}>
           {children({ closeMenu: () => setIsOpen(false) })}
         </div>
       )}

--- a/packages/ui/components/PlanHeaderMenu.tsx
+++ b/packages/ui/components/PlanHeaderMenu.tsx
@@ -7,6 +7,7 @@ import {
 } from './ActionMenu';
 import { useTheme } from './ThemeProvider';
 import { SunIcon, MoonIcon, SystemIcon } from './icons/themeIcons';
+import { getUnsupportedMode } from '../utils/themeRegistry';
 import { ReviewAgentsIcon } from './ReviewAgentsIcon';
 import { MenuVersionSection } from './MenuVersionSection';
 import { TextShimmer } from './TextShimmer';
@@ -58,7 +59,12 @@ export const PlanHeaderMenu: React.FC<PlanHeaderMenuProps> = ({
   bearConfigured,
   octarineConfigured,
 }) => {
-  const { theme, setTheme } = useTheme();
+  const { theme, setTheme, colorTheme } = useTheme();
+  const unsupportedMode = getUnsupportedMode(colorTheme);
+  // When the palette can't render the stored mode, the UI is forced to the
+  // opposite — highlight the mode actually shown instead of the dead one.
+  const highlightedTheme =
+    theme === unsupportedMode ? (unsupportedMode === 'light' ? 'dark' : 'light') : theme;
 
   const showUpdateDot = !!updateInfo?.updateAvailable && !updateInfo.dismissed;
 
@@ -104,14 +110,18 @@ export const PlanHeaderMenu: React.FC<PlanHeaderMenuProps> = ({
               {(['light', 'dark', 'system'] as const).map((mode) => (
                 <button
                   key={mode}
+                  disabled={mode === unsupportedMode}
+                  title={mode === unsupportedMode ? 'Not supported by the current color theme' : undefined}
                   onClick={() => {
                     closeMenu();
                     setTheme(mode);
                   }}
                   className={`flex flex-1 items-center justify-center gap-1.5 rounded-md px-2 py-1 text-[11px] font-medium transition-colors ${
-                    theme === mode
-                      ? 'bg-background text-foreground shadow-sm'
-                      : 'text-muted-foreground hover:text-foreground'
+                    mode === unsupportedMode
+                      ? 'text-muted-foreground opacity-40 cursor-not-allowed'
+                      : highlightedTheme === mode
+                        ? 'bg-background text-foreground shadow-sm'
+                        : 'text-muted-foreground hover:text-foreground'
                   }`}
                 >
                   {mode === 'light' ? <SunIcon /> : mode === 'dark' ? <MoonIcon /> : <SystemIcon />}

--- a/packages/ui/utils/themeRegistry.ts
+++ b/packages/ui/utils/themeRegistry.ts
@@ -565,3 +565,16 @@ export const BUILT_IN_THEMES: ThemeInfo[] = [
     },
   },
 ];
+
+/**
+ * The mode a color theme cannot render, or null if it supports both.
+ * Dark-only palettes silently ignore light mode (and vice versa) in
+ * ThemeProvider — callers use this to disable the incompatible mode
+ * button instead of letting the toggle no-op.
+ */
+export function getUnsupportedMode(themeId: string): 'light' | 'dark' | null {
+  const info = BUILT_IN_THEMES.find(t => t.id === themeId);
+  if (info?.modeSupport === 'dark-only') return 'light';
+  if (info?.modeSupport === 'light-only') return 'dark';
+  return null;
+}


### PR DESCRIPTION
## Summary

The code review editor's Options menu only offered **Light/Dark**, while `ThemeProvider` already supports a `system` mode and the plan editor menu + Settings theme tab already expose it. This PR brings the review menu in line and fixes two issues surfaced along the way.

## Changes

- **`ReviewHeaderMenu.tsx`** — theme picker now maps `light / dark / system`, using the shared `themeIcons` (removed local duplicate Sun/Moon SVGs). Highlighting uses the stored mode directly instead of collapsing `system` to its resolved mode, so the System button highlights correctly.
- **`ActionMenu.tsx`** — widened the default dropdown panel `w-56` → `w-64`. The three-button segmented control overflowed the 224px panel (the "System" label clipped past the container edge). `PlanHeaderMenu` and `ReviewHeaderMenu` are the only `ActionMenu` consumers, and both render the three-button row.
- **`themeRegistry.ts` + both header menus** — added `getUnsupportedMode()` and disabled the incompatible mode button for dark-only/light-only color themes, instead of letting the toggle silently no-op. The highlight follows the mode actually rendered.

## Validation

- `bun run typecheck` — clean
- `bun test` — 1619 pass, 0 fail
- Built in documented order (`apps/review` build → `build:hook`) and manually verified in the browser: System option renders inside the container, follows macOS appearance changes live, and persists across reloads.

## UI verification

![System theme toggle in the review editor Options menu](https://raw.githubusercontent.com/alexanderkreidich/plannotator/assets/system-theme-toggle/system-theme-toggle-verification.png)
