### PR TITLE
fix(config): coerce quoted boolean strings in config.json resolvers

### DIFF
--- a/packages/shared/config.test.ts
+++ b/packages/shared/config.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test, beforeEach, afterAll } from "bun:test";
-import { resolveCursorSandbox } from "./config";
+import {
+  resolveCursorSandbox,
+  resolveUseGlimpse,
+  resolveAnnotateHistory,
+  resolveUseJina,
+} from "./config";
+import type { PlannotatorConfig } from "./config";
 
 const ENV = "PLANNOTATOR_CURSOR_SANDBOX";
 const originalEnv = process.env[ENV];
@@ -44,4 +50,92 @@ describe("resolveCursorSandbox", () => {
       expect(resolveCursorSandbox({})).toBe(true);
     }
   });
+});
+
+// config.json is hand-edited, so boolean settings often arrive as quoted
+// strings ("false" instead of false). Each boolean resolver must coerce those
+// instead of passing the raw string through to `=== false` checks downstream.
+describe("config.json boolean coercion", () => {
+  const cases: Array<{
+    name: string;
+    envVar: string;
+    key: keyof PlannotatorConfig;
+    resolve: (config: PlannotatorConfig) => boolean;
+  }> = [
+    {
+      name: "resolveUseGlimpse",
+      envVar: "PLANNOTATOR_GLIMPSE",
+      key: "glimpse",
+      resolve: resolveUseGlimpse,
+    },
+    {
+      name: "resolveAnnotateHistory",
+      envVar: "PLANNOTATOR_ANNOTATE_HISTORY",
+      key: "annotateHistory",
+      resolve: resolveAnnotateHistory,
+    },
+    {
+      name: "resolveUseJina",
+      envVar: "PLANNOTATOR_JINA",
+      key: "jina",
+      resolve: (config) => resolveUseJina(false, config),
+    },
+    {
+      name: "resolveCursorSandbox",
+      envVar: "PLANNOTATOR_CURSOR_SANDBOX",
+      key: "cursorSandbox",
+      resolve: resolveCursorSandbox,
+    },
+  ];
+
+  const originalEnvs = new Map(cases.map((c) => [c.envVar, process.env[c.envVar]]));
+
+  beforeEach(() => {
+    for (const c of cases) delete process.env[c.envVar];
+  });
+  afterAll(() => {
+    for (const [envVar, value] of originalEnvs) {
+      if (value === undefined) delete process.env[envVar];
+      else process.env[envVar] = value;
+    }
+  });
+
+  const withKey = (c: (typeof cases)[number], value: unknown): PlannotatorConfig =>
+    ({ [c.key]: value }) as PlannotatorConfig;
+
+  for (const c of cases) {
+    describe(c.name, () => {
+      test("real booleans pass through", () => {
+        expect(c.resolve(withKey(c, true))).toBe(true);
+        expect(c.resolve(withKey(c, false))).toBe(false);
+      });
+
+      test("quoted boolean strings coerce (true/false/1/0, any case, padded)", () => {
+        for (const v of ["false", "False", "FALSE", "0", " false "]) {
+          expect(c.resolve(withKey(c, v))).toBe(false);
+        }
+        for (const v of ["true", "True", "TRUE", "1", " true "]) {
+          expect(c.resolve(withKey(c, v))).toBe(true);
+        }
+      });
+
+      test("garbage values fall back to the default (true)", () => {
+        for (const v of ["yes", "no", "disabled", "", 42, 0, null, {}, []]) {
+          expect(c.resolve(withKey(c, v))).toBe(true);
+        }
+      });
+
+      test("absent key falls back to the default (true)", () => {
+        expect(c.resolve({})).toBe(true);
+      });
+
+      test("env var still wins over the config key", () => {
+        process.env[c.envVar] = "false";
+        expect(c.resolve(withKey(c, true))).toBe(false);
+        process.env[c.envVar] = "true";
+        expect(c.resolve(withKey(c, "false"))).toBe(true);
+        delete process.env[c.envVar];
+      });
+    });
+  }
 });

--- a/packages/shared/config.ts
+++ b/packages/shared/config.ts
@@ -235,6 +235,22 @@ export function resolveDefaultDiffType(cfg?: PlannotatorConfig): DefaultDiffType
 }
 
 /**
+ * Coerce a config.json value that should be a boolean. JSON parsing preserves
+ * whatever type the user typed, so a hand-edited `"false"` (quoted) arrives as
+ * a string and would fail `=== false` checks downstream. Accepts real booleans
+ * plus "true"/"false"/"1"/"0" strings; anything else falls back to the default.
+ */
+function coerceConfigBoolean(value: unknown, fallback: boolean): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const v = value.trim().toLowerCase();
+    if (v === "true" || v === "1") return true;
+    if (v === "false" || v === "0") return false;
+  }
+  return fallback;
+}
+
+/**
  * Resolve whether to use Glimpse native window.
  *
  * Priority (highest wins):
@@ -245,8 +261,7 @@ export function resolveUseGlimpse(config: PlannotatorConfig): boolean {
   if (envVal !== undefined) {
     return envVal === "1" || envVal.toLowerCase() === "true";
   }
-  if (config.glimpse !== undefined) return config.glimpse;
-  return true;
+  return coerceConfigBoolean(config.glimpse, true);
 }
 
 /**
@@ -266,8 +281,7 @@ export function resolveAnnotateHistory(config: PlannotatorConfig): boolean {
   if (envVal !== undefined) {
     return envVal === "1" || envVal.toLowerCase() === "true";
   }
-  if (config.annotateHistory !== undefined) return config.annotateHistory;
-  return true;
+  return coerceConfigBoolean(config.annotateHistory, true);
 }
 
 export function resolveUseJina(cliNoJina: boolean, config: PlannotatorConfig): boolean {
@@ -280,11 +294,8 @@ export function resolveUseJina(cliNoJina: boolean, config: PlannotatorConfig): b
     return envVal === "1" || envVal.toLowerCase() === "true";
   }
 
-  // Config file
-  if (config.jina !== undefined) return config.jina;
-
-  // Default: enabled
-  return true;
+  // Config file (default: enabled)
+  return coerceConfigBoolean(config.jina, true);
 }
 
 /**
@@ -316,6 +327,5 @@ export function resolveCursorSandbox(config: PlannotatorConfig): boolean {
     const v = envVal.toLowerCase();
     return v !== "0" && v !== "false" && v !== "disabled";
   }
-  if (config.cursorSandbox !== undefined) return config.cursorSandbox;
-  return true;
+  return coerceConfigBoolean(config.cursorSandbox, true);
 }


### PR DESCRIPTION
## Bug

`~/.plannotator/config.json` is hand-edited, and JSON parsing preserves whatever type the user typed. A quoted boolean like `"cursorSandbox": "false"` therefore arrives as the string `"false"`, and the config resolvers in `packages/shared/config.ts` passed it straight through. Downstream code does strict checks, e.g. `packages/server/marker-review.ts` uses `opts?.cursorSandbox === false ? [] : ["--sandbox", "enabled"]`, so the string `"false"` kept Cursor's sandbox ON. That silently defeats the opt-out added in #1095 for NixOS users whose Cursor sandbox cannot start.

The trap is easy to hit because the env-var path (`PLANNOTATOR_CURSOR_SANDBOX=false`) does accept the string form. Someone who tests via env var and then moves the setting into config.json with quotes ends up with a config that silently stops working.

## Repro

```
bun -e 'import { resolveCursorSandbox } from "./packages/shared/config.ts"; delete process.env.PLANNOTATOR_CURSOR_SANDBOX; console.log(resolveCursorSandbox(JSON.parse("{\"cursorSandbox\": \"false\"}")))'
```

Before this change it prints the string `false` (typeof string). After, it prints the boolean `false`.

## Fix

A private `coerceConfigBoolean(value, fallback)` helper in `packages/shared/config.ts`: real booleans pass through, `"true"`/`"false"`/`"1"`/`"0"` strings (any case, trimmed) coerce, and anything else falls back to the default. Applied to the config-file branch of exactly four resolvers:

- `resolveUseGlimpse` (`config.glimpse`, default true)
- `resolveAnnotateHistory` (`config.annotateHistory`, default true)
- `resolveUseJina` (`config.jina`, default true)
- `resolveCursorSandbox` (`config.cursorSandbox`, default true)

`resolveSharingEnabled` is deliberately untouched: it is keyed on the string sentinel `"disabled"`, works as documented, and fails safe (unknown values leave sharing enabled). Env-var branches are also untouched; they already string-parse correctly and their precedence over config is preserved.

The Pi extension vendors `packages/shared/config.ts` via `apps/pi-extension/vendor.sh`, so it picks the fix up automatically at build time.

## Tests

Extended `packages/shared/config.test.ts` with a table-driven suite over all four resolvers: real booleans pass through, quoted strings coerce (including mixed case and padding), garbage values (`"yes"`, `42`, `null`, etc.) and absent keys fall back to the default, and the env var still wins over the config key. Env vars are cleared per test and restored afterwards. Full `bun test` suite: 2213 pass, 0 fail.