### PR TITLE
perf(pi-extension): exact .ts specifiers cut Pi load from 43.5ms to 15ms

### DIFF
--- a/apps/pi-extension/config.test.ts
+++ b/apps/pi-extension/config.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { loadPlannotatorConfig, formatTodoList, renderTemplate, resolvePhaseProfile } from "./config";
+import { loadPlannotatorConfig, formatTodoList, renderTemplate, resolvePhaseProfile } from "./config.ts";
 
 const tempDirs: string[] = [];
 const originalHome = process.env.HOME;

--- a/apps/pi-extension/import-specifiers.test.ts
+++ b/apps/pi-extension/import-specifiers.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * This package is distributed and executed as raw TypeScript through jiti
+ * (and Bun in tests). A relative ".js" specifier names a file that never
+ * exists here, so jiti reaches it only through a slow last-resort fallback
+ * (~2ms per import vs ~20us for an exact ".ts" hit — ~30ms across the eager
+ * graph); extensionless imports still require probing. Exact ".ts" paths also
+ * satisfy native Node's TypeScript resolver, which remaps neither form.
+ *
+ * All relative specifiers must name the ".ts" file that actually ships.
+ * vendor.sh enforces this for generated/ (normalization pass at the end);
+ * this test enforces it for hand-written sources.
+ */
+
+const ROOT = import.meta.dir;
+const SKIP_DIRS = new Set(["node_modules", "dist", ".git"]);
+const RELATIVE_SPECIFIER =
+  /(?:from\s+|import\s*\(\s*|import\s+)(["'])(\.\.?\/[^"']+)\1/g;
+
+function isInexactTypeScriptSpecifier(specifier: string): boolean {
+  return /\.(?:c|m)?js$/.test(specifier) || !/\.[^/]+$/.test(specifier);
+}
+
+function collectTsFiles(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    if (SKIP_DIRS.has(name)) continue;
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) collectTsFiles(full, out);
+    else if (name.endsWith(".ts") || name.endsWith(".tsx")) out.push(full);
+  }
+  return out;
+}
+
+test("relative import specifiers name the .ts files that actually ship", () => {
+  const offenders: string[] = [];
+  for (const file of collectTsFiles(ROOT)) {
+    const text = readFileSync(file, "utf8");
+    let match: RegExpExecArray | null;
+    RELATIVE_SPECIFIER.lastIndex = 0;
+    while ((match = RELATIVE_SPECIFIER.exec(text))) {
+      const specifier = match[2];
+      if (isInexactTypeScriptSpecifier(specifier)) {
+        offenders.push(`${file.slice(ROOT.length + 1)} -> ${specifier}`);
+      }
+    }
+  }
+  expect(offenders).toEqual([]);
+});

--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -25,15 +25,15 @@ import type {
 	ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
 import { Key } from "@earendil-works/pi-tui";
-import { buildPromptVariables, formatTodoList, loadPlannotatorConfig, renderTemplate, resolvePhaseProfile } from "./config.js";
+import { buildPromptVariables, formatTodoList, loadPlannotatorConfig, renderTemplate, resolvePhaseProfile } from "./config.ts";
 import {
 	type ChecklistItem,
 	markCompletedSteps,
 	parseChecklist,
-} from "./generated/checklist.js";
-import { loadConfig, resolveUseJina } from "./generated/config.js";
-import { readImprovementHook } from "./generated/improvement-hooks.js";
-import { composeImproveContext } from "./generated/pfm-reminder.js";
+} from "./generated/checklist.ts";
+import { loadConfig, resolveUseJina } from "./generated/config.ts";
+import { readImprovementHook } from "./generated/improvement-hooks.ts";
+import { composeImproveContext } from "./generated/pfm-reminder.ts";
 import {
 	hasPlanBrowserHtml,
 	hasReviewBrowserHtml,
@@ -43,14 +43,14 @@ import {
 	startMarkdownAnnotationSession,
 	openPlanReviewBrowser,
 	registerPlannotatorEventListeners,
-} from "./plannotator-events.js";
+} from "./plannotator-events.ts";
 import {
 	findAssistantMessageByEntryId,
 	getAssistantMessageText,
 	getLastAssistantMessageSnapshot,
 	getRecentAssistantMessages,
 	hasSessionMovedPastEntry,
-} from "./assistant-message.js";
+} from "./assistant-message.ts";
 import {
 	getPiSessionIdentity,
 	isCurrentPiSessionDifferentFrom,
@@ -59,7 +59,7 @@ import {
 	registerCurrentPiSession,
 	sendUserMessageToCurrentPiSession,
 	withCurrentPiSessionFallbackHeader,
-} from "./current-pi-session.js";
+} from "./current-pi-session.ts";
 import {
 	getToolsForPhase,
 	isPlanWritePathAllowed,
@@ -67,17 +67,17 @@ import {
 	type Phase,
 	stripPlanningOnlyTools,
 } from "./tool-scope.ts";
-import { isRemoteSession } from "./server/network.js";
+import { isRemoteSession } from "./server/network.ts";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
-type PlannotatorPromptsModule = typeof import("./generated/prompts.js");
+type PlannotatorPromptsModule = typeof import("./generated/prompts.ts");
 
 let promptsModulePromise: Promise<PlannotatorPromptsModule> | undefined;
 
 function loadPlannotatorPrompts(): Promise<PlannotatorPromptsModule> {
 	if (!promptsModulePromise) {
-		promptsModulePromise = import("./generated/prompts.js").catch((error: unknown) => {
+		promptsModulePromise = import("./generated/prompts.ts").catch((error: unknown) => {
 			promptsModulePromise = undefined;
 			throw error;
 		});
@@ -87,10 +87,10 @@ function loadPlannotatorPrompts(): Promise<PlannotatorPromptsModule> {
 
 async function loadAnnotateCommandModules() {
 	const [annotateArgs, atReference, resolveFile, referenceCommon] = await Promise.all([
-		import("./generated/annotate-args.js"),
-		import("./generated/at-reference.js"),
-		import("./generated/resolve-file.js"),
-		import("./generated/reference-common.js"),
+		import("./generated/annotate-args.ts"),
+		import("./generated/at-reference.ts"),
+		import("./generated/resolve-file.ts"),
+		import("./generated/reference-common.ts"),
 	]);
 	return {
 		parseAnnotateArgs: annotateArgs.parseAnnotateArgs,
@@ -448,7 +448,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 			const origin = getPiSessionIdentity(ctx);
 
 			try {
-				const { parseReviewArgs } = await import("./generated/review-args.js");
+				const { parseReviewArgs } = await import("./generated/review-args.ts");
 				const reviewArgs = parseReviewArgs(args ?? "");
 				const session = await startCodeReviewBrowserSession(ctx, {
 					prUrl: reviewArgs.prUrl,
@@ -559,7 +559,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 				const useJina = resolveUseJina(noJina, loadConfig());
 				ctx.ui.notify(`Fetching: ${filePath}${useJina ? " (via Jina Reader)" : " (via fetch+Turndown)"}...`, "info");
 				try {
-					const { isConvertedSource, urlToMarkdown } = await import("./generated/url-to-markdown.js");
+					const { isConvertedSource, urlToMarkdown } = await import("./generated/url-to-markdown.ts");
 					const result = await urlToMarkdown(filePath, { useJina });
 					markdown = result.markdown;
 					sourceConverted = isConvertedSource(result.source);
@@ -608,7 +608,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 						rawHtml = html;
 						markdown = "";
 					} else {
-						const { htmlToMarkdown } = await import("./generated/html-to-markdown.js");
+						const { htmlToMarkdown } = await import("./generated/html-to-markdown.ts");
 						markdown = htmlToMarkdown(html);
 						sourceConverted = true;
 					}
@@ -694,7 +694,7 @@ export default function plannotator(pi: ExtensionAPI): void {
 		description: "Annotate the last assistant message",
 		handler: async (args, ctx) => {
 			// Support --gate on /plannotator-last for the Stop-hook review gate.
-			const { parseAnnotateArgs } = await import("./generated/annotate-args.js");
+			const { parseAnnotateArgs } = await import("./generated/annotate-args.ts");
 			const { gate } = parseAnnotateArgs(args ?? "");
 
 			if (!hasPlanBrowserHtml()) {

--- a/apps/pi-extension/plannotator-browser-runtime.ts
+++ b/apps/pi-extension/plannotator-browser-runtime.ts
@@ -2,7 +2,7 @@ import { readFileSync, statSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-type PlannotatorBrowserModule = typeof import("./plannotator-browser.js");
+type PlannotatorBrowserModule = typeof import("./plannotator-browser.ts");
 
 const moduleDirectory = dirname(fileURLToPath(import.meta.url));
 const planHtmlPath = resolve(moduleDirectory, "plannotator.html");
@@ -68,7 +68,7 @@ export function getStartupErrorMessage(error: unknown): string {
  */
 export function loadPlannotatorBrowser(): Promise<PlannotatorBrowserModule> {
 	if (!browserModulePromise) {
-		browserModulePromise = import("./plannotator-browser.js").catch((error: unknown) => {
+		browserModulePromise = import("./plannotator-browser.ts").catch((error: unknown) => {
 			browserModulePromise = undefined;
 			throw error;
 		});

--- a/apps/pi-extension/plannotator-browser.test.ts
+++ b/apps/pi-extension/plannotator-browser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { shouldUseLocalPrCheckout } from "./plannotator-browser";
+import { shouldUseLocalPrCheckout } from "./plannotator-browser.ts";
 
 describe("shouldUseLocalPrCheckout", () => {
 	test("uses local PR checkout by default", () => {

--- a/apps/pi-extension/plannotator-browser.ts
+++ b/apps/pi-extension/plannotator-browser.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, realpathSync, rmSync, statSync } from "node:f
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
-import { createWorktreePool, type WorktreePool } from "./generated/worktree-pool.js";
+import { createWorktreePool, type WorktreePool } from "./generated/worktree-pool.ts";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
 	prepareLocalReviewDiff,
@@ -20,37 +20,37 @@ import {
 	type DiffType,
 	type VcsSelection,
 	unstageFile,
-} from "./server.js";
-import { openBrowser, isRemoteSession } from "./server/network.js";
-import { detectProjectName } from "./server/project.js";
-import { parsePRUrl, checkPRAuth, fetchPR } from "./server/pr.js";
+} from "./server.ts";
+import { openBrowser, isRemoteSession } from "./server/network.ts";
+import { detectProjectName } from "./server/project.ts";
+import { parsePRUrl, checkPRAuth, fetchPR } from "./server/pr.ts";
 import {
 	getMRLabel,
 	getMRNumberLabel,
 	getDisplayRepo,
 	getCliName,
 	getCliInstallUrl,
-} from "./generated/pr-provider.js";
-import { parseRemoteUrl } from "./generated/repo.js";
-import { fetchRef, createWorktree, removeWorktree, ensureObjectAvailable } from "./generated/worktree.js";
-import { loadConfig, resolveDefaultDiffType, resolveSharingEnabled } from "./generated/config.js";
+} from "./generated/pr-provider.ts";
+import { parseRemoteUrl } from "./generated/repo.ts";
+import { fetchRef, createWorktree, removeWorktree, ensureObjectAvailable } from "./generated/worktree.ts";
+import { loadConfig, resolveDefaultDiffType, resolveSharingEnabled } from "./generated/config.ts";
 import {
 	WorkspaceReviewSession,
 	type WorkspaceDiffType,
-} from "./generated/review-workspace.js";
+} from "./generated/review-workspace.ts";
 import {
 	getPlanBrowserHtml,
 	getReviewBrowserHtml,
 	getStartupErrorMessage,
 	hasPlanBrowserHtml,
 	hasReviewBrowserHtml,
-} from "./plannotator-browser-runtime.js";
-export { getLastAssistantMessageText } from "./assistant-message.js";
+} from "./plannotator-browser-runtime.ts";
+export { getLastAssistantMessageText } from "./assistant-message.ts";
 export {
 	getStartupErrorMessage,
 	hasPlanBrowserHtml,
 	hasReviewBrowserHtml,
-} from "./plannotator-browser-runtime.js";
+} from "./plannotator-browser-runtime.ts";
 
 export type AnnotateMode = "annotate" | "annotate-folder" | "annotate-last";
 export interface PlanReviewDecision {

--- a/apps/pi-extension/plannotator-events.ts
+++ b/apps/pi-extension/plannotator-events.ts
@@ -2,19 +2,19 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import type { DiffType, VcsSelection } from "./server.js";
+import type { DiffType, VcsSelection } from "./server.ts";
 import {
 	getLastAssistantMessageText,
 	getRecentAssistantMessages,
-} from "./assistant-message.js";
+} from "./assistant-message.ts";
 import {
 	getStartupErrorMessage,
 	hasPlanBrowserHtml,
 	hasReviewBrowserHtml,
 	loadPlannotatorBrowser,
-} from "./plannotator-browser-runtime.js";
+} from "./plannotator-browser-runtime.ts";
 
-type PlannotatorBrowserModule = typeof import("./plannotator-browser.js");
+type PlannotatorBrowserModule = typeof import("./plannotator-browser.ts");
 
 /** Start a plan-review browser session after loading the browser/server graph on demand. */
 export function startPlanReviewBrowserSession(

--- a/apps/pi-extension/server.test.ts
+++ b/apps/pi-extension/server.test.ts
@@ -28,10 +28,10 @@ import {
   startPlanReviewServer,
   startReviewServer,
   unstageFile,
-} from "./server";
-import { WorkspaceReviewSession } from "./generated/review-workspace.js";
-import { parseReviewArgs } from "./generated/review-args.js";
-import { warmFileListCache } from "./generated/resolve-file.js";
+} from "./server.ts";
+import { WorkspaceReviewSession } from "./generated/review-workspace.ts";
+import { parseReviewArgs } from "./generated/review-args.ts";
+import { warmFileListCache } from "./generated/resolve-file.ts";
 
 const tempDirs: string[] = [];
 const originalCwd = process.cwd();

--- a/apps/pi-extension/server.ts
+++ b/apps/pi-extension/server.ts
@@ -10,21 +10,21 @@ export type {
 	DiffOption,
 	DiffType,
 	GitContext,
-} from "./generated/review-core.js";
-export type { WorkspaceDiffType } from "./generated/review-workspace.js";
-export type { VcsSelection } from "./server/vcs.js";
+} from "./generated/review-core.ts";
+export type { WorkspaceDiffType } from "./generated/review-workspace.ts";
+export type { VcsSelection } from "./server/vcs.ts";
 export {
 	type AnnotateServerResult,
 	startAnnotateServer,
-} from "./server/serverAnnotate.js";
+} from "./server/serverAnnotate.ts";
 export {
 	type PlanServerResult,
 	startPlanReviewServer,
-} from "./server/serverPlan.js";
+} from "./server/serverPlan.ts";
 export {
 	type ReviewServerResult,
 	startReviewServer,
-} from "./server/serverReview.js";
+} from "./server/serverReview.ts";
 export {
 	canStageFiles,
 	detectManagedVcs,
@@ -42,4 +42,4 @@ export {
 	runVcsDiff,
 	stageFile,
 	unstageFile,
-} from "./server/vcs.js";
+} from "./server/vcs.ts";

--- a/apps/pi-extension/server/agent-jobs.ts
+++ b/apps/pi-extension/server/agent-jobs.ts
@@ -22,16 +22,16 @@ import {
 	serializeAgentSSEEvent,
 	AGENT_HEARTBEAT_COMMENT,
 	AGENT_HEARTBEAT_INTERVAL_MS,
-} from "../generated/agent-jobs.js";
-import { formatClaudeLogEvent } from "../generated/claude-review.js";
+} from "../generated/agent-jobs.ts";
+import { formatClaudeLogEvent } from "../generated/claude-review.ts";
 import {
 	MARKER_ENGINES,
 	formatMarkerLogEvent,
 	type MarkerEngine,
 	type MarkerEngineId,
 	type MarkerModel,
-} from "../generated/marker-review.js";
-import { json, parseBody } from "./helpers.js";
+} from "../generated/marker-review.ts";
+import { json, parseBody } from "./helpers.ts";
 
 // ---------------------------------------------------------------------------
 // Route prefixes

--- a/apps/pi-extension/server/agent-terminal.test.ts
+++ b/apps/pi-extension/server/agent-terminal.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { createServer } from "node:http";
-import { AGENT_TERMINAL_WS_BASE_PATH } from "../generated/agent-terminal.js";
-import { createNodeAgentTerminalBridge, normalizeSpawnOptions } from "./agent-terminal";
-import { startAnnotateServer } from "./serverAnnotate";
+import { AGENT_TERMINAL_WS_BASE_PATH } from "../generated/agent-terminal.ts";
+import { createNodeAgentTerminalBridge, normalizeSpawnOptions } from "./agent-terminal.ts";
+import { startAnnotateServer } from "./serverAnnotate.ts";
 
 describe("pi annotate agent terminal capability", () => {
 	test("normalizes spawn options from the server-owned agent launch plan", () => {

--- a/apps/pi-extension/server/agent-terminal.ts
+++ b/apps/pi-extension/server/agent-terminal.ts
@@ -7,8 +7,8 @@ import {
 	buildAgentTerminalWsPath,
 	type AgentTerminalAgent,
 	type AgentTerminalCapability,
-} from "../generated/agent-terminal.js";
-import { isRemoteSession } from "./network.js";
+} from "../generated/agent-terminal.ts";
+import { isRemoteSession } from "./network.ts";
 import type { PtyBackend, PtyExit, PtySession, PtySpawnOptions, Unsubscribe } from "@plannotator/webtui/core";
 
 type WebTuiCore = typeof import("@plannotator/webtui/core");

--- a/apps/pi-extension/server/ai-runtime.ts
+++ b/apps/pi-extension/server/ai-runtime.ts
@@ -2,9 +2,9 @@ import { execFileSync } from "node:child_process";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { Readable } from "node:stream";
 
-import { isAIEndpointPath } from "../generated/ai/endpoints.js";
-import { resolveCommandFromWhichOutput } from "../generated/ai/providers/command-path.js";
-import { handleApiNotFound, json, toWebRequest } from "./helpers.js";
+import { isAIEndpointPath } from "../generated/ai/endpoints.ts";
+import { resolveCommandFromWhichOutput } from "../generated/ai/providers/command-path.ts";
+import { handleApiNotFound, json, toWebRequest } from "./helpers.ts";
 
 export interface PiAIRuntime {
 	endpoints: Record<string, (req: Request) => Promise<Response>>;
@@ -31,14 +31,14 @@ function whichCmd(cmd: string): string | null {
 
 export async function createPiAIRuntime(options: CreatePiAIRuntimeOptions = {}): Promise<PiAIRuntime | null> {
 	try {
-		const ai = await import("../generated/ai/index.js");
+		const ai = await import("../generated/ai/index.ts");
 		const cwd = options.cwd ?? process.cwd();
 		const registry = new ai.ProviderRegistry();
 		const sessionManager = new ai.SessionManager();
 		const modelDiscovery: Promise<void>[] = [];
 
 		try {
-			await import("../generated/ai/providers/claude-agent-sdk.js");
+			await import("../generated/ai/providers/claude-agent-sdk.ts");
 			const claudePath = whichCmd("claude");
 			const provider = await ai.createProvider({
 				type: "claude-agent-sdk",
@@ -51,7 +51,7 @@ export async function createPiAIRuntime(options: CreatePiAIRuntimeOptions = {}):
 		}
 
 		try {
-			await import("../generated/ai/providers/codex-app-server.js");
+			await import("../generated/ai/providers/codex-app-server.ts");
 			const codexPath = whichCmd("codex");
 			if (codexPath) {
 				const provider = await ai.createProvider({
@@ -71,7 +71,7 @@ export async function createPiAIRuntime(options: CreatePiAIRuntimeOptions = {}):
 		}
 
 		try {
-			await import("../generated/ai/providers/pi-sdk-node.js");
+			await import("../generated/ai/providers/pi-sdk-node.ts");
 			const piPath = whichCmd("pi");
 			if (piPath) {
 				const provider = await ai.createProvider({
@@ -93,7 +93,7 @@ export async function createPiAIRuntime(options: CreatePiAIRuntimeOptions = {}):
 		}
 
 		try {
-			await import("../generated/ai/providers/opencode-sdk.js");
+			await import("../generated/ai/providers/opencode-sdk.ts");
 			const opencodePath = whichCmd("opencode");
 			if (opencodePath) {
 				const provider = await ai.createProvider({

--- a/apps/pi-extension/server/annotations.ts
+++ b/apps/pi-extension/server/annotations.ts
@@ -5,7 +5,7 @@
 
 import { randomUUID } from "node:crypto";
 import type { IncomingMessage } from "node:http";
-import { json, parseBody } from "./helpers";
+import { json, parseBody } from "./helpers.ts";
 
 interface EditorAnnotation {
 	id: string;

--- a/apps/pi-extension/server/external-annotations.ts
+++ b/apps/pi-extension/server/external-annotations.ts
@@ -16,8 +16,8 @@ import {
 	HEARTBEAT_INTERVAL_MS,
 	type StorableAnnotation,
 	type ExternalAnnotationEvent,
-} from "../generated/external-annotation.js";
-import { json, parseBody } from "./helpers.js";
+} from "../generated/external-annotation.ts";
+import { json, parseBody } from "./helpers.ts";
 
 // ---------------------------------------------------------------------------
 // Route prefix

--- a/apps/pi-extension/server/file-browser-watch.test.ts
+++ b/apps/pi-extension/server/file-browser-watch.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { isFileBrowserWatchIgnoredPath } from "./file-browser-watch";
+import { isFileBrowserWatchIgnoredPath } from "./file-browser-watch.ts";
 
 describe("Pi file browser watcher", () => {
 	test("ignores nested excluded folders for watcher paths", () => {

--- a/apps/pi-extension/server/file-browser-watch.ts
+++ b/apps/pi-extension/server/file-browser-watch.ts
@@ -3,10 +3,10 @@ import { existsSync, statSync } from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { isAbsolute, relative } from "node:path";
 
-import { isFileBrowserExcludedPath } from "../generated/reference-common.js";
-import { resolveUserPath } from "../generated/resolve-file.js";
-import { getGitMetadataWatchPaths } from "../generated/workspace-status.js";
-import { json } from "./helpers.js";
+import { isFileBrowserExcludedPath } from "../generated/reference-common.ts";
+import { resolveUserPath } from "../generated/resolve-file.ts";
+import { getGitMetadataWatchPaths } from "../generated/workspace-status.ts";
+import { json } from "./helpers.ts";
 
 interface FileBrowserChangeEvent {
 	type: "ready" | "changed";

--- a/apps/pi-extension/server/handlers.ts
+++ b/apps/pi-extension/server/handlers.ts
@@ -8,10 +8,10 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import type { IncomingMessage } from "node:http";
 import { tmpdir } from "node:os";
 import { join, resolve as resolvePath } from "node:path";
-import { saveDraft, loadDraft, deleteDraft, getDraftGeneration } from "../generated/draft.js";
-import { FAVICON_PNG_BYTES } from "../generated/favicon.js";
+import { saveDraft, loadDraft, deleteDraft, getDraftGeneration } from "../generated/draft.ts";
+import { FAVICON_PNG_BYTES } from "../generated/favicon.ts";
 
-import { json, parseBody, send, toWebRequest } from "./helpers";
+import { json, parseBody, send, toWebRequest } from "./helpers.ts";
 import {
 	type BearConfig,
 	type IntegrationResult,
@@ -20,7 +20,7 @@ import {
 	saveToBear,
 	saveToObsidian,
 	saveToOctarine,
-} from "./integrations.js";
+} from "./integrations.ts";
 
 type Res = import("node:http").ServerResponse;
 

--- a/apps/pi-extension/server/integrations.ts
+++ b/apps/pi-extension/server/integrations.ts
@@ -21,9 +21,9 @@ import {
 	buildHashtags,
 	buildBearContent,
 	detectObsidianVaults,
-} from "../generated/integrations-common.js";
-import { sanitizeTag } from "../generated/project.js";
-import { resolveUserPath } from "../generated/resolve-file.js";
+} from "../generated/integrations-common.ts";
+import { sanitizeTag } from "../generated/project.ts";
+import { resolveUserPath } from "../generated/resolve-file.ts";
 
 export type { ObsidianConfig, BearConfig, OctarineConfig, IntegrationResult };
 export {

--- a/apps/pi-extension/server/network.test.ts
+++ b/apps/pi-extension/server/network.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { createServer } from "node:http";
-import { closeServer, occupyConsecutivePorts } from "../../../tests/helpers/ports";
+import { closeServer, occupyConsecutivePorts } from "../../../tests/helpers/ports.ts";
 import {
 	getServerHostname,
 	getServerPort,
@@ -9,7 +9,7 @@ import {
 	isRemoteSession,
 	listenOnPort,
 	openBrowser,
-} from "./network";
+} from "./network.ts";
 
 const savedEnv: Record<string, string | undefined> = {};
 const envKeys = [

--- a/apps/pi-extension/server/network.ts
+++ b/apps/pi-extension/server/network.ts
@@ -8,8 +8,8 @@ import { existsSync } from "node:fs";
 import type { Server } from "node:http";
 import { release } from "node:os";
 import { delimiter, join } from "node:path";
-import { loadConfig, resolveUseGlimpse } from "../generated/config.js";
-import { parsePortSelection } from "../generated/port-range.js";
+import { loadConfig, resolveUseGlimpse } from "../generated/config.ts";
+import { parsePortSelection } from "../generated/port-range.ts";
 
 const DEFAULT_REMOTE_PORT = 19432;
 const LOOPBACK_HOST = "127.0.0.1";

--- a/apps/pi-extension/server/open-in-apps.ts
+++ b/apps/pi-extension/server/open-in-apps.ts
@@ -21,7 +21,7 @@ import {
 	type OpenInApp,
 	type OpenInKind,
 	type OpenInPlatform,
-} from "../generated/open-in-apps.js";
+} from "../generated/open-in-apps.ts";
 
 function currentPlatform(): OpenInPlatform {
 	switch (process.platform) {

--- a/apps/pi-extension/server/port-startup-compat.test.ts
+++ b/apps/pi-extension/server/port-startup-compat.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { createTestEnvironment } from "../../../tests/helpers/environment";
-import { closeServer, occupyConsecutivePorts } from "../../../tests/helpers/ports";
-import { openBrowser } from "./network";
-import { startPlanReviewServer } from "./serverPlan";
+import { createTestEnvironment } from "../../../tests/helpers/environment.ts";
+import { closeServer, occupyConsecutivePorts } from "../../../tests/helpers/ports.ts";
+import { openBrowser } from "./network.ts";
+import { startPlanReviewServer } from "./serverPlan.ts";
 
 const envKeys = [
 	"PLANNOTATOR_PORT",

--- a/apps/pi-extension/server/pr.ts
+++ b/apps/pi-extension/server/pr.ts
@@ -13,7 +13,7 @@ import {
 	type PRStackTree,
 	type PRListItem,
 	parsePRUrl as parsePRUrlCore,
-} from "../generated/pr-types.js";
+} from "../generated/pr-types.ts";
 import {
 	checkAuth as checkAuthCore,
 	fetchPRContext as fetchPRContextCore,
@@ -25,7 +25,7 @@ import {
 	getUser as getUserCore,
 	markPRFilesViewed as markPRFilesViewedCore,
 	submitPRReview as submitPRReviewCore,
-} from "../generated/pr-provider.js";
+} from "../generated/pr-provider.ts";
 
 const prRuntime: PRRuntime = {
 	async runCommand(cmd, args) {

--- a/apps/pi-extension/server/project.ts
+++ b/apps/pi-extension/server/project.ts
@@ -5,8 +5,8 @@
 
 import { execSync } from "node:child_process";
 import { basename } from "node:path";
-import { sanitizeTag } from "../generated/project.js";
-import { parseRemoteUrl, getDirName } from "../generated/repo.js";
+import { sanitizeTag } from "../generated/project.ts";
+import { parseRemoteUrl, getDirName } from "../generated/repo.ts";
 
 /** Run a git command and return stdout (empty string on error). */
 function git(cmd: string): string {

--- a/apps/pi-extension/server/reference.ts
+++ b/apps/pi-extension/server/reference.ts
@@ -14,21 +14,21 @@ import {
 import type { ServerResponse } from "node:http";
 import { join, resolve as resolvePath } from "node:path";
 
-import { json, parseBody } from "./helpers";
+import { json, parseBody } from "./helpers.ts";
 import type { IncomingMessage } from "node:http";
 
 import {
 	type VaultNode,
 	buildFileTree,
 	isFileBrowserExcludedPath,
-} from "../generated/reference-common.js";
+} from "../generated/reference-common.ts";
 import {
 	filterWorkspaceStatusForDirectory,
 	getWorkspaceStatusForDirectory,
 	getWorkspaceStatusRelativePaths,
 	type WorkspaceFileChange,
-} from "../generated/workspace-status.js";
-import { detectObsidianVaults } from "../generated/integrations-common.js";
+} from "../generated/workspace-status.ts";
+import { detectObsidianVaults } from "../generated/integrations-common.ts";
 import {
 	isAbsoluteUserPath,
 	isCodeFilePath,
@@ -40,16 +40,16 @@ import {
 	ANNOTATABLE_DOC_REGEX,
 	MAX_ANNOTATABLE_FILE_BYTES,
 	isAnnotatableTextPath,
-} from "../generated/resolve-file.js";
-import { parseCodePath } from "../generated/code-file.js";
-import { htmlToMarkdown } from "../generated/html-to-markdown.js";
-import { disabledSourceSave, type SourceFileSnapshot, type SourceSaveCapability } from "../generated/source-save.js";
+} from "../generated/resolve-file.ts";
+import { parseCodePath } from "../generated/code-file.ts";
+import { htmlToMarkdown } from "../generated/html-to-markdown.ts";
+import { disabledSourceSave, type SourceFileSnapshot, type SourceSaveCapability } from "../generated/source-save.ts";
 import {
 	createSourceSaveCapability,
 	createSourceSaveCapabilityFromSnapshot,
 	readSourceFileSnapshot,
 	resolveExistingSourceSaveFile,
-} from "../generated/source-save-node.js";
+} from "../generated/source-save-node.ts";
 import { preloadFile } from "@pierre/diffs/ssr";
 
 type Res = ServerResponse;

--- a/apps/pi-extension/server/serverAnnotate.ts
+++ b/apps/pi-extension/server/serverAnnotate.ts
@@ -3,12 +3,12 @@ import { dirname, resolve as resolvePath } from "node:path";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 
-import { contentHash, deleteDraft } from "../generated/draft.js";
-import { saveToHistory, getPlanVersion, getVersionCount, listVersions } from "../generated/storage.js";
-import { htmlDiff } from "../generated/html-diff.js";
-import { saveConfig, detectGitUser, getServerConfig, loadConfig, resolveSharingEnabled, resolveAnnotateHistory } from "../generated/config.js";
-import { disabledSourceSave, type SourceSaveRequest } from "../generated/source-save.js";
-import { getAnnotateReferenceRootPaths } from "../generated/annotate-reference-roots-node.js";
+import { contentHash, deleteDraft } from "../generated/draft.ts";
+import { saveToHistory, getPlanVersion, getVersionCount, listVersions } from "../generated/storage.ts";
+import { htmlDiff } from "../generated/html-diff.ts";
+import { saveConfig, detectGitUser, getServerConfig, loadConfig, resolveSharingEnabled, resolveAnnotateHistory } from "../generated/config.ts";
+import { disabledSourceSave, type SourceSaveRequest } from "../generated/source-save.ts";
+import { getAnnotateReferenceRootPaths } from "../generated/annotate-reference-roots-node.ts";
 import {
 	createSourceSaveCapability,
 	createSourceSaveCapabilityFromText,
@@ -16,7 +16,7 @@ import {
 	resolveFolderSourceFile,
 	resolveFolderSourceFileForSave,
 	saveSourceFileAtomic,
-} from "../generated/source-save-node.js";
+} from "../generated/source-save-node.ts";
 
 import {
 	handleDraftRequest,
@@ -26,14 +26,14 @@ import {
 	readDraftGenerationFromUrl,
 	handleSaveNotesRequest,
 	handleUploadRequest,
-} from "./handlers.js";
-import { handleApiNotFound, html, json, parseBody, requestUrl } from "./helpers.js";
-import { createPiAIRuntime, handlePiAIRequest } from "./ai-runtime.js";
+} from "./handlers.ts";
+import { handleApiNotFound, html, json, parseBody, requestUrl } from "./helpers.ts";
+import { createPiAIRuntime, handlePiAIRequest } from "./ai-runtime.ts";
 
-import { isRemoteSession, listenOnPort } from "./network.js";
-import { getAvailableOpenInApps, openFileInApp } from "./open-in-apps.js";
+import { isRemoteSession, listenOnPort } from "./network.ts";
+import { getAvailableOpenInApps, openFileInApp } from "./open-in-apps.ts";
 
-import { getRepoInfo } from "./project.js";
+import { getRepoInfo } from "./project.ts";
 import {
 	handleDocRequest,
 	handleDocExistsRequest,
@@ -41,23 +41,23 @@ import {
 	handleObsidianVaultsRequest,
 	handleObsidianFilesRequest,
 	handleObsidianDocRequest,
-} from "./reference.js";
-import { handleFileBrowserStreamRequest } from "./file-browser-watch.js";
-import { resolveUserPath, warmFileListCache } from "../generated/resolve-file.js";
-import { createExternalAnnotationHandler } from "./external-annotations.js";
-import { createNodeAgentTerminalBridge } from "./agent-terminal.js";
+} from "./reference.ts";
+import { handleFileBrowserStreamRequest } from "./file-browser-watch.ts";
+import { resolveUserPath, warmFileListCache } from "../generated/resolve-file.ts";
+import { createExternalAnnotationHandler } from "./external-annotations.ts";
+import { createNodeAgentTerminalBridge } from "./agent-terminal.ts";
 import {
 	HTML_ASSET_ROUTE_PREFIX,
 	encodeHtmlAssetPath,
 	htmlAssetContentType,
 	normalizeHtmlAssetRoutePath,
 	rewriteHtmlAssetReferences,
-} from "../generated/html-assets.js";
-import { inlineHtmlLocalAssets, isWithinDirectory, MAX_HTML_ASSET_BYTES, resolveOpenInTarget } from "../generated/html-assets-node.js";
+} from "../generated/html-assets.ts";
+import { inlineHtmlLocalAssets, isWithinDirectory, MAX_HTML_ASSET_BYTES, resolveOpenInTarget } from "../generated/html-assets-node.ts";
 import {
 	supportsAnnotateAgentTerminalMode,
 	type AgentTerminalCapability,
-} from "../generated/agent-terminal.js";
+} from "../generated/agent-terminal.ts";
 
 export interface AnnotateServerResult {
 	port: number;

--- a/apps/pi-extension/server/serverPlan.ts
+++ b/apps/pi-extension/server/serverPlan.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { createServer } from "node:http";
 
-import { contentHash, deleteDraft } from "../generated/draft.js";
+import { contentHash, deleteDraft } from "../generated/draft.ts";
 import {
 	type ArchivedPlan,
 	generateSlug,
@@ -14,9 +14,9 @@ import {
 	saveAnnotations,
 	saveFinalSnapshot,
 	saveToHistory,
-} from "../generated/storage.js";
-import { createEditorAnnotationHandler } from "./annotations.js";
-import { createExternalAnnotationHandler } from "./external-annotations.js";
+} from "../generated/storage.ts";
+import { createEditorAnnotationHandler } from "./annotations.ts";
+import { createExternalAnnotationHandler } from "./external-annotations.ts";
 import {
 	handleDraftRequest,
 	handleFavicon,
@@ -24,10 +24,10 @@ import {
 	readDraftGenerationFromBody,
 	handleSaveNotesRequest,
 	handleUploadRequest,
-} from "./handlers.js";
-import { handleApiNotFound, html, json, parseBody, requestUrl } from "./helpers.js";
-import { createPiAIRuntime, handlePiAIRequest } from "./ai-runtime.js";
-import { openEditorDiff } from "./ide.js";
+} from "./handlers.ts";
+import { handleApiNotFound, html, json, parseBody, requestUrl } from "./helpers.ts";
+import { createPiAIRuntime, handlePiAIRequest } from "./ai-runtime.ts";
+import { openEditorDiff } from "./ide.ts";
 import {
 	type BearConfig,
 	type IntegrationResult,
@@ -36,13 +36,13 @@ import {
 	saveToBear,
 	saveToObsidian,
 	saveToOctarine,
-} from "./integrations.js";
-import { listenOnPort } from "./network.js";
+} from "./integrations.ts";
+import { listenOnPort } from "./network.ts";
 
-import { loadConfig, saveConfig, detectGitUser, getServerConfig, resolveSharingEnabled } from "../generated/config.js";
-import { readImprovementHook, getImprovementHookExpectedPath } from "../generated/improvement-hooks.js";
-import { composeImproveContext } from "../generated/pfm-reminder.js";
-import { detectProjectName, getRepoInfo } from "./project.js";
+import { loadConfig, saveConfig, detectGitUser, getServerConfig, resolveSharingEnabled } from "../generated/config.ts";
+import { readImprovementHook, getImprovementHookExpectedPath } from "../generated/improvement-hooks.ts";
+import { composeImproveContext } from "../generated/pfm-reminder.ts";
+import { detectProjectName, getRepoInfo } from "./project.ts";
 import {
 	handleDocRequest,
 	handleDocExistsRequest,
@@ -50,9 +50,9 @@ import {
 	handleObsidianDocRequest,
 	handleObsidianFilesRequest,
 	handleObsidianVaultsRequest,
-} from "./reference.js";
-import { handleFileBrowserStreamRequest } from "./file-browser-watch.js";
-import { warmFileListCache } from "../generated/resolve-file.js";
+} from "./reference.ts";
+import { handleFileBrowserStreamRequest } from "./file-browser-watch.ts";
+import { warmFileListCache } from "../generated/resolve-file.ts";
 
 export interface PlanReviewDecision {
 	approved: boolean;

--- a/apps/pi-extension/server/serverReview.ts
+++ b/apps/pi-extension/server/serverReview.ts
@@ -4,15 +4,15 @@ import { createServer } from "node:http";
 import os from "node:os";
 import { basename, resolve as resolvePath } from "node:path";
 
-import { SingleFlight } from "../generated/single-flight.js";
-import { contentHash, deleteDraft } from "../generated/draft.js";
-import { loadConfig, saveConfig, detectGitUser, getServerConfig, resolveSharingEnabled, resolveCursorSandbox } from "../generated/config.js";
+import { SingleFlight } from "../generated/single-flight.ts";
+import { contentHash, deleteDraft } from "../generated/draft.ts";
+import { loadConfig, saveConfig, detectGitUser, getServerConfig, resolveSharingEnabled, resolveCursorSandbox } from "../generated/config.ts";
 
 export type {
 	DiffOption,
 	DiffType,
 	GitContext,
-} from "../generated/review-core.js";
+} from "../generated/review-core.ts";
 
 import {
 	getDisplayRepo,
@@ -23,18 +23,18 @@ import {
 	type PRRef,
 	type PRReviewFileComment,
 	prRefFromMetadata,
-} from "../generated/pr-types.js";
+} from "../generated/pr-types.ts";
 import {
 	PR_CONTEXT_HEARTBEAT_COMMENT,
 	PR_CONTEXT_HEARTBEAT_INTERVAL_MS,
 	createPRContextLiveCache,
 	serializePRContextSSEEvent,
-} from "../generated/pr-context-live.js";
+} from "../generated/pr-context-live.ts";
 import {
 	fetchPRArtifactContent,
 	fetchPRArtifactDocument,
 	PRArtifactDocumentError,
-} from "../generated/pr-artifact-document.js";
+} from "../generated/pr-artifact-document.ts";
 import {
 	type DiffType,
 	type GitContext,
@@ -49,16 +49,16 @@ import {
 	parseWorktreeDiffType,
 	resolveBaseBranch,
 	validateFilePath,
-} from "../generated/review-core.js";
+} from "../generated/review-core.ts";
 import {
 	getGitButlerContextRevision,
 	getGitButlerPatchFingerprint,
-} from "../generated/gitbutler-core.js";
+} from "../generated/gitbutler-core.ts";
 import {
 	getCommitDiffInfo,
 	listCommitHistory,
 	type CommitDiffInfo,
-} from "../generated/commit-history.js";
+} from "../generated/commit-history.ts";
 import {
 	checkoutPRHead,
 	getPRDiffScopeOptions,
@@ -69,15 +69,15 @@ import {
 	runPRFullStackDiff,
 	runPRLayerLocalDiff,
 	type PRDiffScope,
-} from "../generated/pr-stack.js";
+} from "../generated/pr-stack.ts";
 
-import { resolvePoolCwd, type WorktreePool } from "../generated/worktree-pool.js";
-import { createCommitAvatarResolver } from "../generated/commit-avatars.js";
+import { resolvePoolCwd, type WorktreePool } from "../generated/worktree-pool.ts";
+import { createCommitAvatarResolver } from "../generated/commit-avatars.ts";
 
-import { createEditorAnnotationHandler } from "./annotations.js";
-import { createAgentJobHandler, whichCmd as commandExists } from "./agent-jobs.js";
-import { type AgentJobInfo, REVIEW_OUTPUT_FAILED, getAgentJobAnnotationContext, markJobReviewFailed } from "../generated/agent-jobs.js";
-import { createExternalAnnotationHandler } from "./external-annotations.js";
+import { createEditorAnnotationHandler } from "./annotations.ts";
+import { createAgentJobHandler, whichCmd as commandExists } from "./agent-jobs.ts";
+import { type AgentJobInfo, REVIEW_OUTPUT_FAILED, getAgentJobAnnotationContext, markJobReviewFailed } from "../generated/agent-jobs.ts";
+import { createExternalAnnotationHandler } from "./external-annotations.ts";
 import {
 	handleDraftRequest,
 	handleFavicon,
@@ -85,13 +85,13 @@ import {
 	readDraftGenerationFromBody,
 	readDraftGenerationFromUrl,
 	handleUploadRequest,
-} from "./handlers.js";
-import { handleApiNotFound, html, json, parseBody, requestUrl, send } from "./helpers.js";
-import { createPiAIRuntime, handlePiAIRequest } from "./ai-runtime.js";
+} from "./handlers.ts";
+import { handleApiNotFound, html, json, parseBody, requestUrl, send } from "./helpers.ts";
+import { createPiAIRuntime, handlePiAIRequest } from "./ai-runtime.ts";
 
-import { isRemoteSession, listenOnPort } from "./network.js";
-import { getAvailableOpenInApps, openFileInApp } from "./open-in-apps.js";
-import { resolveOpenInTarget } from "../generated/html-assets-node.js";
+import { isRemoteSession, listenOnPort } from "./network.ts";
+import { getAvailableOpenInApps, openFileInApp } from "./open-in-apps.ts";
+import { resolveOpenInTarget } from "../generated/html-assets-node.ts";
 import {
 	fetchPR,
 	fetchPRContext,
@@ -104,24 +104,24 @@ import {
 	parsePRUrl,
 	prCommandRuntime,
 	submitPRReview,
-} from "./pr.js";
-import { getRepoInfo } from "./project.js";
+} from "./pr.ts";
+import { getRepoInfo } from "./project.ts";
 import {
 	composeCodexReviewPrompt,
 	buildCodexCommand,
 	generateOutputPath,
 	parseCodexOutput,
 	transformReviewFindings,
-} from "../generated/codex-review.js";
-import { buildAgentReviewUserMessage, buildAgentReviewUserMessageForTarget, type WorkspaceReviewPromptContext } from "../generated/agent-review-message.js";
+} from "../generated/codex-review.ts";
+import { buildAgentReviewUserMessage, buildAgentReviewUserMessageForTarget, type WorkspaceReviewPromptContext } from "../generated/agent-review-message.ts";
 import {
 	composeClaudeReviewPrompt,
 	buildClaudeCommand,
 	parseClaudeStreamOutput,
 	transformClaudeFindings,
-} from "../generated/claude-review.js";
-import { createTourSession, TOUR_EMPTY_OUTPUT_ERROR } from "../generated/tour-review.js";
-import { createGuideSession, GUIDE_EMPTY_OUTPUT_ERROR } from "../generated/guide-review.js";
+} from "../generated/claude-review.ts";
+import { createTourSession, TOUR_EMPTY_OUTPUT_ERROR } from "../generated/tour-review.ts";
+import { createGuideSession, GUIDE_EMPTY_OUTPUT_ERROR } from "../generated/guide-review.ts";
 import {
 	MARKER_ENGINES,
 	composeMarkerReviewPrompt,
@@ -132,18 +132,18 @@ import {
 	makeMarkerNonce,
 	extractMarkerNonce,
 	type MarkerEngineId,
-} from "../generated/marker-review.js";
+} from "../generated/marker-review.ts";
 import {
 	WorkspaceReviewSession,
 	type WorkspaceDiffType,
-} from "../generated/review-workspace.js";
+} from "../generated/review-workspace.ts";
 import {
 	type CodeNavRequest,
 	type CodeNavRuntime,
 	resolveCodeNav,
 	validateCodeNavRequest,
 	extractChangedFiles,
-} from "../generated/code-nav.js";
+} from "../generated/code-nav.ts";
 import {
 	createDefaultSemanticDiffRuntime,
 	getSemanticDiffAvailability,
@@ -152,13 +152,13 @@ import {
 	semanticDiffCacheKey,
 	semanticDiffFileExtsFromSearchParams,
 	SemanticDiffResponseCache,
-} from "../generated/semantic-diff.js";
-import type { SemanticDiffAvailability, SemanticDiffResponse } from "../generated/semantic-diff-types.js";
-import { discoverCuratedSkills, resolveRequestedReviewProfile, listAllSkills, enableReviewSkill } from "../generated/review-skill-loader.js";
+} from "../generated/semantic-diff.ts";
+import type { SemanticDiffAvailability, SemanticDiffResponse } from "../generated/semantic-diff-types.ts";
+import { discoverCuratedSkills, resolveRequestedReviewProfile, listAllSkills, enableReviewSkill } from "../generated/review-skill-loader.ts";
 import {
 	BUILTIN_DEFAULT_PROFILE,
 	type ReviewProfilesResponse,
-} from "../generated/review-profiles.js";
+} from "../generated/review-profiles.ts";
 import {
 	canStageFiles,
 	detectRemoteDefaultCompareTarget,
@@ -171,7 +171,7 @@ import {
 	stageFile,
 	unstageFile,
 	vcsOwnsDiffType,
-} from "./vcs.js";
+} from "./vcs.ts";
 
 const piCodeNavRuntime: CodeNavRuntime = {
 	runCommand(command, args, options) {
@@ -298,7 +298,7 @@ export async function startReviewServer(options: {
 		? getPRDiffScopeOptions(prMeta, !!(options.worktreePool || options.agentCwd))
 		: [];
 
-	let prListCache: import("../generated/pr-types.js").PRListItem[] | null = null;
+	let prListCache: import("../generated/pr-types.ts").PRListItem[] | null = null;
 	let prListCacheTime = 0;
 	// Platform APIs withhold per-file patches on very large PRs. When the layer
 	// patch is incomplete, a local recompute (exact merge-base diff, no size
@@ -318,7 +318,7 @@ export async function startReviewServer(options: {
 			patchIncomplete: layerPatchIncomplete,
 		});
 	}
-	const prStackTreeCache = new Map<string, import("../generated/pr-types.js").PRStackTree | null>();
+	const prStackTreeCache = new Map<string, import("../generated/pr-types.ts").PRStackTree | null>();
 	const prContextLive = createPRContextLiveCache({ fetchContext: fetchPRContext });
 	const warmPRContext = (url: string, ref: PRRef): void => {
 		prContextLive.warm(url, ref);
@@ -326,7 +326,7 @@ export async function startReviewServer(options: {
 
 	// Fetch full stack tree (best-effort — always try in PR mode so root PRs
 	// that target the default branch can still discover descendant PRs)
-	let prStackTree: import("../generated/pr-types.js").PRStackTree | null = null;
+	let prStackTree: import("../generated/pr-types.ts").PRStackTree | null = null;
 	if (prRef && prMeta) {
 		warmPRContext(prMeta.url, prRef);
 		try {

--- a/apps/pi-extension/server/vcs.ts
+++ b/apps/pi-extension/server/vcs.ts
@@ -12,13 +12,13 @@ import {
 	getGitContext as getGitContextCore,
 	prepareGitCommand,
 	runGitDiff as runGitDiffCore,
-} from "../generated/review-core.js";
+} from "../generated/review-core.ts";
 import {
 	type ReviewJjRuntime,
-} from "../generated/jj-core.js";
+} from "../generated/jj-core.ts";
 import {
 	type ReviewGitButlerRuntime,
-} from "../generated/gitbutler-core.js";
+} from "../generated/gitbutler-core.ts";
 import {
 	type VcsSelection,
 	createGitButlerProvider,
@@ -26,7 +26,7 @@ import {
 	createJjProvider,
 	createVcsApi,
 	resolveInitialDiffType,
-} from "../generated/vcs-core.js";
+} from "../generated/vcs-core.ts";
 
 function runCommand(
 	command: string,

--- a/apps/pi-extension/startup.test.ts
+++ b/apps/pi-extension/startup.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { loadPlannotatorBrowser } from "./plannotator-browser-runtime";
+import { loadPlannotatorBrowser } from "./plannotator-browser-runtime.ts";
 
 const extensionDirectory = dirname(fileURLToPath(import.meta.url));
 
@@ -19,14 +19,14 @@ describe("Pi extension startup boundary", () => {
 	test("keeps invocation-only modules out of the eager index graph", () => {
 		const imports = scanImports("index.ts");
 		const invocationOnlyModules = [
-			"./generated/annotate-args.js",
-			"./generated/at-reference.js",
-			"./generated/html-to-markdown.js",
-			"./generated/prompts.js",
-			"./generated/reference-common.js",
-			"./generated/resolve-file.js",
-			"./generated/review-args.js",
-			"./generated/url-to-markdown.js",
+			"./generated/annotate-args.ts",
+			"./generated/at-reference.ts",
+			"./generated/html-to-markdown.ts",
+			"./generated/prompts.ts",
+			"./generated/reference-common.ts",
+			"./generated/resolve-file.ts",
+			"./generated/review-args.ts",
+			"./generated/url-to-markdown.ts",
 		];
 
 		for (const modulePath of invocationOnlyModules) {
@@ -39,10 +39,10 @@ describe("Pi extension startup boundary", () => {
 		const eventImports = scanImports("plannotator-events.ts");
 		const runtimeImports = scanImports("plannotator-browser-runtime.ts");
 
-		expect(eventImports.eager).not.toContain("./plannotator-browser.js");
-		expect(eventImports.eager).toContain("./plannotator-browser-runtime.js");
-		expect(runtimeImports.eager).not.toContain("./plannotator-browser.js");
-		expect(runtimeImports.dynamic).toContain("./plannotator-browser.js");
+		expect(eventImports.eager).not.toContain("./plannotator-browser.ts");
+		expect(eventImports.eager).toContain("./plannotator-browser-runtime.ts");
+		expect(runtimeImports.eager).not.toContain("./plannotator-browser.ts");
+		expect(runtimeImports.dynamic).toContain("./plannotator-browser.ts");
 	});
 
 	test("coalesces concurrent first-use browser imports", async () => {

--- a/apps/pi-extension/tool-scope.test.ts
+++ b/apps/pi-extension/tool-scope.test.ts
@@ -4,7 +4,7 @@ import {
 	isPlanWritePathAllowed,
 	PLAN_SUBMIT_TOOL,
 	stripPlanningOnlyTools,
-} from "./tool-scope";
+} from "./tool-scope.ts";
 
 describe("pi plan tool scoping", () => {
 	test("planning phase adds the submit tool and discovery helpers", () => {

--- a/apps/pi-extension/vendor.sh
+++ b/apps/pi-extension/vendor.sh
@@ -18,7 +18,7 @@ done
 for f in config storage workspace-status; do
   src="../../packages/shared/$f.ts"
   printf '// @generated — DO NOT EDIT. Source: packages/shared/%s.ts\n' "$f" | cat - "$src" \
-    | sed "s|from ['\"]@plannotator/core/\\([^'\"]*\\)-types['\"]|from './\\1-types.js'|g" \
+    | sed "s|from ['\"]@plannotator/core/\\([^'\"]*\\)-types['\"]|from './\\1-types.ts'|g" \
     > "generated/$f.ts"
 done
 
@@ -38,14 +38,14 @@ done
 for f in agent-review-message codex-review claude-review review-findings marker-review path-utils review-skill-loader; do
   src="../../packages/server/$f.ts"
   printf '// @generated — DO NOT EDIT. Source: packages/server/%s.ts\n' "$f" | cat - "$src" \
-    | sed 's|from "./vcs"|from "./review-core.js"|' \
-    | sed 's|from "./pr"|from "./pr-provider.js"|' \
-    | sed 's|from "./path-utils"|from "./path-utils.js"|' \
-    | sed 's|from "./review-skill-loader"|from "./review-skill-loader.js"|' \
-    | sed 's|from "@plannotator/shared/review-workspace"|from "./review-workspace.js"|' \
-    | sed 's|from "@plannotator/shared/review-profiles"|from "./review-profiles.js"|' \
-    | sed 's|from "@plannotator/shared/external-annotation"|from "./external-annotation.js"|' \
-    | sed 's|from "@plannotator/shared/data-dir"|from "./data-dir"|' \
+    | sed 's|from "./vcs"|from "./review-core.ts"|' \
+    | sed 's|from "./pr"|from "./pr-provider.ts"|' \
+    | sed 's|from "./path-utils"|from "./path-utils.ts"|' \
+    | sed 's|from "./review-skill-loader"|from "./review-skill-loader.ts"|' \
+    | sed 's|from "@plannotator/shared/review-workspace"|from "./review-workspace.ts"|' \
+    | sed 's|from "@plannotator/shared/review-profiles"|from "./review-profiles.ts"|' \
+    | sed 's|from "@plannotator/shared/external-annotation"|from "./external-annotation.ts"|' \
+    | sed 's|from "@plannotator/shared/data-dir"|from "./data-dir.ts"|' \
     > "generated/$f.ts"
 done
 
@@ -54,11 +54,11 @@ done
 for f in tour-review; do
   src="../../packages/server/tour/$f.ts"
   printf '// @generated — DO NOT EDIT. Source: packages/server/tour/%s.ts\n' "$f" | cat - "$src" \
-    | sed 's|from "\.\./vcs"|from "./review-core.js"|' \
-    | sed 's|from "\.\./pr"|from "./pr-provider.js"|' \
-    | sed 's|from "\.\./agent-review-message"|from "./agent-review-message.js"|' \
-    | sed 's|from "@plannotator/shared/tour"|from "./tour.js"|' \
-    | sed 's|from "@plannotator/shared/data-dir"|from "./data-dir"|' \
+    | sed 's|from "\.\./vcs"|from "./review-core.ts"|' \
+    | sed 's|from "\.\./pr"|from "./pr-provider.ts"|' \
+    | sed 's|from "\.\./agent-review-message"|from "./agent-review-message.ts"|' \
+    | sed 's|from "@plannotator/shared/tour"|from "./tour.ts"|' \
+    | sed 's|from "@plannotator/shared/data-dir"|from "./data-dir.ts"|' \
     > "generated/$f.ts"
 done
 
@@ -69,13 +69,13 @@ done
 for f in guide-review; do
   src="../../packages/server/guide/$f.ts"
   printf '// @generated — DO NOT EDIT. Source: packages/server/guide/%s.ts\n' "$f" | cat - "$src" \
-    | sed 's|from "\.\./vcs"|from "./review-core.js"|' \
-    | sed 's|from "\.\./pr"|from "./pr-provider.js"|' \
-    | sed 's|from "\.\./agent-review-message"|from "./agent-review-message.js"|' \
-    | sed 's|from "\.\./marker-review"|from "./marker-review.js"|' \
-    | sed 's|from "\.\./config"|from "./config.js"|' \
-    | sed 's|from "@plannotator/shared/guide"|from "./guide.js"|' \
-    | sed 's|from "@plannotator/shared/data-dir"|from "./data-dir"|' \
+    | sed 's|from "\.\./vcs"|from "./review-core.ts"|' \
+    | sed 's|from "\.\./pr"|from "./pr-provider.ts"|' \
+    | sed 's|from "\.\./agent-review-message"|from "./agent-review-message.ts"|' \
+    | sed 's|from "\.\./marker-review"|from "./marker-review.ts"|' \
+    | sed 's|from "\.\./config"|from "./config.ts"|' \
+    | sed 's|from "@plannotator/shared/guide"|from "./guide.ts"|' \
+    | sed 's|from "@plannotator/shared/data-dir"|from "./data-dir.ts"|' \
     > "generated/$f.ts"
 done
 
@@ -86,11 +86,33 @@ printf '// @generated — DO NOT EDIT. Source: packages/core/ai-context.ts\n' \
 for f in index types provider session-manager endpoints context base-session; do
   src="../../packages/ai/$f.ts"
   printf '// @generated — DO NOT EDIT. Source: packages/ai/%s.ts\n' "$f" | cat - "$src" \
-    | sed "s|from ['\"]@plannotator/core/ai-context['\"]|from './ai-context.js'|g" \
+    | sed "s|from ['\"]@plannotator/core/ai-context['\"]|from './ai-context.ts'|g" \
     > "generated/ai/$f.ts"
 done
 
 for f in claude-agent-sdk codex-app-server opencode-sdk command-path pi-sdk pi-sdk-node pi-events; do
   src="../../packages/ai/providers/$f.ts"
   printf '// @generated — DO NOT EDIT. Source: packages/ai/providers/%s.ts\n' "$f" | cat - "$src" > "generated/ai/providers/$f.ts"
+done
+
+# ---------------------------------------------------------------------------
+# Normalize vendored specifiers to the dialect this package actually runs in.
+#
+# The Pi extension is distributed and executed as raw TypeScript through jiti
+# (and Bun in tests). A relative "./x.js" specifier names a file that never
+# exists here, so jiti reaches it only through a slow last-resort fallback
+# (~2ms per import, ~30ms across the eager graph); extensionless imports still
+# require probing. Exact ".ts" paths avoid both and satisfy native Node's
+# TypeScript resolver, which remaps neither form. Bare specifiers (node:*, npm
+# packages) are untouched. This also covers verbatim-copied files whose sources
+# use either house style, and any future rule in either style.
+find generated -name '*.ts' | while read -r f; do
+  sed -E \
+    -e "s|(from[[:space:]]+['\"])(\.\.?/[^'\"]+)\.js(['\"])|\1\2.ts\3|g" \
+    -e "s|(import[[:space:]]*\(['\"])(\.\.?/[^'\"]+)\.js(['\"])|\1\2.ts\3|g" \
+    -e "s|(import[[:space:]]+['\"])(\.\.?/[^'\"]+)\.js(['\"])|\1\2.ts\3|g" \
+    -e "s|(from[[:space:]]+['\"])(\.\.?/([^'\"/]+/)*[^'\"/.]+)(['\"])|\1\2.ts\4|g" \
+    -e "s|(import[[:space:]]*\(['\"])(\.\.?/([^'\"/]+/)*[^'\"/.]+)(['\"])|\1\2.ts\4|g" \
+    -e "s|(import[[:space:]]+['\"])(\.\.?/([^'\"/]+/)*[^'\"/.]+)(['\"])|\1\2.ts\4|g" \
+    "$f" > "$f.tmp" && mv "$f.tmp" "$f"
 done


### PR DESCRIPTION
## Problem

The Pi extension is distributed and executed as **raw TypeScript** (`pi.extensions` → `index.ts`, `noEmit`) — but its relative import specifiers mix phantom `.js` paths with extensionless paths. The former name files that never exist in this package; both require jiti to probe instead of resolving the exact file.

Pi's loader (jiti) supports the `.js`→`.ts` remap, but only as its **last-resort fallback** — after two full ESM resolution cascades and three constructed `ERR_MODULE_NOT_FOUND`s per import:

| jiti 2.7 `esmResolve`, same file | per resolution |
|---|---:|
| `"./config.js"` (phantom) | **~1,809 µs** |
| `"./config.ts"` (real file) | **~20 µs** |

Multiplied across the eager import graph it cost me around that's **~26 ms of every Pi session start**.

This never shows up in development because Bun does the same remap natively at no cost. `startup.test.ts` guards the eager-graph shape, but under the one runtime that doesn't exhibit the cost.

## Measured result

Extension module import (`PI_TIMING=1`, n=12 interleaved runs, same machine):

| | median |
|---|---:|
| `main` (`.js` + extensionless) | 43.5 ms |
| this branch (exact `.ts`) | **15 ms** |

## What changed

1. **Hand-written sources**: mechanical rewrite of relative `.js` and extensionless specifiers to exact `.ts` paths. The tsconfig already fully permits this (`moduleResolution: "bundler"`, `noEmit`, `allowImportingTsExtensions`) — zero config changes.
2. **`vendor.sh`**: rewrite rules now emit `.ts`, plus a final normalization pass over `generated/` for both `.js` and extensionless source styles — the monorepo conventions are untouched. It covers import/re-export, dynamic import, and side-effect import forms while leaving bare and explicit non-TypeScript specifiers alone.
3. **`import-specifiers.test.ts`**: guards the invariant so future contributions in either style stay correct.

## Validation

- `bun test` — 73/73 (`apps/pi-extension`), 456/456 (`packages/server`, which imports these files)
- all seven TypeScript project checks pass
- packed npm artifact audit: 87 generated TypeScript files; all 327 relative specifier occurrences exact; all `.ts` targets exist
- Scope check: `generated/` and the pi-extension sources are consumed **only** by this package's runtimes (jiti/Bun); the hook, OpenCode, VS Code, and web builds import `packages/*` directly and see no changed bytes
