### PR TITLE
feat: minimal bug-report issue form (version, OS, agent, surface)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,61 @@
+name: Bug report
+description: Something broke or didn't behave as expected
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you do, what did you expect, what happened instead. Screenshots welcome.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Plannotator version
+      description: Paste the output of `plannotator --version`
+      placeholder: plannotator 0.24.1
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: OS
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - Devcontainer / SSH / remote
+    validations:
+      required: true
+  - type: dropdown
+    id: agent
+    attributes:
+      label: Agent
+      description: Which coding agent were you using Plannotator with?
+      options:
+        - Claude Code
+        - OpenCode
+        - Pi
+        - Codex
+        - Amp
+        - Droid
+        - Copilot CLI
+        - Gemini CLI
+        - Kiro CLI
+        - None / standalone CLI
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Where did it happen?
+      options:
+        - Plan review
+        - Code review
+        - Annotate
+        - Install / CLI
+        - VS Code extension
+        - Other
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Feature request or idea
+    url: https://github.com/backnotprop/plannotator/issues/new
+    about: No form needed. Open a blank issue and describe what you want.


### PR DESCRIPTION
New issues currently arrive with no environment details, so triage starts with guesswork: which agent, which surface, which version. Today's example: #1038 named no theme, no install method, no OS detail.

This adds a GitHub issue form for bug reports that captures the critical context in the least disruptive shape possible:

- **What happened?** (the only free-text field)
- **Plannotator version** (paste of `plannotator --version`)
- **OS**, **Agent**, **Where did it happen?** (three one-click dropdowns: plan review / code review / annotate / install / VS Code extension)

Five fields total, all required, four of them answerable in one click each. No repro-steps/expected/actual boilerplate that people leave blank. Feature requests deliberately keep the blank-issue path (config.yml leaves blank issues enabled and points ideas there).

https://claude.ai/code/session_01YXkgsNucxDwAL4GdR4XYRk