### PR TITLE
Persist Guided Reviews across sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -364,6 +364,7 @@ During normal plan review, an Archive sidebar tab provides the same browsing via
 | `/api/pr-switch` | POST | Switch to a different PR in-place (body: `{ url }`). Response includes `semanticDiff?`. |
 | `/api/tour/:jobId` | GET | Fetch Code Tour result (greeting, stops, checklist) for a completed tour job |
 | `/api/tour/:jobId/checklist` | PUT | Persist checklist item state for a Code Tour |
+| `/api/guide/current` | GET | Find the durable Guided Review for the current PR/branch and report staleness |
 | `/api/guide/:jobId` | GET | Fetch Guided Review result (ordered sections with overviews + file refs) for a completed guide job |
 | `/api/guide/:jobId/reviewed` | PUT | Persist per-section reviewed state for a guide |
 | `/api/guide/:jobId/output` | GET | Fetch a failed guide job's captured raw output for manual repair (404 if none captured) |

--- a/apps/marketing/src/content/docs/commands/code-review.md
+++ b/apps/marketing/src/content/docs/commands/code-review.md
@@ -163,6 +163,8 @@ A Guided Review turns the changeset into an ordered, chaptered walkthrough: an a
 
 Open it with the **Guide** button in the review header (or `Mod+Shift+G`), pick an agent and model, and generate. Sections track a per-section "reviewed" state so you can work through a large change in order. Guides run on Claude or Codex natively, and on Cursor, OpenCode, Pi, or GitHub Copilot CLI when those binaries are installed.
 
+Successful guides and their reviewed state are saved under `PLANNOTATOR_DATA_DIR` and return when you reopen the same PR or local branch. A PR and its matching local head branch share the guide when Plannotator can identify the head repository and branch reliably. If the PR head or branch diff has changed, the previous guide remains available with an **Outdated guide** notice; choose **Regenerate guide** explicitly to replace it. A failed regeneration leaves the previous successful guide intact.
+
 ## How review agents prompt the CLI
 
 The review agents (Claude, Codex, Code Tour, Guided Review) shell out to external CLIs — Claude and Codex natively, plus Cursor, OpenCode, Pi, and GitHub Copilot CLI as additional engines for review and guide jobs. Plannotator controls the user message and output schema; the CLI's own harness owns the system prompt. See the [Prompts reference](/docs/reference/prompts/) for the full breakdown of what each provider sends, how the pieces join, and which knobs you can tune per job.
@@ -224,6 +226,7 @@ Runtime keys use Plannotator's runtime identifiers. For code review, the current
 | `/api/ai/permission` | POST | Respond to tool approval request |
 | `/api/agents/capabilities` | GET | Check available agent providers |
 | `/api/agents/jobs` | GET/POST/DELETE | Manage agent jobs (review, Code Tour, Guided Review) |
+| `/api/guide/current` | GET | Find the durable Guided Review for the currently open PR or branch and report whether it is outdated |
 | `/api/guide/:jobId` | GET | Fetch a completed Guided Review (sections, summaries, file refs) |
 | `/api/guide/:jobId/reviewed` | PUT | Persist per-section reviewed state |
 | `/api/code-nav/resolve` | POST | Find symbol definitions/references for code navigation |

--- a/apps/pi-extension/server/agent-jobs.ts
+++ b/apps/pi-extension/server/agent-jobs.ts
@@ -78,7 +78,7 @@ export interface AgentJobHandlerOptions {
 	getServerUrl: () => string;
 	getCwd: () => string;
 	/** Build the command server-side for a given provider. */
-	buildCommand?: (provider: string, config?: Record<string, unknown>) => Promise<{
+	buildCommand?: (provider: string, config: Record<string, unknown> | undefined, jobId: string) => Promise<{
 		command: string[];
 		outputPath?: string;
 		captureStdout?: boolean;
@@ -633,7 +633,7 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions) {
 						if (body.fastMode === true) config.fastMode = true;
 						if (typeof body.reviewProfileId === "string") config.reviewProfileId = body.reviewProfileId;
 						if (typeof body.repairOf === "string") config.repairOf = body.repairOf;
-						const built = await options.buildCommand(provider, Object.keys(config).length > 0 ? config : undefined);
+						const built = await options.buildCommand(provider, Object.keys(config).length > 0 ? config : undefined, jobId);
 						if (built) {
 							command = built.command;
 							outputPath = built.outputPath;

--- a/apps/pi-extension/server/serverReview.ts
+++ b/apps/pi-extension/server/serverReview.ts
@@ -123,6 +123,10 @@ import {
 import { createTourSession, TOUR_EMPTY_OUTPUT_ERROR } from "../generated/tour-review.ts";
 import { createGuideSession, GUIDE_EMPTY_OUTPUT_ERROR } from "../generated/guide-review.ts";
 import {
+	createPRGuidePersistenceContext,
+	resolveLocalGuidePersistenceContext,
+} from "../generated/guide-storage.ts";
+import {
 	MARKER_ENGINES,
 	composeMarkerReviewPrompt,
 	buildMarkerCommand,
@@ -715,6 +719,13 @@ export async function startReviewServer(options: {
 		if (!workspace) return undefined;
 		return workspace.getPromptContext();
 	}
+	async function getCurrentGuidePersistenceContext() {
+		const metadata = prMeta;
+		const patch = currentPatch;
+		if (metadata) return createPRGuidePersistenceContext(metadata, patch);
+		if (workspace || (sessionVcsType && sessionVcsType !== "git")) return null;
+		return resolveLocalGuidePersistenceContext(reviewRuntime, resolveAgentCwd(), patch);
+	}
 
 	// GitButler's picker topology can change while the visible patch stays
 	// byte-identical. Include its compact context revision in the snapshot id so
@@ -848,7 +859,7 @@ export async function startReviewServer(options: {
 		getServerUrl: () => serverUrl,
 		getCwd: resolveAgentCwd,
 
-		async buildCommand(provider, config) {
+		async buildCommand(provider, config, jobId) {
 			// Snapshot every mutable review selector before any await. A concurrent
 			// switch must not retarget the prompt, attribution, or line anchors.
 			const launchPrMeta = prMeta;
@@ -1035,6 +1046,14 @@ export async function startReviewServer(options: {
 					config: guideConfig,
 					...(repair && { repair }),
 				});
+				const persistenceContext = repairOf
+					? guide.getLaunchPersistence(repairOf)
+					: launchPrMeta
+						? createPRGuidePersistenceContext(launchPrMeta, launchPatch)
+						: workspacePrompt || (sessionVcsType && sessionVcsType !== "git")
+							? null
+							: await resolveLocalGuidePersistenceContext(reviewRuntime, cwd, launchPatch);
+				if (persistenceContext) guide.registerPersistence(jobId, persistenceContext);
 				// A repair job's payload is the FAILED job's previously-captured
 				// output, not this launch's diff — its file refs were validated
 				// (and, for onJobComplete, must be re-validated) against the failed
@@ -1354,6 +1373,13 @@ export async function startReviewServer(options: {
 			} catch {
 				json(res, { error: "Invalid JSON" }, 400);
 			}
+			return;
+		}
+
+		// API: Find the durable guide associated with the review target currently open.
+		if (url.pathname === "/api/guide/current" && req.method === "GET") {
+			const context = await getCurrentGuidePersistenceContext();
+			json(res, { guide: context ? guide.getCurrentGuide(context) : null });
 			return;
 		}
 

--- a/apps/pi-extension/vendor.sh
+++ b/apps/pi-extension/vendor.sh
@@ -62,11 +62,9 @@ for f in tour-review; do
     > "generated/$f.ts"
 done
 
-# guide-review lives in packages/server/guide/ — same parent-relative and
-# shared-package import rewrites as tour-review above, plus its own
-# marker-review import (guide's marker-engine support reuses marker-review.ts's
-# nonce/extraction primitives, same as review.ts does).
-for f in guide-review; do
+# Guided Review server modules live in packages/server/guide/ — same
+# parent-relative and shared-package import rewrites as tour-review above.
+for f in guide-review guide-storage; do
   src="../../packages/server/guide/$f.ts"
   printf '// @generated — DO NOT EDIT. Source: packages/server/guide/%s.ts\n' "$f" | cat - "$src" \
     | sed 's|from "\.\./vcs"|from "./review-core.ts"|' \
@@ -75,6 +73,9 @@ for f in guide-review; do
     | sed 's|from "\.\./marker-review"|from "./marker-review.ts"|' \
     | sed 's|from "\.\./config"|from "./config.ts"|' \
     | sed 's|from "@plannotator/shared/guide"|from "./guide.ts"|' \
+    | sed 's|from "@plannotator/shared/repo"|from "./repo.ts"|' \
+    | sed 's|from "@plannotator/shared/pr-types"|from "./pr-types.ts"|' \
+    | sed 's|from "@plannotator/shared/review-core"|from "./review-core.ts"|' \
     | sed 's|from "@plannotator/shared/data-dir"|from "./data-dir.ts"|' \
     > "generated/$f.ts"
 done

--- a/packages/review-editor/components/guide/GuideScreen.test.tsx
+++ b/packages/review-editor/components/guide/GuideScreen.test.tsx
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { AgentLaunchParams } from '@plannotator/ui/hooks/useAgentJobs';
+import { ReviewStateProvider, type ReviewState } from '../../dock/ReviewStateContext';
+
+mock.module('@pierre/diffs/worker/worker.js?worker&inline', () => ({ default: class {} }));
+mock.module('../../hooks/guide/useGuideData', () => ({
+  useCurrentGuide: () => ({
+    guide: {
+      id: 'persisted-guide',
+      outdated: true,
+      generatedAt: 1,
+      engine: 'pi',
+      launch: { engine: 'pi', model: 'openai/gpt-5', thinking: 'low' },
+    },
+    loading: false,
+  }),
+  useGuideData: () => ({
+    guide: {
+      title: 'Persisted guide',
+      intent: 'Review the durable artifact.',
+      sections: [{ title: 'Storage', overview: 'Persists state.', diffs: [] }],
+      reviewed: [true],
+    },
+    loading: false,
+    error: null,
+    reviewed: [true],
+    toggleReviewed: () => {},
+    retry: () => {},
+  }),
+}));
+
+const { GuideScreen } = await import('./GuideScreen');
+const hasDom = typeof document !== 'undefined';
+let root: Root | null = null;
+let host: HTMLElement | null = null;
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  root = null;
+  host?.remove();
+  host = null;
+  if (hasDom) document.body.innerHTML = '';
+});
+
+describe('GuideScreen persisted guide', () => {
+  test.skipIf(!hasDom)('shows Outdated and regenerates with the saved launch settings', async () => {
+    const launches: AgentLaunchParams[] = [];
+    const state = {
+      files: [],
+      rawPatch: 'changed patch',
+      prMetadata: null,
+      currentWorktreePath: null,
+    } as unknown as ReviewState;
+    host = document.createElement('div');
+    document.body.appendChild(host);
+
+    await act(async () => {
+      root = createRoot(host!);
+      root.render(
+        <ReviewStateProvider value={state}>
+          <GuideScreen
+            activeGuideJobId={null}
+            jobs={[]}
+            capabilities={null}
+            launchJob={async (params) => {
+              launches.push(params);
+              return null;
+            }}
+            killJob={async () => {}}
+            onClose={() => {}}
+          />
+        </ReviewStateProvider>,
+      );
+    });
+
+    expect(host.textContent).toContain('Outdated guide');
+    expect(host.textContent).toContain('The reviewed changeset has moved since this guide was generated.');
+    expect(host.textContent).toContain('Persisted guide');
+
+    const outdatedLabel = [...host.querySelectorAll('span')]
+      .find((span) => span.textContent === 'Outdated guide');
+    const outdatedBanner = outdatedLabel?.parentElement?.parentElement;
+    const outdatedMessage = outdatedLabel?.nextElementSibling;
+    expect(outdatedBanner?.classList.contains('text-foreground')).toBe(true);
+    expect(outdatedBanner?.classList.contains('text-warning-foreground')).toBe(false);
+    expect(outdatedMessage?.classList.contains('text-muted-foreground')).toBe(true);
+
+    const regenerate = [...host.querySelectorAll('button')]
+      .find((button) => button.textContent === 'Regenerate guide');
+    expect(regenerate).not.toBeUndefined();
+
+    await act(async () => regenerate?.click());
+    expect(launches).toEqual([{
+      provider: 'guide',
+      label: 'Guided Review',
+      engine: 'pi',
+      model: 'openai/gpt-5',
+      thinking: 'low',
+    }]);
+  });
+});

--- a/packages/review-editor/components/guide/GuideScreen.tsx
+++ b/packages/review-editor/components/guide/GuideScreen.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useRef, useState } from 'react';
+import type { CurrentGuideInfo, GuideLaunchSettings } from '@plannotator/shared/guide';
 import type { AgentJobInfo, AgentCapabilities } from '@plannotator/ui/types';
 import { jobMatchesReviewContext } from '@plannotator/ui/hooks/useAgentJobs';
 import type { AgentLaunchParams } from '@plannotator/ui/hooks/useAgentJobs';
 import type { ReviewEngine } from '@plannotator/ui/hooks/useAgentSettings';
 import { REVIEW_ENGINE_LABEL } from '@plannotator/ui/components/AgentsTab';
 import { isTerminalStatus } from '@plannotator/shared/agent-jobs';
-import { useGuideData } from '../../hooks/guide/useGuideData';
+import { useCurrentGuide, useGuideData } from '../../hooks/guide/useGuideData';
 import { useReviewState } from '../../dock/ReviewStateContext';
 import { GuideEmptyState } from './GuideEmptyState';
 import { GuideGenerating } from './GuideGenerating';
@@ -73,8 +74,17 @@ export const GuideScreen: React.FC<GuideScreenProps> = ({
   // Cancel below targets whichever job this resolves to. Filtered to the
   // current context first — a running guide job for a different PR/context
   // must not steal the takeover.
+  const guideJobs = jobs.filter((j) => j.provider === 'guide' && matchesContext(j));
+  const guideRefreshKey = [
+    state.prMetadata?.url ?? '',
+    state.prMetadata?.headSha ?? '',
+    state.currentWorktreePath ?? '',
+    state.rawPatch,
+    guideJobs.map((job) => `${job.id}:${job.status}`).join(','),
+  ].join('\0');
+  const { guide: currentGuide, loading: currentGuideLoading } = useCurrentGuide(guideRefreshKey);
   const runningJob =
-    [...jobs].reverse().find((j) => j.provider === 'guide' && matchesContext(j) && !isTerminalStatus(j.status)) ?? null;
+    [...guideJobs].reverse().find((j) => !isTerminalStatus(j.status)) ?? null;
 
   if (runningJob) {
     return (
@@ -99,7 +109,6 @@ export const GuideScreen: React.FC<GuideScreenProps> = ({
   // above an already-successful guide. Scoped to the current context — a
   // guide (or failure) from a different PR/local-diff context is irrelevant
   // to what's on screen right now.
-  const guideJobs = jobs.filter((j) => j.provider === 'guide' && matchesContext(j));
   const latestGuideJob = guideJobs.length > 0 ? guideJobs[guideJobs.length - 1] : null;
 
   // The job behind activeGuideJobId may belong to a DIFFERENT context (e.g.
@@ -120,8 +129,8 @@ export const GuideScreen: React.FC<GuideScreenProps> = ({
   // (which has its own finished guide) landed on the empty state — B's guide
   // existed but nothing selected it, since activeGuideJobId still pointed at A.
   const newestDoneGuideJob = [...guideJobs].reverse().find((j) => j.status === 'done') ?? null;
-  const displayGuideJobId =
-    activeGuideJobId && activeGuideMatchesContext ? activeGuideJobId : newestDoneGuideJob?.id ?? null;
+  const displayGuideJobId = currentGuide?.id
+    ?? (activeGuideJobId && activeGuideMatchesContext ? activeGuideJobId : newestDoneGuideJob?.id ?? null);
 
   if (displayGuideJobId) {
     // A guide can already be showing (activeGuideJobId) while a LATER launch
@@ -152,8 +161,19 @@ export const GuideScreen: React.FC<GuideScreenProps> = ({
         failedJob={newerFailedJob}
         capabilities={capabilities}
         launchJob={launchJob}
+        currentGuide={currentGuide?.id === displayGuideJobId ? currentGuide : null}
         onOpenFixedGuide={onOpenFixedGuide}
       />
+    );
+  }
+
+  if (currentGuideLoading) {
+    return (
+      <div className="w-full px-10 py-8">
+        <div className="h-7 w-80 animate-pulse rounded bg-muted/30" />
+        <div className="mt-3 h-4 w-full max-w-md animate-pulse rounded bg-muted/20" />
+        <GuideSectionSkeleton />
+      </div>
     );
   }
 
@@ -195,6 +215,7 @@ function ActiveGuide({
   failedJob,
   capabilities,
   launchJob,
+  currentGuide,
   onOpenFixedGuide,
 }: {
   jobId: string;
@@ -205,10 +226,13 @@ function ActiveGuide({
   failedJob: AgentJobInfo | null;
   capabilities: AgentCapabilities | null;
   launchJob: (params: AgentLaunchParams) => Promise<AgentJobInfo | null>;
+  currentGuide: CurrentGuideInfo | null;
   onOpenFixedGuide?: (jobId: string) => void;
 }) {
   const { guide, loading, error, reviewed, toggleReviewed, retry } = useGuideData(jobId);
   const [focusedFile, setFocusedFile] = useState<string | null>(null);
+  const [regenerating, setRegenerating] = useState(false);
+  const [regenerationError, setRegenerationError] = useState<string | null>(null);
   const state = useReviewState();
 
   // "Details" switches this screen over to the full failure-recovery panel
@@ -246,6 +270,28 @@ function ActiveGuide({
     const firstResolvable = allRefs.find((ref) => filePathsInDiff.has(ref.file));
     if (firstResolvable) setFocusedFile(firstResolvable.file);
   }, [guide, focusedFile, state.files]);
+
+  const handleRegenerate = async () => {
+    if (regenerating) return;
+    setRegenerating(true);
+    setRegenerationError(null);
+    const sourceJob = jobs.find((job) => job.id === jobId);
+    const launch: GuideLaunchSettings = currentGuide?.launch ?? {
+      ...(sourceJob?.engine && { engine: sourceJob.engine }),
+      ...(sourceJob?.model && { model: sourceJob.model }),
+      ...(sourceJob?.effort && { effort: sourceJob.effort }),
+      ...(sourceJob?.reasoningEffort && { reasoningEffort: sourceJob.reasoningEffort }),
+      ...(sourceJob?.fastMode && { fastMode: true }),
+      ...(sourceJob?.thinking && { thinking: sourceJob.thinking }),
+    };
+    try {
+      await launchJob({ provider: 'guide', label: 'Guided Review', ...launch });
+    } catch (err) {
+      setRegenerationError(err instanceof Error ? err.message : 'Could not regenerate the guide.');
+    } finally {
+      setRegenerating(false);
+    }
+  };
 
   const handleFixOutput = async () => {
     if (!failedJob || repairing) return;
@@ -343,11 +389,29 @@ function ActiveGuide({
     );
   }
 
-  const engine = jobs.find((j) => j.id === jobId)?.engine;
+  const engine = jobs.find((j) => j.id === jobId)?.engine ?? currentGuide?.engine;
+  const outdatedBanner = currentGuide?.outdated ? (
+    <div className="flex items-center gap-3 border-b border-warning/30 bg-warning/10 px-4 py-2 text-xs text-foreground">
+      <div className="min-w-0 flex-1">
+        <span className="font-semibold">Outdated guide</span>
+        <span className="ml-1.5 text-muted-foreground">The reviewed changeset has moved since this guide was generated.</span>
+        {regenerationError && <span className="ml-1.5 text-destructive">{regenerationError}</span>}
+      </div>
+      <button
+        type="button"
+        onClick={handleRegenerate}
+        disabled={regenerating}
+        className="shrink-0 rounded-md border border-warning/30 bg-background/70 px-2.5 py-1.5 font-medium text-foreground transition-colors hover:bg-background disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {regenerating ? 'Starting…' : 'Regenerate guide'}
+      </button>
+    </div>
+  ) : null;
 
   return (
     <div className="w-full">
       {failureStrip}
+      {outdatedBanner}
       <GuideView
         guide={guide}
         reviewed={reviewed}

--- a/packages/review-editor/hooks/guide/useGuideData.ts
+++ b/packages/review-editor/hooks/guide/useGuideData.ts
@@ -1,8 +1,41 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { DEMO_GUIDE, DEMO_GUIDE_ID } from '../../demoGuide';
-import type { CodeGuideData } from '@plannotator/shared/guide';
+import type { CodeGuideData, CurrentGuideInfo } from '@plannotator/shared/guide';
 
 export type { GuideDiffRef, GuideSection, CodeGuideOutput, CodeGuideData } from '@plannotator/shared/guide';
+
+export function useCurrentGuide(refreshKey: string): { guide: CurrentGuideInfo | null; loading: boolean } {
+  const [guide, setGuide] = useState<CurrentGuideInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setGuide(null);
+    setLoading(true);
+    fetch('/api/guide/current')
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((data: { guide?: CurrentGuideInfo | null }) => {
+        if (cancelled) return;
+        setGuide(data.guide?.id ? data.guide : null);
+        setLoading(false);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        // Persistence is additive. A missing endpoint/artifact must leave the
+        // existing in-session and demo guide paths working unchanged.
+        setGuide(null);
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshKey]);
+
+  return { guide, loading };
+}
 
 export interface UseGuideDataReturn {
   guide: CodeGuideData | null;

--- a/packages/server/agent-jobs-launch.test.ts
+++ b/packages/server/agent-jobs-launch.test.ts
@@ -41,14 +41,16 @@ function post(body: unknown): Request {
 const JOBS_URL = new URL("http://localhost/api/agents/jobs");
 
 describe("POST /api/agents/jobs — reviewProfileId launch plumbing", () => {
-  test("forwards reviewProfileId into buildCommand config", async () => {
+  test("forwards reviewProfileId and the allocated job ID into buildCommand", async () => {
     let seenConfig: Record<string, unknown> | undefined;
+    let seenJobId: string | undefined;
     const handler = createAgentJobHandler({
       mode: "review",
       getServerUrl: () => "http://localhost:1234",
       getCwd: () => "/tmp",
-      async buildCommand(_provider, config) {
+      async buildCommand(_provider, config, jobId) {
         seenConfig = config;
+        seenJobId = jobId;
         // Return a no-op command that won't actually spawn anything useful.
         return { command: ["true"], reviewProfileId: "user:security", reviewProfileLabel: "Security" };
       },
@@ -57,7 +59,9 @@ describe("POST /api/agents/jobs — reviewProfileId launch plumbing", () => {
     const res = await handler.handle(post({ provider: "codex", reviewProfileId: "user:security" }), JOBS_URL);
 
     expect(res?.status).toBe(201);
+    const { job } = await res!.json();
     expect(seenConfig?.reviewProfileId).toBe("user:security");
+    expect(seenJobId).toBe(job.id);
     handler.killAll();
   });
 

--- a/packages/server/agent-jobs.ts
+++ b/packages/server/agent-jobs.ts
@@ -92,7 +92,7 @@ export interface AgentJobHandlerOptions {
    * Return an object with the command to spawn (and optional output path for result ingestion).
    * Return null to reject or fall through to frontend-supplied command.
    */
-  buildCommand?: (provider: string, config?: Record<string, unknown>) => Promise<{
+  buildCommand?: (provider: string, config: Record<string, unknown> | undefined, jobId: string) => Promise<{
     command: string[];
     outputPath?: string;
     captureStdout?: boolean;
@@ -676,7 +676,7 @@ export function createAgentJobHandler(options: AgentJobHandlerOptions): AgentJob
             if (body.fastMode === true) config.fastMode = true;
             if (typeof body.reviewProfileId === "string") config.reviewProfileId = body.reviewProfileId;
             if (typeof body.repairOf === "string") config.repairOf = body.repairOf;
-            const built = await options.buildCommand(provider, Object.keys(config).length > 0 ? config : undefined);
+            const built = await options.buildCommand(provider, Object.keys(config).length > 0 ? config : undefined, jobId);
             if (built) {
               command = built.command;
               outputPath = built.outputPath;

--- a/packages/server/guide/guide-review.test.ts
+++ b/packages/server/guide/guide-review.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from "bun:test";
-import { readFileSync } from "node:fs";
+import { afterEach, describe, it, expect } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   composeGuideMarkerPrompt,
   createGuideSession,
@@ -8,6 +10,7 @@ import {
   parseGuideStreamOutput,
 } from "./guide-review";
 import { markerClose, markerOpen } from "../marker-review";
+import { createGuideStore, type GuidePersistenceContext } from "./guide-storage";
 
 // Pins the behaviors the PR-993 review rounds fixed. This module previously
 // had NO direct coverage — the repair ladder and validation are pure logic
@@ -16,6 +19,17 @@ import { markerClose, markerOpen } from "../marker-review";
 
 const FILES = ["src/a.ts", "src/b.ts", "src/c.ts"];
 const PI_FIXTURE_NONCE = "pn0123456789ab";
+const tempDirs: string[] = [];
+
+function tempGuideDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "plannotator-guide-session-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
 const piInsufficientCreditsStdout = readFileSync(
   new URL("../fixtures/pi-insufficient-credits.ndjson", import.meta.url),
   "utf8",
@@ -161,6 +175,61 @@ describe("parseGuideStreamOutput", () => {
 
   it("returns null on empty stdout", () => {
     expect(parseGuideStreamOutput("")).toBeNull();
+  });
+});
+
+describe("createGuideSession persistence", () => {
+  const context: GuidePersistenceContext = {
+    targets: [{ kind: "branch", repository: "github.com/acme/widgets", branch: "feature/persist" }],
+    revision: "abc123",
+    fingerprint: "patch-one",
+  };
+
+  it("restores successful guide output, launch settings, and Reviewed state in a new session", async () => {
+    const dir = tempGuideDir();
+    const first = createGuideSession(createGuideStore(dir));
+    first.registerPersistence("job-1", context);
+    const output = JSON.parse(guideJson([
+      { title: "Persisted", overview: "Stored", diffs: [{ file: "src/a.ts" }] },
+    ]));
+    await first.onJobComplete({
+      job: { id: "job-1", engine: "claude", model: "sonnet", effort: "low" },
+      meta: { stdout: JSON.stringify({ type: "result", structured_output: output }) },
+      changedFiles: FILES,
+    });
+    first.saveReviewed("job-1", [true]);
+
+    const restarted = createGuideSession(createGuideStore(dir));
+    expect(restarted.getCurrentGuide(context)).toMatchObject({
+      id: "job-1",
+      outdated: false,
+      engine: "claude",
+      launch: { engine: "claude", model: "sonnet", effort: "low" },
+    });
+    expect(restarted.getGuide("job-1")?.reviewed).toEqual([true]);
+    expect(restarted.getGuide("job-1")?.sections[0].title).toBe("Persisted");
+  });
+
+  it("keeps the previous persisted guide when regeneration fails", async () => {
+    const dir = tempGuideDir();
+    const store = createGuideStore(dir);
+    const first = createGuideSession(store);
+    first.registerPersistence("old-job", context);
+    first.submitManualOutput("old-job", guideJson([
+      { title: "Still available", overview: "Stored", diffs: [{ file: "src/a.ts" }] },
+    ]), FILES);
+
+    first.registerPersistence("failed-job", { ...context, revision: "def456", fingerprint: "patch-two" });
+    await first.onJobComplete({
+      job: { id: "failed-job", engine: "pi", prompt: composeGuideMarkerPrompt("Review", PI_FIXTURE_NONCE) },
+      meta: { stdout: "not valid guide output" },
+      changedFiles: FILES,
+    });
+
+    const restarted = createGuideSession(createGuideStore(dir));
+    expect(restarted.getCurrentGuide({ ...context, revision: "def456", fingerprint: "patch-two" }))
+      .toMatchObject({ id: "old-job", outdated: true });
+    expect(restarted.getGuide("old-job")?.sections[0].title).toBe("Still available");
   });
 });
 

--- a/packages/server/guide/guide-review.ts
+++ b/packages/server/guide/guide-review.ts
@@ -20,9 +20,17 @@ import {
 } from "../marker-review";
 import type {
   CodeGuideOutput,
+  CurrentGuideInfo,
   GuideDiffRef,
+  GuideLaunchSettings,
   GuideSection,
 } from "@plannotator/shared/guide";
+import {
+  createGuideStore,
+  type GuidePersistenceContext,
+  type GuideStore,
+  type PersistedGuide,
+} from "./guide-storage";
 
 export type { CodeGuideOutput, GuideDiffRef, GuideSection };
 
@@ -890,9 +898,8 @@ export interface GuideSessionJobSummary {
   confidence: number;
 }
 
-export interface GuideSessionJobRef {
+export interface GuideSessionJobRef extends GuideLaunchSettings {
   id: string;
-  engine?: string;
   /** Full prompt text stored on the job at launch. Only read for Cursor/OpenCode/
    *  Pi jobs, to recover the per-job marker nonce (extractMarkerNonce) — the
    *  claude/codex paths never touch it. */
@@ -932,6 +939,11 @@ export interface GuideSession {
     error?: string;
   }>;
   getGuide(jobId: string): (CodeGuideOutput & { reviewed: boolean[] }) | null;
+  /** Associate a job with the stable review target and launch-time changeset it represents. */
+  registerPersistence(jobId: string, context: GuidePersistenceContext): void;
+  getLaunchPersistence(jobId: string): GuidePersistenceContext | null;
+  /** Load the newest durable guide matching the review target and hydrate it into this session. */
+  getCurrentGuide(context: GuidePersistenceContext): CurrentGuideInfo | null;
   saveReviewed(jobId: string, reviewed: boolean[]): void;
   getFailedPayload(jobId: string): string | null;
   /** The changed-file set (as of LAUNCH time) recorded for a given job id, or
@@ -1097,11 +1109,39 @@ function extractClaudeFailedPayload(stdout: string): string {
   return stdout;
 }
 
-export function createGuideSession(): GuideSession {
+export function createGuideSession(store: GuideStore = createGuideStore()): GuideSession {
   const guideResults = new Map<string, CodeGuideOutput>();
   const guideReviewed = new Map<string, boolean[]>();
   const failedPayloads = new Map<string, string>();
   const launchChangedFiles = new Map<string, string[]>();
+  const launchPersistence = new Map<string, GuidePersistenceContext>();
+  const launchSettings = new Map<string, GuideLaunchSettings>();
+  const persistedRecords = new Map<string, PersistedGuide>();
+
+  const writePersisted = (record: PersistedGuide): void => {
+    persistedRecords.set(record.id, record);
+    try {
+      store.write(record);
+    } catch (error) {
+      console.error(`[guide] Failed to persist guide ${record.id}:`, error);
+    }
+  };
+
+  const persistGuide = (jobId: string, guide: CodeGuideOutput): void => {
+    const context = launchPersistence.get(jobId);
+    if (!context) return;
+    const launch = launchSettings.get(jobId);
+    writePersisted({
+      version: 1,
+      id: jobId,
+      context,
+      generatedAt: Date.now(),
+      ...(launch?.engine ? { engine: launch.engine } : {}),
+      ...(launch && { launch }),
+      guide,
+      reviewed: guideReviewed.get(jobId) ?? [],
+    });
+  };
 
   return {
     guideResults,
@@ -1178,6 +1218,15 @@ export function createGuideSession(): GuideSession {
     },
 
     async onJobComplete({ job, meta, changedFiles }) {
+      const settings: GuideLaunchSettings = {
+        ...(job.engine && { engine: job.engine }),
+        ...(job.model && { model: job.model }),
+        ...(job.effort && { effort: job.effort }),
+        ...(job.reasoningEffort && { reasoningEffort: job.reasoningEffort }),
+        ...(job.fastMode && { fastMode: true }),
+        ...(job.thinking && { thinking: job.thinking }),
+      };
+      launchSettings.set(job.id, settings);
       // Record the changed-file set this attempt validated against — BEFORE
       // parsing, so both the success and failure paths capture it. A later
       // manual repair (submitManualOutput) reuses this exact set instead of
@@ -1235,6 +1284,7 @@ export function createGuideSession(): GuideSession {
       }
 
       guideResults.set(job.id, result.guide);
+      persistGuide(job.id, result.guide);
       failedPayloads.delete(job.id);
 
       const totalFiles = result.guide.sections.reduce((n, s) => n + s.diffs.length, 0);
@@ -1252,8 +1302,37 @@ export function createGuideSession(): GuideSession {
       return { ...guide, reviewed: guideReviewed.get(jobId) ?? [] };
     },
 
+    registerPersistence(jobId, context) {
+      launchPersistence.set(jobId, context);
+    },
+
+    getLaunchPersistence(jobId) {
+      return launchPersistence.get(jobId) ?? null;
+    },
+
+    getCurrentGuide(context) {
+      const current = store.readCurrent(context);
+      if (!current) return null;
+      const { record } = current;
+      guideResults.set(record.id, record.guide);
+      guideReviewed.set(record.id, record.reviewed);
+      launchPersistence.set(record.id, record.context);
+      persistedRecords.set(record.id, record);
+      if (record.launch) launchSettings.set(record.id, record.launch);
+      return {
+        id: record.id,
+        outdated: current.outdated,
+        generatedAt: record.generatedAt,
+        engine: record.engine,
+        launch: record.launch,
+      };
+    },
+
     saveReviewed(jobId, reviewed) {
-      guideReviewed.set(jobId, reviewed);
+      const normalized = reviewed.map((item) => item === true);
+      guideReviewed.set(jobId, normalized);
+      const record = persistedRecords.get(jobId);
+      if (record) writePersisted({ ...record, reviewed: normalized });
     },
 
     getFailedPayload(jobId) {
@@ -1296,6 +1375,7 @@ export function createGuideSession(): GuideSession {
       if ("error" in result) return { error: result.error };
 
       guideResults.set(jobId, result.guide);
+      persistGuide(jobId, result.guide);
       failedPayloads.delete(jobId);
       const files = result.guide.sections.reduce((n, s) => n + s.diffs.length, 0);
       return { ok: true, sections: result.guide.sections.length, files };

--- a/packages/server/guide/guide-storage.test.ts
+++ b/packages/server/guide/guide-storage.test.ts
@@ -1,0 +1,281 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { CodeGuideOutput } from "@plannotator/shared/guide";
+import {
+  createGuideStore,
+  createPRGuidePersistenceContext,
+  hashGuideChangeset,
+  normalizeRepositoryIdentity,
+  resolveLocalGuidePersistenceContext,
+  type GuidePersistenceContext,
+  type PersistedGuide,
+} from "./guide-storage";
+
+const tempDirs: string[] = [];
+const originalDataDir = process.env.PLANNOTATOR_DATA_DIR;
+
+function tempGuideDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "plannotator-guide-store-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  if (originalDataDir === undefined) delete process.env.PLANNOTATOR_DATA_DIR;
+  else process.env.PLANNOTATOR_DATA_DIR = originalDataDir;
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+const guide: CodeGuideOutput = {
+  title: "Persisted guide",
+  intent: "Verify persistence",
+  sections: [{ title: "Storage", overview: "Durable state", diffs: [{ file: "src/a.ts" }] }],
+};
+
+function branchContext(
+  repository = "github.com/acme/widgets",
+  branch = "feature/persist",
+  revision = "abc123",
+  fingerprint = "patch-one",
+): GuidePersistenceContext {
+  return {
+    targets: [{ kind: "branch", repository, branch }],
+    revision,
+    fingerprint,
+  };
+}
+
+function record(
+  id: string,
+  context: GuidePersistenceContext,
+  generatedAt = 1,
+  reviewed: boolean[] = [],
+): PersistedGuide {
+  return {
+    version: 1,
+    id,
+    context,
+    generatedAt,
+    guide,
+    reviewed,
+    engine: "claude",
+  };
+}
+
+describe("normalizeRepositoryIdentity", () => {
+  it("normalizes host, slashes, case, and .git suffixes", () => {
+    expect(normalizeRepositoryIdentity(" GitHub.COM ", "/Acme/Widgets.git/"))
+      .toBe("github.com/acme/widgets");
+  });
+
+  it("rejects incomplete repository identities", () => {
+    expect(normalizeRepositoryIdentity("", "acme/widgets")).toBeNull();
+    expect(normalizeRepositoryIdentity("github.com", "")).toBeNull();
+  });
+});
+
+describe("createPRGuidePersistenceContext", () => {
+  it("indexes a fork PR by both its PR number and canonical head branch", () => {
+    expect(createPRGuidePersistenceContext({
+      platform: "github",
+      host: "GitHub.com",
+      owner: "Acme",
+      repo: "Widgets",
+      number: 42,
+      title: "Persist guides",
+      author: "dev",
+      baseBranch: "main",
+      headBranch: "feature/persist",
+      headRepository: "Contributor/Widgets",
+      baseSha: "base",
+      headSha: "head",
+      url: "https://github.com/Acme/Widgets/pull/42",
+    }, "patch")?.targets).toEqual([
+      { kind: "pr", repository: "github.com/acme/widgets", number: 42 },
+      { kind: "branch", repository: "github.com/contributor/widgets", branch: "feature/persist" },
+    ]);
+  });
+});
+
+describe("resolveLocalGuidePersistenceContext", () => {
+  it("uses the canonical origin repository, branch, and HEAD", async () => {
+    const responses = new Map([
+      ["branch --show-current", "feature/persist"],
+      ["rev-parse HEAD", "abc123"],
+      ["remote get-url origin", "git@github.com:Acme/Widgets.git"],
+    ]);
+    const context = await resolveLocalGuidePersistenceContext({
+      async runGit(args) {
+        const stdout = responses.get(args.join(" "));
+        return { stdout: stdout ? `${stdout}\n` : "", stderr: "", exitCode: stdout ? 0 : 1 };
+      },
+      async readTextFile() { return null; },
+    }, "/repo", "patch");
+
+    expect(context).toEqual({
+      targets: [{ kind: "branch", repository: "github.com/acme/widgets", branch: "feature/persist" }],
+      revision: "abc123",
+      fingerprint: hashGuideChangeset("patch"),
+    });
+  });
+
+  it("prefers the branch's tracked fork remote over an upstream origin", async () => {
+    const responses = new Map([
+      ["branch --show-current", "feature/persist"],
+      ["rev-parse HEAD", "abc123"],
+      ["for-each-ref --format=%(upstream:remotename) refs/heads/feature/persist", "fork"],
+      ["remote get-url fork", "https://github.com/contributor/widgets.git"],
+      ["remote get-url origin", "https://github.com/acme/widgets.git"],
+    ]);
+    const context = await resolveLocalGuidePersistenceContext({
+      async runGit(args) {
+        const stdout = responses.get(args.join(" "));
+        return { stdout: stdout ? `${stdout}\n` : "", stderr: "", exitCode: stdout ? 0 : 1 };
+      },
+      async readTextFile() { return null; },
+    }, "/repo", "patch");
+
+    expect(context?.targets).toEqual([
+      { kind: "branch", repository: "github.com/contributor/widgets", branch: "feature/persist" },
+    ]);
+  });
+
+  it("keeps explicit forge ports in repository identity", async () => {
+    const resolvePort = (port: number) => resolveLocalGuidePersistenceContext({
+      async runGit(args) {
+        const key = args.join(" ");
+        if (key === "branch --show-current") return { stdout: "main\n", stderr: "", exitCode: 0 };
+        if (key === "rev-parse HEAD") return { stdout: "abc123\n", stderr: "", exitCode: 0 };
+        if (key.startsWith("for-each-ref ")) return { stdout: "origin\n", stderr: "", exitCode: 0 };
+        if (key === "remote get-url origin") return { stdout: `https://git.example:${port}/acme/app.git\n`, stderr: "", exitCode: 0 };
+        return { stdout: "", stderr: "", exitCode: 1 };
+      },
+      async readTextFile() { return null; },
+    }, "/repo", "patch");
+
+    const first = await resolvePort(8443);
+    const second = await resolvePort(9443);
+    expect(first?.targets[0]).toEqual({ kind: "branch", repository: "git.example:8443/acme/app", branch: "main" });
+    expect(second?.targets[0]).toEqual({ kind: "branch", repository: "git.example:9443/acme/app", branch: "main" });
+    expect(first?.targets[0]).not.toEqual(second?.targets[0]);
+  });
+
+  it("does not persist detached HEAD reviews", async () => {
+    const context = await resolveLocalGuidePersistenceContext({
+      async runGit(args) {
+        return args[0] === "branch"
+          ? { stdout: "", stderr: "", exitCode: 0 }
+          : { stdout: "abc123\n", stderr: "", exitCode: 0 };
+      },
+      async readTextFile() { return null; },
+    }, "/repo", "patch");
+
+    expect(context).toBeNull();
+  });
+});
+
+describe("createGuideStore", () => {
+  it("stores default artifacts beneath PLANNOTATOR_DATA_DIR", () => {
+    const dataDir = tempGuideDir();
+    process.env.PLANNOTATOR_DATA_DIR = dataDir;
+    createGuideStore().write(record("job-1", branchContext()));
+
+    expect(existsSync(join(dataDir, "guides"))).toBe(true);
+    expect(readdirSync(join(dataDir, "guides")).some((name) => name.endsWith(".json"))).toBe(true);
+  });
+
+  it("persists a guide and Reviewed state across store instances", () => {
+    const dir = tempGuideDir();
+    const context = branchContext();
+    const first = createGuideStore(dir);
+    first.write(record("job-1", context, 10, [true]));
+
+    const loaded = createGuideStore(dir).readCurrent(context);
+    expect(loaded).not.toBeNull();
+    expect(loaded?.record.id).toBe("job-1");
+    expect(loaded?.record.reviewed).toEqual([true]);
+    expect(loaded?.outdated).toBe(false);
+  });
+
+  it("uses PR head branches as aliases and selects the newest matching record", () => {
+    const dir = tempGuideDir();
+    const branch = { kind: "branch" as const, repository: "github.com/fork/widgets", branch: "feature/persist" };
+    const pr = { kind: "pr" as const, repository: "github.com/acme/widgets", number: 42 };
+    const store = createGuideStore(dir);
+
+    store.write(record("branch-guide", { ...branchContext(branch.repository, branch.branch), targets: [branch] }, 20));
+    store.write(record("older-pr-guide", {
+      targets: [pr],
+      revision: "old",
+      fingerprint: "old",
+    }, 10));
+
+    const loaded = store.readCurrent({
+      targets: [pr, branch],
+      revision: "abc123",
+      fingerprint: "patch-one",
+    });
+    expect(loaded?.record.id).toBe("branch-guide");
+    expect(loaded?.outdated).toBe(false);
+  });
+
+  it("isolates identical branch names in different repositories", () => {
+    const dir = tempGuideDir();
+    const store = createGuideStore(dir);
+    const firstRepo = branchContext("github.com/acme/one", "main");
+    const secondRepo = branchContext("github.com/acme/two", "main");
+    store.write(record("repo-one", firstRepo));
+
+    expect(store.readCurrent(secondRepo)).toBeNull();
+    expect(store.readCurrent(firstRepo)?.record.id).toBe("repo-one");
+  });
+
+  it("marks changed revisions and changed fingerprints outdated", () => {
+    const dir = tempGuideDir();
+    const store = createGuideStore(dir);
+    const original = branchContext();
+    store.write(record("job-1", original));
+
+    expect(store.readCurrent(branchContext(undefined, undefined, "def456", "patch-one"))?.outdated).toBe(true);
+    expect(store.readCurrent(branchContext(undefined, undefined, "abc123", "patch-two"))?.outdated).toBe(true);
+  });
+
+  it("ignores invalid persisted data", () => {
+    const dir = tempGuideDir();
+    const context = branchContext();
+    const store = createGuideStore(dir);
+    store.write(record("job-1", context));
+    const [artifact] = readdirSync(dir).filter((name) => name.endsWith(".json"));
+    writeFileSync(join(dir, artifact), "{not json", "utf8");
+
+    expect(createGuideStore(dir).readCurrent(context)).toBeNull();
+  });
+
+  it("rejects malformed optional guide fields instead of hydrating unsafe UI data", () => {
+    const context = branchContext();
+    for (const malformedGuide of [
+      { ...guide, unplacedFiles: { path: "src/b.ts" } },
+      {
+        ...guide,
+        sections: [{
+          ...guide.sections[0],
+          diffs: [{ file: "src/a.ts", summary: { text: "not a string" } }],
+        }],
+      },
+    ]) {
+      const dir = tempGuideDir();
+      const store = createGuideStore(dir);
+      store.write({ ...record("job-1", context), guide: malformedGuide as unknown as CodeGuideOutput });
+      expect(createGuideStore(dir).readCurrent(context)).toBeNull();
+    }
+  });
+});
+
+describe("hashGuideChangeset", () => {
+  it("is stable and content-sensitive", () => {
+    expect(hashGuideChangeset("same patch")).toBe(hashGuideChangeset("same patch"));
+    expect(hashGuideChangeset("same patch")).not.toBe(hashGuideChangeset("different patch"));
+  });
+});

--- a/packages/server/guide/guide-storage.ts
+++ b/packages/server/guide/guide-storage.ts
@@ -1,0 +1,307 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { getPlannotatorDataDir } from "@plannotator/shared/data-dir";
+import type { CodeGuideOutput, GuideLaunchSettings } from "@plannotator/shared/guide";
+import { parseRemoteHost, parseRemoteUrl } from "@plannotator/shared/repo";
+import type { PRMetadata } from "@plannotator/shared/pr-types";
+import type { ReviewGitRuntime } from "@plannotator/shared/review-core";
+
+export type GuideTarget =
+  | { kind: "pr"; repository: string; number: number }
+  | { kind: "branch"; repository: string; branch: string };
+
+export interface GuidePersistenceContext {
+  /** Primary review target followed by any reliable aliases, such as a PR's head branch. */
+  targets: GuideTarget[];
+  /** PR head SHA or local HEAD at generation time. */
+  revision: string;
+  /** Stable hash of the exact patch used to generate the guide. */
+  fingerprint: string;
+}
+
+export interface PersistedGuide {
+  version: 1;
+  id: string;
+  context: GuidePersistenceContext;
+  generatedAt: number;
+  engine?: string;
+  launch?: GuideLaunchSettings;
+  guide: CodeGuideOutput;
+  reviewed: boolean[];
+}
+
+export interface CurrentPersistedGuide {
+  record: PersistedGuide;
+  outdated: boolean;
+}
+
+export interface GuideStore {
+  readCurrent(context: GuidePersistenceContext): CurrentPersistedGuide | null;
+  write(record: PersistedGuide): void;
+}
+
+export function normalizeRepositoryIdentity(host: string, repositoryPath: string): string | null {
+  const normalizedHost = host.trim().toLowerCase();
+  const normalizedPath = repositoryPath
+    .trim()
+    .replace(/^\/+|\/+$/g, "")
+    .replace(/\.git$/i, "")
+    .toLowerCase();
+  if (!normalizedHost || !normalizedPath) return null;
+  return `${normalizedHost}/${normalizedPath}`;
+}
+
+export function hashGuideChangeset(patch: string): string {
+  return createHash("sha256").update(patch).digest("hex");
+}
+
+export function createPRGuidePersistenceContext(
+  metadata: PRMetadata,
+  patch: string,
+): GuidePersistenceContext | null {
+  const basePath = metadata.platform === "github"
+    ? `${metadata.owner}/${metadata.repo}`
+    : metadata.projectPath;
+  const baseRepository = normalizeRepositoryIdentity(metadata.host, basePath);
+  if (!baseRepository || !metadata.headSha) return null;
+
+  const targets: GuideTarget[] = [{
+    kind: "pr",
+    repository: baseRepository,
+    number: metadata.platform === "github" ? metadata.number : metadata.iid,
+  }];
+  const headPath = metadata.platform === "github"
+    ? metadata.headRepository
+    : metadata.headProjectPath;
+  if (headPath) {
+    const headRepository = normalizeRepositoryIdentity(metadata.host, headPath);
+    if (headRepository && metadata.headBranch) {
+      targets.push({ kind: "branch", repository: headRepository, branch: metadata.headBranch });
+    }
+  }
+
+  return {
+    targets,
+    revision: metadata.headSha,
+    fingerprint: hashGuideChangeset(patch),
+  };
+}
+
+export function createBranchGuidePersistenceContext(
+  repository: string,
+  branch: string,
+  revision: string,
+  patch: string,
+): GuidePersistenceContext | null {
+  if (!repository || !branch || !revision || branch === "HEAD") return null;
+  return {
+    targets: [{ kind: "branch", repository, branch }],
+    revision,
+    fingerprint: hashGuideChangeset(patch),
+  };
+}
+
+function repositoryFromRemote(remoteUrl: string): string | null {
+  let host: string | null = null;
+  try {
+    host = new URL(remoteUrl).host || null;
+  } catch {
+    host = parseRemoteHost(remoteUrl);
+  }
+  const repositoryPath = parseRemoteUrl(remoteUrl);
+  return host && repositoryPath
+    ? normalizeRepositoryIdentity(host, repositoryPath)
+    : null;
+}
+
+/** Resolve a local Git branch without ever conflating similarly-named branches across repositories. */
+export async function resolveLocalGuidePersistenceContext(
+  runtime: ReviewGitRuntime,
+  cwd: string,
+  patch: string,
+): Promise<GuidePersistenceContext | null> {
+  const options = { cwd, interaction: "forbid" as const };
+  const [branchResult, revisionResult] = await Promise.all([
+    runtime.runGit(["branch", "--show-current"], options),
+    runtime.runGit(["rev-parse", "HEAD"], options),
+  ]);
+  const branch = branchResult.exitCode === 0 ? branchResult.stdout.trim() : "";
+  const revision = revisionResult.exitCode === 0 ? revisionResult.stdout.trim() : "";
+  if (!branch || !revision) return null;
+
+  let repository: string | null = null;
+  const trackedRemote = await runtime.runGit(
+    ["for-each-ref", "--format=%(upstream:remotename)", `refs/heads/${branch}`],
+    options,
+  );
+  const trackedRemoteName = trackedRemote.exitCode === 0 ? trackedRemote.stdout.trim() : "";
+  if (trackedRemoteName && trackedRemoteName !== ".") {
+    const trackedRemoteUrl = await runtime.runGit(["remote", "get-url", trackedRemoteName], options);
+    if (trackedRemoteUrl.exitCode === 0) repository = repositoryFromRemote(trackedRemoteUrl.stdout.trim());
+  }
+
+  if (!repository) {
+    const origin = await runtime.runGit(["remote", "get-url", "origin"], options);
+    if (origin.exitCode === 0) repository = repositoryFromRemote(origin.stdout.trim());
+  }
+
+  if (!repository) {
+    const remotes = await runtime.runGit(["remote"], options);
+    const names = remotes.exitCode === 0
+      ? remotes.stdout.split("\n").map((name) => name.trim()).filter(Boolean)
+      : [];
+    if (names.length === 1) {
+      const onlyRemote = await runtime.runGit(["remote", "get-url", names[0]], options);
+      if (onlyRemote.exitCode === 0) repository = repositoryFromRemote(onlyRemote.stdout.trim());
+    }
+  }
+
+  if (!repository) {
+    const commonDirectory = await runtime.runGit(
+      ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+      options,
+    );
+    if (commonDirectory.exitCode === 0 && commonDirectory.stdout.trim()) {
+      repository = `local/${hashGuideChangeset(commonDirectory.stdout.trim())}`;
+    }
+  }
+
+  return repository
+    ? createBranchGuidePersistenceContext(repository, branch, revision, patch)
+    : null;
+}
+
+function targetKey(target: GuideTarget): string {
+  return target.kind === "pr"
+    ? `pr\0${target.repository}\0${target.number}`
+    : `branch\0${target.repository}\0${target.branch}`;
+}
+
+function targetPath(directory: string, target: GuideTarget): string {
+  const key = createHash("sha256").update(targetKey(target)).digest("hex");
+  return join(directory, `${key}.json`);
+}
+
+function sameTarget(left: GuideTarget, right: GuideTarget): boolean {
+  if (left.kind !== right.kind || left.repository !== right.repository) return false;
+  return left.kind === "pr"
+    ? left.number === (right as Extract<GuideTarget, { kind: "pr" }>).number
+    : left.branch === (right as Extract<GuideTarget, { kind: "branch" }>).branch;
+}
+
+function isTarget(value: unknown): value is GuideTarget {
+  if (!value || typeof value !== "object") return false;
+  const target = value as Record<string, unknown>;
+  if (typeof target.repository !== "string" || !target.repository) return false;
+  if (target.kind === "pr") return Number.isInteger(target.number) && Number(target.number) > 0;
+  return target.kind === "branch" && typeof target.branch === "string" && target.branch.length > 0;
+}
+
+function isGuide(value: unknown): value is CodeGuideOutput {
+  if (!value || typeof value !== "object") return false;
+  const guide = value as Record<string, unknown>;
+  if (typeof guide.title !== "string" || typeof guide.intent !== "string" || !Array.isArray(guide.sections)) {
+    return false;
+  }
+  return guide.sections.every((section) => {
+    if (!section || typeof section !== "object") return false;
+    const candidate = section as Record<string, unknown>;
+    return typeof candidate.title === "string"
+      && typeof candidate.overview === "string"
+      && Array.isArray(candidate.diffs)
+      && candidate.diffs.every((diff) => {
+        if (!diff || typeof diff !== "object") return false;
+        const ref = diff as Record<string, unknown>;
+        return typeof ref.file === "string"
+          && (ref.summary === undefined || typeof ref.summary === "string");
+      });
+  }) && (guide.unplacedFiles === undefined
+    || (Array.isArray(guide.unplacedFiles) && guide.unplacedFiles.every((file) => typeof file === "string")));
+}
+
+function isLaunchSettings(value: unknown): value is GuideLaunchSettings {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const launch = value as Record<string, unknown>;
+  return ["engine", "model", "effort", "reasoningEffort", "thinking"]
+    .every((key) => launch[key] === undefined || typeof launch[key] === "string")
+    && (launch.fastMode === undefined || typeof launch.fastMode === "boolean");
+}
+
+function parseRecord(text: string): PersistedGuide | null {
+  try {
+    const value = JSON.parse(text) as Record<string, unknown>;
+    if (value.version !== 1
+      || typeof value.id !== "string"
+      || !value.id
+      || typeof value.generatedAt !== "number"
+      || !Number.isFinite(value.generatedAt)
+      || !value.context
+      || typeof value.context !== "object"
+      || !isGuide(value.guide)
+      || !Array.isArray(value.reviewed)
+      || !value.reviewed.every((item) => typeof item === "boolean")) {
+      return null;
+    }
+    const context = value.context as Record<string, unknown>;
+    if (!Array.isArray(context.targets)
+      || context.targets.length === 0
+      || !context.targets.every(isTarget)
+      || typeof context.revision !== "string"
+      || typeof context.fingerprint !== "string") {
+      return null;
+    }
+    if (value.engine !== undefined && typeof value.engine !== "string") return null;
+    if (value.launch !== undefined && !isLaunchSettings(value.launch)) return null;
+    return value as unknown as PersistedGuide;
+  } catch {
+    return null;
+  }
+}
+
+function uniqueTargets(targets: GuideTarget[]): GuideTarget[] {
+  const seen = new Set<string>();
+  return targets.filter((target) => {
+    const key = targetKey(target);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export function createGuideStore(directory = join(getPlannotatorDataDir(), "guides")): GuideStore {
+  return {
+    readCurrent(context) {
+      let newest: PersistedGuide | null = null;
+      for (const target of uniqueTargets(context.targets)) {
+        let record: PersistedGuide | null = null;
+        try {
+          record = parseRecord(readFileSync(targetPath(directory, target), "utf8"));
+        } catch {
+          // A missing, unreadable, or invalid artifact behaves like no saved guide.
+        }
+        if (!record || !record.context.targets.some((storedTarget) => sameTarget(storedTarget, target))) continue;
+        if (!newest || record.generatedAt >= newest.generatedAt) newest = record;
+      }
+      if (!newest) return null;
+      return {
+        record: newest,
+        outdated: newest.context.revision !== context.revision
+          || newest.context.fingerprint !== context.fingerprint,
+      };
+    },
+
+    write(record) {
+      const targets = uniqueTargets(record.context.targets);
+      if (targets.length === 0) throw new Error("Cannot persist a guide without a target");
+      mkdirSync(directory, { recursive: true });
+      const text = JSON.stringify(record);
+      for (const target of targets) {
+        const finalPath = targetPath(directory, target);
+        const temporaryPath = `${finalPath}.${process.pid}.${randomUUID()}.tmp`;
+        writeFileSync(temporaryPath, text, "utf8");
+        renameSync(temporaryPath, finalPath);
+      }
+    },
+  };
+}

--- a/packages/server/review.ts
+++ b/packages/server/review.ts
@@ -82,6 +82,10 @@ import {
 import { createTourSession, TOUR_EMPTY_OUTPUT_ERROR } from "./tour/tour-review";
 import { createGuideSession, GUIDE_EMPTY_OUTPUT_ERROR } from "./guide/guide-review";
 import {
+  createPRGuidePersistenceContext,
+  resolveLocalGuidePersistenceContext,
+} from "./guide/guide-storage";
+import {
   MARKER_ENGINES,
   composeMarkerReviewPrompt,
   buildMarkerCommand,
@@ -660,6 +664,13 @@ export async function startReviewServer(
     if (!workspace) return undefined;
     return workspace.getPromptContext();
   };
+  const getCurrentGuidePersistenceContext = async () => {
+    const metadata = prMetadata;
+    const patch = currentPatch;
+    if (metadata) return createPRGuidePersistenceContext(metadata, patch);
+    if (workspace || (sessionVcsType && sessionVcsType !== "git")) return null;
+    return resolveLocalGuidePersistenceContext(gitRuntime, resolveAgentCwd(), patch);
+  };
 
   // GitButler's picker topology is live session state: stacks and branches can
   // change without changing the currently-rendered patch. Carry a compact
@@ -796,7 +807,7 @@ export async function startReviewServer(
     getServerUrl: () => serverUrl,
     getCwd: resolveAgentCwd,
 
-    async buildCommand(provider, config) {
+    async buildCommand(provider, config, jobId) {
       // Snapshot ALL launch-relevant state before any await: waiting out the
       // checkout warmup below yields to other requests (e.g. pr-switch), and
       // the job's cwd, prompt, and PR attribution must describe the same PR.
@@ -997,6 +1008,14 @@ export async function startReviewServer(
           config: guideConfig,
           ...(repair && { repair }),
         });
+        const persistenceContext = repairOf
+          ? guide.getLaunchPersistence(repairOf)
+          : launchMetadata
+            ? createPRGuidePersistenceContext(launchMetadata, launchPatch)
+            : workspacePrompt || (sessionVcsType && sessionVcsType !== "git")
+              ? null
+              : await resolveLocalGuidePersistenceContext(gitRuntime, cwd, launchPatch);
+        if (persistenceContext) guide.registerPersistence(jobId, persistenceContext);
         // A repair job's payload is the FAILED job's previously-captured
         // output, not this launch's diff — its file refs were validated
         // (and, for onJobComplete, must be re-validated) against the failed
@@ -1384,6 +1403,12 @@ export async function startReviewServer(
             } catch {
               return Response.json({ error: "Invalid JSON" }, { status: 400 });
             }
+          }
+
+          // API: Find the durable guide associated with the review target currently open.
+          if (url.pathname === "/api/guide/current" && req.method === "GET") {
+            const context = await getCurrentGuidePersistenceContext();
+            return Response.json({ guide: context ? guide.getCurrentGuide(context) : null });
           }
 
           // API: Get guide result

--- a/packages/shared/guide.ts
+++ b/packages/shared/guide.ts
@@ -34,3 +34,21 @@ export interface CodeGuideOutput {
 
 /** UI-side guide shape: server output extended with persisted per-section reviewed state. */
 export type CodeGuideData = CodeGuideOutput & { reviewed: boolean[] };
+
+export interface GuideLaunchSettings {
+  engine?: string;
+  model?: string;
+  effort?: string;
+  reasoningEffort?: string;
+  fastMode?: boolean;
+  thinking?: string;
+}
+
+/** The durable guide, if any, associated with the review target currently open on the server. */
+export interface CurrentGuideInfo {
+  id: string;
+  outdated: boolean;
+  generatedAt: number;
+  engine?: string;
+  launch?: GuideLaunchSettings;
+}

--- a/packages/shared/pr-github.test.ts
+++ b/packages/shared/pr-github.test.ts
@@ -11,6 +11,7 @@ const VIEW_JSON = JSON.stringify({
   author: { login: "dev" },
   baseRefName: "main",
   headRefName: "feature",
+  headRepository: { nameWithOwner: "fork-owner/r" },
   baseRefOid: "a".repeat(40),
   headRefOid: "b".repeat(40),
   url: "https://github.com/o/r/pull/123",
@@ -63,8 +64,10 @@ describe("fetchGhPR", () => {
       number: 123,
       baseBranch: "main",
       headBranch: "feature",
+      headRepository: "fork-owner/r",
       mergeBaseSha: "c".repeat(40),
     });
+    expect(calls.find((c) => c.startsWith("gh pr view"))).toContain("headRepository");
     expect(calls.some((c) => c.includes("/pulls/123/files"))).toBe(false);
   });
 

--- a/packages/shared/pr-github.ts
+++ b/packages/shared/pr-github.ts
@@ -166,7 +166,7 @@ export async function fetchGhPR(
     runtime.runCommand("gh", [
       "pr", "view", String(ref.number),
       "--repo", repo,
-      "--json", "id,title,author,baseRefName,headRefName,baseRefOid,headRefOid,url,changedFiles",
+      "--json", "id,title,author,baseRefName,headRefName,headRepository,baseRefOid,headRefOid,url,changedFiles",
     ]),
     runtime.runCommand("gh", [
       "repo", "view", repo,
@@ -231,6 +231,7 @@ export async function fetchGhPR(
     author: { login: string };
     baseRefName: string;
     headRefName: string;
+    headRepository?: { nameWithOwner?: string } | null;
     baseRefOid: string;
     headRefOid: string;
     url: string;
@@ -262,6 +263,7 @@ export async function fetchGhPR(
     author: raw.author.login,
     baseBranch: raw.baseRefName,
     headBranch: raw.headRefName,
+    headRepository: raw.headRepository?.nameWithOwner,
     defaultBranch: repoResult.exitCode === 0 && repoResult.stdout.trim() && repoResult.stdout.trim() !== "null"
       ? repoResult.stdout.trim()
       : undefined,

--- a/packages/shared/pr-gitlab.test.ts
+++ b/packages/shared/pr-gitlab.test.ts
@@ -46,6 +46,8 @@ describe("fetchGlMR", () => {
               author: { username: "reviewer" },
               source_branch: "feature/app",
               target_branch: "main",
+              source_project_id: 20,
+              target_project_id: 10,
               diff_refs: {
                 base_sha: "a".repeat(40),
                 head_sha: "b".repeat(40),
@@ -57,9 +59,16 @@ describe("fetchGlMR", () => {
             exitCode: 0,
           };
         }
-        if (endpoint === "projects/group%2Fproject") {
+        if (endpoint === "projects/10") {
           return {
             stdout: JSON.stringify({ default_branch: "main" }),
+            stderr: "",
+            exitCode: 0,
+          };
+        }
+        if (endpoint === "projects/20") {
+          return {
+            stdout: JSON.stringify({ path_with_namespace: "contributor/project" }),
             stderr: "",
             exitCode: 0,
           };
@@ -81,6 +90,7 @@ describe("fetchGlMR", () => {
       iid: 42,
       baseBranch: "main",
       headBranch: "feature/app",
+      headProjectPath: "contributor/project",
     });
     expect(result.rawPatch).toBe(rawPatch);
     expect(result.rawPatch).toContain("diff --git a/package-lock.json b/package-lock.json");
@@ -115,6 +125,7 @@ function gitlabRuntime(opts: {
     author: { username: "u" },
     source_branch: "feature",
     target_branch: "main",
+    source_project_id: null,
     diff_refs: { base_sha: "a".repeat(40), head_sha: "b".repeat(40), start_sha: "a".repeat(40) },
     web_url: "https://gitlab.com/g/p/-/merge_requests/1",
   });
@@ -149,6 +160,7 @@ describe("fetchGlMR raw_diffs fallback", () => {
     const result = await fetchGlMR(runtime, REF);
     expect(result.rawPatch).toContain("diff --git a/src/a.ts b/src/a.ts");
     expect(result.rawPatch).toContain("+new");
+    expect(result.metadata.platform === "gitlab" && result.metadata.headProjectPath).toBeUndefined();
     expect(calls.some((c) => c.includes("/diffs?per_page=100"))).toBe(true);
   });
 

--- a/packages/shared/pr-gitlab.ts
+++ b/packages/shared/pr-gitlab.ts
@@ -200,7 +200,8 @@ export async function fetchGlMR(
     author: { username: string };
     source_branch: string;
     target_branch: string;
-    target_project_id?: number;
+    source_project_id?: number | null;
+    target_project_id?: number | null;
     diff_refs: { base_sha: string; head_sha: string; start_sha: string } | null;
     web_url: string;
   };
@@ -221,6 +222,22 @@ export async function fetchGlMR(
     }
   } catch { /* default branch is best-effort metadata */ }
 
+  let headProjectPath: string | undefined;
+  if (typeof raw.source_project_id === "number" && raw.source_project_id === raw.target_project_id) {
+    headProjectPath = ref.projectPath;
+  } else if (typeof raw.source_project_id === "number") {
+    try {
+      const sourceProjectResult = await runtime.runCommand(
+        "glab",
+        apiArgs(ref.host, `projects/${raw.source_project_id}`),
+      );
+      if (sourceProjectResult.exitCode === 0 && sourceProjectResult.stdout.trim()) {
+        const sourceProject = JSON.parse(sourceProjectResult.stdout) as { path_with_namespace?: string };
+        headProjectPath = sourceProject.path_with_namespace;
+      }
+    } catch { /* source project is best-effort metadata */ }
+  }
+
   const metadata: PRMetadata = {
     platform: "gitlab",
     host: ref.host,
@@ -230,6 +247,7 @@ export async function fetchGlMR(
     author: raw.author.username,
     baseBranch: raw.target_branch,
     headBranch: raw.source_branch,
+    headProjectPath,
     defaultBranch,
     baseSha: raw.diff_refs.base_sha,
     headSha: raw.diff_refs.head_sha,

--- a/packages/shared/pr-types.ts
+++ b/packages/shared/pr-types.ts
@@ -65,6 +65,8 @@ export interface GithubPRMetadata {
   author: string;
   baseBranch: string;
   headBranch: string;
+  /** `owner/repo` for the PR head, including fork ownership when cross-repository. */
+  headRepository?: string;
   /** Repository default branch, used to infer whether this PR targets another PR branch. */
   defaultBranch?: string;
   baseSha: string;
@@ -84,6 +86,8 @@ export interface GitlabMRMetadata {
   author: string;
   baseBranch: string;
   headBranch: string;
+  /** Namespace/project path for the MR source, including fork namespace when cross-project. */
+  headProjectPath?: string;
   /** Project default branch, used to infer whether this MR targets another MR branch. */
   defaultBranch?: string;
   baseSha: string;


### PR DESCRIPTION
## Summary

- persist Guided Review output, generation settings, and per-section Reviewed state across server sessions
- isolate artifacts by canonical repository + PR/MR or branch, while reusing them across reliably matched hosted and local head branches
- retain stale guides with an explicit Outdated warning and regeneration action; failed regeneration leaves the prior guide intact
- keep Bun and Pi review server behavior in parity and document the durable workflow

## Testing

- [x] `bun test` — 2246 passed
- [x] `DOM_TESTS=1 bun test packages/review-editor/components/guide/GuideScreen.test.tsx packages/review-editor/components/guide/GuideSectionCard.test.tsx`
- [x] `bun run typecheck`
- [x] `bun run build:pi`
- [x] `bun run build:opencode`
- [x] `bun run build:marketing`
- [x] compiled standalone Plannotator binary
- [x] independent review: `openai-codex/gpt-5.6-sol` — PASS

Closes #1112