### PR TITLE
Add Bing Webmaster Tools site verification

### DIFF
--- a/apps/marketing/public/BingSiteAuth.xml
+++ b/apps/marketing/public/BingSiteAuth.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<users>
+	<user>6FDB3627CFB4473FBBADE3861C946F87</user>
+</users>


### PR DESCRIPTION
## Summary

- add the Bing Webmaster Tools verification file at the marketing site root

## Verification

- `bun run build:marketing`
- confirmed the built root artifact is byte-identical to the supplied source
- confirmed the built preview returns HTTP 200 with `text/xml` at `/BingSiteAuth.xml`