### PR TITLE
Validate submitted findings without starting a second review

### DIFF
--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -877,10 +877,10 @@ if (args[0] === "sessions") {
     console.log(getReviewApprovedPrompt(detectedOrigin));
   } else {
     console.log(result.feedback);
-    // Append the triage-first suffix whenever the reviewer sent annotations to
+    // Append the verification-only suffix whenever the reviewer sent annotations to
     // act on — in PR mode too. Platform PR actions (approve/comment posted to
     // the host) come back with an empty annotation set and a status message;
-    // those must NOT get the "triage and don't change code" instruction.
+    // those must NOT get the "verify findings and don't change code" instruction.
     if (result.annotations.length > 0) {
       console.log(getReviewDeniedSuffix(detectedOrigin));
     }

--- a/apps/marketing/src/content/docs/commands/code-review.md
+++ b/apps/marketing/src/content/docs/commands/code-review.md
@@ -154,7 +154,7 @@ The review agents (Claude, Codex, Code Tour, Guided Review) shell out to externa
 - **Send Feedback** formats your annotations and sends them to the agent
 - **Approve** sends a review-approval prompt to the agent. By default this says no changes were requested, and you can override it in `~/.plannotator/config.json`.
 
-After submission, the agent receives your feedback and can act on it, whether that's fixing issues, explaining decisions, or making the requested changes.
+After submission, the agent receives your feedback. By default, Plannotator tells it to verify each submitted finding against the code, discuss its verdicts before changing code, and not review the rest of the diff for additional issues. You can replace this suffix with `prompts.review.denied` in `~/.plannotator/config.json`.
 
 ### Customizing the approval prompt
 

--- a/apps/marketing/src/content/docs/guides/custom-feedback.md
+++ b/apps/marketing/src/content/docs/guides/custom-feedback.md
@@ -59,6 +59,8 @@ These are sent during code review (`/plannotator-review`).
 | `approved` | You approve a code review with no feedback | none |
 | `denied` | Appended after your review feedback | none |
 
+The built-in `review.denied` suffix asks the receiving agent to verify only the submitted findings against the code, give each one a verdict with evidence, and discuss the validated findings before changing code. It explicitly tells the agent not to review the rest of the diff or search for additional issues. An override replaces this entire suffix.
+
 ## Template variables
 
 Templates use `{{variable}}` placeholders. Here's what each one contains:
@@ -169,6 +171,22 @@ write). Execute the plan in {{planFilePath}}. {{doneMsg}}
 {{feedback}}
 
 Please address the annotation feedback above.
+```
+
+**Review feedback suffix (default):**
+
+```
+Treat the findings above as unverified review input. Inspect every finding
+against the actual code; do not assume automated feedback is correct. For each
+finding, give a clear verdict (Confirmed / Partly / Not a bug / Intended) with
+concise code evidence. Say whether it was introduced by the current changes,
+was pre-existing, or reflects deliberate scope.
+
+Review only the incoming findings. Do not independently review the rest of the
+diff or search for issues that were not submitted.
+
+Do not change any code until we have discussed the verdicts and validated
+findings.
 ```
 
 ## Example: context anchoring with a Decisions Log

--- a/apps/opencode-plugin/commands.ts
+++ b/apps/opencode-plugin/commands.ts
@@ -172,7 +172,7 @@ export async function handleReviewCommand(
       const shouldSwitchAgent = result.agentSwitch && result.agentSwitch !== "disabled";
       const targetAgent = result.agentSwitch || "build";
 
-      // Append the triage-first suffix when the reviewer sent annotations to
+      // Append the verification-only suffix when the reviewer sent annotations to
       // act on (PR mode included). Platform PR actions post a status message
       // with no annotations — those go through verbatim, no suffix.
       const message = result.approved

--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -462,7 +462,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 								safeNotify(ctx, "Code review closed (no feedback).", "info", origin);
 								return;
 							}
-							// Append the triage-first suffix when the reviewer sent
+							// Append the verification-only suffix when the reviewer sent
 							// annotations to act on (PR mode included). Platform PR actions
 							// (approve/comment posted to the host) come back with an empty
 							// annotation set and a status message — don't tell the agent to

--- a/packages/shared/prompts.test.ts
+++ b/packages/shared/prompts.test.ts
@@ -307,18 +307,60 @@ describe("getAnnotateApprovedPrompt", () => {
 // ─── A4b. Review denied suffix ───────────────────────────────────────────────
 
 describe("getReviewDeniedSuffix", () => {
-  test("every runtime gets the same triage-first default — no agent starts coding off raw review feedback", () => {
+  test("every runtime gets the same verification-only default", () => {
     const runtimes = ["claude-code", "opencode", "pi", "amp", "droid", "codex", "copilot-cli", "gemini-cli", "kiro-cli"] as const;
     for (const runtime of runtimes) {
       expect(getReviewDeniedSuffix(runtime, {})).toBe(DEFAULT_REVIEW_DENIED_SUFFIX);
     }
-    expect(DEFAULT_REVIEW_DENIED_SUFFIX).toContain("Do not change any code until we've discussed");
+  });
+
+  test("requires verdicts backed by code evidence for every incoming finding", () => {
+    expect(DEFAULT_REVIEW_DENIED_SUFFIX).toContain(
+      "Inspect every finding against the actual code",
+    );
+    expect(DEFAULT_REVIEW_DENIED_SUFFIX).toContain(
+      "do not assume automated feedback is correct",
+    );
+    expect(DEFAULT_REVIEW_DENIED_SUFFIX).toContain(
+      "Confirmed / Partly / Not a bug / Intended",
+    );
+    expect(DEFAULT_REVIEW_DENIED_SUFFIX).toContain("with concise code evidence");
+    expect(DEFAULT_REVIEW_DENIED_SUFFIX).toContain(
+      "introduced by the current changes, was pre-existing, or reflects deliberate scope",
+    );
+  });
+
+  test("limits review to submitted findings", () => {
+    expect(DEFAULT_REVIEW_DENIED_SUFFIX).toContain("Review only the incoming findings");
+    expect(DEFAULT_REVIEW_DENIED_SUFFIX).toContain(
+      "Do not independently review the rest of the diff or search for issues that were not submitted",
+    );
+    expect(DEFAULT_REVIEW_DENIED_SUFFIX).not.toMatch(
+      /independently review the current diff yourself|start (?:a|an) (?:independent|new) review|surface what it missed|(?:find|search for) additional findings|actively look for/i,
+    );
+  });
+
+  test("keeps code changes blocked until after discussion", () => {
+    expect(DEFAULT_REVIEW_DENIED_SUFFIX).toContain(
+      "Do not change any code until we have discussed the verdicts and validated findings",
+    );
   });
 
   test("uses configured override", () => {
     expect(getReviewDeniedSuffix("claude-code", {
       prompts: { review: { denied: "\nFix everything." } },
     })).toBe("\nFix everything.");
+  });
+
+  test("runtime-specific override wins over the generic suffix", () => {
+    expect(getReviewDeniedSuffix("pi", {
+      prompts: {
+        review: {
+          denied: "Generic review suffix.",
+          runtimes: { pi: { denied: "Pi review suffix." } },
+        },
+      },
+    })).toBe("Pi review suffix.");
   });
 });
 

--- a/packages/shared/prompts.ts
+++ b/packages/shared/prompts.ts
@@ -39,7 +39,7 @@ export function buildPlanFileRule(toolName: string, planFilePath?: string): stri
 
 export const DEFAULT_REVIEW_APPROVED_PROMPT = "# Code Review\n\nCode review completed — no changes requested.";
 
-export const DEFAULT_REVIEW_DENIED_SUFFIX = "\n\nThe findings above came from an automated review of the current changes. Do two things, kept in separate sections:\n\n1. Triage each incoming finding — open the code it points at and give a verdict (Confirmed / Partly / Not a bug / Intended) with evidence (file:line + what the code actually does). Say whether it's introduced by these changes, pre-existing, or a deliberate scope decision. Rank by real user impact.\n\n2. Independently review the current diff yourself — don't just grade the list, surface what it missed, at the same bar (file:line, concrete failure scenario, severity). Actively look for: parallel code paths that should have changed together but didn't; state that outlives its context (cleared on one transition but not another); new-feature vs sibling-feature consistency (drafts, counts, persistence, exports); edge cases where the new thing is the only thing present; seams where new code meets existing code.\n\nFor each real issue, describe it concretely in plain language: the exact place it lives and the real-world trigger that hits it — the specific call, endpoint, command, input, or user action — plus the state or conditions under which it goes wrong. Not an abstract description.\n\nDo not change any code until we've discussed the findings.";
+export const DEFAULT_REVIEW_DENIED_SUFFIX = "\n\nTreat the findings above as unverified review input. Inspect every finding against the actual code; do not assume automated feedback is correct. For each finding, give a clear verdict (Confirmed / Partly / Not a bug / Intended) with concise code evidence. Say whether it was introduced by the current changes, was pre-existing, or reflects deliberate scope.\n\nReview only the incoming findings. Do not independently review the rest of the diff or search for issues that were not submitted.\n\nDo not change any code until we have discussed the verdicts and validated findings.";
 
 export const DEFAULT_PLAN_DENIED_PROMPT =
   "YOUR PLAN WAS NOT APPROVED.\n\nYou MUST revise the plan to address ALL of the feedback below before calling {{toolName}} again.\n\nRules:\n{{planFileRule}}- Do not resubmit the same plan unchanged.\n- Do NOT change the plan title (first # heading) unless the user explicitly asks you to.\n\n{{feedback}}";
@@ -117,7 +117,7 @@ export function getReviewDeniedSuffix(
   config?: PlannotatorConfig,
 ): string {
   // Intentionally no per-runtime defaults: every agent gets the same
-  // triage-first instruction so none of them start coding off raw review
+  // verification-only instruction so none of them start coding off raw review
   // feedback. Per-runtime customization stays available via config
   // (prompts.review.runtimes.<runtime>.denied).
   return getConfiguredPrompt({


### PR DESCRIPTION
## Problem

The default review-feedback suffix told the receiving implementation agent to independently review the current diff and surface anything the submitted findings missed. A real user reported that this turns feedback validation into an unwanted second full review.

## Change

- Replace the default suffix with a narrower instruction to inspect every incoming finding against the actual code.
- Require a clear verdict, concise code evidence, and whether each finding is introduced, pre-existing, or deliberate scope.
- Explicitly prohibit reviewing the rest of the diff or searching for unsubmitted issues.
- Keep code changes blocked until the verdicts and validated findings have been discussed.
- Preserve generic and per-runtime prompt overrides, approval and exit behavior, and platform-action routing.
- Document the new default and override semantics.

## Verification

- Focused prompt, config integration, and OpenCode bridge tests: 77 passed
- Full test suite: 1,986 passed, 90 skipped, 0 failed
- Typecheck: passed
- Review, hook, and OpenCode builds: passed
- Marketing documentation build: passed

## Existing follow-up

This PR intentionally does not change delivery routing. The OpenCode CLI bridge already omits the denied suffix for PR-mode outcomes, while the native OpenCode, Bun, and Pi paths decide from the presence of annotations. That pre-existing routing gap should be handled separately.