### PR TITLE
Soften Pinpoint hover feedback

### DIFF
--- a/packages/ui/components/PinpointOverlay.tsx
+++ b/packages/ui/components/PinpointOverlay.tsx
@@ -65,18 +65,18 @@ export const PinpointOverlay: React.FC<PinpointOverlayProps> = ({ target, contai
 
   return (
     <>
-      {/* Outline box */}
+      {/* Background wash */}
       <div
-        className="border-2 border-dashed border-primary/50 bg-primary/5 rounded"
+        className="bg-primary/10 rounded-sm"
         style={{
           position: 'absolute',
-          top: position.top - 2,
-          left: position.left - 2,
-          width: position.width + 4,
-          height: position.height + 4,
+          top: position.top,
+          left: position.left,
+          width: position.width,
+          height: position.height,
           pointerEvents: 'none',
           zIndex: 20,
-          transition: 'all 100ms ease-out',
+          transition: 'top 100ms ease-out, left 100ms ease-out, width 100ms ease-out, height 100ms ease-out',
         }}
       />
       {/* Label badge */}

--- a/packages/ui/components/Viewer.tsx
+++ b/packages/ui/components/Viewer.tsx
@@ -574,7 +574,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
       <article
         ref={containerRef}
         data-print-region="article"
-        className={`w-full bg-card rounded-xl py-5 md:py-8 lg:py-10 xl:py-12 relative ${gridEnabled ? 'px-5 md:px-8 lg:px-10 xl:px-12 shadow-xl border border-border/50' : ''} ${inputMethod === 'pinpoint' ? 'cursor-crosshair' : ''}`}
+        className={`w-full bg-card rounded-xl py-5 md:py-8 lg:py-10 xl:py-12 relative ${gridEnabled ? 'px-5 md:px-8 lg:px-10 xl:px-12 shadow-xl border border-border/50' : ''} ${inputMethod === 'pinpoint' ? 'cursor-pointer' : ''}`}
         style={{ WebkitTouchCallout: 'none' } as React.CSSProperties}
       >
         {/* Repo info + plan diff badge + demo badge + linked doc badge + archive badge - top left */}
@@ -984,7 +984,6 @@ const ImageLightbox: React.FC<{ src: string; alt: string; onClose: () => void }>
     </div>
   );
 };
-
 
 
 

--- a/packages/ui/components/html-viewer/bridge-script.ts
+++ b/packages/ui/components/html-viewer/bridge-script.ts
@@ -41,14 +41,13 @@ export const ANNOTATION_HIGHLIGHT_CSS = `
   filter: brightness(1.2);
 }
 .plannotator-pinpoint-hover {
-  outline: 2px solid var(--pn-focus-highlight, #4493f8) !important;
-  outline-offset: 1px;
-  cursor: crosshair !important;
+  background-color: oklch(from var(--pn-focus-highlight, #4493f8) l c h / 0.12) !important;
+  border-radius: 3px;
+  cursor: pointer !important;
 }
-/* SVG nodes can't take a CSS outline — stroke their shapes instead. */
-.plannotator-pinpoint-hover rect, .plannotator-pinpoint-hover path,
-.plannotator-pinpoint-hover circle, .plannotator-pinpoint-hover ellipse, .plannotator-pinpoint-hover polygon {
-  stroke: var(--pn-focus-highlight, #4493f8) !important; stroke-width: 2.5px !important;
+/* SVG groups can't render a CSS background, so use a soft glow instead. */
+.plannotator-pinpoint-hover:is(g, svg) {
+  filter: drop-shadow(0 0 4px oklch(from var(--pn-focus-highlight, #4493f8) l c h / 0.55));
 }
 `;
 


### PR DESCRIPTION
## Summary
- replace the dashed Pinpoint outline with a soft background wash
- use the pointer cursor for Pinpoint targets
- mirror the treatment in raw HTML, with a soft SVG glow fallback

## Validation
- `bun test` (2154 passed, 98 skipped)
- `bun run typecheck`
- `bun run build:review && bun run build:hook`
- visual QA in the local plan/annotate app