### PR TITLE
Fix OpenCode plan cleanup after cancellation

### DIFF
--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -115,6 +115,10 @@ import { detectProjectName } from "@plannotator/server/project";
 import { hostnameOrFallback } from "@plannotator/shared/project";
 import { readImprovementHook } from "@plannotator/shared/improvement-hooks";
 import { composeImproveContext } from "@plannotator/shared/pfm-reminder";
+import {
+  waitForPlanReviewCloseDelay,
+  waitForPlanReviewDecision,
+} from "@plannotator/shared/plan-review-lifecycle";
 import { AGENT_CONFIG, type Origin } from "@plannotator/shared/agents";
 import {
   findDroidSessionLogsByAncestorWalk,
@@ -1359,26 +1363,20 @@ if (args[0] === "sessions") {
     label: `plan-${planProject}`,
   });
 
-  const result = timeoutSeconds === null
-    ? await server.waitForDecision()
-    : await new Promise<Awaited<ReturnType<typeof server.waitForDecision>>>((resolve) => {
-        const timeoutId = setTimeout(
-          () =>
-            resolve({
-              approved: false,
-              feedback: `[Plannotator] No response within ${timeoutSeconds} seconds. Port released automatically. Please call submit_plan again.`,
-            }),
-          timeoutSeconds * 1000,
-        );
-
-        server.waitForDecision().then((decision) => {
-          clearTimeout(timeoutId);
-          resolve(decision);
-        });
-      });
-
-  await Bun.sleep(1500);
-  server.stop();
+  let result: Awaited<ReturnType<typeof server.waitForDecision>>;
+  try {
+    result = await waitForPlanReviewDecision({
+      waitForDecision: server.waitForDecision,
+      timeoutMs: timeoutSeconds === null ? null : timeoutSeconds * 1000,
+      timeoutResult: {
+        approved: false,
+        feedback: `[Plannotator] No response within ${timeoutSeconds} seconds. Port released automatically. Please call submit_plan again.`,
+      },
+    });
+    await waitForPlanReviewCloseDelay(1500);
+  } finally {
+    await server.stop();
+  }
 
   console.log(JSON.stringify({
     approved: result.approved,

--- a/apps/opencode-plugin/cli-bridge.ts
+++ b/apps/opencode-plugin/cli-bridge.ts
@@ -52,6 +52,7 @@ interface RunCliOptions {
   readyLabel: string;
   extraEnv?: Record<string, string | undefined>;
   bridge?: OpenCodeBridgeContext;
+  abortSignal?: AbortSignal;
 }
 
 interface RunCliResult {
@@ -283,7 +284,34 @@ function logReadyFile(client: OpenCodeClient, readyFile: string, readyLabel: str
   }
 }
 
+function getAbortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException("The operation was aborted", "AbortError");
+}
+
+function getErrorCode(error: unknown): string | undefined {
+  if (!(error instanceof Error)) return undefined;
+  const code = Reflect.get(error, "code");
+  return typeof code === "string" ? code : undefined;
+}
+
+function signalChildProcess(
+  child: ReturnType<typeof spawn>,
+  signal: NodeJS.Signals,
+  detached: boolean,
+): void {
+  if (detached && child.pid !== undefined) {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch (error) {
+      if (getErrorCode(error) !== "ESRCH") throw error;
+    }
+  }
+  child.kill(signal);
+}
+
 async function runPlannotatorCli(options: RunCliOptions): Promise<RunCliResult> {
+  options.abortSignal?.throwIfAborted();
   const readyFile = path.join(
     tmpdir(),
     `plannotator-opencode-${process.pid}-${Date.now()}-${randomUUID()}.jsonl`,
@@ -305,59 +333,113 @@ async function runPlannotatorCli(options: RunCliOptions): Promise<RunCliResult> 
   const spawnConfig = buildCliSpawnConfig(bin, options.args);
   log(options.client, "info", `[Plannotator] Starting ${options.readyLabel}...`);
 
-  return await new Promise((resolve, reject) => {
-    const child = spawn(spawnConfig.command, spawnConfig.args, {
-      cwd,
-      env,
-      shell: spawnConfig.shell,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
+  const abortSignal = options.abortSignal;
+  const detached = abortSignal !== undefined && process.platform !== "win32";
+  let child: ReturnType<typeof spawn> | undefined;
+  let interval: ReturnType<typeof setInterval> | undefined;
+  let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
+  let abortListener: (() => void) | undefined;
+  let stderrForwarder: ReturnType<typeof createCliStderrForwarder> | undefined;
 
-    let stdout = "";
-    let stderr = "";
-    const stderrForwarder = createCliStderrForwarder(options.client, toastedUrls);
-    const interval = setInterval(
-      () => logReadyFile(options.client, readyFile, options.readyLabel, loggedUrls, toastedUrls),
-      250,
-    );
+  try {
+    return await new Promise<RunCliResult>((resolve, reject) => {
+      let stdout = "";
+      let stderr = "";
+      let processError: NodeJS.ErrnoException | undefined;
+      let aborted = false;
 
-    if (!child.stdin || !child.stdout || !child.stderr) {
-      clearInterval(interval);
-      rmSync(readyFile, { force: true });
-      reject(new Error("Failed to open pipes for the plannotator CLI process."));
-      return;
-    }
+      const requestTermination = () => {
+        if (!child || child.exitCode !== null || child.signalCode !== null) return;
+        try {
+          signalChildProcess(child, "SIGTERM", detached);
+        } catch (error) {
+          processError = error instanceof Error ? error : new Error(String(error));
+        }
+        if (forceKillTimer !== undefined) return;
+        forceKillTimer = setTimeout(() => {
+          if (!child || child.exitCode !== null || child.signalCode !== null) return;
+          try {
+            signalChildProcess(child, "SIGKILL", detached);
+          } catch {
+            // The close/error handlers report the original termination failure.
+          }
+        }, 1000);
+      };
 
-    child.stdout.setEncoding("utf-8");
-    child.stderr.setEncoding("utf-8");
-    child.stdout.on("data", (chunk) => {
-      stdout += chunk;
-    });
-    child.stderr.on("data", (chunk) => {
-      stderr += chunk;
-      stderrForwarder.push(chunk);
-    });
-    child.on("error", (error: NodeJS.ErrnoException) => {
-      clearInterval(interval);
-      stderrForwarder.flush();
-      logReadyFile(options.client, readyFile, options.readyLabel, loggedUrls, toastedUrls);
-      rmSync(readyFile, { force: true });
-      if (error.code === "ENOENT") {
-        reject(new Error("Could not find the plannotator CLI. Install it with: curl -fsSL https://plannotator.ai/install.sh | bash"));
-        return;
+      child = spawn(spawnConfig.command, spawnConfig.args, {
+        cwd,
+        env,
+        shell: spawnConfig.shell,
+        stdio: ["pipe", "pipe", "pipe"],
+        detached,
+      });
+      stderrForwarder = createCliStderrForwarder(options.client, toastedUrls);
+      interval = setInterval(
+        () => logReadyFile(options.client, readyFile, options.readyLabel, loggedUrls, toastedUrls),
+        250,
+      );
+
+      if (!child.stdin || !child.stdout || !child.stderr) {
+        processError = new Error("Failed to open pipes for the plannotator CLI process.");
+        requestTermination();
+      } else {
+        child.stdout.setEncoding("utf-8");
+        child.stderr.setEncoding("utf-8");
+        child.stdout.on("data", (chunk) => {
+          stdout += chunk;
+        });
+        child.stderr.on("data", (chunk) => {
+          stderr += chunk;
+          stderrForwarder?.push(chunk);
+        });
+        child.stdin.once("error", (error: NodeJS.ErrnoException) => {
+          processError ??= error;
+          requestTermination();
+        });
+        child.stdin.end(options.input ?? "");
       }
-      reject(error);
-    });
-    child.on("close", (exitCode) => {
-      clearInterval(interval);
-      stderrForwarder.flush();
-      logReadyFile(options.client, readyFile, options.readyLabel, loggedUrls, toastedUrls);
-      rmSync(readyFile, { force: true });
-      resolve({ stdout, stderr, exitCode });
-    });
 
-    child.stdin.end(options.input ?? "");
-  });
+      child.once("error", (error: NodeJS.ErrnoException) => {
+        processError ??= error;
+        requestTermination();
+      });
+      child.once("close", (exitCode) => {
+        if (aborted && abortSignal) {
+          reject(getAbortReason(abortSignal));
+          return;
+        }
+        if (processError?.code === "ENOENT") {
+          reject(new Error("Could not find the plannotator CLI. Install it with: curl -fsSL https://plannotator.ai/install.sh | bash"));
+          return;
+        }
+        if (processError) {
+          reject(processError);
+          return;
+        }
+        resolve({ stdout, stderr, exitCode });
+      });
+
+      if (abortSignal) {
+        abortListener = () => {
+          aborted = true;
+          requestTermination();
+        };
+        abortSignal.addEventListener("abort", abortListener, { once: true });
+        if (abortSignal.aborted) abortListener();
+      }
+    });
+  } finally {
+    if (interval !== undefined) clearInterval(interval);
+    if (forceKillTimer !== undefined) clearTimeout(forceKillTimer);
+    if (abortSignal && abortListener) abortSignal.removeEventListener("abort", abortListener);
+    stderrForwarder?.flush();
+    try {
+      logReadyFile(options.client, readyFile, options.readyLabel, loggedUrls, toastedUrls);
+    } catch {
+      // Ready metadata is best-effort during child teardown.
+    }
+    rmSync(readyFile, { force: true });
+  }
 }
 
 export function buildAnnotateCliArgs(parsed: ParsedAnnotateArgs): string[] {
@@ -374,6 +456,7 @@ export async function runCliPlanReview(input: {
   planContent: string;
   cwd?: string;
   timeoutSeconds: number | null;
+  abortSignal: AbortSignal;
   bridge?: OpenCodeBridgeContext;
 }): Promise<OpenCodePlanReviewResult> {
   const result = await runPlannotatorCli({
@@ -387,6 +470,7 @@ export async function runCliPlanReview(input: {
     }),
     readyLabel: "plan review",
     bridge: input.bridge,
+    abortSignal: input.abortSignal,
   });
 
   if (result.exitCode !== 0) {

--- a/apps/opencode-plugin/cli-cancellation.test.ts
+++ b/apps/opencode-plugin/cli-cancellation.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { fileURLToPath } from "node:url";
+import { createTestEnvironment } from "../../tests/helpers/environment";
+import { closeServer, occupyConsecutivePorts } from "../../tests/helpers/ports";
+import { runCliPlanReview } from "./cli-bridge";
+
+const envKeys = [
+  "PLANNOTATOR_BIN",
+  "PLANNOTATOR_PORT",
+  "PLANNOTATOR_REMOTE",
+  "PLANNOTATOR_SKIP_BROWSER_OPEN",
+  "PLANNOTATOR_TEST_CLI_MODE",
+] as const;
+const environment = createTestEnvironment(envKeys, "plannotator-opencode-cli-cancel-");
+const fixturePath = fileURLToPath(new URL("./fixtures/test-plan-cli.ts", import.meta.url));
+
+afterEach(() => environment.restore());
+
+async function prepareCliEnvironment(): Promise<number> {
+  environment.reset();
+  const { start, servers } = await occupyConsecutivePorts(1);
+  await closeServer(servers[0]);
+  process.env.PLANNOTATOR_BIN = fixturePath;
+  process.env.PLANNOTATOR_PORT = String(start);
+  process.env.PLANNOTATOR_REMOTE = "0";
+  process.env.PLANNOTATOR_SKIP_BROWSER_OPEN = "1";
+  return start;
+}
+
+function readyClient(): {
+  client: { app: { log: (entry: { message: string }) => void } };
+  ready: Promise<string>;
+} {
+  let resolveReady: (url: string) => void = () => {};
+  const ready = new Promise<string>((resolve) => {
+    resolveReady = resolve;
+  });
+  return {
+    client: {
+      app: {
+        log: (entry) => {
+          const url = entry.message.match(/http:\/\/localhost:\d+/)?.[0];
+          if (url) resolveReady(url);
+        },
+      },
+    },
+    ready,
+  };
+}
+
+async function waitWithTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timeoutId = setTimeout(() => reject(new Error("Timed out waiting for CLI fixture")), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  }
+}
+
+async function expectRejectedWith(
+  promise: Promise<unknown>,
+  expected: unknown,
+): Promise<void> {
+  try {
+    await promise;
+    throw new Error("Expected promise to reject");
+  } catch (error) {
+    expect(error).toBe(expected);
+  }
+}
+
+async function expectPortReusable(port: number): Promise<void> {
+  const replacement = Bun.serve({
+    hostname: "127.0.0.1",
+    port,
+    fetch: () => new Response("reused"),
+  });
+  await replacement.stop(true);
+}
+
+describe("OpenCode CLI plan-review lifetime", () => {
+  test("cancellation terminates the CLI child before returning", async () => {
+    const port = await prepareCliEnvironment();
+    const observed = readyClient();
+    const controller = new AbortController();
+    const review = runCliPlanReview({
+      client: observed.client,
+      planContent: "# CLI cancellation",
+      timeoutSeconds: null,
+      abortSignal: controller.signal,
+    });
+
+    expect(await waitWithTimeout(observed.ready, 3000)).toBe(`http://localhost:${port}`);
+    const abortReason = new DOMException("Cancelled by OpenCode", "AbortError");
+    controller.abort(abortReason);
+    await expectRejectedWith(review, abortReason);
+    await expectPortReusable(port);
+  });
+
+  test("a CLI failure after binding still cleans up bridge resources", async () => {
+    const port = await prepareCliEnvironment();
+    process.env.PLANNOTATOR_TEST_CLI_MODE = "fail-after-ready";
+    const review = runCliPlanReview({
+      client: { app: { log: () => {} } },
+      planContent: "# CLI failure",
+      timeoutSeconds: null,
+      abortSignal: new AbortController().signal,
+    });
+
+    await expect(review).rejects.toThrow("fixture failed after binding");
+    await expectPortReusable(port);
+  });
+});

--- a/apps/opencode-plugin/embedded.ts
+++ b/apps/opencode-plugin/embedded.ts
@@ -1,4 +1,8 @@
 import { recoverNativeFetchConstructors } from "./fetch-shim";
+import {
+  waitForPlanReviewCloseDelay,
+  waitForPlanReviewDecision,
+} from "@plannotator/shared/plan-review-lifecycle";
 
 export interface EmbeddedPlanReviewInput {
   client: any;
@@ -8,6 +12,7 @@ export interface EmbeddedPlanReviewInput {
   pasteApiUrl?: string;
   htmlContent: string;
   timeoutSeconds: number | null;
+  abortSignal: AbortSignal;
   logReady: (url: string, isRemote: boolean, port: number) => void;
 }
 
@@ -31,6 +36,7 @@ async function loadCommandHandlers() {
 export async function runEmbeddedPlanReview(
   input: EmbeddedPlanReviewInput,
 ): Promise<EmbeddedPlanReviewResult> {
+  input.abortSignal.throwIfAborted();
   const { startPlannotatorServer, handleServerReady } = await loadPlanServer();
   const server = await startPlannotatorServer({
     plan: input.planContent,
@@ -47,27 +53,22 @@ export async function runEmbeddedPlanReview(
   });
 
   const timeoutMs = input.timeoutSeconds === null ? null : input.timeoutSeconds * 1000;
-  const result = timeoutMs === null
-    ? await server.waitForDecision()
-    : await new Promise<Awaited<ReturnType<typeof server.waitForDecision>>>((resolve) => {
-        const timeoutId = setTimeout(
-          () =>
-            resolve({
-              approved: false,
-              feedback: `[Plannotator] No response within ${input.timeoutSeconds} seconds. Port released automatically. Please call submit_plan again.`,
-            }),
-          timeoutMs,
-        );
+  try {
+    const result = await waitForPlanReviewDecision({
+      waitForDecision: server.waitForDecision,
+      timeoutMs,
+      timeoutResult: {
+        approved: false,
+        feedback: `[Plannotator] No response within ${input.timeoutSeconds} seconds. Port released automatically. Please call submit_plan again.`,
+      },
+      signal: input.abortSignal,
+    });
 
-        server.waitForDecision().then((decision) => {
-          clearTimeout(timeoutId);
-          resolve(decision);
-        });
-      });
-
-  await Bun.sleep(1500);
-  server.stop();
-  return result;
+    await waitForPlanReviewCloseDelay(1500, input.abortSignal);
+    return result;
+  } finally {
+    await server.stop();
+  }
 }
 
 export async function handleEmbeddedCommand(

--- a/apps/opencode-plugin/fixtures/test-plan-cli.ts
+++ b/apps/opencode-plugin/fixtures/test-plan-cli.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env bun
+
+import { appendFileSync } from "node:fs";
+
+await Bun.stdin.text();
+
+const port = Number(process.env.PLANNOTATOR_PORT);
+if (!Number.isInteger(port) || port < 1) {
+  throw new Error("PLANNOTATOR_PORT must contain a fixed test port");
+}
+
+const server = Bun.serve({
+  hostname: "127.0.0.1",
+  port,
+  fetch: () => Response.json({ plan: "# CLI fixture" }),
+});
+
+const readyFile = process.env.PLANNOTATOR_READY_FILE;
+if (readyFile) {
+  appendFileSync(readyFile, `${JSON.stringify({
+    url: `http://localhost:${port}`,
+    isRemote: false,
+    port,
+  })}\n`, "utf8");
+}
+
+if (process.env.PLANNOTATOR_TEST_CLI_MODE === "fail-after-ready") {
+  setTimeout(() => {
+    server.stop(true);
+    console.error("fixture failed after binding");
+    process.exit(2);
+  }, 300);
+}
+
+const stop = () => {
+  server.stop(true);
+  process.exit(143);
+};
+process.once("SIGINT", stop);
+process.once("SIGTERM", stop);
+
+await new Promise(() => {});

--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -216,6 +216,7 @@ type EmbeddedRuntimeModule = {
     pasteApiUrl?: string;
     htmlContent: string;
     timeoutSeconds: number | null;
+    abortSignal: AbortSignal;
     logReady: (url: string, isRemote: boolean, port: number) => void;
   }) => Promise<OpenCodePlanReviewResult>;
   handleEmbeddedCommand: (
@@ -242,6 +243,7 @@ async function importEmbeddedRuntime(): Promise<EmbeddedRuntimeModule> {
   return await import(sourceSpecifier) as EmbeddedRuntimeModule;
 }
 
+/** Run one OpenCode plan review in the configured runtime. */
 async function runPlanReview(input: {
   client: any;
   runtime: RuntimeMode;
@@ -251,9 +253,11 @@ async function runPlanReview(input: {
   pasteApiUrl?: string;
   htmlContent: string;
   timeoutSeconds: number | null;
+  abortSignal: AbortSignal;
   cwd?: string;
   bridge: OpenCodeBridgeContext;
 }): Promise<OpenCodePlanReviewResult> {
+  input.abortSignal.throwIfAborted();
   if (input.runtime === "embedded" && !hasEmbeddedRuntime()) {
     throw new Error(getEmbeddedRuntimeError());
   }
@@ -269,9 +273,11 @@ async function runPlanReview(input: {
         pasteApiUrl: input.pasteApiUrl,
         htmlContent: input.htmlContent,
         timeoutSeconds: input.timeoutSeconds,
+        abortSignal: input.abortSignal,
         logReady: (url) => logPlannotatorReady(input.client, "plan review", url),
       });
     } catch (error) {
+      input.abortSignal.throwIfAborted();
       if (input.runtime === "embedded") throw error;
       try {
         void input.client.app.log({
@@ -287,6 +293,7 @@ async function runPlanReview(input: {
     planContent: input.planContent,
     cwd: input.cwd,
     timeoutSeconds: input.timeoutSeconds,
+    abortSignal: input.abortSignal,
     bridge: input.bridge,
   });
 }
@@ -600,12 +607,14 @@ Do NOT proceed with implementation until your plan is approved.`);
         },
 
         async execute(args, context) {
-          const invokingAgent = (context as { agent?: string }).agent;
+          const invokingAgent = context.agent;
           if (shouldRejectSubmitPlanForAgent(invokingAgent, workflowOptions)) {
             return `Plannotator is configured for plan-agent mode. submit_plan can only be called by: ${workflowOptions.planningAgents.join(", ")}.
 
 Use /plannotator-last or /plannotator-annotate for manual review, or set workflow to all-agents to allow broader submit_plan access.`;
           }
+
+          context.abort.throwIfAborted();
 
           if (!args.edits || args.edits.length === 0) {
             return "Error: No edits provided. Pass at least one edit with start and content.";
@@ -660,10 +669,12 @@ Use /plannotator-last or /plannotator-annotate for manual review, or set workflo
               pasteApiUrl: getPasteApiUrl(),
               htmlContent: getPlanHtml(),
               timeoutSeconds,
+              abortSignal: context.abort,
               cwd: ctx.directory,
               bridge: await getBridgeContext(),
             });
           } catch (error) {
+            context.abort.throwIfAborted();
             return `[Plannotator] Failed to open plan review: ${error instanceof Error ? error.message : String(error)}`;
           }
 

--- a/apps/opencode-plugin/plan-review-lifecycle.test.ts
+++ b/apps/opencode-plugin/plan-review-lifecycle.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createTestEnvironment } from "../../tests/helpers/environment";
+import { closeServer, occupyConsecutivePorts } from "../../tests/helpers/ports";
+import { runEmbeddedPlanReview } from "./embedded";
+
+const envKeys = [
+  "PLANNOTATOR_PORT",
+  "PLANNOTATOR_REMOTE",
+  "PLANNOTATOR_DATA_DIR",
+  "PLANNOTATOR_SKIP_BROWSER_OPEN",
+] as const;
+const environment = createTestEnvironment(envKeys, "plannotator-opencode-lifecycle-");
+const client = {
+  app: {
+    agents: async () => ({ data: [] }),
+  },
+};
+
+afterEach(() => environment.restore());
+
+async function useFreeFixedPort(): Promise<number> {
+  const { start, servers } = await occupyConsecutivePorts(1);
+  await closeServer(servers[0]);
+  process.env.PLANNOTATOR_PORT = String(start);
+  return start;
+}
+
+function prepareEnvironment(): void {
+  environment.reset();
+  process.env.PLANNOTATOR_REMOTE = "0";
+  process.env.PLANNOTATOR_SKIP_BROWSER_OPEN = "1";
+  process.env.PLANNOTATOR_DATA_DIR = environment.makeTempDir();
+}
+
+function readyObserver(): {
+  ready: Promise<string>;
+  logReady: (url: string) => void;
+} {
+  let resolveReady: (url: string) => void = () => {};
+  const ready = new Promise<string>((resolve) => {
+    resolveReady = resolve;
+  });
+  return { ready, logReady: resolveReady };
+}
+
+async function expectRejectedWith(
+  promise: Promise<unknown>,
+  expected: unknown,
+): Promise<void> {
+  try {
+    await promise;
+    throw new Error("Expected promise to reject");
+  } catch (error) {
+    expect(error).toBe(expected);
+  }
+}
+
+async function expectPortReusable(port: number): Promise<void> {
+  const replacement = Bun.serve({
+    hostname: "127.0.0.1",
+    port,
+    fetch: () => new Response("reused"),
+  });
+  await replacement.stop(true);
+}
+
+describe("OpenCode embedded plan-review lifetime", () => {
+  test("cancellation releases a fixed port for an immediate denied resubmission", async () => {
+    prepareEnvironment();
+    const port = await useFreeFixedPort();
+    const firstReady = readyObserver();
+    const firstController = new AbortController();
+    const firstReview = runEmbeddedPlanReview({
+      client,
+      planContent: "# First plan",
+      sharingEnabled: false,
+      htmlContent: "<!doctype html><html><body>plan</body></html>",
+      timeoutSeconds: null,
+      abortSignal: firstController.signal,
+      logReady: firstReady.logReady,
+    });
+
+    const firstUrl = await firstReady.ready;
+    expect(firstUrl).toBe(`http://localhost:${port}`);
+    expect((await fetch(`${firstUrl}/api/plan`)).status).toBe(200);
+    const abortReason = new DOMException("Cancelled by OpenCode", "AbortError");
+    firstController.abort(abortReason);
+    await expectRejectedWith(firstReview, abortReason);
+
+    const secondReady = readyObserver();
+    const secondController = new AbortController();
+    const secondReview = runEmbeddedPlanReview({
+      client,
+      planContent: "# Revised plan",
+      sharingEnabled: false,
+      htmlContent: "<!doctype html><html><body>plan</body></html>",
+      timeoutSeconds: null,
+      abortSignal: secondController.signal,
+      logReady: secondReady.logReady,
+    });
+
+    const secondUrl = await secondReady.ready;
+    expect(secondUrl).toBe(`http://localhost:${port}`);
+    const response = await fetch(`${secondUrl}/api/deny`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        feedback: "Revise this plan",
+        planSave: { enabled: false },
+      }),
+    });
+    expect(response.status).toBe(200);
+    await expect(secondReview).resolves.toEqual({
+      approved: false,
+      feedback: "Revise this plan",
+    });
+    await expectPortReusable(port);
+  });
+
+  test("keeps an unbounded review alive through normal approval", async () => {
+    prepareEnvironment();
+    const port = await useFreeFixedPort();
+    const observed = readyObserver();
+    const controller = new AbortController();
+    const review = runEmbeddedPlanReview({
+      client,
+      planContent: "# Long-running plan",
+      sharingEnabled: false,
+      htmlContent: "<!doctype html><html><body>plan</body></html>",
+      timeoutSeconds: null,
+      abortSignal: controller.signal,
+      logReady: observed.logReady,
+    });
+
+    const url = await observed.ready;
+    expect(await Promise.race([
+      review.then(() => "settled"),
+      Bun.sleep(50).then(() => "waiting"),
+    ])).toBe("waiting");
+    const response = await fetch(`${url}/api/approve`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ planSave: { enabled: false } }),
+    });
+    expect(response.status).toBe(200);
+    await expect(review).resolves.toEqual({ approved: true });
+    await expectPortReusable(port);
+  });
+
+  test("configured timeout returns feedback and releases the fixed port", async () => {
+    prepareEnvironment();
+    const port = await useFreeFixedPort();
+    const observed = readyObserver();
+    const review = runEmbeddedPlanReview({
+      client,
+      planContent: "# Timed plan",
+      sharingEnabled: false,
+      htmlContent: "<!doctype html><html><body>plan</body></html>",
+      timeoutSeconds: 0.01,
+      abortSignal: new AbortController().signal,
+      logReady: observed.logReady,
+    });
+
+    await observed.ready;
+    await expect(review).resolves.toEqual({
+      approved: false,
+      feedback: "[Plannotator] No response within 0.01 seconds. Port released automatically. Please call submit_plan again.",
+    });
+    await expectPortReusable(port);
+  });
+
+  test("ready callback failure releases the server before rejecting", async () => {
+    prepareEnvironment();
+    const port = await useFreeFixedPort();
+    const readyError = new Error("OpenCode ready notification failed");
+    const review = runEmbeddedPlanReview({
+      client,
+      planContent: "# Ready failure",
+      sharingEnabled: false,
+      htmlContent: "<!doctype html><html><body>plan</body></html>",
+      timeoutSeconds: null,
+      abortSignal: new AbortController().signal,
+      logReady: () => {
+        throw readyError;
+      },
+    });
+
+    await expectRejectedWith(review, readyError);
+    await expectPortReusable(port);
+  });
+});

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -81,7 +81,7 @@ export interface ServerOptions {
   /** Base URL of the paste service API for short URL sharing */
   pasteApiUrl?: string;
   /** Called when server starts with the URL, remote status, and port */
-  onReady?: (url: string, isRemote: boolean, port: number) => void;
+  onReady?: (url: string, isRemote: boolean, port: number) => void | Promise<void>;
   /** OpenCode client for querying available agents (OpenCode only) */
   opencodeClient?: OpencodeClient;
   /** When set to "archive", server runs in read-only archive browser mode */
@@ -107,8 +107,8 @@ export interface ServerResult {
   }>;
   /** Wait for user to close (archive mode only) */
   waitForDone?: () => Promise<void>;
-  /** Stop the server */
-  stop: () => void;
+  /** Stop the server and close active browser connections. */
+  stop: () => Promise<void>;
 }
 
 // --- Server Implementation ---
@@ -587,6 +587,17 @@ export async function startPlannotatorServer(
 
   const port = server.port!;
   const serverUrl = `http://localhost:${port}`;
+  let stopPromise: Promise<void> | undefined;
+  const stop = () => {
+    stopPromise ??= (async () => {
+      try {
+        aiRuntime?.dispose();
+      } finally {
+        await server.stop(true);
+      }
+    })();
+    return stopPromise;
+  };
 
   // The cache warm must never gate the listening socket. Its async filesystem
   // walk yields between directories while requests remain serviceable.
@@ -594,7 +605,12 @@ export async function startPlannotatorServer(
 
   // Notify caller that server is ready
   if (onReady) {
-    onReady(serverUrl, isRemote, port);
+    try {
+      await onReady(serverUrl, isRemote, port);
+    } catch (error) {
+      await stop();
+      throw error;
+    }
   }
 
   return {
@@ -603,9 +619,6 @@ export async function startPlannotatorServer(
     isRemote,
     waitForDecision: () => decisionPromise,
     ...(donePromise && { waitForDone: () => donePromise }),
-    stop: () => {
-      aiRuntime?.dispose();
-      server.stop();
-    },
+    stop,
   };
 }

--- a/packages/server/port-startup-compat.test.ts
+++ b/packages/server/port-startup-compat.test.ts
@@ -50,7 +50,7 @@ describe("Bun startup port compatibility", () => {
       });
       expect(openedUrl).toBe(server.url);
     } finally {
-      server.stop();
+      await server.stop();
     }
   });
 
@@ -77,7 +77,34 @@ describe("Bun startup port compatibility", () => {
       expect(server.url).toBe(`http://localhost:${start}`);
       expect(ready).toEqual({ url: server.url, isRemote: false, port: start });
     } finally {
-      server.stop();
+      await server.stop();
     }
+  });
+
+  test("an async ready failure releases the fixed port before startup rejects", async () => {
+    environment.reset();
+    const { start, servers } = await occupyConsecutivePorts(1);
+    await closeServer(servers[0]);
+    process.env.PLANNOTATOR_REMOTE = "0";
+    process.env.PLANNOTATOR_PORT = String(start);
+    process.env.PLANNOTATOR_DATA_DIR = environment.makeTempDir();
+    const readyError = new Error("ready handoff failed");
+
+    await expect(startPlannotatorServer({
+      plan: "# Ready failure cleanup",
+      origin: "codex",
+      htmlContent: "<!doctype html><html><body>plan</body></html>",
+      onReady: async () => {
+        await Promise.resolve();
+        throw readyError;
+      },
+    })).rejects.toBe(readyError);
+
+    const replacement = Bun.serve({
+      hostname: "127.0.0.1",
+      port: start,
+      fetch: () => new Response("reused"),
+    });
+    await replacement.stop(true);
   });
 });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -61,6 +61,7 @@
     "./workspace-status": "./workspace-status.ts",
     "./open-in-apps": "./open-in-apps.ts",
     "./port-range": "./port-range.ts",
+    "./plan-review-lifecycle": "./plan-review-lifecycle.ts",
     "./review-profiles": "./review-profiles.ts",
     "./commit-avatars": "./commit-avatars.ts"
   },

--- a/packages/shared/plan-review-lifecycle.ts
+++ b/packages/shared/plan-review-lifecycle.ts
@@ -1,0 +1,81 @@
+/** Options for waiting on a plan-review decision with bounded lifetime signals. */
+export interface PlanReviewWaitOptions<T> {
+  /** The browser decision owned by the running plan server. */
+  waitForDecision: () => Promise<T>;
+  /** Optional configured timeout. `null` keeps the review open indefinitely. */
+  timeoutMs: number | null;
+  /** Result returned when the configured timeout expires. */
+  timeoutResult: T;
+  /** Optional host cancellation signal for the tool invocation. */
+  signal?: AbortSignal;
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException("The operation was aborted", "AbortError");
+}
+
+/**
+ * Wait for a plan decision, configured timeout, or host cancellation.
+ *
+ * The caller retains ownership of the server and must stop it in `finally`.
+ * This function owns and removes the timeout and abort listener it creates.
+ */
+export async function waitForPlanReviewDecision<T>(
+  options: PlanReviewWaitOptions<T>,
+): Promise<T> {
+  const { signal } = options;
+  if (signal?.aborted) throw abortReason(signal);
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  let abortListener: (() => void) | undefined;
+  const contenders: Promise<T>[] = [options.waitForDecision()];
+
+  const timeoutMs = options.timeoutMs;
+  if (timeoutMs !== null) {
+    contenders.push(new Promise<T>((resolve) => {
+      timeoutId = setTimeout(() => resolve(options.timeoutResult), timeoutMs);
+    }));
+  }
+
+  if (signal) {
+    contenders.push(new Promise<T>((_resolve, reject) => {
+      abortListener = () => reject(abortReason(signal));
+      signal.addEventListener("abort", abortListener, { once: true });
+      if (signal.aborted) abortListener();
+    }));
+  }
+
+  try {
+    return await Promise.race(contenders);
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+    if (signal && abortListener) signal.removeEventListener("abort", abortListener);
+  }
+}
+
+/**
+ * Keep the browser response visible briefly after a decision while still
+ * allowing host cancellation to release the server immediately.
+ */
+export async function waitForPlanReviewCloseDelay(
+  delayMs: number,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (signal?.aborted) throw abortReason(signal);
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  let abortListener: (() => void) | undefined;
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      timeoutId = setTimeout(resolve, delayMs);
+      if (!signal) return;
+      abortListener = () => reject(abortReason(signal));
+      signal.addEventListener("abort", abortListener, { once: true });
+      if (signal.aborted) abortListener();
+    });
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+    if (signal && abortListener) signal.removeEventListener("abort", abortListener);
+  }
+}


### PR DESCRIPTION
## Summary

- consume the pinned OpenCode tool cancellation contract through ToolContext.abort
- thread cancellation through embedded and CLI plan-review lifetimes, with awaitable server shutdown and finally-owned timers, listeners, ready files, and child processes
- preserve the backing plan on cancellation so an immediate edited resubmission can reuse the same fixed port
- add regressions for cancel/reuse, long-running approval, configured timeout, ready-callback failure, and CLI failure cleanup

## Validation

- focused lifecycle tests: 9 passed
- full suite: 1990 passed, 90 skipped, 0 failed
- bun run typecheck
- bun run build
- npm pack plus installed-package export smoke test
- OpenCode 1.17.12 packaged runtime: cancel and immediately reuse the same fixed port twice

Closes #1046.

Reported by @fabians-px — thank you.