### PR TITLE
fix(review): expand collapsed guide files when jumping via section file chips

### DIFF
--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -260,6 +260,12 @@ const ReviewApp: React.FC = () => {
     // site that forgets the synchronous clear.
     setGuideRevealFile(null);
   }, [guideOpen, activeGuideJobId]);
+  // Reveal entry point for jumps originating inside the guide itself (section
+  // file chips) — same fresh-token contract as the sidebar reveal sites below
+  // so repeat jumps to the same file re-fire the expand/focus/scroll effects.
+  const handleGuideRevealFile = useCallback((filePath: string) => {
+    setGuideRevealFile(prev => ({ path: filePath, token: (prev?.token ?? 0) + 1 }));
+  }, []);
   const [copyFeedback, setCopyFeedback] = useState<string | null>(null);
   const [copyRawDiffStatus, setCopyRawDiffStatus] = useState<'idle' | 'success' | 'error'>('idle');
   const [viewedFiles, setViewedFiles] = useState<Set<string>>(new Set());
@@ -2317,6 +2323,7 @@ const ReviewApp: React.FC = () => {
     canStagePath: isPathStageable,
     currentWorktreePath: activeWorktreePath,
     guideRevealFile,
+    onGuideRevealFile: handleGuideRevealFile,
     stageError,
     searchQuery: isSearchPending ? '' : debouncedSearchQuery,
     isSearchPending,
@@ -2376,7 +2383,7 @@ const ReviewApp: React.FC = () => {
     handleAddAnnotation, handleAddFileComment, handleAddFileCommentForFile, handleEditAnnotation,
     handleSelectAnnotation, handleNavigateToAnnotation, handleDeleteAnnotation, viewedFiles,
     handleToggleViewed, stagedFiles, stagingFile, stageFile,
-    canStageFiles, isPathStageable, activeWorktreePath, guideRevealFile, stageError, isSearchPending, debouncedSearchQuery,
+    canStageFiles, isPathStageable, activeWorktreePath, guideRevealFile, handleGuideRevealFile, stageError, isSearchPending, debouncedSearchQuery,
     activeFileSearchMatches, activeSearchMatchId, activeSearchMatch, searchMatches,
     aiAvailable, aiMessages, aiIsCreatingSession, aiIsStreaming,
     handleAskAI, handleAskAIForFile, handleViewAIResponse, handleClickAIMarker,

--- a/packages/review-editor/components/guide/GuideDiffSection.tsx
+++ b/packages/review-editor/components/guide/GuideDiffSection.tsx
@@ -71,11 +71,12 @@ export const GuideDiffSection: React.FC<GuideDiffSectionProps> = ({ diffRef, isF
     if (!wasViewed) setCollapsed(true);
   };
 
-  // Reveal channel (state.guideRevealFile): a sidebar jump — annotation click
-  // or AI line citation — targeted THIS file. The viewed-collapse above
-  // unmounts the diff body, so the jump would silently no-op on a collapsed
-  // file; expand it first. GuideSectionCard's companion effect handles the
-  // section-level expand and scroll — this one only reopens the file.
+  // Reveal channel (state.guideRevealFile): a jump — sidebar annotation click,
+  // AI line citation, or a section file chip — targeted THIS file. The
+  // viewed-collapse above unmounts the diff body, so the jump would silently
+  // no-op on a collapsed file; expand it first. GuideSectionCard's companion
+  // effect handles the section-level expand and scroll — this one only
+  // reopens the file.
   const revealTarget = state.guideRevealFile?.path === diffRef.file ? state.guideRevealFile : null;
   useEffect(() => {
     if (revealTarget) setCollapsed(false);

--- a/packages/review-editor/components/guide/GuideSectionCard.test.tsx
+++ b/packages/review-editor/components/guide/GuideSectionCard.test.tsx
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { GuideSection } from '@plannotator/shared/guide';
+import { ReviewStateProvider, type ReviewState } from '../../dock/ReviewStateContext';
+
+// DiffViewer (imported via GuideDiffSection) loads its diff worker through a
+// Vite `?worker&inline` virtual module that bun's test resolver can't parse;
+// stub it before the component graph loads (hence the dynamic import below).
+mock.module('@pierre/diffs/worker/worker.js?worker&inline', () => ({ default: class {} }));
+const { GuideSectionCard } = await import('./GuideSectionCard');
+
+const hasDom = typeof document !== 'undefined';
+
+const section: GuideSection = {
+  title: 'Payment localization module',
+  overview: '',
+  diffs: [{ file: 'src/payments/localize.ts' }],
+};
+
+// Minimal slice of ReviewState the card (and its GuideDiffSection children,
+// which render the missing-file placeholder because `files` is empty) touches.
+function makeState(overrides: Partial<ReviewState>): ReviewState {
+  return {
+    files: [],
+    guideRevealFile: null,
+    ...overrides,
+  } as unknown as ReviewState;
+}
+
+let root: Root | null = null;
+let host: HTMLElement | null = null;
+
+afterEach(async () => {
+  if (root !== null) {
+    await act(async () => root?.unmount());
+    root = null;
+  }
+  host?.remove();
+  host = null;
+  if (hasDom) document.body.innerHTML = '';
+});
+
+function renderCard(state: ReviewState, props: Partial<React.ComponentProps<typeof GuideSectionCard>> = {}) {
+  const element = (
+    <ReviewStateProvider value={state}>
+      <GuideSectionCard
+        section={section}
+        index={0}
+        total={1}
+        reviewed={false}
+        onToggleReviewed={() => {}}
+        focusedFile={null}
+        onFocusFile={() => {}}
+        {...props}
+      />
+    </ReviewStateProvider>
+  );
+  return element;
+}
+
+describe('GuideSectionCard', () => {
+  test.skipIf(!hasDom)('file chip click routes through the reveal channel', async () => {
+    const revealed: string[] = [];
+    const state = makeState({
+      onGuideRevealFile: (filePath: string) => revealed.push(filePath),
+    });
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    await act(async () => {
+      root = createRoot(host!);
+      root.render(renderCard(state));
+    });
+
+    const chip = host.querySelector<HTMLButtonElement>('button[title="src/payments/localize.ts"]');
+    expect(chip).not.toBeNull();
+    await act(async () => {
+      chip!.click();
+    });
+
+    // The chip must NOT scroll directly — only the reveal channel can expand
+    // a collapsed (viewed) target diff before the scroll happens.
+    expect(revealed).toEqual(['src/payments/localize.ts']);
+  });
+
+  test.skipIf(!hasDom)('a reveal targeting a file in a collapsed section expands and focuses it', async () => {
+    const focused: string[] = [];
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    await act(async () => {
+      root = createRoot(host!);
+      root.render(renderCard(makeState({}), { reviewed: true, onFocusFile: (p) => focused.push(p) }));
+    });
+
+    // Collapsed row only: no file chips mounted.
+    expect(host.querySelector('button[title="src/payments/localize.ts"]')).toBeNull();
+
+    await act(async () => {
+      root!.render(
+        renderCard(makeState({ guideRevealFile: { path: 'src/payments/localize.ts', token: 1 } }), {
+          reviewed: true,
+          onFocusFile: (p) => focused.push(p),
+        }),
+      );
+    });
+
+    expect(host.querySelector('button[title="src/payments/localize.ts"]')).not.toBeNull();
+    expect(focused).toEqual(['src/payments/localize.ts']);
+  });
+});

--- a/packages/review-editor/components/guide/GuideSectionCard.tsx
+++ b/packages/review-editor/components/guide/GuideSectionCard.tsx
@@ -21,8 +21,9 @@ function Checkbox({ checked }: { checked: boolean }) {
   );
 }
 
-/** Left-column file chip: name, directory, +/- counts. Clicking scrolls the
- *  matching diff card in the right column into view. */
+/** Left-column file chip: name, directory, +/- counts. Clicking reveals the
+ *  matching diff card in the right column — expanding it if collapsed — and
+ *  scrolls it into view (via the guideRevealFile channel). */
 function FileChip({
   file,
   additions,
@@ -75,7 +76,8 @@ interface GuideSectionCardProps {
 /**
  * One chapter of the guide, laid out as a two-column body: overview on the
  * left (title, position, Reviewed checkbox, prose, file chips), the section's
- * diffs on the right. Clicking a file chip scrolls its diff into view.
+ * diffs on the right. Clicking a file chip reveals its diff (expanding it if
+ * collapsed) and scrolls it into view.
  *
  * Collapsing is independent of Reviewed: the chevron (or the collapsed row)
  * toggles it freely, while checking Reviewed also collapses by default.
@@ -98,11 +100,12 @@ export const GuideSectionCard: React.FC<GuideSectionCardProps> = ({
   const position = `${String(index + 1).padStart(2, '0')} / ${String(total).padStart(2, '0')}`;
   const isCollapsed = collapsedOverride ?? reviewed;
 
-  // Reveal channel (state.guideRevealFile): a sidebar jump — annotation click
-  // or AI line citation — targeted a file placed in THIS section while the
-  // guide is open. Expand if collapsed (a reviewed section has no mounted
-  // viewer, so the jump would otherwise silently no-op), focus the file so
-  // the selection/AI history bind to it, then scroll its diff into view.
+  // Reveal channel (state.guideRevealFile): a jump — sidebar annotation click,
+  // AI line citation, or a section file chip — targeted a file placed in THIS
+  // section while the guide is open. Expand if collapsed (a reviewed section
+  // has no mounted viewer, so the jump would otherwise silently no-op), focus
+  // the file so the selection/AI history bind to it, then scroll its diff
+  // into view.
   // rAF: the expansion's mount commits first; the element exists by the next
   // frame. Keyed on the token so the same file can be revealed repeatedly;
   // only the (unique — first-placement-wins) containing card matches.
@@ -233,12 +236,15 @@ export const GuideSectionCard: React.FC<GuideSectionCardProps> = ({
                     deletions={file?.deletions}
                     missing={!file}
                     onClick={() => {
-                      // Retarget the guide's focus arbiter too: scrolling under
-                      // a stationary pointer fires no pointerenter, so without
-                      // this the annotation toolbar / pending selection / AI
-                      // history stay bound to the previously-focused diff.
-                      if (file) onFocusFile(ref.file);
-                      diffElements.current.get(ref.file)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                      // Route through the reveal channel rather than scrolling
+                      // directly: the target diff may be collapsed (marked
+                      // viewed), and only the reveal token re-expands it in
+                      // GuideDiffSection before this card's reveal effect
+                      // focuses and scrolls — a bare scrollIntoView would land
+                      // on the collapsed header with no code. The effect also
+                      // retargets the focus arbiter (scrolling under a
+                      // stationary pointer fires no pointerenter).
+                      state.onGuideRevealFile?.(ref.file);
                     }}
                   />
                 );

--- a/packages/review-editor/dock/ReviewStateContext.tsx
+++ b/packages/review-editor/dock/ReviewStateContext.tsx
@@ -113,14 +113,21 @@ export interface ReviewState {
    *  activeWorktreePath memo — the same parse that drives the sections/tree
    *  UI, so context matching aligns with what's on screen). */
   currentWorktreePath?: string | null;
-  /** Guide-mode reveal channel: set (with a fresh token) when a sidebar jump
-   *  — annotation click or AI line citation — targets a file while the guide
-   *  takeover is open. The GuideSectionCard containing that file expands its
+  /** Guide-mode reveal channel: set (with a fresh token) when a jump —
+   *  sidebar annotation click, AI line citation, or a section file chip —
+   *  targets a file while the guide takeover is open. The GuideSectionCard
+   *  containing that file expands its
    *  collapsed (reviewed) section, focuses the file's diff, and scrolls to
    *  it; without this, jumps into collapsed sections silently no-op because
    *  no viewer is mounted for the file. Cleared when the guide closes so a
    *  reopen doesn't replay the last reveal. */
   guideRevealFile?: { path: string; token: number } | null;
+  /** Sets guideRevealFile with a fresh token. Entry point for jumps that
+   *  originate INSIDE the guide (section file chips) so they get the same
+   *  expand-focus-scroll treatment as the sidebar paths above — a direct
+   *  scrollIntoView would land on a bare header when the target diff is
+   *  collapsed (marked viewed). */
+  onGuideRevealFile?: (filePath: string) => void;
   stageError: string | null;
 
   // Search


### PR DESCRIPTION
## Bug

Guided review has three jump-to-file entry points. Two of them, sidebar annotation clicks and AI line citations, were wired through the guideRevealFile reveal channel added with the collapsible file diffs (#1068), so a collapsed target expands before the scroll. The third, the per-section file chips in GuideSectionCard's left column, still scrolled directly with scrollIntoView.

Repro: open a guided review, mark a file as viewed (its diff collapses to just the header bar), then click that file's chip in its section's file list. The page scrolls to the collapsed header, no code is shown and nothing expands, so the click looks like a no-op.

## Fix

Route the chip click through the same reveal channel the other two paths use, instead of scrolling directly:

- ReviewStateContext gains an optional onGuideRevealFile(filePath) alongside the existing guideRevealFile field.
- App.tsx implements it with the same fresh-token setter the annotation-click and AI-citation sites already use, so repeat clicks on the same chip re-fire.
- The chip's onClick now just calls state.onGuideRevealFile(file). The existing token-keyed effects do the rest in the established order: GuideDiffSection re-expands the collapsed file, GuideSectionCard expands the section if needed, retargets the focus arbiter, and scrolls via requestAnimationFrame after the expansion has mounted. The chip's old direct scrollIntoView and onFocusFile calls are removed, so there is no double scroll and no scroll before layout changes.

No new mechanism, no changes to the reveal channel itself, and collapse persistence is untouched. Client-only change.

## Verification

- bun test: 2193 pass, 0 fail
- DOM_TESTS=1 bun test packages/review-editor: 149 pass, 0 fail
- bun run --cwd apps/review build: builds clean
- New test GuideSectionCard.test.tsx covers the chip click calling the reveal setter and a reveal expanding a collapsed section