### PR TITLE
fix(annotate): use annotate feedback template for clipboard copy, not plan-deny

### DIFF
--- a/apps/pi-extension/server/serverAnnotate.ts
+++ b/apps/pi-extension/server/serverAnnotate.ts
@@ -6,7 +6,8 @@ import { randomUUID } from "node:crypto";
 import { contentHash, deleteDraft } from "../generated/draft.js";
 import { saveToHistory, getPlanVersion, getVersionCount, listVersions } from "../generated/storage.js";
 import { htmlDiff } from "../generated/html-diff.js";
-import { saveConfig, detectGitUser, getServerConfig, loadConfig, resolveSharingEnabled, resolveAnnotateHistory } from "../generated/config.js";
+import { saveConfig, detectGitUser, getServerConfig, loadConfig, resolveSharingEnabled, resolveAnnotateHistory, type PromptRuntime } from "../generated/config.js";
+import { getAnnotateFileFeedbackTemplate, getAnnotateMessageFeedbackTemplate } from "../generated/prompts.js";
 import { disabledSourceSave, type SourceSaveRequest } from "../generated/source-save.js";
 import { getAnnotateReferenceRootPaths } from "../generated/annotate-reference-roots-node.js";
 import {
@@ -435,6 +436,19 @@ export async function startAnnotateServer(options: {
 				serverConfig: getServerConfig(gitUser),
 				agentTerminal: agentTerminalCapability,
 				...(options.recentMessages ? { recentMessages: options.recentMessages } : {}),
+				// Resolved copy-wrapper templates (config-aware, placeholders
+				// intact) so clipboard Copy matches what Send Feedback produces
+				// instead of the plan-deny wrap (#1107). Resolved per request so
+				// config edits mid-session behave like Send Feedback (which
+				// resolves at submit time).
+				feedbackTemplates: {
+					fileFeedback: getAnnotateFileFeedbackTemplate(
+						(options.origin ?? "pi") as PromptRuntime,
+					),
+					messageFeedback: getAnnotateMessageFeedbackTemplate(
+						(options.origin ?? "pi") as PromptRuntime,
+					),
+				},
 			});
 		} else if (url.pathname === "/api/plan/version" && req.method === "GET") {
 			// fetch a specific version of the annotated file (version diff base picker)

--- a/packages/core/feedback-templates.test.ts
+++ b/packages/core/feedback-templates.test.ts
@@ -2,7 +2,9 @@ import { describe, test, expect } from "bun:test";
 import {
   annotateFileFeedback,
   annotateMessageFeedback,
+  applyFeedbackTemplate,
   planDenyFeedback,
+  wrapFeedbackForClipboard,
 } from "./feedback-templates";
 
 describe("feedback-templates", () => {
@@ -86,4 +88,81 @@ describe("feedback-templates", () => {
     expect(result).toContain("Please address the annotation feedback above.");
   });
 
+});
+
+describe("applyFeedbackTemplate", () => {
+  test("substitutes known placeholders", () => {
+    const result = applyFeedbackTemplate("Review {{filePath}}: {{feedback}}", {
+      filePath: "/repo/README.md",
+      feedback: "Fix the intro",
+    });
+    expect(result).toBe("Review /repo/README.md: Fix the intro");
+  });
+
+  test("leaves unknown placeholders untouched (resolveTemplate parity)", () => {
+    const result = applyFeedbackTemplate("{{feedback}} {{mystery}}", {
+      feedback: "hi",
+    });
+    expect(result).toBe("hi {{mystery}}");
+  });
+});
+
+/**
+ * Clipboard copy wrapping (#1107): the Copy buttons must never wrap annotate
+ * feedback with the plan-deny framing — that template falsely tells the agent
+ * its plan was rejected. Copy must match what Send Feedback produces.
+ */
+describe("wrapFeedbackForClipboard", () => {
+  test("plan-review mode keeps the plan-deny wrap (unchanged behavior)", () => {
+    const result = wrapFeedbackForClipboard("Fix auth", { mode: "plan-review" });
+    expect(result).toBe(planDenyFeedback("Fix auth"));
+    expect(result).toContain("YOUR PLAN WAS NOT APPROVED.");
+  });
+
+  test("annotate-file without a server template uses the default annotate wrap", () => {
+    const result = wrapFeedbackForClipboard("Fix the intro", {
+      mode: "annotate-file",
+      filePath: "/repo/README.md",
+      fileHeader: "File",
+    });
+    expect(result).toBe(
+      annotateFileFeedback("Fix the intro", { filePath: "/repo/README.md", fileHeader: "File" }),
+    );
+    expect(result).not.toContain("YOUR PLAN WAS NOT APPROVED.");
+  });
+
+  test("annotate-file applies the server-resolved template with substitution", () => {
+    const result = wrapFeedbackForClipboard("Fix the intro", {
+      mode: "annotate-file",
+      template: "{{fileHeader}} {{filePath}} notes:\n\n{{feedback}}\n\nAnswer questions directly.",
+      filePath: "/repo/README.md",
+      fileHeader: "File",
+    });
+    expect(result).toBe(
+      "File /repo/README.md notes:\n\nFix the intro\n\nAnswer questions directly.",
+    );
+  });
+
+  test("annotate-file defaults fileHeader to File when the template needs it", () => {
+    const result = wrapFeedbackForClipboard("Fix it", {
+      mode: "annotate-file",
+      template: "{{fileHeader}}: {{filePath}} — {{feedback}}",
+      filePath: "/repo/doc.md",
+    });
+    expect(result).toBe("File: /repo/doc.md — Fix it");
+  });
+
+  test("annotate-message without a server template uses the default message wrap", () => {
+    const result = wrapFeedbackForClipboard("Wrong conclusion", { mode: "annotate-message" });
+    expect(result).toBe(annotateMessageFeedback("Wrong conclusion"));
+    expect(result).not.toContain("YOUR PLAN WAS NOT APPROVED.");
+  });
+
+  test("annotate-message applies the server-resolved template with substitution", () => {
+    const result = wrapFeedbackForClipboard("Wrong conclusion", {
+      mode: "annotate-message",
+      template: "Message review:\n\n{{feedback}}",
+    });
+    expect(result).toBe("Message review:\n\nWrong conclusion");
+  });
 });

--- a/packages/core/feedback-templates.ts
+++ b/packages/core/feedback-templates.ts
@@ -9,7 +9,8 @@
  * (which depend on node:fs, node:os, node:child_process). Keep it self-contained.
  *
  * Server-side call sites use getPlanDeniedPrompt() from ./prompts directly.
- * This module is only kept for the browser's wrapFeedbackForAgent clipboard feature.
+ * This module is only kept for the browser's clipboard copy features
+ * (wrapFeedbackForAgent / wrapFeedbackForClipboard).
  */
 
 export interface PlanDenyFeedbackOptions {
@@ -43,3 +44,70 @@ export const annotateFileFeedback = (
 
 export const annotateMessageFeedback = (feedback: string): string =>
   `# Message Annotations\n\n${feedback}\n\nPlease address the annotation feedback above.`;
+
+/**
+ * Browser-safe `{{placeholder}}` substitution with the same semantics as
+ * resolveTemplate() in @plannotator/shared/prompts: unknown placeholders are
+ * left untouched. Used by the clipboard copy paths to apply a server-resolved
+ * feedback template without any node: imports.
+ */
+export const applyFeedbackTemplate = (
+  template: string,
+  vars: Record<string, string | undefined>,
+): string =>
+  template.replace(/\{\{(\w+)\}\}/g, (match, key) => {
+    const val = vars[key];
+    return val !== undefined ? val : match;
+  });
+
+/**
+ * Resolved (config-aware, unsubstituted) feedback templates shipped by the
+ * annotate server in the /api/plan payload. Absent outside annotate mode.
+ */
+export interface AnnotateFeedbackTemplates {
+  /** File/folder annotate wrap — placeholders: {{feedback}}, {{filePath}}, {{fileHeader}}. */
+  fileFeedback?: string;
+  /** Message annotate wrap (annotate-last) — placeholder: {{feedback}}. */
+  messageFeedback?: string;
+}
+
+export type ClipboardFeedbackContext =
+  | { mode: "plan-review" }
+  | { mode: "annotate-file"; template?: string; filePath: string; fileHeader?: string }
+  | { mode: "annotate-message"; template?: string };
+
+/**
+ * Mode-aware wrapper for the clipboard Copy paths (#1107).
+ *
+ * Plan review keeps the deliberately forceful plan-deny framing. Annotate
+ * sessions use the server-resolved template when the server shipped one
+ * (matching what Send Feedback produces, including user-customized
+ * prompts.annotate.* templates in ~/.plannotator/config.json), and fall back
+ * to the built-in annotate defaults when it did not (e.g. shared/static
+ * sessions never enter annotate mode and keep plan-deny behavior).
+ */
+export const wrapFeedbackForClipboard = (
+  feedback: string,
+  context: ClipboardFeedbackContext,
+): string => {
+  if (context.mode === "annotate-file") {
+    if (context.template) {
+      return applyFeedbackTemplate(context.template, {
+        feedback,
+        filePath: context.filePath,
+        fileHeader: context.fileHeader ?? "File",
+      });
+    }
+    return annotateFileFeedback(feedback, {
+      filePath: context.filePath,
+      fileHeader: context.fileHeader,
+    });
+  }
+  if (context.mode === "annotate-message") {
+    if (context.template) {
+      return applyFeedbackTemplate(context.template, { feedback });
+    }
+    return annotateMessageFeedback(feedback);
+  }
+  return planDenyFeedback(feedback);
+};

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useLayoutEffect, useMemo, useRef, useCallba
 import { toast, Toaster } from 'sonner';
 import { type Origin, getAgentName } from '@plannotator/shared/agents';
 import { shouldStripFrontmatter } from '@plannotator/shared/annotatable';
-import { annotateFileFeedback, annotateMessageFeedback } from '@plannotator/shared/feedback-templates';
+import { annotateFileFeedback, annotateMessageFeedback, wrapFeedbackForClipboard, type AnnotateFeedbackTemplates } from '@plannotator/shared/feedback-templates';
 import { parseMarkdownToBlocks, exportAnnotations, exportLinkedDocAnnotations, exportEditorAnnotations, exportCodeFileAnnotations, exportMessageAnnotations, extractFrontmatter, wrapFeedbackForAgent, Frontmatter, type LinkedDocAnnotationEntry, type MessageAnnotationEntry } from '@plannotator/ui/utils/parser';
 import { Viewer, ViewerHandle } from '@plannotator/ui/components/Viewer';
 import { HtmlViewer } from '@plannotator/ui/components/html-viewer';
@@ -391,6 +391,9 @@ const App: React.FC = () => {
     submitLabel: 'Submit',
   });
   const [sourceInfo, setSourceInfo] = useState<string | undefined>();
+  // Server-resolved annotate copy-wrapper templates (config-aware) so
+  // clipboard Copy matches Send Feedback instead of the plan-deny wrap (#1107).
+  const [feedbackTemplates, setFeedbackTemplates] = useState<AnnotateFeedbackTemplates | null>(null);
   const [sourceConverted, setSourceConverted] = useState(false);
   const [renderAs, setRenderAs] = useState<'markdown' | 'html'>('markdown');
   // HTML plans render edge-to-edge (full-viewport) instead of in the centered,
@@ -2251,7 +2254,7 @@ const App: React.FC = () => {
         if (!res.ok) throw new Error('Not in API mode');
         return res.json();
       })
-      .then((data: { plan: string; origin?: Origin; mode?: 'annotate' | 'annotate-last' | 'annotate-folder' | 'archive' | 'goal-setup'; goalSetup?: GoalSetupBundle; filePath?: string; sourceInfo?: string; sourceConverted?: boolean; sourceSave?: SourceSaveCapability; gate?: boolean; renderAs?: 'html' | 'markdown'; rawHtml?: string; shareHtml?: string; diffHtml?: string; convertHtml?: boolean; sharingEnabled?: boolean; shareBaseUrl?: string; pasteApiUrl?: string; repoInfo?: { display: string; branch?: string; host?: string }; previousPlan?: string | null; versionInfo?: { version: number; totalVersions: number; project: string }; archivePlans?: ArchivedPlan[]; projectRoot?: string; isWSL?: boolean; serverConfig?: { displayName?: string; gitUser?: string }; recentMessages?: PickerMessage[]; agentTerminal?: AgentTerminalCapability }) => {
+      .then((data: { plan: string; origin?: Origin; mode?: 'annotate' | 'annotate-last' | 'annotate-folder' | 'archive' | 'goal-setup'; goalSetup?: GoalSetupBundle; filePath?: string; sourceInfo?: string; sourceConverted?: boolean; sourceSave?: SourceSaveCapability; gate?: boolean; renderAs?: 'html' | 'markdown'; rawHtml?: string; shareHtml?: string; diffHtml?: string; convertHtml?: boolean; sharingEnabled?: boolean; shareBaseUrl?: string; pasteApiUrl?: string; repoInfo?: { display: string; branch?: string; host?: string }; previousPlan?: string | null; versionInfo?: { version: number; totalVersions: number; project: string }; archivePlans?: ArchivedPlan[]; projectRoot?: string; isWSL?: boolean; serverConfig?: { displayName?: string; gitUser?: string }; recentMessages?: PickerMessage[]; agentTerminal?: AgentTerminalCapability; feedbackTemplates?: AnnotateFeedbackTemplates }) => {
         // Initialize config store with server-provided values (config file > cookie > default)
         configStore.init(data.serverConfig);
         // Session-level force-markdown preference (--markdown); threaded into folder/linked
@@ -2314,6 +2317,7 @@ const App: React.FC = () => {
           setSelectedMessageId(null);
         }
         setSourceInfo(data.sourceInfo ?? undefined);
+        setFeedbackTemplates(data.feedbackTemplates ?? null);
         setSourceConverted(!!data.sourceConverted);
         if (data.filePath) {
           setImageBaseDir(data.mode === 'annotate-folder' ? data.filePath : data.filePath.replace(/\/[^/]+$/, ''));
@@ -2586,6 +2590,31 @@ const App: React.FC = () => {
 
     return annotateFileFeedback(feedback, getAnnotateFeedbackTarget());
   }, [annotateSource, getAnnotateFeedbackTarget]);
+
+  // Clipboard copy wrapper (#1107): plan review keeps the deliberately forceful
+  // plan-deny framing; annotate sessions wrap with the server-resolved template
+  // (the same one Send Feedback gets, including custom prompts.annotate.*
+  // config), falling back to the built-in annotate defaults when the server
+  // didn't ship one. Shared/static and archive sessions never set annotateMode
+  // and keep today's behavior.
+  const wrapCopiedFeedback = useCallback((feedback: string) => {
+    if (annotateMode) {
+      if (annotateSource === 'message') {
+        return wrapFeedbackForClipboard(feedback, {
+          mode: 'annotate-message',
+          template: feedbackTemplates?.messageFeedback,
+        });
+      }
+      const target = getAnnotateFeedbackTarget();
+      return wrapFeedbackForClipboard(feedback, {
+        mode: 'annotate-file',
+        template: feedbackTemplates?.fileFeedback,
+        filePath: target.filePath,
+        fileHeader: target.fileHeader,
+      });
+    }
+    return wrapFeedbackForAgent(feedback);
+  }, [annotateMode, annotateSource, feedbackTemplates, getAnnotateFeedbackTarget]);
 
   const currentFeedbackPayload = useMemo(() => getCurrentFeedbackPayload(), [
     agentFeedbackRevision,
@@ -4470,7 +4499,7 @@ const App: React.FC = () => {
             onClose={() => setIsPanelOpen(false)}
             onQuickCopy={async () => {
               const output = getCurrentFeedbackPayload();
-              await navigator.clipboard.writeText(wrapFeedbackForAgent(output));
+              await navigator.clipboard.writeText(wrapCopiedFeedback(output));
             }}
             onShare={canShareCurrentSession ? () => { setIsPanelOpen(false); setInitialExportTab('share'); setShowExport(true); } : undefined}
             otherFileAnnotations={otherFileAnnotations}
@@ -4572,6 +4601,7 @@ const App: React.FC = () => {
           markdown={markdown}
           isApiMode={isApiMode}
           initialTab={initialExportTab}
+          wrapCopiedAnnotations={wrapCopiedFeedback}
         />
 
         {/* Import Modal */}

--- a/packages/server/annotate.ts
+++ b/packages/server/annotate.ts
@@ -23,6 +23,7 @@ import { saveToHistory, getPlanVersion, getVersionCount, listVersions } from "@p
 import { htmlDiff } from "@plannotator/shared/html-diff";
 import { disabledSourceSave, type SourceSaveRequest } from "@plannotator/shared/source-save";
 import { getAnnotateReferenceRootPaths } from "@plannotator/shared/annotate-reference-roots-node";
+import { getAnnotateFileFeedbackTemplate, getAnnotateMessageFeedbackTemplate } from "@plannotator/shared/prompts";
 import {
 	createSourceSaveCapability,
 	createSourceSaveCapabilityFromText,
@@ -407,6 +408,15 @@ export async function startAnnotateServer(
               serverConfig: getServerConfig(gitUser),
               agentTerminal: agentTerminal.capability,
               ...(recentMessages ? { recentMessages } : {}),
+              // Resolved copy-wrapper templates (config-aware, placeholders
+              // intact) so clipboard Copy matches what Send Feedback produces
+              // instead of the plan-deny wrap (#1107). Resolved per request so
+              // config edits mid-session behave like Send Feedback (which
+              // resolves at submit time).
+              feedbackTemplates: {
+                fileFeedback: getAnnotateFileFeedbackTemplate(origin),
+                messageFeedback: getAnnotateMessageFeedbackTemplate(origin),
+              },
             });
           }
 

--- a/packages/shared/prompts.test.ts
+++ b/packages/shared/prompts.test.ts
@@ -17,7 +17,9 @@ import {
   getPlanApprovedWithNotesPrompt,
   getPlanAutoApprovedPrompt,
   getAnnotateFileFeedbackPrompt,
+  getAnnotateFileFeedbackTemplate,
   getAnnotateMessageFeedbackPrompt,
+  getAnnotateMessageFeedbackTemplate,
   getAnnotateApprovedPrompt,
   getReviewDeniedSuffix,
   resolveTemplate,
@@ -289,6 +291,50 @@ describe("getAnnotateMessageFeedbackPrompt", () => {
       prompts: { annotate: { messageFeedback: "Notes: {{feedback}}" } },
     }, { feedback: "fix" });
     expect(result).toBe("Notes: fix");
+  });
+});
+
+// Unsubstituted template getters — shipped to the browser via the annotate
+// /api/plan payload so clipboard Copy can reproduce the Send Feedback wrap
+// (including config overrides) client-side (#1107).
+describe("getAnnotateFileFeedbackTemplate / getAnnotateMessageFeedbackTemplate", () => {
+  test("returns the default templates with placeholders intact", () => {
+    expect(getAnnotateFileFeedbackTemplate("claude-code", {})).toBe(
+      DEFAULT_ANNOTATE_FILE_FEEDBACK_PROMPT,
+    );
+    expect(getAnnotateMessageFeedbackTemplate("claude-code", {})).toBe(
+      DEFAULT_ANNOTATE_MESSAGE_FEEDBACK_PROMPT,
+    );
+    expect(getAnnotateFileFeedbackTemplate("claude-code", {})).toContain("{{feedback}}");
+  });
+
+  test("returns configured overrides without variable substitution", () => {
+    const config = {
+      prompts: {
+        annotate: {
+          fileFeedback: "Review {{filePath}}: {{feedback}}",
+          messageFeedback: "Notes: {{feedback}}",
+        },
+      },
+    };
+    expect(getAnnotateFileFeedbackTemplate("opencode", config)).toBe(
+      "Review {{filePath}}: {{feedback}}",
+    );
+    expect(getAnnotateMessageFeedbackTemplate("opencode", config)).toBe(
+      "Notes: {{feedback}}",
+    );
+  });
+
+  test("runtime-specific override wins over generic", () => {
+    const result = getAnnotateFileFeedbackTemplate("pi", {
+      prompts: {
+        annotate: {
+          fileFeedback: "Generic: {{feedback}}",
+          runtimes: { pi: { fileFeedback: "Pi: {{feedback}}" } },
+        },
+      },
+    });
+    expect(result).toBe("Pi: {{feedback}}");
   });
 });
 

--- a/packages/shared/prompts.ts
+++ b/packages/shared/prompts.ts
@@ -201,19 +201,45 @@ export function getPlanAutoApprovedPrompt(
 
 // ─── Annotate wrappers ──────────────────────────────────────────────────────
 
-export function getAnnotateFileFeedbackPrompt(
+/**
+ * The resolved annotate file-feedback template WITHOUT variable substitution
+ * (placeholders like {{feedback}} intact). Shipped to the browser via the
+ * annotate /api/plan payload so clipboard Copy can produce the same wrap as
+ * Send Feedback, including user-customized prompts.annotate.fileFeedback.
+ */
+export function getAnnotateFileFeedbackTemplate(
   runtime?: PromptRuntime | null,
   config?: PlannotatorConfig,
-  vars?: FeedbackVars,
 ): string {
-  const template = getConfiguredPrompt({
+  return getConfiguredPrompt({
     section: "annotate",
     key: "fileFeedback",
     runtime,
     config,
     fallback: DEFAULT_ANNOTATE_FILE_FEEDBACK_PROMPT,
   });
-  return resolveTemplate(template, vars ?? {});
+}
+
+/** Message-annotate counterpart of getAnnotateFileFeedbackTemplate(). */
+export function getAnnotateMessageFeedbackTemplate(
+  runtime?: PromptRuntime | null,
+  config?: PlannotatorConfig,
+): string {
+  return getConfiguredPrompt({
+    section: "annotate",
+    key: "messageFeedback",
+    runtime,
+    config,
+    fallback: DEFAULT_ANNOTATE_MESSAGE_FEEDBACK_PROMPT,
+  });
+}
+
+export function getAnnotateFileFeedbackPrompt(
+  runtime?: PromptRuntime | null,
+  config?: PlannotatorConfig,
+  vars?: FeedbackVars,
+): string {
+  return resolveTemplate(getAnnotateFileFeedbackTemplate(runtime, config), vars ?? {});
 }
 
 export function getAnnotateMessageFeedbackPrompt(
@@ -221,14 +247,7 @@ export function getAnnotateMessageFeedbackPrompt(
   config?: PlannotatorConfig,
   vars?: FeedbackVars,
 ): string {
-  const template = getConfiguredPrompt({
-    section: "annotate",
-    key: "messageFeedback",
-    runtime,
-    config,
-    fallback: DEFAULT_ANNOTATE_MESSAGE_FEEDBACK_PROMPT,
-  });
-  return resolveTemplate(template, vars ?? {});
+  return resolveTemplate(getAnnotateMessageFeedbackTemplate(runtime, config), vars ?? {});
 }
 
 export function getAnnotateApprovedPrompt(

--- a/packages/ui/components/ExportModal.tsx
+++ b/packages/ui/components/ExportModal.tsx
@@ -57,6 +57,13 @@ interface ExportModalProps {
   initialTab?: Tab;
   /** Override the save-to-notes wire. Default: POST /api/save-notes (today's behavior). */
   onSaveToNotes?: (payload: SaveToNotesPayload) => Promise<SaveToNotesResult>;
+  /**
+   * Wrap the annotations output for the clipboard Copy button. Annotate
+   * sessions pass a mode-aware wrapper so Copy matches Send Feedback instead
+   * of the plan-deny framing (#1107). Default: plan-deny wrap (today's
+   * plan-review behavior).
+   */
+  wrapCopiedAnnotations?: (feedback: string) => string;
 }
 
 type Tab = 'share' | 'annotations' | 'notes';
@@ -81,6 +88,7 @@ export const ExportModal: React.FC<ExportModalProps> = ({
   isApiMode = false,
   initialTab,
   onSaveToNotes = defaultSaveToNotes,
+  wrapCopiedAnnotations = wrapFeedbackForAgent,
 }) => {
   const defaultTab = initialTab || (sharingEnabled ? 'share' : 'annotations');
   const [activeTab, setActiveTab] = useState<Tab>(defaultTab);
@@ -125,7 +133,7 @@ export const ExportModal: React.FC<ExportModalProps> = ({
   };
 
   const handleCopyAnnotations = async () => {
-    await handleCopy(wrapFeedbackForAgent(annotationsOutput), 'annotations');
+    await handleCopy(wrapCopiedAnnotations(annotationsOutput), 'annotations');
   };
 
   // Whether the hash URL is large enough to warrant a short URL option


### PR DESCRIPTION
## The bug

In annotate sessions, the clipboard Copy paths (the Export modal Copy button and the annotation panel quick copy) always wrapped the exported annotations with the plan-deny template. Copied text started with "YOUR PLAN WAS NOT APPROVED." even though the user was annotating a file, not reviewing a plan. That template is deliberately forceful directive framing (tuned in #224), so pasting the copied text into an agent falsely tells it a plan was rejected and pushes it into plan-revision behavior.

Meanwhile Send Feedback posts raw text and the server wraps it with the annotate template via getAnnotateFileFeedbackPrompt(), which also honors user-customized templates in ~/.plannotator/config.json (prompts.annotate.fileFeedback / messageFeedback). So Copy and Send Feedback produced different agent-facing payloads.

Root cause: wrapFeedbackForAgent() in packages/ui/utils/parser.ts unconditionally calls planDenyFeedback() with no mode awareness, and both copy call sites used it.

## The fix

Copy is now mode-aware and config-faithful:

1. Server ships the resolved template. Both annotate servers add a feedbackTemplates field to the /api/plan payload carrying the config-resolved fileFeedback and messageFeedback templates with placeholders intact ({{feedback}}, {{filePath}}, {{fileHeader}}). Resolution stays server-side (the browser cannot read config.json); new getters getAnnotateFileFeedbackTemplate / getAnnotateMessageFeedbackTemplate in packages/shared/prompts.ts back both the payload and the existing prompt functions, so Send Feedback output is byte-identical to before.
2. Client wraps mode-aware. New browser-safe wrapFeedbackForClipboard() and applyFeedbackTemplate() in packages/core/feedback-templates.ts (no node: imports). The plan editor routes both copy paths through a single wrapper with this fallback chain:
   - annotate file/folder session: server-provided fileFeedback template, substituted with the current target; falls back to the built-in annotateFileFeedback default if the server field is absent
   - annotate-last (message) session: server-provided messageFeedback template, falling back to annotateMessageFeedback
   - plan review: planDenyFeedback, unchanged
   - shared/portal static views and archive mode never enter annotate mode and keep current behavior
3. Both runtimes covered. The field is added in the Bun annotate server (packages/server/annotate.ts) and the Pi mirror (apps/pi-extension/server/serverAnnotate.ts). Pi consumes the new getters through its vendored generated modules; nothing in generated/ is hand-edited.
4. Send Feedback is untouched everywhere. Only what Copy produces changes.

ExportModal takes an optional wrapCopiedAnnotations prop whose default reproduces today's behavior, so the review editor and any other consumers are unchanged.

## Verification

- New unit tests in packages/core/feedback-templates.test.ts cover the wrap selection: plan mode keeps the deny template, annotate mode with a server template applies it with substitution, annotate mode without one uses the default annotate template, unknown placeholders are left intact, and the message variant mirrors all of that. packages/shared/prompts.test.ts covers the new template getters including config and runtime overrides.
- Full bun test: 2224 pass, 0 fail.
- bun run typecheck passes; bun run build:review and bun run build:hook both build cleanly (artifacts not committed, maintainer rebuilds at release).
- End-to-end: started both the Bun and Pi annotate servers against a sandboxed PLANNOTATOR_DATA_DIR and confirmed /api/plan ships the default templates, and the exact custom prompts.annotate.fileFeedback from config.json when configured.

Closes #1107
