### PR TITLE
fix(review): keep background remote discovery noninteractive

### DIFF
--- a/apps/pi-extension/server/vcs.ts
+++ b/apps/pi-extension/server/vcs.ts
@@ -1,13 +1,16 @@
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import {
 	type DiffResult,
 	type DiffType,
 	type GitCommandResult,
+	type GitCommandOptions,
 	type GitContext,
 	type GitDiffOptions,
+	type PreparedGitCommand,
 	type ReviewGitRuntime,
 	getGitContext as getGitContextCore,
+	prepareGitCommand,
 	runGitDiff as runGitDiffCore,
 } from "../generated/review-core.js";
 import {
@@ -25,17 +28,39 @@ function runCommand(
 	command: string,
 	args: string[],
 	notFoundMessage: string,
-	options?: { cwd?: string; timeoutMs?: number },
+	options?: GitCommandOptions,
+	preparedGitCommand?: PreparedGitCommand,
 ): Promise<GitCommandResult> {
 	return new Promise((resolve) => {
 		const proc = spawn(command, args, {
 			cwd: options?.cwd,
+			detached: preparedGitCommand?.isolateProcessGroup ?? false,
+			env: preparedGitCommand?.env,
 			stdio: ["ignore", "pipe", "pipe"],
+			windowsHide: true,
 		});
 
 		let timer: ReturnType<typeof setTimeout> | undefined;
 		if (options?.timeoutMs) {
-			timer = setTimeout(() => proc.kill(), options.timeoutMs);
+			timer = setTimeout(() => {
+				if (preparedGitCommand?.isolateProcessGroup && proc.pid && process.platform !== "win32") {
+					try {
+						process.kill(-proc.pid, "SIGKILL");
+						return;
+					} catch {
+						// Fall through when the process exited between the timer and signal.
+					}
+				}
+				if (preparedGitCommand?.isolateProcessGroup && proc.pid && process.platform === "win32") {
+					const killed = spawnSync(
+						"taskkill.exe",
+						["/pid", String(proc.pid), "/t", "/f"],
+						{ stdio: "ignore", windowsHide: true },
+					);
+					if (killed.status === 0) return;
+				}
+				proc.kill("SIGKILL");
+			}, options.timeoutMs);
 		}
 
 		const stdoutChunks: Buffer[] = [];
@@ -62,9 +87,10 @@ function runCommand(
 export const reviewRuntime: ReviewGitRuntime = {
 	runGit(
 		args: string[],
-		options?: { cwd?: string; timeoutMs?: number },
+		options?: GitCommandOptions,
 	): Promise<GitCommandResult> {
-		return runCommand("git", ["-c", "core.quotePath=false", ...args], "git not found", options);
+		const command = prepareGitCommand(args, options, process.env);
+		return runCommand("git", command.args, "git not found", options, command);
 	},
 
 	async readTextFile(path: string): Promise<string | null> {

--- a/packages/server/git-background.test.ts
+++ b/packages/server/git-background.test.ts
@@ -1,0 +1,348 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+interface RuntimeFixture {
+  name: string;
+  modulePath: string;
+  exportName: string;
+}
+
+interface SshInvocation {
+  pid: number;
+  args: string[];
+  gitTerminalPrompt?: string;
+  sshAskpassRequire?: string;
+}
+
+const fixtures: RuntimeFixture[] = [
+  {
+    name: "Bun",
+    modulePath: resolve(import.meta.dir, "git.ts"),
+    exportName: "runtime",
+  },
+  {
+    name: "Pi",
+    modulePath: resolve(import.meta.dir, "../../apps/pi-extension/server/vcs.ts"),
+    exportName: "reviewRuntime",
+  },
+];
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function createSshFixture(): { repo: string; marker: string; command: string } {
+  const root = mkdtempSync(join(tmpdir(), "plannotator-git-background-"));
+  tempDirs.push(root);
+  const repo = join(root, "repo");
+  const marker = join(root, "ssh-invocations.jsonl");
+  const fakeSsh = join(root, "fake-ssh.ts");
+  mkdirSync(repo);
+
+  for (const args of [
+    ["init", "--quiet", repo],
+    ["-C", repo, "remote", "add", "origin", "ssh://example.invalid/repository"],
+  ]) {
+    const result = spawnSync("git", args, { encoding: "utf-8" });
+    if (result.status !== 0) throw new Error(result.stderr || `git ${args.join(" ")} failed`);
+  }
+
+  writeFileSync(
+    fakeSsh,
+    `import { appendFileSync, openSync, writeSync } from "node:fs";
+const args = process.argv.slice(2);
+const marker = process.env.SSH_MARKER;
+if (!marker) throw new Error("SSH_MARKER is required");
+appendFileSync(marker, JSON.stringify({
+  pid: process.pid,
+  args,
+  gitTerminalPrompt: process.env.GIT_TERMINAL_PROMPT,
+  sshAskpassRequire: process.env.SSH_ASKPASS_REQUIRE,
+}) + "\\n");
+const batchMode = args.some((arg) => /^(?:-o)?BatchMode=yes$/i.test(arg));
+const behavior = process.env.SSH_BEHAVIOR ?? "prompt";
+if (behavior === "hang" || (behavior === "prompt" && !batchMode)) {
+  const prompt = "Enter passphrase for key '/tmp/plannotator-test-key':\\n";
+  if (behavior === "prompt") {
+    try {
+      const tty = openSync("/dev/tty", "w");
+      writeSync(tty, prompt);
+    } catch {
+      process.stderr.write(prompt);
+    }
+  }
+  await Bun.sleep(30_000);
+}
+process.exit(1);
+`,
+    "utf-8",
+  );
+  chmodSync(fakeSsh, 0o755);
+
+  return {
+    repo,
+    marker,
+    command: `${shellQuote(process.execPath)} ${shellQuote(fakeSsh)}`,
+  };
+}
+
+function createHttpCredentialFixture(remoteUrl: string): {
+  repo: string;
+  askpassMarker: string;
+  askpass: string;
+} {
+  const root = mkdtempSync(join(tmpdir(), "plannotator-git-credentials-"));
+  tempDirs.push(root);
+  const repo = join(root, "repo");
+  const askpassMarker = join(root, "askpass-invoked");
+  const askpass = join(root, "fake-askpass.ts");
+  mkdirSync(repo);
+
+  for (const args of [
+    ["init", "--quiet", repo],
+    ["-C", repo, "remote", "add", "origin", remoteUrl],
+  ]) {
+    const result = spawnSync("git", args, { encoding: "utf-8" });
+    if (result.status !== 0) throw new Error(result.stderr || `git ${args.join(" ")} failed`);
+  }
+
+  writeFileSync(
+    askpass,
+    `#!${process.execPath}
+import { appendFileSync } from "node:fs";
+const marker = process.env.ASKPASS_MARKER;
+if (!marker) throw new Error("ASKPASS_MARKER is required");
+appendFileSync(marker, "invoked\\n");
+await Bun.sleep(30_000);
+`,
+    "utf-8",
+  );
+  chmodSync(askpass, 0o755);
+
+  return { repo, askpassMarker, askpass };
+}
+
+function parseSshInvocation(line: string): SshInvocation | null {
+  const value: unknown = JSON.parse(line);
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("pid" in value) ||
+    typeof value.pid !== "number" ||
+    !("args" in value) ||
+    !Array.isArray(value.args) ||
+    !value.args.every((arg) => typeof arg === "string")
+  ) {
+    return null;
+  }
+  const gitTerminalPrompt = "gitTerminalPrompt" in value && typeof value.gitTerminalPrompt === "string"
+    ? value.gitTerminalPrompt
+    : undefined;
+  const sshAskpassRequire = "sshAskpassRequire" in value && typeof value.sshAskpassRequire === "string"
+    ? value.sshAskpassRequire
+    : undefined;
+  return { pid: value.pid, args: value.args, gitTerminalPrompt, sshAskpassRequire };
+}
+
+function readInvocations(marker: string): SshInvocation[] {
+  try {
+    return readFileSync(marker, "utf-8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .flatMap((line) => {
+        const invocation = parseSshInvocation(line);
+        return invocation ? [invocation] : [];
+      });
+  } catch {
+    return [];
+  }
+}
+
+function terminateTransports(invocations: SshInvocation[]): void {
+  for (const invocation of invocations) {
+    try {
+      process.kill(invocation.pid, "SIGKILL");
+    } catch {
+      // The fixed path exits before cleanup reaches it.
+    }
+  }
+}
+
+describe.skipIf(process.platform === "win32")("background remote discovery", () => {
+  for (const fixture of fixtures) {
+    test(`${fixture.name} discovery cannot prompt through a controlling terminal`, () => {
+      const { repo, marker, command } = createSshFixture();
+      const runtimeUrl = pathToFileURL(fixture.modulePath).href;
+      const reviewCoreUrl = pathToFileURL(resolve(import.meta.dir, "../shared/review-core.ts")).href;
+      const source = `
+        const runtimeModule = await import(${JSON.stringify(runtimeUrl)});
+        const { detectRemoteDefaultInfo } = await import(${JSON.stringify(reviewCoreUrl)});
+        const result = await detectRemoteDefaultInfo(
+          runtimeModule[${JSON.stringify(fixture.exportName)}],
+          ${JSON.stringify(repo)},
+        );
+        if (result !== null) process.exit(2);
+      `;
+
+      const result = spawnSync(process.execPath, ["--eval", source], {
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          GIT_SSH_COMMAND: command,
+          SSH_MARKER: marker,
+        },
+        timeout: 2_000,
+      });
+      const invocations = readInvocations(marker);
+      terminateTransports(invocations);
+
+      expect(invocations.length).toBeGreaterThan(0);
+      expect(invocations.every((invocation) => invocation.gitTerminalPrompt === "0")).toBe(true);
+      expect(invocations.every((invocation) => invocation.sshAskpassRequire === "never")).toBe(true);
+      expect(
+        invocations.every((invocation) =>
+          invocation.args.some((arg) => /^(?:-o)?BatchMode=yes$/i.test(arg)),
+        ),
+      ).toBe(true);
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+    }, 5_000);
+
+    test(`${fixture.name} timeout kills the Git transport process tree`, async () => {
+      const { repo, marker, command } = createSshFixture();
+      const runtimeUrl = pathToFileURL(fixture.modulePath).href;
+      const source = `
+        const runtimeModule = await import(${JSON.stringify(runtimeUrl)});
+        await runtimeModule[${JSON.stringify(fixture.exportName)}].runGit(
+          ["ls-remote", "--symref", "origin", "HEAD"],
+          { cwd: ${JSON.stringify(repo)}, timeoutMs: 150, interaction: "forbid" },
+        );
+      `;
+
+      const startedAt = performance.now();
+      const result = spawnSync(process.execPath, ["--eval", source], {
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          GIT_SSH_COMMAND: command,
+          SSH_BEHAVIOR: "hang",
+          SSH_MARKER: marker,
+        },
+        timeout: 2_000,
+      });
+      const elapsedMs = performance.now() - startedAt;
+      const invocations = readInvocations(marker);
+      await Bun.sleep(50);
+
+      try {
+        expect(invocations.length).toBeGreaterThan(0);
+        expect(result.error).toBeUndefined();
+        expect(result.status).toBe(0);
+        expect(elapsedMs).toBeLessThan(1_000);
+        for (const invocation of invocations) {
+          expect(() => process.kill(invocation.pid, 0)).toThrow();
+        }
+      } finally {
+        terminateTransports(invocations);
+      }
+    }, 5_000);
+
+    test(`${fixture.name} interactive fetch keeps the inherited authentication policy`, () => {
+      const { repo, marker, command } = createSshFixture();
+      const runtimeUrl = pathToFileURL(fixture.modulePath).href;
+      const source = `
+        const runtimeModule = await import(${JSON.stringify(runtimeUrl)});
+        await runtimeModule[${JSON.stringify(fixture.exportName)}].runGit(
+          ["fetch", "origin", "main"],
+          { cwd: ${JSON.stringify(repo)}, timeoutMs: 2_000 },
+        );
+      `;
+
+      const result = spawnSync(process.execPath, ["--eval", source], {
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          GIT_SSH_COMMAND: command,
+          GIT_TERMINAL_PROMPT: "inherited",
+          SSH_ASKPASS_REQUIRE: "force",
+          SSH_BEHAVIOR: "record",
+          SSH_MARKER: marker,
+        },
+        timeout: 2_000,
+      });
+      const invocations = readInvocations(marker);
+      terminateTransports(invocations);
+
+      expect(invocations.length).toBeGreaterThan(0);
+      expect(invocations.every((invocation) => invocation.gitTerminalPrompt === "inherited")).toBe(true);
+      expect(invocations.every((invocation) => invocation.sshAskpassRequire === "force")).toBe(true);
+      expect(
+        invocations.every((invocation) =>
+          invocation.args.every((arg) => !/^(?:-o)?BatchMode=yes$/i.test(arg)),
+        ),
+      ).toBe(true);
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+    }, 5_000);
+
+    test(`${fixture.name} background HTTP(S) auth does not invoke askpass`, async () => {
+      const authServer = Bun.serve({
+        hostname: "127.0.0.1",
+        port: 0,
+        fetch() {
+          return new Response("Authentication required", {
+            status: 401,
+            headers: { "WWW-Authenticate": 'Basic realm="Plannotator test"' },
+          });
+        },
+      });
+      const { repo, askpassMarker, askpass } = createHttpCredentialFixture(
+        `http://127.0.0.1:${authServer.port}/repository.git`,
+      );
+      const runtimeUrl = pathToFileURL(fixture.modulePath).href;
+      const source = `
+        const runtimeModule = await import(${JSON.stringify(runtimeUrl)});
+        await runtimeModule[${JSON.stringify(fixture.exportName)}].runGit(
+          ["ls-remote", "--symref", "origin", "HEAD"],
+          { cwd: ${JSON.stringify(repo)}, timeoutMs: 500, interaction: "forbid" },
+        );
+      `;
+
+      try {
+        const proc = Bun.spawn([process.execPath, "--eval", source], {
+          env: {
+            ...process.env,
+            ASKPASS_MARKER: askpassMarker,
+            GIT_ASKPASS: askpass,
+          },
+          stdin: "ignore",
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([
+          new Response(proc.stdout).text(),
+          new Response(proc.stderr).text(),
+          proc.exited,
+        ]);
+
+        expect({ stdout, stderr, exitCode }).toMatchObject({ exitCode: 0 });
+        expect(() => readFileSync(askpassMarker, "utf-8")).toThrow();
+      } finally {
+        authServer.stop(true);
+      }
+    }, 5_000);
+  }
+});

--- a/packages/server/git.ts
+++ b/packages/server/git.ts
@@ -10,6 +10,7 @@ import {
   type DiffResult,
   type DiffType,
   type GitCommandResult,
+  type GitCommandOptions,
   type GitContext,
   type GitDiffOptions,
   type ReviewGitRuntime,
@@ -22,6 +23,7 @@ import {
   gitAddFile as gitAddFileCore,
   gitResetFile as gitResetFileCore,
   parseWorktreeDiffType,
+  prepareGitCommand,
   runGitDiff as runGitDiffCore,
   runGitDiffWithContext as runGitDiffWithContextCore,
   validateFilePath,
@@ -38,17 +40,39 @@ export type {
 
 async function runGit(
   args: string[],
-  options?: { cwd?: string; timeoutMs?: number },
+  options?: GitCommandOptions,
 ): Promise<GitCommandResult> {
-  const proc = Bun.spawn(["git", "-c", "core.quotePath=false", ...args], {
+  const command = prepareGitCommand(args, options, process.env);
+  const proc = Bun.spawn(["git", ...command.args], {
     cwd: options?.cwd,
+    detached: command.isolateProcessGroup,
+    env: command.env,
+    stdin: "ignore",
     stdout: "pipe",
     stderr: "pipe",
+    windowsHide: true,
   });
 
   let timer: ReturnType<typeof setTimeout> | undefined;
   if (options?.timeoutMs) {
-    timer = setTimeout(() => proc.kill(), options.timeoutMs);
+    timer = setTimeout(() => {
+      if (command.isolateProcessGroup && process.platform !== "win32") {
+        try {
+          process.kill(-proc.pid, "SIGKILL");
+          return;
+        } catch {
+          // Fall through when the process exited between the timer and signal.
+        }
+      }
+      if (command.isolateProcessGroup && process.platform === "win32") {
+        const killed = Bun.spawnSync(
+          ["taskkill.exe", "/pid", String(proc.pid), "/t", "/f"],
+          { stdin: "ignore", stdout: "ignore", stderr: "ignore", windowsHide: true },
+        );
+        if (killed.exitCode === 0) return;
+      }
+      proc.kill("SIGKILL");
+    }, options.timeoutMs);
   }
 
   const [stdout, stderr, exitCode] = await Promise.all([

--- a/packages/shared/review-core.test.ts
+++ b/packages/shared/review-core.test.ts
@@ -4,6 +4,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { join, resolve as resolvePath } from "node:path";
 import {
+  detectRemoteDefaultInfo,
   getDefaultBranch,
   getFileContentsForDiff,
   getGitContext,
@@ -14,6 +15,7 @@ import {
   listRecentCommits,
   parseCommitDiffType,
   parseWorktreeDiffType,
+  prepareGitCommand,
   runGitDiff,
   splitPorcelainRename,
   type DiffType,
@@ -106,6 +108,117 @@ afterEach(() => {
 });
 
 describe("review-core", () => {
+  test("background Git policy is process-local and noninteractive for OpenSSH", () => {
+    const environment = {
+      PATH: "/usr/bin",
+      GIT_SSH_COMMAND: "custom-ssh --proxy jump-host",
+    };
+
+    const command = prepareGitCommand(
+      ["ls-remote", "--symref", "origin", "HEAD"],
+      { timeoutMs: 5_000, interaction: "forbid" },
+      environment,
+    );
+
+    expect(environment).toEqual({
+      PATH: "/usr/bin",
+      GIT_SSH_COMMAND: "custom-ssh --proxy jump-host",
+    });
+    expect(command.args).toEqual([
+      "-c",
+      "core.quotePath=false",
+      "-c",
+      "credential.interactive=false",
+      "ls-remote",
+      "--symref",
+      "origin",
+      "HEAD",
+    ]);
+    expect(command.env).toMatchObject({
+      PATH: "/usr/bin",
+      GIT_TERMINAL_PROMPT: "0",
+      GIT_SSH_COMMAND: "custom-ssh --proxy jump-host -o BatchMode=yes -o ConnectTimeout=5",
+      SSH_ASKPASS_REQUIRE: "never",
+    });
+    expect(command.isolateProcessGroup).toBe(true);
+  });
+
+  test("background Git policy uses plink batch mode on Windows-style SSH setups", () => {
+    const command = prepareGitCommand(
+      ["ls-remote", "origin", "HEAD"],
+      { timeoutMs: 1_500, interaction: "forbid" },
+      {
+        GIT_SSH: "C:\\Program Files\\PuTTY\\plink.exe",
+        GIT_SSH_VARIANT: "plink",
+      },
+    );
+
+    expect(command.env?.GIT_TERMINAL_PROMPT).toBe("0");
+    expect(command.env?.GIT_SSH_COMMAND).toBe(
+      '"C:\\\\Program Files\\\\PuTTY\\\\plink.exe" -batch',
+    );
+    expect(command.isolateProcessGroup).toBe(true);
+  });
+
+  test("interactive Git policy preserves authentication and terminal behavior", () => {
+    const command = prepareGitCommand(
+      ["fetch", "origin", "main"],
+      { timeoutMs: 30_000 },
+      {
+        GIT_TERMINAL_PROMPT: "1",
+        GIT_SSH_COMMAND: "custom-ssh",
+      },
+    );
+
+    expect(command).toEqual({
+      args: ["-c", "core.quotePath=false", "fetch", "origin", "main"],
+      isolateProcessGroup: false,
+    });
+  });
+
+  test("remote-default discovery requests bounded noninteractive execution", async () => {
+    const calls: Array<{ args: string[]; options: unknown }> = [];
+    const runtime: ReviewGitRuntime = {
+      async runGit(args, options) {
+        calls.push({ args, options });
+        return { stdout: "", stderr: "origin is absent", exitCode: 2 };
+      },
+      async readTextFile() {
+        return null;
+      },
+    };
+
+    await expect(detectRemoteDefaultInfo(runtime, "/repo")).resolves.toBeNull();
+    expect(calls).toEqual([
+      {
+        args: ["ls-remote", "--symref", "origin", "HEAD"],
+        options: { cwd: "/repo", timeoutMs: 5_000, interaction: "forbid" },
+      },
+    ]);
+  });
+
+  test("remote-default discovery tolerates a repository without an origin", async () => {
+    const repoDir = initRepo();
+    const runtime = makeRuntime(repoDir);
+
+    await expect(detectRemoteDefaultInfo(runtime, repoDir)).resolves.toBeNull();
+  });
+
+  test("remote-default discovery still resolves an accessible ordinary remote", async () => {
+    const repoDir = initRepo();
+    const remoteDir = makeTempDir("plannotator-review-core-remote-");
+    git(remoteDir, ["init", "--bare", "--initial-branch=main"]);
+    git(repoDir, ["remote", "add", "origin", remoteDir]);
+    git(repoDir, ["push", "--set-upstream", "origin", "main"]);
+    const head = git(repoDir, ["rev-parse", "HEAD"]);
+    const runtime = makeRuntime(repoDir);
+
+    await expect(detectRemoteDefaultInfo(runtime, repoDir)).resolves.toEqual({
+      branch: "origin/main",
+      remoteHeadSha: head,
+    });
+  });
+
   test("uncommitted diff includes tracked and untracked files", async () => {
     const repoDir = initRepo();
     const runtime = makeRuntime(repoDir);
@@ -526,4 +639,3 @@ describe("commit diff mode", () => {
     expect(after).toBe(before);
   });
 });
-

--- a/packages/shared/review-core.ts
+++ b/packages/shared/review-core.ts
@@ -115,12 +115,96 @@ export interface GitCommandResult {
   exitCode: number;
 }
 
+/** Per-command execution policy understood by every review Git runtime. */
+export interface GitCommandOptions {
+  cwd?: string;
+  timeoutMs?: number;
+  /** Whether the command may ask the user for credentials. Defaults to `"allow"`. */
+  interaction?: "allow" | "forbid";
+}
+
+/** Runtime-neutral Git arguments and subprocess policy produced at the process boundary. */
+export interface PreparedGitCommand {
+  /** Arguments passed after the `git` executable. */
+  args: string[];
+  /** Per-process environment. Omitted when the inherited environment is unchanged. */
+  env?: Record<string, string | undefined>;
+  /** Whether the runtime must put the command in its own killable process group. */
+  isolateProcessGroup: boolean;
+}
+
 export interface ReviewGitRuntime {
   runGit: (
     args: string[],
-    options?: { cwd?: string; timeoutMs?: number },
+    options?: GitCommandOptions,
   ) => Promise<GitCommandResult>;
   readTextFile: (path: string) => Promise<string | null>;
+}
+
+function quoteGitSshPath(path: string): string {
+  return `"${path.replace(/["\\$`]/g, "\\$&")}"`;
+}
+
+function inheritedSshCommand(environment: Readonly<Record<string, string | undefined>>): string {
+  const command = environment.GIT_SSH_COMMAND?.trim();
+  if (command) return command;
+  const executable = environment.GIT_SSH?.trim();
+  return executable ? quoteGitSshPath(executable) : "ssh";
+}
+
+function usesPlink(
+  environment: Readonly<Record<string, string | undefined>>,
+  sshCommand: string,
+): boolean {
+  const variant = environment.GIT_SSH_VARIANT?.trim().toLowerCase();
+  if (variant === "plink" || variant === "tortoiseplink") return true;
+  if (variant === "ssh" || variant === "simple") return false;
+  return /(?:^|[\\/])(?:tortoise)?plink(?:\.exe)?(?:[\s"']|$)/i.test(sshCommand);
+}
+
+/**
+ * Prepare one Git subprocess without mutating the parent environment.
+ *
+ * Commands that forbid interaction disable Git credential prompts, request SSH
+ * batch mode (including PuTTY/plink), and request process-group isolation so
+ * the runtime can terminate transport children on timeout. Interactive Git
+ * commands retain the caller's exact authentication behavior.
+ */
+export function prepareGitCommand(
+  args: string[],
+  options: GitCommandOptions | undefined,
+  environment: Readonly<Record<string, string | undefined>>,
+): PreparedGitCommand {
+  const interaction = options?.interaction ?? "allow";
+  if (interaction === "allow") {
+    return {
+      args: ["-c", "core.quotePath=false", ...args],
+      isolateProcessGroup: false,
+    };
+  }
+
+  const sshCommand = inheritedSshCommand(environment);
+  const connectTimeoutSeconds = Math.max(1, Math.ceil((options?.timeoutMs ?? 5_000) / 1_000));
+  const sshBatchOptions = usesPlink(environment, sshCommand)
+    ? "-batch"
+    : `-o BatchMode=yes -o ConnectTimeout=${connectTimeoutSeconds}`;
+
+  return {
+    args: [
+      "-c",
+      "core.quotePath=false",
+      "-c",
+      "credential.interactive=false",
+      ...args,
+    ],
+    env: {
+      ...environment,
+      GIT_TERMINAL_PROMPT: "0",
+      GIT_SSH_COMMAND: `${sshCommand} ${sshBatchOptions}`,
+      SSH_ASKPASS_REQUIRE: "never",
+    },
+    isolateProcessGroup: true,
+  };
 }
 
 export interface GitDiffOptions {
@@ -237,8 +321,9 @@ export interface RemoteDefaultInfo {
  * background at server startup — the caller fires it with `.then()` and uses
  * the result if/when it arrives.
  *
- * Timeout-guarded: if the network is slow or absent, the promise resolves
- * (with `null`) once the timeout fires. Never throws.
+ * Noninteractive and timeout-guarded: credential/SSH prompts are forbidden,
+ * and a slow or absent network resolves with `null` once the timeout fires.
+ * Never throws.
  */
 export async function detectRemoteDefaultInfo(
   runtime: ReviewGitRuntime,
@@ -247,7 +332,7 @@ export async function detectRemoteDefaultInfo(
   try {
     const lsRemote = await runtime.runGit(
       ["ls-remote", "--symref", "origin", "HEAD"],
-      { cwd, timeoutMs: 5000 },
+      { cwd, timeoutMs: 5000, interaction: "forbid" },
     );
     if (lsRemote.exitCode !== 0) return null;
     const match = lsRemote.stdout.match(/^ref:\s+refs\/heads\/(\S+)\s+HEAD/m);


### PR DESCRIPTION
## Summary

- mark startup and staleness `git ls-remote` discovery as noninteractive without mutating the parent environment
- disable Git credential prompts, request SSH/OpenSSH or plink batch mode, and isolate the background process group so timeout cleanup includes transport children
- keep explicit user-triggered fetch/update commands on the existing interactive authentication path
- apply the same execution policy in the Bun and Pi runtimes through the vendored shared core

## Root cause

The remote-default query predates the regression, but #990 made remote-tip discovery an unconditional startup/staleness probe. Its five-second timeout killed only the top-level Git process. OpenSSH could still open the controlling terminal for a passphrase, overlaying and freezing the Pi TUI, while the transport child kept the captured pipes alive.

## Verification

- faithful pseudo-terminal fake-SSH reproduction fails on `main` and passes in both Bun and Pi with this change
- transport-child hang and process-group kill cleanup covered in both runtimes
- Git/OpenSSH askpass and HTTP credential challenge covered
- missing remote, accessible local remote, OpenSSH, plink-style, public HTTPS, and authenticated ordinary SSH paths checked
- interactive fetch authentication policy regression-covered
- `bun test`
- `bun run typecheck`
- `bun run build:pi`
- compiled Bun CLI build and smoke check
- Pi generated `review-core` byte parity check

## Credit

Reported by @r3clin3r in #1020, including the key reproduction detail that reverting the Pi extension to 0.20.3 avoided the freeze. Thank you for the clear report and regression boundary.

Closes #1020