### PR TITLE
Route legacy docs and blog URLs to docs.plannotator.ai

### DIFF
--- a/apps/marketing/astro.config.mjs
+++ b/apps/marketing/astro.config.mjs
@@ -7,7 +7,15 @@ import tailwindcss from '@tailwindcss/vite';
 export default defineConfig({
   site: 'https://plannotator.ai',
   output: 'static',
-  integrations: [react(), sitemap(), mdx()],
+  integrations: [
+    react(),
+    sitemap({
+      filter: (page) =>
+        !page.startsWith('https://plannotator.ai/docs/') &&
+        !page.startsWith('https://plannotator.ai/blog/'),
+    }),
+    mdx(),
+  ],
   markdown: {
     shikiConfig: {
       themes: {

--- a/apps/marketing/cloudfront/url-rewrite.js
+++ b/apps/marketing/cloudfront/url-rewrite.js
@@ -1,0 +1,64 @@
+function handler(event) {
+  var request = event.request;
+  var uri = request.uri;
+  var normalizedUri = uri.length > 1 && uri.endsWith('/') ? uri.slice(0, -1) : uri;
+
+  var redirects = {
+    '/docs': 'https://docs.plannotator.ai/',
+    '/docs/commands/annotate-last': 'https://docs.plannotator.ai/open-source/reference/cli#annotate-the-last-agent-message',
+    '/docs/commands/annotate': 'https://docs.plannotator.ai/open-source/workflows/documents',
+    '/docs/commands/code-review': 'https://docs.plannotator.ai/open-source/workflows/local-changes',
+    '/docs/commands/plan-review': 'https://docs.plannotator.ai/open-source/workflows/plan-review',
+    '/docs/getting-started/configuration': 'https://docs.plannotator.ai/open-source/reference/configuration',
+    '/docs/getting-started/installation': 'https://docs.plannotator.ai/open-source/start/installation',
+    '/docs/getting-started/quickstart': 'https://docs.plannotator.ai/open-source/start/quickstart',
+    '/docs/getting-started/ui-settings': 'https://docs.plannotator.ai/open-source/reference/configuration#browser-ui-settings',
+    '/docs/guides/ai-code-review': 'https://docs.plannotator.ai/open-source/workflows/agent-reviews',
+    '/docs/guides/ai-features': 'https://docs.plannotator.ai/open-source/workflows/ask-ai',
+    '/docs/guides/annotate-gates-and-json-responses': 'https://docs.plannotator.ai/open-source/reference/hooks#output-contracts',
+    '/docs/guides/claude-code': 'https://docs.plannotator.ai/open-source/agents/claude-code',
+    '/docs/guides/custom-feedback': 'https://docs.plannotator.ai/open-source/reference/custom-feedback',
+    '/docs/guides/hook-integration': 'https://docs.plannotator.ai/open-source/reference/hooks',
+    '/docs/guides/kiro-cli': 'https://docs.plannotator.ai/open-source/agents/kiro-cli',
+    '/docs/guides/obsidian-integration': 'https://docs.plannotator.ai/open-source/agents/notes',
+    '/docs/guides/opencode-migration-0-19-1': 'https://docs.plannotator.ai/open-source/agents/opencode',
+    '/docs/guides/opencode': 'https://docs.plannotator.ai/open-source/agents/opencode',
+    '/docs/guides/remote-and-devcontainers': 'https://docs.plannotator.ai/open-source/troubleshooting#remote-ssh-and-development-containers',
+    '/docs/guides/self-hosting': 'https://docs.plannotator.ai/open-source/workflows/sharing#use-your-own-share-services',
+    '/docs/guides/sharing-and-collaboration': 'https://docs.plannotator.ai/open-source/workflows/sharing',
+    '/docs/guides/troubleshooting': 'https://docs.plannotator.ai/open-source/troubleshooting',
+    '/docs/integrations/external-annotations-api': 'https://docs.plannotator.ai/open-source/reference/external-annotations',
+    '/docs/reference/api-endpoints': 'https://docs.plannotator.ai/open-source/reference/local-api',
+    '/docs/reference/environment-variables': 'https://docs.plannotator.ai/open-source/reference/environment-variables',
+    '/docs/reference/keyboard-shortcuts': 'https://docs.plannotator.ai/open-source/reference/keyboard-shortcuts',
+    '/docs/reference/prompts': 'https://docs.plannotator.ai/open-source/reference/custom-feedback',
+    '/docs/reference/verifying-your-install': 'https://docs.plannotator.ai/open-source/start/installation#pin-or-verify-a-release',
+    '/blog': 'https://docs.plannotator.ai/learn/',
+    '/blog/annotate-any-web-page-or-html-file': 'https://docs.plannotator.ai/learn/annotate-any-web-page-or-html-file',
+    '/blog/continuously-improve-claude-code-plans': 'https://docs.plannotator.ai/code-context/compound-with-plannotator',
+    '/blog/local-diff-review-for-coding-agents': 'https://docs.plannotator.ai/learn/local-diff-review-for-coding-agents',
+    '/blog/plan-diff-see-what-changed': 'https://docs.plannotator.ai/learn/plan-diff-see-what-changed',
+    '/blog/plannotator-meets-pi': 'https://docs.plannotator.ai/open-source/agents/pi',
+    '/blog/sharing-plans-with-your-team': 'https://docs.plannotator.ai/workspaces/review-plans-and-technical-decisions',
+    '/blog/welcome': 'https://docs.plannotator.ai/open-source/'
+  };
+
+  if (redirects[normalizedUri]) {
+    return {
+      statusCode: 301,
+      statusDescription: 'Moved Permanently',
+      headers: {
+        location: { value: redirects[normalizedUri] },
+        'cache-control': { value: 'public, max-age=3600' }
+      }
+    };
+  }
+
+  if (uri.endsWith('/')) {
+    request.uri += 'index.html';
+  } else if (!uri.includes('.')) {
+    request.uri += '/index.html';
+  }
+
+  return request;
+}

--- a/apps/marketing/cloudfront/url-rewrite.test.ts
+++ b/apps/marketing/cloudfront/url-rewrite.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+type CloudFrontRequest = {
+  uri: string;
+};
+
+type CloudFrontResult = CloudFrontRequest | {
+  statusCode: number;
+  headers: Record<string, { value: string }>;
+};
+
+const source = readFileSync(new URL('./url-rewrite.js', import.meta.url), 'utf8');
+const handler = new Function(`${source}; return handler;`)() as (event: {
+  request: CloudFrontRequest;
+}) => CloudFrontResult;
+
+function run(uri: string): CloudFrontResult {
+  return handler({ request: { uri } });
+}
+
+describe('marketing CloudFront URL handling', () => {
+  test('redirects old documentation URLs directly to the matching new page', () => {
+    expect(run('/docs/getting-started/installation')).toEqual({
+      statusCode: 301,
+      statusDescription: 'Moved Permanently',
+      headers: {
+        location: { value: 'https://docs.plannotator.ai/open-source/start/installation' },
+        'cache-control': { value: 'public, max-age=3600' },
+      },
+    });
+  });
+
+  test('handles trailing-slash variants in the same redirect hop', () => {
+    expect(run('/docs/getting-started/installation/')).toEqual(
+      run('/docs/getting-started/installation'),
+    );
+  });
+
+  test('redirects old blog URLs to their matching Learn pages', () => {
+    const result = run('/blog/plan-diff-see-what-changed/') as {
+      statusCode: number;
+      headers: Record<string, { value: string }>;
+    };
+
+    expect(result.statusCode).toBe(301);
+    expect(result.headers.location.value).toBe(
+      'https://docs.plannotator.ai/learn/plan-diff-see-what-changed',
+    );
+  });
+
+  test('keeps the existing static-site rewrite for non-migrated routes', () => {
+    expect(run('/code-review')).toEqual({ uri: '/code-review/index.html' });
+    expect(run('/')).toEqual({ uri: '/index.html' });
+    expect(run('/assets/icon-codex.png')).toEqual({ uri: '/assets/icon-codex.png' });
+  });
+
+  test('fits within the CloudFront Functions code-size limit', () => {
+    expect(Buffer.byteLength(source, 'utf8')).toBeLessThanOrEqual(10_000);
+  });
+});

--- a/apps/marketing/public/robots.txt
+++ b/apps/marketing/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://plannotator.ai/sitemap-index.xml

--- a/apps/marketing/src/components/Footer.astro
+++ b/apps/marketing/src/components/Footer.astro
@@ -13,18 +13,18 @@ const { authors, community } = await getContributors();
     <div>
       <h4 class="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">Product</h4>
       <ul class="space-y-1.5">
-        <li><a href="/docs/commands/plan-review/" class="text-muted-foreground hover:text-foreground transition-colors">Plan Review</a></li>
+        <li><a href="https://docs.plannotator.ai/open-source/workflows/plan-review" class="text-muted-foreground hover:text-foreground transition-colors">Plan Review</a></li>
         <li><a href="/code-review/" class="text-muted-foreground hover:text-foreground transition-colors">Code Review</a></li>
-        <li><a href="/docs/getting-started/installation/" class="text-muted-foreground hover:text-foreground transition-colors">Install</a></li>
+        <li><a href="https://docs.plannotator.ai/open-source/start/installation" class="text-muted-foreground hover:text-foreground transition-colors">Install</a></li>
       </ul>
     </div>
     <div>
       <h4 class="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">Resources</h4>
       <ul class="space-y-1.5">
-        <li><a href="/docs/getting-started/quickstart/" class="text-muted-foreground hover:text-foreground transition-colors">Quickstart</a></li>
-        <li><a href="/docs/guides/claude-code/" class="text-muted-foreground hover:text-foreground transition-colors">Claude Code</a></li>
-        <li><a href="/docs/guides/opencode/" class="text-muted-foreground hover:text-foreground transition-colors">OpenCode</a></li>
-        <li><a href="/blog/" class="text-muted-foreground hover:text-foreground transition-colors">Blog</a></li>
+        <li><a href="https://docs.plannotator.ai/open-source/start/quickstart" class="text-muted-foreground hover:text-foreground transition-colors">Quickstart</a></li>
+        <li><a href="https://docs.plannotator.ai/open-source/agents/claude-code" class="text-muted-foreground hover:text-foreground transition-colors">Claude Code</a></li>
+        <li><a href="https://docs.plannotator.ai/open-source/agents/opencode" class="text-muted-foreground hover:text-foreground transition-colors">OpenCode</a></li>
+        <li><a href="https://docs.plannotator.ai/learn/" class="text-muted-foreground hover:text-foreground transition-colors">Learn</a></li>
       </ul>
     </div>
     <div>

--- a/apps/marketing/src/components/Nav.astro
+++ b/apps/marketing/src/components/Nav.astro
@@ -15,7 +15,7 @@ const isWorkspacesActive = currentPath.startsWith('/workspaces/');
   <div class="flex items-center gap-3">
     <div class="flex items-center gap-1.5 sm:gap-2 text-xs">
       <a
-        href="/docs/getting-started/installation/"
+        href="https://docs.plannotator.ai/open-source/start/installation"
         class:list={[
           'transition-colors',
           isDocsActive ? 'text-foreground font-medium' : 'text-muted-foreground hover:text-foreground',
@@ -25,7 +25,7 @@ const isWorkspacesActive = currentPath.startsWith('/workspaces/');
       </a>
       <span class="text-muted-foreground/50 hidden sm:inline">|</span>
       <a
-        href="/blog/"
+        href="https://docs.plannotator.ai/learn/"
         class:list={[
           'transition-colors hidden sm:inline',
           isBlogActive ? 'text-foreground font-medium' : 'text-muted-foreground hover:text-foreground',

--- a/apps/marketing/src/pages/code-review.astro
+++ b/apps/marketing/src/pages/code-review.astro
@@ -425,13 +425,13 @@ const description =
           Claude Code, OpenCode, Codex, Pi, Copilot CLI, Droid, and more.
         </p>
         <div class="cr-cta-actions">
-          <a href="/docs/getting-started/installation/" class="cr-btn">
+          <a href="https://docs.plannotator.ai/open-source/start/installation" class="cr-btn">
             Install Plannotator
             <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6" />
             </svg>
           </a>
-          <a href="/docs/commands/code-review/" class="cr-btn cr-btn-outline">Read the docs</a>
+          <a href="https://docs.plannotator.ai/open-source/workflows/local-changes" class="cr-btn cr-btn-outline">Read the docs</a>
         </div>
       </section>
     </main>

--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -396,7 +396,7 @@ import AnnoReplace from '../components/landing/AnnoReplace.astro';
             View on GitHub &rarr;
           </a>
           <a
-            href="/docs/getting-started/installation/"
+            href="https://docs.plannotator.ai/open-source/start/installation"
             class="text-sm text-muted-foreground hover:text-foreground transition-colors"
           >
             Read the docs &rarr;
@@ -458,7 +458,7 @@ import AnnoReplace from '../components/landing/AnnoReplace.astro';
               Watch the demo
             </a>
             <a
-              href="/docs/getting-started/installation/"
+              href="https://docs.plannotator.ai/open-source/start/installation"
               class="text-xs text-muted-foreground hover:text-foreground transition-colors"
             >
               All agent guides &rarr;

--- a/apps/marketing/src/pages/rss.xml.ts
+++ b/apps/marketing/src/pages/rss.xml.ts
@@ -2,6 +2,16 @@ import rss from '@astrojs/rss';
 import { getCollection } from 'astro:content';
 import type { APIContext } from 'astro';
 
+const migratedLinks: Record<string, string> = {
+  'annotate-any-web-page-or-html-file': 'https://docs.plannotator.ai/learn/annotate-any-web-page-or-html-file',
+  'continuously-improve-claude-code-plans': 'https://docs.plannotator.ai/code-context/compound-with-plannotator',
+  'local-diff-review-for-coding-agents': 'https://docs.plannotator.ai/learn/local-diff-review-for-coding-agents',
+  'plan-diff-see-what-changed': 'https://docs.plannotator.ai/learn/plan-diff-see-what-changed',
+  'plannotator-meets-pi': 'https://docs.plannotator.ai/open-source/agents/pi',
+  'sharing-plans-with-your-team': 'https://docs.plannotator.ai/workspaces/review-plans-and-technical-decisions',
+  welcome: 'https://docs.plannotator.ai/open-source/',
+};
+
 export async function GET(context: APIContext) {
   const posts = (await getCollection('blog'))
     .filter((post) => !post.data.draft)
@@ -15,7 +25,7 @@ export async function GET(context: APIContext) {
       title: post.data.title,
       description: post.data.description,
       pubDate: post.data.date,
-      link: `/blog/${post.id}/`,
+      link: migratedLinks[post.id] ?? `/blog/${post.id}/`,
     })),
   });
 }

--- a/scripts/install.cmd
+++ b/scripts/install.cmd
@@ -418,7 +418,7 @@ if "!VERIFY_ATTESTATION!"=="1" (
     )
 ) else (
     echo SHA256 verified. For build provenance verification, see
-    echo https://plannotator.ai/docs/getting-started/installation/#verifying-your-install
+    echo https://docs.plannotator.ai/open-source/start/installation#pin-or-verify-a-release
 )
 
 REM Install binary

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -341,7 +341,7 @@ if ($verifyAttestationResolved) {
     }
 } else {
     Write-Host "SHA256 verified. For build provenance verification, see"
-    Write-Host "https://plannotator.ai/docs/getting-started/installation/#verifying-your-install"
+    Write-Host "https://docs.plannotator.ai/open-source/start/installation#pin-or-verify-a-release"
 }
 
 Move-Item -Force $tmpFile "$installDir\plannotator.exe"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -415,7 +415,7 @@ if [ "$verify_attestation" -eq 1 ]; then
     fi
 else
     echo "SHA256 verified. For build provenance verification, see"
-    echo "https://plannotator.ai/docs/getting-started/installation/#verifying-your-install"
+    echo "https://docs.plannotator.ai/open-source/start/installation#pin-or-verify-a-release"
 fi
 
 # Remove old binary first (handles Windows .exe and locked file issues)


### PR DESCRIPTION
## Summary
- redirect every public legacy `/docs` and `/blog` route to its exact `docs.plannotator.ai` replacement
- remove migrated routes from the root sitemap and publish an explicit root robots file
- update root navigation, RSS, and installer help URLs to the new documentation
- preserve the existing marketing homepage, product pages, artwork, and static-route rewriting

## Validation
- `bun test apps/marketing/cloudfront/url-rewrite.test.ts`
- `bun run build:marketing`
- all 38 legacy URL ledger rows match the CloudFront function output
- all 30 unique docs destinations return 200 in the local Mintlify preview
- generated root sitemap contains only current root/product/privacy routes
- `git diff --check`