### PR TITLE
fix(ui): parse YAML block scalars in frontmatter

### DIFF
--- a/packages/ui/utils/parser.test.ts
+++ b/packages/ui/utils/parser.test.ts
@@ -1078,6 +1078,12 @@ name: bar
     expect(frontmatter?.name).toBe("bar");
   });
 
+  test("CRLF line endings do not leak \\r into the value", () => {
+    const md = "---\r\ndescription: >-\r\n  one two\r\n  three\r\n---\r\n# Hi";
+    const { frontmatter } = extractFrontmatter(md);
+    expect(frontmatter?.description).toBe("one two three");
+  });
+
   test("plain single-line values and arrays still parse", () => {
     const md = `---
 name: foo

--- a/packages/ui/utils/parser.test.ts
+++ b/packages/ui/utils/parser.test.ts
@@ -1029,6 +1029,69 @@ describe("extractFrontmatter — contentStartLine", () => {
   });
 });
 
+describe("extractFrontmatter — block scalars", () => {
+  test("folded (>-) joins wrapped lines with spaces", () => {
+    const md = `---
+description: >-
+  one two
+  three four
+---
+# Hi`;
+    const { frontmatter } = extractFrontmatter(md);
+    expect(frontmatter?.description).toBe("one two three four");
+  });
+
+  test("folded (>) treats a blank line as a paragraph break", () => {
+    const md = `---
+description: >
+  one two
+  three four
+
+  five six
+---
+# Hi`;
+    const { frontmatter } = extractFrontmatter(md);
+    expect(frontmatter?.description).toBe("one two three four\nfive six");
+  });
+
+  test("literal (|) preserves newlines", () => {
+    const md = `---
+note: |
+  line one
+  line two
+---
+# Hi`;
+    const { frontmatter } = extractFrontmatter(md);
+    expect(frontmatter?.note).toBe("line one\nline two");
+  });
+
+  test("block scalar does not swallow the next key", () => {
+    const md = `---
+description: >-
+  one two
+  three
+name: bar
+---
+# Hi`;
+    const { frontmatter } = extractFrontmatter(md);
+    expect(frontmatter?.description).toBe("one two three");
+    expect(frontmatter?.name).toBe("bar");
+  });
+
+  test("plain single-line values and arrays still parse", () => {
+    const md = `---
+name: foo
+tags:
+  - a
+  - b
+---
+# Hi`;
+    const { frontmatter } = extractFrontmatter(md);
+    expect(frontmatter?.name).toBe("foo");
+    expect(frontmatter?.tags).toEqual(["a", "b"]);
+  });
+});
+
 describe("parseMarkdownToBlocks — startLine accuracy", () => {
   test("basic blocks get correct startLine", () => {
     const md = "# Heading\n\nParagraph\n\n- Item";

--- a/packages/ui/utils/parser.ts
+++ b/packages/ui/utils/parser.ts
@@ -62,7 +62,9 @@ function parseBlockScalar(
   const body: string[] = [];
   let j = bodyStart;
   for (; j < lines.length; j++) {
-    const bodyLine = lines[j];
+    // CRLF sources split on '\n' leave a trailing '\r' that would otherwise
+    // survive into the folded value (every other parser path trims lines).
+    const bodyLine = lines[j].replace(/\r$/, '');
     if (bodyLine.trim() === '') {
       body.push('');
       continue;

--- a/packages/ui/utils/parser.ts
+++ b/packages/ui/utils/parser.ts
@@ -8,6 +8,74 @@ export interface Frontmatter {
   [key: string]: string | string[];
 }
 
+/** Number of leading whitespace characters on a line. */
+function indentWidth(line: string): number {
+  return line.length - line.trimStart().length;
+}
+
+/** Strip the common leading indentation shared by all non-empty lines. */
+function dedentLines(lines: string[]): string[] {
+  const indents = lines.filter((l) => l !== '').map(indentWidth);
+  const minIndent = indents.length ? Math.min(...indents) : 0;
+  return lines.map((l) => (l === '' ? '' : l.slice(minIndent)));
+}
+
+/**
+ * Fold YAML `>`-style scalar lines: adjacent non-empty lines join with a
+ * single space, and a run of N blank lines between paragraphs folds to N
+ * newlines.
+ */
+function foldScalarLines(lines: string[]): string {
+  let text = '';
+  let started = false;
+  let blanks = 0;
+  for (const l of lines) {
+    if (l === '') {
+      blanks++;
+      continue;
+    }
+    if (!started) {
+      text = l;
+      started = true;
+    } else {
+      text += blanks > 0 ? '\n'.repeat(blanks) : ' ';
+      text += l;
+    }
+    blanks = 0;
+  }
+  return text;
+}
+
+/**
+ * Parse a YAML block scalar (`|` literal keeps newlines / `>` folded joins
+ * with spaces) whose body is the run of lines below `bodyStart` indented
+ * deeper than `keyIndent`. Trailing blank lines are dropped and chomping
+ * indicators are treated as strip. Returns the value and the index of the
+ * last line the scalar consumed.
+ */
+function parseBlockScalar(
+  lines: string[],
+  bodyStart: number,
+  keyIndent: number,
+  folded: boolean,
+): { value: string; endIndex: number } {
+  const body: string[] = [];
+  let j = bodyStart;
+  for (; j < lines.length; j++) {
+    const bodyLine = lines[j];
+    if (bodyLine.trim() === '') {
+      body.push('');
+      continue;
+    }
+    if (indentWidth(bodyLine) <= keyIndent) break; // dedent ends the block
+    body.push(bodyLine);
+  }
+  const dedented = dedentLines(body);
+  while (dedented.length && dedented[dedented.length - 1] === '') dedented.pop();
+  const value = (folded ? foldScalarLines(dedented) : dedented.join('\n')).trim();
+  return { value, endIndex: j - 1 };
+}
+
 /**
  * Extract YAML frontmatter from markdown if present.
  * Returns the parsed frontmatter, the remaining markdown, and the 1-based
@@ -44,8 +112,10 @@ export function extractFrontmatter(markdown: string): { frontmatter: Frontmatter
   let currentKey: string | null = null;
   let currentArray: string[] | null = null;
 
-  for (const line of frontmatterRaw.split('\n')) {
-    const trimmedLine = line.trim();
+  const lines = frontmatterRaw.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const rawLine = lines[i];
+    const trimmedLine = rawLine.trim();
 
     // Array item (- value)
     if (trimmedLine.startsWith('- ') && currentKey) {
@@ -64,6 +134,27 @@ export function extractFrontmatter(markdown: string): { frontmatter: Frontmatter
       currentKey = trimmedLine.slice(0, colonIndex).trim();
       const value = trimmedLine.slice(colonIndex + 1).trim();
       currentArray = null;
+
+      // Block scalar: `|` (literal, keep newlines) or `>` (folded, join with
+      // spaces), each with optional chomping indicator (`-`/`+`). The value
+      // spans the following lines indented deeper than the key, e.g.
+      //   description: >-
+      //     line one
+      //     line two
+      // Without this, the indicator (">-") was stored verbatim and the body
+      // silently dropped.
+      const blockScalar = value.match(/^([|>])[+-]?$/);
+      if (blockScalar) {
+        const { value: scalarValue, endIndex } = parseBlockScalar(
+          lines,
+          i + 1,
+          indentWidth(rawLine),
+          blockScalar[1] === '>',
+        );
+        frontmatter[currentKey] = scalarValue;
+        i = endIndex;
+        continue;
+      }
 
       if (value) {
         frontmatter[currentKey] = value;


### PR DESCRIPTION
## Problem

`extractFrontmatter` (`packages/ui/utils/parser.ts`) is a line-based `key: value` parser with no support for YAML **block scalars**. When a value is a folded (`>`) or literal (`|`) scalar, the parser stores the bare indicator as the value and silently drops the indented body.

A document with:

```yaml
---
name: example
description: >-
  one two
  three four
---
```

parses to `description === ">-"`, so the description renders empty (just `>-`) in the plan/annotate viewer. This shows up in the wild because agent skill `SKILL.md` files routinely fold their long `description` field with `>-`.

## Fix

When the value after the colon matches a block-scalar indicator (`|`/`>` with optional `+`/`-` chomping), consume the following lines indented deeper than the key as the value:

- `>` (folded) — adjacent non-empty lines join with a space; a run of N blank lines folds to N newlines
- `|` (literal) — newlines preserved
- common leading indentation stripped; trailing blank lines dropped

Extracted three small private helpers (`indentWidth`, `dedentLines`, `foldScalarLines`) plus `parseBlockScalar` to keep `extractFrontmatter` readable. Plain single-line values and `-` arrays are unchanged.

Obviously this isn't a comprehensive YAML extractor though so this just patches over this (one) issue (for now)

## Tests

Added an `extractFrontmatter — block scalars` suite covering folded `>-`, folded `>` with a paragraph break, literal `|`, "doesn't swallow the next key", and a plain-value/array regression.

- `bun test packages/ui/utils/parser.test.ts` → 126 pass, 0 fail
- `tsc --noEmit -p packages/ui/tsconfig.json` → clean

No `node:` imports added (keeps `@plannotator/core` browser-safe). UI bundle rebuild left to the maintainer.