### PR TITLE
feat: annotate accepts YAML, JSON, TOML and other plain-text files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,7 +248,11 @@ Claude Code: plannotator annotate subcommand runs
 OpenCode/Pi: event handler intercepts command
         ↓
 Input type detected:
-  .md/.mdx   → file read from disk
+  .md/.mdx/.txt → file read from disk
+  plain-text config/data formats (.yaml .yml .json .jsonc .json5 .toml .ini .cfg .conf .properties .csv .tsv .log .xml .env.example)
+             → read from disk, rendered as plain text exactly like .txt (.env itself is
+               deliberately excluded — it commonly holds secrets and annotate history
+               copies file contents; source-code extensions stay with code review)
   .html/.htm → file read, rendered as raw HTML by default (or converted to markdown with --markdown)
   https://   → fetched via Jina Reader (default) or fetch+Turndown (--no-jina)
   folder/    → file browser opened, files converted on demand
@@ -412,7 +416,7 @@ Every plan is automatically saved to `~/.plannotator/history/{project}/{slug}/` 
 
 This powers the version history API (`/api/plan/version`, `/api/plan/versions`) and the plan diff system.
 
-**Annotate mode** also saves history on open, so the same version diff works when annotating a standalone `.md`/`.txt`/`.html` file. It keys the slug by **file path** — `annotate-{sanitized-basename}-{hash8}` — rather than heading + date, so re-opening the same file groups its versions even as its content (and headings) change. **Note this writes a copy of each annotated file's content** under `~/.plannotator/history/` (or `PLANNOTATOR_DATA_DIR`); disable via `PLANNOTATOR_ANNOTATE_HISTORY=0` or `{ "annotateHistory": false }` in `~/.plannotator/config.json` to keep annotate sessions stateless (the version diff is then unavailable). For `--render-html` files the diff is rendered as the real page with inline `<ins>`/`<del>` highlights via `htmlDiff()` (`packages/shared/html-diff.ts`).
+**Annotate mode** also saves history on open, so the same version diff works when annotating a standalone `.md`/`.txt`/`.html` file (or any other supported plain-text file, e.g. `.yaml`/`.json`/`.toml`). It keys the slug by **file path** — `annotate-{sanitized-basename}-{hash8}` — rather than heading + date, so re-opening the same file groups its versions even as its content (and headings) change. **Note this writes a copy of each annotated file's content** under `~/.plannotator/history/` (or `PLANNOTATOR_DATA_DIR`); disable via `PLANNOTATOR_ANNOTATE_HISTORY=0` or `{ "annotateHistory": false }` in `~/.plannotator/config.json` to keep annotate sessions stateless (the version diff is then unavailable). For `--render-html` files the diff is rendered as the real page with inline `<ins>`/`<del>` highlights via `htmlDiff()` (`packages/shared/html-diff.ts`).
 
 History saves independently of the `planSave` user setting (which controls decision snapshots in `~/.plannotator/plans/`). Storage functions live in `packages/shared/storage.ts` (runtime-agnostic, re-exported by `packages/server/storage.ts`). Pi copies the shared files at build time. Slug format: `{sanitized-heading}-YYYY-MM-DD` (heading first for readability).
 

--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -96,7 +96,7 @@ import { urlToMarkdown, isConvertedSource } from "@plannotator/shared/url-to-mar
 import { createWorktreePool, type WorktreePool, type PoolEntry } from "@plannotator/shared/worktree-pool";
 import { parsePRUrl, checkPRAuth, fetchPR, getCliName, getCliInstallUrl, getMRLabel, getMRNumberLabel, getDisplayRepo } from "@plannotator/server/pr";
 import { writeRemoteShareLink } from "@plannotator/server/share-url";
-import { resolveMarkdownFile, resolveUserPath, hasMarkdownFiles } from "@plannotator/shared/resolve-file";
+import { resolveMarkdownFile, resolveUserPath, hasMarkdownFiles, ANNOTATABLE_DOC_REGEX, ANNOTATABLE_EXTENSIONS_HINT } from "@plannotator/shared/resolve-file";
 import { FILE_BROWSER_EXCLUDED } from "@plannotator/shared/reference-common";
 import { statSync, rmSync, realpathSync, existsSync } from "fs";
 import { parseRemoteUrl } from "@plannotator/shared/repo";
@@ -954,9 +954,9 @@ if (args[0] === "sessions") {
 
     if (folderCandidate !== null) {
       const resolvedArg = resolveUserPath(folderCandidate, projectRoot);
-      // Folder annotation mode (markdown/plain text + HTML files)
-      if (!hasMarkdownFiles(resolvedArg, FILE_BROWSER_EXCLUDED, /\.(mdx?|txt|html?)$/i)) {
-        console.error(`No markdown, text, or HTML files found in ${resolvedArg}`);
+      // Folder annotation mode (markdown/plain text/config + HTML files)
+      if (!hasMarkdownFiles(resolvedArg, FILE_BROWSER_EXCLUDED, ANNOTATABLE_DOC_REGEX)) {
+        console.error(`No annotatable files (markdown, plain-text, config, or HTML) found in ${resolvedArg}`);
         process.exit(1);
       }
       folderPath = resolvedArg;
@@ -1010,7 +1010,7 @@ if (args[0] === "sessions") {
             const ext = path.extname(resolvedPath).toLowerCase();
             console.error(
               `File type not supported: ${ext}\n` +
-              `Only .md, .mdx, .txt, .html, .htm files are supported.\n` +
+              `Supported types: ${ANNOTATABLE_EXTENSIONS_HINT}\n` +
               `For code review, use: plannotator review [file]`
             );
           } else {

--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -96,7 +96,7 @@ import { urlToMarkdown, isConvertedSource } from "@plannotator/shared/url-to-mar
 import { createWorktreePool, type WorktreePool, type PoolEntry } from "@plannotator/shared/worktree-pool";
 import { parsePRUrl, checkPRAuth, fetchPR, getCliName, getCliInstallUrl, getMRLabel, getMRNumberLabel, getDisplayRepo } from "@plannotator/server/pr";
 import { writeRemoteShareLink } from "@plannotator/server/share-url";
-import { resolveMarkdownFile, resolveUserPath, hasMarkdownFiles, ANNOTATABLE_DOC_REGEX, ANNOTATABLE_EXTENSIONS_HINT } from "@plannotator/shared/resolve-file";
+import { resolveMarkdownFile, resolveUserPath, hasMarkdownFiles, ANNOTATABLE_DOC_REGEX, ANNOTATABLE_EXTENSIONS_HINT, MAX_ANNOTATABLE_FILE_BYTES } from "@plannotator/shared/resolve-file";
 import { FILE_BROWSER_EXCLUDED } from "@plannotator/shared/reference-common";
 import { statSync, rmSync, realpathSync, existsSync } from "fs";
 import { parseRemoteUrl } from "@plannotator/shared/repo";
@@ -1020,6 +1020,10 @@ if (args[0] === "sessions") {
         }
 
         absolutePath = resolved.path;
+        if (Bun.file(absolutePath).size > MAX_ANNOTATABLE_FILE_BYTES) {
+          console.error(`File too large to annotate (max 2MB): ${absolutePath}`);
+          process.exit(1);
+        }
         markdown = await Bun.file(absolutePath).text();
         console.error(`Resolved: ${absolutePath}`);
       }

--- a/apps/kiro-cli/skills/plannotator-annotate/SKILL.md
+++ b/apps/kiro-cli/skills/plannotator-annotate/SKILL.md
@@ -12,4 +12,4 @@ Run:
 PLANNOTATOR_ORIGIN=kiro-cli plannotator annotate $ARGUMENTS
 ```
 
-`$ARGUMENTS` should be a markdown file path, folder path, html file path, or URL.
+`$ARGUMENTS` should be a markdown or plain-text config file path (.md, .txt, .yaml, .json, .toml, .ini, .csv, .log, …), folder path, html file path, or URL.

--- a/apps/marketing/src/content/docs/commands/annotate.md
+++ b/apps/marketing/src/content/docs/commands/annotate.md
@@ -13,9 +13,16 @@ The `/plannotator-annotate` command opens files, URLs, or folders in the Plannot
 | Input | Command | What happens |
 |-------|---------|--------------|
 | Markdown file | `plannotator annotate README.md` | Opens the file directly |
+| Plain-text file | `plannotator annotate config.yaml` | Opens the file directly, rendered as plain text |
 | HTML file | `plannotator annotate docs/guide.html` | Renders the HTML directly |
 | URL | `plannotator annotate https://docs.stripe.com/api` | Fetches the page, converts to markdown, then opens |
-| Folder | `plannotator annotate ./docs/` | Opens a file browser showing all `.md`, `.mdx`, `.html`, and `.htm` files |
+| Folder | `plannotator annotate ./docs/` | Opens a file browser showing all supported files |
+
+### Supported file types
+
+Beyond `.md`, `.mdx`, `.txt`, `.html`, and `.htm`, annotate accepts common plain-text config and data formats: `.yaml`, `.yml`, `.json`, `.jsonc`, `.json5`, `.toml`, `.ini`, `.cfg`, `.conf`, `.properties`, `.csv`, `.tsv`, `.log`, `.xml`, and `.env.example`. These render exactly like `.txt` — as plain text you can select and annotate.
+
+`.env` is deliberately not supported: it commonly holds secrets, and annotate's version history copies file contents into the data dir (`~/.plannotator/history/`). Use `.env.example` for the secret-free template. Source-code files (`.ts`, `.py`, …) are also excluded — use `plannotator review` for code.
 
 ### Slash command (inside an agent session)
 

--- a/apps/opencode-plugin/commands.ts
+++ b/apps/opencode-plugin/commands.ts
@@ -22,7 +22,7 @@ import {
   getReviewDeniedSuffix,
   getAnnotateFileFeedbackPrompt,
 } from "@plannotator/shared/prompts";
-import { resolveMarkdownFile, resolveUserPath, hasMarkdownFiles } from "@plannotator/shared/resolve-file";
+import { resolveMarkdownFile, resolveUserPath, hasMarkdownFiles, ANNOTATABLE_DOC_REGEX } from "@plannotator/shared/resolve-file";
 import { FILE_BROWSER_EXCLUDED } from "@plannotator/shared/reference-common";
 import { htmlToMarkdown } from "@plannotator/shared/html-to-markdown";
 import { parseAnnotateArgs } from "@plannotator/shared/annotate-args";
@@ -256,8 +256,8 @@ export async function handleAnnotateCommand(
     }
 
     if (isFolder) {
-      if (!hasMarkdownFiles(resolvedArg, FILE_BROWSER_EXCLUDED, /\.(mdx?|txt|html?)$/i)) {
-        client.app.log({ level: "error", message: `No markdown, text, or HTML files found in ${resolvedArg}` });
+      if (!hasMarkdownFiles(resolvedArg, FILE_BROWSER_EXCLUDED, ANNOTATABLE_DOC_REGEX)) {
+        client.app.log({ level: "error", message: `No annotatable files (markdown, plain-text, config, or HTML) found in ${resolvedArg}` });
         return;
       }
       folderPath = resolvedArg;

--- a/apps/opencode-plugin/commands.ts
+++ b/apps/opencode-plugin/commands.ts
@@ -22,7 +22,7 @@ import {
   getReviewDeniedSuffix,
   getAnnotateFileFeedbackPrompt,
 } from "@plannotator/shared/prompts";
-import { resolveMarkdownFile, resolveUserPath, hasMarkdownFiles, ANNOTATABLE_DOC_REGEX } from "@plannotator/shared/resolve-file";
+import { resolveMarkdownFile, resolveUserPath, hasMarkdownFiles, ANNOTATABLE_DOC_REGEX, MAX_ANNOTATABLE_FILE_BYTES } from "@plannotator/shared/resolve-file";
 import { FILE_BROWSER_EXCLUDED } from "@plannotator/shared/reference-common";
 import { htmlToMarkdown } from "@plannotator/shared/html-to-markdown";
 import { parseAnnotateArgs } from "@plannotator/shared/annotate-args";
@@ -306,6 +306,10 @@ export async function handleAnnotateCommand(
       }
 
       absolutePath = resolved.path;
+      if (Bun.file(absolutePath).size > MAX_ANNOTATABLE_FILE_BYTES) {
+        client.app.log({ level: "error", message: `File too large to annotate (max 2MB): ${absolutePath}` });
+        return;
+      }
       client.app.log({ level: "info", message: `Resolved: ${absolutePath}` });
       markdown = await Bun.file(absolutePath).text();
     }

--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -97,6 +97,9 @@ async function loadAnnotateCommandModules() {
 		resolveAtReference: atReference.resolveAtReference,
 		hasMarkdownFiles: resolveFile.hasMarkdownFiles,
 		resolveUserPath: resolveFile.resolveUserPath,
+		isAnnotatableTextPath: resolveFile.isAnnotatableTextPath,
+		ANNOTATABLE_DOC_REGEX: resolveFile.ANNOTATABLE_DOC_REGEX,
+		ANNOTATABLE_EXTENSIONS_HINT: resolveFile.ANNOTATABLE_EXTENSIONS_HINT,
 		FILE_BROWSER_EXCLUDED: referenceCommon.FILE_BROWSER_EXCLUDED,
 	};
 }
@@ -517,6 +520,9 @@ export default function plannotator(pi: ExtensionAPI): void {
 				parseAnnotateArgs,
 				resolveAtReference,
 				resolveUserPath,
+				isAnnotatableTextPath,
+				ANNOTATABLE_DOC_REGEX,
+				ANNOTATABLE_EXTENSIONS_HINT,
 			} = await loadAnnotateCommandModules();
 			// Split known annotate flags from the path. --json is silently
 			// accepted (Pi writes back via sendUserMessage, not stdout).
@@ -585,8 +591,8 @@ export default function plannotator(pi: ExtensionAPI): void {
 				}
 
 				if (isFolder) {
-					if (!hasMarkdownFiles(absolutePath, FILE_BROWSER_EXCLUDED, /\.(mdx?|txt|html?)$/i)) {
-						ctx.ui.notify(`No markdown, text, or HTML files found in ${absolutePath}`, "error");
+					if (!hasMarkdownFiles(absolutePath, FILE_BROWSER_EXCLUDED, ANNOTATABLE_DOC_REGEX)) {
+						ctx.ui.notify(`No annotatable files (markdown, plain-text, config, or HTML) found in ${absolutePath}`, "error");
 						return;
 					}
 					markdown = "";
@@ -607,8 +613,8 @@ export default function plannotator(pi: ExtensionAPI): void {
 					sourceInfo = basename(absolutePath);
 					ctx.ui.notify(`Opening annotation UI for ${filePath}...`, "info");
 				} else {
-					if (!/\.(mdx?|txt)$/i.test(absolutePath)) {
-						ctx.ui.notify("Only .md, .mdx, .txt, .html, .htm files are supported.", "error");
+					if (!isAnnotatableTextPath(absolutePath)) {
+						ctx.ui.notify(`File type not supported. Supported types: ${ANNOTATABLE_EXTENSIONS_HINT}`, "error");
 						return;
 					}
 					markdown = readFileSync(absolutePath, "utf-8");

--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -100,6 +100,7 @@ async function loadAnnotateCommandModules() {
 		isAnnotatableTextPath: resolveFile.isAnnotatableTextPath,
 		ANNOTATABLE_DOC_REGEX: resolveFile.ANNOTATABLE_DOC_REGEX,
 		ANNOTATABLE_EXTENSIONS_HINT: resolveFile.ANNOTATABLE_EXTENSIONS_HINT,
+		MAX_ANNOTATABLE_FILE_BYTES: resolveFile.MAX_ANNOTATABLE_FILE_BYTES,
 		FILE_BROWSER_EXCLUDED: referenceCommon.FILE_BROWSER_EXCLUDED,
 	};
 }
@@ -523,6 +524,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 				isAnnotatableTextPath,
 				ANNOTATABLE_DOC_REGEX,
 				ANNOTATABLE_EXTENSIONS_HINT,
+				MAX_ANNOTATABLE_FILE_BYTES,
 			} = await loadAnnotateCommandModules();
 			// Split known annotate flags from the path. --json is silently
 			// accepted (Pi writes back via sendUserMessage, not stdout).
@@ -615,6 +617,10 @@ export default function plannotator(pi: ExtensionAPI): void {
 				} else {
 					if (!isAnnotatableTextPath(absolutePath)) {
 						ctx.ui.notify(`File type not supported. Supported types: ${ANNOTATABLE_EXTENSIONS_HINT}`, "error");
+						return;
+					}
+					if (statSync(absolutePath).size > MAX_ANNOTATABLE_FILE_BYTES) {
+						ctx.ui.notify(`File too large to annotate (max 2MB): ${absolutePath}`, "error");
 						return;
 					}
 					markdown = readFileSync(absolutePath, "utf-8");

--- a/apps/pi-extension/server/reference.ts
+++ b/apps/pi-extension/server/reference.ts
@@ -37,6 +37,8 @@ import {
 	resolveUserPath,
 	isWithinProjectRoot,
 	warmFileListCache,
+	ANNOTATABLE_DOC_REGEX,
+	isAnnotatableTextPath,
 } from "../generated/resolve-file.js";
 import { parseCodePath } from "../generated/code-file.js";
 import { htmlToMarkdown } from "../generated/html-to-markdown.js";
@@ -213,7 +215,7 @@ function jsonDoc(
 }
 
 /** Recursively walk a directory collecting files by extension, skipping ignored dirs. */
-const FILE_BROWSER_EXTENSIONS = /\.(mdx?|txt|html?)$/i;
+const FILE_BROWSER_EXTENSIONS = ANNOTATABLE_DOC_REGEX;
 
 function walkMarkdownFiles(dir: string, root: string, results: string[], extensions: RegExp = FILE_BROWSER_EXTENSIONS): void {
 	let entries: Dirent[];
@@ -258,10 +260,17 @@ export async function handleDocRequest(res: Res, url: URL, options: HandleDocOpt
 	const base = url.searchParams.get("base");
 	const resolvedBase = getTrustedBaseDir(base, allowedRoots);
 	const convert = url.searchParams.get("convert") === "1";
+	// `?doc=1` (set by the file browser) forces annotatable plain-text rendering
+	// for extensions that overlap CODE_FILE_REGEX (.yaml, .json, .toml, .ini,
+	// .xml). Without it, those paths keep the syntax-highlighted code-file
+	// popout response, so code-file links inside documents are unaffected.
+	const forceDoc = url.searchParams.get("doc") === "1";
+	const wantsDocRender = (path: string) =>
+		ANNOTATABLE_DOC_REGEX.test(path) && (forceDoc || !isCodeFilePath(path));
 	if (
 		resolvedBase &&
 		!isAbsoluteUserPath(requestedPath) &&
-		/\.(mdx?|txt|html?)$/i.test(requestedPath)
+		wantsDocRender(requestedPath)
 	) {
 		const fromBase = resolveUserPath(requestedPath, resolvedBase);
 		if (!isWithinAllowedRoots(fromBase, allowedRoots)) {
@@ -316,7 +325,10 @@ export async function handleDocRequest(res: Res, url: URL, options: HandleDocOpt
 	}
 
 	// Code files: try literal resolve first; on miss, fall back to smart resolver.
-	if (isCodeFilePath(requestedPath)) {
+	// Skipped when the client asked for doc rendering (`?doc=1`) on an
+	// annotatable plain-text path — those fall through to the markdown
+	// resolution below and render like .txt.
+	if (isCodeFilePath(requestedPath) && !(forceDoc && isAnnotatableTextPath(requestedPath))) {
 		const parsed = parseCodePath(requestedPath);
 		const cleanPath = parsed.filePath;
 		const literalPath = resolveUserPath(cleanPath, resolvedBase || projectRoot);

--- a/apps/pi-extension/server/reference.ts
+++ b/apps/pi-extension/server/reference.ts
@@ -38,6 +38,7 @@ import {
 	isWithinProjectRoot,
 	warmFileListCache,
 	ANNOTATABLE_DOC_REGEX,
+	MAX_ANNOTATABLE_FILE_BYTES,
 	isAnnotatableTextPath,
 } from "../generated/resolve-file.js";
 import { parseCodePath } from "../generated/code-file.js";
@@ -279,6 +280,10 @@ export async function handleDocRequest(res: Res, url: URL, options: HandleDocOpt
 		}
 		try {
 			if (existsSync(fromBase)) {
+				if (statSync(fromBase).size > MAX_ANNOTATABLE_FILE_BYTES) {
+					json(res, { error: "File too large (max 2MB)" }, 413);
+					return;
+				}
 				const snapshot = readSourceFileSnapshot(fromBase);
 				const raw = snapshot.text;
 				const isHtml = /\.html?$/i.test(requestedPath);
@@ -366,7 +371,7 @@ export async function handleDocRequest(res: Res, url: URL, options: HandleDocOpt
 
 		try {
 			const stat = statSync(resolvedCode);
-			if (stat.size > 2 * 1024 * 1024) {
+			if (stat.size > MAX_ANNOTATABLE_FILE_BYTES) {
 				json(res, { error: "File too large (max 2MB)" }, 413);
 				return;
 			}
@@ -419,6 +424,10 @@ export async function handleDocRequest(res: Res, url: URL, options: HandleDocOpt
 	}
 
 	try {
+		if (statSync(result.path).size > MAX_ANNOTATABLE_FILE_BYTES) {
+			json(res, { error: "File too large (max 2MB)" }, 413);
+			return;
+		}
 		const snapshot = readSourceFileSnapshot(result.path);
 		jsonDoc(res, { markdown: snapshot.text, filepath: result.path, renderAs: "markdown" }, options, undefined, snapshot);
 	} catch {

--- a/apps/pi-extension/vendor.sh
+++ b/apps/pi-extension/vendor.sh
@@ -8,7 +8,7 @@ rm -rf generated
 mkdir -p generated generated/ai/providers
 
 # Modules that MOVED to @plannotator/core — vendor the real impl from core.
-for f in feedback-templates project favicon code-file external-annotation agent-jobs agent-terminal source-save open-in-apps; do
+for f in feedback-templates project favicon code-file annotatable external-annotation agent-jobs agent-terminal source-save open-in-apps; do
   src="../../packages/core/$f.ts"
   printf '// @generated — DO NOT EDIT. Source: packages/core/%s.ts\n' "$f" | cat - "$src" > "generated/$f.ts"
 done

--- a/apps/skills/core/plannotator-annotate/SKILL.md
+++ b/apps/skills/core/plannotator-annotate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plannotator-annotate
-description: Open Plannotator's annotation UI for a markdown file, HTML file, URL, or folder and then respond to the returned annotations.
+description: Open Plannotator's annotation UI for a markdown file, plain-text config file (.yaml, .json, .toml, .ini, .csv, .log, …), HTML file, URL, or folder and then respond to the returned annotations.
 disable-model-invocation: true
 ---
 

--- a/packages/core/annotatable.ts
+++ b/packages/core/annotatable.ts
@@ -54,3 +54,31 @@ export function isAnnotatableDocPath(input: string): boolean {
  */
 export const ANNOTATABLE_EXTENSIONS_HINT =
 	".md, .mdx, .txt, .html, .htm, .yaml, .yml, .json, .jsonc, .json5, .toml, .ini, .cfg, .conf, .properties, .csv, .tsv, .log, .xml, .env.example";
+
+/**
+ * Size cap for files served/read as annotatable documents — the same 2MB
+ * limit the code-file popout has always enforced. Applies to the annotate
+ * CLI single-file read and the /api/doc document branches in both runtimes:
+ * a multi-GB `server.log` must produce a clear error, not OOM the server
+ * (and get copied into annotate history).
+ */
+export const MAX_ANNOTATABLE_FILE_BYTES = 2 * 1024 * 1024;
+
+/**
+ * Whether the markdown parser should strip a leading `--- ... ---` pair as
+ * frontmatter for a document from `path`.
+ *
+ * Frontmatter is a markdown convention. Non-markdown plain-text sources use
+ * the same delimiters for real content — a multi-document YAML (k8s style)
+ * starts with `---\napiVersion: …\n---` — so stripping there swallows the
+ * first document. Strip only for markdown sources (.md/.mdx) and for sources
+ * without a file path (plans and agent messages are always markdown);
+ * converted sources (URLs, .html via --markdown) keep stripping too since
+ * their markdown is generated.
+ */
+export function shouldStripFrontmatter(path: string | null | undefined): boolean {
+	if (!path) return true;
+	const trimmed = path.trim();
+	if (/\.mdx?$/i.test(trimmed)) return true;
+	return !isAnnotatableTextPath(trimmed);
+}

--- a/packages/core/annotatable.ts
+++ b/packages/core/annotatable.ts
@@ -1,0 +1,56 @@
+/**
+ * Annotatable file-type predicates — the single source of truth for which
+ * files the annotate flow accepts (#1029).
+ *
+ * Annotate reads files as UTF-8 text and renders them exactly the way `.txt`
+ * is rendered (plain text through the markdown pipeline), so any
+ * unambiguously plain-text format is safe to accept. The set is deliberately
+ * conservative:
+ *
+ * - Markdown/plain docs: .md .mdx .txt
+ * - Config/data formats: .yaml .yml .json .jsonc .json5 .toml .ini .cfg
+ *   .conf .properties .csv .tsv .log .xml .env.example
+ *
+ * Deliberate exclusions:
+ * - `.env` — commonly holds secrets, and annotate's per-file version history
+ *   copies file contents into the data dir (`~/.plannotator/history/`).
+ *   `.env.example` (the secret-free template convention) is accepted.
+ * - Source-code extensions (.ts, .py, …) — those belong to the code-file
+ *   link/popout system (`CODE_FILE_REGEX` in `code-file.ts`) and would also
+ *   flood the annotate folder file browser.
+ *
+ * Note the overlap with `CODE_FILE_REGEX` (.yaml/.json/.toml/.ini/.xml appear
+ * in both): a path's *rendering* depends on the surface. Code-file links
+ * inside a document keep the syntax-highlighted popout; the annotate CLI and
+ * the annotate file browser render the same file as an annotatable plain-text
+ * document.
+ */
+
+/** Plain-text file extensions annotate accepts as markdown-rendered text (no HTML). */
+export const ANNOTATABLE_TEXT_REGEX =
+	/(\.(mdx?|txt|ya?ml|jsonc?|json5|toml|ini|cfg|conf|properties|csv|tsv|log|xml)|\.env\.example)$/i;
+
+/**
+ * Everything the annotate surfaces can open: the plain-text set plus
+ * .html/.htm (which render as raw HTML via their own branch). Used by folder
+ * discovery and the file-browser listing.
+ */
+export const ANNOTATABLE_DOC_REGEX =
+	/(\.(mdx?|txt|html?|ya?ml|jsonc?|json5|toml|ini|cfg|conf|properties|csv|tsv|log|xml)|\.env\.example)$/i;
+
+/** True when annotate can open `input` as a plain-text (markdown-rendered) document. */
+export function isAnnotatableTextPath(input: string): boolean {
+	return ANNOTATABLE_TEXT_REGEX.test(input.trim());
+}
+
+/** True when annotate can open `input` at all (plain text or raw HTML). */
+export function isAnnotatableDocPath(input: string): boolean {
+	return ANNOTATABLE_DOC_REGEX.test(input.trim());
+}
+
+/**
+ * Human-readable description of the accepted set for error messages —
+ * keep in sync with the regexes above.
+ */
+export const ANNOTATABLE_EXTENSIONS_HINT =
+	".md, .mdx, .txt, .html, .htm, .yaml, .yml, .json, .jsonc, .json5, .toml, .ini, .cfg, .conf, .properties, .csv, .tsv, .log, .xml, .env.example";

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "exports": {
     "./agents": "./agents.ts",
+    "./annotatable": "./annotatable.ts",
     "./agent-jobs": "./agent-jobs.ts",
     "./agent-terminal": "./agent-terminal.ts",
     "./browser-paths": "./browser-paths.ts",

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useLayoutEffect, useMemo, useRef, useCallback } from 'react';
 import { toast, Toaster } from 'sonner';
 import { type Origin, getAgentName } from '@plannotator/shared/agents';
-import { ANNOTATABLE_TEXT_REGEX } from '@plannotator/shared/annotatable';
+import { shouldStripFrontmatter } from '@plannotator/shared/annotatable';
 import { annotateFileFeedback, annotateMessageFeedback } from '@plannotator/shared/feedback-templates';
 import { parseMarkdownToBlocks, exportAnnotations, exportLinkedDocAnnotations, exportEditorAnnotations, exportCodeFileAnnotations, exportMessageAnnotations, extractFrontmatter, wrapFeedbackForAgent, Frontmatter, type LinkedDocAnnotationEntry, type MessageAnnotationEntry } from '@plannotator/ui/utils/parser';
 import { Viewer, ViewerHandle } from '@plannotator/ui/components/Viewer';
@@ -92,6 +92,7 @@ import type { AIContext } from '@plannotator/ai';
 import type { CommentAskAIContext } from '@plannotator/ui/components/CommentPopover';
 import {
   hasSourceSaveConflictSnapshot,
+  isSourceSaveFilePath,
   type SourceSaveCapability,
   type SourceSaveResponse,
 } from '@plannotator/shared/source-save';
@@ -267,8 +268,28 @@ const App: React.FC = () => {
   const editableDocuments = useEditableDocuments();
   const activeEditableDocument = editableDocuments.activeDocument;
   const displayedMarkdown = activeEditableDocument?.currentText ?? markdown;
-  const frontmatter = useMemo(() => extractFrontmatter(displayedMarkdown).frontmatter, [displayedMarkdown]);
-  const blocks = useMemo(() => parseMarkdownToBlocks(displayedMarkdown), [displayedMarkdown]);
+  const [sourceFilePath, setSourceFilePath] = useState<string | undefined>();
+  // Mirrors linkedDocHook.filepath (declared later) so the parse memos below
+  // can key frontmatter behavior off the ACTIVE document's path. Kept in sync
+  // by an effect after the hook is created.
+  const [linkedDocParsePath, setLinkedDocParsePath] = useState<string | null>(null);
+  const activeParseDocPath = linkedDocParsePath ?? sourceFilePath;
+  // Frontmatter stripping is a markdown convention — for non-markdown
+  // annotatable sources (.yaml/.txt/…) a leading `--- … ---` pair is real
+  // content (multi-document YAML), so it must survive parsing.
+  const parseFrontmatter = shouldStripFrontmatter(activeParseDocPath);
+  const parseFrontmatterRef = useRef(parseFrontmatter);
+  useEffect(() => {
+    parseFrontmatterRef.current = parseFrontmatter;
+  }, [parseFrontmatter]);
+  const frontmatter = useMemo(
+    () => (parseFrontmatter ? extractFrontmatter(displayedMarkdown).frontmatter : null),
+    [displayedMarkdown, parseFrontmatter],
+  );
+  const blocks = useMemo(
+    () => parseMarkdownToBlocks(displayedMarkdown, { frontmatter: parseFrontmatter }),
+    [displayedMarkdown, parseFrontmatter],
+  );
   const [showExport, setShowExport] = useState(false);
   const [showImport, setShowImport] = useState(false);
   const [showFeedbackPrompt, setShowFeedbackPrompt] = useState(false);
@@ -384,7 +405,6 @@ const App: React.FC = () => {
   // Hide the floating HTML annotation controls (toolstrip + action cluster) so the
   // user can read the rendered page unobstructed. Selections/annotations are unaffected.
   const [htmlToolsHidden, setHtmlToolsHidden] = useState(false);
-  const [sourceFilePath, setSourceFilePath] = useState<string | undefined>();
   const [imageBaseDir, setImageBaseDir] = useState<string | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -769,6 +789,13 @@ const App: React.FC = () => {
     onAfterBack: restoreLinkedDocumentEditableKey,
   });
 
+  // Keep the early parse-path mirror in sync with the active linked doc so
+  // the blocks/frontmatter memos (declared before this hook) parse with the
+  // right frontmatter rule for the file on screen.
+  useEffect(() => {
+    setLinkedDocParsePath(linkedDocHook.filepath ?? null);
+  }, [linkedDocHook.filepath]);
+
   // Active document's directory — feeds both click-time popout fetches and
   // the validator hook so they resolve against the same base. Drifting
   // these would silently re-introduce the demote-correct-link bug.
@@ -983,7 +1010,9 @@ const App: React.FC = () => {
       for (const [filepath, doc] of state.linkedDocSession.docs) {
         linkedDocs.set(filepath, {
           ...doc,
-          blocks: doc.markdown ? parseMarkdownToBlocks(doc.markdown) : undefined,
+          blocks: doc.markdown
+            ? parseMarkdownToBlocks(doc.markdown, { frontmatter: shouldStripFrontmatter(filepath) })
+            : undefined,
         });
       }
       return {
@@ -1321,7 +1350,10 @@ const App: React.FC = () => {
       const enriched: Map<string, LinkedDocAnnotationEntry> = new Map(docAnnotations);
       for (const [filepath, entry] of enriched) {
         if (entry.markdown) {
-          enriched.set(filepath, { ...entry, blocks: parseMarkdownToBlocks(entry.markdown) });
+          enriched.set(filepath, {
+            ...entry,
+            blocks: parseMarkdownToBlocks(entry.markdown, { frontmatter: shouldStripFrontmatter(filepath) }),
+          });
         }
       }
       output += exportLinkedDocAnnotations(enriched);
@@ -1537,7 +1569,9 @@ const App: React.FC = () => {
   // which isn't in state yet when the remap runs.
   const applyEditedDocument = useCallback((next: string, list?: Annotation[]): Annotation[] => {
     const sourceAnnotations = list ?? annotationsRef.current;
-    const newBlocks = parseMarkdownToBlocks(next);
+    // Match the display parse (blocks memo) — the active document's
+    // frontmatter rule must apply here too or the remapped blockIds drift.
+    const newBlocks = parseMarkdownToBlocks(next, { frontmatter: parseFrontmatterRef.current });
     const remapped = sourceAnnotations.map((a) => {
       if (a.diffContext || a.type === AnnotationType.GLOBAL_COMMENT || a.id.startsWith('ann-checkbox-')) return a;
       const blk = newBlocks.find((b) => b.content.includes(a.originalText));
@@ -4035,7 +4069,11 @@ const App: React.FC = () => {
                     toast('Finish editing first', { description: 'Use "Done editing" before opening files.' });
                     return;
                   }
-                  if (isEditingMarkdown && !ANNOTATABLE_TEXT_REGEX.test(args[0])) {
+                  // Mid-edit, only files that can themselves be edited (source-save
+                  // capable: .md/.mdx/.txt) may be opened. Wider annotatable types
+                  // (.yaml/.json/…) are view-only — switching to one mid-edit would
+                  // silently downgrade "Done editing" to feedback-only edits.
+                  if (isEditingMarkdown && !isSourceSaveFilePath(args[0])) {
                     toast('Finish editing first', { description: 'Use "Done editing" before opening non-editable files.' });
                     return;
                   }

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useLayoutEffect, useMemo, useRef, useCallback } from 'react';
 import { toast, Toaster } from 'sonner';
 import { type Origin, getAgentName } from '@plannotator/shared/agents';
+import { ANNOTATABLE_TEXT_REGEX } from '@plannotator/shared/annotatable';
 import { annotateFileFeedback, annotateMessageFeedback } from '@plannotator/shared/feedback-templates';
 import { parseMarkdownToBlocks, exportAnnotations, exportLinkedDocAnnotations, exportEditorAnnotations, exportCodeFileAnnotations, exportMessageAnnotations, extractFrontmatter, wrapFeedbackForAgent, Frontmatter, type LinkedDocAnnotationEntry, type MessageAnnotationEntry } from '@plannotator/ui/utils/parser';
 import { Viewer, ViewerHandle } from '@plannotator/ui/components/Viewer';
@@ -1086,7 +1087,10 @@ const App: React.FC = () => {
 
     const buildUrl = dirState?.isVault
       ? (path: string) => `/api/reference/obsidian/doc?vaultPath=${encodeURIComponent(dirPath)}&path=${encodeURIComponent(path)}`
-      : (path: string) => `/api/doc?path=${encodeURIComponent(path)}&base=${encodeURIComponent(dirPath)}${convertHtml ? '&convert=1' : ''}`;
+      // `doc=1`: file-browser selections always want annotatable document
+      // rendering — without it, extensions that overlap the code-file set
+      // (.yaml, .json, .toml, …) would come back as code-file popout payloads.
+      : (path: string) => `/api/doc?path=${encodeURIComponent(path)}&base=${encodeURIComponent(dirPath)}&doc=1${convertHtml ? '&convert=1' : ''}`;
     linkedDocHook.open(absolutePath, buildUrl, 'files');
     fileBrowser.setActiveFile(absolutePath);
   }, [editableDocuments, linkedDocHook, fileBrowser, convertHtml, isEditingMarkdown]);
@@ -4031,7 +4035,7 @@ const App: React.FC = () => {
                     toast('Finish editing first', { description: 'Use "Done editing" before opening files.' });
                     return;
                   }
-                  if (isEditingMarkdown && !/\.(mdx?|txt)$/i.test(args[0])) {
+                  if (isEditingMarkdown && !ANNOTATABLE_TEXT_REGEX.test(args[0])) {
                     toast('Finish editing first', { description: 'Use "Done editing" before opening non-editable files.' });
                     return;
                   }

--- a/packages/server/reference-handlers.test.ts
+++ b/packages/server/reference-handlers.test.ts
@@ -316,3 +316,39 @@ describe("annotatable plain-text files (#1029)", () => {
 		expect(data.markdown).toBe("a,b\n1,2\n");
 	});
 });
+
+describe("annotatable document size cap", () => {
+	test("doc=1 rejects an oversized file with 413", async () => {
+		const root = makeTempDir("plannotator-doc-cap-");
+		const big = join(root, "huge.yaml");
+		writeFileSync(big, `key: ${"x".repeat(2 * 1024 * 1024 + 1)}\n`);
+
+		const res = await getDoc(big, { rootPaths: [root], doc: true });
+		const data = await res.json() as { error?: string };
+
+		expect(res.status).toBe(413);
+		expect(data.error).toBe("File too large (max 2MB)");
+	});
+
+	test("markdown fallback rejects an oversized .md with 413", async () => {
+		const root = makeTempDir("plannotator-md-cap-");
+		writeFileSync(join(root, "huge.md"), `# big\n${"x".repeat(2 * 1024 * 1024 + 1)}\n`);
+
+		const res = await getDoc("huge.md", { rootPaths: [root] });
+		const data = await res.json() as { error?: string };
+
+		expect(res.status).toBe(413);
+		expect(data.error).toBe("File too large (max 2MB)");
+	});
+
+	test("base-relative branch rejects an oversized relative doc with 413", async () => {
+		const root = makeTempDir("plannotator-base-cap-");
+		writeFileSync(join(root, "big.txt"), "x".repeat(2 * 1024 * 1024 + 1));
+
+		const res = await getDoc("big.txt", { rootPaths: [root], base: root });
+		const data = await res.json() as { error?: string };
+
+		expect(res.status).toBe(413);
+		expect(data.error).toBe("File too large (max 2MB)");
+	});
+});

--- a/packages/server/reference-handlers.test.ts
+++ b/packages/server/reference-handlers.test.ts
@@ -51,10 +51,11 @@ async function postDocExists(body: unknown, options: { rootPath?: string; rootPa
 	}>;
 }
 
-async function getDoc(path: string, options: { base?: string; rootPaths?: string[]; sourceSaveFilePath?: string }) {
+async function getDoc(path: string, options: { base?: string; rootPaths?: string[]; sourceSaveFilePath?: string; doc?: boolean }) {
 	const url = new URL("http://localhost/api/doc");
 	url.searchParams.set("path", path);
 	if (options.base) url.searchParams.set("base", options.base);
+	if (options.doc) url.searchParams.set("doc", "1");
 	return handleDoc(new Request(url.toString()), {
 		rootPaths: options.rootPaths,
 		sourceSaveFilePath: options.sourceSaveFilePath,
@@ -249,5 +250,69 @@ describe("handleFileBrowserFiles", () => {
 				process.env.PLANNOTATOR_FILE_BROWSER_MAX_FILES = previousLimit;
 			}
 		}
+	});
+});
+
+describe("annotatable plain-text files (#1029)", () => {
+	test("file browser lists config formats but not source code or .env", async () => {
+		const root = makeTempDir("plannotator-files-annotatable-");
+		writeTempFile(root, "docs/plan.md", "# plan\n");
+		writeTempFile(root, "config.yaml", "key: value\n");
+		writeTempFile(root, "settings.toml", "[table]\n");
+		writeTempFile(root, "data.csv", "a,b\n1,2\n");
+		writeTempFile(root, ".env.example", "API_KEY=\n");
+		writeTempFile(root, ".env", "API_KEY=secret\n");
+		writeTempFile(root, "app.ts", "export {};\n");
+
+		const url = new URL("http://localhost/api/reference/files");
+		url.searchParams.set("dirPath", root);
+		const res = await handleFileBrowserFiles(new Request(url.toString()));
+		const data = await res.json() as { tree: VaultNode[] };
+
+		expect(res.status).toBe(200);
+		expect(flattenTree(data.tree).sort()).toEqual([
+			".env.example",
+			"config.yaml",
+			"data.csv",
+			"docs/plan.md",
+			"settings.toml",
+		]);
+	});
+
+	test("doc=1 serves a .yaml file as an annotatable markdown document", async () => {
+		const root = makeTempDir("plannotator-doc-yaml-");
+		const file = writeTempFile(root, "config.yaml", "key: value\n");
+
+		const res = await getDoc(file, { rootPaths: [root], doc: true });
+		const data = await res.json() as { markdown?: string; codeFile?: boolean; renderAs?: string };
+
+		expect(res.status).toBe(200);
+		expect(data.codeFile).toBeUndefined();
+		expect(data.markdown).toBe("key: value\n");
+		expect(data.renderAs).toBe("markdown");
+	});
+
+	test("without doc=1, a .yaml path keeps the code-file popout response", async () => {
+		const root = makeTempDir("plannotator-doc-yaml-code-");
+		writeTempFile(root, "config.yaml", "key: value\n");
+
+		const res = await getDoc("config.yaml", { rootPaths: [root] });
+		const data = await res.json() as { codeFile?: boolean; contents?: string };
+
+		expect(res.status).toBe(200);
+		expect(data.codeFile).toBe(true);
+		expect(data.contents).toBe("key: value\n");
+	});
+
+	test("non-code annotatable extensions serve as markdown without doc=1", async () => {
+		const root = makeTempDir("plannotator-doc-csv-");
+		writeTempFile(root, "data.csv", "a,b\n1,2\n");
+
+		const res = await getDoc("data.csv", { rootPaths: [root] });
+		const data = await res.json() as { markdown?: string; codeFile?: boolean };
+
+		expect(res.status).toBe(200);
+		expect(data.codeFile).toBeUndefined();
+		expect(data.markdown).toBe("a,b\n1,2\n");
 	});
 });

--- a/packages/server/reference-handlers.ts
+++ b/packages/server/reference-handlers.ts
@@ -27,6 +27,7 @@ import {
 	getFileBrowserMaxFiles,
 	warmFileListCache,
 	ANNOTATABLE_DOC_REGEX,
+	MAX_ANNOTATABLE_FILE_BYTES,
 	isAnnotatableTextPath,
 } from "@plannotator/shared/resolve-file";
 import { htmlToMarkdown } from "@plannotator/shared/html-to-markdown";
@@ -237,6 +238,9 @@ export async function handleDoc(req: Request, options: HandleDocOptions = {}): P
 		try {
 			const file = Bun.file(fromBase);
 			if (await file.exists()) {
+				if (file.size > MAX_ANNOTATABLE_FILE_BYTES) {
+					return Response.json({ error: "File too large (max 2MB)" }, { status: 413 });
+				}
 				const snapshot = readSourceFileSnapshot(fromBase);
 				const raw = snapshot.text;
 				const isHtml = /\.html?$/i.test(requestedPath);
@@ -320,7 +324,7 @@ export async function handleDoc(req: Request, options: HandleDocOptions = {}): P
 
 		try {
 			const file = Bun.file(resolvedCode);
-			if (file.size > 2 * 1024 * 1024) {
+			if (file.size > MAX_ANNOTATABLE_FILE_BYTES) {
 				return Response.json({ error: "File too large (max 2MB)" }, { status: 413 });
 			}
 			const contents = await file.text();
@@ -371,6 +375,9 @@ export async function handleDoc(req: Request, options: HandleDocOptions = {}): P
 	}
 
 	try {
+		if (Bun.file(result.path).size > MAX_ANNOTATABLE_FILE_BYTES) {
+			return Response.json({ error: "File too large (max 2MB)" }, { status: 413 });
+		}
 		const snapshot = readSourceFileSnapshot(result.path);
 		return docJson({ markdown: snapshot.text, filepath: result.path, renderAs: "markdown" }, options, snapshot);
 	} catch {

--- a/packages/server/reference-handlers.ts
+++ b/packages/server/reference-handlers.ts
@@ -26,6 +26,8 @@ import {
 	isWithinProjectRoot,
 	getFileBrowserMaxFiles,
 	warmFileListCache,
+	ANNOTATABLE_DOC_REGEX,
+	isAnnotatableTextPath,
 } from "@plannotator/shared/resolve-file";
 import { htmlToMarkdown } from "@plannotator/shared/html-to-markdown";
 import { disabledSourceSave, type SourceFileSnapshot, type SourceSaveCapability } from "@plannotator/shared/source-save";
@@ -216,10 +218,17 @@ export async function handleDoc(req: Request, options: HandleDocOptions = {}): P
 	// HTML renders raw by default; `?convert=1` (set by the frontend when the session's
 	// --markdown preference is on) forces Turndown conversion instead.
 	const convert = url.searchParams.get("convert") === "1";
+	// `?doc=1` (set by the file browser) forces annotatable plain-text rendering
+	// for extensions that overlap CODE_FILE_REGEX (.yaml, .json, .toml, .ini,
+	// .xml). Without it, those paths keep the syntax-highlighted code-file
+	// popout response, so code-file links inside documents are unaffected.
+	const forceDoc = url.searchParams.get("doc") === "1";
+	const wantsDocRender = (path: string) =>
+		ANNOTATABLE_DOC_REGEX.test(path) && (forceDoc || !isCodeFilePath(path));
 	if (
 		resolvedBase &&
 		!isAbsoluteUserPath(requestedPath) &&
-		/\.(mdx?|txt|html?)$/i.test(requestedPath)
+		wantsDocRender(requestedPath)
 	) {
 		const fromBase = resolveUserPath(requestedPath, resolvedBase);
 		if (!isWithinAllowedRoots(fromBase, allowedRoots)) {
@@ -269,7 +278,10 @@ export async function handleDoc(req: Request, options: HandleDocOptions = {}): P
 
 	// Code files: try literal resolve first; on miss, fall back to the smart
 	// resolver which walks the project for case-insensitive / suffix matches.
-	if (isCodeFilePath(requestedPath)) {
+	// Skipped when the client asked for doc rendering (`?doc=1`) on an
+	// annotatable plain-text path — those fall through to the markdown
+	// resolution below and render like .txt.
+	if (isCodeFilePath(requestedPath) && !(forceDoc && isAnnotatableTextPath(requestedPath))) {
 		const parsed = parseCodePath(requestedPath);
 		const cleanPath = parsed.filePath;
 		const literalPath = resolveUserPath(cleanPath, resolvedBase || projectRoot);
@@ -543,7 +555,7 @@ export async function handleObsidianDoc(req: Request): Promise<Response> {
 
 // --- File Browser ---
 
-const FILE_BROWSER_EXTENSIONS = /\.(mdx?|txt|html?)$/i;
+const FILE_BROWSER_EXTENSIONS = ANNOTATABLE_DOC_REGEX;
 
 function includeWorkspaceFile(relativePath: string, _change: WorkspaceFileChange): boolean {
 	return FILE_BROWSER_EXTENSIONS.test(relativePath) && !isFileBrowserExcludedPath(relativePath);

--- a/packages/shared/annotatable.ts
+++ b/packages/shared/annotatable.ts
@@ -1,0 +1,1 @@
+export * from "@plannotator/core/annotatable";

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "exports": {
     "./agents": "./agents.ts",
+    "./annotatable": "./annotatable.ts",
     "./compress": "./compress.ts",
     "./crypto": "./crypto.ts",
     "./diff-paths": "./diff-paths.ts",

--- a/packages/shared/resolve-file.test.ts
+++ b/packages/shared/resolve-file.test.ts
@@ -5,6 +5,8 @@ import { join } from "path";
 import {
 	getFileBrowserMaxFiles,
 	hasMarkdownFiles,
+	isAnnotatableDocPath,
+	isAnnotatableTextPath,
 	resolveCodeFile,
 	resolveMarkdownFile,
 	warmFileListCache,
@@ -304,5 +306,99 @@ describe("explicit parent-relative markdown paths (#1085)", () => {
 		} finally {
 			rmSync(cwd, { recursive: true, force: true });
 		}
+	});
+});
+
+describe("annotatable plain-text files (#1029)", () => {
+	test("resolves an exact relative .yaml path", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "plannotator-annotatable-yaml-"));
+		try {
+			mkdirSync(join(cwd, "config"));
+			writeFileSync(join(cwd, "config", "app.yaml"), "key: value\n");
+			expect(resolveMarkdownFile("config/app.yaml", cwd)).toEqual({
+				kind: "found",
+				path: join(cwd, "config", "app.yaml"),
+			});
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	test("resolves a bare filename in-root for a config format", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "plannotator-annotatable-bare-"));
+		try {
+			mkdirSync(join(cwd, "nested"));
+			writeFileSync(join(cwd, "nested", "Cargo.toml"), "[package]\n");
+			expect(resolveMarkdownFile("cargo.toml", cwd)).toEqual({
+				kind: "found",
+				path: join(cwd, "nested", "Cargo.toml"),
+			});
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	test("accepts each newly supported extension", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "plannotator-annotatable-all-"));
+		try {
+			const names = [
+				"a.yaml", "b.yml", "c.json", "d.jsonc", "e.json5", "f.toml",
+				"g.ini", "h.cfg", "i.conf", "j.properties", "k.csv", "l.tsv",
+				"m.log", "n.xml", "sample.env.example",
+			];
+			for (const name of names) {
+				writeFileSync(join(cwd, name), "content\n");
+			}
+			for (const name of names) {
+				expect(resolveMarkdownFile(name, cwd)).toEqual({
+					kind: "found",
+					path: join(cwd, name),
+				});
+			}
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	test("still rejects source-code extensions", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "plannotator-annotatable-code-"));
+		try {
+			writeFileSync(join(cwd, "script.py"), "print('hi')\n");
+			expect(resolveMarkdownFile("script.py", cwd)).toEqual({
+				kind: "not_found",
+				input: "script.py",
+			});
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	test("rejects .env but accepts .env.example", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "plannotator-annotatable-env-"));
+		try {
+			writeFileSync(join(cwd, ".env"), "SECRET=1\n");
+			writeFileSync(join(cwd, ".env.example"), "SECRET=\n");
+			expect(resolveMarkdownFile(".env", cwd)).toEqual({
+				kind: "not_found",
+				input: ".env",
+			});
+			expect(resolveMarkdownFile(".env.example", cwd)).toEqual({
+				kind: "found",
+				path: join(cwd, ".env.example"),
+			});
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	test("predicates classify text vs doc vs unsupported paths", () => {
+		expect(isAnnotatableTextPath("notes.yaml")).toBe(true);
+		expect(isAnnotatableTextPath("notes.txt")).toBe(true);
+		expect(isAnnotatableTextPath("page.html")).toBe(false);
+		expect(isAnnotatableTextPath("app.ts")).toBe(false);
+		expect(isAnnotatableTextPath(".env")).toBe(false);
+		expect(isAnnotatableDocPath("page.html")).toBe(true);
+		expect(isAnnotatableDocPath("config.json5")).toBe(true);
+		expect(isAnnotatableDocPath("binary.png")).toBe(false);
 	});
 });

--- a/packages/shared/resolve-file.ts
+++ b/packages/shared/resolve-file.ts
@@ -14,10 +14,16 @@ import { isAbsolute, join, resolve, win32 } from "path";
 import { existsSync, readdirSync, type Dirent } from "fs";
 import { readdir } from "node:fs/promises";
 
-const MARKDOWN_PATH_REGEX = /\.(mdx?|txt)$/i;
-
+import { ANNOTATABLE_TEXT_REGEX } from "./annotatable";
 import { CODE_FILE_REGEX as CODE_FILE_BASENAME_REGEX } from "./code-file";
 export { CODE_FILE_REGEX, isCodeFilePath } from "./code-file";
+export {
+	ANNOTATABLE_TEXT_REGEX,
+	ANNOTATABLE_DOC_REGEX,
+	ANNOTATABLE_EXTENSIONS_HINT,
+	isAnnotatableTextPath,
+	isAnnotatableDocPath,
+} from "./annotatable";
 
 const WINDOWS_DRIVE_PATH_PATTERNS = [
 	/^\/cygdrive\/([a-zA-Z])\/(.+)$/,
@@ -194,8 +200,14 @@ function resolveAbsolutePath(
 		: resolve(input);
 }
 
+/**
+ * The set of files single-file annotate resolution accepts. Wider than
+ * markdown proper (#1029): any unambiguously plain-text format renders the
+ * way .txt does. HTML is excluded — it has its own resolution branch at the
+ * call sites.
+ */
 function isSearchableMarkdownPath(input: string): boolean {
-	return MARKDOWN_PATH_REGEX.test(input.trim());
+	return ANNOTATABLE_TEXT_REGEX.test(input.trim());
 }
 
 /** Check if a path looks like a Windows absolute path (e.g. C:\ or C:/) */
@@ -263,7 +275,7 @@ function walkMarkdownFiles(dir: string, root: string, results: string[], ignored
 			root,
 			results,
 			ignoredDirs,
-			(name) => /\.(mdx?|txt)$/i.test(name),
+			(name) => ANNOTATABLE_TEXT_REGEX.test(name),
 			{ visitedFiles: 0, limit: getFileBrowserMaxFiles() },
 		);
 	} catch {
@@ -453,7 +465,7 @@ function resolveMarkdownFileCore(
 	const isBareFilename = !searchInput.includes("/");
 	const targetLookupKey = getLookupKey(searchInput, isBareFilename);
 
-	// Restrict to markdown files
+	// Restrict to annotatable plain-text files (markdown + config formats)
 	if (!isSearchableMarkdownPath(normalizedInput)) {
 		return { kind: "not_found", input };
 	}

--- a/packages/shared/resolve-file.ts
+++ b/packages/shared/resolve-file.ts
@@ -21,6 +21,7 @@ export {
 	ANNOTATABLE_TEXT_REGEX,
 	ANNOTATABLE_DOC_REGEX,
 	ANNOTATABLE_EXTENSIONS_HINT,
+	MAX_ANNOTATABLE_FILE_BYTES,
 	isAnnotatableTextPath,
 	isAnnotatableDocPath,
 } from "./annotatable";

--- a/packages/ui/components/sidebar/FileBrowser.tsx
+++ b/packages/ui/components/sidebar/FileBrowser.tsx
@@ -43,6 +43,9 @@ interface AggregateWorkspaceChange {
   files: number;
 }
 
+// Display-name stripping only — deliberately narrower than the annotatable
+// set. Config files (config.yaml vs config.json) keep their extensions so
+// same-named siblings stay distinguishable in the tree.
 const FILE_EXTENSION_RE = /\.(mdx?|txt|html?)$/i;
 
 function normalizeFilterText(value: string): string {
@@ -418,7 +421,7 @@ const DirSection: React.FC<{
   if (dir.tree.length === 0) {
     return (
       <div className="px-3 py-2 text-[11px] text-muted-foreground">
-        No markdown or text files found
+        No annotatable files found
       </div>
     );
   }

--- a/packages/ui/utils/parser.test.ts
+++ b/packages/ui/utils/parser.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import { parseMarkdownToBlocks, computeListIndices, extractFrontmatter, exportAnnotations } from "./parser";
+import { shouldStripFrontmatter } from "@plannotator/core/annotatable";
 import type { Block } from "../types";
 
 /** Tiny factory for list-item blocks used by computeListIndices tests. */
@@ -1143,11 +1144,34 @@ describe("parseMarkdownToBlocks — non-markdown plain text (#1029)", () => {
     expect(blocks.map((b) => b.content).join("\n")).toContain('"name": "plannotator"');
   });
 
-  test("YAML document-start marker is not swallowed as frontmatter content loss", () => {
-    // A YAML file often starts with `---`; the parser treats a leading
-    // `---` pair as frontmatter, but the remaining document must survive.
-    const yaml = "---\nkey: value\nother: thing\n---\nrest: here\n";
-    const blocks = parseMarkdownToBlocks(yaml);
-    expect(blocks.map((b) => b.content).join("\n")).toContain("rest: here");
+  test("multi-document YAML keeps its first document with frontmatter: false", () => {
+    // A k8s-style multi-document YAML starts with `---`. With frontmatter
+    // stripping disabled (the rule for non-markdown annotatable sources),
+    // the FIRST document must survive parsing.
+    const yaml = "---\napiVersion: v1\nkind: ConfigMap\n---\napiVersion: v1\nkind: Secret\n";
+    const blocks = parseMarkdownToBlocks(yaml, { frontmatter: false });
+    const joined = blocks.map((b) => b.content).join("\n");
+    expect(joined).toContain("kind: ConfigMap");
+    expect(joined).toContain("kind: Secret");
+    // First real content line keeps its original line number (nothing consumed).
+    expect(blocks[0].startLine).toBe(1);
+  });
+
+  test("default parse still strips markdown frontmatter", () => {
+    const md = "---\ntitle: Plan\n---\n# Heading\nbody\n";
+    const blocks = parseMarkdownToBlocks(md);
+    const joined = blocks.map((b) => b.content).join("\n");
+    expect(joined).not.toContain("title: Plan");
+    expect(joined).toContain("body");
+  });
+
+  test("shouldStripFrontmatter keys off the source path", () => {
+    expect(shouldStripFrontmatter(undefined)).toBe(true); // plans/messages
+    expect(shouldStripFrontmatter("notes.md")).toBe(true);
+    expect(shouldStripFrontmatter("guide.mdx")).toBe(true);
+    expect(shouldStripFrontmatter("deploy.yaml")).toBe(false);
+    expect(shouldStripFrontmatter("notes.txt")).toBe(false);
+    expect(shouldStripFrontmatter("data.csv")).toBe(false);
+    expect(shouldStripFrontmatter("https://example.com/page")).toBe(true); // converted source
   });
 });

--- a/packages/ui/utils/parser.test.ts
+++ b/packages/ui/utils/parser.test.ts
@@ -1110,3 +1110,44 @@ describe("exportAnnotations — line labels", () => {
     expect(output).toContain("(lines 3–5)");
   });
 });
+
+describe("parseMarkdownToBlocks — non-markdown plain text (#1029)", () => {
+  /**
+   * Annotate now accepts YAML/JSON/TOML-style config files and renders them
+   * through the same pipeline as .txt. The parser must treat structured
+   * config content as ordinary text without crashing or dropping lines.
+   */
+  test("YAML content parses into blocks without crashing", () => {
+    const yaml = [
+      "name: plannotator",
+      "on:",
+      "  push:",
+      "    branches: [main]",
+      "jobs:",
+      "  build:",
+      "    steps:",
+      "      - uses: actions/checkout@v4",
+      "      - run: bun test",
+    ].join("\n");
+    const blocks = parseMarkdownToBlocks(yaml);
+    expect(blocks.length).toBeGreaterThan(0);
+    const joined = blocks.map((b) => b.content).join("\n");
+    expect(joined).toContain("name: plannotator");
+    expect(joined).toContain("uses: actions/checkout@v4");
+  });
+
+  test("JSON content parses into blocks without crashing", () => {
+    const json = '{\n  "name": "plannotator",\n  "private": true\n}';
+    const blocks = parseMarkdownToBlocks(json);
+    expect(blocks.length).toBeGreaterThan(0);
+    expect(blocks.map((b) => b.content).join("\n")).toContain('"name": "plannotator"');
+  });
+
+  test("YAML document-start marker is not swallowed as frontmatter content loss", () => {
+    // A YAML file often starts with `---`; the parser treats a leading
+    // `---` pair as frontmatter, but the remaining document must survive.
+    const yaml = "---\nkey: value\nother: thing\n---\nrest: here\n";
+    const blocks = parseMarkdownToBlocks(yaml);
+    expect(blocks.map((b) => b.content).join("\n")).toContain("rest: here");
+  });
+});

--- a/packages/ui/utils/parser.ts
+++ b/packages/ui/utils/parser.ts
@@ -101,13 +101,26 @@ const VOID_HTML_TAGS: ReadonlySet<string> = new Set([
 
 const HTML_BLOCK_OPEN_RE = /^<\/?([a-zA-Z][a-zA-Z0-9]*)(?:\s|>|\/|$)/;
 
+export interface ParseMarkdownOptions {
+  /**
+   * Strip a leading `--- ... ---` pair as frontmatter (default true).
+   * Pass false for non-markdown plain-text sources (.yaml/.json/.txt/…)
+   * where the delimiters are real content — a multi-document YAML starts
+   * with them (see shouldStripFrontmatter in @plannotator/core/annotatable).
+   */
+  frontmatter?: boolean;
+}
+
 /**
  * A simplified markdown parser that splits content into linear blocks.
  * For a production app, we would use a robust AST walker (remark),
  * but for this demo, we want predictable text-anchoring.
  */
-export const parseMarkdownToBlocks = (markdown: string): Block[] => {
-  const { content: cleanMarkdown, contentStartLine } = extractFrontmatter(markdown);
+export const parseMarkdownToBlocks = (markdown: string, options?: ParseMarkdownOptions): Block[] => {
+  const { content: cleanMarkdown, contentStartLine } =
+    options?.frontmatter === false
+      ? { content: markdown, contentStartLine: 1 }
+      : extractFrontmatter(markdown);
   const lines = cleanMarkdown.split('\n');
   const blocks: Block[] = [];
   let currentId = 0;


### PR DESCRIPTION
## What

`/plannotator-annotate` (and `plannotator annotate`) now accepts common plain-text config and data formats instead of rejecting everything that isn't `.md`/`.mdx`/`.txt`/`.html`/`.htm`. The content pipeline already reads files as UTF-8 text, so the restriction was purely an extension whitelist — as reported by @Serhioromano in #1029.

**New accepted extensions:** `.yaml` `.yml` `.json` `.jsonc` `.json5` `.toml` `.ini` `.cfg` `.conf` `.properties` `.csv` `.tsv` `.log` `.xml` `.env.example`

These render exactly the way `.txt` renders today — plain text through the markdown pipeline, selectable and annotatable. Syntax-highlighted / code-fence rendering for structured formats is a possible follow-up, deliberately out of scope here.

**Deliberate exclusions:**
- `.env` — it commonly holds secrets, and annotate's per-file version history copies file contents into `~/.plannotator/history/`. The secret-free `.env.example` convention is accepted instead.
- Source-code extensions (`.ts`, `.py`, …) — they belong to the code-file link/popout system and code review, and would flood the annotate folder file browser.

## How

New single source of truth: `packages/core/annotatable.ts` exporting `ANNOTATABLE_TEXT_REGEX` (plain-text set) and `ANNOTATABLE_DOC_REGEX` (plain-text + HTML), re-exported through `@plannotator/shared/resolve-file` and vendored into the Pi extension via `vendor.sh`. Per-call-site decisions:

| Site | Decision |
|------|----------|
| `resolveMarkdownFile` accept + fuzzy walk (`packages/shared/resolve-file.ts`) | Widened to `ANNOTATABLE_TEXT_REGEX` — single-file annotate and bare-filename in-root search now find config files. HTML keeps its own branch at call sites. |
| Folder discovery (hook CLI, OpenCode, Pi) | Widened to `ANNOTATABLE_DOC_REGEX`; error messages updated. |
| File-browser listing (Bun `reference-handlers.ts`, Pi `reference.ts`) | Widened to `ANNOTATABLE_DOC_REGEX` in both runtimes. |
| `/api/doc` serve guards (both runtimes) | New `doc=1` query param, set only by the file browser. Extensions that overlap `CODE_FILE_REGEX` (`.yaml`/`.json`/`.toml`/`.ini`/`.xml`) render as annotatable documents **only** with `doc=1`; without it they keep the `codeFile: true` popout response, so code-file links inside plans/docs are unaffected. Non-overlapping new extensions (`.csv`, `.log`, …) serve as documents unconditionally. |
| Linked-doc link regexes (`InlineMarkdown`, `HtmlBlock`) | **Unchanged** — `config.yaml` links inside a document keep the syntax-highlighted code popout, which is the better rendering for a reference link. |
| File-browser display names | Extension stripping stays narrow (`.md`/`.txt`/`.html`) so `config.yaml` and `config.json` siblings stay distinguishable. |
| Mid-edit file-open guard (`packages/editor/App.tsx`) | Gates on `isSourceSaveFilePath` (`.md`/`.mdx`/`.txt`) — config files are view-only (no source-save capability), so they cannot be opened mid-edit; this avoids silently downgrading "Done editing" to feedback-only edits. |
| Obsidian vault walkers | **Unchanged** — vaults stay markdown-only. |

**Frontmatter rule (from review):** stripping a leading `--- … ---` pair is a markdown convention; for non-markdown plain-text sources those delimiters are real content (a k8s multi-document YAML starts with them). `parseMarkdownToBlocks` gained a `{ frontmatter }` option and the editor keys it off the active document's path via `shouldStripFrontmatter()`: strip for `.md`/`.mdx` and pathless/converted sources (plans, agent messages, URLs, `--markdown` HTML); keep raw for every other annotatable text type (including `.txt`, whose leading `---` pair previously vanished too).

**Size cap (from review):** a shared `MAX_ANNOTATABLE_FILE_BYTES` (2MB — the same limit the code-file popout has always enforced, now single-sourced) guards the annotate CLI single-file read in all three runtimes and the `/api/doc` document branches in both servers. A multi-GB `server.log` now gets a clear "File too large to annotate (max 2MB)" error instead of OOMing the server and being copied into annotate history. Note: this also caps `.md`/`.txt` document serves, previously unbounded — a behavior change only for pathological inputs.

Annotate history slug (`annotate-{basename}-{hash8}`) is extension-agnostic and works unchanged for the new types; Bun and Pi servers are updated in lockstep. Agent-facing skill docs (`plannotator-annotate` core + Kiro) now mention the config formats.

## Tests

- `packages/shared/resolve-file.test.ts`: accept cases for every new extension, bare-filename in-root resolution, `.py` rejection, `.env` rejected / `.env.example` accepted, predicate classification.
- `packages/server/reference-handlers.test.ts`: file-browser listing includes config formats and excludes `.env`/source code; `doc=1` serves `.yaml` as markdown; without `doc=1` the code-popout response is preserved; `.csv` serves as markdown unconditionally; 413 size-cap coverage for the `doc=1`, markdown-fallback, and base-relative branches.
- `packages/ui/utils/parser.test.ts`: YAML/JSON content parses without loss; multi-document YAML keeps its **first** document with `frontmatter: false`; default parse still strips markdown frontmatter; `shouldStripFrontmatter` path-rule coverage.

All suites green: `bun test packages/shared packages/server packages/ui packages/editor packages/core apps/opencode-plugin apps/pi-extension` (1,776 pass, 0 fail), `bun run typecheck` (includes Pi vendor + strict-consumer), review+hook bundles build, and CLI smoke tests (`annotate x.py` → helpful error; `annotate smoke.yaml` → resolves and opens; 3MB `big.yaml` → size-cap error).

Closes #1029 — thanks @Serhioromano for the detailed report.

https://claude.ai/code/session_01YXkgsNucxDwAL4GdR4XYRk