### PR TITLE
perf(pi): lazy-load runtime graph to cut startup time

### DIFF
--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -31,28 +31,9 @@ import {
 	markCompletedSteps,
 	parseChecklist,
 } from "./generated/checklist.js";
-import { hasMarkdownFiles, resolveUserPath } from "./generated/resolve-file.js";
-import { FILE_BROWSER_EXCLUDED } from "./generated/reference-common.js";
-import { htmlToMarkdown } from "./generated/html-to-markdown.js";
-import { urlToMarkdown, isConvertedSource } from "./generated/url-to-markdown.js";
 import { loadConfig, resolveUseJina } from "./generated/config.js";
 import { readImprovementHook } from "./generated/improvement-hooks.js";
 import { composeImproveContext } from "./generated/pfm-reminder.js";
-import {
-	getReviewApprovedPrompt,
-	getReviewDeniedSuffix,
-	getPlanDeniedPrompt,
-	getPlanApprovedPrompt,
-	getPlanApprovedWithNotesPrompt,
-	getPlanAutoApprovedPrompt,
-	getPlanToolName,
-	buildPlanFileRule,
-	getAnnotateFileFeedbackPrompt,
-	getAnnotateMessageFeedbackPrompt,
-} from "./generated/prompts.js";
-import { parseAnnotateArgs } from "./generated/annotate-args.js";
-import { parseReviewArgs } from "./generated/review-args.js";
-import { resolveAtReference } from "./generated/at-reference.js";
 import {
 	hasPlanBrowserHtml,
 	hasReviewBrowserHtml,
@@ -89,6 +70,36 @@ import {
 import { isRemoteSession } from "./server/network.js";
 
 // ── Types ──────────────────────────────────────────────────────────────
+
+type PlannotatorPromptsModule = typeof import("./generated/prompts.js");
+
+let promptsModulePromise: Promise<PlannotatorPromptsModule> | undefined;
+
+function loadPlannotatorPrompts(): Promise<PlannotatorPromptsModule> {
+	if (!promptsModulePromise) {
+		promptsModulePromise = import("./generated/prompts.js").catch((error: unknown) => {
+			promptsModulePromise = undefined;
+			throw error;
+		});
+	}
+	return promptsModulePromise;
+}
+
+async function loadAnnotateCommandModules() {
+	const [annotateArgs, atReference, resolveFile, referenceCommon] = await Promise.all([
+		import("./generated/annotate-args.js"),
+		import("./generated/at-reference.js"),
+		import("./generated/resolve-file.js"),
+		import("./generated/reference-common.js"),
+	]);
+	return {
+		parseAnnotateArgs: annotateArgs.parseAnnotateArgs,
+		resolveAtReference: atReference.resolveAtReference,
+		hasMarkdownFiles: resolveFile.hasMarkdownFiles,
+		resolveUserPath: resolveFile.resolveUserPath,
+		FILE_BROWSER_EXCLUDED: referenceCommon.FILE_BROWSER_EXCLUDED,
+	};
+}
 
 
 type SavedPhaseState = {
@@ -433,6 +444,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 			const origin = getPiSessionIdentity(ctx);
 
 			try {
+				const { parseReviewArgs } = await import("./generated/review-args.js");
 				const reviewArgs = parseReviewArgs(args ?? "");
 				const session = await startCodeReviewBrowserSession(ctx, {
 					prUrl: reviewArgs.prUrl,
@@ -442,13 +454,14 @@ export default function plannotator(pi: ExtensionAPI): void {
 				ctx.ui.notify(sessionOpenedMessage("Code review opened", session.url), "info");
 				void session
 					.waitForDecision()
-					.then((result) => {
+					.then(async (result) => {
 						try {
 							if (result.exit) {
 								safeNotify(ctx, "Code review session closed.", "info", origin);
 								return;
 							}
 							if (result.approved) {
+								const { getReviewApprovedPrompt } = await loadPlannotatorPrompts();
 								sendUserMessageWithCurrentSessionFallback(
 									pi,
 									getReviewApprovedPrompt("pi", loadConfig()),
@@ -467,9 +480,11 @@ export default function plannotator(pi: ExtensionAPI): void {
 							// (approve/comment posted to the host) come back with an empty
 							// annotation set and a status message — don't tell the agent to
 							// "address" a platform action.
-							const reviewFeedback = (result.annotations?.length ?? 0) > 0
-								? `${result.feedback}${getReviewDeniedSuffix("pi", loadConfig())}`
-								: result.feedback;
+							let reviewFeedback = result.feedback;
+							if ((result.annotations?.length ?? 0) > 0) {
+								const { getReviewDeniedSuffix } = await loadPlannotatorPrompts();
+								reviewFeedback += getReviewDeniedSuffix("pi", loadConfig());
+							}
 							sendUserMessageWithCurrentSessionFallback(
 								pi,
 								reviewFeedback,
@@ -496,6 +511,13 @@ export default function plannotator(pi: ExtensionAPI): void {
 	pi.registerCommand("plannotator-annotate", {
 		description: "Open markdown file or folder in annotation UI",
 		handler: async (args, ctx) => {
+			const {
+				FILE_BROWSER_EXCLUDED,
+				hasMarkdownFiles,
+				parseAnnotateArgs,
+				resolveAtReference,
+				resolveUserPath,
+			} = await loadAnnotateCommandModules();
 			// Split known annotate flags from the path. --json is silently
 			// accepted (Pi writes back via sendUserMessage, not stdout).
 			// `rawFilePath` keeps any leading `@` for the literal-@ fallback
@@ -529,6 +551,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 				const useJina = resolveUseJina(noJina, loadConfig());
 				ctx.ui.notify(`Fetching: ${filePath}${useJina ? " (via Jina Reader)" : " (via fetch+Turndown)"}...`, "info");
 				try {
+					const { isConvertedSource, urlToMarkdown } = await import("./generated/url-to-markdown.js");
 					const result = await urlToMarkdown(filePath, { useJina });
 					markdown = result.markdown;
 					sourceConverted = isConvertedSource(result.source);
@@ -577,6 +600,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 						rawHtml = html;
 						markdown = "";
 					} else {
+						const { htmlToMarkdown } = await import("./generated/html-to-markdown.js");
 						markdown = htmlToMarkdown(html);
 						sourceConverted = true;
 					}
@@ -612,7 +636,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 				ctx.ui.notify(sessionOpenedMessage("Annotation opened", session.url), "info");
 				void session
 					.waitForDecision()
-					.then((result) => {
+					.then(async (result) => {
 						try {
 							if (result.exit) {
 								safeNotify(ctx, "Annotation session closed.", "info", origin);
@@ -626,6 +650,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 								safeNotify(ctx, "Annotation closed (no feedback).", "info", origin);
 								return;
 							}
+							const { getAnnotateFileFeedbackPrompt } = await loadPlannotatorPrompts();
 							sendUserMessageWithCurrentSessionFallback(
 								pi,
 								getAnnotateFileFeedbackPrompt("pi", loadConfig(), {
@@ -657,6 +682,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 		description: "Annotate the last assistant message",
 		handler: async (args, ctx) => {
 			// Support --gate on /plannotator-last for the Stop-hook review gate.
+			const { parseAnnotateArgs } = await import("./generated/annotate-args.js");
 			const { gate } = parseAnnotateArgs(args ?? "");
 
 			if (!hasPlanBrowserHtml()) {
@@ -686,7 +712,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 				ctx.ui.notify(sessionOpenedMessage("Last-message annotation opened", session.url), "info");
 				void session
 					.waitForDecision()
-					.then((result) => {
+					.then(async (result) => {
 						try {
 							if (result.exit) {
 								safeNotify(ctx, "Annotation session closed.", "info", origin);
@@ -705,9 +731,10 @@ export default function plannotator(pi: ExtensionAPI): void {
 							const target = result.selectedMessageId && result.selectedMessageId !== snapshot.entryId
 								? findAssistantMessageByEntryId(ctx, result.selectedMessageId) ?? snapshot
 								: snapshot;
-								const feedback = result.feedbackScope !== "messages" && shouldAnchorLastMessageFeedback(ctx, target.entryId, origin)
+							const feedback = result.feedbackScope !== "messages" && shouldAnchorLastMessageFeedback(ctx, target.entryId, origin)
 									? anchorMessageFeedback(result.feedback, target.text)
 									: result.feedback;
+							const { getAnnotateMessageFeedbackPrompt } = await loadPlannotatorPrompts();
 							sendUserMessageWithCurrentSessionFallback(
 								pi,
 								getAnnotateMessageFeedbackPrompt("pi", loadConfig(), {
@@ -860,6 +887,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 				pi.appendEntry("plannotator-execute", { lastSubmittedPath });
 				persistState();
 				justApprovedPlan = true;
+				const { getPlanAutoApprovedPrompt } = await loadPlannotatorPrompts();
 				return {
 					content: [
 						{
@@ -897,6 +925,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 						: "";
 
 				if (result.feedback) {
+					const { getPlanApprovedWithNotesPrompt } = await loadPlannotatorPrompts();
 					return {
 						content: [
 							{
@@ -913,6 +942,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 					};
 				}
 
+				const { getPlanApprovedPrompt } = await loadPlannotatorPrompts();
 				return {
 					content: [
 						{
@@ -931,6 +961,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 			// Denied
 			persistState();
 			const feedbackText = result.feedback || "Plan rejected. Please revise.";
+			const { buildPlanFileRule, getPlanDeniedPrompt, getPlanToolName } = await loadPlannotatorPrompts();
 			return {
 				content: [
 					{

--- a/apps/pi-extension/package.json
+++ b/apps/pi-extension/package.json
@@ -31,6 +31,7 @@
     "assistant-message.ts",
     "current-pi-session.ts",
     "plannotator-browser.ts",
+    "plannotator-browser-runtime.ts",
     "plannotator-events.ts",
     "server.ts",
     "tool-scope.ts",

--- a/apps/pi-extension/plannotator-browser-runtime.ts
+++ b/apps/pi-extension/plannotator-browser-runtime.ts
@@ -1,0 +1,77 @@
+import { readFileSync, statSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+type PlannotatorBrowserModule = typeof import("./plannotator-browser.js");
+
+const moduleDirectory = dirname(fileURLToPath(import.meta.url));
+const planHtmlPath = resolve(moduleDirectory, "plannotator.html");
+const reviewHtmlPath = resolve(moduleDirectory, "review-editor.html");
+
+let browserModulePromise: Promise<PlannotatorBrowserModule> | undefined;
+let planHtmlContent: string | undefined;
+let reviewHtmlContent: string | undefined;
+
+function hasReadableAsset(path: string, cachedContent: string | undefined): boolean {
+	if (cachedContent) return true;
+	try {
+		const stats = statSync(path);
+		return stats.isFile() && stats.size > 0;
+	} catch {
+		return false;
+	}
+}
+
+function readBrowserAsset(path: string, cachedContent: string | undefined): string {
+	if (cachedContent !== undefined) return cachedContent;
+	try {
+		return readFileSync(path, "utf-8");
+	} catch {
+		return "";
+	}
+}
+
+/** Return whether the built plan/annotation/archive UI is available without reading it into memory. */
+export function hasPlanBrowserHtml(): boolean {
+	return hasReadableAsset(planHtmlPath, planHtmlContent);
+}
+
+/** Return whether the built code-review UI is available without reading it into memory. */
+export function hasReviewBrowserHtml(): boolean {
+	return hasReadableAsset(reviewHtmlPath, reviewHtmlContent);
+}
+
+/** Read and cache the built plan/annotation/archive UI on first use. */
+export function getPlanBrowserHtml(): string {
+	const content = readBrowserAsset(planHtmlPath, planHtmlContent);
+	if (content) planHtmlContent = content;
+	return content;
+}
+
+/** Read and cache the built code-review UI on first use. */
+export function getReviewBrowserHtml(): string {
+	const content = readBrowserAsset(reviewHtmlPath, reviewHtmlContent);
+	if (content) reviewHtmlContent = content;
+	return content;
+}
+
+/** Convert a startup failure into the stable user-facing message used by Pi commands and events. */
+export function getStartupErrorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : "Unknown error";
+}
+
+/**
+ * Load the browser/server graph on first use.
+ *
+ * Concurrent callers share one import, while a failed import is cleared so a
+ * later invocation can retry instead of retaining a permanently rejected promise.
+ */
+export function loadPlannotatorBrowser(): Promise<PlannotatorBrowserModule> {
+	if (!browserModulePromise) {
+		browserModulePromise = import("./plannotator-browser.js").catch((error: unknown) => {
+			browserModulePromise = undefined;
+			throw error;
+		});
+	}
+	return browserModulePromise;
+}

--- a/apps/pi-extension/plannotator-browser.ts
+++ b/apps/pi-extension/plannotator-browser.ts
@@ -1,9 +1,8 @@
 import { existsSync, readFileSync, realpathSync, rmSync, statSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
 import { createWorktreePool, type WorktreePool } from "./generated/worktree-pool.js";
-import { fileURLToPath } from "node:url";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
 	prepareLocalReviewDiff,
@@ -39,7 +38,19 @@ import {
 	WorkspaceReviewSession,
 	type WorkspaceDiffType,
 } from "./generated/review-workspace.js";
+import {
+	getPlanBrowserHtml,
+	getReviewBrowserHtml,
+	getStartupErrorMessage,
+	hasPlanBrowserHtml,
+	hasReviewBrowserHtml,
+} from "./plannotator-browser-runtime.js";
 export { getLastAssistantMessageText } from "./assistant-message.js";
+export {
+	getStartupErrorMessage,
+	hasPlanBrowserHtml,
+	hasReviewBrowserHtml,
+} from "./plannotator-browser-runtime.js";
 
 export type AnnotateMode = "annotate" | "annotate-folder" | "annotate-last";
 export interface PlanReviewDecision {
@@ -61,36 +72,8 @@ export interface PlanReviewBrowserSession extends BrowserDecisionSession<PlanRev
 	onDecision: (listener: (result: PlanReviewDecision) => void | Promise<void>) => () => void;
 }
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-let planHtmlContent = "";
-let reviewHtmlContent = "";
-
-try {
-	planHtmlContent = readFileSync(resolve(__dirname, "plannotator.html"), "utf-8");
-} catch {
-	// built assets unavailable
-}
-
-try {
-	reviewHtmlContent = readFileSync(resolve(__dirname, "review-editor.html"), "utf-8");
-} catch {
-	// built assets unavailable
-}
-
 function delay(ms: number): Promise<void> {
 	return new Promise((resolvePromise) => setTimeout(resolvePromise, ms));
-}
-
-export function hasPlanBrowserHtml(): boolean {
-	return Boolean(planHtmlContent);
-}
-
-export function hasReviewBrowserHtml(): boolean {
-	return Boolean(reviewHtmlContent);
-}
-
-export function getStartupErrorMessage(err: unknown): string {
-	return err instanceof Error ? err.message : "Unknown error";
 }
 
 async function openBrowserForServer(serverUrl: string, ctx: ExtensionContext): Promise<void> {
@@ -185,7 +168,11 @@ export async function startPlanReviewBrowserSession(
 	ctx: ExtensionContext,
 	planContent: string,
 ): Promise<PlanReviewBrowserSession> {
-	if (!ctx.hasUI || !planHtmlContent) {
+	if (!ctx.hasUI) {
+		throw new Error("Plannotator browser review is unavailable in this session.");
+	}
+	const planHtmlContent = getPlanBrowserHtml();
+	if (!planHtmlContent) {
 		throw new Error("Plannotator browser review is unavailable in this session.");
 	}
 
@@ -242,7 +229,11 @@ export async function startCodeReviewBrowserSession(
 		exit?: boolean;
 	}>
 > {
-	if (!ctx.hasUI || !reviewHtmlContent) {
+	if (!ctx.hasUI) {
+		throw new Error("Plannotator code review browser is unavailable in this session.");
+	}
+	const reviewHtmlContent = getReviewBrowserHtml();
+	if (!reviewHtmlContent) {
 		throw new Error("Plannotator code review browser is unavailable in this session.");
 	}
 
@@ -527,7 +518,11 @@ export async function startMarkdownAnnotationSession(
 	convertHtml?: boolean,
 	recentMessages?: { messageId: string; text: string; timestamp?: string }[],
 ): Promise<BrowserDecisionSession<{ feedback: string; exit?: boolean; approved?: boolean; selectedMessageId?: string; feedbackScope?: "message" | "messages" }>> {
-	if (!ctx.hasUI || !planHtmlContent) {
+	if (!ctx.hasUI) {
+		throw new Error("Plannotator annotation browser is unavailable in this session.");
+	}
+	const planHtmlContent = getPlanBrowserHtml();
+	if (!planHtmlContent) {
 		throw new Error("Plannotator annotation browser is unavailable in this session.");
 	}
 
@@ -603,7 +598,11 @@ export async function openArchiveBrowserAction(
 	ctx: ExtensionContext,
 	customPlanPath?: string,
 ): Promise<{ opened: boolean }> {
-	if (!ctx.hasUI || !planHtmlContent) {
+	if (!ctx.hasUI) {
+		throw new Error("Plannotator archive browser is unavailable in this session.");
+	}
+	const planHtmlContent = getPlanBrowserHtml();
+	if (!planHtmlContent) {
 		throw new Error("Plannotator archive browser is unavailable in this session.");
 	}
 

--- a/apps/pi-extension/plannotator-events.ts
+++ b/apps/pi-extension/plannotator-events.ts
@@ -3,19 +3,81 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { DiffType, VcsSelection } from "./server.js";
-import { getRecentAssistantMessages } from "./assistant-message.js";
 import {
 	getLastAssistantMessageText,
+	getRecentAssistantMessages,
+} from "./assistant-message.js";
+import {
 	getStartupErrorMessage,
-	openArchiveBrowserAction,
-	openCodeReview,
-	openLastMessageAnnotation,
-	openMarkdownAnnotation,
-	startCodeReviewBrowserSession,
-	startLastMessageAnnotationSession,
-	startMarkdownAnnotationSession,
-	startPlanReviewBrowserSession,
-} from "./plannotator-browser.js";
+	hasPlanBrowserHtml,
+	hasReviewBrowserHtml,
+	loadPlannotatorBrowser,
+} from "./plannotator-browser-runtime.js";
+
+type PlannotatorBrowserModule = typeof import("./plannotator-browser.js");
+
+/** Start a plan-review browser session after loading the browser/server graph on demand. */
+export function startPlanReviewBrowserSession(
+	...args: Parameters<PlannotatorBrowserModule["startPlanReviewBrowserSession"]>
+): ReturnType<PlannotatorBrowserModule["startPlanReviewBrowserSession"]> {
+	return loadPlannotatorBrowser().then((browser) => browser.startPlanReviewBrowserSession(...args));
+}
+
+/** Open a plan review after loading the browser/server graph on demand. */
+export function openPlanReviewBrowser(
+	...args: Parameters<PlannotatorBrowserModule["openPlanReviewBrowser"]>
+): ReturnType<PlannotatorBrowserModule["openPlanReviewBrowser"]> {
+	return loadPlannotatorBrowser().then((browser) => browser.openPlanReviewBrowser(...args));
+}
+
+/** Start a code-review browser session after loading the browser/server graph on demand. */
+export function startCodeReviewBrowserSession(
+	...args: Parameters<PlannotatorBrowserModule["startCodeReviewBrowserSession"]>
+): ReturnType<PlannotatorBrowserModule["startCodeReviewBrowserSession"]> {
+	return loadPlannotatorBrowser().then((browser) => browser.startCodeReviewBrowserSession(...args));
+}
+
+/** Open a code review after loading the browser/server graph on demand. */
+export function openCodeReview(
+	...args: Parameters<PlannotatorBrowserModule["openCodeReview"]>
+): ReturnType<PlannotatorBrowserModule["openCodeReview"]> {
+	return loadPlannotatorBrowser().then((browser) => browser.openCodeReview(...args));
+}
+
+/** Start a markdown-annotation session after loading the browser/server graph on demand. */
+export function startMarkdownAnnotationSession(
+	...args: Parameters<PlannotatorBrowserModule["startMarkdownAnnotationSession"]>
+): ReturnType<PlannotatorBrowserModule["startMarkdownAnnotationSession"]> {
+	return loadPlannotatorBrowser().then((browser) => browser.startMarkdownAnnotationSession(...args));
+}
+
+/** Open a markdown annotation after loading the browser/server graph on demand. */
+export function openMarkdownAnnotation(
+	...args: Parameters<PlannotatorBrowserModule["openMarkdownAnnotation"]>
+): ReturnType<PlannotatorBrowserModule["openMarkdownAnnotation"]> {
+	return loadPlannotatorBrowser().then((browser) => browser.openMarkdownAnnotation(...args));
+}
+
+/** Start a last-message annotation session after loading the browser/server graph on demand. */
+export function startLastMessageAnnotationSession(
+	...args: Parameters<PlannotatorBrowserModule["startLastMessageAnnotationSession"]>
+): ReturnType<PlannotatorBrowserModule["startLastMessageAnnotationSession"]> {
+	return loadPlannotatorBrowser().then((browser) => browser.startLastMessageAnnotationSession(...args));
+}
+
+/** Open a last-message annotation after loading the browser/server graph on demand. */
+export function openLastMessageAnnotation(
+	...args: Parameters<PlannotatorBrowserModule["openLastMessageAnnotation"]>
+): ReturnType<PlannotatorBrowserModule["openLastMessageAnnotation"]> {
+	return loadPlannotatorBrowser().then((browser) => browser.openLastMessageAnnotation(...args));
+}
+
+/** Open the plan archive after loading the browser/server graph on demand. */
+export function openArchiveBrowserAction(
+	...args: Parameters<PlannotatorBrowserModule["openArchiveBrowserAction"]>
+): ReturnType<PlannotatorBrowserModule["openArchiveBrowserAction"]> {
+	return loadPlannotatorBrowser().then((browser) => browser.openArchiveBrowserAction(...args));
+}
 
 export const PLANNOTATOR_REQUEST_CHANNEL = "plannotator:request" as const;
 export const PLANNOTATOR_REVIEW_RESULT_CHANNEL = "plannotator:review-result" as const;
@@ -365,14 +427,5 @@ export {
 	getLastAssistantMessageText,
 	hasPlanBrowserHtml,
 	hasReviewBrowserHtml,
-	startCodeReviewBrowserSession,
-	startLastMessageAnnotationSession,
-	startMarkdownAnnotationSession,
 	getStartupErrorMessage,
-	openArchiveBrowserAction,
-	openCodeReview,
-	openLastMessageAnnotation,
-	openMarkdownAnnotation,
-	openPlanReviewBrowser,
-	startPlanReviewBrowserSession,
-} from "./plannotator-browser.js";
+};

--- a/apps/pi-extension/startup.test.ts
+++ b/apps/pi-extension/startup.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadPlannotatorBrowser } from "./plannotator-browser-runtime";
+
+const extensionDirectory = dirname(fileURLToPath(import.meta.url));
+
+function scanImports(filename: string): { eager: Set<string>; dynamic: Set<string> } {
+	const source = readFileSync(join(extensionDirectory, filename), "utf-8");
+	const imports = new Bun.Transpiler({ loader: "ts" }).scan(source).imports;
+	return {
+		eager: new Set(imports.filter((entry) => entry.kind === "import-statement").map((entry) => entry.path)),
+		dynamic: new Set(imports.filter((entry) => entry.kind === "dynamic-import").map((entry) => entry.path)),
+	};
+}
+
+describe("Pi extension startup boundary", () => {
+	test("keeps invocation-only modules out of the eager index graph", () => {
+		const imports = scanImports("index.ts");
+		const invocationOnlyModules = [
+			"./generated/annotate-args.js",
+			"./generated/at-reference.js",
+			"./generated/html-to-markdown.js",
+			"./generated/prompts.js",
+			"./generated/reference-common.js",
+			"./generated/resolve-file.js",
+			"./generated/review-args.js",
+			"./generated/url-to-markdown.js",
+		];
+
+		for (const modulePath of invocationOnlyModules) {
+			expect(imports.eager).not.toContain(modulePath);
+			expect(imports.dynamic).toContain(modulePath);
+		}
+	});
+
+	test("loads the browser/server graph only through the shared dynamic boundary", () => {
+		const eventImports = scanImports("plannotator-events.ts");
+		const runtimeImports = scanImports("plannotator-browser-runtime.ts");
+
+		expect(eventImports.eager).not.toContain("./plannotator-browser.js");
+		expect(eventImports.eager).toContain("./plannotator-browser-runtime.js");
+		expect(runtimeImports.eager).not.toContain("./plannotator-browser.js");
+		expect(runtimeImports.dynamic).toContain("./plannotator-browser.js");
+	});
+
+	test("coalesces concurrent first-use browser imports", async () => {
+		const first = loadPlannotatorBrowser();
+		const second = loadPlannotatorBrowser();
+
+		expect(second).toBe(first);
+		const browser = await first;
+		expect(browser.startPlanReviewBrowserSession).toBeFunction();
+		expect(browser.startCodeReviewBrowserSession).toBeFunction();
+		expect(browser.startMarkdownAnnotationSession).toBeFunction();
+	});
+
+	test("ships the lazy runtime in the npm package", () => {
+		const manifest = JSON.parse(
+			readFileSync(join(extensionDirectory, "package.json"), "utf-8"),
+		) as { files?: unknown };
+
+		expect(Array.isArray(manifest.files)).toBe(true);
+		expect(manifest.files).toContain("plannotator-browser-runtime.ts");
+	});
+});


### PR DESCRIPTION
## Summary

- keep the Pi extension registration path lightweight and dynamically import the browser/server graph only when a Plannotator action is invoked
- lazy-load command-only parsing, conversion, and prompt modules; coalesce concurrent first-use imports and clear failed imports so later invocations can retry
- defer the 22 MB plan UI and 17 MB review UI reads until the corresponding browser action, then cache successful reads
- preserve the raw TypeScript package layout and Pi jiti resolver behavior instead of introducing a second compiled artifact that could drift from generated vendor sources or peer aliases
- add regression coverage for the startup boundary, concurrent first use, and npm package contents

The eager local graph drops from 100 modules / 1,121,898 source bytes (73 generated modules and 19 server modules) to 14 modules / 112,478 source bytes (6 generated modules and 1 server module).

## Measurements

Environment: macOS 26.3 arm64, Node 24.15.0, Pi 0.80.9. Baseline was the published `@plannotator/pi-extension@0.23.1`; the candidate was built and packed from this branch.

Each cell is the median of seven fresh Pi launches. `PI_TIMING=1` supplied import and main-total timings. Cold runs used an isolated empty `PI_CODING_AGENT_DIR` plus a unique `TMPDIR`/jiti cache per launch; warm runs reused one cache. The command was Pi RPC mode with stdin closed immediately, so no model request was made.

| Timing | Published | This PR | Change |
| --- | ---: | ---: | ---: |
| Extension import, cold | 1,232 ms | 140 ms | -88.6% |
| Extension import, warm | 440 ms | 33 ms | -92.5% |
| Pi main total, cold | 1,244 ms | 151 ms | -87.9% |
| Pi main total, warm | 451 ms | 43 ms | -90.5% |

Raw extension-import samples in milliseconds:

- published cold: `1195 1383 1190 1232 1291 1447 1094`
- candidate cold: `149 132 150 140 135 136 142`
- published warm: `443 422 481 440 425 440 415`
- candidate warm: `38 33 35 33 32 36 33`

The first Plannotator action intentionally pays the deferred jiti compilation cost once. Every action awaits the shared import before starting its server, so there is no first-use race, and failures are surfaced and remain retryable.

## Validation

- `bun run typecheck`
- `bun test` — 1,987 passed, 90 skipped, 0 failed
- `bun run build:pi`
- release-style `bun pm pack`, npm extraction/dependency installation, and Pi 0.80.9 loading from the installed package
- packaged command registration for `/plannotator`, `/plannotator-review`, `/plannotator-annotate`, and `/plannotator-last`
- packaged plan session served `/api/plan` with the submitted content
- packaged review session served `/api/diff`, `/api/ai/capabilities`, `/api/agents/capabilities`, and `/api/agents/jobs`, then shut down cleanly
- packaged annotate session loaded a real markdown file, served annotate mode and AI capabilities, then shut down cleanly
- old/new `plannotator-events` runtime export sets compared equal (17 exports)
- Windows AI-runtime smoke entry still bundles successfully; Windows execution remains covered by the existing CI job

Reported by @tomsej (Radek Tomšej). Thanks for the precise profiling and diagnosis.

Closes #1058