### PR TITLE
fix: align Codex model catalog and reasoning efforts with the current Codex CLI

### DIFF
--- a/packages/ai/providers/codex-app-server.ts
+++ b/packages/ai/providers/codex-app-server.ts
@@ -45,7 +45,7 @@ import {
 } from "./command-path.ts";
 
 const PROVIDER_NAME = "codex-sdk";
-const DEFAULT_MODEL = "gpt-5.4";
+const DEFAULT_MODEL = "gpt-5.6-sol";
 const CLIENT_NAME = "plannotator";
 /** Kill an idle app-server process after this long with no query. */
 const IDLE_TIMEOUT_MS = 10 * 60_000;
@@ -73,6 +73,8 @@ const REASONING_EFFORT_LABELS: Record<string, string> = {
   medium: "Medium",
   high: "High",
   xhigh: "xhigh",
+  max: "Max",
+  ultra: "Ultra",
 };
 
 type ProviderModel = {
@@ -525,7 +527,7 @@ export class CodexAppServerProvider implements AIProvider {
   // (model/list). Reasoning efforts are intentionally omitted here so the UI
   // hides the control until we have the model's actual supported set.
   models: ProviderModel[] = [
-    { id: "gpt-5.4", label: "GPT-5.4", default: true },
+    { id: "gpt-5.6-sol", label: "GPT-5.6 Sol", default: true },
   ];
 
   private config: CodexSDKConfig;

--- a/packages/review-editor/components/guide/GuideEmptyState.tsx
+++ b/packages/review-editor/components/guide/GuideEmptyState.tsx
@@ -10,7 +10,7 @@ import {
   TOUR_CLAUDE_MODELS,
   CLAUDE_EFFORT,
   CODEX_MODELS,
-  CODEX_REASONING,
+  codexReasoningOptions,
   PI_THINKING,
   REVIEW_ENGINE_LABEL,
 } from '@plannotator/ui/components/AgentsTab';
@@ -468,7 +468,7 @@ export const GuideEmptyState: React.FC<GuideEmptyStateProps> = ({ capabilities, 
                 <InlinePicker label="Effort" value={guideClaudeEffort} options={CLAUDE_EFFORT} onChange={setGuideClaudeEffort} />
               )}
               {engine === 'codex' && (
-                <InlinePicker label="Reasoning" value={guideCodexReasoning} options={CODEX_REASONING} onChange={setGuideCodexReasoning} />
+                <InlinePicker label="Reasoning" value={guideCodexReasoning} options={codexReasoningOptions(guideCodexModel)} onChange={setGuideCodexReasoning} />
               )}
               {engine === 'pi' && (
                 <InlinePicker label="Thinking" value={guidePiThinking} options={PI_THINKING} onChange={setGuidePiThinking} />

--- a/packages/server/guide/guide-review.ts
+++ b/packages/server/guide/guide-review.ts
@@ -1139,8 +1139,9 @@ export function createGuideSession(): GuideSession {
 
         if (engine === "codex") {
           const outputPath = generateGuideOutputPath();
-          const command = await buildGuideCodexCommand({ cwd, outputPath, prompt: repairPrompt, model: model || undefined, reasoningEffort: "minimal", fastMode: false });
-          return { command, outputPath, prompt: repairPrompt, label: "Guide Repair", engine: "codex", model, reasoningEffort: "minimal" };
+          // "low" not "minimal": no current Codex model supports minimal.
+          const command = await buildGuideCodexCommand({ cwd, outputPath, prompt: repairPrompt, model: model || undefined, reasoningEffort: "low", fastMode: false });
+          return { command, outputPath, prompt: repairPrompt, label: "Guide Repair", engine: "codex", model, reasoningEffort: "low" };
         }
 
         const { command, stdinPrompt } = buildGuideClaudeCommand(repairPrompt, model, "low");

--- a/packages/ui/components/AgentsTab.test.ts
+++ b/packages/ui/components/AgentsTab.test.ts
@@ -9,14 +9,16 @@ test("uses the canonical GPT-5.6 Sol model ID", () => {
 });
 
 describe("CODEX_MODELS catalog", () => {
-  test("omits gpt-5.3-codex (saved picks of it are force-migrated away)", () => {
-    expect(CODEX_MODELS.some(({ value }) => value === "gpt-5.3-codex")).toBe(false);
+  test("omits models rejected or API-shut-down for every auth mode", () => {
+    // gpt-5.3-codex: ChatGPT-account Codex rejects it outright. The other
+    // three: API-level shutdown 2026-07-23 per OpenAI's deprecations page.
+    for (const value of ["gpt-5.3-codex", "gpt-5.2-codex", "gpt-5.1-codex-max", "gpt-5.1-codex-mini"]) {
+      expect(CODEX_MODELS.some((m) => m.value === value)).toBe(false);
+    }
   });
 
-  test("keeps the 5.2/5.1 family for API-key Codex users", () => {
-    for (const value of ["gpt-5.2-codex", "gpt-5.2", "gpt-5.1-codex-max", "gpt-5.1-codex-mini"]) {
-      expect(catalogEntry(value)?.efforts).toEqual(["low", "medium", "high", "xhigh"]);
-    }
+  test("keeps gpt-5.2 (still API-valid) with the historical effort set", () => {
+    expect(catalogEntry("gpt-5.2")?.efforts).toEqual(["low", "medium", "high", "xhigh"]);
   });
 
   test("GPT-5.6 family carries the CLI catalog's efforts and defaults", () => {

--- a/packages/ui/components/AgentsTab.test.ts
+++ b/packages/ui/components/AgentsTab.test.ts
@@ -1,10 +1,84 @@
-import { expect, test } from "bun:test";
-import { CODEX_MODELS } from "./AgentsTab";
+import { describe, expect, test } from "bun:test";
+import { CODEX_MODELS, codexReasoningOptions } from "./AgentsTab";
+
+const catalogEntry = (value: string) => CODEX_MODELS.find((m) => m.value === value);
 
 test("uses the canonical GPT-5.6 Sol model ID", () => {
-  expect(CODEX_MODELS).toContainEqual({
-    value: "gpt-5.6-sol",
-    label: "GPT-5.6 Sol",
-  });
+  expect(catalogEntry("gpt-5.6-sol")?.label).toBe("GPT-5.6 Sol");
   expect(CODEX_MODELS.some(({ value }) => value === "gpt-5.6")).toBe(false);
+});
+
+describe("CODEX_MODELS catalog", () => {
+  test("omits gpt-5.3-codex (saved picks of it are force-migrated away)", () => {
+    expect(CODEX_MODELS.some(({ value }) => value === "gpt-5.3-codex")).toBe(false);
+  });
+
+  test("keeps the 5.2/5.1 family for API-key Codex users", () => {
+    for (const value of ["gpt-5.2-codex", "gpt-5.2", "gpt-5.1-codex-max", "gpt-5.1-codex-mini"]) {
+      expect(catalogEntry(value)?.efforts).toEqual(["low", "medium", "high", "xhigh"]);
+    }
+  });
+
+  test("GPT-5.6 family carries the CLI catalog's efforts and defaults", () => {
+    expect(catalogEntry("gpt-5.6-sol")).toEqual({
+      value: "gpt-5.6-sol",
+      label: "GPT-5.6 Sol",
+      efforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
+      defaultEffort: "low",
+    });
+    expect(catalogEntry("gpt-5.6-terra")).toEqual({
+      value: "gpt-5.6-terra",
+      label: "GPT-5.6 Terra",
+      efforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
+      defaultEffort: "medium",
+    });
+    expect(catalogEntry("gpt-5.6-luna")).toEqual({
+      value: "gpt-5.6-luna",
+      label: "GPT-5.6 Luna",
+      efforts: ["low", "medium", "high", "xhigh", "max"],
+      defaultEffort: "medium",
+    });
+  });
+
+  test("spark defaults to high; 5.5/5.4 default to medium", () => {
+    expect(catalogEntry("gpt-5.3-codex-spark")?.defaultEffort).toBe("high");
+    expect(catalogEntry("gpt-5.5")?.defaultEffort).toBe("medium");
+    expect(catalogEntry("gpt-5.4")?.defaultEffort).toBe("medium");
+    expect(catalogEntry("gpt-5.4-mini")?.defaultEffort).toBe("medium");
+  });
+
+  test("no model offers minimal, and every default effort is supported", () => {
+    for (const model of CODEX_MODELS) {
+      expect(model.efforts).not.toContain("minimal");
+      expect(model.efforts).toContain(model.defaultEffort);
+    }
+  });
+});
+
+describe("codexReasoningOptions", () => {
+  test("offers only the selected model's efforts, with Max/Ultra labels", () => {
+    expect(codexReasoningOptions("gpt-5.6-sol")).toEqual([
+      { value: "low", label: "Low" },
+      { value: "medium", label: "Medium" },
+      { value: "high", label: "High" },
+      { value: "xhigh", label: "XHigh" },
+      { value: "max", label: "Max" },
+      { value: "ultra", label: "Ultra" },
+    ]);
+    expect(codexReasoningOptions("gpt-5.5").map(({ value }) => value)).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+  });
+
+  test("falls back to the low..xhigh set for unknown models", () => {
+    expect(codexReasoningOptions("future-codex-model").map(({ value }) => value)).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+  });
 });

--- a/packages/ui/components/AgentsTab.tsx
+++ b/packages/ui/components/AgentsTab.tsx
@@ -22,6 +22,7 @@ import { useAgentSettings } from '../hooks/useAgentSettings';
 import type { AgentEngine, AgentMode, ReviewEngine } from '../hooks/useAgentSettings';
 import type { AgentLaunchParams } from '../hooks/useAgentJobs';
 import { ConfigRow, SegmentedPicker, Toggle, SelectMenu } from './AgentControls';
+import { CODEX_MODELS, CODEX_EFFORT_LABELS, codexReasoningOptions } from '../utils/codexModels';
 
 export type { AgentLaunchParams } from '../hooks/useAgentJobs';
 
@@ -49,30 +50,10 @@ export const CLAUDE_EFFORT: Array<{ value: string; label: string }> = [
   { value: 'max', label: 'Max' },
 ];
 
-export const CODEX_MODELS: Array<{ value: string; label: string }> = [
-  // GPT-5.6 naming scheme: `-sol` is the flagship, `-terra` is the mid
-  // price/performance tier, and `-luna` is the efficient high-volume tier.
-  { value: 'gpt-5.6-sol', label: 'GPT-5.6 Sol' },
-  { value: 'gpt-5.6-terra', label: 'GPT-5.6 Terra' },
-  { value: 'gpt-5.6-luna', label: 'GPT-5.6 Luna' },
-  { value: 'gpt-5.5', label: 'GPT-5.5' },
-  { value: 'gpt-5.4', label: 'GPT-5.4' },
-  { value: 'gpt-5.3-codex', label: 'GPT-5.3 Codex' },
-  { value: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark' },
-  { value: 'gpt-5.2-codex', label: 'GPT-5.2 Codex' },
-  { value: 'gpt-5.2', label: 'GPT-5.2' },
-  { value: 'gpt-5.1-codex-max', label: 'GPT-5.1 Codex Max' },
-  { value: 'gpt-5.1-codex-mini', label: 'GPT-5.1 Codex Mini' },
-  { value: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' },
-];
-
-export const CODEX_REASONING: Array<{ value: string; label: string }> = [
-  { value: 'minimal', label: 'Minimal' },
-  { value: 'low', label: 'Low' },
-  { value: 'medium', label: 'Medium' },
-  { value: 'high', label: 'High' },
-  { value: 'xhigh', label: 'XHigh' },
-];
+// Codex model catalog + per-model reasoning efforts live in
+// utils/codexModels (useAgentSettings needs them too, for effort clamping);
+// re-exported here so both launch surfaces keep one import site.
+export { CODEX_MODELS, codexReasoningOptions } from '../utils/codexModels';
 
 // Tour/guide Claude catalog: the CLI's latest-resolving aliases on top
 // (verified against `claude --help`: "Provide an alias for the latest model
@@ -275,7 +256,7 @@ function formatEffort(value: string): string {
 }
 
 function formatReasoning(value: string): string {
-  return catalogLabel(CODEX_REASONING, value);
+  return CODEX_EFFORT_LABELS[value] ?? value;
 }
 
 // --- Add-a-review dialog: a type-ahead picker over every discovered skill ---
@@ -1117,7 +1098,7 @@ export const AgentsTab: React.FC<AgentsTabProps> = ({
                       <SelectMenu value={codexModel} options={CODEX_MODELS} onChange={setCodexModel} />
                     </ConfigRow>
                     <ConfigRow label="Reasoning" stacked>
-                      <SegmentedPicker options={CODEX_REASONING} value={codexReasoning} onChange={setCodexReasoning} />
+                      <SegmentedPicker options={codexReasoningOptions(codexModel)} value={codexReasoning} onChange={setCodexReasoning} />
                     </ConfigRow>
                     <ConfigRow label="Fast mode">
                       <Toggle checked={codexFast} onChange={setCodexFast} />
@@ -1160,7 +1141,7 @@ export const AgentsTab: React.FC<AgentsTabProps> = ({
                 {tourEngine === 'codex' && (
                   <>
                     <ConfigRow label="Reasoning" stacked>
-                      <SegmentedPicker options={CODEX_REASONING} value={tourCodexReasoning} onChange={setTourCodexReasoning} />
+                      <SegmentedPicker options={codexReasoningOptions(tourCodexModel)} value={tourCodexReasoning} onChange={setTourCodexReasoning} />
                     </ConfigRow>
                     <ConfigRow label="Fast mode">
                       <Toggle checked={tourCodexFast} onChange={setTourCodexFast} />
@@ -1195,7 +1176,7 @@ export const AgentsTab: React.FC<AgentsTabProps> = ({
                     deliberately not offered for guide. */}
                 {guideEngine === 'codex' && (
                   <ConfigRow label="Reasoning" stacked>
-                    <SegmentedPicker options={CODEX_REASONING} value={guideCodexReasoning} onChange={setGuideCodexReasoning} />
+                    <SegmentedPicker options={codexReasoningOptions(guideCodexModel)} value={guideCodexReasoning} onChange={setGuideCodexReasoning} />
                   </ConfigRow>
                 )}
 

--- a/packages/ui/hooks/useAgentSettings.test.ts
+++ b/packages/ui/hooks/useAgentSettings.test.ts
@@ -5,6 +5,7 @@ import {
   parseReviewProfileByEngine,
   sanitizeCodexPerModel,
 } from "./useAgentSettings";
+import { clampCodexReasoning } from "../utils/codexModels";
 
 describe("sanitizeCodexPerModel", () => {
   test("returns empty object for undefined/empty input", () => {
@@ -25,6 +26,18 @@ describe("sanitizeCodexPerModel", () => {
     });
     expect(result).toEqual({
       "gpt-5.3-codex": { reasoning: DEFAULT_CODEX_REASONING, fast: true },
+    });
+  });
+
+  test("migrates reasoning: 'minimal' to 'low', preserving fast", () => {
+    expect(
+      sanitizeCodexPerModel({
+        "gpt-5.5": { reasoning: "minimal", fast: true },
+        "gpt-5.6-sol": { reasoning: "minimal", fast: false },
+      }),
+    ).toEqual({
+      "gpt-5.5": { reasoning: "low", fast: true },
+      "gpt-5.6-sol": { reasoning: "low", fast: false },
     });
   });
 
@@ -100,6 +113,50 @@ describe("migrateCodexSection", () => {
       };
       expect(migrateCodexSection(section, "gpt-5.5")).toEqual(section);
     }
+  });
+
+  test("keeps the 5.2/5.1 family (still valid for API-key Codex)", () => {
+    for (const model of ["gpt-5.2-codex", "gpt-5.2", "gpt-5.1-codex-max", "gpt-5.1-codex-mini"]) {
+      expect(migrateCodexSection({ model, perModel: {} }, "gpt-5.5").model).toBe(model);
+    }
+  });
+
+  test("moves a saved gpt-5.3-codex pick to the fallback and minimal reasoning to low", () => {
+    expect(
+      migrateCodexSection(
+        {
+          model: "gpt-5.3-codex",
+          perModel: {
+            "gpt-5.3-codex": { reasoning: "minimal", fast: true },
+          },
+        },
+        "gpt-5.5",
+      ),
+    ).toEqual({
+      model: "gpt-5.5",
+      perModel: {
+        "gpt-5.3-codex": { reasoning: "low", fast: true },
+      },
+    });
+  });
+});
+
+describe("clampCodexReasoning", () => {
+  test("keeps a supported effort", () => {
+    expect(clampCodexReasoning("gpt-5.6-sol", "ultra")).toBe("ultra");
+    expect(clampCodexReasoning("gpt-5.6-luna", "max")).toBe("max");
+    expect(clampCodexReasoning("gpt-5.5", "xhigh")).toBe("xhigh");
+  });
+
+  test("snaps an unsupported effort to the model's catalog default", () => {
+    expect(clampCodexReasoning("gpt-5.5", "max")).toBe("medium");
+    expect(clampCodexReasoning("gpt-5.6-luna", "ultra")).toBe("medium");
+    expect(clampCodexReasoning("gpt-5.3-codex-spark", "minimal")).toBe("high");
+    expect(clampCodexReasoning("gpt-5.6-sol", "minimal")).toBe("low");
+  });
+
+  test("passes unknown models through unchanged", () => {
+    expect(clampCodexReasoning("future-codex-model", "max")).toBe("max");
   });
 });
 

--- a/packages/ui/hooks/useAgentSettings.test.ts
+++ b/packages/ui/hooks/useAgentSettings.test.ts
@@ -115,10 +115,55 @@ describe("migrateCodexSection", () => {
     }
   });
 
-  test("keeps the 5.2/5.1 family (still valid for API-key Codex)", () => {
-    for (const model of ["gpt-5.2-codex", "gpt-5.2", "gpt-5.1-codex-max", "gpt-5.1-codex-mini"]) {
-      expect(migrateCodexSection({ model, perModel: {} }, "gpt-5.5").model).toBe(model);
+  test("keeps gpt-5.2 (still API-valid — only the ChatGPT product retired it)", () => {
+    expect(migrateCodexSection({ model: "gpt-5.2", perModel: {} }, "gpt-5.5").model).toBe("gpt-5.2");
+  });
+
+  test("moves API-shut-down picks with no direct replacement to the fallback", () => {
+    for (const model of ["gpt-5.2-codex", "gpt-5.1-codex-max"]) {
+      expect(migrateCodexSection({ model, perModel: {} }, "gpt-5.5").model).toBe("gpt-5.5");
     }
+  });
+
+  test("moves a gpt-5.1-codex-mini pick and preference to gpt-5.4-mini", () => {
+    expect(
+      migrateCodexSection(
+        {
+          model: "gpt-5.1-codex-mini",
+          perModel: {
+            "gpt-5.1-codex-mini": { reasoning: "xhigh", fast: true },
+            "gpt-5.5": { reasoning: "medium", fast: false },
+          },
+        },
+        "gpt-5.5",
+      ),
+    ).toEqual({
+      model: "gpt-5.4-mini",
+      perModel: {
+        "gpt-5.4-mini": { reasoning: "xhigh", fast: true },
+        "gpt-5.5": { reasoning: "medium", fast: false },
+      },
+    });
+  });
+
+  test("keeps the canonical gpt-5.4-mini preference when both keys exist", () => {
+    expect(
+      migrateCodexSection(
+        {
+          model: "gpt-5.1-codex-mini",
+          perModel: {
+            "gpt-5.1-codex-mini": { reasoning: "low", fast: false },
+            "gpt-5.4-mini": { reasoning: "high", fast: true },
+          },
+        },
+        "gpt-5.5",
+      ),
+    ).toEqual({
+      model: "gpt-5.4-mini",
+      perModel: {
+        "gpt-5.4-mini": { reasoning: "high", fast: true },
+      },
+    });
   });
 
   test("moves a saved gpt-5.3-codex pick to the fallback and minimal reasoning to low", () => {

--- a/packages/ui/hooks/useAgentSettings.ts
+++ b/packages/ui/hooks/useAgentSettings.ts
@@ -200,6 +200,20 @@ export function sanitizeCodexPerModel(
   return out;
 }
 
+// Saved model IDs that migrate to a direct replacement: the stale gpt-5.6
+// slug (renamed to -sol when the tiered family shipped) and gpt-5.1-codex-mini
+// (API shutdown 2026-07-23; gpt-5.4-mini is OpenAI's recommended replacement).
+const RENAMED_CODEX_MODELS: Record<string, string> = {
+  'gpt-5.6': 'gpt-5.6-sol',
+  'gpt-5.1-codex-mini': 'gpt-5.4-mini',
+};
+
+// Saved model IDs with no direct replacement — migrate to the surface's
+// fallback. gpt-5.3-codex is rejected outright by ChatGPT-account Codex;
+// gpt-5.2-codex and gpt-5.1-codex-max hit the API-level shutdown on
+// 2026-07-23 (OpenAI recommends gpt-5.5, which every fallback already is).
+const RETIRED_CODEX_MODELS = new Set(['gpt-5.3-codex', 'gpt-5.2-codex', 'gpt-5.1-codex-max']);
+
 // One-shot model migrations for a saved Codex section. Keep its per-model
 // preferences aligned with the canonical model ID while sanitizing them.
 export function migrateCodexSection(
@@ -207,19 +221,19 @@ export function migrateCodexSection(
   fallback: string,
 ): CodexSection {
   const perModel = sanitizeCodexPerModel(section?.perModel);
-  const legacyPreference = perModel['gpt-5.6'];
-  if (legacyPreference) {
-    perModel['gpt-5.6-sol'] ??= legacyPreference;
-    delete perModel['gpt-5.6'];
+  for (const [legacy, replacement] of Object.entries(RENAMED_CODEX_MODELS)) {
+    const legacyPreference = perModel[legacy];
+    if (legacyPreference) {
+      perModel[replacement] ??= legacyPreference;
+      delete perModel[legacy];
+    }
   }
 
   const savedModel = section?.model;
   const model =
-    savedModel === 'gpt-5.6'
-      ? 'gpt-5.6-sol'
-      : typeof savedModel !== 'string' || savedModel === 'gpt-5.3-codex'
-        ? fallback
-        : savedModel;
+    typeof savedModel !== 'string' || RETIRED_CODEX_MODELS.has(savedModel)
+      ? fallback
+      : (RENAMED_CODEX_MODELS[savedModel] ?? savedModel);
   return { model, perModel };
 }
 

--- a/packages/ui/hooks/useAgentSettings.ts
+++ b/packages/ui/hooks/useAgentSettings.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { getItem, setItem } from '../utils/storage';
+import { clampCodexReasoning } from '../utils/codexModels';
 
 const COOKIE_KEY = 'plannotator.agents';
 
@@ -176,7 +177,9 @@ const initialState: AgentSettingsState = {
 
 // One-shot migration: drop any cached "none" codex reasoning entries. The
 // dropdown no longer offers "None" (codex-rs rejects it as a config value);
-// fall back to the default instead of shipping an invalid flag.
+// fall back to the default instead of shipping an invalid flag. Saved
+// "minimal" entries migrate to "low": no current Codex model supports
+// minimal, and low is the nearest effort that every model does.
 export function sanitizeCodexPerModel(
   perModel: Record<string, { reasoning: string; fast: boolean }> | undefined,
 ): Record<string, { reasoning: string; fast: boolean }> {
@@ -186,6 +189,10 @@ export function sanitizeCodexPerModel(
     if (!entry || typeof entry !== 'object') continue;
     if (entry.reasoning === 'none') {
       if (entry.fast) out[model] = { reasoning: DEFAULT_CODEX_REASONING, fast: true };
+      continue;
+    }
+    if (entry.reasoning === 'minimal') {
+      out[model] = { ...entry, reasoning: 'low' };
       continue;
     }
     out[model] = entry;
@@ -514,13 +521,27 @@ export function useAgentSettings() {
   }, []);
 
   const claudeEffort = state.claude.perModel[state.claude.model]?.effort ?? DEFAULT_CLAUDE_EFFORT;
-  const codexReasoning = state.codex.perModel[state.codex.model]?.reasoning ?? DEFAULT_CODEX_REASONING;
+  // Codex reasoning is clamped through the model's supported-effort set: a
+  // saved (or surface-default) effort the selected model doesn't support
+  // snaps to that model's catalog default. Every consumer — the pickers AND
+  // the launch payloads — reads these derived values, so an unsupported
+  // effort can never reach `-c model_reasoning_effort=`.
+  const codexReasoning = clampCodexReasoning(
+    state.codex.model,
+    state.codex.perModel[state.codex.model]?.reasoning ?? DEFAULT_CODEX_REASONING,
+  );
   const codexFast = state.codex.perModel[state.codex.model]?.fast ?? DEFAULT_CODEX_FAST;
   const tourClaudeEffort = state.tourClaude.perModel[state.tourClaude.model]?.effort ?? DEFAULT_TOUR_CLAUDE_EFFORT;
-  const tourCodexReasoning = state.tourCodex.perModel[state.tourCodex.model]?.reasoning ?? DEFAULT_TOUR_CODEX_REASONING;
+  const tourCodexReasoning = clampCodexReasoning(
+    state.tourCodex.model,
+    state.tourCodex.perModel[state.tourCodex.model]?.reasoning ?? DEFAULT_TOUR_CODEX_REASONING,
+  );
   const tourCodexFast = state.tourCodex.perModel[state.tourCodex.model]?.fast ?? DEFAULT_TOUR_CODEX_FAST;
   const guideClaudeEffort = state.guideClaude.perModel[state.guideClaude.model]?.effort ?? DEFAULT_GUIDE_CLAUDE_EFFORT;
-  const guideCodexReasoning = state.guideCodex.perModel[state.guideCodex.model]?.reasoning ?? DEFAULT_GUIDE_CODEX_REASONING;
+  const guideCodexReasoning = clampCodexReasoning(
+    state.guideCodex.model,
+    state.guideCodex.perModel[state.guideCodex.model]?.reasoning ?? DEFAULT_GUIDE_CODEX_REASONING,
+  );
 
   return {
     selectedMode: state.selectedMode,

--- a/packages/ui/utils/codexModels.ts
+++ b/packages/ui/utils/codexModels.ts
@@ -1,0 +1,80 @@
+/**
+ * Codex Model Catalog
+ *
+ * Single source of truth for the Codex models offered by the launch panels
+ * (AgentsTab + GuideEmptyState) and their per-model reasoning efforts.
+ * Aligned with the Codex CLI's own model catalog (codex-cli 0.144): each
+ * entry carries the efforts that model actually accepts plus the CLI's
+ * default effort for it, so the UI never offers (or launches) an effort the
+ * model would reject. Lives in utils/ rather than AgentsTab so
+ * useAgentSettings can clamp saved efforts without importing a component.
+ */
+
+export interface CodexModelOption {
+  value: string;
+  label: string;
+  /** Reasoning efforts this model supports, per the Codex CLI catalog. */
+  efforts: string[];
+  /** The CLI's default effort for this model — the clamp target when a saved
+   *  effort isn't in `efforts`. */
+  defaultEffort: string;
+}
+
+// The two effort ladders in the current catalog. No model supports `minimal`
+// anymore (saved picks migrate to `low` — see useAgentSettings).
+const EFFORTS_THROUGH_XHIGH = ['low', 'medium', 'high', 'xhigh'];
+const EFFORTS_THROUGH_MAX = [...EFFORTS_THROUGH_XHIGH, 'max'];
+const EFFORTS_THROUGH_ULTRA = [...EFFORTS_THROUGH_MAX, 'ultra'];
+
+export const CODEX_MODELS: CodexModelOption[] = [
+  // GPT-5.6 naming scheme: `-sol` is the flagship, `-terra` is the mid
+  // price/performance tier, and `-luna` is the efficient high-volume tier.
+  { value: 'gpt-5.6-sol', label: 'GPT-5.6 Sol', efforts: EFFORTS_THROUGH_ULTRA, defaultEffort: 'low' },
+  { value: 'gpt-5.6-terra', label: 'GPT-5.6 Terra', efforts: EFFORTS_THROUGH_ULTRA, defaultEffort: 'medium' },
+  { value: 'gpt-5.6-luna', label: 'GPT-5.6 Luna', efforts: EFFORTS_THROUGH_MAX, defaultEffort: 'medium' },
+  { value: 'gpt-5.5', label: 'GPT-5.5', efforts: EFFORTS_THROUGH_XHIGH, defaultEffort: 'medium' },
+  { value: 'gpt-5.4', label: 'GPT-5.4', efforts: EFFORTS_THROUGH_XHIGH, defaultEffort: 'medium' },
+  { value: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark', efforts: EFFORTS_THROUGH_XHIGH, defaultEffort: 'high' },
+  // The 5.2/5.1 family is absent from the CLI catalog and rejected for
+  // ChatGPT-account Codex, but still available to API-key users — keep them.
+  // (gpt-5.3-codex is NOT kept: saved picks of it are already force-migrated
+  // away in useAgentSettings, so offering it would be incoherent.) They
+  // predate max/ultra, so they get the safe historical effort set.
+  { value: 'gpt-5.2-codex', label: 'GPT-5.2 Codex', efforts: EFFORTS_THROUGH_XHIGH, defaultEffort: 'medium' },
+  { value: 'gpt-5.2', label: 'GPT-5.2', efforts: EFFORTS_THROUGH_XHIGH, defaultEffort: 'medium' },
+  { value: 'gpt-5.1-codex-max', label: 'GPT-5.1 Codex Max', efforts: EFFORTS_THROUGH_XHIGH, defaultEffort: 'medium' },
+  { value: 'gpt-5.1-codex-mini', label: 'GPT-5.1 Codex Mini', efforts: EFFORTS_THROUGH_XHIGH, defaultEffort: 'medium' },
+  { value: 'gpt-5.4-mini', label: 'GPT-5.4 Mini', efforts: EFFORTS_THROUGH_XHIGH, defaultEffort: 'medium' },
+];
+
+/** Display labels for the reasoning-effort ids across every model. */
+export const CODEX_EFFORT_LABELS: Record<string, string> = {
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
+  xhigh: 'XHigh',
+  max: 'Max',
+  ultra: 'Ultra',
+};
+
+// Fallback effort set for a model we don't know (a saved pick of a future
+// model id passes through migration untouched, so the picker still needs
+// SOMETHING to offer). low..xhigh is supported by every catalog model.
+const UNKNOWN_MODEL_EFFORTS = EFFORTS_THROUGH_XHIGH;
+
+/** The reasoning-effort picker options for one model — only the efforts that
+ *  model actually supports. */
+export function codexReasoningOptions(model: string): Array<{ value: string; label: string }> {
+  const entry = CODEX_MODELS.find((m) => m.value === model);
+  const efforts = entry?.efforts ?? UNKNOWN_MODEL_EFFORTS;
+  return efforts.map((value) => ({ value, label: CODEX_EFFORT_LABELS[value] ?? value }));
+}
+
+/** Clamp a saved reasoning effort to what the model supports: an unsupported
+ *  effort snaps to the model's catalog default effort. Unknown models pass
+ *  through unchanged (we can't know their supported set). */
+export function clampCodexReasoning(model: string, reasoning: string): string {
+  const entry = CODEX_MODELS.find((m) => m.value === model);
+  if (!entry) return reasoning;
+  return entry.efforts.includes(reasoning) ? reasoning : entry.defaultEffort;
+}

--- a/packages/ui/utils/codexModels.ts
+++ b/packages/ui/utils/codexModels.ts
@@ -35,15 +35,14 @@ export const CODEX_MODELS: CodexModelOption[] = [
   { value: 'gpt-5.5', label: 'GPT-5.5', efforts: EFFORTS_THROUGH_XHIGH, defaultEffort: 'medium' },
   { value: 'gpt-5.4', label: 'GPT-5.4', efforts: EFFORTS_THROUGH_XHIGH, defaultEffort: 'medium' },
   { value: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark', efforts: EFFORTS_THROUGH_XHIGH, defaultEffort: 'high' },
-  // The 5.2/5.1 family is absent from the CLI catalog and rejected for
-  // ChatGPT-account Codex, but still available to API-key users — keep them.
-  // (gpt-5.3-codex is NOT kept: saved picks of it are already force-migrated
-  // away in useAgentSettings, so offering it would be incoherent.) They
-  // predate max/ultra, so they get the safe historical effort set.
-  { value: 'gpt-5.2-codex', label: 'GPT-5.2 Codex', efforts: EFFORTS_THROUGH_XHIGH, defaultEffort: 'medium' },
+  // gpt-5.2 is retained: it was retired from the ChatGPT product (steered to
+  // 5.5) but the API still serves it, so API-key Codex users keep it. The
+  // rest of the 5.2/5.1 family (gpt-5.2-codex, gpt-5.1-codex-max,
+  // gpt-5.1-codex-mini — and gpt-5.3-codex before them) is API-shut-down per
+  // OpenAI's deprecations page (2026-07-23), dead for ALL auth modes; saved
+  // picks migrate in useAgentSettings. gpt-5.2 predates max/ultra, so it
+  // gets the safe historical effort set.
   { value: 'gpt-5.2', label: 'GPT-5.2', efforts: EFFORTS_THROUGH_XHIGH, defaultEffort: 'medium' },
-  { value: 'gpt-5.1-codex-max', label: 'GPT-5.1 Codex Max', efforts: EFFORTS_THROUGH_XHIGH, defaultEffort: 'medium' },
-  { value: 'gpt-5.1-codex-mini', label: 'GPT-5.1 Codex Mini', efforts: EFFORTS_THROUGH_XHIGH, defaultEffort: 'medium' },
   { value: 'gpt-5.4-mini', label: 'GPT-5.4 Mini', efforts: EFFORTS_THROUGH_XHIGH, defaultEffort: 'medium' },
 ];
 


### PR DESCRIPTION
Aligns the Codex launch-panel catalog (review / tour / guide) and the Ask AI fallback with what the current Codex CLI (codex-cli 0.144) actually serves, and prunes models OpenAI is shutting down at the API level. Follow-up to #1076 / #1070, which fixed the bare `gpt-5.6` slug to `gpt-5.6-sol`.

## Ground truth (local Codex CLI model catalog)

| slug | visibility | default effort | supported efforts |
|---|---|---|---|
| gpt-5.6-sol | list | low | low, medium, high, xhigh, max, ultra |
| gpt-5.6-terra | list | medium | low, medium, high, xhigh, max, ultra |
| gpt-5.6-luna | list | medium | low, medium, high, xhigh, max |
| gpt-5.5 | list | medium | low, medium, high, xhigh |
| gpt-5.4 | hide | medium | low, medium, high, xhigh |
| gpt-5.4-mini | hide | medium | low, medium, high, xhigh |
| gpt-5.3-codex-spark | list | high | low, medium, high, xhigh |
| codex-auto-review | hide | medium | low, medium, high, xhigh |

No model supports `minimal`.

## Changes

**Pruned: `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`.** Per [OpenAI's API deprecations page](https://developers.openai.com/api/docs/deprecations), `gpt-5.2-codex`, `gpt-5.1-codex-max`, and `gpt-5.1-codex-mini` (like `gpt-5.3-codex` before them) hit an **API-level shutdown on 2026-07-23** — i.e. they die for ALL auth modes, API key included, before this ships. `gpt-5.3-codex` was already being force-migrated away because ChatGPT-account Codex rejects it outright with a live 400 ("The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account") — the exact failure mode the others are now headed for.

**Retained: `gpt-5.2`.** It was retired from the ChatGPT *product* on June 12 (steered to 5.5), but product retirement ≠ API deprecation — the API still serves it, so API-key Codex users keep it. It predates max/ultra and keeps the historical `low..xhigh` effort set.

**Saved-pick migrations** (extending the existing `gpt-5.3-codex` / `gpt-5.6`→`gpt-5.6-sol` machinery in `migrateCodexSection`): `gpt-5.2-codex` → fallback, `gpt-5.1-codex-max` → fallback (every surface fallback is already `gpt-5.5`, OpenAI's recommended replacement), and `gpt-5.1-codex-mini` → `gpt-5.4-mini` (OpenAI's own recommended replacement), carrying its perModel preference under the new key the same way the 5.6→sol rename does. `gpt-5.2` migrates nothing.

**Per-model reasoning-effort gating.** The catalog now lives in `packages/ui/utils/codexModels.ts` (re-exported from `AgentsTab` so both launch surfaces keep one import site) and carries each model's supported efforts + default effort from the CLI catalog. The reasoning pickers (review/tour/guide in `AgentsTab`, plus `GuideEmptyState`) offer only the selected model's efforts — including the new **Max** and **Ultra** tiers on the GPT-5.6 family. `useAgentSettings` clamps: a saved effort the selected model doesn't support snaps to that model's catalog default effort (unknown/future model ids pass through). Since every consumer — pickers and launch payloads — reads the clamped derived values, an unsupported effort can't reach `-c model_reasoning_effort=`.

**`minimal` is gone.** Saved per-model reasoning entries migrate `minimal` → `low` (nearest universally supported effort), following the existing `none`-entry sanitizer. The guide-repair launch's hardcoded `reasoningEffort: "minimal"` becomes `"low"` too.

**Launch path verified, both runtimes.** `reasoningEffort` flows opaquely from the UI through `POST /api/agents/jobs` into `-c model_reasoning_effort=<value>` (`codex-review.ts`, `tour-review.ts`, `guide-review.ts`); the Bun server validates field *names* only, never effort values, and the Pi server's codex builder is generated from the same Bun source at build time — so `max`/`ultra` pass through with no server changes needed.

**Ask AI.** The `codex-app-server` provider discovers the real model list (with per-model supported efforts) at runtime and self-corrects, so only its static fallback changed: fallback entry + `DEFAULT_MODEL` bump from `gpt-5.4` (now hidden) to `gpt-5.6-sol`, plus Max/Ultra display labels.

**Tests.** Catalog contents (pruned IDs absent, `gpt-5.2` retained, 5.6 family efforts/defaults, no `minimal`, per-model picker options), the new saved-pick migrations, the `minimal` → `low` migration, and the clamping rule. `bun test packages/ui` green; full `bun test packages/server packages/shared packages/ui` green except 5 pre-existing `git-background.test.ts` failures that reproduce on a clean tree; `bun run typecheck` clean.

https://claude.ai/code/session_01YXkgsNucxDwAL4GdR4XYRk