### PR TITLE
Fix workspace discovery for symlinked repositories

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,6 +89,9 @@ jobs:
         shell: bash
         run: bash apps/pi-extension/vendor.sh
 
+      - name: Run workspace symlink tests
+        run: bun test packages/server/review-workspace.test.ts --test-name-pattern discoverWorkspaceRepoPaths
+
       - name: Build Pi AI runtime smoke
         run: bun build scripts/smoke-pi-extension-ai-runtime.ts --target=node --outfile "$env:RUNNER_TEMP/pi-ai-runtime-smoke.mjs"
 

--- a/apps/pi-extension/server.test.ts
+++ b/apps/pi-extension/server.test.ts
@@ -1,6 +1,15 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { createServer as createNetServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -34,6 +43,10 @@ function makeTempDir(prefix: string): string {
   const dir = mkdtempSync(join(tmpdir(), prefix));
   tempDirs.push(dir);
   return dir;
+}
+
+function linkDirectory(target: string, path: string): void {
+  symlinkSync(target, path, process.platform === "win32" ? "junction" : "dir");
 }
 
 function writeTempFile(root: string, relativePath: string, content = "x"): string {
@@ -665,11 +678,12 @@ describe("pi review server", () => {
   test("workspace mode maps prefixed paths to child repos", async () => {
     const homeDir = makeTempDir("plannotator-pi-home-");
     const root = makeTempDir("plannotator-pi-workspace-");
+    const apiTarget = makeTempDir("plannotator-pi-workspace-api-");
     const apiDir = join(root, "api");
     const semDir = makeTempDir("plannotator-pi-workspace-switch-sem-");
     const cwdLogPath = join(semDir, "cwd-log");
     const inputLogPath = join(semDir, "input.patch");
-    mkdirSync(apiDir, { recursive: true });
+    linkDirectory(apiTarget, apiDir);
     process.env.HOME = homeDir;
     process.env.PLANNOTATOR_PORT = String(await reservePort());
     process.env.PLANNOTATOR_SEM_PATH = makeMockSem(semDir, { runCwdLogPath: cwdLogPath, inputLogPath });

--- a/packages/server/review-workspace.test.ts
+++ b/packages/server/review-workspace.test.ts
@@ -6,7 +6,16 @@
  */
 
 import { afterEach, describe, expect, it } from "bun:test";
-import { chmodSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -49,6 +58,10 @@ function initRepo(dir: string, initialBranch = "main"): void {
   writeFileSync(join(dir, "README.md"), "# Test\n", "utf-8");
   git(dir, ["add", "README.md"]);
   git(dir, ["commit", "-m", "initial"]);
+}
+
+function linkDirectory(target: string, path: string): void {
+  symlinkSync(resolve(target), path, process.platform === "win32" ? "junction" : "dir");
 }
 
 function makeMockSem(dir: string, options: {
@@ -578,6 +591,105 @@ describe("review-workspace", () => {
       expect(repos).toContain(backendApi);
       expect(repos).not.toContain(root);
       expect(repos).not.toContain(backend); // backend itself is not a repo
+    });
+
+    it("uses a symlinked Git repo's logical workspace path end to end", async () => {
+      const root = makeTempDir("plannotator-workspace-symlink-git-");
+      const targetRoot = makeTempDir("plannotator-workspace-symlink-git-target-");
+      const targetRepo = join(targetRoot, "backend-service");
+      const alias = join(root, "backend");
+      mkdirSync(targetRepo, { recursive: true });
+      initRepo(targetRepo);
+      writeFileSync(join(targetRepo, "README.md"), "# Changed through alias\n", "utf-8");
+      linkDirectory(targetRepo, alias);
+
+      const workspace = await buildLocalWorkspaceReview(root);
+
+      expect(workspace.repos).toHaveLength(1);
+      expect(workspace.repos[0]).toMatchObject({ cwd: alias, label: "backend", selected: true });
+      expect(workspace.rawPatch).toContain("diff --git a/backend/README.md b/backend/README.md");
+    });
+
+    it("discovers a symlinked JJ repo using its logical workspace path", () => {
+      const root = makeTempDir("plannotator-workspace-symlink-jj-");
+      const targetRoot = makeTempDir("plannotator-workspace-symlink-jj-target-");
+      const targetRepo = join(targetRoot, "jj-service");
+      const alias = join(root, "frontend");
+      mkdirSync(join(targetRepo, ".jj"), { recursive: true });
+      linkDirectory(targetRepo, alias);
+
+      expect(discoverWorkspaceRepoPaths(root)).toEqual([alias]);
+    });
+
+    it("discovers repos nested below a symlinked directory", () => {
+      const root = makeTempDir("plannotator-workspace-symlink-nested-");
+      const targetRoot = makeTempDir("plannotator-workspace-symlink-nested-target-");
+      const targetRepo = join(targetRoot, "services", "api");
+      const alias = join(root, "projects");
+      mkdirSync(targetRepo, { recursive: true });
+      initRepo(targetRepo);
+      linkDirectory(targetRoot, alias);
+
+      expect(discoverWorkspaceRepoPaths(root)).toEqual([join(alias, "services", "api")]);
+    });
+
+    it("does not recurse forever through a directory-link cycle", () => {
+      const root = makeTempDir("plannotator-workspace-symlink-cycle-");
+      const container = join(root, "packages");
+      const repo = join(container, "api");
+      mkdirSync(repo, { recursive: true });
+      initRepo(repo);
+      linkDirectory(root, join(container, "back-to-root"));
+
+      expect(discoverWorkspaceRepoPaths(root)).toEqual([repo]);
+    });
+
+    it("ignores broken directory links", () => {
+      const root = makeTempDir("plannotator-workspace-symlink-broken-");
+      const targetRoot = makeTempDir("plannotator-workspace-symlink-broken-target-");
+      const brokenTarget = join(targetRoot, "removed");
+      mkdirSync(brokenTarget, { recursive: true });
+      linkDirectory(brokenTarget, join(root, "broken"));
+      rmSync(brokenTarget, { recursive: true });
+
+      expect(discoverWorkspaceRepoPaths(root)).toEqual([]);
+    });
+
+    it.skipIf(process.platform === "win32")("ignores symlinks to files", () => {
+      const root = makeTempDir("plannotator-workspace-symlink-file-");
+      const targetRoot = makeTempDir("plannotator-workspace-symlink-file-target-");
+      const targetFile = join(targetRoot, "README.md");
+      writeFileSync(targetFile, "not a directory\n", "utf-8");
+      symlinkSync(targetFile, join(root, "linked-file"), "file");
+
+      expect(discoverWorkspaceRepoPaths(root)).toEqual([]);
+    });
+
+    it("chooses the first logical alias deterministically for duplicate targets", () => {
+      const root = makeTempDir("plannotator-workspace-symlink-duplicates-");
+      const targetRoot = makeTempDir("plannotator-workspace-symlink-duplicates-target-");
+      const targetRepo = join(targetRoot, "service");
+      const alphaAlias = join(root, "alpha");
+      mkdirSync(targetRepo, { recursive: true });
+      initRepo(targetRepo);
+      linkDirectory(targetRepo, join(root, "zeta"));
+      linkDirectory(targetRepo, alphaAlias);
+
+      expect(discoverWorkspaceRepoPaths(root)).toEqual([alphaAlias]);
+    });
+
+    it("does not follow a directory link whose logical name is skipped", () => {
+      const root = makeTempDir("plannotator-workspace-symlink-skip-");
+      const targetRoot = makeTempDir("plannotator-workspace-symlink-skip-target-");
+      const targetRepo = join(targetRoot, "dependency-repo");
+      const realRepo = join(root, "app");
+      mkdirSync(targetRepo, { recursive: true });
+      mkdirSync(realRepo, { recursive: true });
+      initRepo(targetRepo);
+      initRepo(realRepo);
+      linkDirectory(targetRepo, join(root, "node_modules"));
+
+      expect(discoverWorkspaceRepoPaths(root)).toEqual([realRepo]);
     });
 
     it("stops recursion at git repo boundaries (does not discover nested repos inside other repos)", () => {

--- a/packages/shared/review-workspace-node.ts
+++ b/packages/shared/review-workspace-node.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, type Dirent } from "node:fs";
+import { existsSync, readdirSync, realpathSync, statSync, type Dirent } from "node:fs";
 import { basename, relative, resolve } from "node:path";
 
 import {
@@ -159,10 +159,34 @@ function hasVcsMarker(dirPath: string): boolean {
   return VCS_MARKERS.some((marker) => existsSync(resolve(dirPath, marker)));
 }
 
-function collectWorkspaceRepos(root: string, current: string, results: string[]): void {
+function resolveDirectoryRealPath(path: string): string | null {
+  try {
+    if (!statSync(path).isDirectory()) return null;
+    return realpathSync(path);
+  } catch {
+    return null;
+  }
+}
+
+function compareDirentsByName(a: Dirent, b: Dirent): number {
+  if (a.name < b.name) return -1;
+  if (a.name > b.name) return 1;
+  return 0;
+}
+
+function collectWorkspaceRepos(
+  root: string,
+  current: string,
+  visitedRealPaths: Set<string>,
+  results: string[],
+): void {
+  const realPath = resolveDirectoryRealPath(current);
+  if (!realPath || visitedRealPaths.has(realPath)) return;
+  visitedRealPaths.add(realPath);
+
   let entries: Dirent[];
   try {
-    entries = readdirSync(current, { withFileTypes: true });
+    entries = readdirSync(current, { withFileTypes: true }).sort(compareDirentsByName);
   } catch {
     return;
   }
@@ -173,16 +197,24 @@ function collectWorkspaceRepos(root: string, current: string, results: string[])
   }
 
   for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
     if (SKIP_DIRS.has(entry.name)) continue;
-    collectWorkspaceRepos(root, resolve(current, entry.name), results);
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+    collectWorkspaceRepos(root, resolve(current, entry.name), visitedRealPaths, results);
   }
 }
 
+/**
+ * Discovers the first Git or JJ repository below each workspace path.
+ *
+ * Directory symlinks and junctions are followed while their logical paths are
+ * retained for labels and file routing. Each canonical directory is traversed
+ * at most once, so cycles and duplicate aliases cannot duplicate repositories.
+ * Unreadable, broken, and non-directory entries are ignored.
+ */
 export function discoverWorkspaceRepoPaths(root: string): string[] {
   const resolvedRoot = resolve(root);
   const results: string[] = [];
-  collectWorkspaceRepos(resolvedRoot, resolvedRoot, results);
+  collectWorkspaceRepos(resolvedRoot, resolvedRoot, new Set<string>(), results);
   return results.sort();
 }
 


### PR DESCRIPTION
## Summary

- follow directory symlinks and Windows junctions during workspace repository discovery while retaining logical workspace aliases
- canonicalize visited directories to deduplicate aliases and terminate symlink loops; ignore broken and non-directory links
- cover Git, JJ, nested targets, normal directories, and the vendored Pi server path

## Validation

- `bun test packages/server/review-workspace.test.ts` (47 passed)
- focused Pi workspace server test (1 passed)
- `bun test` (1,991 passed, 90 DOM-gated skips, 0 failed)
- CI DOM slices (115 passed)
- `bun run typecheck`
- `bun run build:pi`
- `bun run build`
- Pi vendor parity test plus byte-for-byte shared/generated source checks
- real `windows-latest` junction discovery suite and Pi Node runtime smoke (passed)

Closes #1054. Reported by @fruxxxl (AlexSh) — thank you for the clear reproduction and root-cause analysis.