### PR TITLE
fix(install): pass --global to npx skills add so extras do not leak into cwd

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ plannotator/
 │       │   ├── plannotator-review/    # Lightweight: opens review UI
 │       │   ├── plannotator-annotate/  # Lightweight: opens annotate UI
 │       │   └── plannotator-last/      # Lightweight: annotates last message
-│       └── extra/                 # EXTRA skills — NOT default-installed (except Kiro); add via `npx skills add backnotprop/plannotator/apps/skills/extra`
+│       └── extra/                 # EXTRA skills — NOT default-installed (except Kiro); add via `npx skills add backnotprop/plannotator/apps/skills/extra --global`
 │           ├── plannotator-compound/        # Research analysis agent (map-reduce over denied plans)
 │           ├── plannotator-setup-goal/      # Goal package scaffolder for /goal workflows
 │           └── plannotator-visual-explainer/ # Visual HTML generator (plans, diagrams, PR explainers) with Plannotator theming

--- a/apps/marketing/src/content/docs/getting-started/installation.md
+++ b/apps/marketing/src/content/docs/getting-started/installation.md
@@ -138,7 +138,7 @@ Upgrading from an older version? The installer removes the legacy `~/.claude/com
 Optional extra skills (compound planning, setup-goal, visual explainer) are not installed by default. Add them with:
 
 ```bash
-npx skills add backnotprop/plannotator/apps/skills/extra
+npx skills add backnotprop/plannotator/apps/skills/extra --global
 ```
 
 ## OpenCode
@@ -243,7 +243,7 @@ Notes:
 The installer also copies Plannotator's core skills (`plannotator-review`, `plannotator-annotate`, `plannotator-last`) into `~/.agents/skills` — the official OpenAI agent skills path. Optional extra skills (compound planning, setup-goal, visual explainer) are not installed by default; add them with:
 
 ```bash
-npx skills add backnotprop/plannotator/apps/skills/extra
+npx skills add backnotprop/plannotator/apps/skills/extra --global
 ```
 
 You can still use the direct commands at any time:

--- a/apps/marketing/src/content/docs/guides/claude-code.md
+++ b/apps/marketing/src/content/docs/guides/claude-code.md
@@ -92,7 +92,7 @@ Annotates the agent's most recent message. See the [annotate last docs](/docs/co
 Optional extra skills (compound planning, setup-goal, visual explainer) are not installed by default. Add them with:
 
 ```bash
-npx skills add backnotprop/plannotator/apps/skills/extra
+npx skills add backnotprop/plannotator/apps/skills/extra --global
 ```
 
 ## Plugin installation

--- a/scripts/install.cmd
+++ b/scripts/install.cmd
@@ -680,10 +680,10 @@ if "!EXTRAS_CHOICE!"=="yes" if "!EXTRAS_PRESENT!"=="0" (
     if !ERRORLEVEL! equ 0 if "!RUN_WIZARD!"=="1" set "NPX_OK=1"
     if "!NPX_OK!"=="1" (
         echo Launching the skills CLI for the extras ^(pick your agents in its UI^)...
-        call npx skills add backnotprop/plannotator/apps/skills/extra
-        if not !ERRORLEVEL! equ 0 echo skills CLI did not complete - install later with: npx skills add backnotprop/plannotator/apps/skills/extra
+        call npx skills add backnotprop/plannotator/apps/skills/extra --global
+        if not !ERRORLEVEL! equ 0 echo skills CLI did not complete - install later with: npx skills add backnotprop/plannotator/apps/skills/extra --global
     ) else (
-        echo Install the extras with: npx skills add backnotprop/plannotator/apps/skills/extra
+        echo Install the extras with: npx skills add backnotprop/plannotator/apps/skills/extra --global
     )
 )
 
@@ -969,7 +969,7 @@ echo The /plannotator-review, /plannotator-annotate, and /plannotator-last skill
 if not "!EXTRAS_CHOICE!"=="yes" (
     echo.
     echo Optional skills ^(compound planning, setup-goal, visual explainer^):
-    echo   npx skills add backnotprop/plannotator/apps/skills/extra
+    echo   npx skills add backnotprop/plannotator/apps/skills/extra --global
 )
 
 REM Warn if plannotator is configured in both settings.json hooks AND the plugin (causes double execution)

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -706,12 +706,12 @@ if ($runWizard -or $Extras -or $NoExtras -or $ModelInvocable) {
 if (($extrasChoice -eq "yes") -and (-not $extrasPresent)) {
     if ($canPrompt -and (Get-Command npx -ErrorAction SilentlyContinue)) {
         Write-Host "Launching the skills CLI for the extras (pick your agents in its UI)..."
-        npx skills add backnotprop/plannotator/apps/skills/extra
+        npx skills add backnotprop/plannotator/apps/skills/extra --global
         if ($LASTEXITCODE -ne 0) {
-            Write-Host "skills CLI did not complete - install later with: npx skills add backnotprop/plannotator/apps/skills/extra"
+            Write-Host "skills CLI did not complete - install later with: npx skills add backnotprop/plannotator/apps/skills/extra --global"
         }
     } else {
-        Write-Host "Install the extras with: npx skills add backnotprop/plannotator/apps/skills/extra"
+        Write-Host "Install the extras with: npx skills add backnotprop/plannotator/apps/skills/extra --global"
     }
 }
 
@@ -1052,7 +1052,7 @@ Write-Host "The /plannotator-review, /plannotator-annotate, and /plannotator-las
 if ($extrasChoice -ne "yes") {
     Write-Host ""
     Write-Host "Optional skills (compound planning, setup-goal, visual explainer):"
-    Write-Host "  npx skills add backnotprop/plannotator/apps/skills/extra"
+    Write-Host "  npx skills add backnotprop/plannotator/apps/skills/extra --global"
 }
 
 # Warn if plannotator is configured in both settings.json hooks AND the plugin (causes double execution)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1084,10 +1084,10 @@ fi
 if [ "$extras_choice" = "yes" ] && [ "$extras_present" -eq 0 ]; then
     if [ "$can_prompt" -eq 1 ] && command -v npx >/dev/null 2>&1; then
         echo "Launching the skills CLI for the extras (pick your agents in its UI)..."
-        npx skills add backnotprop/plannotator/apps/skills/extra < /dev/tty || \
-            echo "skills CLI did not complete — install later with: npx skills add backnotprop/plannotator/apps/skills/extra"
+        npx skills add backnotprop/plannotator/apps/skills/extra --global < /dev/tty || \
+            echo "skills CLI did not complete — install later with: npx skills add backnotprop/plannotator/apps/skills/extra --global"
     else
-        echo "Install the extras with: npx skills add backnotprop/plannotator/apps/skills/extra"
+        echo "Install the extras with: npx skills add backnotprop/plannotator/apps/skills/extra --global"
     fi
 fi
 
@@ -1442,7 +1442,7 @@ echo "The /plannotator-review, /plannotator-annotate, and /plannotator-last comm
 if [ "$extras_choice" != "yes" ]; then
     echo ""
     echo "Optional skills (compound planning, setup-goal, visual explainer):"
-    echo "  npx skills add backnotprop/plannotator/apps/skills/extra"
+    echo "  npx skills add backnotprop/plannotator/apps/skills/extra --global"
 fi
 
 # Warn if plannotator is configured in both settings.json hooks AND the plugin (causes double execution)

--- a/scripts/install.test.ts
+++ b/scripts/install.test.ts
@@ -133,7 +133,7 @@ describe("install.sh", () => {
     // Answers persist to the data dir and silent re-runs reuse them.
     expect(script).toContain('PREFS_FILE="$_config_dir/install-prefs"');
     // Extras install is delegated to the skills CLI with the terminal attached.
-    expect(script).toContain("npx skills add backnotprop/plannotator/apps/skills/extra < /dev/tty");
+    expect(script).toContain("npx skills add backnotprop/plannotator/apps/skills/extra --global < /dev/tty");
     // Flip pass unlocks INSTALLED copies only (repo sources always stay
     // locked) and flips the Codex sidecar to match.
     expect(script).toContain("grep -v '^disable-model-invocation: true$'");
@@ -215,7 +215,7 @@ describe("install.sh", () => {
 
   test("suggests installing extras via npx skills add", () => {
     expect(script).toContain("Optional skills (compound planning, setup-goal, visual explainer):");
-    expect(script).toContain("npx skills add backnotprop/plannotator/apps/skills/extra");
+    expect(script).toContain("npx skills add backnotprop/plannotator/apps/skills/extra --global");
   });
 
   test("no longer installs core skills to ~/.codex/skills", () => {
@@ -477,7 +477,7 @@ describe("install.ps1", () => {
 
   test("suggests installing extras via npx skills add", () => {
     expect(script).toContain("Optional skills (compound planning, setup-goal, visual explainer):");
-    expect(script).toContain("npx skills add backnotprop/plannotator/apps/skills/extra");
+    expect(script).toContain("npx skills add backnotprop/plannotator/apps/skills/extra --global");
   });
 
   test("Pi extension update keeps no settings.json package-skills filter", () => {
@@ -641,7 +641,7 @@ describe("install.cmd", () => {
 
   test("suggests installing extras via npx skills add", () => {
     expect(script).toContain("Optional skills");
-    expect(script).toContain("npx skills add backnotprop/plannotator/apps/skills/extra");
+    expect(script).toContain("npx skills add backnotprop/plannotator/apps/skills/extra --global");
   });
 
   test("Gemini settings merge uses || idiom (issue #506 regression)", () => {
@@ -765,6 +765,26 @@ describe("Core Plannotator skills", () => {
 describe("install shared behavior", () => {
   const sh = readScript("install.sh");
   const ps = readScript("install.ps1");
+
+  test("every extras install command uses global scope", () => {
+    const files = [
+      "scripts/install.sh",
+      "scripts/install.ps1",
+      "scripts/install.cmd",
+      "AGENTS.md",
+      "apps/marketing/src/content/docs/getting-started/installation.md",
+      "apps/marketing/src/content/docs/guides/claude-code.md",
+    ];
+    const command = "npx skills add backnotprop/plannotator/apps/skills/extra";
+
+    for (const file of files) {
+      const contents = readFileSync(join(scriptsDir, "..", file), "utf-8").replace(/\r\n?/g, "\n");
+      const commandCount = contents.split(command).length - 1;
+      const globalCommandCount = contents.split(`${command} --global`).length - 1;
+      expect(commandCount, `${file} should contain an extras install command`).toBeGreaterThan(0);
+      expect(globalCommandCount, `${file} has an extras install command without --global`).toBe(commandCount);
+    }
+  });
 
   test("install.cmd contains no unix redirect bash-isms", () => {
     // Tripwire: during PR #850 development, three freshly written `>nul`


### PR DESCRIPTION
Plannotator's optional extra-skills installation was unscoped. When an installer or a copied install-later command ran inside a Git repository, the Skills CLI could use project scope and write Plannotator skills into that repository's `.agents/skills/` directory.

This change makes the intended user-level behavior explicit by adding `--global` everywhere Plannotator installs or documents its extra skills.

Closes https://github.com/backnotprop/plannotator/issues/1077

## Why

A global application installer should not modify an unrelated repository based on the caller's current directory. Explicit scope makes the result consistent across supported platforms and avoids dirtying projects with accidental skill files.

## Changes

- Add `--global` to the extra-skills commands in `scripts/install.sh`, `scripts/install.ps1`, and `scripts/install.cmd`.
- Update `AGENTS.md` and the installation and Claude Code marketing guides so copied commands match installer behavior.
- Update the existing shell assertion and add a deterministic parity test that inspects every extra-skills command across the installers and checked documentation, requires at least one occurrence in every checked file, and rejects any occurrence without `--global`.

The installers retain their existing prompts, quoting, and platform-specific control flow.

## Validation

- `bun test scripts/install.test.ts`: 86 passed, 0 failed, 501 assertions.
- `bash -n scripts/install.sh`: passed.
- `shellcheck -S error scripts/install.sh`: passed.
- `bun run build:marketing`: passed, 40 pages built.
- `bun run typecheck` with TypeScript 5.9.3 available on `PATH`: passed.
- `bun test`: 2,129 passed, 99 skipped, 0 failed.
- Pre-fix live reproduction with Skills CLI 1.5.14: the unscoped command created three project-local skill directories and `skills-lock.json`; the generated artifacts were removed.
- Post-fix isolated-home E2E with Skills CLI 1.5.19: the emitted `--global` command installed exactly three skills under the temporary home, left the temporary Git project clean, created no project lockfile, and left the user's real `~/.agents` state unchanged. The temporary home was removed afterward.

The deterministic regression test establishes source parity for every checked command, while the isolated-home E2E proves the external CLI's global installation behavior without changing the user's real global state.

## Manual testing gaps

No live PowerShell or Command Prompt installer run was performed on Windows (I don't have that system).

