### PR TITLE
fix(review): make header responsive

### DIFF
--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -2704,13 +2704,13 @@ const ReviewApp: React.FC = () => {
       {isSwitchingPRScope && <PRSwitchOverlay />}
       <div className="h-screen flex flex-col bg-background overflow-hidden">
         {/* Header */}
-        <header className="py-1 flex items-center justify-between px-2 md:px-4 border-b border-border/50 bg-card/50 backdrop-blur-xl z-50">
-          <div className="min-w-0 flex items-center gap-2 md:gap-3">
+        <header className="py-1 flex flex-col min-[480px]:flex-row items-stretch min-[480px]:items-center min-[480px]:justify-between gap-1 min-[480px]:gap-0 px-2 lg:px-4 border-b border-border/50 bg-card/50 backdrop-blur-xl z-50">
+          <div className="min-w-0 flex flex-1 items-center gap-2 lg:gap-3">
             {shouldShowFileTree && (
               <>
                 <button
                   onClick={() => setIsFileTreeOpen(prev => !prev)}
-                  className={`p-1 rounded-md transition-all focus-visible:outline-none ${
+                  className={`h-7 w-7 flex shrink-0 items-center justify-center rounded-md transition-all focus-visible:outline-none ${
                     isFileTreeOpen
                       ? 'text-primary'
                       : 'text-muted-foreground hover:text-foreground hover:bg-muted'
@@ -2719,7 +2719,7 @@ const ReviewApp: React.FC = () => {
                 >
                   <FolderTree className="w-3.5 h-3.5" />
                 </button>
-                <div className="w-px h-5 bg-border/50 mx-1 hidden md:block" />
+                <div className="w-px h-5 bg-border/50 mx-1 hidden lg:block" />
               </>
             )}
             {hasSearchableFiles && (
@@ -2732,7 +2732,7 @@ const ReviewApp: React.FC = () => {
                     }
                     setGuideOpen(prev => !prev);
                   }}
-                  className={`relative flex items-center gap-1 px-2 py-1 rounded-md text-xs font-medium transition-colors ${
+                  className={`relative flex h-7 shrink-0 items-center gap-1 px-2 rounded-md text-xs font-medium transition-colors ${
                     guideOpen ? 'bg-primary/15 text-primary' : 'bg-muted hover:bg-muted/80'
                   }`}
                   title={guideOpen ? 'Back to the diff workspace' : 'Open guided review'}
@@ -2746,16 +2746,17 @@ const ReviewApp: React.FC = () => {
                     guideOpen ? 'Go back' : 'Guide'
                   )}
                 </button>
-                <div className="w-px h-5 bg-border/50 mx-1 hidden md:block" />
+                <div className="w-px h-5 bg-border/50 mx-1 hidden lg:block" />
               </>
             )}
             {prMetadata ? (
-              <div className="min-w-0 flex items-center gap-2 md:gap-3">
+              <div className="min-w-0 flex flex-1 items-center gap-2 lg:gap-3 overflow-hidden">
                 <span
-                  className="text-xs text-muted-foreground/60 inline-flex items-center gap-1 whitespace-nowrap"
+                  className="min-w-0 max-w-[160px] xl:max-w-[240px] text-xs text-muted-foreground/60 hidden sm:inline-flex items-center gap-1"
+                  title={displayRepo}
                 >
                   <RepoIcon className="w-3 h-3 flex-shrink-0" />
-                  {displayRepo}
+                  <span className="truncate">{displayRepo}</span>
                 </span>
                 <PRSelector
                   mrNumberLabel={mrNumberLabel}
@@ -2777,7 +2778,7 @@ const ReviewApp: React.FC = () => {
                 />
               </div>
             ) : repoInfo ? (
-              <div className="min-w-0 flex items-center gap-2 md:gap-3">
+              <div className="min-w-0 flex flex-1 items-center gap-2 lg:gap-3 overflow-hidden">
                 {repoInfo.branch && (
                   <span
                     className="text-xs font-mono text-foreground truncate"
@@ -2799,7 +2800,7 @@ const ReviewApp: React.FC = () => {
             )}
           </div>
 
-          <div className="flex items-center gap-1 md:gap-2">
+          <div className="min-w-0 w-full min-[480px]:w-auto flex flex-wrap min-[480px]:flex-nowrap shrink-0 items-center justify-end gap-1 lg:gap-2">
             {/* Split/Unified toggle + diff options moved to the dock tab strip
                 (rightHeaderActionsComponent → ReviewDockRightActions). */}
             {origin ? (
@@ -2815,13 +2816,13 @@ const ReviewApp: React.FC = () => {
                         if (showDestSpotlight) dismissDestSpotlight();
                         setShowDestinationMenu(prev => !prev);
                       }}
-                      className="flex items-center gap-1 px-2 py-1 rounded-md text-xs font-medium bg-muted hover:bg-muted/80 transition-colors"
+                      className="flex h-7 items-center gap-1 px-2 rounded-md text-xs font-medium bg-muted hover:bg-muted/80 transition-colors"
                       title={reviewDestination === 'platform' ? `Posting to ${platformLabel} ${mrLabel}` : 'Sending to agent session'}
                     >
                       {reviewDestination === 'platform' ? (
                         <>
                           {prMetadata?.platform === 'gitlab' ? <GitLabIcon className="w-3.5 h-3.5" /> : <GitHubIcon className="w-3.5 h-3.5" />}
-                          <span>{platformLabel}</span>
+                          <span className="hidden lg:inline">{platformLabel}</span>
                         </>
                       ) : 'Agent'}
                       <svg className="w-3 h-3 opacity-60" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -3005,6 +3006,7 @@ const ReviewApp: React.FC = () => {
                       onClick={() => totalAnnotationCount > 0 ? setShowExitWarning(true) : handleExit()}
                       disabled={isSendingFeedback || isApproving || isExiting || isPlatformActioning}
                       isLoading={isExiting}
+                      labelBreakpoint="lg"
                     />
                     {/* Progressive disclosure: only show Post Comments once there
                         are annotations to post — mirrors agent mode hiding Send
@@ -3020,6 +3022,7 @@ const ReviewApp: React.FC = () => {
                         loadingLabel="Posting..."
                         shortLoadingLabel="Posting..."
                         title="Post review to platform"
+                        labelBreakpoint="lg"
                       />
                     )}
                     <div className="relative group/approve">
@@ -3039,6 +3042,7 @@ const ReviewApp: React.FC = () => {
                             ? `You can't approve your own ${mrLabel}`
                             : "Approve - no changes needed"
                         }
+                        labelBreakpoint="lg"
                       />
                       {platformUser && prMetadata?.author === platformUser && (
                         <div className="absolute top-full right-0 mt-2 px-3 py-2 bg-popover border border-border rounded-lg shadow-xl text-xs text-foreground w-48 text-center opacity-0 invisible group-hover/approve:opacity-100 group-hover/approve:visible transition-all pointer-events-none z-50">
@@ -3075,7 +3079,7 @@ const ReviewApp: React.FC = () => {
               </button>
             )}
 
-            <div className="w-px h-5 bg-border/50 mx-1 hidden md:block" />
+            <div className="w-px h-5 bg-border/50 mx-1 hidden lg:block" />
 
             {/* Sidebar tab toggles */}
             <button
@@ -3129,7 +3133,7 @@ const ReviewApp: React.FC = () => {
               </button>
             )}
 
-            <div className="w-px h-5 bg-border/50 mx-1 hidden md:block" />
+            <div className="w-px h-5 bg-border/50 mx-1 hidden lg:block" />
 
             <ReviewHeaderMenu
               onOpenSettings={() => setOpenSettingsMenu(true)}

--- a/packages/review-editor/components/AgentReviewActions.tsx
+++ b/packages/review-editor/components/AgentReviewActions.tsx
@@ -40,6 +40,7 @@ export const AgentReviewActions: React.FC<AgentReviewActionsProps> = ({
         onClick={onExit}
         disabled={busy}
         isLoading={isExiting}
+        labelBreakpoint="lg"
       />
 
       {hasAnnotations && (
@@ -51,6 +52,7 @@ export const AgentReviewActions: React.FC<AgentReviewActionsProps> = ({
           shortLabel="Send"
           loadingLabel="Sending..."
           title="Send feedback"
+          labelBreakpoint="lg"
         />
       )}
 
@@ -61,6 +63,7 @@ export const AgentReviewActions: React.FC<AgentReviewActionsProps> = ({
           isLoading={isApproving}
           dimmed={totalAnnotationCount > 0}
           title="Approve - no changes needed"
+          labelBreakpoint="lg"
         />
         {totalAnnotationCount > 0 && (
           <div className="absolute top-full right-0 mt-2 px-3 py-2 bg-popover border border-border rounded-lg shadow-xl text-xs text-foreground w-56 text-center opacity-0 invisible group-hover/approve:opacity-100 group-hover/approve:visible transition-all pointer-events-none z-50">

--- a/packages/review-editor/components/PRSelector.tsx
+++ b/packages/review-editor/components/PRSelector.tsx
@@ -112,12 +112,12 @@ export function PRSelector({ mrNumberLabel, prTitle, currentNumber, onSelect, di
         <button
           type="button"
           disabled={disabled}
-          className="text-xs text-annotation-comment/80 hover:text-annotation-comment inline-flex items-center gap-1 truncate max-w-[340px] rounded px-1 -mx-1 transition-colors hover:bg-muted/20 disabled:opacity-60 disabled:cursor-wait"
+          className="h-7 text-xs text-annotation-comment/80 hover:text-annotation-comment inline-flex items-center gap-1 truncate max-w-[340px] rounded px-1 -mx-1 transition-colors hover:bg-muted/20 disabled:opacity-60 disabled:cursor-wait"
           title={prTitle}
         >
           <PullRequestIcon className="w-3 h-3 flex-shrink-0" />
           <span className="font-mono whitespace-nowrap">{mrNumberLabel}</span>
-          <span className="truncate hidden md:inline">{prTitle}</span>
+          <span className="truncate hidden lg:inline">{prTitle}</span>
           <svg
             className={`w-2.5 h-2.5 flex-shrink-0 text-muted-foreground/30 transition-transform duration-150 ${open ? 'rotate-180' : ''}`}
             fill="none"

--- a/packages/review-editor/components/ReviewHeaderMenu.tsx
+++ b/packages/review-editor/components/ReviewHeaderMenu.tsx
@@ -59,7 +59,7 @@ export const ReviewHeaderMenu: React.FC<ReviewHeaderMenuProps> = ({
             if (!isOpen && showUpdateDot) updateInfo?.dismiss();
             toggleMenu();
           }}
-          className={`relative flex items-center gap-1.5 p-1.5 md:px-2.5 md:py-1 rounded-md text-xs font-medium transition-colors ${
+          className={`relative flex h-7 items-center gap-1.5 px-1.5 lg:px-2.5 rounded-md text-xs font-medium transition-colors ${
             isOpen
               ? 'bg-muted text-foreground'
               : 'text-muted-foreground hover:text-foreground hover:bg-muted'
@@ -70,14 +70,14 @@ export const ReviewHeaderMenu: React.FC<ReviewHeaderMenuProps> = ({
         >
           {isOpen ? <CloseIcon /> : <MenuIcon />}
           {showUpdateDot ? (
-            <TextShimmer className="hidden md:inline text-xs font-medium" duration={2.5} spread={1.5}>
+            <TextShimmer className="hidden lg:inline text-xs font-medium" duration={2.5} spread={1.5}>
               Options
             </TextShimmer>
           ) : (
-            <span className="hidden md:inline">Options</span>
+            <span className="hidden lg:inline">Options</span>
           )}
           {showUpdateDot && (
-            <span className="absolute top-0.5 right-0.5 md:-top-0.5 md:-right-0.5 w-2 h-2 rounded-full bg-primary ring-2 ring-background" />
+            <span className="absolute top-0.5 right-0.5 lg:-top-0.5 lg:-right-0.5 w-2 h-2 rounded-full bg-primary ring-2 ring-background" />
           )}
         </button>
       )}

--- a/packages/review-editor/components/StackedPRLabel.tsx
+++ b/packages/review-editor/components/StackedPRLabel.tsx
@@ -152,7 +152,7 @@ export function StackedPRLabel({
             type="button"
             disabled={isSwitchingScope}
             title={`Stack: comparing vs ${scopeTarget}`}
-            className="text-[10px] text-annotation-comment/70 hover:text-annotation-comment inline-flex items-center gap-1 whitespace-nowrap transition-colors rounded px-1.5 py-0.5 hover:bg-muted/20 disabled:opacity-60 disabled:cursor-wait"
+            className="h-7 text-[10px] text-annotation-comment/70 hover:text-annotation-comment inline-flex items-center gap-1 whitespace-nowrap transition-colors rounded px-1.5 hover:bg-muted/20 disabled:opacity-60 disabled:cursor-wait"
           />
         }
       >

--- a/packages/ui/components/ToolbarButtons.test.tsx
+++ b/packages/ui/components/ToolbarButtons.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ApproveButton, ExitButton, FeedbackButton } from './ToolbarButtons';
+
+const noop = () => undefined;
+
+describe('ToolbarButtons responsive labels', () => {
+  test('preserves the existing medium breakpoint by default', () => {
+    const html = renderToStaticMarkup(
+      <>
+        <FeedbackButton onClick={noop} shortLabel="Send" />
+        <ApproveButton onClick={noop} />
+        <ExitButton onClick={noop} />
+      </>,
+    );
+
+    expect(html).toContain('hidden md:inline lg:hidden');
+    expect(html).toContain('hidden lg:inline');
+    expect(html).toContain('md:hidden');
+  });
+
+  test('can remain compact until the large breakpoint', () => {
+    const html = renderToStaticMarkup(
+      <>
+        <FeedbackButton onClick={noop} shortLabel="Post" labelBreakpoint="lg" />
+        <ApproveButton onClick={noop} labelBreakpoint="lg" />
+        <ExitButton onClick={noop} labelBreakpoint="lg" />
+      </>,
+    );
+
+    expect(html).toContain('hidden lg:inline xl:hidden');
+    expect(html).toContain('hidden xl:inline');
+    expect(html).toContain('lg:hidden');
+    expect(html).toContain('aria-label="Close session without sending feedback"');
+    expect(html).toContain('lucide-x');
+  });
+});

--- a/packages/ui/components/ToolbarButtons.tsx
+++ b/packages/ui/components/ToolbarButtons.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Button } from './ui/button';
 import { cn } from '../lib/utils';
-import { Send, Check } from 'lucide-react';
+import { Send, Check, X } from 'lucide-react';
+
+type ToolbarLabelBreakpoint = 'md' | 'lg';
 
 interface FeedbackButtonProps {
   onClick: () => void;
@@ -13,6 +15,7 @@ interface FeedbackButtonProps {
   shortLoadingLabel?: string;
   title?: string;
   muted?: boolean;
+  labelBreakpoint?: ToolbarLabelBreakpoint;
 }
 
 export const FeedbackButton: React.FC<FeedbackButtonProps> = ({
@@ -25,6 +28,7 @@ export const FeedbackButton: React.FC<FeedbackButtonProps> = ({
   shortLoadingLabel,
   title = 'Send Feedback',
   muted = false,
+  labelBreakpoint = 'md',
 }) => (
   <Button
     variant="outline"
@@ -37,11 +41,17 @@ export const FeedbackButton: React.FC<FeedbackButtonProps> = ({
   >
     {shortLabel ? (
       <>
-        <span className="hidden md:inline lg:hidden">{isLoading ? (shortLoadingLabel ?? loadingLabel) : shortLabel}</span>
-        <span className="hidden lg:inline">{isLoading ? loadingLabel : label}</span>
+        <span className={labelBreakpoint === 'lg' ? 'hidden lg:inline xl:hidden' : 'hidden md:inline lg:hidden'}>
+          {isLoading ? (shortLoadingLabel ?? loadingLabel) : shortLabel}
+        </span>
+        <span className={labelBreakpoint === 'lg' ? 'hidden xl:inline' : 'hidden lg:inline'}>
+          {isLoading ? loadingLabel : label}
+        </span>
       </>
     ) : (
-      <span className="hidden md:inline">{isLoading ? loadingLabel : label}</span>
+      <span className={labelBreakpoint === 'lg' ? 'hidden lg:inline' : 'hidden md:inline'}>
+        {isLoading ? loadingLabel : label}
+      </span>
     )}
   </Button>
 );
@@ -57,6 +67,7 @@ export interface ApproveButtonProps {
   title?: string;
   dimmed?: boolean;
   muted?: boolean;
+  labelBreakpoint?: ToolbarLabelBreakpoint;
 }
 
 export const ApproveButton: React.FC<ApproveButtonProps> = ({
@@ -70,6 +81,7 @@ export const ApproveButton: React.FC<ApproveButtonProps> = ({
   title,
   dimmed = false,
   muted = false,
+  labelBreakpoint = 'md',
 }) => (
   <Button
     variant="success"
@@ -84,8 +96,12 @@ export const ApproveButton: React.FC<ApproveButtonProps> = ({
       dimmed && !muted && !disabled && 'bg-success/50 text-success-foreground/70 hover:bg-success hover:text-success-foreground',
     )}
   >
-    <span className="md:hidden">{isLoading ? mobileLoadingLabel : mobileLabel}</span>
-    <span className="hidden md:inline">{isLoading ? loadingLabel : label}</span>
+    <span className={labelBreakpoint === 'lg' ? 'lg:hidden' : 'md:hidden'}>
+      {isLoading ? mobileLoadingLabel : mobileLabel}
+    </span>
+    <span className={labelBreakpoint === 'lg' ? 'hidden lg:inline' : 'hidden md:inline'}>
+      {isLoading ? loadingLabel : label}
+    </span>
   </Button>
 );
 
@@ -94,6 +110,7 @@ interface ExitButtonProps {
   disabled?: boolean;
   isLoading?: boolean;
   title?: string;
+  labelBreakpoint?: ToolbarLabelBreakpoint;
 }
 
 export const ExitButton: React.FC<ExitButtonProps> = ({
@@ -101,6 +118,7 @@ export const ExitButton: React.FC<ExitButtonProps> = ({
   disabled = false,
   isLoading = false,
   title = 'Close session without sending feedback',
+  labelBreakpoint = 'md',
 }) => (
   <Button
     variant="secondary"
@@ -108,9 +126,12 @@ export const ExitButton: React.FC<ExitButtonProps> = ({
     onClick={onClick}
     disabled={disabled || isLoading}
     title={title}
+    aria-label={title}
     className="bg-muted text-muted-foreground hover:bg-muted/80"
   >
-    <span className="md:hidden">{isLoading ? '...' : '✕'}</span>
-    <span className="hidden md:inline">{isLoading ? 'Closing...' : 'Close'}</span>
+    <span className={labelBreakpoint === 'lg' ? 'lg:hidden' : 'md:hidden'}>
+      {isLoading ? '…' : <X className="size-3.5" aria-hidden="true" />}
+    </span>
+    <span className={labelBreakpoint === 'lg' ? 'hidden lg:inline' : 'hidden md:inline'}>{isLoading ? 'Closing...' : 'Close'}</span>
   </Button>
 );


### PR DESCRIPTION
## Summary

- keep the code-review header on one row at constrained desktop widths and defer stacking until below 480px
- collapse verbose repository, PR, destination, action, and Options labels at responsive breakpoints
- normalize every header control to a 28px height and replace the compact Close glyph with a proper accessible icon
- add focused coverage for the shared toolbar label breakpoint contract

## Verification

- `bun test packages/ui/components/ToolbarButtons.test.tsx`
- `bun run typecheck`
- `bun run build:review`
- `bun run build:hook`
- visually verified the production build against real PR #1068 at 565px and 829px: no overlap or horizontal overflow; all visible header controls are 28px tall