### PR TITLE
docs(annotate): explain per-file version history [accepted in new docs repo]

### DIFF
--- a/apps/marketing/src/content/docs/commands/annotate.md
+++ b/apps/marketing/src/content/docs/commands/annotate.md
@@ -76,7 +76,7 @@ Three ways to disable Jina Reader, in priority order:
 
 1. **CLI flag:** `--no-jina`
 2. **Environment variable:** `PLANNOTATOR_JINA=0` or `PLANNOTATOR_JINA=false`
-3. **Config file:** `~/.plannotator/config.json` with `{ "jina": false }`
+3. **Config file:** `config.json` in the Plannotator data directory with `{ "jina": false }` (`~/.plannotator/config.json` by default, or `$PLANNOTATOR_DATA_DIR/config.json` when overridden)
 
 If none of these are set, Jina is enabled by default.
 
@@ -99,6 +99,18 @@ For local HTML files, `--markdown` switches from raw HTML rendering to markdown 
 ## Source badge
 
 When annotating an HTML file or URL (not plain markdown), a small badge appears under the document title showing where the content came from. For URLs it shows the hostname (e.g. "stripe.com"). For HTML files it shows the filename (e.g. "guide.html").
+
+## Per-file version history
+
+Opening a non-empty local `.md`, `.mdx`, `.txt`, `.html`, or `.htm` file saves a copy for version history. Empty files do not create history. History is keyed by the file's resolved path, so reopening the same path after editing it exposes the previous/current diff and its earlier versions in the sidebar's Version Browser. Consecutive opens with identical content are deduplicated and do not create another version.
+
+### Privacy and retention
+
+History stores complete copies of eligible local files. For HTML files rendered directly (the default), it stores the raw HTML source; with `--markdown`, it stores the converted markdown. Versions are not automatically pruned or expired and remain until you manually remove them.
+
+These copies are stored under `~/.plannotator/history/` by default, or under `$PLANNOTATOR_DATA_DIR/history/` when the data directory is overridden. To keep local file annotation stateless, set `PLANNOTATOR_ANNOTATE_HISTORY=0` or add `"annotateHistory": false` to the active config file: `~/.plannotator/config.json` by default, or `$PLANNOTATOR_DATA_DIR/config.json` when overridden. The environment variable takes precedence over the config setting.
+
+URL annotation, folder browsing, and last-message annotation do not use per-file version history.
 
 ## Annotate mode differences
 
@@ -192,10 +204,11 @@ The agent receives this and can act on each annotation.
 
 ## Environment variables
 
-The annotate server respects the same environment variables as plan review, plus two specific to URL annotation:
+The annotate server respects the same environment variables as plan review. `PLANNOTATOR_ANNOTATE_HISTORY` controls eligible local-file history; `PLANNOTATOR_JINA` and `JINA_API_KEY` apply to URL annotation.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `PLANNOTATOR_ANNOTATE_HISTORY` | enabled | Set to `0` or `false` to disable per-file version history for local file annotation. |
 | `PLANNOTATOR_JINA` | enabled | Set to `0` or `false` to disable Jina Reader for URL annotation. |
 | `JINA_API_KEY` | (none) | Optional Jina Reader API key for higher rate limits (500 RPM vs 20 RPM). |
 

--- a/apps/marketing/src/content/docs/reference/environment-variables.md
+++ b/apps/marketing/src/content/docs/reference/environment-variables.md
@@ -38,8 +38,11 @@ All Plannotator environment variables and their defaults.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `PLANNOTATOR_JINA` | enabled | Set to `0` or `false` to disable Jina Reader for URL annotation. Set to `1` or `true` to enable (this is the default). Can also be set via `~/.plannotator/config.json` (`{ "jina": false }`) or per-invocation via `--no-jina`. |
+| `PLANNOTATOR_ANNOTATE_HISTORY` | enabled | Set to `0` or `false` to disable per-file version history for non-empty local file annotation. Set to `1` or `true` to enable (this is the default). Can also be set in the active config file (`{ "annotateHistory": false }`); the environment variable takes precedence. Does not apply to URL, folder, or last-message annotation. |
+| `PLANNOTATOR_JINA` | enabled | Set to `0` or `false` to disable Jina Reader for URL annotation. Set to `1` or `true` to enable (this is the default). Can also be set in the active config file (`{ "jina": false }`) or per-invocation via `--no-jina`. |
 | `JINA_API_KEY` | (none) | Optional Jina Reader API key for higher rate limits. Without it: 20 req/min. With it: 500 req/min. Free keys available from [Jina](https://jina.ai/reader/) and include 10M tokens. |
+
+The active config file is `~/.plannotator/config.json` by default, or `$PLANNOTATOR_DATA_DIR/config.json` when the data directory is overridden.
 
 ## Paste service variables
 


### PR DESCRIPTION
> **Important/Disclaimer (same note in all my PRs):** This is not spam (I created 4 PRs after the weekend of hard work + 2 from previous weeks), just my willing to help: I have been stress testing this tool (thank you for Plannotator!), finding some enhancements, proposing a couple of improvements and fixing some issues. I keep all these features/fixes in topic branches (to be able to publish them, now here as PRs), but I have been using all them in a local integration branch that I use to run plannotator with all these contributions (I use it in all projects and CLI harnesses I own). Therefore, apart from the tests per branch and ad hoc manual tests, I have been using it flawlessly. I decided to create the PRs, in case they are useful for you. Feel free to drop, update, extend.... anything you want. I am willing to contribute, so if you prefer that I tackle something or rebase/solve merge conflicts in the future (At 2026-07-20: all is ready!), please, don't hesitate to ping me. I am sharing this amount of work in case it is useful for you all.
> The plannotator "binary" that I use many times per day, it is based on the integration branch that has these PRs (branches cherrypicked) in order: 
> - https://github.com/backnotprop/plannotator/pull/1076, https://github.com/backnotprop/plannotator/pull/1078 (using them for 2 weeks)
> - https://github.com/backnotprop/plannotator/pull/1087, https://github.com/backnotprop/plannotator/pull/1089, https://github.com/backnotprop/plannotator/pull/1091, https://github.com/backnotprop/plannotator/pull/1092 (using them for 3 days; now just rebased)
>
> <img width="908" height="167" alt="image" src="https://github.com/user-attachments/assets/b3d23332-8ea0-480f-a8ea-4a07601fe04d" />

## Summary

Document the existing per-file version history used when annotating eligible, non-empty local markdown, text, and HTML files.

The annotate command page now explains when history is saved, what raw HTML and `--markdown` sessions retain, how reopening the same resolved path powers previous/current diffs and the Version Browser, how identical content is deduplicated, where copies and the active config are stored, how long copies remain, how to disable history, and which input modes are excluded.

Closes https://github.com/backnotprop/plannotator/issues/1086

## Why

The annotate page previously omitted both the iteration feature and its privacy controls. Users could miss the Version Browser workflow or assume local file annotation was stateless without knowing what content is copied, where copies are stored, how long they remain, or how to opt out.

## Changes

- Add a per-file version history section to `apps/marketing/src/content/docs/commands/annotate.md`.
- Add `PLANNOTATOR_ANNOTATE_HISTORY` to `apps/marketing/src/content/docs/reference/environment-variables.md`.
- List the supported non-empty local single-file extensions.
- Explain resolved-path identity, previous/current diffs, Version Browser access, and consecutive-content deduplication.
- Clarify that raw HTML sessions retain HTML source while `--markdown` sessions retain converted markdown.
- Document indefinite retention until manual deletion.
- Document the default and `PLANNOTATOR_DATA_DIR` history and active-config locations.
- Document the environment-variable and config-file opt-outs, including environment-variable precedence.
- Clarify that URL, folder, and last-message annotation do not use per-file history.

## Validation

Focused validation on the rebased documentation branch on 2026-07-20:

- `bun run build:marketing`: passed; Astro generated 40 static pages, including `/docs/commands/annotate/`.
- `bun run typecheck`: passed.
- `git diff --check`: passed.

Integration validation:

- `bun run typecheck`: passed.
- Full serialized test suite: 2,221 passed, 99 skipped, 0 failed, with 6,125 assertions across 193 files.
- Marketing build: passed; generated 40 pages.
- Review build: passed; transformed 3,511 modules.
- Hook build: passed; transformed 5,582 modules.
- OpenCode build: passed; embedded 690 modules and built 90 Node modules.
- Pi build: passed.

## Manual testing gaps

- No live browser annotate session was performed because this contribution only documents existing behavior.
- No Windows or Linux validation was performed; focused validation used macOS.
- No screenshots were captured because the rendered UI and runtime behavior are unchanged.

## Compatibility

This change updates documentation only and is based on `upstream/main` at `2594b374` (Plannotator 0.24.1). It does not alter annotate storage, history, retention, configuration, UI, or command behavior.