### PR TITLE
fix(review): use canonical GPT-5.6 Sol model ID

### DIFF
--- a/packages/ui/components/AgentsTab.test.ts
+++ b/packages/ui/components/AgentsTab.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "bun:test";
+import { CODEX_MODELS } from "./AgentsTab";
+
+test("uses the canonical GPT-5.6 Sol model ID", () => {
+  expect(CODEX_MODELS).toContainEqual({
+    value: "gpt-5.6-sol",
+    label: "GPT-5.6 Sol",
+  });
+  expect(CODEX_MODELS.some(({ value }) => value === "gpt-5.6")).toBe(false);
+});

--- a/packages/ui/components/AgentsTab.tsx
+++ b/packages/ui/components/AgentsTab.tsx
@@ -50,10 +50,9 @@ export const CLAUDE_EFFORT: Array<{ value: string; label: string }> = [
 ];
 
 export const CODEX_MODELS: Array<{ value: string; label: string }> = [
-  // GPT-5.6 naming scheme: the bare `gpt-5.6` alias routes to `gpt-5.6-sol`
-  // (flagship); `-terra` is the mid price/performance tier and `-luna` the
-  // efficient high-volume tier.
-  { value: 'gpt-5.6', label: 'GPT-5.6' },
+  // GPT-5.6 naming scheme: `-sol` is the flagship, `-terra` is the mid
+  // price/performance tier, and `-luna` is the efficient high-volume tier.
+  { value: 'gpt-5.6-sol', label: 'GPT-5.6 Sol' },
   { value: 'gpt-5.6-terra', label: 'GPT-5.6 Terra' },
   { value: 'gpt-5.6-luna', label: 'GPT-5.6 Luna' },
   { value: 'gpt-5.5', label: 'GPT-5.5' },

--- a/packages/ui/hooks/useAgentSettings.test.ts
+++ b/packages/ui/hooks/useAgentSettings.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { sanitizeCodexPerModel, parseReviewProfileByEngine, DEFAULT_CODEX_REASONING } from "./useAgentSettings";
+import {
+  DEFAULT_CODEX_REASONING,
+  migrateCodexSection,
+  parseReviewProfileByEngine,
+  sanitizeCodexPerModel,
+} from "./useAgentSettings";
 
 describe("sanitizeCodexPerModel", () => {
   test("returns empty object for undefined/empty input", () => {
@@ -40,6 +45,61 @@ describe("sanitizeCodexPerModel", () => {
     expect(sanitizeCodexPerModel(input)).toEqual({
       valid: { reasoning: "high", fast: false },
     });
+  });
+});
+
+describe("migrateCodexSection", () => {
+  test("moves a stale GPT-5.6 selection and preference while preserving unrelated preferences", () => {
+    expect(
+      migrateCodexSection(
+        {
+          model: "gpt-5.6",
+          perModel: {
+            "gpt-5.6": { reasoning: "xhigh", fast: true },
+            "gpt-5.5": { reasoning: "medium", fast: false },
+          },
+        },
+        "gpt-5.5",
+      ),
+    ).toEqual({
+      model: "gpt-5.6-sol",
+      perModel: {
+        "gpt-5.6-sol": { reasoning: "xhigh", fast: true },
+        "gpt-5.5": { reasoning: "medium", fast: false },
+      },
+    });
+  });
+
+  test("keeps the canonical preference when stale and canonical keys both exist", () => {
+    expect(
+      migrateCodexSection(
+        {
+          model: "gpt-5.6",
+          perModel: {
+            "gpt-5.6": { reasoning: "low", fast: false },
+            "gpt-5.6-sol": { reasoning: "high", fast: true },
+          },
+        },
+        "gpt-5.5",
+      ),
+    ).toEqual({
+      model: "gpt-5.6-sol",
+      perModel: {
+        "gpt-5.6-sol": { reasoning: "high", fast: true },
+      },
+    });
+  });
+
+  test("passes valid and unknown model IDs through unchanged", () => {
+    for (const model of ["gpt-5.5", "future-codex-model"]) {
+      const section = {
+        model,
+        perModel: {
+          [model]: { reasoning: "medium", fast: false },
+        },
+      };
+      expect(migrateCodexSection(section, "gpt-5.5")).toEqual(section);
+    }
   });
 });
 

--- a/packages/ui/hooks/useAgentSettings.ts
+++ b/packages/ui/hooks/useAgentSettings.ts
@@ -193,12 +193,27 @@ export function sanitizeCodexPerModel(
   return out;
 }
 
-// One-shot migration: gpt-5.3-codex is deprecated (ChatGPT-account Codex
-// rejects it with a 400), so a saved pick of it silently becomes the current
-// default rather than shipping a launch that can never succeed.
-function migrateCodexModel(value: unknown, fallback: string): string {
-  if (typeof value !== 'string' || value === 'gpt-5.3-codex') return fallback;
-  return value;
+// One-shot model migrations for a saved Codex section. Keep its per-model
+// preferences aligned with the canonical model ID while sanitizing them.
+export function migrateCodexSection(
+  section: { model?: unknown; perModel?: Record<string, { reasoning: string; fast: boolean }> } | undefined,
+  fallback: string,
+): CodexSection {
+  const perModel = sanitizeCodexPerModel(section?.perModel);
+  const legacyPreference = perModel['gpt-5.6'];
+  if (legacyPreference) {
+    perModel['gpt-5.6-sol'] ??= legacyPreference;
+    delete perModel['gpt-5.6'];
+  }
+
+  const savedModel = section?.model;
+  const model =
+    savedModel === 'gpt-5.6'
+      ? 'gpt-5.6-sol'
+      : typeof savedModel !== 'string' || savedModel === 'gpt-5.3-codex'
+        ? fallback
+        : savedModel;
+  return { model, perModel };
 }
 
 function parseEngine(value: unknown): AgentEngine {
@@ -248,10 +263,7 @@ function readCookie(): AgentSettingsState {
         model: typeof parsed.claude?.model === 'string' ? parsed.claude.model : DEFAULT_CLAUDE_MODEL,
         perModel: parsed.claude?.perModel ?? {},
       },
-      codex: {
-        model: migrateCodexModel(parsed.codex?.model, DEFAULT_CODEX_MODEL),
-        perModel: sanitizeCodexPerModel(parsed.codex?.perModel),
-      },
+      codex: migrateCodexSection(parsed.codex, DEFAULT_CODEX_MODEL),
       cursor: {
         model: typeof parsed.cursor?.model === 'string' ? parsed.cursor.model : DEFAULT_CURSOR_MODEL,
       },
@@ -269,18 +281,12 @@ function readCookie(): AgentSettingsState {
         model: typeof parsed.tourClaude?.model === 'string' ? parsed.tourClaude.model : DEFAULT_TOUR_CLAUDE_MODEL,
         perModel: parsed.tourClaude?.perModel ?? {},
       },
-      tourCodex: {
-        model: migrateCodexModel(parsed.tourCodex?.model, DEFAULT_TOUR_CODEX_MODEL),
-        perModel: sanitizeCodexPerModel(parsed.tourCodex?.perModel),
-      },
+      tourCodex: migrateCodexSection(parsed.tourCodex, DEFAULT_TOUR_CODEX_MODEL),
       guideClaude: {
         model: typeof parsed.guideClaude?.model === 'string' ? parsed.guideClaude.model : DEFAULT_GUIDE_CLAUDE_MODEL,
         perModel: parsed.guideClaude?.perModel ?? {},
       },
-      guideCodex: {
-        model: migrateCodexModel(parsed.guideCodex?.model, DEFAULT_GUIDE_CODEX_MODEL),
-        perModel: sanitizeCodexPerModel(parsed.guideCodex?.perModel),
-      },
+      guideCodex: migrateCodexSection(parsed.guideCodex, DEFAULT_GUIDE_CODEX_MODEL),
       guideCursor: {
         model: typeof parsed.guideCursor?.model === 'string' ? parsed.guideCursor.model : DEFAULT_GUIDE_CURSOR_MODEL,
       },


### PR DESCRIPTION
Use the Codex catalog's canonical `gpt-5.6-sol` identifier for GPT-5.6 Sol and migrate persisted `gpt-5.6` settings so existing users do not keep sending the stale model ID.

Fixes #1070

## Root cause

The review settings catalog exposed GPT-5.6 Sol with the model value `gpt-5.6`, while OpenAI Codex 0.144.4 publishes the model as `gpt-5.6-sol` in its authoritative `models.json`. AgentsTab feeds that catalog value into persisted Codex settings, so both new selections and previously saved review, tour, or guide selections could retain the stale identifier.

## Changes

- Change the AgentsTab model catalog entry to `gpt-5.6-sol` with the display label `GPT-5.6 Sol`.
- Add `migrateCodexSection` to migrate stale review, tour, and guide model selections.
- Migrate per-model reasoning-effort and fast-mode preferences from `gpt-5.6` to `gpt-5.6-sol`.
- Preserve an existing canonical preference when both stale and canonical keys are present, remove stale keys, and leave unrelated model settings unchanged.
- Add focused catalog and settings migration coverage.

This does not change provider defaults, reasoning options, fast-mode behavior, or settings for unrelated models.

## Validation

- `bun test packages/ui/components/AgentsTab.test.ts packages/ui/hooks/useAgentSettings.test.ts`: 13 passed, 0 failed, 16 assertions.
- `bun run typecheck` with TypeScript 5.9.3 available on `PATH`: passed.
- `bun test`: 2,132 passed, 99 skipped, 0 failed.
- `bun run --cwd apps/review build`: passed.
- `bun run build:hook`: passed after the review build.

## Manual testing gap

A live launch against Codex 0.144.4 was not run because the locally installed Codex CLI was older during validation. The canonical identifier was verified against Codex 0.144.4 `models.json`, and the focused tests cover catalog selection plus persisted migration behavior.

Please, let me know if you want that I do some further E2E test/proof. Otherwise, ready.