### PR TITLE
fix(annotate): stop wrapping Copy feedback with plan-deny message

### DIFF
--- a/packages/core/feedback-templates.ts
+++ b/packages/core/feedback-templates.ts
@@ -8,8 +8,9 @@
  * bundled into the browser SPA. It must NOT import from ./prompts or ./config
  * (which depend on node:fs, node:os, node:child_process). Keep it self-contained.
  *
- * Server-side call sites use getPlanDeniedPrompt() from ./prompts directly.
- * This module is only kept for the browser's wrapFeedbackForAgent clipboard feature.
+ * Server-side call sites use getPlanDeniedPrompt() / getAnnotate*Prompt() from
+ * ./prompts directly. This module is kept for the browser's wrapFeedbackForAgent
+ * clipboard feature (plan deny + annotate file/message defaults).
  */
 
 export interface PlanDenyFeedbackOptions {

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect, useLayoutEffect, useMemo, useRef, useCallba
 import { toast, Toaster } from 'sonner';
 import { type Origin, getAgentName } from '@plannotator/shared/agents';
 import { shouldStripFrontmatter } from '@plannotator/shared/annotatable';
-import { annotateFileFeedback, annotateMessageFeedback } from '@plannotator/shared/feedback-templates';
 import { parseMarkdownToBlocks, exportAnnotations, exportLinkedDocAnnotations, exportEditorAnnotations, exportCodeFileAnnotations, exportMessageAnnotations, extractFrontmatter, wrapFeedbackForAgent, Frontmatter, type LinkedDocAnnotationEntry, type MessageAnnotationEntry } from '@plannotator/ui/utils/parser';
 import { Viewer, ViewerHandle } from '@plannotator/ui/components/Viewer';
 import { HtmlViewer } from '@plannotator/ui/components/html-viewer';
@@ -2579,13 +2578,21 @@ const App: React.FC = () => {
     sourceFilePath,
   ]);
 
+  /** Mode-aware agent framing for Send (agent terminal) and Copy clipboard. */
   const buildAnnotateAgentFeedback = useCallback((feedback: string) => {
-    if (annotateSource === 'message') {
-      return annotateMessageFeedback(feedback);
-    }
-
-    return annotateFileFeedback(feedback, getAnnotateFeedbackTarget());
+    const target = getAnnotateFeedbackTarget();
+    return wrapFeedbackForAgent(feedback, {
+      mode: 'annotate',
+      annotateSource,
+      filePath: target.filePath,
+      fileHeader: target.fileHeader,
+    });
   }, [annotateSource, getAnnotateFeedbackTarget]);
+
+  const formatAnnotationsForAgent = useCallback((feedback: string) => {
+    if (annotateMode) return buildAnnotateAgentFeedback(feedback);
+    return wrapFeedbackForAgent(feedback);
+  }, [annotateMode, buildAnnotateAgentFeedback]);
 
   const currentFeedbackPayload = useMemo(() => getCurrentFeedbackPayload(), [
     agentFeedbackRevision,
@@ -4470,7 +4477,7 @@ const App: React.FC = () => {
             onClose={() => setIsPanelOpen(false)}
             onQuickCopy={async () => {
               const output = getCurrentFeedbackPayload();
-              await navigator.clipboard.writeText(wrapFeedbackForAgent(output));
+              await navigator.clipboard.writeText(formatAnnotationsForAgent(output));
             }}
             onShare={canShareCurrentSession ? () => { setIsPanelOpen(false); setInitialExportTab('share'); setShowExport(true); } : undefined}
             otherFileAnnotations={otherFileAnnotations}
@@ -4572,6 +4579,7 @@ const App: React.FC = () => {
           markdown={markdown}
           isApiMode={isApiMode}
           initialTab={initialExportTab}
+          formatAnnotationsForAgent={formatAnnotationsForAgent}
         />
 
         {/* Import Modal */}

--- a/packages/ui/components/ExportModal.tsx
+++ b/packages/ui/components/ExportModal.tsx
@@ -55,6 +55,12 @@ interface ExportModalProps {
   markdown?: string;
   isApiMode?: boolean;
   initialTab?: Tab;
+  /**
+   * Wrap annotation output for agent clipboard paste.
+   * Defaults to plan-deny framing; annotate sessions should pass a mode-aware
+   * wrapper so Copy matches Send Feedback / agent-terminal delivery (#1107).
+   */
+  formatAnnotationsForAgent?: (feedback: string) => string;
   /** Override the save-to-notes wire. Default: POST /api/save-notes (today's behavior). */
   onSaveToNotes?: (payload: SaveToNotesPayload) => Promise<SaveToNotesResult>;
 }
@@ -80,6 +86,7 @@ export const ExportModal: React.FC<ExportModalProps> = ({
   markdown,
   isApiMode = false,
   initialTab,
+  formatAnnotationsForAgent = wrapFeedbackForAgent,
   onSaveToNotes = defaultSaveToNotes,
 }) => {
   const defaultTab = initialTab || (sharingEnabled ? 'share' : 'annotations');
@@ -125,7 +132,7 @@ export const ExportModal: React.FC<ExportModalProps> = ({
   };
 
   const handleCopyAnnotations = async () => {
-    await handleCopy(wrapFeedbackForAgent(annotationsOutput), 'annotations');
+    await handleCopy(formatAnnotationsForAgent(annotationsOutput), 'annotations');
   };
 
   // Whether the hash URL is large enough to warrant a short URL option

--- a/packages/ui/utils/parser.test.ts
+++ b/packages/ui/utils/parser.test.ts
@@ -1,5 +1,11 @@
 import { describe, test, expect } from "bun:test";
-import { parseMarkdownToBlocks, computeListIndices, extractFrontmatter, exportAnnotations } from "./parser";
+import {
+  parseMarkdownToBlocks,
+  computeListIndices,
+  extractFrontmatter,
+  exportAnnotations,
+  wrapFeedbackForAgent,
+} from "./parser";
 import { shouldStripFrontmatter } from "@plannotator/core/annotatable";
 import type { Block } from "../types";
 
@@ -1109,6 +1115,60 @@ describe("exportAnnotations — line labels", () => {
     const anns = [{ blockId: math.id, type: "COMMENT", text: "clarify", originalText: "x + y", startOffset: 0 }];
     const output = exportAnnotations(mathBlocks, anns);
     expect(output).toContain("(lines 3–5)");
+  });
+});
+
+describe("wrapFeedbackForAgent — mode-aware clipboard framing (#1107)", () => {
+  const feedback = "## 1. Fix intro\n> Too vague.";
+
+  test("defaults to plan-deny framing for plan review", () => {
+    const result = wrapFeedbackForAgent(feedback);
+    expect(result).toContain("YOUR PLAN WAS NOT APPROVED.");
+    expect(result).toContain(feedback);
+  });
+
+  test("explicit plan mode still uses plan-deny framing", () => {
+    const result = wrapFeedbackForAgent(feedback, { mode: "plan" });
+    expect(result).toContain("YOUR PLAN WAS NOT APPROVED.");
+  });
+
+  test("annotate file mode uses markdown annotation framing", () => {
+    const result = wrapFeedbackForAgent(feedback, {
+      mode: "annotate",
+      annotateSource: "file",
+      filePath: "docs/guide.md",
+      fileHeader: "File",
+    });
+    expect(result).not.toContain("YOUR PLAN WAS NOT APPROVED.");
+    expect(result).toContain("# Markdown Annotations");
+    expect(result).toContain("File: docs/guide.md");
+    expect(result).toContain(feedback);
+  });
+
+  test("annotate folder mode labels the path as Folder", () => {
+    const result = wrapFeedbackForAgent(feedback, {
+      mode: "annotate-folder",
+      annotateSource: "folder",
+      filePath: "/repo/docs",
+    });
+    expect(result).not.toContain("YOUR PLAN WAS NOT APPROVED.");
+    expect(result).toContain("Folder: /repo/docs");
+  });
+
+  test("annotate message mode uses message framing", () => {
+    const result = wrapFeedbackForAgent(feedback, {
+      mode: "annotate",
+      annotateSource: "message",
+    });
+    expect(result).not.toContain("YOUR PLAN WAS NOT APPROVED.");
+    expect(result).toContain("# Message Annotations");
+    expect(result).toContain(feedback);
+  });
+
+  test("annotate-last mode maps to message framing", () => {
+    const result = wrapFeedbackForAgent(feedback, { mode: "annotate-last" });
+    expect(result).toContain("# Message Annotations");
+    expect(result).not.toContain("YOUR PLAN WAS NOT APPROVED.");
   });
 });
 

--- a/packages/ui/utils/parser.ts
+++ b/packages/ui/utils/parser.ts
@@ -1,5 +1,9 @@
 import type { Block, Annotation, CodeAnnotation, EditorAnnotation, ImageAttachment } from '../types';
-import { planDenyFeedback } from '@plannotator/core/feedback-templates';
+import {
+  annotateFileFeedback,
+  annotateMessageFeedback,
+  planDenyFeedback,
+} from '@plannotator/core/feedback-templates';
 
 /**
  * Parsed YAML frontmatter as key-value pairs.
@@ -646,9 +650,62 @@ export function groupBlocks(blocks: Block[]): RenderGroup[] {
   return groups;
 }
 
-/** Wrap feedback output with the deny preamble for pasting into agent sessions */
-export const wrapFeedbackForAgent = (feedback: string): string =>
-  planDenyFeedback(feedback);
+/**
+ * Options for wrapping annotation output before clipboard paste into an agent.
+ *
+ * Plan review keeps the plan-deny preamble. Annotate sessions must use the
+ * annotate wrappers — otherwise file/message feedback is mislabeled as a plan
+ * rejection (see #1107).
+ */
+export interface WrapFeedbackForAgentOptions {
+  /** Session kind. Defaults to plan-deny wrapping for backward compatibility. */
+  mode?: 'plan' | 'annotate' | 'annotate-last' | 'annotate-folder';
+  /** Annotate source subtype when mode is annotate*. */
+  annotateSource?: 'file' | 'folder' | 'message' | null;
+  filePath?: string;
+  fileHeader?: string;
+  /** Plan-deny tool name (ExitPlanMode, submit_plan, …). */
+  toolName?: string;
+  planFilePath?: string;
+}
+
+/**
+ * Wrap feedback for pasting into agent sessions.
+ *
+ * - Plan review → plan-deny preamble ("YOUR PLAN WAS NOT APPROVED.")
+ * - Annotate file/folder → markdown annotation preamble
+ * - Annotate message → message annotation preamble
+ */
+export const wrapFeedbackForAgent = (
+  feedback: string,
+  options: WrapFeedbackForAgentOptions = {},
+): string => {
+  const mode = options.mode;
+  const isAnnotate =
+    mode === 'annotate' ||
+    mode === 'annotate-last' ||
+    mode === 'annotate-folder' ||
+    options.annotateSource != null;
+
+  if (isAnnotate) {
+    if (options.annotateSource === 'message' || mode === 'annotate-last') {
+      return annotateMessageFeedback(feedback);
+    }
+    const fileHeader =
+      options.fileHeader ??
+      (options.annotateSource === 'folder' || mode === 'annotate-folder' ? 'Folder' : 'File');
+    return annotateFileFeedback(feedback, {
+      filePath: options.filePath ?? 'current file',
+      fileHeader,
+    });
+  }
+
+  return planDenyFeedback(
+    feedback,
+    options.toolName,
+    options.planFilePath ? { planFilePath: options.planFilePath } : undefined,
+  );
+};
 
 export interface ExportAnnotationsOptions {
   sourceConverted?: boolean;


### PR DESCRIPTION
## Summary

Fixes #1107.

In annotate sessions, **Copy** always wrapped annotation output with the plan-rejection preamble (`YOUR PLAN WAS NOT APPROVED.`), while **Send Feedback** used annotate-specific framing. This made clipboard paste unsuitable for file/message annotation workflows.

### Changes
- Make `wrapFeedbackForAgent()` mode-aware:
  - plan review → plan-deny framing (unchanged)
  - annotate file/folder → `# Markdown Annotations` framing
  - annotate message / `annotate-last` → `# Message Annotations` framing
- Wire Export modal Copy and annotation panel Quick Copy through a shared `formatAnnotationsForAgent` path so both match agent-terminal delivery.
- Add unit coverage for mode-aware wrapping.

## Test plan

- [x] `bun test packages/ui/utils/parser.test.ts packages/core/feedback-templates.test.ts`
- [ ] Annotate a Markdown file (`/plannotator-annotate path/to/file.md`), add annotations, **Copy** from export view — clipboard must **not** contain `YOUR PLAN WAS NOT APPROVED.`
- [ ] Same session: **Copy** should include `# Markdown Annotations` and the file path
- [ ] Plan review session: **Copy** still includes plan-deny framing
- [ ] Annotate-last / message annotate: **Copy** uses `# Message Annotations`
- [ ] Quick Copy from the annotation panel matches Export modal Copy