### PR TITLE
Place open-in selector after file context

### DIFF
--- a/packages/ui/components/DocBadges.test.tsx
+++ b/packages/ui/components/DocBadges.test.tsx
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { resetStorageBackend, setStorageBackend } from '../utils/storage';
+import { DocBadges, type DocBadgesProps } from './DocBadges';
+
+const hasDom = typeof document !== 'undefined';
+
+const originalFetch = globalThis.fetch;
+let host: HTMLElement | null = null;
+let root: Root | null = null;
+
+function exactText(text: string): HTMLElement {
+  const match = Array.from(host?.querySelectorAll<HTMLElement>('span') ?? [])
+    .find((element) => element.textContent === text);
+  if (!match) throw new Error(`Expected to find text: ${text}`);
+  return match;
+}
+
+function openInButton(): HTMLButtonElement {
+  const button = host?.querySelector<HTMLButtonElement>('button[aria-label="Open in Finder"]');
+  if (!button) throw new Error('Expected the Finder open-in button to render');
+  return button;
+}
+
+function appearsBefore(first: Node, second: Node): boolean {
+  return (first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0;
+}
+
+async function renderBadges(props: Partial<DocBadgesProps>): Promise<void> {
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  root = createRoot(host);
+
+  await act(async () => {
+    root!.render(<DocBadges layout="column" {...props} />);
+  });
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('DocBadges open-in placement', () => {
+  beforeEach(() => {
+    setStorageBackend({
+      getItem: () => 'reveal',
+      setItem: () => {},
+      removeItem: () => {},
+    });
+    Object.defineProperty(globalThis, 'fetch', {
+      configurable: true,
+      writable: true,
+      value: async () => Response.json({
+        available: true,
+        apps: [{ id: 'reveal', label: 'Finder', kind: 'file-manager', icon: 'finder' }],
+      }),
+    });
+  });
+
+  afterEach(async () => {
+    if (root) await act(async () => root!.unmount());
+    root = null;
+    host?.remove();
+    host = null;
+    Object.defineProperty(globalThis, 'fetch', {
+      configurable: true,
+      writable: true,
+      value: originalFetch,
+    });
+    resetStorageBackend();
+  });
+
+  test.skipIf(!hasDom)('places the selector after the repository and branch for a local annotate file', async () => {
+    await renderBadges({
+      repoInfo: { display: 'plannotator/workspaces', branch: 'rooms/resurrect' },
+      openInAppPath: '/tmp/runbook.md',
+    });
+
+    const repository = exactText('plannotator/workspaces');
+    const branch = exactText('rooms/resurrect');
+    const button = openInButton();
+    const repositoryRow = repository.parentElement;
+
+    expect(repositoryRow).not.toBeNull();
+    expect(repositoryRow?.contains(branch)).toBe(true);
+    expect(repositoryRow?.contains(button)).toBe(true);
+    expect(appearsBefore(repository, branch)).toBe(true);
+    expect(appearsBefore(branch, button)).toBe(true);
+  });
+
+  test.skipIf(!hasDom)('does not add a selector in plan mode', async () => {
+    await renderBadges({
+      repoInfo: { display: 'plannotator/workspaces', branch: 'rooms/resurrect' },
+      openInAppPath: null,
+    });
+
+    expect(exactText('plannotator/workspaces')).toBeInstanceOf(HTMLElement);
+    expect(host?.querySelector('button[aria-label="Open in Finder"]')).toBeNull();
+  });
+
+  test.skipIf(!hasDom)('keeps the selector after an explicit source filename', async () => {
+    await renderBadges({
+      repoInfo: { display: 'plannotator/workspaces', branch: 'rooms/resurrect' },
+      sourceInfo: 'runbook.html',
+      openInAppPath: '/tmp/runbook.html',
+    });
+
+    const source = exactText('runbook.html');
+    const button = openInButton();
+
+    expect(source.parentElement?.contains(button)).toBe(true);
+    expect(appearsBefore(source, button)).toBe(true);
+    expect(host?.querySelectorAll('button[aria-label="Open in Finder"]')).toHaveLength(1);
+  });
+
+  test.skipIf(!hasDom)('keeps a standalone selector when no repository or file row exists', async () => {
+    await renderBadges({ openInAppPath: '/tmp/runbook.md' });
+
+    expect(openInButton()).toBeInstanceOf(HTMLButtonElement);
+  });
+
+  test.skipIf(!hasDom)('does not add a selector for a URL annotation', async () => {
+    await renderBadges({
+      sourceInfo: 'https://example.com/runbook',
+      openInAppPath: 'https://example.com/runbook',
+    });
+
+    expect(exactText('example.com')).toBeInstanceOf(HTMLElement);
+    expect(host?.querySelector('button[aria-label="Open in Finder"]')).toBeNull();
+  });
+
+  test.skipIf(!hasDom)('keeps folder-file selectors after the active filename', async () => {
+    await renderBadges({
+      linkedDocInfo: {
+        filepath: '/tmp/docs/runbook.md',
+        onBack: () => {},
+        variant: 'folder-file',
+      },
+      openInAppPath: '/tmp/docs/runbook.md',
+    });
+
+    const filename = exactText('runbook.md');
+    const button = openInButton();
+
+    expect(filename.parentElement?.contains(button)).toBe(true);
+    expect(appearsBefore(filename, button)).toBe(true);
+  });
+});

--- a/packages/ui/components/DocBadges.tsx
+++ b/packages/ui/components/DocBadges.tsx
@@ -78,10 +78,6 @@ export const DocBadges: React.FC<DocBadgesProps> = ({
 
   return (
     <div className={outerClass}>
-      {/* Open-in-app normally renders inline (to the right) within the source /
-          linked-doc rows below. This standalone fallback only fires when there
-          is no file row to attach to. Hidden in the sticky row and for URLs. */}
-      {!isRow && canOpenInApp && !sourceInfo && !linkedDocInfo && openInButton}
       {/* Row layout (sticky lane) omits repo/branch to keep the bar compact —
           they'd otherwise push the container wide enough to visually extend
           under the action buttons. Plan-diff badge still renders below. */}
@@ -104,8 +100,15 @@ export const DocBadges: React.FC<DocBadgesProps> = ({
               <span className="truncate">{repoInfo.branch}</span>
             </span>
           )}
+          {/* Markdown/text annotate sessions have no separate source badge, so
+              keep the open-in control attached to the repository context. */}
+          {canOpenInApp && !sourceInfo && openInButton}
         </div>
       )}
+
+      {/* Non-repository files still need an open-in entry when there is no
+          source or linked-document row to attach it to. */}
+      {!isRow && canOpenInApp && !repoInfo && !sourceInfo && !linkedDocInfo && openInButton}
 
       {sourceInfo && !linkedDocInfo && !isRow && (
         <div className="flex items-center gap-1">

--- a/packages/ui/components/Viewer.consumer.test.tsx
+++ b/packages/ui/components/Viewer.consumer.test.tsx
@@ -16,6 +16,7 @@ import { AnnotationType, type Block } from '../types';
 // Keep the adjacent public theme/menu contracts in that same DOM run without
 // requiring workflow-only test-path maintenance.
 import './ActionMenu.test';
+import './DocBadges.test';
 import './ThemeProvider.test';
 
 const hasDom = typeof document !== 'undefined';


### PR DESCRIPTION
## Summary

- move the full open-in split control into the repository row after the repo and branch for Markdown/text annotate sessions
- preserve the existing after-filename placement for HTML files and folder-selected files, plus the standalone fallback for local files outside a repository
- keep plan mode and URL annotations free of local open-in controls
- add DOM regression coverage for every placement and visibility mode

## Testing

- DOM_TESTS=1 bun test packages/ui/components/Viewer.consumer.test.tsx
- bun run typecheck
- bun test (2,029 passed, 96 skipped)