### PR TITLE
feat(editor): add Vim keyboard annotation controls and live HUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,22 @@ See the [verification docs](https://docs.plannotator.ai/open-source/start/instal
 
 Settings are saved in cookies (not localStorage) because each hook invocation runs on a random port. You can also set options through environment variables or `~/.plannotator/config.json`.
 
+### Optional Vim controls
+
+Plan and annotate views offer a default-off **Vim controls** profile under
+**Settings → Shortcuts**. Once enabled, focus the document and use `j` / `k`
+to move one rendered block at a time. After `l` refines into a semantic level,
+`j` / `k` move among sibling rows, cells, or inline targets; `h` moves back to
+the containing target. Refining past the deepest target enters text. `v`
+starts characterwise Visual selection and
+`V` selects whole blocks. `Space` opens the normal annotation toolbar; `c`,
+`d`, `m`, and `t` select comment, redline, markup, and label actions. The same
+semantic target graph drives pointer Pinpoint and keyboard navigation. Press
+`?` in the document for the contextual key reference. Inputs, dialogs,
+editors, `Tab`, and all pointer interactions retain their native behavior.
+See [Vim controls](docs/vim-controls.md) for the interaction contract and
+implementation architecture.
+
 | Variable | Description |
 |---|---|
 | `PLANNOTATOR_REMOTE` | `1`/`true` for remote mode, `0`/`false` for local, unset for SSH auto-detection |

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ Settings are saved in cookies (not localStorage) because each hook invocation ru
 ### Optional Vim controls
 
 Plan and annotate views offer a default-off **Vim controls** profile under
-**Settings → Shortcuts**. Once enabled, focus the document and use `j` / `k`
+**Settings → Vim**. Once enabled, focus the document and use `j` / `k`
 to move one rendered block at a time. After `l` refines into a semantic level,
 `j` / `k` move among sibling rows, cells, or inline targets; `h` moves back to
 the containing target. Refining past the deepest target enters text. `v`

--- a/README.md
+++ b/README.md
@@ -346,6 +346,10 @@ starts characterwise Visual selection and
 semantic target graph drives pointer Pinpoint and keyboard navigation. Press
 `?` in the document for the contextual key reference. Inputs, dialogs,
 editors, `Tab`, and all pointer interactions retain their native behavior.
+An additional default-off **Vim HUD** toggle appears beneath Vim controls. It
+uses the product-demo HUD styling to show recent handled keys, the current
+block/line/word/Visual phase, and the command meaning without capturing text
+typed into comments or other controls.
 See [Vim controls](docs/vim-controls.md) for the interaction contract and
 implementation architecture.
 

--- a/README.md
+++ b/README.md
@@ -346,6 +346,8 @@ starts characterwise Visual selection and
 semantic target graph drives pointer Pinpoint and keyboard navigation. Press
 `?` in the document for the contextual key reference. Inputs, dialogs,
 editors, `Tab`, and all pointer interactions retain their native behavior.
+The document takes focus automatically when the page is otherwise neutral;
+press `Escape` from app chrome to return to it without clicking.
 An additional default-off **Vim HUD** toggle appears beneath Vim controls. It
 uses the product-demo HUD styling to show recent handled keys, the current
 block/line/word/Visual phase, and the command meaning without capturing text

--- a/README.md
+++ b/README.md
@@ -349,9 +349,12 @@ editors, `Tab`, and all pointer interactions retain their native behavior.
 The document takes focus automatically when the page is otherwise neutral;
 press `Escape` from app chrome to return to it without clicking.
 An additional default-off **Vim HUD** toggle appears beneath Vim controls. It
-uses the product-demo HUD styling to show recent handled keys, the current
-block/line/word/Visual phase, and the command meaning without capturing text
-typed into comments or other controls.
+uses the product-demo styling for the live target reticle and navigation
+context. Its bottom-right **Key panel** is independently hideable while the
+reticle remains active; `?` still opens the complete key map on demand. The
+panel shows recent handled keys, the current block/line/word/Visual phase, and
+the command meaning without capturing text typed into comments or other
+controls.
 See [Vim controls](docs/vim-controls.md) for the interaction contract and
 implementation architecture.
 

--- a/docs/vim-controls.md
+++ b/docs/vim-controls.md
@@ -43,6 +43,9 @@ annotation in the plan and annotate applications.
 
 - Activating Vim controls enters **BLOCK** at the semantic block nearest the
   viewport: a paragraph, heading, list item, code block, table, and so on.
+- When the page is otherwise neutral, the enabled document takes keyboard
+  focus automatically. From app chrome, `Escape` returns focus to the document;
+  editors and open dialogs retain first ownership of the key.
 - `j` / `k`: next or previous block; after refining, next or previous
   semantic sibling (for example, another table row, cell, or inline target).
 - `gg` / `G`: first or last block.

--- a/docs/vim-controls.md
+++ b/docs/vim-controls.md
@@ -113,3 +113,6 @@ removes the document focus surface and leaves existing behavior unchanged.
 Vim HUD is independently cookie-persisted, default off, and only records or
 renders commands while enabled. Text entered into annotation composers is
 neither captured nor displayed.
+
+Both controls live in their own **Settings → Vim** panel. The Shortcuts panel
+is reserved for the key-binding reference.

--- a/docs/vim-controls.md
+++ b/docs/vim-controls.md
@@ -126,3 +126,11 @@ cookie-persisted, defaults on, and never controls the reticle.
 
 Both controls live in their own **Settings → Vim** panel. The Shortcuts panel
 is reserved for the key-binding reference.
+
+## UX smoke testing
+
+The user-journey matrix and latest real-app run record live in
+[`tests/manual/vim-ux-smoke.md`](../tests/manual/vim-ux-smoke.md). It covers
+focus recovery, structural and exact-text navigation, every annotation entry
+point, HUD learning, copy behavior, rapid-input races, and native-control
+compatibility across Markdown and sandboxed raw HTML.

--- a/docs/vim-controls.md
+++ b/docs/vim-controls.md
@@ -74,6 +74,12 @@ tell when `j` / `k` move by blocks versus lines. Raw HTML mirrors the same
 target treatment inside its sandboxed iframe while using the shared parent key
 HUD and key map.
 
+The bottom-right **Key panel** is independently persisted and defaults on for
+backward compatibility. Its Hide control removes only that panel; the reticle,
+cursor, and Vim navigation remain active. Users can restore it in
+**Settings → Vim**, or press `?` while it is hidden to temporarily open the
+complete key map. Closing the map returns to the reticle-only HUD.
+
 Pointer Pinpoint and keyboard navigation resolve through the same canonical
 graph, which owns target identity, hierarchy, labels, annotation ranges, and
 overlay elements. Table rows, cells, and inline formatting remain keyboard
@@ -115,7 +121,8 @@ document. No global letter-key listener is installed. Disabling the setting
 removes the document focus surface and leaves existing behavior unchanged.
 Vim HUD is independently cookie-persisted, default off, and only records or
 renders commands while enabled. Text entered into annotation composers is
-neither captured nor displayed.
+neither captured nor displayed. The HUD key panel is separately
+cookie-persisted, defaults on, and never controls the reticle.
 
 Both controls live in their own **Settings → Vim** panel. The Shortcuts panel
 is reserved for the key-binding reference.

--- a/docs/vim-controls.md
+++ b/docs/vim-controls.md
@@ -1,0 +1,100 @@
+# Vim controls
+
+Vim controls provide optional, fully keyboard-driven Select and Pinpoint
+annotation in the plan and annotate applications.
+
+## Goal
+
+- Add an opt-in Vim mode setting. It must default to off.
+- Preserve every existing pointer and keyboard interaction when Vim mode is
+  off.
+- Support keyboard navigation and annotation in both Select and Pinpoint.
+- Support Markdown and raw-HTML documents.
+- Route keyboard-created annotations through the same annotation pipeline as
+  pointer-created annotations.
+- Make the rendered document's semantic structure—not DOM focus—the primary
+  navigation model.
+- Use one semantic target graph for pointer Pinpoint and keyboard navigation.
+- Cover the behavior with automated tests against representative documents.
+
+## Compatibility invariants
+
+1. Vim mode is disabled for every existing user unless they explicitly enable
+   it.
+2. With Vim mode disabled, no Vim key handler may consume or alter an
+   unmodified key.
+3. Vim commands never run while focus is in an input, textarea, contenteditable
+   region, dialog, annotation composer, label picker, image editor, or another
+   embedded editor.
+4. `Tab` and `Shift+Tab` keep their native focus-navigation behavior.
+5. Pointer Select, pointer Pinpoint, Alt-hold, and Alt-double-tap continue to
+   work as they do today.
+6. Keyboard selection must create the same annotation data and highlight DOM
+   as the corresponding pointer selection.
+7. Escape unwinds only the innermost active Vim/annotation state.
+
+## Intended interaction
+
+### Navigation model
+
+`DOCUMENT → BLOCK → INLINE TARGET → TEXT → VISUAL SELECTION`
+
+- Activating Vim controls enters **BLOCK** at the semantic block nearest the
+  viewport: a paragraph, heading, list item, code block, table, and so on.
+- `j` / `k`: next or previous block; after refining, next or previous
+  semantic sibling (for example, another table row, cell, or inline target).
+- `gg` / `G`: first or last block.
+- `l`: refine into a child target; from the deepest target, enter text.
+- `h`: return to the containing target.
+- `v`: begin or end characterwise Visual selection.
+- `V`: select the whole current block; `j` / `k` extend by whole blocks.
+- In text, `h` / `l`, `w` / `b` / `e`, `0` / `$`, and `j` / `k` use precise
+  caret motions.
+- `o`: swap the fixed and moving ends of a selection.
+- `Escape`: back out exactly one level.
+
+The document element may own technical keyboard focus, but it is never drawn
+as the active target. BLOCK and INLINE use the existing Pinpoint wash and
+label around the exact semantic element. TEXT uses a caret. VISUAL and VISUAL
+BLOCK use the browser selection. The status badge reports BLOCK, INLINE,
+NORMAL, VISUAL, VISUAL BLOCK, or ACTION.
+
+Pointer Pinpoint and keyboard navigation resolve through the same canonical
+graph, which owns target identity, hierarchy, labels, annotation ranges, and
+overlay elements. Table rows, cells, and inline formatting remain keyboard
+reachable: `l` enters a level, `j` / `k` move among siblings, and `h` returns
+to the parent before block navigation resumes.
+
+### Actions
+
+- `Enter`: use the active Markup, Comment, Redline, or Label mode.
+- `Space`: open the existing annotation action toolbar.
+- `c`: comment.
+- `d`: redline/delete.
+- `m`: markup.
+- `t`: label.
+- `y`: copy.
+- `Escape`: cancel one layer.
+- `?`: show contextual help.
+
+Annotation actions apply to BLOCK/INLINE targets or an active VISUAL range.
+In NORMAL text state, first create a range with `v`; a collapsed caret is not
+silently promoted to the whole containing block.
+
+## Architecture
+
+Markdown documents use a canonical semantic target graph shared by pointer
+Pinpoint and keyboard navigation. It owns block order, hierarchy, labels,
+annotation ranges, and overlay elements. Text positions are serialized as a
+block ID plus a text offset, so cursor and Visual state survive highlight DOM
+mutations without retaining stale text nodes.
+
+Keyboard-created ranges enter the same `@plannotator/web-highlighter`
+`fromRange()` pipeline as pointer selections. Code blocks and formulas retain
+their specialized annotation paths. Raw HTML keeps its range and focus state
+inside the sandboxed iframe, then posts through the existing, source-validated
+annotation bridge.
+
+Vim controls are cookie-persisted, default off, and scoped to the focused
+document. No global letter-key listener is installed. Disabling the setting
+removes the document focus surface and leaves existing behavior unchanged.

--- a/docs/vim-controls.md
+++ b/docs/vim-controls.md
@@ -6,6 +6,8 @@ annotation in the plan and annotate applications.
 ## Goal
 
 - Add an opt-in Vim mode setting. It must default to off.
+- Offer a second, separately opt-in HUD that visualizes only handled Vim
+  commands.
 - Preserve every existing pointer and keyboard interaction when Vim mode is
   off.
 - Support keyboard navigation and annotation in both Select and Pinpoint.
@@ -56,8 +58,12 @@ annotation in the plan and annotate applications.
 The document element may own technical keyboard focus, but it is never drawn
 as the active target. BLOCK and INLINE use the existing Pinpoint wash and
 label around the exact semantic element. TEXT uses a caret. VISUAL and VISUAL
-BLOCK use the browser selection. The status badge reports BLOCK, INLINE,
-NORMAL, VISUAL, VISUAL BLOCK, or ACTION.
+BLOCK use the browser selection. The compact status badge reports BLOCK,
+INLINE, NORMAL, VISUAL, VISUAL BLOCK, or ACTION. Users who additionally enable
+**Vim HUD** get the same information in a larger bottom-right command display:
+recent handled keys, the active navigation granularity, the input method, and
+a contextual action description. The HUD uses the same component and styling
+for Markdown and raw HTML.
 
 Pointer Pinpoint and keyboard navigation resolve through the same canonical
 graph, which owns target identity, hierarchy, labels, annotation ranges, and
@@ -98,3 +104,6 @@ annotation bridge.
 Vim controls are cookie-persisted, default off, and scoped to the focused
 document. No global letter-key listener is installed. Disabling the setting
 removes the document focus surface and leaves existing behavior unchanged.
+Vim HUD is independently cookie-persisted, default off, and only records or
+renders commands while enabled. Text entered into annotation composers is
+neither captured nor displayed.

--- a/docs/vim-controls.md
+++ b/docs/vim-controls.md
@@ -56,14 +56,20 @@ annotation in the plan and annotate applications.
 - `Escape`: back out exactly one level.
 
 The document element may own technical keyboard focus, but it is never drawn
-as the active target. BLOCK and INLINE use the existing Pinpoint wash and
-label around the exact semantic element. TEXT uses a caret. VISUAL and VISUAL
-BLOCK use the browser selection. The compact status badge reports BLOCK,
-INLINE, NORMAL, VISUAL, VISUAL BLOCK, or ACTION. Users who additionally enable
-**Vim HUD** get the same information in a larger bottom-right command display:
-recent handled keys, the active navigation granularity, the input method, and
-a contextual action description. The HUD uses the same component and styling
-for Markdown and raw HTML.
+as the active target. Without the optional HUD, BLOCK and INLINE use the
+existing Pinpoint wash, TEXT uses a caret, and VISUAL / VISUAL BLOCK use the
+browser selection. The compact status badge reports BLOCK, INLINE, NORMAL,
+VISUAL, VISUAL BLOCK, or ACTION. Users who additionally enable **Vim HUD** get
+the video treatment on the real document: a violet four-corner reticle and
+target label around the live semantic block, caret, or selection, plus the
+larger bottom-right command display with recent handled keys, active navigation
+granularity, input method, and contextual action description. The HUD's visible
+**Key map** control—or `?`—expands that same bottom-right panel into a complete
+legend grouped by Document, Text, Select, Annotate, and Control commands. The
+group matching the current navigation level is highlighted so a learner can
+tell when `j` / `k` move by blocks versus lines. Raw HTML mirrors the same
+target treatment inside its sandboxed iframe while using the shared parent key
+HUD and key map.
 
 Pointer Pinpoint and keyboard navigation resolve through the same canonical
 graph, which owns target identity, hierarchy, labels, annotation ranges, and
@@ -81,7 +87,7 @@ to the parent before block navigation resumes.
 - `t`: label.
 - `y`: copy.
 - `Escape`: cancel one layer.
-- `?`: show contextual help.
+- `?`: expand or collapse the contextual HUD key map.
 
 Annotation actions apply to BLOCK/INLINE targets or an active VISUAL range.
 In NORMAL text state, first create a range with `v`; a collapsed caret is not

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -323,6 +323,7 @@ const App: React.FC = () => {
   });
   const gridEnabled = useConfigValue('gridEnabled');
   const vimModeEnabled = useConfigValue('vimModeEnabled');
+  const vimHudEnabled = useConfigValue('vimHudEnabled');
   const [uiPrefs, setUiPrefs] = useState(() => getUIPreferences());
 
   // Plan-area width (inside the OverlayScrollArea, after sidebar/panel
@@ -4514,6 +4515,7 @@ const App: React.FC = () => {
                     mode={editorMode}
                     inputMethod={inputMethod}
                     vimModeEnabled={vimModeEnabled}
+                    vimHudEnabled={vimModeEnabled && vimHudEnabled}
                     globalAttachments={globalAttachments}
                     onAddGlobalAttachment={handleAddGlobalAttachment}
                     onRemoveGlobalAttachment={handleRemoveGlobalAttachment}
@@ -4548,6 +4550,7 @@ const App: React.FC = () => {
                     mode={editorMode}
                     inputMethod={inputMethod}
                     vimModeEnabled={vimModeEnabled}
+                    vimHudEnabled={vimModeEnabled && vimHudEnabled}
                     taterMode={taterMode}
                     gridEnabled={gridEnabled}
                     globalAttachments={globalAttachments}

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -48,6 +48,7 @@ import { getEditorMode, saveEditorMode } from '@plannotator/ui/utils/editorMode'
 import { getInputMethod, saveInputMethod } from '@plannotator/ui/utils/inputMethod';
 import { useInputMethodSwitch } from '@plannotator/ui/hooks/useInputMethodSwitch';
 import { usePrintMode } from '@plannotator/ui/hooks/usePrintMode';
+import { requestVimDocumentFocus } from '@plannotator/ui/hooks/useVimDocumentFocus';
 import { useResizablePanel } from '@plannotator/ui/hooks/useResizablePanel';
 import { ResizeHandle } from '@plannotator/ui/components/ResizeHandle';
 import { OverlayScrollArea } from '@plannotator/ui/components/OverlayScrollArea';
@@ -326,6 +327,11 @@ const App: React.FC = () => {
   const gridEnabled = useConfigValue('gridEnabled');
   const vimModeEnabled = useConfigValue('vimModeEnabled');
   const vimHudEnabled = useConfigValue('vimHudEnabled');
+  const vimHudKeyPanelEnabled = useConfigValue('vimHudKeyPanelEnabled');
+  const handleVimHudKeyPanelChange = useCallback((enabled: boolean) => {
+    configStore.set('vimHudKeyPanelEnabled', enabled);
+    requestVimDocumentFocus();
+  }, []);
   const [uiPrefs, setUiPrefs] = useState(() => getUIPreferences());
 
   // Plan-area width (inside the OverlayScrollArea, after sidebar/panel
@@ -4533,6 +4539,8 @@ const App: React.FC = () => {
                     inputMethod={inputMethod}
                     vimModeEnabled={vimModeEnabled}
                     vimHudEnabled={vimModeEnabled && vimHudEnabled}
+                    vimHudKeyPanelEnabled={vimHudKeyPanelEnabled}
+                    onVimHudKeyPanelChange={handleVimHudKeyPanelChange}
                     globalAttachments={globalAttachments}
                     onAddGlobalAttachment={handleAddGlobalAttachment}
                     onRemoveGlobalAttachment={handleRemoveGlobalAttachment}
@@ -4568,6 +4576,8 @@ const App: React.FC = () => {
                     inputMethod={inputMethod}
                     vimModeEnabled={vimModeEnabled}
                     vimHudEnabled={vimModeEnabled && vimHudEnabled}
+                    vimHudKeyPanelEnabled={vimHudKeyPanelEnabled}
+                    onVimHudKeyPanelChange={handleVimHudKeyPanelChange}
                     taterMode={taterMode}
                     gridEnabled={gridEnabled}
                     globalAttachments={globalAttachments}

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -322,6 +322,7 @@ const App: React.FC = () => {
     return stored === 'true';
   });
   const gridEnabled = useConfigValue('gridEnabled');
+  const vimModeEnabled = useConfigValue('vimModeEnabled');
   const [uiPrefs, setUiPrefs] = useState(() => getUIPreferences());
 
   // Plan-area width (inside the OverlayScrollArea, after sidebar/panel
@@ -4512,6 +4513,7 @@ const App: React.FC = () => {
                     selectedAnnotationId={selectedAnnotationId}
                     mode={editorMode}
                     inputMethod={inputMethod}
+                    vimModeEnabled={vimModeEnabled}
                     globalAttachments={globalAttachments}
                     onAddGlobalAttachment={handleAddGlobalAttachment}
                     onRemoveGlobalAttachment={handleRemoveGlobalAttachment}
@@ -4545,6 +4547,7 @@ const App: React.FC = () => {
                     selectedAnnotationId={selectedAnnotationId}
                     mode={editorMode}
                     inputMethod={inputMethod}
+                    vimModeEnabled={vimModeEnabled}
                     taterMode={taterMode}
                     gridEnabled={gridEnabled}
                     globalAttachments={globalAttachments}

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -30,6 +30,7 @@ import { CompletionOverlay } from '@plannotator/ui/components/CompletionOverlay'
 import { useUpdateCheck } from '@plannotator/ui/hooks/useUpdateCheck';
 import { PlanAIAnnouncementDialog } from '@plannotator/ui/components/PlanAIAnnouncementDialog';
 import { LookAndFeelAnnouncementDialog } from '@plannotator/ui/components/LookAndFeelAnnouncementDialog';
+import { VimModeAnnouncementDialog } from '@plannotator/ui/components/VimModeAnnouncementDialog';
 import { getObsidianSettings, getEffectiveVaultPath, isObsidianConfigured, CUSTOM_PATH_SENTINEL } from '@plannotator/ui/utils/obsidian';
 import { getBearSettings } from '@plannotator/ui/utils/bear';
 import { getOctarineSettings, isOctarineConfigured } from '@plannotator/ui/utils/octarine';
@@ -40,6 +41,7 @@ import { type AIProviderOption } from '@plannotator/ui/utils/aiProvider';
 import { useAIProviderConfig } from '@plannotator/ui/hooks/useAIProviderConfig';
 import { markPlanAIAnnouncementSeen, needsPlanAIAnnouncement } from '@plannotator/ui/utils/planAIAnnouncement';
 import { markLookAndFeelAnnouncementSeen, needsLookAndFeelAnnouncement } from '@plannotator/ui/utils/lookAndFeelAnnouncement';
+import { markVimModeAnnouncementSeen, needsVimModeAnnouncement } from '@plannotator/ui/utils/vimModeAnnouncement';
 import { buildDefaultPrompt, useAIChat } from '@plannotator/ui/hooks/useAIChat';
 import { getUIPreferences, type UIPreferences, type PlanWidth } from '@plannotator/ui/utils/uiPreferences';
 import { getEditorMode, saveEditorMode } from '@plannotator/ui/utils/editorMode';
@@ -470,6 +472,7 @@ const App: React.FC = () => {
   });
   const [showPlanAIAnnouncement, setShowPlanAIAnnouncement] = useState(needsPlanAIAnnouncement);
   const [showLookAndFeelAnnouncement, setShowLookAndFeelAnnouncement] = useState(needsLookAndFeelAnnouncement);
+  const [showVimModeAnnouncement, setShowVimModeAnnouncement] = useState(needsVimModeAnnouncement);
   const isMobile = useIsMobile();
 
   const viewerRef = useRef<ViewerHandle>(null);
@@ -593,6 +596,11 @@ const App: React.FC = () => {
   const dismissLookAndFeelAnnouncement = useCallback(() => {
     markLookAndFeelAnnouncementSeen();
     setShowLookAndFeelAnnouncement(false);
+  }, []);
+
+  const dismissVimModeAnnouncement = useCallback(() => {
+    markVimModeAnnouncementSeen();
+    setShowVimModeAnnouncement(false);
   }, []);
 
   const handleAIChatToggle = useCallback(() => {
@@ -3987,9 +3995,18 @@ const App: React.FC = () => {
     !isSharedSession &&
     !goalSetupMode &&
     !showPermissionModeSetup;
+  const shouldShowVimModeAnnouncement =
+    showVimModeAnnouncement &&
+    !shouldShowLookAndFeelAnnouncement &&
+    !isSharedSession &&
+    !archive.archiveMode &&
+    !goalSetupMode &&
+    !showPermissionModeSetup &&
+    !submitted;
   const shouldShowPlanAIAnnouncement =
     showPlanAIAnnouncement &&
     !shouldShowLookAndFeelAnnouncement &&
+    !shouldShowVimModeAnnouncement &&
     canUseAI &&
     aiSessionEnabled &&
     isApiMode &&
@@ -4951,6 +4968,15 @@ const App: React.FC = () => {
           gridEnabled={gridEnabled}
           onToggleGrid={(v) => configStore.set('gridEnabled', v)}
           onDismiss={dismissLookAndFeelAnnouncement}
+        />
+
+        <VimModeAnnouncementDialog
+          isOpen={shouldShowVimModeAnnouncement}
+          vimModeEnabled={vimModeEnabled}
+          vimHudEnabled={vimHudEnabled}
+          onVimModeChange={(enabled) => configStore.set('vimModeEnabled', enabled)}
+          onVimHudChange={(enabled) => configStore.set('vimHudEnabled', enabled)}
+          onDismiss={dismissVimModeAnnouncement}
         />
 
         {/* Image Annotator for pasted images */}

--- a/packages/editor/shortcuts.ts
+++ b/packages/editor/shortcuts.ts
@@ -10,6 +10,7 @@ import {
   imageAnnotatorShortcuts,
   inputMethodShortcuts,
   viewerShortcuts,
+  vimSelectionShortcuts,
   type ShortcutSurface,
 } from '@plannotator/ui/shortcuts';
 
@@ -81,6 +82,7 @@ const sharedPlanSurfaceShortcuts = [
   inputMethodShortcuts,
   annotationToolbarShortcuts,
   viewerShortcuts,
+  vimSelectionShortcuts,
   commentPopoverShortcuts,
   annotationPanelShortcuts,
   imageAnnotatorShortcuts,

--- a/packages/ui/components/AnnotationToolbar.tsx
+++ b/packages/ui/components/AnnotationToolbar.tsx
@@ -123,7 +123,7 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
   // Type-to-comment + Alt+N / bare digit quick label shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.isComposing) return;
+      if (e.defaultPrevented || e.isComposing) return;
       if (isEditableElement(e.target) || isEditableElement(document.activeElement)) return;
 
       // When picker is open, let FloatingQuickLabelPicker own all keyboard input

--- a/packages/ui/components/KeyboardShortcuts.tsx
+++ b/packages/ui/components/KeyboardShortcuts.tsx
@@ -1,4 +1,9 @@
 import React from 'react';
+import {
+  formatShortcutBindingTokens,
+  listScopeShortcuts,
+  vimSelectionShortcuts,
+} from '../shortcuts';
 import { isMac, modKey, altKey } from '../utils/platform';
 
 /* ─── Key cap component ─── */
@@ -108,6 +113,24 @@ const sharedPlanEditorShortcuts: ShortcutSection[] = [
   imageAnnotatorShortcuts,
 ];
 
+const vimShortcuts: ShortcutSection[] = (() => {
+  const sections = new Map<string, Shortcut[]>();
+  const entries = listScopeShortcuts(vimSelectionShortcuts)
+    .sort((left, right) => (left.displayOrder ?? 0) - (right.displayOrder ?? 0));
+
+  for (const entry of entries) {
+    const shortcuts = sections.get(entry.section) ?? [];
+    shortcuts.push({
+      keys: formatShortcutBindingTokens(entry.bindings[0] ?? ''),
+      desc: entry.description,
+      hint: entry.hint,
+    });
+    sections.set(entry.section, shortcuts);
+  }
+
+  return Array.from(sections, ([title, shortcuts]) => ({ title, shortcuts }));
+})();
+
 const planActionShortcuts: ShortcutSection = {
   title: 'Actions',
   shortcuts: [
@@ -191,8 +214,19 @@ const reviewShortcuts: ShortcutSection[] = [
 
 /* ─── Exported panel ─── */
 
-export const KeyboardShortcuts: React.FC<{ mode: 'plan' | 'annotate' | 'review' }> = ({ mode }) => {
-  const sections = mode === 'review' ? reviewShortcuts : mode === 'annotate' ? annotateShortcuts : planShortcuts;
+/** Render the surface shortcut reference, including opt-in Vim commands. */
+export const KeyboardShortcuts: React.FC<{
+  mode: 'plan' | 'annotate' | 'review';
+  vimModeEnabled?: boolean;
+}> = ({ mode, vimModeEnabled = false }) => {
+  const baseSections = mode === 'review'
+    ? reviewShortcuts
+    : mode === 'annotate'
+      ? annotateShortcuts
+      : planShortcuts;
+  const sections = vimModeEnabled && mode !== 'review'
+    ? [...vimShortcuts, ...baseSections]
+    : baseSections;
 
   return (
     <div className="space-y-4">

--- a/packages/ui/components/PinpointOverlay.tsx
+++ b/packages/ui/components/PinpointOverlay.tsx
@@ -67,6 +67,7 @@ export const PinpointOverlay: React.FC<PinpointOverlayProps> = ({ target, contai
     <>
       {/* Background wash */}
       <div
+        data-pinpoint-overlay
         className="bg-primary/10 rounded-sm"
         style={{
           position: 'absolute',
@@ -81,6 +82,7 @@ export const PinpointOverlay: React.FC<PinpointOverlayProps> = ({ target, contai
       />
       {/* Label badge */}
       <div
+        data-pinpoint-label={target.label}
         style={{
           position: 'absolute',
           top: position.top - 22,

--- a/packages/ui/components/Settings.tsx
+++ b/packages/ui/components/Settings.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import type { Origin } from '@plannotator/core/agents';
 import type { DiffLineBgIntensity } from '@plannotator/core/config-types';
@@ -70,6 +70,7 @@ import {
   saveFileBrowserSettings,
   type FileBrowserSettings,
 } from '../utils/fileBrowser';
+import { requestVimDocumentFocus } from '../hooks/useVimDocumentFocus';
 
 type SettingsTab = 'general' | 'theme' | 'git' | 'display' | 'saving' | 'labels' | 'vim' | 'shortcuts' | 'ai' | 'files' | 'obsidian' | 'bear' | 'octarine' | 'comments' | 'hooks';
 
@@ -255,10 +256,11 @@ function VimSettingsTab({
           <div>
             <div className="text-xs font-semibold">Learn while you navigate</div>
             <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-              Focus the document, then use <span className="font-mono text-foreground">j</span> and{' '}
-              <span className="font-mono text-foreground">k</span> to move by block. With the HUD
-              enabled, press <span className="font-mono text-foreground">?</span> for the complete
-              contextual key map.
+              Vim takes focus automatically when the page is ready. From other app controls, press{' '}
+              <span className="font-mono text-foreground">Esc</span> to return to the document, then
+              use <span className="font-mono text-foreground">j</span> and{' '}
+              <span className="font-mono text-foreground">k</span> to move by block. Press{' '}
+              <span className="font-mono text-foreground">?</span> for the complete key map.
             </p>
           </div>
         </div>
@@ -721,7 +723,22 @@ const CommentsTab: React.FC = () => {
 
 export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange, onIdentityChange, origin, mode = 'plan', onUIPreferencesChange, externalOpen, onExternalClose, aiProviders = [], gitUser, sinceBaseUnavailable, onDetectObsidianVaults }) => {
   const [showDialog, setShowDialog] = useState(false);
+  const settingsWasOpenRef = useRef(false);
   const [themePreview, setThemePreview] = useState(false);
+
+  useEffect(() => {
+    const wasOpen = settingsWasOpenRef.current;
+    settingsWasOpenRef.current = showDialog;
+    if (
+      wasOpen
+      && !showDialog
+      && !themePreview
+      && mode !== 'review'
+      && configStore.get('vimModeEnabled')
+    ) {
+      requestVimDocumentFocus();
+    }
+  }, [mode, showDialog, themePreview]);
 
   useEffect(() => {
     if (!themePreview) return;
@@ -987,12 +1004,23 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
         >
           <div
             className="bg-card border border-border rounded-xl w-full max-w-2xl max-h-[85vh] flex flex-col shadow-2xl relative overflow-hidden"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="plannotator-settings-title"
             onClick={e => e.stopPropagation()}
+            onKeyDown={(event) => {
+              if (event.key !== 'Escape' || event.defaultPrevented) return;
+              event.preventDefault();
+              event.stopPropagation();
+              setShowDialog(false);
+            }}
           >
             {taterMode && <TaterSpritePullup />}
             <div className="flex items-center justify-between p-4 border-b border-border">
-              <h3 className="font-semibold text-sm">Settings</h3>
+              <h3 id="plannotator-settings-title" className="font-semibold text-sm">Settings</h3>
               <button
+                type="button"
+                aria-label="Close settings"
                 onClick={() => setShowDialog(false)}
                 className="p-1.5 rounded-md bg-muted hover:bg-muted/80 text-foreground transition-colors"
               >
@@ -1728,7 +1756,11 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
                                       saveQuickLabels(updated);
                                       setEditingTipIndex(null);
                                     }
-                                    if (e.key === 'Escape') setEditingTipIndex(null);
+                                    if (e.key === 'Escape') {
+                                      e.preventDefault();
+                                      e.stopPropagation();
+                                      setEditingTipIndex(null);
+                                    }
                                   }}
                                   placeholder="AI instruction tip..."
                                   className="flex-1 px-2 py-1 bg-background/60 rounded text-[10px] text-muted-foreground placeholder:text-muted-foreground/30 focus:outline-none focus:ring-1 focus:ring-primary/50"

--- a/packages/ui/components/Settings.tsx
+++ b/packages/ui/components/Settings.tsx
@@ -207,16 +207,20 @@ function ToggleSwitch({ checked, onChange, label, description, disabled = false 
 interface VimSettingsTabProps {
   readonly vimModeEnabled: boolean;
   readonly vimHudEnabled: boolean;
+  readonly vimHudKeyPanelEnabled: boolean;
   readonly onVimModeChange: (enabled: boolean) => void;
   readonly onVimHudChange: (enabled: boolean) => void;
+  readonly onVimHudKeyPanelChange: (enabled: boolean) => void;
 }
 
 /** First-class Vim configuration, separate from the shortcut reference. */
 function VimSettingsTab({
   vimModeEnabled,
   vimHudEnabled,
+  vimHudKeyPanelEnabled,
   onVimModeChange,
   onVimHudChange,
+  onVimHudKeyPanelChange,
 }: VimSettingsTabProps) {
   return (
     <div className="space-y-5">
@@ -241,10 +245,22 @@ function VimSettingsTab({
           label="Vim HUD"
           description={
             vimModeEnabled
-              ? 'Show the target reticle, live keypress feedback, and navigation context.'
-              : 'Enable Vim controls first to use the target reticle and live key guide.'
+              ? 'Show the four-corner target reticle and navigation context.'
+              : 'Enable Vim controls first to use the target reticle.'
           }
           disabled={!vimModeEnabled}
+        />
+        <div className="border-t border-border" />
+        <ToggleSwitch
+          checked={vimModeEnabled && vimHudEnabled && vimHudKeyPanelEnabled}
+          onChange={onVimHudKeyPanelChange}
+          label="Key panel"
+          description={
+            vimModeEnabled && vimHudEnabled
+              ? 'Show the bottom-right live keypress legend and command panel.'
+              : 'Enable the Vim HUD first to use the live keypress legend.'
+          }
+          disabled={!vimModeEnabled || !vimHudEnabled}
         />
       </div>
 
@@ -260,7 +276,8 @@ function VimSettingsTab({
               <span className="font-mono text-foreground">Esc</span> to return to the document, then
               use <span className="font-mono text-foreground">j</span> and{' '}
               <span className="font-mono text-foreground">k</span> to move by block. Press{' '}
-              <span className="font-mono text-foreground">?</span> for the complete key map.
+              <span className="font-mono text-foreground">?</span> for the complete key map,
+              even when the Key panel is hidden.
             </p>
           </div>
         </div>
@@ -752,6 +769,7 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
   const gridEnabled = useConfigValue('gridEnabled');
   const vimModeEnabled = useConfigValue('vimModeEnabled');
   const vimHudEnabled = useConfigValue('vimHudEnabled');
+  const vimHudKeyPanelEnabled = useConfigValue('vimHudKeyPanelEnabled');
   const [identity, setIdentity] = useState('');
   const [obsidian, setObsidian] = useState<ObsidianSettings>({
     enabled: false,
@@ -1819,8 +1837,11 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
                   <VimSettingsTab
                     vimModeEnabled={vimModeEnabled}
                     vimHudEnabled={vimHudEnabled}
+                    vimHudKeyPanelEnabled={vimHudKeyPanelEnabled}
                     onVimModeChange={(enabled) => configStore.set('vimModeEnabled', enabled)}
                     onVimHudChange={(enabled) => configStore.set('vimHudEnabled', enabled)}
+                    onVimHudKeyPanelChange={(enabled) =>
+                      configStore.set('vimHudKeyPanelEnabled', enabled)}
                   />
                 )}
 

--- a/packages/ui/components/Settings.tsx
+++ b/packages/ui/components/Settings.tsx
@@ -665,6 +665,7 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
   }, [themePreview]);
   const [activeTab, setActiveTab] = useState<SettingsTab>('general');
   const gridEnabled = useConfigValue('gridEnabled');
+  const vimModeEnabled = useConfigValue('vimModeEnabled');
   const [identity, setIdentity] = useState('');
   const [obsidian, setObsidian] = useState<ObsidianSettings>({
     enabled: false,
@@ -1711,7 +1712,20 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
 
                 {/* === SHORTCUTS TAB === */}
                 {activeTab === 'shortcuts' && (
-                  <KeyboardShortcuts mode={mode} />
+                  <>
+                    {mode !== 'review' && (
+                      <>
+                        <ToggleSwitch
+                          checked={vimModeEnabled}
+                          onChange={(enabled) => configStore.set('vimModeEnabled', enabled)}
+                          label="Vim controls"
+                          description="Navigate and annotate documents with Vim-style keys. Off by default."
+                        />
+                        <div className="border-t border-border" />
+                      </>
+                    )}
+                    <KeyboardShortcuts mode={mode} vimModeEnabled={vimModeEnabled} />
+                  </>
                 )}
 
                 {/* === COMMENTS TAB === */}

--- a/packages/ui/components/Settings.tsx
+++ b/packages/ui/components/Settings.tsx
@@ -71,7 +71,7 @@ import {
   type FileBrowserSettings,
 } from '../utils/fileBrowser';
 
-type SettingsTab = 'general' | 'theme' | 'git' | 'display' | 'saving' | 'labels' | 'shortcuts' | 'ai' | 'files' | 'obsidian' | 'bear' | 'octarine' | 'comments' | 'hooks';
+type SettingsTab = 'general' | 'theme' | 'git' | 'display' | 'saving' | 'labels' | 'vim' | 'shortcuts' | 'ai' | 'files' | 'obsidian' | 'bear' | 'octarine' | 'comments' | 'hooks';
 
 interface SettingsProps {
   taterMode: boolean;
@@ -169,23 +169,27 @@ function SegmentedControl<T extends string>({ options, value, onChange }: {
   );
 }
 
-function ToggleSwitch({ checked, onChange, label, description }: {
+function ToggleSwitch({ checked, onChange, label, description, disabled = false }: {
   checked: boolean;
   onChange: (v: boolean) => void;
   label: string;
   description?: string;
+  disabled?: boolean;
 }) {
   return (
-    <div className="flex items-center justify-between">
+    <div className={`flex items-center justify-between gap-4 ${disabled ? 'opacity-50' : ''}`}>
       <div>
         <div className="text-sm font-medium">{label}</div>
         {description && <div className="text-xs text-muted-foreground">{description}</div>}
       </div>
       <button
+        type="button"
         role="switch"
+        aria-label={label}
         aria-checked={checked}
+        disabled={disabled}
         onClick={() => onChange(!checked)}
-        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+        className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors disabled:cursor-not-allowed ${
           checked ? 'bg-primary' : 'bg-muted'
         }`}
       >
@@ -195,6 +199,70 @@ function ToggleSwitch({ checked, onChange, label, description }: {
           }`}
         />
       </button>
+    </div>
+  );
+}
+
+interface VimSettingsTabProps {
+  readonly vimModeEnabled: boolean;
+  readonly vimHudEnabled: boolean;
+  readonly onVimModeChange: (enabled: boolean) => void;
+  readonly onVimHudChange: (enabled: boolean) => void;
+}
+
+/** First-class Vim configuration, separate from the shortcut reference. */
+function VimSettingsTab({
+  vimModeEnabled,
+  vimHudEnabled,
+  onVimModeChange,
+  onVimHudChange,
+}: VimSettingsTabProps) {
+  return (
+    <div className="space-y-5">
+      <div>
+        <div className="text-sm font-semibold">Vim mode</div>
+        <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+          Navigate, select, and annotate the rendered document without reaching for the mouse.
+        </p>
+      </div>
+
+      <div className="space-y-4 rounded-xl border border-border bg-muted/20 p-4">
+        <ToggleSwitch
+          checked={vimModeEnabled}
+          onChange={onVimModeChange}
+          label="Vim controls"
+          description="Use Vim-style keys for document navigation and annotation. Off by default."
+        />
+        <div className="border-t border-border" />
+        <ToggleSwitch
+          checked={vimModeEnabled && vimHudEnabled}
+          onChange={onVimHudChange}
+          label="Vim HUD"
+          description={
+            vimModeEnabled
+              ? 'Show the target reticle, live keypress feedback, and navigation context.'
+              : 'Enable Vim controls first to use the target reticle and live key guide.'
+          }
+          disabled={!vimModeEnabled}
+        />
+      </div>
+
+      <div className="rounded-xl border border-primary/20 bg-primary/[0.05] p-4">
+        <div className="flex items-start gap-3">
+          <span className="grid h-7 w-7 shrink-0 place-items-center rounded-md bg-primary/15 font-mono text-xs font-bold text-primary">
+            ?
+          </span>
+          <div>
+            <div className="text-xs font-semibold">Learn while you navigate</div>
+            <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+              Focus the document, then use <span className="font-mono text-foreground">j</span> and{' '}
+              <span className="font-mono text-foreground">k</span> to move by block. With the HUD
+              enabled, press <span className="font-mono text-foreground">?</span> for the complete
+              contextual key map.
+            </p>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }
@@ -712,6 +780,9 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
       if (aiProviders.length > 0) {
         t.push({ id: 'ai', label: 'AI' });
       }
+    }
+    if (mode !== 'review') {
+      t.push({ id: 'vim', label: 'Vim' });
     }
     t.push({ id: 'shortcuts', label: 'Shortcuts' });
     if (mode === 'plan') {
@@ -1711,32 +1782,19 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
                   </>
                 )}
 
+                {/* === VIM TAB === */}
+                {activeTab === 'vim' && mode !== 'review' && (
+                  <VimSettingsTab
+                    vimModeEnabled={vimModeEnabled}
+                    vimHudEnabled={vimHudEnabled}
+                    onVimModeChange={(enabled) => configStore.set('vimModeEnabled', enabled)}
+                    onVimHudChange={(enabled) => configStore.set('vimHudEnabled', enabled)}
+                  />
+                )}
+
                 {/* === SHORTCUTS TAB === */}
                 {activeTab === 'shortcuts' && (
-                  <>
-                    {mode !== 'review' && (
-                      <>
-                        <ToggleSwitch
-                          checked={vimModeEnabled}
-                          onChange={(enabled) => configStore.set('vimModeEnabled', enabled)}
-                          label="Vim controls"
-                          description="Navigate and annotate documents with Vim-style keys. Off by default."
-                        />
-                        {vimModeEnabled && (
-                          <div className="ml-5 border-l border-primary/20 pl-4">
-                            <ToggleSwitch
-                              checked={vimHudEnabled}
-                              onChange={(enabled) => configStore.set('vimHudEnabled', enabled)}
-                              label="Vim HUD"
-                              description="Show live keys, command history, and navigation context."
-                            />
-                          </div>
-                        )}
-                        <div className="border-t border-border" />
-                      </>
-                    )}
-                    <KeyboardShortcuts mode={mode} vimModeEnabled={vimModeEnabled} />
-                  </>
+                  <KeyboardShortcuts mode={mode} vimModeEnabled={vimModeEnabled} />
                 )}
 
                 {/* === COMMENTS TAB === */}

--- a/packages/ui/components/Settings.tsx
+++ b/packages/ui/components/Settings.tsx
@@ -666,6 +666,7 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
   const [activeTab, setActiveTab] = useState<SettingsTab>('general');
   const gridEnabled = useConfigValue('gridEnabled');
   const vimModeEnabled = useConfigValue('vimModeEnabled');
+  const vimHudEnabled = useConfigValue('vimHudEnabled');
   const [identity, setIdentity] = useState('');
   const [obsidian, setObsidian] = useState<ObsidianSettings>({
     enabled: false,
@@ -1721,6 +1722,16 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
                           label="Vim controls"
                           description="Navigate and annotate documents with Vim-style keys. Off by default."
                         />
+                        {vimModeEnabled && (
+                          <div className="ml-5 border-l border-primary/20 pl-4">
+                            <ToggleSwitch
+                              checked={vimHudEnabled}
+                              onChange={(enabled) => configStore.set('vimHudEnabled', enabled)}
+                              label="Vim HUD"
+                              description="Show live keys, command history, and navigation context."
+                            />
+                          </div>
+                        )}
                         <div className="border-t border-border" />
                       </>
                     )}

--- a/packages/ui/components/Settings.vim.test.tsx
+++ b/packages/ui/components/Settings.vim.test.tsx
@@ -86,4 +86,20 @@ describe('Settings Vim panel', () => {
       document.querySelector('button[role="switch"][aria-label="Vim controls"]'),
     ).not.toBeNull();
   });
+
+  test.skipIf(!hasDom)('exposes modal semantics and closes on Escape', async () => {
+    await mountSettings('plan');
+    const dialog = document.querySelector<HTMLElement>('[role="dialog"]');
+    expect(dialog?.getAttribute('aria-labelledby')).toBe('plannotator-settings-title');
+
+    await act(async () => {
+      dialog?.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      }));
+    });
+
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+  });
 });

--- a/packages/ui/components/Settings.vim.test.tsx
+++ b/packages/ui/components/Settings.vim.test.tsx
@@ -40,12 +40,14 @@ describe('Settings Vim panel', () => {
     host = null;
     configStore.set('vimModeEnabled', false);
     configStore.set('vimHudEnabled', false);
+    configStore.set('vimHudKeyPanelEnabled', true);
     if (hasDom) document.body.replaceChildren();
   });
 
   test.skipIf(!hasDom)('keeps Vim configuration in a dedicated plan settings panel', async () => {
     configStore.set('vimModeEnabled', false);
     configStore.set('vimHudEnabled', false);
+    configStore.set('vimHudKeyPanelEnabled', true);
     await mountSettings('plan');
 
     await act(async () => buttonWithExactText('Vim').click());
@@ -56,16 +58,29 @@ describe('Settings Vim panel', () => {
     const hudToggle = document.querySelector<HTMLButtonElement>(
       'button[role="switch"][aria-label="Vim HUD"]',
     );
+    const keyPanelToggle = document.querySelector<HTMLButtonElement>(
+      'button[role="switch"][aria-label="Key panel"]',
+    );
     expect(vimToggle).not.toBeNull();
     expect(hudToggle?.disabled).toBe(true);
+    expect(keyPanelToggle?.disabled).toBe(true);
     expect(document.body.textContent).toContain('Learn while you navigate');
 
     await act(async () => vimToggle?.click());
     expect(hudToggle?.disabled).toBe(false);
+    expect(keyPanelToggle?.disabled).toBe(true);
+
+    await act(async () => hudToggle?.click());
+    expect(keyPanelToggle?.disabled).toBe(false);
+    expect(keyPanelToggle?.getAttribute('aria-checked')).toBe('true');
+
+    await act(async () => keyPanelToggle?.click());
+    expect(configStore.get('vimHudKeyPanelEnabled')).toBe(false);
 
     await act(async () => buttonWithExactText('Shortcuts').click());
     expect(document.querySelector('button[role="switch"][aria-label="Vim controls"]')).toBeNull();
     expect(document.querySelector('button[role="switch"][aria-label="Vim HUD"]')).toBeNull();
+    expect(document.querySelector('button[role="switch"][aria-label="Key panel"]')).toBeNull();
   });
 
   test.skipIf(!hasDom)('does not offer document Vim settings in code review', async () => {

--- a/packages/ui/components/Settings.vim.test.tsx
+++ b/packages/ui/components/Settings.vim.test.tsx
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { configStore } from '../config';
+import { Settings } from './Settings';
+
+const hasDom = typeof document !== 'undefined';
+let root: Root | null = null;
+let host: HTMLElement | null = null;
+
+function buttonWithExactText(text: string): HTMLButtonElement {
+  const button = Array.from(document.querySelectorAll<HTMLButtonElement>('button'))
+    .find(candidate => candidate.textContent?.trim() === text);
+  if (!button) throw new Error(`Button labelled "${text}" did not render`);
+  return button;
+}
+
+async function mountSettings(mode: 'plan' | 'annotate' | 'review'): Promise<void> {
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  root = createRoot(host);
+  await act(async () => {
+    root?.render(
+      <Settings
+        taterMode={false}
+        onTaterModeChange={() => {}}
+        mode={mode}
+        externalOpen
+      />,
+    );
+  });
+}
+
+describe('Settings Vim panel', () => {
+  afterEach(async () => {
+    const mountedRoot = root;
+    if (mountedRoot) await act(async () => mountedRoot.unmount());
+    root = null;
+    host?.remove();
+    host = null;
+    configStore.set('vimModeEnabled', false);
+    configStore.set('vimHudEnabled', false);
+    if (hasDom) document.body.replaceChildren();
+  });
+
+  test.skipIf(!hasDom)('keeps Vim configuration in a dedicated plan settings panel', async () => {
+    configStore.set('vimModeEnabled', false);
+    configStore.set('vimHudEnabled', false);
+    await mountSettings('plan');
+
+    await act(async () => buttonWithExactText('Vim').click());
+
+    const vimToggle = document.querySelector<HTMLButtonElement>(
+      'button[role="switch"][aria-label="Vim controls"]',
+    );
+    const hudToggle = document.querySelector<HTMLButtonElement>(
+      'button[role="switch"][aria-label="Vim HUD"]',
+    );
+    expect(vimToggle).not.toBeNull();
+    expect(hudToggle?.disabled).toBe(true);
+    expect(document.body.textContent).toContain('Learn while you navigate');
+
+    await act(async () => vimToggle?.click());
+    expect(hudToggle?.disabled).toBe(false);
+
+    await act(async () => buttonWithExactText('Shortcuts').click());
+    expect(document.querySelector('button[role="switch"][aria-label="Vim controls"]')).toBeNull();
+    expect(document.querySelector('button[role="switch"][aria-label="Vim HUD"]')).toBeNull();
+  });
+
+  test.skipIf(!hasDom)('does not offer document Vim settings in code review', async () => {
+    await mountSettings('review');
+
+    expect(
+      Array.from(document.querySelectorAll<HTMLButtonElement>('button'))
+        .some(candidate => candidate.textContent?.trim() === 'Vim'),
+    ).toBe(false);
+  });
+
+  test.skipIf(!hasDom)('offers the dedicated Vim panel in annotate mode', async () => {
+    await mountSettings('annotate');
+
+    await act(async () => buttonWithExactText('Vim').click());
+
+    expect(
+      document.querySelector('button[role="switch"][aria-label="Vim controls"]'),
+    ).not.toBeNull();
+  });
+});

--- a/packages/ui/components/Viewer.tsx
+++ b/packages/ui/components/Viewer.tsx
@@ -127,6 +127,8 @@ interface ViewerProps {
   readOnly?: boolean;
   /** Opt-in Vim-style keyboard selection. Default false for compatibility. */
   vimModeEnabled?: boolean;
+  /** Replace the compact Vim badge with the live video-style key HUD. */
+  vimHudEnabled?: boolean;
 }
 
 export interface ViewerHandle {
@@ -217,6 +219,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
   allowImages = true,
   readOnly = false,
   vimModeEnabled = false,
+  vimHudEnabled = false,
 }, ref) => {
   const [copied, setCopied] = useState(false);
   const [lightbox, setLightbox] = useState<{ src: string; alt: string } | null>(null);
@@ -429,6 +432,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
   const vim = useVimSelection({
     containerRef,
     enabled: vimModeActive,
+    hudEnabled: vimHudEnabled,
     blocked: vimBlocked,
     activeMode: mode,
     contentVersion: blocks,
@@ -976,6 +980,8 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
             inputMethod={inputMethod}
             state={vim.state}
             focused={vim.focused}
+            hudEnabled={vimHudEnabled}
+            hudCommand={vim.hudCommand}
             helpOpen={vim.helpOpen}
             onCloseHelp={vim.closeHelp}
           />

--- a/packages/ui/components/Viewer.tsx
+++ b/packages/ui/components/Viewer.tsx
@@ -137,6 +137,12 @@ export interface ViewerHandle {
   applySharedAnnotations: (annotations: Annotation[]) => void;
 }
 
+interface CodeBlockToolbarTarget {
+  readonly block: Block;
+  readonly element: HTMLElement;
+  readonly activation: 'pointer' | 'keyboard';
+}
+
 /**
  * Renders YAML frontmatter as a styled metadata card.
  */
@@ -263,7 +269,8 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
   // `-1`/`-2`/... suffixes rather than colliding on the same id.
   const headingSlugMap = useMemo(() => buildHeadingSlugMap(blocks), [blocks]);
   const isTouchDevice = useMemo(() => window.matchMedia('(pointer: coarse)').matches, []);
-  const [hoveredCodeBlock, setHoveredCodeBlock] = useState<{ block: Block; element: HTMLElement } | null>(null);
+  const [codeBlockToolbar, setCodeBlockToolbar] =
+    useState<CodeBlockToolbarTarget | null>(null);
   const [isCodeBlockToolbarExiting, setIsCodeBlockToolbarExiting] = useState(false);
   const [hoveredTable, setHoveredTable] = useState<{ block: Block; element: HTMLElement } | null>(null);
   const [isTableToolbarExiting, setIsTableToolbarExiting] = useState(false);
@@ -407,7 +414,11 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
       return;
     }
     if (effectiveMode === 'selection') {
-      setHoveredCodeBlock({ block, element });
+      if (hoverTimeoutRef.current) {
+        clearTimeout(hoverTimeoutRef.current);
+        hoverTimeoutRef.current = null;
+      }
+      setCodeBlockToolbar({ block, element, activation: 'keyboard' });
       return;
     }
     setViewerCommentPopover({
@@ -420,12 +431,13 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
   }, [applyCodeBlockAnnotation, blocks]);
 
   const vimModeActive = vimModeEnabled && !readOnly;
+  const keyboardCodeBlockToolbarOpen = codeBlockToolbar?.activation === 'keyboard';
   const vimBlocked = !!toolbarState
     || !!hookCommentPopover
     || !!viewerCommentPopover
     || !!hookQuickLabelPicker
     || !!codeBlockQuickLabelPicker
-    || !!hoveredCodeBlock
+    || keyboardCodeBlockToolbarOpen
     || !!isPlanDiffActive
     || !!popoutTable
     || !!lightbox;
@@ -448,6 +460,32 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
     onSelectRange: highlightRange,
     onCodeBlockClick: handlePinpointCodeBlockClick,
   });
+  const vimOwnsHudTarget = vimHudEnabled
+    && vim.state.phase !== 'inactive'
+    && (vim.focused || vim.state.phase === 'action');
+  const vimOwnsDocumentNavigation = vimModeActive
+    && vim.focused
+    && vim.state.phase !== 'inactive'
+    && vim.state.phase !== 'action';
+  const legacyVimTarget = !vimHudEnabled
+    && (vim.focused || vim.state.phase === 'action')
+    ? vim.activeTarget
+    : null;
+  const pinpointOverlayTarget = vimOwnsHudTarget
+    ? null
+    : legacyVimTarget ?? (inputMethod === 'pinpoint' ? hoverTarget : null);
+
+  useEffect(() => {
+    if (!vimOwnsDocumentNavigation) return;
+    if (hoverTimeoutRef.current) {
+      clearTimeout(hoverTimeoutRef.current);
+      hoverTimeoutRef.current = null;
+    }
+    setCodeBlockToolbar((current) => (
+      current?.activation === 'pointer' ? null : current
+    ));
+    setIsCodeBlockToolbarExiting(false);
+  }, [vimOwnsDocumentNavigation]);
 
   // Suppress native context menu on touch devices (prevents cut/copy/paste overlay on mobile)
   useEffect(() => {
@@ -573,42 +611,42 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
   // --- Viewer-specific: code block annotation ---
 
   const handleCodeBlockAnnotate = (type: AnnotationType) => {
-    if (!hoveredCodeBlock) return;
-    const codeEl = hoveredCodeBlock.element.querySelector('code');
+    if (!codeBlockToolbar) return;
+    const codeEl = codeBlockToolbar.element.querySelector('code');
     if (!codeEl) return;
-    applyCodeBlockAnnotation(hoveredCodeBlock.block.id, codeEl, type);
-    setHoveredCodeBlock(null);
+    applyCodeBlockAnnotation(codeBlockToolbar.block.id, codeEl, type);
+    setCodeBlockToolbar(null);
   };
 
   const handleCodeBlockQuickLabel = (label: QuickLabel) => {
-    if (!hoveredCodeBlock) return;
-    const codeEl = hoveredCodeBlock.element.querySelector('code');
+    if (!codeBlockToolbar) return;
+    const codeEl = codeBlockToolbar.element.querySelector('code');
     if (!codeEl) return;
     applyCodeBlockAnnotation(
-      hoveredCodeBlock.block.id, codeEl, AnnotationType.COMMENT,
+      codeBlockToolbar.block.id, codeEl, AnnotationType.COMMENT,
       `${label.emoji} ${label.text}`, undefined, true, label.tip
     );
-    setHoveredCodeBlock(null);
+    setCodeBlockToolbar(null);
   };
 
   const handleCodeBlockToolbarClose = () => {
-    setHoveredCodeBlock(null);
+    setCodeBlockToolbar(null);
   };
 
   // Viewer-specific comment popover handlers (code blocks + global comments)
 
   const handleCodeBlockRequestComment = (initialChar?: string) => {
-    if (!hoveredCodeBlock) return;
-    const codeText = hoveredCodeBlock.element.querySelector('code')?.textContent || '';
+    if (!codeBlockToolbar) return;
+    const codeText = codeBlockToolbar.element.querySelector('code')?.textContent || '';
     setViewerCommentPopover({
-      anchorEl: hoveredCodeBlock.element,
+      anchorEl: codeBlockToolbar.element,
       contextText: codeText.slice(0, 80),
       selectedText: codeText,
       initialText: initialChar,
       isGlobal: false,
-      codeBlock: hoveredCodeBlock,
+      codeBlock: codeBlockToolbar,
     });
-    setHoveredCodeBlock(null);
+    setCodeBlockToolbar(null);
   };
 
   const handleViewerCommentSubmit = (text: string, images?: ImageAttachment[]) => {
@@ -843,22 +881,35 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
                 // Cancel exit animation if re-entering
                 setIsCodeBlockToolbarExiting(false);
                 // Only show hover toolbar if no selection toolbar is active
-                if (!toolbarState) {
-                  setHoveredCodeBlock({ block: group.block, element });
+                if (
+                  !toolbarState
+                  && !vimOwnsDocumentNavigation
+                  && !keyboardCodeBlockToolbarOpen
+                ) {
+                  setCodeBlockToolbar({
+                    block: group.block,
+                    element,
+                    activation: 'pointer',
+                  });
                 }
               }}
               onLeave={inputMethod === 'pinpoint' ? () => {} : () => {
+                if (keyboardCodeBlockToolbarOpen) return;
                 // Delay then start exit animation
                 hoverTimeoutRef.current = setTimeout(() => {
                   setIsCodeBlockToolbarExiting(true);
                   // After exit animation, unmount
                   setTimeout(() => {
-                    setHoveredCodeBlock(null);
+                    setCodeBlockToolbar(null);
                     setIsCodeBlockToolbarExiting(false);
                   }, 150);
                 }, 100);
               }}
-              isHovered={inputMethod !== 'pinpoint' && hoveredCodeBlock?.block.id === group.block.id}
+              isHovered={
+                inputMethod !== 'pinpoint'
+                && !vimOwnsDocumentNavigation
+                && codeBlockToolbar?.block.id === group.block.id
+              }
             />
           ) : (
             <BlockRenderer imageBaseDir={imageBaseDir} onImageClick={(src, alt) => setLightbox({ src, alt })} key={group.block.id} block={group.block} onOpenLinkedDoc={onOpenLinkedDoc} onOpenCodeFile={onOpenCodeFile} onNavigateAnchor={scrollToAnchor} onToggleCheckbox={readOnly ? undefined : onToggleCheckbox} checkboxOverrides={checkboxOverrides} githubRepo={repoInfo?.display} headingAnchorId={headingSlugMap.get(group.block.id)} />
@@ -917,35 +968,39 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
         )}
 
         {/* Code block hover toolbar */}
-        {hoveredCodeBlock && !toolbarState && (
-          <ToolbarErrorBoundary>
-          <AnnotationToolbar
-            element={hoveredCodeBlock.element}
-            positionMode="top-right"
-            onAnnotate={handleCodeBlockAnnotate}
-            onClose={handleCodeBlockToolbarClose}
-            onRequestComment={handleCodeBlockRequestComment}
-            onQuickLabel={handleCodeBlockQuickLabel}
-            isExiting={isCodeBlockToolbarExiting}
-            onMouseEnter={() => {
-              if (hoverTimeoutRef.current) {
-                clearTimeout(hoverTimeoutRef.current);
-                hoverTimeoutRef.current = null;
-              }
-              setIsCodeBlockToolbarExiting(false);
-            }}
-            onMouseLeave={() => {
-              hoverTimeoutRef.current = setTimeout(() => {
-                setIsCodeBlockToolbarExiting(true);
-                setTimeout(() => {
-                  setHoveredCodeBlock(null);
+        {codeBlockToolbar
+          && !toolbarState
+          && !(vimOwnsDocumentNavigation && codeBlockToolbar.activation === 'pointer')
+          && (
+            <ToolbarErrorBoundary>
+              <AnnotationToolbar
+                element={codeBlockToolbar.element}
+                positionMode="top-right"
+                onAnnotate={handleCodeBlockAnnotate}
+                onClose={handleCodeBlockToolbarClose}
+                onRequestComment={handleCodeBlockRequestComment}
+                onQuickLabel={handleCodeBlockQuickLabel}
+                isExiting={isCodeBlockToolbarExiting}
+                onMouseEnter={() => {
+                  if (hoverTimeoutRef.current) {
+                    clearTimeout(hoverTimeoutRef.current);
+                    hoverTimeoutRef.current = null;
+                  }
                   setIsCodeBlockToolbarExiting(false);
-                }, 150);
-              }, 100);
-            }}
-          />
-          </ToolbarErrorBoundary>
-        )}
+                }}
+                onMouseLeave={() => {
+                  if (codeBlockToolbar.activation === 'keyboard') return;
+                  hoverTimeoutRef.current = setTimeout(() => {
+                    setIsCodeBlockToolbarExiting(true);
+                    setTimeout(() => {
+                      setCodeBlockToolbar(null);
+                      setIsCodeBlockToolbarExiting(false);
+                    }, 150);
+                  }, 100);
+                }}
+              />
+            </ToolbarErrorBoundary>
+          )}
 
         {/* Table popout dialog — portaled into containerRef so annotations */}
         {/* can walk into its text nodes the same way they do the inline table. */}
@@ -967,10 +1022,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
         {/* Pinpoint hover overlay */}
         {(inputMethod === 'pinpoint' || vim.activeTarget) && (
           <PinpointOverlay
-            target={
-              (vim.focused || vim.state.phase === 'action' ? vim.activeTarget : null)
-              ?? (inputMethod === 'pinpoint' ? hoverTarget : null)
-            }
+            target={pinpointOverlayTarget}
             containerRef={containerRef}
           />
         )}
@@ -982,8 +1034,10 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
             focused={vim.focused}
             hudEnabled={vimHudEnabled}
             hudCommand={vim.hudCommand}
+            activeTarget={vim.activeTarget}
             helpOpen={vim.helpOpen}
-            onCloseHelp={vim.closeHelp}
+            onHelpOpenChange={vim.onHelpOpenChange}
+            onHudFocusLeave={vim.onHudFocusLeave}
           />
         )}
 

--- a/packages/ui/components/Viewer.tsx
+++ b/packages/ui/components/Viewer.tsx
@@ -447,6 +447,10 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
     || !!isPlanDiffActive
     || !!popoutTable
     || !!lightbox;
+  const clearPinpointHoverRef = useRef<() => void>(() => {});
+  const handleVimCommand = useCallback(() => {
+    clearPinpointHoverRef.current();
+  }, []);
   const vim = useVimSelection({
     containerRef,
     enabled: vimModeActive,
@@ -457,15 +461,17 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
     onHighlightRange: highlightRange,
     onCodeBlockAction: handleKeyboardCodeBlockAction,
     onMathAction: highlightMathElement,
+    onHandledCommand: handleVimCommand,
   });
 
-  const { hoverTarget } = usePinpoint({
+  const { hoverTarget, clearHover: clearPinpointHover } = usePinpoint({
     containerRef,
     inputMethod,
     enabled: !readOnly && !toolbarState && !hookCommentPopover && !viewerCommentPopover && !hookQuickLabelPicker && !codeBlockQuickLabelPicker && !(isPlanDiffActive ?? false) && !vim.helpOpen,
     onSelectRange: highlightRange,
     onCodeBlockClick: handlePinpointCodeBlockClick,
   });
+  clearPinpointHoverRef.current = clearPinpointHover;
   const vimOwnsHudTarget = vimHudEnabled
     && vim.state.phase !== 'inactive'
     && (vim.focused || vim.state.phase === 'action');
@@ -479,7 +485,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
     : null;
   const pinpointOverlayTarget = vimOwnsHudTarget
     ? null
-    : legacyVimTarget ?? (inputMethod === 'pinpoint' ? hoverTarget : null);
+    : (inputMethod === 'pinpoint' ? hoverTarget : null) ?? legacyVimTarget;
 
   useEffect(() => {
     if (!vimOwnsDocumentNavigation) return;

--- a/packages/ui/components/Viewer.tsx
+++ b/packages/ui/components/Viewer.tsx
@@ -45,8 +45,10 @@ import { DocBadges, type LinkedDocBadgeInfo } from './DocBadges';
 import { PinpointOverlay } from './PinpointOverlay';
 import { usePinpoint } from '../hooks/usePinpoint';
 import { useAnnotationHighlighter } from '../hooks/useAnnotationHighlighter';
+import { useVimSelection } from '../hooks/useVimSelection';
 import { useScrollViewport } from '../hooks/useScrollViewport';
 import { decodeAnchorHash } from '../utils/anchors';
+import { VimModeOverlay } from './VimModeOverlay';
 
 interface ViewerProps {
   blocks: Block[];
@@ -123,6 +125,8 @@ interface ViewerProps {
    *  comment, attachments, checkbox toggles). Existing annotations still
    *  render and remain selectable. Default false — today's behavior. */
   readOnly?: boolean;
+  /** Opt-in Vim-style keyboard selection. Default false for compatibility. */
+  vimModeEnabled?: boolean;
 }
 
 export interface ViewerHandle {
@@ -164,6 +168,12 @@ const FrontmatterCard: React.FC<{ frontmatter: Frontmatter }> = ({ frontmatter }
   );
 };
 
+/**
+ * Render and annotate a parsed Markdown document.
+ *
+ * Pointer and opt-in keyboard annotations share the same highlight callbacks;
+ * the imperative handle mutates only highlights owned by this viewer.
+ */
 export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
   blocks,
   markdown,
@@ -206,6 +216,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
   onAskAI,
   allowImages = true,
   readOnly = false,
+  vimModeEnabled = false,
 }, ref) => {
   const [copied, setCopied] = useState(false);
   const [lightbox, setLightbox] = useState<{ src: string; alt: string } | null>(null);
@@ -276,7 +287,6 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
 
   // Shared annotation infrastructure via hook
   const {
-    highlighterRef,
     toolbarState,
     commentPopover: hookCommentPopover,
     quickLabelPicker: hookQuickLabelPicker,
@@ -288,6 +298,8 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
     handleCommentClose: hookCommentClose,
     handleFloatingQuickLabel: hookFloatingQuickLabel,
     handleQuickLabelPickerDismiss: hookQuickLabelPickerDismiss,
+    highlightRange,
+    highlightMathElement,
     removeHighlight: hookRemoveHighlight,
     clearAllHighlights,
     applyAnnotations,
@@ -307,17 +319,56 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
   const modeRef = useRef<EditorMode>(mode);
   useEffect(() => { modeRef.current = mode; }, [mode]);
 
+  const applyCodeBlockAnnotation = useCallback((
+    blockId: string,
+    codeEl: Element,
+    type: AnnotationType,
+    text?: string,
+    images?: ImageAttachment[],
+    isQuickLabel?: boolean,
+    quickLabelTip?: string,
+  ) => {
+    const id = `codeblock-${Date.now()}`;
+    const codeText = codeEl.textContent || '';
+
+    const wrapper = document.createElement('mark');
+    wrapper.className = `annotation-highlight ${type === AnnotationType.DELETION ? 'deletion' : type === AnnotationType.COMMENT ? 'comment' : ''}`.trim();
+    wrapper.dataset.bindId = id;
+    wrapper.textContent = codeText;
+
+    codeEl.replaceChildren(wrapper);
+
+    const newAnnotation: Annotation = {
+      id,
+      blockId,
+      startOffset: 0,
+      endOffset: codeText.length,
+      type,
+      text,
+      originalText: codeText,
+      createdA: Date.now(),
+      author: getIdentity(),
+      images,
+      ...(isQuickLabel ? { isQuickLabel: true } : {}),
+      ...(quickLabelTip ? { quickLabelTip } : {}),
+    };
+
+    onAddAnnotationRef.current(newAnnotation);
+    window.getSelection()?.removeAllRanges();
+  }, []);
+
   // Pinpoint mode: hover + click to select elements
   const handlePinpointCodeBlockClick = useCallback((blockId: string, element: HTMLElement) => {
+    const block = blocks.find((candidate) => candidate.id === blockId);
     const codeEl = element.querySelector('code');
-    if (!codeEl) return;
+    if (!block || !codeEl) return;
     // In pinpoint mode, apply code block annotation based on current editor mode
     if (modeRef.current === 'redline') {
       applyCodeBlockAnnotation(blockId, codeEl, AnnotationType.DELETION);
     } else if (modeRef.current === 'quickLabel') {
       setCodeBlockQuickLabelPicker({
         anchorEl: element,
-        codeBlock: { block: blocks.find(b => b.id === blockId)!, element },
+        codeBlock: { block, element },
       });
     } else {
       // Show comment popover anchored to the code block
@@ -326,16 +377,71 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
         contextText: (codeEl.textContent || '').slice(0, 80),
         selectedText: codeEl.textContent || '',
         isGlobal: false,
-        codeBlock: { block: blocks.find(b => b.id === blockId)!, element },
+        codeBlock: { block, element },
       });
     }
-  }, [blocks]);
+  }, [applyCodeBlockAnnotation, blocks]);
+
+  const handleKeyboardCodeBlockAction = useCallback((
+    blockId: string,
+    element: HTMLElement,
+    modeOverride?: EditorMode,
+  ) => {
+    const block = blocks.find((candidate) => candidate.id === blockId);
+    const codeEl = element.querySelector('code');
+    if (!block || !codeEl) return;
+
+    const effectiveMode = modeOverride ?? modeRef.current;
+    if (effectiveMode === 'redline') {
+      applyCodeBlockAnnotation(blockId, codeEl, AnnotationType.DELETION);
+      return;
+    }
+    if (effectiveMode === 'quickLabel') {
+      setCodeBlockQuickLabelPicker({
+        anchorEl: element,
+        codeBlock: { block, element },
+      });
+      return;
+    }
+    if (effectiveMode === 'selection') {
+      setHoveredCodeBlock({ block, element });
+      return;
+    }
+    setViewerCommentPopover({
+      anchorEl: element,
+      contextText: (codeEl.textContent || '').slice(0, 80),
+      selectedText: codeEl.textContent || '',
+      isGlobal: false,
+      codeBlock: { block, element },
+    });
+  }, [applyCodeBlockAnnotation, blocks]);
+
+  const vimModeActive = vimModeEnabled && !readOnly;
+  const vimBlocked = !!toolbarState
+    || !!hookCommentPopover
+    || !!viewerCommentPopover
+    || !!hookQuickLabelPicker
+    || !!codeBlockQuickLabelPicker
+    || !!hoveredCodeBlock
+    || !!isPlanDiffActive
+    || !!popoutTable
+    || !!lightbox;
+  const vim = useVimSelection({
+    containerRef,
+    enabled: vimModeActive,
+    blocked: vimBlocked,
+    activeMode: mode,
+    contentVersion: blocks,
+    onHighlightRange: highlightRange,
+    onCodeBlockAction: handleKeyboardCodeBlockAction,
+    onMathAction: highlightMathElement,
+  });
 
   const { hoverTarget } = usePinpoint({
     containerRef,
-    highlighterRef,
     inputMethod,
-    enabled: !readOnly && !toolbarState && !hookCommentPopover && !viewerCommentPopover && !hookQuickLabelPicker && !codeBlockQuickLabelPicker && !(isPlanDiffActive ?? false),
+    enabled: !readOnly && !toolbarState && !hookCommentPopover && !viewerCommentPopover && !hookQuickLabelPicker && !codeBlockQuickLabelPicker && !(isPlanDiffActive ?? false) && !vim.helpOpen,
+    onSelectRange: highlightRange,
     onCodeBlockClick: handlePinpointCodeBlockClick,
   });
 
@@ -462,45 +568,6 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
 
   // --- Viewer-specific: code block annotation ---
 
-  const applyCodeBlockAnnotation = (
-    blockId: string,
-    codeEl: Element,
-    type: AnnotationType,
-    text?: string,
-    images?: ImageAttachment[],
-    isQuickLabel?: boolean,
-    quickLabelTip?: string,
-  ) => {
-    const id = `codeblock-${Date.now()}`;
-    const codeText = codeEl.textContent || '';
-
-    const wrapper = document.createElement('mark');
-    wrapper.className = `annotation-highlight ${type === AnnotationType.DELETION ? 'deletion' : type === AnnotationType.COMMENT ? 'comment' : ''}`.trim();
-    wrapper.dataset.bindId = id;
-    wrapper.textContent = codeText;
-
-    codeEl.innerHTML = '';
-    codeEl.appendChild(wrapper);
-
-    const newAnnotation: Annotation = {
-      id,
-      blockId,
-      startOffset: 0,
-      endOffset: codeText.length,
-      type,
-      text,
-      originalText: codeText,
-      createdA: Date.now(),
-      author: getIdentity(),
-      images,
-      ...(isQuickLabel ? { isQuickLabel: true } : {}),
-      ...(quickLabelTip ? { quickLabelTip } : {}),
-    };
-
-    onAddAnnotationRef.current(newAnnotation);
-    window.getSelection()?.removeAllRanges();
-  };
-
   const handleCodeBlockAnnotate = (type: AnnotationType) => {
     if (!hoveredCodeBlock) return;
     const codeEl = hoveredCodeBlock.element.querySelector('code');
@@ -580,8 +647,20 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
       <article
         ref={containerRef}
         data-print-region="article"
+        data-vim-mode={vimModeActive ? 'enabled' : undefined}
+        data-vim-phase={vimModeActive ? vim.state.phase : undefined}
+        data-vim-focused={vimModeActive ? String(vim.focused) : undefined}
+        data-vim-blocked={vimModeActive ? String(vimBlocked) : undefined}
+        data-vim-target-key={vimModeActive ? vim.activeTarget?.key : undefined}
+        tabIndex={vimModeActive ? 0 : undefined}
+        onFocus={vim.onFocus}
+        onBlur={vim.onBlur}
+        onMouseDown={vim.onMouseDown}
         className={`w-full bg-card rounded-xl py-5 md:py-8 lg:py-10 xl:py-12 relative ${gridEnabled ? 'px-5 md:px-8 lg:px-10 xl:px-12 shadow-xl border border-border/50' : ''} ${inputMethod === 'pinpoint' ? 'cursor-pointer' : ''}`}
-        style={{ WebkitTouchCallout: 'none' } as React.CSSProperties}
+        style={{
+          WebkitTouchCallout: 'none',
+          ...(vimModeActive ? { outline: 'none' } : {}),
+        } as React.CSSProperties}
       >
         {/* Repo info + plan diff badge + demo badge + linked doc badge + archive badge - top left */}
         {(repoInfo || hasPreviousVersion || showDemoBadge || linkedDocInfo || archiveInfo || sourceInfo || openInAppPath) && (
@@ -882,8 +961,24 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
         )}
 
         {/* Pinpoint hover overlay */}
-        {inputMethod === 'pinpoint' && (
-          <PinpointOverlay target={hoverTarget} containerRef={containerRef} />
+        {(inputMethod === 'pinpoint' || vim.activeTarget) && (
+          <PinpointOverlay
+            target={
+              (vim.focused || vim.state.phase === 'action' ? vim.activeTarget : null)
+              ?? (inputMethod === 'pinpoint' ? hoverTarget : null)
+            }
+            containerRef={containerRef}
+          />
+        )}
+        {vimModeActive && (
+          <VimModeOverlay
+            containerRef={containerRef}
+            inputMethod={inputMethod}
+            state={vim.state}
+            focused={vim.focused}
+            helpOpen={vim.helpOpen}
+            onCloseHelp={vim.closeHelp}
+          />
         )}
 
         {/* Comment popover — hook handles text selection, Viewer handles global + code block */}
@@ -992,7 +1087,3 @@ const ImageLightbox: React.FC<{ src: string; alt: string; onClose: () => void }>
     </div>
   );
 };
-
-
-
-

--- a/packages/ui/components/Viewer.tsx
+++ b/packages/ui/components/Viewer.tsx
@@ -129,6 +129,10 @@ interface ViewerProps {
   vimModeEnabled?: boolean;
   /** Replace the compact Vim badge with the live video-style key HUD. */
   vimHudEnabled?: boolean;
+  /** Show the bottom-right key panel without affecting the HUD reticle. */
+  vimHudKeyPanelEnabled?: boolean;
+  /** Persist a user request to hide the bottom-right key panel. */
+  onVimHudKeyPanelChange?: (enabled: boolean) => void;
 }
 
 export interface ViewerHandle {
@@ -226,6 +230,8 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
   readOnly = false,
   vimModeEnabled = false,
   vimHudEnabled = false,
+  vimHudKeyPanelEnabled = true,
+  onVimHudKeyPanelChange,
 }, ref) => {
   const [copied, setCopied] = useState(false);
   const [lightbox, setLightbox] = useState<{ src: string; alt: string } | null>(null);
@@ -1033,10 +1039,16 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
             state={vim.state}
             focused={vim.focused}
             hudEnabled={vimHudEnabled}
+            keyPanelEnabled={vimHudKeyPanelEnabled}
             hudCommand={vim.hudCommand}
             activeTarget={vim.activeTarget}
             helpOpen={vim.helpOpen}
             onHelpOpenChange={vim.onHelpOpenChange}
+            onKeyPanelHide={
+              onVimHudKeyPanelChange
+                ? () => onVimHudKeyPanelChange(false)
+                : undefined
+            }
             onHudFocusLeave={vim.onHudFocusLeave}
           />
         )}

--- a/packages/ui/components/Viewer.vimMode.integration.test.tsx
+++ b/packages/ui/components/Viewer.vimMode.integration.test.tsx
@@ -1,0 +1,229 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import type { Annotation } from '../types';
+
+const hasDom = typeof document !== 'undefined';
+const viewerModule = hasDom ? await import('./Viewer') : null;
+const parserModule = hasDom ? await import('../utils/parser') : null;
+
+const FIXTURES = [
+  '05-real-world-plan.md',
+  '10-inline-gaps-and-bullets.md',
+  '12-gfm-and-inline-extras.md',
+] as const;
+
+function keydown(target: HTMLElement, key: string): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    bubbles: true,
+    cancelable: true,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
+
+describe.if(hasDom)('Viewer Vim mode with repository fixtures', () => {
+  for (const fixture of FIXTURES) {
+    test(`selects and redlines rendered content in ${fixture}`, async () => {
+      if (!viewerModule || !parserModule) {
+        throw new Error('DOM test environment is not registered');
+      }
+      const markdown = readFileSync(
+        resolve(import.meta.dir, '../../../tests/test-fixtures', fixture),
+        'utf8',
+      );
+      const host = document.createElement('div');
+      document.body.appendChild(host);
+      const root = createRoot(host);
+      const annotations: Annotation[] = [];
+
+      await act(async () => {
+        root.render(
+          <viewerModule.Viewer
+            blocks={parserModule.parseMarkdownToBlocks(markdown)}
+            markdown={markdown}
+            annotations={[]}
+            onAddAnnotation={(annotation) => annotations.push(annotation)}
+            onSelectAnnotation={() => {}}
+            selectedAnnotationId={null}
+            mode="selection"
+            inputMethod="drag"
+            taterMode={false}
+            stickyActions={false}
+            disableCodePathValidation
+            vimModeEnabled
+          />,
+        );
+      });
+
+      const article = host.querySelector<HTMLElement>('[data-vim-mode="enabled"]');
+      if (!article) throw new Error(`Vim article missing for ${fixture}`);
+      act(() => article.focus());
+      act(() => { keydown(article, 'v'); });
+      act(() => { keydown(article, 'w'); });
+      let action: KeyboardEvent | null = null;
+      act(() => { action = keydown(article, 'd'); });
+
+      expect(action?.defaultPrevented).toBe(true);
+      expect(annotations).toHaveLength(1);
+      expect(annotations[0]?.originalText.trim().length).toBeGreaterThan(0);
+      expect(host.querySelectorAll('mark.annotation-highlight.deletion').length)
+        .toBeGreaterThan(0);
+
+      act(() => root.unmount());
+      host.remove();
+      window.getSelection()?.removeAllRanges();
+    });
+  }
+
+  test('does not install a keyboard focus surface when Vim mode is disabled', async () => {
+    if (!viewerModule || !parserModule) {
+      throw new Error('DOM test environment is not registered');
+    }
+    const markdown = '# Compatibility\n\nExisting interaction remains unchanged.';
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    await act(async () => {
+      root.render(
+        <viewerModule.Viewer
+          blocks={parserModule.parseMarkdownToBlocks(markdown)}
+          markdown={markdown}
+          annotations={[]}
+          onAddAnnotation={() => {}}
+          onSelectAnnotation={() => {}}
+          selectedAnnotationId={null}
+          mode="selection"
+          inputMethod="drag"
+          taterMode={false}
+          stickyActions={false}
+          disableCodePathValidation
+          vimModeEnabled={false}
+        />,
+      );
+    });
+
+    const article = host.querySelector<HTMLElement>('[data-print-region="article"]');
+    if (!article) throw new Error('Viewer article missing');
+    const event = keydown(article, 'v');
+    expect(event.defaultPrevented).toBe(false);
+    expect(article.hasAttribute('tabindex')).toBe(false);
+    expect(article.hasAttribute('data-vim-mode')).toBe(false);
+
+    act(() => root.unmount());
+    host.remove();
+  });
+
+  test('paints the active block instead of outlining the document container', async () => {
+    if (!viewerModule || !parserModule) {
+      throw new Error('DOM test environment is not registered');
+    }
+    const markdown = [
+      '# Block cursor',
+      '',
+      'First paragraph.',
+      '',
+      'Second paragraph.',
+    ].join('\n');
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    await act(async () => {
+      root.render(
+        <viewerModule.Viewer
+          blocks={parserModule.parseMarkdownToBlocks(markdown)}
+          markdown={markdown}
+          annotations={[]}
+          onAddAnnotation={() => {}}
+          onSelectAnnotation={() => {}}
+          selectedAnnotationId={null}
+          mode="selection"
+          inputMethod="drag"
+          taterMode={false}
+          stickyActions={false}
+          disableCodePathValidation
+          vimModeEnabled
+        />,
+      );
+    });
+
+    const article = host.querySelector<HTMLElement>('[data-vim-mode="enabled"]');
+    if (!article) throw new Error('Vim article missing');
+    act(() => article.focus());
+
+    expect(article.style.outline).toContain('none');
+    expect(article.className).not.toContain('focus-visible:ring');
+    expect(article.dataset.vimPhase).toBe('block');
+    expect(host.querySelector('[data-pinpoint-overlay]')).not.toBeNull();
+    expect(host.querySelector<HTMLElement>('[data-pinpoint-label]')?.dataset.pinpointLabel)
+      .toContain('heading');
+
+    act(() => { keydown(article, 'j'); });
+    expect(host.querySelector<HTMLElement>('[data-pinpoint-label]')?.dataset.pinpointLabel)
+      .toContain('First paragraph');
+
+    act(() => root.unmount());
+    host.remove();
+  });
+
+  test('pointer Pinpoint and keyboard refinement paint the same inline target', async () => {
+    if (!viewerModule || !parserModule) {
+      throw new Error('DOM test environment is not registered');
+    }
+    const markdown = 'Alpha **bravo** charlie.';
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    await act(async () => {
+      root.render(
+        <viewerModule.Viewer
+          blocks={parserModule.parseMarkdownToBlocks(markdown)}
+          markdown={markdown}
+          annotations={[]}
+          onAddAnnotation={() => {}}
+          onSelectAnnotation={() => {}}
+          selectedAnnotationId={null}
+          mode="selection"
+          inputMethod="pinpoint"
+          taterMode={false}
+          stickyActions={false}
+          disableCodePathValidation
+          vimModeEnabled
+        />,
+      );
+    });
+
+    const article = host.querySelector<HTMLElement>('[data-vim-mode="enabled"]');
+    const strong = host.querySelector<HTMLElement>('strong');
+    if (!article || !strong) throw new Error('Missing inline Pinpoint fixture');
+
+    act(() => {
+      strong.dispatchEvent(new MouseEvent('mousemove', {
+        bubbles: true,
+        clientX: 10,
+        clientY: 10,
+      }));
+    });
+    const pointerLabel = host
+      .querySelector<HTMLElement>('[data-pinpoint-label]')
+      ?.dataset.pinpointLabel;
+    expect(pointerLabel).toContain('bold');
+
+    act(() => article.focus());
+    act(() => { keydown(article, 'l'); });
+    expect(article.dataset.vimTargetKey).toContain(':inline:0');
+    expect(
+      host.querySelector<HTMLElement>('[data-pinpoint-label]')?.dataset.pinpointLabel,
+    ).toBe(pointerLabel);
+
+    act(() => root.unmount());
+    host.remove();
+  });
+});

--- a/packages/ui/components/Viewer.vimMode.integration.test.tsx
+++ b/packages/ui/components/Viewer.vimMode.integration.test.tsx
@@ -262,7 +262,13 @@ describe.if(hasDom)('Viewer Vim mode with repository fixtures', () => {
     act(() => { keydown(article, 'j'); });
 
     const hud = document.querySelector<HTMLElement>('[data-vim-key-hud]');
+    const reticle = host.querySelector<HTMLElement>('[data-vim-target-reticle]');
     expect(hud).not.toBeNull();
+    expect(reticle).not.toBeNull();
+    expect(reticle?.dataset.vimTargetLabel).toBe('BLOCK · PARAGRAPH');
+    expect(host.querySelectorAll('[data-vim-target-corner]')).toHaveLength(4);
+    expect(host.querySelector('[data-vim-target-fill]')).not.toBeNull();
+    expect(host.querySelector('[data-pinpoint-overlay]')).toBeNull();
     expect(document.querySelector('[data-vim-mode-badge]')).toBeNull();
     expect(hud?.style.height).toBe('88px');
     expect(hud?.style.bottom).toBe('150px');
@@ -283,6 +289,182 @@ describe.if(hasDom)('Viewer Vim mode with repository fixtures', () => {
         .map((element) => element.dataset.vimHudPreviousKey),
     ).toEqual(['j', 'k', 'j']);
     expect(document.querySelector('[data-vim-hud-active-key="k"]')).not.toBeNull();
+
+    const mapToggle = document.querySelector<HTMLButtonElement>(
+      '[data-vim-key-map-toggle]',
+    );
+    expect(mapToggle).not.toBeNull();
+    expect(mapToggle?.getAttribute('aria-expanded')).toBe('false');
+    act(() => { mapToggle?.focus(); });
+    expect(document.activeElement).toBe(mapToggle);
+    expect(document.querySelector('[data-vim-key-hud]')).not.toBeNull();
+    act(() => { mapToggle?.click(); });
+
+    expect(mapToggle?.getAttribute('aria-expanded')).toBe('true');
+    expect(document.querySelector('[data-vim-key-map]')).not.toBeNull();
+    expect(document.querySelectorAll('[data-vim-key-map-group]')).toHaveLength(5);
+    expect(document.querySelector(
+      '[data-vim-key-map-group="structure"][data-current="true"]',
+    )).not.toBeNull();
+    expect(document.querySelector(
+      '[data-vim-key-map-action="wordForward"]',
+    )?.textContent).toContain('Move to next word');
+    expect(document.querySelector(
+      '[data-vim-key-map-action="comment"]',
+    )?.textContent).toContain('Comment selection or target');
+
+    act(() => { keydown(article, '?'); });
+    expect(document.querySelector('[data-vim-key-map]')).toBeNull();
+    expect(mapToggle?.getAttribute('aria-expanded')).toBe('false');
+
+    act(() => { keydown(article, '?'); });
+    expect(document.querySelector('[data-vim-key-map]')).not.toBeNull();
+    act(() => { keydown(article, '?'); });
+    expect(document.querySelector('[data-vim-key-map]')).toBeNull();
+
+    act(() => root.unmount());
+    host.remove();
+  });
+
+  test('moves the HUD reticle from semantic blocks to the real caret and visual range', async () => {
+    if (!viewerModule || !parserModule) {
+      throw new Error('DOM test environment is not registered');
+    }
+    const markdown = '# Reticle\n\nAlpha bravo charlie.';
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    await act(async () => {
+      root.render(
+        <viewerModule.Viewer
+          blocks={parserModule.parseMarkdownToBlocks(markdown)}
+          markdown={markdown}
+          annotations={[]}
+          onAddAnnotation={() => {}}
+          onSelectAnnotation={() => {}}
+          selectedAnnotationId={null}
+          mode="selection"
+          inputMethod="drag"
+          taterMode={false}
+          stickyActions={false}
+          disableCodePathValidation
+          vimModeEnabled
+          vimHudEnabled
+        />,
+      );
+    });
+
+    const article = host.querySelector<HTMLElement>('[data-vim-mode="enabled"]');
+    if (!article) throw new Error('Vim article missing');
+    act(() => article.focus());
+    act(() => { keydown(article, 'l'); });
+
+    let reticle = host.querySelector<HTMLElement>('[data-vim-target-reticle]');
+    expect(article.dataset.vimPhase).toBe('text');
+    expect(reticle?.dataset.vimTargetPhase).toBe('text');
+    expect(reticle?.dataset.vimTargetLabel).toBe('CURSOR · INLINE TEXT');
+    expect(host.querySelector('[data-vim-cursor]')).not.toBeNull();
+
+    act(() => { keydown(article, 'v'); });
+    act(() => { keydown(article, 'e'); });
+    reticle = host.querySelector<HTMLElement>('[data-vim-target-reticle]');
+    expect(article.dataset.vimPhase).toBe('visual');
+    expect(reticle?.dataset.vimTargetPhase).toBe('visual');
+    expect(reticle?.dataset.vimTargetLabel).toBe('VISUAL · EXACT TOKEN');
+
+    act(() => root.unmount());
+    host.remove();
+    window.getSelection()?.removeAllRanges();
+  });
+
+  test('keeps j and k under Vim ownership when a code block crosses the pointer', async () => {
+    if (!viewerModule || !parserModule) {
+      throw new Error('DOM test environment is not registered');
+    }
+    const markdown = [
+      '# Keyboard ownership',
+      '',
+      'Before code.',
+      '',
+      '```ts',
+      'const value = 32;',
+      '```',
+      '',
+      'After code.',
+    ].join('\n');
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    await act(async () => {
+      root.render(
+        <viewerModule.Viewer
+          blocks={parserModule.parseMarkdownToBlocks(markdown)}
+          markdown={markdown}
+          annotations={[]}
+          onAddAnnotation={() => {}}
+          onSelectAnnotation={() => {}}
+          selectedAnnotationId={null}
+          mode="selection"
+          inputMethod="drag"
+          taterMode={false}
+          stickyActions={false}
+          disableCodePathValidation
+          vimModeEnabled
+          vimHudEnabled
+        />,
+      );
+    });
+
+    const article = host.querySelector<HTMLElement>('[data-vim-mode="enabled"]');
+    const codeBlock = host.querySelector<HTMLElement>('pre')?.parentElement;
+    if (!article || !codeBlock) throw new Error('Missing code-hover Vim fixture');
+    act(() => article.focus());
+
+    // Scrolling with j/k can move a code block underneath a stationary pointer.
+    // React reports that as mouseenter even though the user did not switch to
+    // pointer annotation.
+    act(() => {
+      codeBlock.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+    });
+
+    let nextEvent: KeyboardEvent | null = null;
+    let previousEvent: KeyboardEvent | null = null;
+    act(() => { nextEvent = keydown(article, 'j'); });
+    act(() => { previousEvent = keydown(article, 'k'); });
+
+    expect(nextEvent?.defaultPrevented).toBe(true);
+    expect(previousEvent?.defaultPrevented).toBe(true);
+    expect(article.dataset.vimBlocked).toBe('false');
+    expect(document.querySelector('.annotation-toolbar')).toBeNull();
+    expect(document.querySelector('[data-comment-popover="true"]')).toBeNull();
+    expect(document.querySelector('textarea')).toBeNull();
+
+    // The same code toolbar may take keyboard ownership only after an explicit
+    // Vim action on the code target.
+    act(() => { keydown(article, 'j'); });
+    act(() => { keydown(article, 'j'); });
+    expect(article.dataset.vimTargetKey).toContain(':code');
+    let openActionsEvent: KeyboardEvent | null = null;
+    act(() => { openActionsEvent = keydown(article, 'Enter'); });
+    expect(openActionsEvent?.defaultPrevented).toBe(true);
+    expect(article.dataset.vimPhase).toBe('action');
+    expect(article.dataset.vimBlocked).toBe('true');
+    expect(document.querySelector('.annotation-toolbar')).not.toBeNull();
+
+    const alreadyHandledEvent = new KeyboardEvent('keydown', {
+      key: 'z',
+      bubbles: true,
+      cancelable: true,
+    });
+    alreadyHandledEvent.preventDefault();
+    act(() => { article.dispatchEvent(alreadyHandledEvent); });
+    expect(document.querySelector('[data-comment-popover="true"]')).toBeNull();
+
+    act(() => { keydown(article, 'x'); });
+    expect(document.querySelector('[data-comment-popover="true"]')).not.toBeNull();
+    expect(document.querySelector<HTMLTextAreaElement>('textarea')?.value).toBe('x');
 
     act(() => root.unmount());
     host.remove();

--- a/packages/ui/components/Viewer.vimMode.integration.test.tsx
+++ b/packages/ui/components/Viewer.vimMode.integration.test.tsx
@@ -235,6 +235,7 @@ describe.if(hasDom)('Viewer Vim mode with repository fixtures', () => {
     const host = document.createElement('div');
     document.body.appendChild(host);
     const root = createRoot(host);
+    let keyPanelEnabled = true;
 
     await act(async () => {
       root.render(
@@ -252,6 +253,7 @@ describe.if(hasDom)('Viewer Vim mode with repository fixtures', () => {
           disableCodePathValidation
           vimModeEnabled
           vimHudEnabled
+          onVimHudKeyPanelChange={(enabled) => { keyPanelEnabled = enabled; }}
         />,
       );
     });
@@ -319,8 +321,64 @@ describe.if(hasDom)('Viewer Vim mode with repository fixtures', () => {
 
     act(() => { keydown(article, '?'); });
     expect(document.querySelector('[data-vim-key-map]')).not.toBeNull();
-    act(() => { keydown(article, '?'); });
+
+    const hideButton = document.querySelector<HTMLButtonElement>(
+      '[data-vim-key-panel-hide]',
+    );
+    expect(hideButton?.getAttribute('title')).toContain('keep target reticle');
+    act(() => { hideButton?.click(); });
+    expect(keyPanelEnabled).toBe(false);
     expect(document.querySelector('[data-vim-key-map]')).toBeNull();
+
+    act(() => root.unmount());
+    host.remove();
+  });
+
+  test('keeps the HUD reticle active when its persistent key panel is hidden', async () => {
+    if (!viewerModule || !parserModule) {
+      throw new Error('DOM test environment is not registered');
+    }
+    const markdown = '# Reticle only\n\nNavigate without a persistent legend.';
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    await act(async () => {
+      root.render(
+        <viewerModule.Viewer
+          blocks={parserModule.parseMarkdownToBlocks(markdown)}
+          markdown={markdown}
+          annotations={[]}
+          onAddAnnotation={() => {}}
+          onSelectAnnotation={() => {}}
+          selectedAnnotationId={null}
+          mode="selection"
+          inputMethod="pinpoint"
+          taterMode={false}
+          stickyActions={false}
+          disableCodePathValidation
+          vimModeEnabled
+          vimHudEnabled
+          vimHudKeyPanelEnabled={false}
+        />,
+      );
+    });
+
+    const article = host.querySelector<HTMLElement>('[data-vim-mode="enabled"]');
+    if (!article) throw new Error('Vim article missing');
+    act(() => article.focus());
+    act(() => { keydown(article, 'j'); });
+
+    expect(host.querySelector('[data-vim-target-reticle]')).not.toBeNull();
+    expect(document.querySelector('[data-vim-key-hud]')).toBeNull();
+
+    act(() => { keydown(article, '?'); });
+    expect(document.querySelector('[data-vim-key-hud]')).not.toBeNull();
+    expect(document.querySelector('[data-vim-key-map]')).not.toBeNull();
+
+    act(() => { keydown(article, '?'); });
+    expect(document.querySelector('[data-vim-key-hud]')).toBeNull();
+    expect(host.querySelector('[data-vim-target-reticle]')).not.toBeNull();
 
     act(() => root.unmount());
     host.remove();

--- a/packages/ui/components/Viewer.vimMode.integration.test.tsx
+++ b/packages/ui/components/Viewer.vimMode.integration.test.tsx
@@ -119,6 +119,50 @@ describe.if(hasDom)('Viewer Vim mode with repository fixtures', () => {
     host.remove();
   });
 
+  test('opens the shared annotation toolbar from m in the real Viewer pipeline', async () => {
+    if (!viewerModule || !parserModule) {
+      throw new Error('DOM test environment is not registered');
+    }
+    const markdown = '# Actions\n\nAnnotate this paragraph.';
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    await act(async () => {
+      root.render(
+        <viewerModule.Viewer
+          blocks={parserModule.parseMarkdownToBlocks(markdown)}
+          markdown={markdown}
+          annotations={[]}
+          onAddAnnotation={() => {}}
+          onSelectAnnotation={() => {}}
+          selectedAnnotationId={null}
+          mode="comment"
+          inputMethod="drag"
+          taterMode={false}
+          stickyActions={false}
+          disableCodePathValidation
+          vimModeEnabled
+        />,
+      );
+    });
+
+    const article = host.querySelector<HTMLElement>('[data-vim-mode="enabled"]');
+    if (!article) throw new Error('Vim article missing');
+    act(() => article.focus());
+    let markupEvent: KeyboardEvent | null = null;
+    act(() => { markupEvent = keydown(article, 'm'); });
+
+    expect(markupEvent?.defaultPrevented).toBe(true);
+    expect(article.dataset.vimPhase).toBe('action');
+    expect(article.dataset.vimBlocked).toBe('true');
+    expect(document.querySelector('.annotation-toolbar')).not.toBeNull();
+    expect(document.querySelector('[data-comment-popover="true"]')).toBeNull();
+
+    act(() => root.unmount());
+    host.remove();
+  });
+
   test('paints the active block instead of outlining the document container', async () => {
     if (!viewerModule || !parserModule) {
       throw new Error('DOM test environment is not registered');
@@ -222,6 +266,11 @@ describe.if(hasDom)('Viewer Vim mode with repository fixtures', () => {
     expect(
       host.querySelector<HTMLElement>('[data-pinpoint-label]')?.dataset.pinpointLabel,
     ).toBe(pointerLabel);
+    act(() => { keydown(article, 'h'); });
+    expect(article.dataset.vimTargetKey).toContain(':block');
+    expect(
+      host.querySelector<HTMLElement>('[data-pinpoint-label]')?.dataset.pinpointLabel,
+    ).toContain('paragraph');
 
     act(() => root.unmount());
     host.remove();

--- a/packages/ui/components/Viewer.vimMode.integration.test.tsx
+++ b/packages/ui/components/Viewer.vimMode.integration.test.tsx
@@ -226,4 +226,65 @@ describe.if(hasDom)('Viewer Vim mode with repository fixtures', () => {
     act(() => root.unmount());
     host.remove();
   });
+
+  test('renders the video-style HUD from real handled commands instead of the compact badge', async () => {
+    if (!viewerModule || !parserModule) {
+      throw new Error('DOM test environment is not registered');
+    }
+    const markdown = '# Keyboard HUD\n\nFirst paragraph.\n\nSecond paragraph.';
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    await act(async () => {
+      root.render(
+        <viewerModule.Viewer
+          blocks={parserModule.parseMarkdownToBlocks(markdown)}
+          markdown={markdown}
+          annotations={[]}
+          onAddAnnotation={() => {}}
+          onSelectAnnotation={() => {}}
+          selectedAnnotationId={null}
+          mode="selection"
+          inputMethod="pinpoint"
+          taterMode={false}
+          stickyActions={false}
+          disableCodePathValidation
+          vimModeEnabled
+          vimHudEnabled
+        />,
+      );
+    });
+
+    const article = host.querySelector<HTMLElement>('[data-vim-mode="enabled"]');
+    if (!article) throw new Error('Vim article missing');
+    act(() => article.focus());
+    act(() => { keydown(article, 'j'); });
+
+    const hud = document.querySelector<HTMLElement>('[data-vim-key-hud]');
+    expect(hud).not.toBeNull();
+    expect(document.querySelector('[data-vim-mode-badge]')).toBeNull();
+    expect(hud?.style.height).toBe('88px');
+    expect(hud?.style.bottom).toBe('150px');
+    expect(hud?.style.borderRadius).toBe('20px');
+    expect(hud?.style.background).toContain('rgba(43,35,59,0.46)');
+    expect(hud?.style.backdropFilter).toBe('blur(10px)');
+    expect(document.querySelector('[data-vim-hud-active-key="j"]')).not.toBeNull();
+    expect(document.querySelector('[data-vim-hud-phase]')?.textContent)
+      .toBe('BLOCK / PINPOINT');
+    expect(document.querySelector('[data-vim-hud-command]')?.textContent)
+      .toBe('Next block');
+
+    act(() => { keydown(article, 'k'); });
+    act(() => { keydown(article, 'j'); });
+    act(() => { keydown(article, 'k'); });
+    expect(
+      Array.from(document.querySelectorAll<HTMLElement>('[data-vim-hud-previous-key]'))
+        .map((element) => element.dataset.vimHudPreviousKey),
+    ).toEqual(['j', 'k', 'j']);
+    expect(document.querySelector('[data-vim-hud-active-key="k"]')).not.toBeNull();
+
+    act(() => root.unmount());
+    host.remove();
+  });
 });

--- a/packages/ui/components/VimKeyHud.tsx
+++ b/packages/ui/components/VimKeyHud.tsx
@@ -1,0 +1,271 @@
+import { useLayoutEffect, useRef, useState } from 'react';
+import type { InputMethod } from '../types';
+import type { VimHudCommand, VimHudPhase } from '../utils/vimHud';
+
+const HUD_MONO_FONT = '"SFMono-Regular", "JetBrains Mono", Menlo, var(--font-mono), monospace';
+// Match the seven-frame pressed state in the 30fps product-demo HUD.
+const PRESSED_DURATION_MS = (7 / 30) * 1000;
+
+interface PreviousKeyProps {
+  readonly keyLabel: string;
+  readonly opacity: number;
+}
+
+function PreviousKey({ keyLabel, opacity }: PreviousKeyProps) {
+  return (
+    <div
+      data-vim-hud-previous-key={keyLabel}
+      style={{
+        width: 34,
+        height: 34,
+        display: 'grid',
+        flex: '0 0 auto',
+        placeItems: 'center',
+        borderRadius: 9,
+        color: '#cfc8dc',
+        background: 'rgba(26,24,34,0.9)',
+        border: '1px solid rgba(255,255,255,0.09)',
+        borderBottom: '3px solid rgba(0,0,0,0.72)',
+        opacity,
+        fontFamily: HUD_MONO_FONT,
+        fontSize: keyLabel.length > 1 ? 9 : 14,
+        fontWeight: 850,
+      }}
+    >
+      {keyLabel}
+    </div>
+  );
+}
+
+interface ActiveKeyProps {
+  readonly keyLabel: string;
+  readonly pressed: boolean;
+}
+
+function ActiveKey({ keyLabel, pressed }: ActiveKeyProps) {
+  return (
+    <div
+      data-vim-hud-active-key={keyLabel}
+      data-pressed={pressed ? 'true' : 'false'}
+      style={{
+        width: 58,
+        height: 58,
+        display: 'grid',
+        flex: '0 0 auto',
+        placeItems: 'center',
+        borderRadius: 14,
+        color: pressed ? '#1b1427' : '#f5f0ff',
+        background: pressed
+          ? 'linear-gradient(180deg, #eee9ff, #a78bfa)'
+          : 'linear-gradient(180deg, #292535, #15121d)',
+        border: pressed
+          ? '1px solid rgba(255,255,255,0.92)'
+          : '1px solid rgba(196,181,253,0.34)',
+        borderBottom: pressed
+          ? '4px solid #6750a4'
+          : '4px solid rgba(0,0,0,0.82)',
+        boxShadow: pressed
+          ? '0 0 32px rgba(167,139,250,0.72), 0 8px 24px rgba(0,0,0,0.42)'
+          : '0 0 20px rgba(167,139,250,0.17), 0 8px 24px rgba(0,0,0,0.42)',
+        fontFamily: HUD_MONO_FONT,
+        fontSize: keyLabel.length > 1 ? 13 : 29,
+        fontWeight: 900,
+      }}
+    >
+      {keyLabel}
+    </div>
+  );
+}
+
+/** Props for the pixel-faithful, live Vim HUD used by both document renderers. */
+export interface VimKeyHudProps {
+  readonly command: VimHudCommand | null;
+  readonly phase: VimHudPhase;
+  readonly inputMethod: InputMethod;
+}
+
+/**
+ * Render the video HUD against real handled Vim commands.
+ *
+ * Key feedback changes instantly rather than animating navigation, preserving
+ * the responsiveness expected by high-frequency keyboard users.
+ */
+export function VimKeyHud({
+  command,
+  phase,
+  inputMethod,
+}: VimKeyHudProps) {
+  const [history, setHistory] = useState<readonly VimHudCommand[]>([]);
+  const [pressedSequence, setPressedSequence] = useState<number | null>(null);
+  const releaseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useLayoutEffect(() => {
+    if (!command) {
+      if (releaseTimerRef.current) clearTimeout(releaseTimerRef.current);
+      releaseTimerRef.current = null;
+      setHistory((current) => (current.length === 0 ? current : []));
+      setPressedSequence(null);
+      return;
+    }
+
+    setHistory((current) => {
+      if (current.at(-1)?.sequence === command.sequence) return current;
+      return [...current, command].slice(-4);
+    });
+    setPressedSequence(command.sequence);
+    if (releaseTimerRef.current) clearTimeout(releaseTimerRef.current);
+    releaseTimerRef.current = setTimeout(() => {
+      setPressedSequence((current) => (
+        current === command.sequence ? null : current
+      ));
+    }, PRESSED_DURATION_MS);
+
+    return () => {
+      if (releaseTimerRef.current) clearTimeout(releaseTimerRef.current);
+      releaseTimerRef.current = null;
+    };
+  }, [command]);
+
+  const previous = history
+    .filter((entry) => entry.sequence !== command?.sequence)
+    .slice(-3);
+  const keyLabel = command?.key ?? '·';
+  const description = command?.description ?? 'Move by document meaning';
+  const inputLabel = inputMethod === 'pinpoint' ? 'PINPOINT' : 'SELECT';
+
+  return (
+    <div
+      data-vim-key-hud
+      role="status"
+      aria-live="polite"
+      aria-label={`${phase} ${inputLabel}: ${keyLabel}, ${description}`}
+      style={{
+        position: 'fixed',
+        right: 'min(48px, 4vw)',
+        bottom: 150,
+        zIndex: 120,
+        width: 'min(650px, calc(100vw - 32px))',
+        height: 88,
+        display: 'flex',
+        alignItems: 'center',
+        overflow: 'hidden',
+        padding: '12px 16px',
+        borderRadius: 20,
+        color: '#f7f4ff',
+        background: 'linear-gradient(180deg, rgba(43,35,59,0.46), rgba(13,11,20,0.34))',
+        border: '1px solid rgba(196,181,253,0.25)',
+        boxShadow: '0 22px 58px rgba(0,0,0,0.52), 0 0 32px rgba(167,139,250,0.1), inset 0 1px 0 rgba(255,255,255,0.07)',
+        backdropFilter: 'blur(10px)',
+        WebkitBackdropFilter: 'blur(10px)',
+        pointerEvents: 'none',
+      }}
+    >
+      <div
+        data-vim-hud-history
+        aria-hidden="true"
+        style={{
+          width: 112,
+          display: 'flex',
+          flex: '0 0 auto',
+          alignItems: 'center',
+          justifyContent: 'flex-end',
+          gap: 5,
+        }}
+      >
+        {previous.map((entry, index) => (
+          <PreviousKey
+            key={entry.sequence}
+            keyLabel={entry.key}
+            opacity={0.28 + index * 0.24}
+          />
+        ))}
+      </div>
+
+      <div
+        aria-hidden="true"
+        style={{
+          width: 1,
+          height: 46,
+          flex: '0 0 auto',
+          margin: '0 15px',
+          background: 'linear-gradient(180deg, transparent, rgba(255,255,255,0.14), transparent)',
+        }}
+      />
+
+      <ActiveKey
+        keyLabel={keyLabel}
+        pressed={command?.sequence === pressedSequence}
+      />
+
+      <div
+        style={{
+          minWidth: 0,
+          flex: 1,
+          marginLeft: 16,
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            color: '#a99fba',
+            fontFamily: HUD_MONO_FONT,
+            fontSize: 10,
+            fontWeight: 850,
+            letterSpacing: '0.16em',
+          }}
+        >
+          <span
+            aria-hidden="true"
+            style={{
+              width: 6,
+              height: 6,
+              flex: '0 0 auto',
+              borderRadius: 99,
+              background: '#a78bfa',
+              boxShadow: '0 0 13px rgba(167,139,250,0.88)',
+            }}
+          />
+          <span data-vim-hud-phase>{phase} / {inputLabel}</span>
+        </div>
+        <div
+          data-vim-hud-command
+          style={{
+            marginTop: 5,
+            overflow: 'hidden',
+            color: '#f4f0f8',
+            fontSize: 19,
+            fontWeight: 690,
+            lineHeight: 1.08,
+            whiteSpace: 'nowrap',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {description}
+        </div>
+      </div>
+
+      <div
+        aria-hidden="true"
+        style={{
+          alignSelf: 'stretch',
+          width: 76,
+          display: 'grid',
+          flex: '0 0 auto',
+          alignContent: 'center',
+          justifyItems: 'end',
+          color: '#6f6879',
+          fontFamily: HUD_MONO_FONT,
+          fontSize: 9,
+          fontWeight: 800,
+          letterSpacing: '0.11em',
+          lineHeight: 1.45,
+        }}
+      >
+        <span>VIM</span>
+        <span style={{ color: '#9c89d6' }}>SELECT</span>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/components/VimKeyHud.tsx
+++ b/packages/ui/components/VimKeyHud.tsx
@@ -1,3 +1,4 @@
+import { EyeOff } from 'lucide-react';
 import { useLayoutEffect, useRef, useState } from 'react';
 import type { InputMethod } from '../types';
 import {
@@ -255,6 +256,8 @@ export interface VimKeyHudProps {
   readonly inputMethod: InputMethod;
   readonly expanded: boolean;
   readonly onExpandedChange: (expanded: boolean) => void;
+  /** Hide the persistent key panel while leaving the targeting HUD enabled. */
+  readonly onHide?: () => void;
   /** Notify the owner when keyboard focus leaves the HUD for another surface. */
   readonly onFocusLeave?: () => void;
 }
@@ -271,6 +274,7 @@ export function VimKeyHud({
   inputMethod,
   expanded,
   onExpandedChange,
+  onHide,
   onFocusLeave,
 }: VimKeyHudProps) {
   const [history, setHistory] = useState<readonly VimHudCommand[]>([]);
@@ -454,6 +458,38 @@ export function VimKeyHud({
             {phase} {inputLabel}: {keyLabel}, {description}
           </span>
         </div>
+
+        {onHide && (
+          <button
+            type="button"
+            data-vim-key-panel-hide
+            aria-label="Hide Vim key panel"
+            title="Hide key panel (keep target reticle)"
+            onPointerDown={(event) => {
+              // Preserve document ownership for pointer users. Keyboard
+              // activation is handed back by the owner after hiding.
+              event.preventDefault();
+            }}
+            onClick={onHide}
+            style={{
+              width: 40,
+              height: 40,
+              display: 'grid',
+              flex: '0 0 auto',
+              placeItems: 'center',
+              marginLeft: 10,
+              padding: 0,
+              border: '1px solid rgba(196,181,253,0.16)',
+              borderRadius: 10,
+              color: '#aaa0ba',
+              background: 'rgba(17,14,24,0.2)',
+              cursor: 'pointer',
+              pointerEvents: 'auto',
+            }}
+          >
+            <EyeOff size={15} strokeWidth={1.8} aria-hidden="true" />
+          </button>
+        )}
 
         <button
           type="button"

--- a/packages/ui/components/VimKeyHud.tsx
+++ b/packages/ui/components/VimKeyHud.tsx
@@ -1,10 +1,23 @@
 import { useLayoutEffect, useRef, useState } from 'react';
 import type { InputMethod } from '../types';
-import type { VimHudCommand, VimHudPhase } from '../utils/vimHud';
+import {
+  getVimHudLegendGroups,
+  isVimHudLegendGroupActive,
+  type VimHudCommand,
+  type VimHudLegendGroup,
+  type VimHudLegendGroupId,
+  type VimHudPhase,
+} from '../utils/vimHud';
 
 const HUD_MONO_FONT = '"SFMono-Regular", "JetBrains Mono", Menlo, var(--font-mono), monospace';
 // Match the seven-frame pressed state in the 30fps product-demo HUD.
 const PRESSED_DURATION_MS = (7 / 30) * 1000;
+const KEY_MAP_COLUMNS: readonly (readonly VimHudLegendGroupId[])[] = [
+  ['structure', 'control'],
+  ['text'],
+  ['selection', 'annotation'],
+];
+const KEY_MAP_GROUPS = getVimHudLegendGroups();
 
 interface PreviousKeyProps {
   readonly keyLabel: string;
@@ -77,11 +90,173 @@ function ActiveKey({ keyLabel, pressed }: ActiveKeyProps) {
   );
 }
 
+interface VimKeyMapGroupProps {
+  readonly group: VimHudLegendGroup;
+  readonly phase: VimHudPhase;
+  readonly activeActionId: VimHudCommand['actionId'] | null;
+}
+
+function VimKeyMapGroup({
+  group,
+  phase,
+  activeActionId,
+}: VimKeyMapGroupProps) {
+  const active = isVimHudLegendGroupActive(group.id, phase);
+
+  return (
+    <section
+      data-vim-key-map-group={group.id}
+      data-current={active ? 'true' : 'false'}
+      aria-current={active ? 'true' : undefined}
+      style={{
+        padding: '11px 12px 9px',
+        borderRadius: 13,
+        border: active
+          ? '1px solid rgba(196,181,253,0.34)'
+          : '1px solid rgba(255,255,255,0.075)',
+        color: '#f5f0ff',
+        background: active
+          ? 'linear-gradient(180deg, rgba(97,71,148,0.25), rgba(24,19,34,0.24))'
+          : 'rgba(13,11,20,0.22)',
+        boxShadow: active
+          ? 'inset 0 1px 0 rgba(255,255,255,0.06), 0 0 24px rgba(139,92,246,0.08)'
+          : 'inset 0 1px 0 rgba(255,255,255,0.035)',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          gap: 8,
+          marginBottom: 7,
+        }}
+      >
+        <div style={{ minWidth: 0 }}>
+          <div
+            style={{
+              color: active ? '#d8ccff' : '#b4acc1',
+              fontFamily: HUD_MONO_FONT,
+              fontSize: 10,
+              fontWeight: 900,
+              letterSpacing: '0.14em',
+              lineHeight: 1.1,
+              textTransform: 'uppercase',
+            }}
+          >
+            {group.title}
+          </div>
+          <div
+            style={{
+              marginTop: 4,
+              color: '#817989',
+              fontSize: 10,
+              fontWeight: 590,
+              lineHeight: 1.25,
+            }}
+          >
+            {group.description}
+          </div>
+        </div>
+        {active && (
+          <span
+            style={{
+              flex: '0 0 auto',
+              padding: '3px 5px',
+              borderRadius: 5,
+              color: '#d8ccff',
+              background: 'rgba(167,139,250,0.13)',
+              fontFamily: HUD_MONO_FONT,
+              fontSize: 7,
+              fontWeight: 900,
+              letterSpacing: '0.11em',
+            }}
+          >
+            NOW
+          </span>
+        )}
+      </div>
+
+      <div style={{ display: 'grid', gap: 3 }}>
+        {group.items.map((item) => {
+          const isNavigationGroup = group.id === 'structure' || group.id === 'text';
+          const isLatestAction = item.actionId === activeActionId
+            && (!isNavigationGroup || active);
+          return (
+            <div
+              key={`${group.id}-${item.actionId}`}
+              data-vim-key-map-action={item.actionId}
+              data-latest={isLatestAction ? 'true' : 'false'}
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '48px minmax(0, 1fr)',
+                alignItems: 'center',
+                minHeight: 23,
+                gap: 7,
+                borderRadius: 7,
+                color: isLatestAction ? '#f7f3ff' : '#bbb4c4',
+                background: isLatestAction
+                  ? 'rgba(167,139,250,0.095)'
+                  : 'transparent',
+              }}
+            >
+              <kbd
+                style={{
+                  minWidth: 29,
+                  width: 'fit-content',
+                  maxWidth: 48,
+                  height: 21,
+                  display: 'inline-grid',
+                  placeItems: 'center',
+                  padding: '0 6px',
+                  overflow: 'hidden',
+                  border: isLatestAction
+                    ? '1px solid rgba(216,204,255,0.52)'
+                    : '1px solid rgba(255,255,255,0.11)',
+                  borderBottom: isLatestAction
+                    ? '3px solid rgba(103,80,164,0.92)'
+                    : '3px solid rgba(0,0,0,0.64)',
+                  borderRadius: 6,
+                  color: isLatestAction ? '#f6f0ff' : '#d5cedf',
+                  background: isLatestAction
+                    ? 'linear-gradient(180deg, rgba(107,82,158,0.72), rgba(44,34,63,0.75))'
+                    : 'linear-gradient(180deg, rgba(43,39,51,0.84), rgba(23,20,29,0.84))',
+                  fontFamily: HUD_MONO_FONT,
+                  fontSize: item.key.length > 3 ? 8 : 10,
+                  fontWeight: 850,
+                  lineHeight: 1,
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {item.key}
+              </kbd>
+              <span
+                style={{
+                  minWidth: 0,
+                  fontSize: 10,
+                  fontWeight: isLatestAction ? 680 : 580,
+                  lineHeight: 1.15,
+                }}
+              >
+                {item.description}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
 /** Props for the pixel-faithful, live Vim HUD used by both document renderers. */
 export interface VimKeyHudProps {
   readonly command: VimHudCommand | null;
   readonly phase: VimHudPhase;
   readonly inputMethod: InputMethod;
+  readonly expanded: boolean;
+  readonly onExpandedChange: (expanded: boolean) => void;
+  /** Notify the owner when keyboard focus leaves the HUD for another surface. */
+  readonly onFocusLeave?: () => void;
 }
 
 /**
@@ -94,6 +269,9 @@ export function VimKeyHud({
   command,
   phase,
   inputMethod,
+  expanded,
+  onExpandedChange,
+  onFocusLeave,
 }: VimKeyHudProps) {
   const [history, setHistory] = useState<readonly VimHudCommand[]>([]);
   const [pressedSequence, setPressedSequence] = useState<number | null>(null);
@@ -136,18 +314,32 @@ export function VimKeyHud({
   return (
     <div
       data-vim-key-hud
-      role="status"
-      aria-live="polite"
-      aria-label={`${phase} ${inputLabel}: ${keyLabel}, ${description}`}
+      data-expanded={expanded ? 'true' : 'false'}
+      role="region"
+      aria-label="Vim keyboard HUD"
+      onBlur={(event) => {
+        if (
+          event.relatedTarget instanceof Node
+          && event.currentTarget.contains(event.relatedTarget)
+        ) {
+          return;
+        }
+        onFocusLeave?.();
+      }}
       style={{
         position: 'fixed',
         right: 'min(48px, 4vw)',
         bottom: 150,
         zIndex: 120,
-        width: 'min(650px, calc(100vw - 32px))',
-        height: 88,
+        width: expanded
+          ? 'min(860px, calc(100vw - 32px))'
+          : 'min(650px, calc(100vw - 32px))',
+        height: expanded
+          ? 'min(560px, calc(100dvh - 174px))'
+          : 88,
         display: 'flex',
-        alignItems: 'center',
+        flexDirection: 'column',
+        alignItems: 'stretch',
         overflow: 'hidden',
         padding: '12px 16px',
         borderRadius: 20,
@@ -161,111 +353,307 @@ export function VimKeyHud({
       }}
     >
       <div
-        data-vim-hud-history
-        aria-hidden="true"
+        data-vim-hud-summary
         style={{
-          width: 112,
+          width: '100%',
+          height: 63,
           display: 'flex',
           flex: '0 0 auto',
           alignItems: 'center',
-          justifyContent: 'flex-end',
-          gap: 5,
-        }}
-      >
-        {previous.map((entry, index) => (
-          <PreviousKey
-            key={entry.sequence}
-            keyLabel={entry.key}
-            opacity={0.28 + index * 0.24}
-          />
-        ))}
-      </div>
-
-      <div
-        aria-hidden="true"
-        style={{
-          width: 1,
-          height: 46,
-          flex: '0 0 auto',
-          margin: '0 15px',
-          background: 'linear-gradient(180deg, transparent, rgba(255,255,255,0.14), transparent)',
-        }}
-      />
-
-      <ActiveKey
-        keyLabel={keyLabel}
-        pressed={command?.sequence === pressedSequence}
-      />
-
-      <div
-        style={{
-          minWidth: 0,
-          flex: 1,
-          marginLeft: 16,
         }}
       >
         <div
+          data-vim-hud-history
+          aria-hidden="true"
           style={{
+            width: 112,
             display: 'flex',
+            flex: '0 0 auto',
             alignItems: 'center',
-            gap: 8,
-            color: '#a99fba',
+            justifyContent: 'flex-end',
+            gap: 5,
+          }}
+        >
+          {previous.map((entry, index) => (
+            <PreviousKey
+              key={entry.sequence}
+              keyLabel={entry.key}
+              opacity={0.28 + index * 0.24}
+            />
+          ))}
+        </div>
+
+        <div
+          aria-hidden="true"
+          style={{
+            width: 1,
+            height: 46,
+            flex: '0 0 auto',
+            margin: '0 15px',
+            background: 'linear-gradient(180deg, transparent, rgba(255,255,255,0.14), transparent)',
+          }}
+        />
+
+        <ActiveKey
+          keyLabel={keyLabel}
+          pressed={command?.sequence === pressedSequence}
+        />
+
+        <div
+          style={{
+            minWidth: 0,
+            flex: 1,
+            marginLeft: 16,
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              color: '#a99fba',
+              fontFamily: HUD_MONO_FONT,
+              fontSize: 10,
+              fontWeight: 850,
+              letterSpacing: '0.16em',
+            }}
+          >
+            <span
+              aria-hidden="true"
+              style={{
+                width: 6,
+                height: 6,
+                flex: '0 0 auto',
+                borderRadius: 99,
+                background: '#a78bfa',
+                boxShadow: '0 0 13px rgba(167,139,250,0.88)',
+              }}
+            />
+            <span data-vim-hud-phase>{phase} / {inputLabel}</span>
+          </div>
+          <div
+            data-vim-hud-command
+            style={{
+              marginTop: 5,
+              overflow: 'hidden',
+              color: '#f4f0f8',
+              fontSize: 19,
+              fontWeight: 690,
+              lineHeight: 1.08,
+              whiteSpace: 'nowrap',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            {description}
+          </div>
+          <span
+            role="status"
+            aria-live="polite"
+            className="sr-only"
+          >
+            {phase} {inputLabel}: {keyLabel}, {description}
+          </span>
+        </div>
+
+        <button
+          type="button"
+          data-vim-key-map-toggle
+          aria-expanded={expanded}
+          aria-controls="vim-hud-key-map"
+          aria-label={expanded ? 'Collapse Vim key map' : 'Expand Vim key map'}
+          onPointerDown={(event) => {
+            // Keep keyboard ownership on the document/iframe while the pointer
+            // toggles this fixed HUD control.
+            event.preventDefault();
+          }}
+          onClick={() => onExpandedChange(!expanded)}
+          className="vim-key-hud__map-toggle"
+          style={{
+            width: 92,
+            minWidth: 44,
+            minHeight: 44,
+            display: 'grid',
+            flex: '0 0 auto',
+            gridTemplateColumns: '1fr auto',
+            alignItems: 'center',
+            gap: 7,
+            marginLeft: 12,
+            padding: '7px 8px 7px 10px',
+            border: '1px solid rgba(196,181,253,0.18)',
+            borderRadius: 11,
+            color: '#afa5bf',
+            background: expanded
+              ? 'rgba(167,139,250,0.13)'
+              : 'rgba(17,14,24,0.22)',
             fontFamily: HUD_MONO_FONT,
-            fontSize: 10,
-            fontWeight: 850,
-            letterSpacing: '0.16em',
+            cursor: 'pointer',
+            pointerEvents: 'auto',
           }}
         >
           <span
+            style={{
+              display: 'grid',
+              justifyItems: 'start',
+              fontSize: 8,
+              fontWeight: 850,
+              letterSpacing: '0.1em',
+              lineHeight: 1.35,
+            }}
+          >
+            <span>VIM</span>
+            <span style={{ color: '#b39ce7' }}>
+              {expanded ? 'CLOSE' : 'KEY MAP'}
+            </span>
+          </span>
+          <kbd
             aria-hidden="true"
             style={{
-              width: 6,
-              height: 6,
-              flex: '0 0 auto',
-              borderRadius: 99,
-              background: '#a78bfa',
-              boxShadow: '0 0 13px rgba(167,139,250,0.88)',
+              width: 25,
+              height: 25,
+              display: 'grid',
+              placeItems: 'center',
+              border: '1px solid rgba(216,204,255,0.34)',
+              borderBottom: '3px solid rgba(0,0,0,0.66)',
+              borderRadius: 7,
+              color: '#eee8ff',
+              background: 'linear-gradient(180deg, rgba(64,55,78,0.9), rgba(27,23,35,0.9))',
+              fontSize: 12,
+              fontWeight: 900,
             }}
-          />
-          <span data-vim-hud-phase>{phase} / {inputLabel}</span>
-        </div>
-        <div
-          data-vim-hud-command
-          style={{
-            marginTop: 5,
-            overflow: 'hidden',
-            color: '#f4f0f8',
-            fontSize: 19,
-            fontWeight: 690,
-            lineHeight: 1.08,
-            whiteSpace: 'nowrap',
-            textOverflow: 'ellipsis',
-          }}
-        >
-          {description}
-        </div>
+          >
+            ?
+          </kbd>
+        </button>
       </div>
 
-      <div
-        aria-hidden="true"
-        style={{
-          alignSelf: 'stretch',
-          width: 76,
-          display: 'grid',
-          flex: '0 0 auto',
-          alignContent: 'center',
-          justifyItems: 'end',
-          color: '#6f6879',
-          fontFamily: HUD_MONO_FONT,
-          fontSize: 9,
-          fontWeight: 800,
-          letterSpacing: '0.11em',
-          lineHeight: 1.45,
-        }}
-      >
-        <span>VIM</span>
-        <span style={{ color: '#9c89d6' }}>SELECT</span>
-      </div>
+      {expanded && (
+        <div
+          id="vim-hud-key-map"
+          data-vim-key-map
+          style={{
+            minHeight: 0,
+            display: 'flex',
+            flex: 1,
+            flexDirection: 'column',
+            paddingTop: 10,
+            borderTop: '1px solid rgba(255,255,255,0.085)',
+            pointerEvents: 'auto',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              flex: '0 0 auto',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 16,
+              padding: '2px 2px 10px',
+            }}
+          >
+            <div>
+              <div
+                style={{
+                  color: '#f4efff',
+                  fontSize: 14,
+                  fontWeight: 760,
+                  lineHeight: 1.15,
+                }}
+              >
+                Vim key map
+              </div>
+              <div
+                style={{
+                  marginTop: 3,
+                  color: '#92899e',
+                  fontSize: 10,
+                  fontWeight: 570,
+                }}
+              >
+                The highlighted section matches your current navigation level.
+              </div>
+            </div>
+            <div
+              style={{
+                flex: '0 0 auto',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 7,
+                color: '#a99fba',
+                fontFamily: HUD_MONO_FONT,
+                fontSize: 9,
+                fontWeight: 850,
+                letterSpacing: '0.11em',
+              }}
+            >
+              <span
+                aria-hidden="true"
+                style={{
+                  width: 6,
+                  height: 6,
+                  borderRadius: 99,
+                  background: '#a78bfa',
+                  boxShadow: '0 0 12px rgba(167,139,250,0.82)',
+                }}
+              />
+              {phase} MODE
+            </div>
+          </div>
+
+          <div
+            className="vim-key-hud__map-scroll"
+            style={{
+              minHeight: 0,
+              flex: 1,
+              overflow: 'auto',
+              overscrollBehavior: 'contain',
+              padding: '0 2px 4px',
+              scrollbarGutter: 'stable',
+            }}
+          >
+            <div className="vim-key-hud__map-columns">
+              {KEY_MAP_COLUMNS.map((groupIds, columnIndex) => (
+                <div
+                  key={columnIndex}
+                  style={{
+                    display: 'grid',
+                    alignContent: 'start',
+                    gap: 9,
+                  }}
+                >
+                  {KEY_MAP_GROUPS
+                    .filter((group) => groupIds.includes(group.id))
+                    .map((group) => (
+                      <VimKeyMapGroup
+                        key={group.id}
+                        group={group}
+                        phase={phase}
+                        activeActionId={command?.actionId ?? null}
+                      />
+                    ))}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div
+            style={{
+              display: 'flex',
+              flex: '0 0 auto',
+              justifyContent: 'space-between',
+              gap: 12,
+              padding: '9px 2px 0',
+              color: '#777080',
+              fontFamily: HUD_MONO_FONT,
+              fontSize: 8,
+              fontWeight: 780,
+              letterSpacing: '0.08em',
+            }}
+          >
+            <span>PRESS ? TO CLOSE</span>
+            <span>ESC BACKS OUT ONE LEVEL</span>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/ui/components/VimModeAnnouncementDialog.test.tsx
+++ b/packages/ui/components/VimModeAnnouncementDialog.test.tsx
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import React, { act, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { VimModeAnnouncementDialog } from './VimModeAnnouncementDialog';
+
+const hasDom = typeof document !== 'undefined';
+let root: Root | null = null;
+let host: HTMLElement | null = null;
+
+interface HarnessProps {
+  readonly initialVim?: boolean;
+  readonly initialHud?: boolean;
+  readonly onDismiss?: () => void;
+}
+
+function Harness({
+  initialVim = false,
+  initialHud = false,
+  onDismiss,
+}: HarnessProps) {
+  const [isOpen, setIsOpen] = useState(true);
+  const [vimEnabled, setVimEnabled] = useState(initialVim);
+  const [hudEnabled, setHudEnabled] = useState(initialHud);
+
+  return (
+    <VimModeAnnouncementDialog
+      isOpen={isOpen}
+      vimModeEnabled={vimEnabled}
+      vimHudEnabled={hudEnabled}
+      onVimModeChange={setVimEnabled}
+      onVimHudChange={setHudEnabled}
+      onDismiss={() => {
+        onDismiss?.();
+        setIsOpen(false);
+      }}
+    />
+  );
+}
+
+async function mountDialog(props: HarnessProps = {}): Promise<void> {
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  root = createRoot(host);
+  await act(async () => {
+    root?.render(<Harness {...props} />);
+  });
+}
+
+function switches(): HTMLButtonElement[] {
+  return Array.from(document.querySelectorAll<HTMLButtonElement>('button[role="switch"]'));
+}
+
+function buttonWithText(text: string): HTMLButtonElement {
+  const button = Array.from(document.querySelectorAll<HTMLButtonElement>('button'))
+    .find(candidate => candidate.textContent?.includes(text));
+  if (!button) throw new Error(`Button containing "${text}" did not render`);
+  return button;
+}
+
+describe('VimModeAnnouncementDialog', () => {
+  afterEach(async () => {
+    const mountedRoot = root;
+    if (mountedRoot) await act(async () => mountedRoot.unmount());
+    root = null;
+    host?.remove();
+    host = null;
+    if (hasDom) document.body.replaceChildren();
+  });
+
+  test.skipIf(!hasDom)('renders as a labelled modal with the real setup options', async () => {
+    await mountDialog();
+
+    const dialog = document.querySelector('[role="dialog"]');
+    expect(dialog?.getAttribute('aria-modal')).toBe('true');
+    expect(dialog?.textContent).toContain('Navigate and annotate at Vim speed');
+    expect(dialog?.textContent).toContain('This is a demo');
+    expect(dialog?.textContent).not.toContain('Ship collaborative review');
+    expect(dialog?.textContent).toContain('Recommended');
+    const selectionTarget = dialog?.querySelector('[data-vim-demo-target="selection"]');
+    expect(selectionTarget?.querySelectorAll('.vim-announcement-reticle--selection')).toHaveLength(4);
+    expect(selectionTarget?.querySelector('.vim-announcement-comment')).not.toBeNull();
+    expect(switches()).toHaveLength(2);
+    expect(switches().map(button => button.getAttribute('aria-checked'))).toEqual([
+      'false',
+      'false',
+    ]);
+  });
+
+  test.skipIf(!hasDom)('enabling HUD also enables Vim, and disabling Vim clears HUD', async () => {
+    await mountDialog();
+
+    switches()[1].focus();
+    await act(async () => switches()[1].click());
+    expect(switches().map(button => button.getAttribute('aria-checked'))).toEqual([
+      'true',
+      'true',
+    ]);
+    expect(document.activeElement).toBe(switches()[1]);
+
+    await act(async () => switches()[0].click());
+    expect(switches().map(button => button.getAttribute('aria-checked'))).toEqual([
+      'false',
+      'false',
+    ]);
+  });
+
+  test.skipIf(!hasDom)('the default primary action enables Vim and HUD before dismissing', async () => {
+    const onDismiss = mock(() => {});
+    await mountDialog({ onDismiss });
+
+    await act(async () => buttonWithText('Enable Vim + HUD').click());
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('[data-vim-announcement-dialog]')).toBeNull();
+  });
+
+  test.skipIf(!hasDom)('Escape dismisses the dialog and restores prior focus', async () => {
+    const priorButton = document.createElement('button');
+    priorButton.textContent = 'Prior focus';
+    document.body.appendChild(priorButton);
+    priorButton.focus();
+    const onDismiss = mock(() => {});
+    await mountDialog({ initialVim: true, initialHud: true, onDismiss });
+
+    expect(document.activeElement?.textContent).toContain('Start with Vim + HUD');
+
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(document.activeElement).toBe(priorButton);
+  });
+});

--- a/packages/ui/components/VimModeAnnouncementDialog.tsx
+++ b/packages/ui/components/VimModeAnnouncementDialog.tsx
@@ -1,0 +1,568 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Crosshair, Keyboard } from 'lucide-react';
+import type { VimSelectionActionId, VimSelectionHudContext } from '../shortcuts';
+import type { SemanticTarget } from '../utils/blockTargeting';
+import {
+  createVimHudCommand,
+  getVimHudPhase,
+} from '../utils/vimHud';
+import type { VimRestorableState } from '../utils/vimNavigation';
+import { getVimReticleLabel } from '../utils/vimReticle';
+
+interface VimModeAnnouncementDialogProps {
+  readonly isOpen: boolean;
+  readonly vimModeEnabled: boolean;
+  readonly vimHudEnabled: boolean;
+  readonly onVimModeChange: (enabled: boolean) => void;
+  readonly onVimHudChange: (enabled: boolean) => void;
+  readonly onDismiss: () => void;
+}
+
+interface SwitchRowProps {
+  readonly checked: boolean;
+  readonly title: string;
+  readonly description: string;
+  readonly icon: React.ReactNode;
+  readonly recommended?: boolean;
+  readonly onChange: (checked: boolean) => void;
+}
+
+type ShowcaseTarget = Pick<SemanticTarget, 'kind' | 'label'>;
+
+interface ShowcaseStepSpec {
+  readonly actionId: VimSelectionActionId;
+  readonly rawKey: string;
+  readonly commandContext: VimSelectionHudContext;
+  readonly resultContext: VimSelectionHudContext;
+  readonly reticleState: VimRestorableState;
+  readonly target: ShowcaseTarget | null;
+}
+
+const DEMO_BLOCK_TARGET: ShowcaseTarget = {
+  kind: 'block',
+  label: 'paragraph: "Keep collaboration responsive"',
+};
+const DEMO_INLINE_TARGET: ShowcaseTarget = {
+  kind: 'inline',
+  label: 'code: "operationBatchSize: 32"',
+};
+const DEMO_TEXT_START = { blockId: 'demo-inline-code', textOffset: 0 };
+const DEMO_VALUE_START = { blockId: 'demo-inline-code', textOffset: 20 };
+const DEMO_VALUE_END = { blockId: 'demo-inline-code', textOffset: 22 };
+
+const SHOWCASE_STEP_SPECS: readonly ShowcaseStepSpec[] = [
+  {
+    actionId: 'moveDown',
+    rawKey: 'j',
+    commandContext: 'block',
+    resultContext: 'block',
+    reticleState: { phase: 'block', targetKey: 'demo-block' },
+    target: DEMO_BLOCK_TARGET,
+  },
+  {
+    actionId: 'refine',
+    rawKey: 'l',
+    commandContext: 'block',
+    resultContext: 'inline',
+    reticleState: { phase: 'inline', targetKey: 'demo-inline-code' },
+    target: DEMO_INLINE_TARGET,
+  },
+  {
+    actionId: 'refine',
+    rawKey: 'l',
+    commandContext: 'inline',
+    resultContext: 'text',
+    reticleState: {
+      phase: 'text',
+      targetKey: 'demo-inline-code',
+      cursor: DEMO_TEXT_START,
+    },
+    target: null,
+  },
+  {
+    actionId: 'wordForward',
+    rawKey: 'w',
+    commandContext: 'text',
+    resultContext: 'text',
+    reticleState: {
+      phase: 'text',
+      targetKey: 'demo-inline-code',
+      cursor: DEMO_VALUE_START,
+    },
+    target: null,
+  },
+  {
+    actionId: 'visual',
+    rawKey: 'v',
+    commandContext: 'text',
+    resultContext: 'visual',
+    reticleState: {
+      phase: 'visual',
+      targetKey: 'demo-inline-code',
+      anchor: DEMO_VALUE_START,
+      cursor: DEMO_VALUE_START,
+    },
+    target: null,
+  },
+  {
+    actionId: 'wordEnd',
+    rawKey: 'e',
+    commandContext: 'visual',
+    resultContext: 'visual',
+    reticleState: {
+      phase: 'visual',
+      targetKey: 'demo-inline-code',
+      anchor: DEMO_VALUE_START,
+      cursor: DEMO_VALUE_END,
+    },
+    target: null,
+  },
+  {
+    actionId: 'comment',
+    rawKey: 'c',
+    commandContext: 'visual',
+    resultContext: 'action',
+    reticleState: {
+      phase: 'visual',
+      targetKey: 'demo-inline-code',
+      anchor: DEMO_VALUE_START,
+      cursor: DEMO_VALUE_END,
+    },
+    target: null,
+  },
+];
+
+const SHOWCASE_STEPS = SHOWCASE_STEP_SPECS.map((spec, index) => {
+  const command = createVimHudCommand(
+    index + 1,
+    spec.actionId,
+    spec.rawKey,
+    spec.commandContext,
+  );
+  return {
+    ...command,
+    phase: getVimHudPhase(spec.resultContext, spec.actionId),
+    reticleLabel: getVimReticleLabel(
+      spec.reticleState,
+      spec.target,
+      command,
+    ),
+  };
+});
+
+function SwitchRow({
+  checked,
+  title,
+  description,
+  icon,
+  recommended = false,
+  onChange,
+}: SwitchRowProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onChange(!checked)}
+      className="vim-announcement-switch w-full min-h-24 rounded-xl border border-border bg-muted/25 p-4 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-card"
+    >
+      <span className="flex items-start gap-3">
+        <span
+          aria-hidden="true"
+          className={`mt-0.5 grid h-9 w-9 shrink-0 place-items-center rounded-lg border ${
+            checked
+              ? 'border-primary/40 bg-primary/15 text-primary'
+              : 'border-border bg-background/60 text-muted-foreground'
+          }`}
+        >
+          {icon}
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="flex flex-wrap items-center gap-2">
+            <span className="text-sm font-semibold text-foreground">{title}</span>
+            {recommended && (
+              <span className="rounded-full border border-primary/25 bg-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-primary">
+                Recommended
+              </span>
+            )}
+          </span>
+          <span className="mt-1 block text-xs leading-relaxed text-muted-foreground">
+            {description}
+          </span>
+        </span>
+        <span
+          aria-hidden="true"
+          className={`vim-announcement-switch__track mt-1 ${
+            checked ? 'vim-announcement-switch__track--checked' : ''
+          }`}
+        >
+          <span className="vim-announcement-switch__thumb" />
+        </span>
+      </span>
+    </button>
+  );
+}
+
+function ShowcaseReticle({
+  step,
+  label,
+  className,
+}: {
+  readonly step: number;
+  readonly label: string;
+  readonly className: string;
+}) {
+  return (
+    <span
+      className={`vim-announcement-step vim-announcement-step--${step} vim-announcement-reticle ${className}`}
+    >
+      <span className="vim-announcement-reticle__corner vim-announcement-reticle__corner--top-left" />
+      <span className="vim-announcement-reticle__corner vim-announcement-reticle__corner--top-right" />
+      <span className="vim-announcement-reticle__corner vim-announcement-reticle__corner--bottom-left" />
+      <span className="vim-announcement-reticle__corner vim-announcement-reticle__corner--bottom-right" />
+      <span className="vim-announcement-reticle__label">
+        <span className="vim-announcement-reticle__dot" />
+        {label}
+      </span>
+    </span>
+  );
+}
+
+function VimShowcase() {
+  const [isPlaying, setIsPlaying] = useState(() => (
+    typeof document === 'undefined' || document.visibilityState !== 'hidden'
+  ));
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      setIsPlaying(document.visibilityState !== 'hidden');
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, []);
+
+  return (
+    <div
+      className="vim-announcement-showcase relative h-full min-h-[350px] overflow-hidden rounded-xl border border-white/10 bg-[#111019] min-[821px]:min-h-[430px]"
+      data-playing={isPlaying ? 'true' : 'false'}
+      aria-hidden="true"
+    >
+      <div className="vim-announcement-showcase__canvas absolute inset-0">
+        <div className="absolute inset-x-0 top-0 flex h-10 items-center gap-1.5 border-b border-white/[0.07] bg-white/[0.025] px-4">
+          <span className="h-2 w-2 rounded-full bg-white/10" />
+          <span className="h-2 w-2 rounded-full bg-white/10" />
+          <span className="h-2 w-2 rounded-full bg-white/10" />
+          <span className="ml-2 font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-white/35">
+            vim-mode-demo.md
+          </span>
+        </div>
+
+        <div className="absolute inset-x-0 bottom-0 top-10 px-7 pb-24 pt-6 text-[#cbc7d4]">
+          <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[#8b8398]">
+            Vim mode demo
+          </div>
+          <div className="mt-2 text-[21px] font-semibold tracking-[-0.02em] text-[#f3eff9]">
+            This is a demo
+          </div>
+          <p className="mt-4 max-w-[430px] text-[12px] leading-[1.75] text-[#aaa4b4]">
+            Watch Vim mode move through a sample document, refine into exact text,
+            select a value, and open a comment.
+          </p>
+
+          <p
+            data-vim-demo-target="block"
+            className="relative mt-5 rounded-lg border border-white/[0.07] bg-[#1b1923] px-4 py-4 text-[12px] leading-7 text-[#bdb6c9]"
+          >
+            <ShowcaseReticle
+              step={1}
+              label={SHOWCASE_STEPS[0].reticleLabel}
+              className="vim-announcement-reticle--block"
+            />
+            Keep collaboration responsive by setting{' '}
+            <code
+              data-vim-demo-target="inline"
+              className="relative inline-flex rounded bg-[#25222e] px-1.5 font-mono text-[11px] text-[#79c0ff]"
+            >
+              <ShowcaseReticle
+                step={2}
+                label={SHOWCASE_STEPS[1].reticleLabel}
+                className="vim-announcement-reticle--inline"
+              />
+              <span
+                data-vim-demo-target="word"
+                className="relative inline-block"
+              >
+                operationBatchSize
+                <ShowcaseReticle
+                  step={3}
+                  label={SHOWCASE_STEPS[2].reticleLabel}
+                  className="vim-announcement-reticle--cursor-start"
+                />
+              </span>
+              <span className="text-[#bdb6c9]">: </span>
+              <span
+                data-vim-demo-target="selection"
+                className="relative inline-block"
+              >
+                <span className="vim-announcement-code-selection rounded-[3px] px-0.5 text-[#d2a8ff]">
+                  32
+                </span>
+                <ShowcaseReticle
+                  step={4}
+                  label={SHOWCASE_STEPS[3].reticleLabel}
+                  className="vim-announcement-reticle--selection"
+                />
+                <ShowcaseReticle
+                  step={5}
+                  label={SHOWCASE_STEPS[4].reticleLabel}
+                  className="vim-announcement-reticle--selection"
+                />
+                <ShowcaseReticle
+                  step={6}
+                  label={SHOWCASE_STEPS[5].reticleLabel}
+                  className="vim-announcement-reticle--selection"
+                />
+                <ShowcaseReticle
+                  step={7}
+                  label={SHOWCASE_STEPS[6].reticleLabel}
+                  className="vim-announcement-reticle--selection"
+                />
+                <span className="vim-announcement-step vim-announcement-step--7 vim-announcement-comment">
+                  <span className="block text-[10px] font-semibold text-[#f3eff9]">
+                    Comment on “32”
+                  </span>
+                  <span className="mt-1 block text-[9px] text-[#9e96aa]">
+                    Explain why this batch size is safe…
+                  </span>
+                </span>
+              </span>
+            </code>
+            . One <kbd className="font-mono text-[#c4b5fd]">w</kbd> jumps from the
+            variable to its value.
+          </p>
+        </div>
+
+        <div className="absolute bottom-5 right-5 z-20 flex h-[62px] w-[250px] items-center gap-3 rounded-xl border border-[#c4b5fd]/20 bg-[#16121f]/70 px-3.5 shadow-[0_16px_40px_rgba(0,0,0,0.42)] backdrop-blur-md">
+          <div className="relative h-10 w-10 shrink-0">
+            {SHOWCASE_STEPS.map((item, index) => (
+              <kbd
+                key={`${item.key}-${index}`}
+                className={`vim-announcement-step vim-announcement-step--${index + 1} absolute inset-0 grid place-items-center rounded-lg border border-[#ddd4ff]/70 border-b-[3px] border-b-[#6750a4] bg-gradient-to-b from-[#eee9ff] to-[#a78bfa] font-mono text-xl font-black text-[#1b1427] shadow-[0_0_24px_rgba(167,139,250,0.52)]`}
+              >
+                {item.key}
+              </kbd>
+            ))}
+          </div>
+          <div className="relative h-9 min-w-0 flex-1">
+            {SHOWCASE_STEPS.map((item, index) => (
+              <div
+                key={`${item.phase}-${index}`}
+                className={`vim-announcement-step vim-announcement-step--${index + 1} absolute inset-0 flex flex-col justify-center`}
+              >
+                <div className="font-mono text-[9px] font-black tracking-[0.16em] text-[#d8ccff]">
+                  {item.phase}
+                </div>
+                <div className="mt-1 truncate text-[11px] font-semibold text-[#f5f0ff]">
+                  {item.description}
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="font-mono text-[9px] font-bold text-[#817989]">1 / 1</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Introduces Vim navigation and lets the user persist the real Vim and HUD settings.
+ */
+export function VimModeAnnouncementDialog({
+  isOpen,
+  vimModeEnabled,
+  vimHudEnabled,
+  onVimModeChange,
+  onVimHudChange,
+  onDismiss,
+}: VimModeAnnouncementDialogProps) {
+  const primaryActionRef = useRef<HTMLButtonElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const onDismissRef = useRef(onDismiss);
+
+  useEffect(() => {
+    onDismissRef.current = onDismiss;
+  }, [onDismiss]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    previousFocusRef.current = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+    primaryActionRef.current?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onDismissRef.current();
+        return;
+      }
+      if (event.key !== 'Tab') return;
+
+      const dialog = document.querySelector<HTMLElement>('[data-vim-announcement-dialog]');
+      const focusable = Array.from(
+        dialog?.querySelectorAll<HTMLElement>('button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])')
+          ?? [],
+      );
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      previousFocusRef.current?.focus();
+      previousFocusRef.current = null;
+    };
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const handleVimModeChange = (enabled: boolean) => {
+    onVimModeChange(enabled);
+    if (!enabled && vimHudEnabled) onVimHudChange(false);
+  };
+
+  const handleVimHudChange = (enabled: boolean) => {
+    if (enabled && !vimModeEnabled) onVimModeChange(true);
+    onVimHudChange(enabled);
+  };
+
+  const handlePrimaryAction = () => {
+    if (!vimModeEnabled) {
+      onVimModeChange(true);
+      onVimHudChange(true);
+    }
+    onDismiss();
+  };
+
+  const primaryLabel = !vimModeEnabled
+    ? 'Enable Vim + HUD'
+    : vimHudEnabled
+      ? 'Start with Vim + HUD'
+      : 'Start with Vim';
+
+  return createPortal(
+    <div className="vim-announcement-backdrop fixed inset-0 z-[100] flex items-center justify-center bg-background/90 p-4 backdrop-blur-sm">
+      <div
+        data-vim-announcement-dialog
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="vim-announcement-title"
+        aria-describedby="vim-announcement-description"
+        className="vim-announcement-dialog flex h-[760px] max-h-[calc(100dvh-2rem)] w-full max-w-5xl flex-col overflow-hidden rounded-xl border border-border bg-card shadow-2xl max-[820px]:h-[calc(100dvh-2rem)]"
+      >
+        <header className="border-b border-border px-7 py-6">
+          <div className="flex items-center gap-2.5">
+            <span className="inline-flex items-center rounded-full border border-primary/25 bg-primary/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.13em] text-primary">
+              New · Keyboard navigation
+            </span>
+          </div>
+          <h2 id="vim-announcement-title" className="mt-3 text-2xl font-semibold tracking-tight">
+            Navigate and annotate at Vim speed
+          </h2>
+          <p
+            id="vim-announcement-description"
+            className="mt-1.5 max-w-3xl text-sm leading-relaxed text-muted-foreground"
+          >
+            Move through document structure, refine into exact text, and annotate without reaching
+            for the mouse. Start with the HUD to see every target and command as you learn.
+          </p>
+        </header>
+
+        <div className="grid min-h-0 flex-1 grid-cols-[1.35fr_0.85fr] gap-6 overflow-y-auto px-7 py-6 max-[820px]:grid-cols-1">
+          <section aria-label="Vim controls preview" className="min-h-[350px] min-[821px]:min-h-[430px]">
+            <VimShowcase />
+          </section>
+
+          <section aria-label="Vim controls settings" className="flex min-w-0 flex-col">
+            <div>
+              <div className="text-sm font-semibold">Choose your starting setup</div>
+              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                These are the real saved settings. You can change them anytime.
+              </p>
+            </div>
+
+            <div className="mt-4 space-y-3">
+              <SwitchRow
+                checked={vimModeEnabled}
+                title="Vim controls"
+                description="Use J/K to move by block, L/H to move in or out, then W/B/E and V for precise text selection."
+                icon={<Keyboard className="h-[18px] w-[18px]" />}
+                onChange={handleVimModeChange}
+              />
+              <SwitchRow
+                checked={vimModeEnabled && vimHudEnabled}
+                title="Vim HUD"
+                description="Adds the four-corner target reticle, live keypress feedback, and a complete ? key map."
+                icon={<Crosshair className="h-[18px] w-[18px]" />}
+                recommended
+                onChange={handleVimHudChange}
+              />
+            </div>
+
+            <div className="mt-auto rounded-xl border border-primary/20 bg-primary/[0.06] p-4">
+              <div className="flex items-start gap-2.5">
+                <span className="mt-0.5 grid h-6 w-6 shrink-0 place-items-center rounded-md bg-primary/15 text-primary">
+                  <span className="font-mono text-xs font-black">?</span>
+                </span>
+                <div>
+                  <div className="text-xs font-semibold text-foreground">Learn as you navigate</div>
+                  <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
+                    With HUD enabled, press <kbd className="rounded border border-border bg-background/70 px-1.5 py-0.5 font-mono text-[10px] text-foreground">?</kbd>{' '}
+                    in the document to expand the complete command map.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+
+        <footer className="flex items-center justify-between gap-4 border-t border-border px-7 py-5">
+          <p className="text-xs text-muted-foreground">
+            Change this anytime in Options → Shortcuts.
+          </p>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onDismiss}
+              className="vim-announcement-secondary-action min-h-10 rounded-lg border border-border px-4 text-sm font-medium text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-card"
+            >
+              Not now
+            </button>
+            <button
+              ref={primaryActionRef}
+              type="button"
+              onClick={handlePrimaryAction}
+              className="vim-announcement-primary-action min-h-10 rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-card"
+            >
+              {primaryLabel}
+            </button>
+          </div>
+        </footer>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/packages/ui/components/VimModeAnnouncementDialog.tsx
+++ b/packages/ui/components/VimModeAnnouncementDialog.tsx
@@ -541,7 +541,7 @@ export function VimModeAnnouncementDialog({
 
         <footer className="flex items-center justify-between gap-4 border-t border-border px-7 py-5">
           <p className="text-xs text-muted-foreground">
-            Change this anytime in Options → Shortcuts.
+            Change this anytime in Settings → Vim.
           </p>
           <div className="flex items-center gap-2">
             <button

--- a/packages/ui/components/VimModeOverlay.tsx
+++ b/packages/ui/components/VimModeOverlay.tsx
@@ -28,10 +28,12 @@ export interface VimModeOverlayProps {
   state: VimSelectionState;
   focused: boolean;
   hudEnabled: boolean;
+  keyPanelEnabled: boolean;
   hudCommand: VimHudCommand | null;
   activeTarget: SemanticTarget | null;
   helpOpen: boolean;
   onHelpOpenChange: (open: boolean) => void;
+  onKeyPanelHide?: () => void;
   onHudFocusLeave: () => void;
 }
 
@@ -45,10 +47,12 @@ export function VimModeOverlay({
   state,
   focused,
   hudEnabled,
+  keyPanelEnabled,
   hudCommand,
   activeTarget,
   helpOpen,
   onHelpOpenChange,
+  onKeyPanelHide,
   onHudFocusLeave,
 }: VimModeOverlayProps) {
   const [cursorPosition, setCursorPosition] = useState<CursorPosition | null>(null);
@@ -106,7 +110,8 @@ export function VimModeOverlay({
 
   const active = state.phase !== 'inactive'
     && (focused || state.phase === 'action');
-  const hudVisible = hudEnabled && (active || helpOpen);
+  const keyPanelVisible = hudEnabled
+    && (helpOpen || (keyPanelEnabled && active));
   const phaseLabel = state.phase === 'visual-block'
     ? 'VISUAL BLOCK'
     : state.phase === 'text'
@@ -139,13 +144,21 @@ export function VimModeOverlay({
         />
       )}
 
-      {hudVisible && createPortal(
+      {keyPanelVisible && createPortal(
         <VimKeyHud
           command={hudCommand}
           phase={hudPhase}
           inputMethod={inputMethod}
           expanded={helpOpen}
           onExpandedChange={onHelpOpenChange}
+          onHide={
+            onKeyPanelHide
+              ? () => {
+                onHelpOpenChange(false);
+                onKeyPanelHide();
+              }
+              : undefined
+          }
           onFocusLeave={onHudFocusLeave}
         />,
         document.body,

--- a/packages/ui/components/VimModeOverlay.tsx
+++ b/packages/ui/components/VimModeOverlay.tsx
@@ -1,0 +1,187 @@
+import {
+  useLayoutEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from 'react';
+import { createPortal } from 'react-dom';
+import type { InputMethod } from '../types';
+import {
+  resolveTextPosition,
+  type VimSelectionState,
+} from '../utils/vimNavigation';
+
+interface CursorPosition {
+  readonly top: number;
+  readonly left: number;
+  readonly height: number;
+}
+
+/** Props for Vim's cursor, status, and contextual-help feedback. */
+export interface VimModeOverlayProps {
+  containerRef: RefObject<HTMLElement | null>;
+  inputMethod: InputMethod;
+  state: VimSelectionState;
+  focused: boolean;
+  helpOpen: boolean;
+  onCloseHelp: () => void;
+}
+
+/**
+ * Render immediate, non-interactive feedback for Vim mode without changing
+ * document layout or intercepting pointer selection.
+ */
+export function VimModeOverlay({
+  containerRef,
+  inputMethod,
+  state,
+  focused,
+  helpOpen,
+  onCloseHelp,
+}: VimModeOverlayProps) {
+  const [cursorPosition, setCursorPosition] = useState<CursorPosition | null>(null);
+  const rafRef = useRef(0);
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (
+      !container
+      || !focused
+      || state.phase !== 'text'
+    ) {
+      setCursorPosition(null);
+      return;
+    }
+    const cursor = state.cursor;
+
+    const update = () => {
+      const point = resolveTextPosition(container, cursor);
+      if (!point) {
+        setCursorPosition(null);
+        return;
+      }
+
+      const range = document.createRange();
+      range.setStart(point.node, point.offset);
+      range.collapse(true);
+      const rect = range.getClientRects()[0] ?? range.getBoundingClientRect();
+      const containerRect = container.getBoundingClientRect();
+      const parent = point.node.parentElement;
+      const lineHeight = parent
+        ? Number.parseFloat(getComputedStyle(parent).lineHeight)
+        : Number.NaN;
+      setCursorPosition({
+        top: rect.top - containerRect.top,
+        left: rect.left - containerRect.left,
+        height: rect.height || lineHeight || 18,
+      });
+    };
+
+    const scheduleUpdate = () => {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(update);
+    };
+
+    update();
+    window.addEventListener('resize', scheduleUpdate, { passive: true });
+    window.addEventListener('scroll', scheduleUpdate, { passive: true, capture: true });
+    return () => {
+      cancelAnimationFrame(rafRef.current);
+      window.removeEventListener('resize', scheduleUpdate);
+      window.removeEventListener('scroll', scheduleUpdate, true);
+    };
+  }, [containerRef, focused, state]);
+
+  const active = state.phase !== 'inactive'
+    && (focused || state.phase === 'action');
+  const phaseLabel = state.phase === 'visual-block'
+    ? 'VISUAL BLOCK'
+    : state.phase === 'text'
+      ? 'NORMAL'
+      : state.phase.toUpperCase();
+  const inputLabel = inputMethod === 'pinpoint' ? 'PINPOINT' : 'SELECT';
+
+  return (
+    <>
+      {cursorPosition && (
+        <div
+          data-vim-cursor
+          aria-hidden="true"
+          className="absolute z-[22] w-[2px] rounded-full bg-primary pointer-events-none"
+          style={{
+            top: cursorPosition.top,
+            left: cursorPosition.left,
+            height: cursorPosition.height,
+          }}
+        />
+      )}
+
+      {active && createPortal(
+        <div
+          data-vim-mode-badge
+          aria-live="polite"
+          className="fixed bottom-4 left-1/2 z-[120] -translate-x-1/2 rounded-md border border-primary/30 bg-popover/95 px-2.5 py-1 font-mono text-[10px] font-semibold tracking-wide text-primary shadow-lg backdrop-blur-sm pointer-events-none"
+        >
+          {phaseLabel} · {inputLabel}
+        </div>,
+        document.body,
+      )}
+
+      {helpOpen && createPortal(
+        <div
+          className="fixed inset-0 z-[140] flex items-center justify-center bg-background/65 p-4 backdrop-blur-sm"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Vim controls"
+          onKeyDown={(event) => {
+            if (event.key === 'Escape' || event.key === '?') {
+              event.preventDefault();
+              event.stopPropagation();
+              onCloseHelp();
+            }
+          }}
+          onMouseDown={(event) => {
+            if (event.target === event.currentTarget) onCloseHelp();
+          }}
+        >
+          <div className="w-full max-w-lg rounded-xl border border-border bg-popover p-5 shadow-2xl">
+            <div className="mb-4 flex items-start justify-between gap-4">
+              <div>
+                <div className="text-sm font-semibold">Vim controls</div>
+                <div className="text-xs text-muted-foreground">
+                  Move through document structure, refine into text, then annotate.
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={onCloseHelp}
+                className="rounded px-2 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+              >
+                Close
+              </button>
+            </div>
+            <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-xs">
+              <kbd className="font-mono text-primary">j / k · gg / G</kbd>
+              <span>Previous / next block or sibling; first / last block</span>
+              <kbd className="font-mono text-primary">h / l · Esc</kbd>
+              <span>Move out, refine inward, or back out one level</span>
+              <kbd className="font-mono text-primary">v / V</kbd>
+              <span>Precise text / whole-block selection</span>
+              <kbd className="font-mono text-primary">h j k l · w b e · 0 $</kbd>
+              <span>Text motions after entering NORMAL</span>
+              <kbd className="font-mono text-primary">o</kbd>
+              <span>Swap the ends of a Visual selection</span>
+              <kbd className="font-mono text-primary">Enter</kbd>
+              <span>Use the active annotation mode</span>
+              <kbd className="font-mono text-primary">Space · c d m t y</kbd>
+              <span>Actions, comment, delete, markup, tag, copy</span>
+              <kbd className="font-mono text-primary">Esc · ?</kbd>
+              <span>Cancel current state / toggle this help</span>
+            </div>
+          </div>
+        </div>,
+        document.body,
+      )}
+    </>
+  );
+}

--- a/packages/ui/components/VimModeOverlay.tsx
+++ b/packages/ui/components/VimModeOverlay.tsx
@@ -6,12 +6,14 @@ import {
 } from 'react';
 import { createPortal } from 'react-dom';
 import type { InputMethod } from '../types';
+import type { SemanticTarget } from '../utils/blockTargeting';
 import {
   resolveTextPosition,
   type VimSelectionState,
 } from '../utils/vimNavigation';
 import { getVimHudPhase, type VimHudCommand } from '../utils/vimHud';
 import { VimKeyHud } from './VimKeyHud';
+import { VimTargetReticle } from './VimTargetReticle';
 
 interface CursorPosition {
   readonly top: number;
@@ -27,8 +29,10 @@ export interface VimModeOverlayProps {
   focused: boolean;
   hudEnabled: boolean;
   hudCommand: VimHudCommand | null;
+  activeTarget: SemanticTarget | null;
   helpOpen: boolean;
-  onCloseHelp: () => void;
+  onHelpOpenChange: (open: boolean) => void;
+  onHudFocusLeave: () => void;
 }
 
 /**
@@ -42,8 +46,10 @@ export function VimModeOverlay({
   focused,
   hudEnabled,
   hudCommand,
+  activeTarget,
   helpOpen,
-  onCloseHelp,
+  onHelpOpenChange,
+  onHudFocusLeave,
 }: VimModeOverlayProps) {
   const [cursorPosition, setCursorPosition] = useState<CursorPosition | null>(null);
   const rafRef = useRef(0);
@@ -100,6 +106,7 @@ export function VimModeOverlay({
 
   const active = state.phase !== 'inactive'
     && (focused || state.phase === 'action');
+  const hudVisible = hudEnabled && (active || helpOpen);
   const phaseLabel = state.phase === 'visual-block'
     ? 'VISUAL BLOCK'
     : state.phase === 'text'
@@ -114,7 +121,7 @@ export function VimModeOverlay({
         <div
           data-vim-cursor
           aria-hidden="true"
-          className="absolute z-[22] w-[2px] rounded-full bg-primary pointer-events-none"
+          className="absolute z-[26] w-[2px] rounded-full bg-primary pointer-events-none"
           style={{
             top: cursorPosition.top,
             left: cursorPosition.left,
@@ -123,11 +130,23 @@ export function VimModeOverlay({
         />
       )}
 
-      {active && hudEnabled && createPortal(
+      {active && hudEnabled && (
+        <VimTargetReticle
+          containerRef={containerRef}
+          state={state}
+          target={activeTarget}
+          command={hudCommand}
+        />
+      )}
+
+      {hudVisible && createPortal(
         <VimKeyHud
           command={hudCommand}
           phase={hudPhase}
           inputMethod={inputMethod}
+          expanded={helpOpen}
+          onExpandedChange={onHelpOpenChange}
+          onFocusLeave={onHudFocusLeave}
         />,
         document.body,
       )}
@@ -143,7 +162,7 @@ export function VimModeOverlay({
         document.body,
       )}
 
-      {helpOpen && createPortal(
+      {helpOpen && !hudEnabled && createPortal(
         <div
           className="fixed inset-0 z-[140] flex items-center justify-center bg-background/65 p-4 backdrop-blur-sm"
           role="dialog"
@@ -153,11 +172,11 @@ export function VimModeOverlay({
             if (event.key === 'Escape' || event.key === '?') {
               event.preventDefault();
               event.stopPropagation();
-              onCloseHelp();
+              onHelpOpenChange(false);
             }
           }}
           onMouseDown={(event) => {
-            if (event.target === event.currentTarget) onCloseHelp();
+            if (event.target === event.currentTarget) onHelpOpenChange(false);
           }}
         >
           <div className="w-full max-w-lg rounded-xl border border-border bg-popover p-5 shadow-2xl">
@@ -170,7 +189,7 @@ export function VimModeOverlay({
               </div>
               <button
                 type="button"
-                onClick={onCloseHelp}
+                onClick={() => onHelpOpenChange(false)}
                 className="rounded px-2 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
               >
                 Close

--- a/packages/ui/components/VimModeOverlay.tsx
+++ b/packages/ui/components/VimModeOverlay.tsx
@@ -10,6 +10,8 @@ import {
   resolveTextPosition,
   type VimSelectionState,
 } from '../utils/vimNavigation';
+import { getVimHudPhase, type VimHudCommand } from '../utils/vimHud';
+import { VimKeyHud } from './VimKeyHud';
 
 interface CursorPosition {
   readonly top: number;
@@ -23,6 +25,8 @@ export interface VimModeOverlayProps {
   inputMethod: InputMethod;
   state: VimSelectionState;
   focused: boolean;
+  hudEnabled: boolean;
+  hudCommand: VimHudCommand | null;
   helpOpen: boolean;
   onCloseHelp: () => void;
 }
@@ -36,6 +40,8 @@ export function VimModeOverlay({
   inputMethod,
   state,
   focused,
+  hudEnabled,
+  hudCommand,
   helpOpen,
   onCloseHelp,
 }: VimModeOverlayProps) {
@@ -100,6 +106,7 @@ export function VimModeOverlay({
       ? 'NORMAL'
       : state.phase.toUpperCase();
   const inputLabel = inputMethod === 'pinpoint' ? 'PINPOINT' : 'SELECT';
+  const hudPhase = getVimHudPhase(state.phase, hudCommand?.actionId);
 
   return (
     <>
@@ -116,7 +123,16 @@ export function VimModeOverlay({
         />
       )}
 
-      {active && createPortal(
+      {active && hudEnabled && createPortal(
+        <VimKeyHud
+          command={hudCommand}
+          phase={hudPhase}
+          inputMethod={inputMethod}
+        />,
+        document.body,
+      )}
+
+      {active && !hudEnabled && createPortal(
         <div
           data-vim-mode-badge
           aria-live="polite"

--- a/packages/ui/components/VimTargetReticle.tsx
+++ b/packages/ui/components/VimTargetReticle.tsx
@@ -1,0 +1,284 @@
+import {
+  useLayoutEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from 'react';
+import { useScrollViewport } from '../hooks/useScrollViewport';
+import type { SemanticTarget } from '../utils/blockTargeting';
+import {
+  createRangeBetweenTextPositions,
+  resolveTextPosition,
+  type VimRestorableState,
+  type VimSelectionState,
+} from '../utils/vimNavigation';
+import type { VimHudCommand } from '../utils/vimHud';
+import { getVimReticleLabel } from '../utils/vimReticle';
+
+const CORNER_SIZE = 28;
+const MIN_TARGET_WIDTH = 44;
+const MIN_TARGET_HEIGHT = 32;
+const TARGET_PADDING_X = 5;
+const TARGET_PADDING_Y = 4;
+
+interface ReticlePosition {
+  readonly top: number;
+  readonly left: number;
+  readonly width: number;
+  readonly height: number;
+  readonly labelTop: number;
+}
+
+/** Live document geometry and command context required by the Vim target reticle. */
+export interface VimTargetReticleProps {
+  readonly containerRef: RefObject<HTMLElement | null>;
+  readonly state: VimSelectionState;
+  readonly target: SemanticTarget | null;
+  readonly command: VimHudCommand | null;
+}
+
+function effectiveState(state: VimSelectionState): VimRestorableState | null {
+  if (state.phase === 'inactive') return null;
+  return state.phase === 'action' ? state.returnTo : state;
+}
+
+function getRangeRect(range: Range): DOMRect | null {
+  let rects: DOMRect[] = [];
+  if (typeof range.getClientRects === 'function') {
+    try {
+      rects = Array.from(range.getClientRects());
+    } catch {
+      rects = [];
+    }
+  }
+  const visibleRects = rects.filter((rect) => rect.width > 0 || rect.height > 0);
+  if (visibleRects.length === 0) {
+    if (typeof range.getBoundingClientRect !== 'function') return null;
+    try {
+      return range.getBoundingClientRect();
+    } catch {
+      return null;
+    }
+  }
+
+  const left = Math.min(...visibleRects.map((rect) => rect.left));
+  const top = Math.min(...visibleRects.map((rect) => rect.top));
+  const right = Math.max(...visibleRects.map((rect) => rect.right));
+  const bottom = Math.max(...visibleRects.map((rect) => rect.bottom));
+  return new DOMRect(left, top, right - left, bottom - top);
+}
+
+function getNativeSelectionRect(container: HTMLElement): DOMRect | null {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) return null;
+  const range = selection.getRangeAt(0);
+  if (
+    !container.contains(range.startContainer)
+    || !container.contains(range.endContainer)
+  ) {
+    return null;
+  }
+  return getRangeRect(range);
+}
+
+function getTargetRect(
+  container: HTMLElement,
+  state: VimRestorableState,
+  target: SemanticTarget | null,
+): DOMRect | null {
+  if (state.phase === 'block' || state.phase === 'inline') {
+    return target?.element.getBoundingClientRect() ?? null;
+  }
+
+  if (state.phase === 'visual') {
+    const range = createRangeBetweenTextPositions(
+      container,
+      state.anchor,
+      state.cursor,
+    );
+    return range ? getRangeRect(range) : null;
+  }
+
+  if (state.phase === 'visual-block') {
+    return getNativeSelectionRect(container);
+  }
+
+  const point = resolveTextPosition(container, state.cursor);
+  if (!point) return null;
+  const range = document.createRange();
+  range.setStart(point.node, point.offset);
+  range.collapse(true);
+  const rect = getRangeRect(range);
+  if (!rect) return null;
+
+  const parent = point.node.parentElement;
+  const lineHeight = parent
+    ? Number.parseFloat(getComputedStyle(parent).lineHeight)
+    : Number.NaN;
+  return new DOMRect(
+    rect.left,
+    rect.top,
+    Math.max(rect.width, 1),
+    rect.height || lineHeight || 18,
+  );
+}
+
+function relativePosition(
+  targetRect: DOMRect,
+  containerRect: DOMRect,
+  compact: boolean,
+  minimumLabelViewportTop: number,
+): ReticlePosition {
+  const paddingX = compact ? 10 : TARGET_PADDING_X;
+  const paddingY = compact ? 6 : TARGET_PADDING_Y;
+  const naturalWidth = targetRect.width + paddingX * 2;
+  const naturalHeight = targetRect.height + paddingY * 2;
+  const width = Math.max(MIN_TARGET_WIDTH, naturalWidth);
+  const height = Math.max(MIN_TARGET_HEIGHT, naturalHeight);
+  const targetCenterX = targetRect.left - containerRect.left + targetRect.width / 2;
+  const targetCenterY = targetRect.top - containerRect.top + targetRect.height / 2;
+  const left = Math.max(0, targetCenterX - width / 2);
+  const top = Math.max(0, targetCenterY - height / 2);
+  const aboveLabelTop = top - 36;
+
+  return {
+    left,
+    top,
+    width,
+    height,
+    labelTop: aboveLabelTop + containerRect.top >= minimumLabelViewportTop
+      ? aboveLabelTop
+      : Math.max(
+          top + height + 6,
+          minimumLabelViewportTop - containerRect.top,
+        ),
+  };
+}
+
+/**
+ * Draw the video HUD's targeting treatment on top of the real Vim target.
+ *
+ * Geometry always comes from the live semantic element, caret, or browser
+ * selection. The overlay never owns focus and never participates in layout.
+ */
+export function VimTargetReticle({
+  containerRef,
+  state,
+  target,
+  command,
+}: VimTargetReticleProps) {
+  const [position, setPosition] = useState<ReticlePosition | null>(null);
+  const rafRef = useRef(0);
+  const scrollViewport = useScrollViewport();
+  const restoredState = effectiveState(state);
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container || !restoredState) {
+      setPosition(null);
+      return;
+    }
+
+    const update = () => {
+      const targetRect = getTargetRect(container, restoredState, target);
+      if (!targetRect) {
+        setPosition(null);
+        return;
+      }
+      const containerRect = container.getBoundingClientRect();
+      const viewportTop = scrollViewport?.getBoundingClientRect().top ?? containerRect.top;
+      const stickyBottom = container
+        .querySelector<HTMLElement>('[data-sticky-actions]')
+        ?.getBoundingClientRect()
+        .bottom;
+      setPosition(relativePosition(
+        targetRect,
+        containerRect,
+        restoredState.phase === 'text',
+        Math.max(viewportTop + 4, stickyBottom ? stickyBottom + 6 : 0),
+      ));
+    };
+    const scheduleUpdate = () => {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(update);
+    };
+
+    update();
+    window.addEventListener('resize', scheduleUpdate, { passive: true });
+    scrollViewport?.addEventListener('scroll', scheduleUpdate, { passive: true });
+    const resizeObserver = typeof ResizeObserver === 'undefined'
+      ? null
+      : new ResizeObserver(scheduleUpdate);
+    resizeObserver?.observe(container);
+    if (target?.element) resizeObserver?.observe(target.element);
+    return () => {
+      cancelAnimationFrame(rafRef.current);
+      window.removeEventListener('resize', scheduleUpdate);
+      scrollViewport?.removeEventListener('scroll', scheduleUpdate);
+      resizeObserver?.disconnect();
+    };
+  }, [containerRef, restoredState, scrollViewport, target]);
+
+  if (!position || !restoredState) return null;
+
+  const label = getVimReticleLabel(restoredState, target, command);
+  const cornerRight = Math.max(0, position.width - CORNER_SIZE);
+  const cornerBottom = Math.max(0, position.height - CORNER_SIZE);
+  const fillTransform = `translate3d(${position.left}px, ${position.top}px, 0) scale(${
+    position.width / 100
+  }, ${position.height / 100})`;
+
+  return (
+    <div
+      data-vim-target-reticle
+      data-vim-target-label={label}
+      data-vim-target-phase={restoredState.phase}
+      aria-hidden="true"
+      className="vim-target-reticle"
+    >
+      <div
+        data-vim-target-fill
+        className="vim-target-reticle__fill"
+        style={{ transform: fillTransform }}
+      />
+      <div
+        data-vim-target-corner="top-left"
+        className="vim-target-reticle__corner vim-target-reticle__corner--top-left"
+        style={{ transform: `translate3d(${position.left}px, ${position.top}px, 0)` }}
+      />
+      <div
+        data-vim-target-corner="top-right"
+        className="vim-target-reticle__corner vim-target-reticle__corner--top-right"
+        style={{
+          transform: `translate3d(${position.left + cornerRight}px, ${position.top}px, 0)`,
+        }}
+      />
+      <div
+        data-vim-target-corner="bottom-left"
+        className="vim-target-reticle__corner vim-target-reticle__corner--bottom-left"
+        style={{
+          transform: `translate3d(${position.left}px, ${position.top + cornerBottom}px, 0)`,
+        }}
+      />
+      <div
+        data-vim-target-corner="bottom-right"
+        className="vim-target-reticle__corner vim-target-reticle__corner--bottom-right"
+        style={{
+          transform: `translate3d(${
+            position.left + cornerRight
+          }px, ${position.top + cornerBottom}px, 0)`,
+        }}
+      />
+      <div
+        data-vim-target-label
+        className="vim-target-reticle__label"
+        style={{
+          transform: `translate3d(${position.left}px, ${position.labelTop}px, 0)`,
+        }}
+      >
+        <span className="vim-target-reticle__label-dot" />
+        <span>{label}</span>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/components/html-viewer/HtmlViewer.tsx
+++ b/packages/ui/components/html-viewer/HtmlViewer.tsx
@@ -41,6 +41,14 @@ function isLightTheme(): boolean {
   return document.documentElement.classList.contains("light");
 }
 
+function isBridgeReadyMessage(value: unknown): boolean {
+  return typeof value === "object"
+    && value !== null
+    && "type" in value
+    && value.type === `${PREFIX}ready`;
+}
+
+/** Inputs for the sandboxed raw-HTML viewer and its parent-side annotation UI. */
 export interface HtmlViewerProps {
   rawHtml: string;
   annotations: Annotation[];
@@ -50,6 +58,8 @@ export interface HtmlViewerProps {
   mode: EditorMode;
   /** Input method: 'drag' = text selection, 'pinpoint' = click an element. */
   inputMethod: InputMethod;
+  /** Opt-in Vim-style keyboard selection. Default false for compatibility. */
+  vimModeEnabled?: boolean;
   globalAttachments?: ImageAttachment[];
   onAddGlobalAttachment?: (image: ImageAttachment) => void;
   onRemoveGlobalAttachment?: (path: string) => void;
@@ -71,6 +81,10 @@ export interface HtmlViewerProps {
   title?: string;
 }
 
+/**
+ * Render arbitrary HTML in a sandbox and adapt its validated bridge messages
+ * to the same annotation controls used by the Markdown viewer.
+ */
 export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
   (
     {
@@ -81,6 +95,7 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
       selectedAnnotationId,
       mode,
       inputMethod,
+      vimModeEnabled = false,
       globalAttachments = [],
       onAddGlobalAttachment,
       onRemoveGlobalAttachment,
@@ -98,7 +113,9 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
     const iframeRef = useRef<HTMLIFrameElement>(null);
     const globalCommentButtonRef = useRef<HTMLButtonElement>(null);
     const [iframeHeight, setIframeHeight] = useState(600);
-    const [iframeReady, setIframeReady] = useState(false);
+    // Increment on every bridge-ready event so srcdoc navigations re-send
+    // state even though the iframe element and its WindowProxy are reused.
+    const [iframeReadyVersion, setIframeReadyVersion] = useState(0);
     const [globalCommentPopover, setGlobalCommentPopover] = useState<{
       anchorEl: HTMLElement;
       contextText: string;
@@ -133,9 +150,10 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
     });
 
     useEffect(() => {
-      function handler(e: MessageEvent) {
-        if (e.data?.type === `${PREFIX}ready`) {
-          setIframeReady(true);
+      function handler(e: MessageEvent<unknown>) {
+        if (e.source !== iframeRef.current?.contentWindow) return;
+        if (isBridgeReadyMessage(e.data)) {
+          setIframeReadyVersion((version) => version + 1);
         }
       }
       window.addEventListener("message", handler);
@@ -143,24 +161,51 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
     }, []);
 
     useEffect(() => {
-      if (!iframeReady) return;
+      if (iframeReadyVersion === 0) return;
       if (annotations.length > 0) {
         hook.applyAnnotations(annotations);
       }
-    }, [iframeReady]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [iframeReadyVersion]); // eslint-disable-line react-hooks/exhaustive-deps
 
     // Tell the bridge the current input method (drag vs pinpoint). Re-posts on
     // ready (fresh iframe) and whenever the user switches it in the toolstrip.
     useEffect(() => {
-      if (!iframeReady) return;
+      if (iframeReadyVersion === 0) return;
       iframeRef.current?.contentWindow?.postMessage(
         { type: `${PREFIX}set-input-method`, method: inputMethod },
         "*",
       );
-    }, [iframeReady, inputMethod]);
+    }, [iframeReadyVersion, inputMethod]);
 
     useEffect(() => {
-      if (!iframeReady) return;
+      if (iframeReadyVersion === 0) return;
+      iframeRef.current?.contentWindow?.postMessage(
+        { type: `${PREFIX}set-vim-mode`, enabled: vimModeEnabled, mode },
+        "*",
+      );
+    }, [iframeReadyVersion, mode, vimModeEnabled]);
+
+    const vimOverlayWasOpenRef = useRef(false);
+    useEffect(() => {
+      const overlayOpen = !!hook.toolbarState || !!hook.commentPopover || !!hook.quickLabelPicker;
+      const wasOpen = vimOverlayWasOpenRef.current;
+      vimOverlayWasOpenRef.current = overlayOpen;
+      if (
+        vimModeEnabled
+        && wasOpen
+        && !overlayOpen
+        && (document.activeElement === document.body || document.activeElement === null)
+      ) {
+        iframeRef.current?.focus({ preventScroll: true });
+        iframeRef.current?.contentWindow?.postMessage(
+          { type: `${PREFIX}focus-vim` },
+          "*",
+        );
+      }
+    }, [hook.commentPopover, hook.quickLabelPicker, hook.toolbarState, vimModeEnabled]);
+
+    useEffect(() => {
+      if (iframeReadyVersion === 0) return;
       function sendTheme() {
         iframeRef.current?.contentWindow?.postMessage(
           {
@@ -179,7 +224,7 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
         attributeFilter: ["class", "style"],
       });
       return () => observer.disconnect();
-    }, [iframeReady, hostTheme]);
+    }, [iframeReadyVersion, hostTheme]);
 
     useImperativeHandle(ref, () => ({
       removeHighlight: hook.removeHighlight,
@@ -288,6 +333,7 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
               border: "none",
               display: "block",
               colorScheme: "auto",
+              outline: vimModeEnabled ? "none" : undefined,
             }}
             title={title}
           />

--- a/packages/ui/components/html-viewer/HtmlViewer.tsx
+++ b/packages/ui/components/html-viewer/HtmlViewer.tsx
@@ -126,6 +126,10 @@ export interface HtmlViewerProps {
   vimModeEnabled?: boolean;
   /** Replace the iframe-local compact badge with the shared live key HUD. */
   vimHudEnabled?: boolean;
+  /** Show the parent key panel without affecting the iframe HUD reticle. */
+  vimHudKeyPanelEnabled?: boolean;
+  /** Persist a user request to hide the parent key panel. */
+  onVimHudKeyPanelChange?: (enabled: boolean) => void;
   globalAttachments?: ImageAttachment[];
   onAddGlobalAttachment?: (image: ImageAttachment) => void;
   onRemoveGlobalAttachment?: (path: string) => void;
@@ -163,6 +167,8 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
       inputMethod,
       vimModeEnabled = false,
       vimHudEnabled = false,
+      vimHudKeyPanelEnabled = true,
+      onVimHudKeyPanelChange,
       globalAttachments = [],
       onAddGlobalAttachment,
       onRemoveGlobalAttachment,
@@ -504,7 +510,10 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
         </div>
 
         {vimHudActive
-          && (vimBridgePhase !== "inactive" || vimHelpOpen)
+          && (vimHelpOpen || (
+            vimHudKeyPanelEnabled
+            && vimBridgePhase !== "inactive"
+          ))
           && (iframeFocused || vimBridgePhase === "action" || vimHelpOpen)
           && createPortal(
             <VimKeyHud
@@ -513,6 +522,14 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
               inputMethod={inputMethod}
               expanded={vimHelpOpen}
               onExpandedChange={handleVimHelpOpenChange}
+              onHide={
+                onVimHudKeyPanelChange
+                  ? () => {
+                    handleVimHelpOpenChange(false);
+                    onVimHudKeyPanelChange(false);
+                  }
+                  : undefined
+              }
               onFocusLeave={handleVimHudFocusLeave}
             />,
             document.body,

--- a/packages/ui/components/html-viewer/HtmlViewer.tsx
+++ b/packages/ui/components/html-viewer/HtmlViewer.tsx
@@ -8,13 +8,23 @@ import {
   useState,
 } from "react";
 import { createPortal } from "react-dom";
+import {
+  isVimSelectionActionId,
+  type VimSelectionHudContext,
+} from "../../shortcuts";
 import type { Annotation, EditorMode, ImageAttachment, InputMethod } from "../../types";
 import { AnnotationType } from "../../types";
 import { getIdentity } from "../../utils/identity";
+import {
+  createVimHudCommand,
+  getVimHudPhase,
+  type VimHudCommand,
+} from "../../utils/vimHud";
 import { AnnotationToolbar } from "../AnnotationToolbar";
 import { AttachmentsButton } from "../AttachmentsButton";
 import { CommentPopover, type CommentAskAIHandler } from "../CommentPopover";
 import { FloatingQuickLabelPicker } from "../FloatingQuickLabelPicker";
+import { VimKeyHud } from "../VimKeyHud";
 import type { ViewerHandle } from "../Viewer";
 import { useHtmlAnnotation } from "./useHtmlAnnotation";
 import {
@@ -48,6 +58,51 @@ function isBridgeReadyMessage(value: unknown): boolean {
     && value.type === `${PREFIX}ready`;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parseVimSelectionHudContext(
+  value: unknown,
+): VimSelectionHudContext | null {
+  return value === "inactive"
+    || value === "block"
+    || value === "inline"
+    || value === "text"
+    || value === "visual"
+    || value === "visual-block"
+    || value === "action"
+    ? value
+    : null;
+}
+
+interface VimBridgeCommand {
+  readonly actionId: Parameters<typeof createVimHudCommand>[1];
+  readonly key: string;
+  readonly context: VimSelectionHudContext;
+}
+
+function parseVimBridgeCommand(value: unknown): VimBridgeCommand | null {
+  if (
+    !isRecord(value)
+    || value.type !== `${PREFIX}vim-command`
+    || !isVimSelectionActionId(value.actionId)
+    || typeof value.key !== "string"
+  ) {
+    return null;
+  }
+  const context = parseVimSelectionHudContext(value.context);
+  return context
+    ? { actionId: value.actionId, key: value.key, context }
+    : null;
+}
+
+function parseVimBridgeState(value: unknown): VimSelectionHudContext | null {
+  return isRecord(value) && value.type === `${PREFIX}vim-state`
+    ? parseVimSelectionHudContext(value.phase)
+    : null;
+}
+
 /** Inputs for the sandboxed raw-HTML viewer and its parent-side annotation UI. */
 export interface HtmlViewerProps {
   rawHtml: string;
@@ -60,6 +115,8 @@ export interface HtmlViewerProps {
   inputMethod: InputMethod;
   /** Opt-in Vim-style keyboard selection. Default false for compatibility. */
   vimModeEnabled?: boolean;
+  /** Replace the iframe-local compact badge with the shared live key HUD. */
+  vimHudEnabled?: boolean;
   globalAttachments?: ImageAttachment[];
   onAddGlobalAttachment?: (image: ImageAttachment) => void;
   onRemoveGlobalAttachment?: (path: string) => void;
@@ -96,6 +153,7 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
       mode,
       inputMethod,
       vimModeEnabled = false,
+      vimHudEnabled = false,
       globalAttachments = [],
       onAddGlobalAttachment,
       onRemoveGlobalAttachment,
@@ -116,6 +174,12 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
     // Increment on every bridge-ready event so srcdoc navigations re-send
     // state even though the iframe element and its WindowProxy are reused.
     const [iframeReadyVersion, setIframeReadyVersion] = useState(0);
+    const [iframeFocused, setIframeFocused] = useState(false);
+    const [vimBridgePhase, setVimBridgePhase] =
+      useState<VimSelectionHudContext>("inactive");
+    const [vimHudCommand, setVimHudCommand] = useState<VimHudCommand | null>(null);
+    const vimHudSequenceRef = useRef(0);
+    const vimHudActive = vimModeEnabled && vimHudEnabled;
     const [globalCommentPopover, setGlobalCommentPopover] = useState<{
       anchorEl: HTMLElement;
       contextText: string;
@@ -154,11 +218,36 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
         if (e.source !== iframeRef.current?.contentWindow) return;
         if (isBridgeReadyMessage(e.data)) {
           setIframeReadyVersion((version) => version + 1);
+          setVimBridgePhase("inactive");
+          setVimHudCommand(null);
+          return;
+        }
+        if (!vimHudActive) return;
+        const vimState = parseVimBridgeState(e.data);
+        if (vimState) {
+          setVimBridgePhase(vimState);
+          return;
+        }
+        const vimCommand = parseVimBridgeCommand(e.data);
+        if (vimCommand) {
+          vimHudSequenceRef.current += 1;
+          setVimHudCommand(createVimHudCommand(
+            vimHudSequenceRef.current,
+            vimCommand.actionId,
+            vimCommand.key,
+            vimCommand.context,
+          ));
         }
       }
       window.addEventListener("message", handler);
       return () => window.removeEventListener("message", handler);
-    }, []);
+    }, [vimHudActive]);
+
+    useEffect(() => {
+      if (vimHudActive) return;
+      setVimBridgePhase("inactive");
+      setVimHudCommand(null);
+    }, [vimHudActive]);
 
     useEffect(() => {
       if (iframeReadyVersion === 0) return;
@@ -180,10 +269,15 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
     useEffect(() => {
       if (iframeReadyVersion === 0) return;
       iframeRef.current?.contentWindow?.postMessage(
-        { type: `${PREFIX}set-vim-mode`, enabled: vimModeEnabled, mode },
+        {
+          type: `${PREFIX}set-vim-mode`,
+          enabled: vimModeEnabled,
+          hudEnabled: vimHudEnabled,
+          mode,
+        },
         "*",
       );
-    }, [iframeReadyVersion, mode, vimModeEnabled]);
+    }, [iframeReadyVersion, mode, vimHudEnabled, vimModeEnabled]);
 
     const vimOverlayWasOpenRef = useRef(false);
     useEffect(() => {
@@ -336,9 +430,23 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
               outline: vimModeEnabled ? "none" : undefined,
             }}
             title={title}
+            onFocus={() => setIframeFocused(true)}
+            onBlur={() => setIframeFocused(false)}
           />
           </article>
         </div>
+
+        {vimHudActive
+          && vimBridgePhase !== "inactive"
+          && (iframeFocused || vimBridgePhase === "action")
+          && createPortal(
+            <VimKeyHud
+              command={vimHudCommand}
+              phase={getVimHudPhase(vimBridgePhase, vimHudCommand?.actionId)}
+              inputMethod={inputMethod}
+            />,
+            document.body,
+          )}
 
         {/* Toolbar portal */}
         {hook.toolbarState &&

--- a/packages/ui/components/html-viewer/HtmlViewer.tsx
+++ b/packages/ui/components/html-viewer/HtmlViewer.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from "react";
 import { createPortal } from "react-dom";
+import { useVimDocumentFocus } from "../../hooks/useVimDocumentFocus";
 import {
   isVimSelectionActionId,
   type VimSelectionHudContext,
@@ -278,6 +279,25 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
       setIframeFocused(false);
     }, []);
 
+    const focusVimDocument = useCallback((): boolean => {
+      const iframe = iframeRef.current;
+      if (!vimModeEnabled || !iframe) return false;
+      if (document.activeElement === iframe) return false;
+      iframe.focus({ preventScroll: true });
+      if (document.activeElement !== iframe) return false;
+      iframe.contentWindow?.postMessage(
+        { type: `${PREFIX}focus-vim` },
+        "*",
+      );
+      return true;
+    }, [vimModeEnabled]);
+
+    useVimDocumentFocus({
+      enabled: vimModeEnabled,
+      blocked: !!hook.toolbarState || !!hook.commentPopover || !!hook.quickLabelPicker,
+      focusDocument: focusVimDocument,
+    });
+
     useEffect(() => {
       if (iframeReadyVersion === 0) return;
       if (annotations.length > 0) {
@@ -297,7 +317,8 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
 
     useEffect(() => {
       if (iframeReadyVersion === 0) return;
-      iframeRef.current?.contentWindow?.postMessage(
+      const iframe = iframeRef.current;
+      iframe?.contentWindow?.postMessage(
         {
           type: `${PREFIX}set-vim-mode`,
           enabled: vimModeEnabled,
@@ -306,6 +327,15 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
         },
         "*",
       );
+      if (vimModeEnabled && iframe === document.activeElement) {
+        // The initial parent focus can land before the sandbox bridge is ready.
+        // Reassert it after configuration so raw HTML enters BLOCK immediately,
+        // matching the Markdown surface instead of waiting for the first key.
+        iframe.contentWindow?.postMessage(
+          { type: `${PREFIX}focus-vim` },
+          "*",
+        );
+      }
     }, [iframeReadyVersion, mode, vimHudEnabled, vimModeEnabled]);
 
     const vimOverlayWasOpenRef = useRef(false);

--- a/packages/ui/components/html-viewer/HtmlViewer.tsx
+++ b/packages/ui/components/html-viewer/HtmlViewer.tsx
@@ -15,6 +15,7 @@ import {
 } from "../../shortcuts";
 import type { Annotation, EditorMode, ImageAttachment, InputMethod } from "../../types";
 import { AnnotationType } from "../../types";
+import { copyTextPreservingFocus } from "../../utils/clipboard";
 import { getIdentity } from "../../utils/identity";
 import {
   createVimHudCommand,
@@ -109,6 +110,18 @@ function parseVimBridgeHelp(value: unknown): boolean | null {
     && value.type === `${PREFIX}vim-help`
     && typeof value.open === "boolean"
     ? value.open
+    : null;
+}
+
+const MAX_VIM_COPY_TEXT_LENGTH = 2 * 1024 * 1024;
+
+function parseVimBridgeCopy(value: unknown): string | null {
+  return isRecord(value)
+    && value.type === `${PREFIX}vim-copy`
+    && typeof value.text === "string"
+    && value.text.length > 0
+    && value.text.length <= MAX_VIM_COPY_TEXT_LENGTH
+    ? value.text
     : null;
 }
 
@@ -239,6 +252,18 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
           setVimHelpOpen(false);
           return;
         }
+        const vimCopy = parseVimBridgeCopy(e.data);
+        if (vimCopy !== null) {
+          const iframe = iframeRef.current;
+          if (
+            vimModeEnabled
+            && iframe
+            && document.activeElement === iframe
+          ) {
+            copyTextPreservingFocus(vimCopy, iframe);
+          }
+          return;
+        }
         if (!vimHudActive) return;
         const vimHelp = parseVimBridgeHelp(e.data);
         if (vimHelp !== null) {
@@ -263,7 +288,7 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
       }
       window.addEventListener("message", handler);
       return () => window.removeEventListener("message", handler);
-    }, [vimHudActive]);
+    }, [vimHudActive, vimModeEnabled]);
 
     useEffect(() => {
       if (vimHudActive) return;
@@ -483,29 +508,29 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
               </div>
             )}
             <iframe
-            ref={iframeRef}
-            srcDoc={srcdoc}
-            sandbox="allow-scripts"
-            style={{
-              width: "100%",
-              height: fullViewport ? "100%" : `${iframeHeight}px`,
-              border: "none",
-              display: "block",
-              colorScheme: "auto",
-              outline: vimModeEnabled ? "none" : undefined,
-            }}
-            title={title}
-            onFocus={() => setIframeFocused(true)}
-            onBlur={(event) => {
-              if (
-                event.relatedTarget instanceof Element
-                && event.relatedTarget.closest('[data-vim-key-hud]')
-              ) {
-                return;
-              }
-              setIframeFocused(false);
-            }}
-          />
+              ref={iframeRef}
+              srcDoc={srcdoc}
+              sandbox="allow-scripts"
+              style={{
+                width: "100%",
+                height: fullViewport ? "100%" : `${iframeHeight}px`,
+                border: "none",
+                display: "block",
+                colorScheme: "auto",
+                outline: vimModeEnabled ? "none" : undefined,
+              }}
+              title={title}
+              onFocus={() => setIframeFocused(true)}
+              onBlur={(event) => {
+                if (
+                  event.relatedTarget instanceof Element
+                  && event.relatedTarget.closest('[data-vim-key-hud]')
+                ) {
+                  return;
+                }
+                setIframeFocused(false);
+              }}
+            />
           </article>
         </div>
 

--- a/packages/ui/components/html-viewer/HtmlViewer.tsx
+++ b/packages/ui/components/html-viewer/HtmlViewer.tsx
@@ -103,6 +103,14 @@ function parseVimBridgeState(value: unknown): VimSelectionHudContext | null {
     : null;
 }
 
+function parseVimBridgeHelp(value: unknown): boolean | null {
+  return isRecord(value)
+    && value.type === `${PREFIX}vim-help`
+    && typeof value.open === "boolean"
+    ? value.open
+    : null;
+}
+
 /** Inputs for the sandboxed raw-HTML viewer and its parent-side annotation UI. */
 export interface HtmlViewerProps {
   rawHtml: string;
@@ -178,6 +186,7 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
     const [vimBridgePhase, setVimBridgePhase] =
       useState<VimSelectionHudContext>("inactive");
     const [vimHudCommand, setVimHudCommand] = useState<VimHudCommand | null>(null);
+    const [vimHelpOpen, setVimHelpOpen] = useState(false);
     const vimHudSequenceRef = useRef(0);
     const vimHudActive = vimModeEnabled && vimHudEnabled;
     const [globalCommentPopover, setGlobalCommentPopover] = useState<{
@@ -220,9 +229,15 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
           setIframeReadyVersion((version) => version + 1);
           setVimBridgePhase("inactive");
           setVimHudCommand(null);
+          setVimHelpOpen(false);
           return;
         }
         if (!vimHudActive) return;
+        const vimHelp = parseVimBridgeHelp(e.data);
+        if (vimHelp !== null) {
+          setVimHelpOpen(vimHelp);
+          return;
+        }
         const vimState = parseVimBridgeState(e.data);
         if (vimState) {
           setVimBridgePhase(vimState);
@@ -247,7 +262,21 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
       if (vimHudActive) return;
       setVimBridgePhase("inactive");
       setVimHudCommand(null);
+      setVimHelpOpen(false);
     }, [vimHudActive]);
+
+    const handleVimHelpOpenChange = useCallback((open: boolean) => {
+      setVimHelpOpen(open);
+      iframeRef.current?.contentWindow?.postMessage(
+        { type: `${PREFIX}set-vim-help`, open },
+        "*",
+      );
+    }, []);
+
+    const handleVimHudFocusLeave = useCallback(() => {
+      if (iframeRef.current === document.activeElement) return;
+      setIframeFocused(false);
+    }, []);
 
     useEffect(() => {
       if (iframeReadyVersion === 0) return;
@@ -431,19 +460,30 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
             }}
             title={title}
             onFocus={() => setIframeFocused(true)}
-            onBlur={() => setIframeFocused(false)}
+            onBlur={(event) => {
+              if (
+                event.relatedTarget instanceof Element
+                && event.relatedTarget.closest('[data-vim-key-hud]')
+              ) {
+                return;
+              }
+              setIframeFocused(false);
+            }}
           />
           </article>
         </div>
 
         {vimHudActive
-          && vimBridgePhase !== "inactive"
-          && (iframeFocused || vimBridgePhase === "action")
+          && (vimBridgePhase !== "inactive" || vimHelpOpen)
+          && (iframeFocused || vimBridgePhase === "action" || vimHelpOpen)
           && createPortal(
             <VimKeyHud
               command={vimHudCommand}
               phase={getVimHudPhase(vimBridgePhase, vimHudCommand?.actionId)}
               inputMethod={inputMethod}
+              expanded={vimHelpOpen}
+              onExpandedChange={handleVimHelpOpenChange}
+              onFocusLeave={handleVimHudFocusLeave}
             />,
             document.body,
           )}

--- a/packages/ui/components/html-viewer/HtmlViewer.vimHud.test.tsx
+++ b/packages/ui/components/html-viewer/HtmlViewer.vimHud.test.tsx
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+const hasDom = typeof document !== 'undefined';
+const htmlViewerModule = hasDom ? await import('./HtmlViewer') : null;
+
+afterEach(() => {
+  if (hasDom) document.body.replaceChildren();
+});
+
+describe.if(hasDom)('HtmlViewer Vim HUD bridge', () => {
+  test('renders validated iframe command messages through the shared parent HUD', async () => {
+    if (!htmlViewerModule) {
+      throw new Error('DOM test environment is not registered');
+    }
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    await act(async () => {
+      root.render(
+        <htmlViewerModule.HtmlViewer
+          rawHtml="<html><body><p>First</p><p>Second</p></body></html>"
+          annotations={[]}
+          onAddAnnotation={() => {}}
+          onSelectAnnotation={() => {}}
+          selectedAnnotationId={null}
+          mode="selection"
+          inputMethod="pinpoint"
+          vimModeEnabled
+          vimHudEnabled
+        />,
+      );
+    });
+
+    const iframe = host.querySelector<HTMLIFrameElement>('iframe');
+    if (!iframe?.contentWindow) throw new Error('HTML iframe missing');
+    act(() => iframe.focus());
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        source: iframe.contentWindow,
+        data: {
+          type: 'plannotator-bridge-vim-state',
+          phase: 'block',
+        },
+      }));
+      window.dispatchEvent(new MessageEvent('message', {
+        source: iframe.contentWindow,
+        data: {
+          type: 'plannotator-bridge-vim-command',
+          actionId: 'moveDown',
+          key: 'j',
+          context: 'block',
+        },
+      }));
+    });
+
+    expect(document.querySelector('[data-vim-key-hud]')).not.toBeNull();
+    expect(document.querySelector('[data-vim-hud-active-key="j"]')).not.toBeNull();
+    expect(document.querySelector('[data-vim-hud-phase]')?.textContent)
+      .toBe('BLOCK / PINPOINT');
+    expect(document.querySelector('[data-vim-hud-command]')?.textContent)
+      .toBe('Next block');
+
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        source: iframe.contentWindow,
+        data: {
+          type: 'plannotator-bridge-vim-command',
+          actionId: 'not-a-real-action',
+          key: 'x',
+          context: 'block',
+        },
+      }));
+    });
+    expect(document.querySelector('[data-vim-hud-active-key="j"]')).not.toBeNull();
+
+    await act(async () => {
+      root.render(
+        <htmlViewerModule.HtmlViewer
+          rawHtml="<html><body><p>First</p><p>Second</p></body></html>"
+          annotations={[]}
+          onAddAnnotation={() => {}}
+          onSelectAnnotation={() => {}}
+          selectedAnnotationId={null}
+          mode="selection"
+          inputMethod="pinpoint"
+          vimModeEnabled
+          vimHudEnabled={false}
+        />,
+      );
+    });
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        source: iframe.contentWindow,
+        data: {
+          type: 'plannotator-bridge-vim-command',
+          actionId: 'moveUp',
+          key: 'k',
+          context: 'block',
+        },
+      }));
+    });
+    expect(document.querySelector('[data-vim-key-hud]')).toBeNull();
+
+    act(() => root.unmount());
+  });
+});

--- a/packages/ui/components/html-viewer/HtmlViewer.vimHud.test.tsx
+++ b/packages/ui/components/html-viewer/HtmlViewer.vimHud.test.tsx
@@ -11,6 +11,113 @@ afterEach(() => {
 });
 
 describe.if(hasDom)('HtmlViewer Vim HUD bridge', () => {
+  test('copies only validated Vim text from the focused sandbox', async () => {
+    if (!htmlViewerModule) {
+      throw new Error('DOM test environment is not registered');
+    }
+    const clipboardDescriptor = Object.getOwnPropertyDescriptor(
+      navigator,
+      'clipboard',
+    );
+    const writes: string[] = [];
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: async (text: string) => {
+          writes.push(text);
+        },
+      },
+    });
+
+    const host = document.createElement('div');
+    const outsideButton = document.createElement('button');
+    document.body.append(host, outsideButton);
+    const root = createRoot(host);
+
+    try {
+      await act(async () => {
+        root.render(
+          <htmlViewerModule.HtmlViewer
+            rawHtml="<html><body><p>Raw copy target</p></body></html>"
+            annotations={[]}
+            onAddAnnotation={() => {}}
+            onSelectAnnotation={() => {}}
+            selectedAnnotationId={null}
+            mode="selection"
+            inputMethod="drag"
+            vimModeEnabled
+            vimHudEnabled={false}
+          />,
+        );
+      });
+
+      const iframe = host.querySelector<HTMLIFrameElement>('iframe');
+      if (!iframe?.contentWindow) throw new Error('HTML iframe missing');
+      const postCopy = (text: unknown) => {
+        window.dispatchEvent(new MessageEvent('message', {
+          source: iframe.contentWindow,
+          data: {
+            type: 'plannotator-bridge-vim-copy',
+            text,
+          },
+        }));
+      };
+
+      act(() => outsideButton.focus());
+      act(() => postCopy('not focused'));
+      expect(writes).toEqual([]);
+
+      act(() => iframe.focus());
+      act(() => postCopy('Raw copy target'));
+      expect(writes).toEqual(['Raw copy target']);
+      expect(document.activeElement).toBe(iframe);
+
+      act(() => postCopy(''));
+      act(() => postCopy({ unsafe: true }));
+      act(() => postCopy('x'.repeat(2 * 1024 * 1024 + 1)));
+      act(() => {
+        window.dispatchEvent(new MessageEvent('message', {
+          source: window,
+          data: {
+            type: 'plannotator-bridge-vim-copy',
+            text: 'wrong source',
+          },
+        }));
+      });
+      expect(writes).toEqual(['Raw copy target']);
+
+      await act(async () => {
+        root.render(
+          <htmlViewerModule.HtmlViewer
+            rawHtml="<html><body><p>Raw copy target</p></body></html>"
+            annotations={[]}
+            onAddAnnotation={() => {}}
+            onSelectAnnotation={() => {}}
+            selectedAnnotationId={null}
+            mode="selection"
+            inputMethod="drag"
+            vimModeEnabled={false}
+            vimHudEnabled={false}
+          />,
+        );
+      });
+      act(() => iframe.focus());
+      act(() => postCopy('disabled'));
+      expect(writes).toEqual(['Raw copy target']);
+    } finally {
+      act(() => root.unmount());
+      if (clipboardDescriptor) {
+        Object.defineProperty(
+          navigator,
+          'clipboard',
+          clipboardDescriptor,
+        );
+      } else {
+        delete (navigator as Navigator & { clipboard?: Clipboard }).clipboard;
+      }
+    }
+  });
+
   test('renders validated iframe command messages through the shared parent HUD', async () => {
     if (!htmlViewerModule) {
       throw new Error('DOM test environment is not registered');

--- a/packages/ui/components/html-viewer/HtmlViewer.vimHud.test.tsx
+++ b/packages/ui/components/html-viewer/HtmlViewer.vimHud.test.tsx
@@ -119,6 +119,48 @@ describe.if(hasDom)('HtmlViewer Vim HUD bridge', () => {
           mode="selection"
           inputMethod="pinpoint"
           vimModeEnabled
+          vimHudEnabled
+          vimHudKeyPanelEnabled={false}
+        />,
+      );
+    });
+    act(() => iframe.focus());
+    expect(document.querySelector('[data-vim-key-hud]')).toBeNull();
+
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        source: iframe.contentWindow,
+        data: {
+          type: 'plannotator-bridge-vim-help',
+          open: true,
+        },
+      }));
+    });
+    expect(document.querySelector('[data-vim-key-hud]')).not.toBeNull();
+    expect(document.querySelector('[data-vim-key-map]')).not.toBeNull();
+
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        source: iframe.contentWindow,
+        data: {
+          type: 'plannotator-bridge-vim-help',
+          open: false,
+        },
+      }));
+    });
+    expect(document.querySelector('[data-vim-key-hud]')).toBeNull();
+
+    await act(async () => {
+      root.render(
+        <htmlViewerModule.HtmlViewer
+          rawHtml="<html><body><p>First</p><p>Second</p></body></html>"
+          annotations={[]}
+          onAddAnnotation={() => {}}
+          onSelectAnnotation={() => {}}
+          selectedAnnotationId={null}
+          mode="selection"
+          inputMethod="pinpoint"
+          vimModeEnabled
           vimHudEnabled={false}
         />,
       );

--- a/packages/ui/components/html-viewer/HtmlViewer.vimHud.test.tsx
+++ b/packages/ui/components/html-viewer/HtmlViewer.vimHud.test.tsx
@@ -64,6 +64,37 @@ describe.if(hasDom)('HtmlViewer Vim HUD bridge', () => {
     expect(document.querySelector('[data-vim-hud-command]')?.textContent)
       .toBe('Next block');
 
+    const mapToggle = document.querySelector<HTMLButtonElement>(
+      '[data-vim-key-map-toggle]',
+    );
+    act(() => mapToggle?.focus());
+    expect(document.activeElement).toBe(mapToggle);
+    expect(document.querySelector('[data-vim-key-hud]')).not.toBeNull();
+
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        source: iframe.contentWindow,
+        data: {
+          type: 'plannotator-bridge-vim-help',
+          open: true,
+        },
+      }));
+    });
+    expect(document.querySelector('[data-vim-key-map]')).not.toBeNull();
+    expect(document.querySelector('[data-vim-key-hud]')?.getAttribute('data-expanded'))
+      .toBe('true');
+
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        source: iframe.contentWindow,
+        data: {
+          type: 'plannotator-bridge-vim-help',
+          open: false,
+        },
+      }));
+    });
+    expect(document.querySelector('[data-vim-key-map]')).toBeNull();
+
     act(() => {
       window.dispatchEvent(new MessageEvent('message', {
         source: iframe.contentWindow,

--- a/packages/ui/components/html-viewer/bridge-script.ts
+++ b/packages/ui/components/html-viewer/bridge-script.ts
@@ -49,6 +49,59 @@ export const ANNOTATION_HIGHLIGHT_CSS = `
 .plannotator-pinpoint-hover:is(g, svg) {
   filter: drop-shadow(0 0 4px oklch(from var(--pn-focus-highlight, #4493f8) l c h / 0.55));
 }
+body[data-plannotator-vim-focus-owner]:focus {
+  outline: none !important;
+}
+[data-plannotator-vim-cursor] {
+  position: fixed;
+  z-index: 2147483646;
+  width: 2px;
+  min-height: 1em;
+  border-radius: 2px;
+  background: var(--pn-focus-highlight, #4493f8);
+  pointer-events: none;
+}
+[data-plannotator-vim-badge] {
+  position: fixed;
+  z-index: 2147483647;
+  left: 50%;
+  bottom: 12px;
+  transform: translateX(-50%);
+  padding: 4px 9px;
+  border: 1px solid color-mix(in srgb, var(--pn-focus-highlight, #4493f8) 35%, transparent);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--pn-background, #111) 94%, transparent);
+  color: var(--pn-focus-highlight, #4493f8);
+  box-shadow: 0 4px 18px rgba(0,0,0,.25);
+  font: 700 10px/1.2 ui-monospace, SFMono-Regular, Menlo, monospace;
+  letter-spacing: .04em;
+  pointer-events: none;
+}
+[data-plannotator-vim-help] {
+  position: fixed;
+  z-index: 2147483647;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: color-mix(in srgb, var(--pn-background, #111) 68%, transparent);
+  backdrop-filter: blur(8px);
+}
+[data-plannotator-vim-help] > div {
+  width: min(480px, 100%);
+  padding: 18px;
+  border: 1px solid color-mix(in srgb, var(--pn-foreground, #eee) 18%, transparent);
+  border-radius: 12px;
+  background: var(--pn-background, #111);
+  color: var(--pn-foreground, #eee);
+  box-shadow: 0 18px 60px rgba(0,0,0,.35);
+  font: 12px/1.55 system-ui, sans-serif;
+}
+[data-plannotator-vim-help] kbd {
+  color: var(--pn-focus-highlight, #4493f8);
+  font: 700 11px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+}
 `;
 
 export const BRIDGE_SCRIPT = `(function() {
@@ -59,6 +112,7 @@ export const BRIDGE_SCRIPT = `(function() {
   // (hostTheme), only viewer-namespaced --pn-* properties may be written to its
   // root, and its class list is never touched.
   window.addEventListener('message', function(e) {
+    if (e.source !== parent) return;
     if (!e.data || e.data.type !== PREFIX + 'theme') return;
     var root = document.documentElement;
     var tokens = e.data.tokens || {};
@@ -91,6 +145,16 @@ export const BRIDGE_SCRIPT = `(function() {
   var pendingRange = null; // live range for the pending selection (scroll tracking)
   var currentInputMethod = 'drag'; // 'drag' = text selection, 'pinpoint' = click an element
   var pinpointHover = null;
+  var vimEnabled = false;
+  var vimPhase = 'inactive';
+  var vimActiveMode = 'selection';
+  var vimPinpointEl = null;
+  var vimVisualBlockAnchorEl = null;
+  var vimPendingG = false;
+  var vimPendingGTimer = 0;
+  var vimHelpOpen = false;
+  var vimAddedBodyTabIndex = false;
+  var vimActionReturn = null;
   // A plain click on an element-annotation target opens the toolbar, but the same
   // click's mouseup schedules a handleSelection() that would see an empty selection
   // and immediately clear it. This flag suppresses that one trailing clear.
@@ -102,7 +166,7 @@ export const BRIDGE_SCRIPT = `(function() {
     setTimeout(handleSelection, 10);
   });
 
-  function handleSelection() {
+  function handleSelection(modeOverride) {
     var sel = window.getSelection();
     if (!sel || sel.isCollapsed || !sel.rangeCount) {
       // Trailing clear from a plain-click element annotation — consume it once.
@@ -112,12 +176,12 @@ export const BRIDGE_SCRIPT = `(function() {
         pendingSelection = null;
         pendingRange = null;
       }
-      return;
+      return false;
     }
     skipNextClear = false; // a real text selection happened
     var range = sel.getRangeAt(0);
     var text = sel.toString().trim();
-    if (!text) return;
+    if (!text) return false;
 
     var rect = range.getBoundingClientRect();
     pendingRange = range;
@@ -132,8 +196,10 @@ export const BRIDGE_SCRIPT = `(function() {
     parent.postMessage({
       type: PREFIX + 'selection',
       text: text,
+      modeOverride: modeOverride || undefined,
       rect: { top: rect.top, left: rect.left, width: rect.width, height: rect.height }
     }, '*');
+    return true;
   }
 
   // Keep the toolbar/popover attached while the iframe content scrolls: re-post the
@@ -147,6 +213,8 @@ export const BRIDGE_SCRIPT = `(function() {
     if (r.bottom < 0 || r.top > window.innerHeight) {
       // Selection scrolled out of view — close the toolbar (matches markdown).
       parent.postMessage({ type: PREFIX + 'selection-clear' }, '*');
+      pendingSelection = null;
+      pendingRange = null;
       return;
     }
     parent.postMessage({
@@ -161,6 +229,7 @@ export const BRIDGE_SCRIPT = `(function() {
 
   // --- Mark Creation ---
   window.addEventListener('message', function(e) {
+    if (e.source !== parent) return;
     if (!e.data || !e.data.type) return;
     var type = e.data.type;
 
@@ -176,6 +245,7 @@ export const BRIDGE_SCRIPT = `(function() {
         pendingRange = null;
         window.getSelection().removeAllRanges();
       }
+      restoreVimSemanticTarget();
     }
 
     else if (type === PREFIX + 'find-and-mark') {
@@ -194,6 +264,14 @@ export const BRIDGE_SCRIPT = `(function() {
     else if (type === PREFIX + 'clear-marks') {
       var marks = document.querySelectorAll('.annotation-highlight[data-bind-id]');
       for (var i = marks.length - 1; i >= 0; i--) unwrapMark(marks[i]);
+    }
+
+    else if (type === PREFIX + 'cancel-selection') {
+      pendingSelection = null;
+      pendingRange = null;
+      skipNextClear = false;
+      window.getSelection().removeAllRanges();
+      restoreVimSemanticTarget();
     }
 
     else if (type === PREFIX + 'scroll-to') {
@@ -220,33 +298,204 @@ export const BRIDGE_SCRIPT = `(function() {
         if (pinpointHover) { pinpointHover.classList.remove('plannotator-pinpoint-hover'); pinpointHover = null; }
         if (pinpointLabelEl) pinpointLabelEl.style.display = 'none';
       }
+      if (vimEnabled) updateVimUi();
+    }
+
+    else if (type === PREFIX + 'set-vim-mode') {
+      var wasVimEnabled = vimEnabled;
+      vimEnabled = e.data.enabled === true;
+      vimActiveMode = e.data.mode === 'comment'
+        || e.data.mode === 'redline'
+        || e.data.mode === 'quickLabel'
+        ? e.data.mode
+        : 'selection';
+      if (!vimEnabled) {
+        clearVimUi();
+        vimPinpointEl = null;
+        vimPhase = 'inactive';
+      } else if (!wasVimEnabled) {
+        prepareVimFocusOwner();
+        vimPhase = 'inactive';
+        updateVimUi();
+      } else {
+        updateVimUi();
+      }
+    }
+
+    else if (type === PREFIX + 'focus-vim') {
+      if (vimEnabled) {
+        ensureVimFocus();
+        if (vimPhase === 'inactive') resetVimSemanticNavigation();
+        updateVimUi();
+      }
     }
   });
 
   // --- Pinpoint: hover to outline a whole element, click to select its text ---
   // Reuses the normal selection pipeline — a pinpoint click just sets the iframe
   // selection over the element's text, then runs handleSelection() like a drag.
-  var PINPOINT_SKIP = { SCRIPT: 1, STYLE: 1, NOSCRIPT: 1, HTML: 1, BODY: 1, HEAD: 1 };
-  var PINPOINT_INLINE = { A: 1, SPAN: 1, EM: 1, STRONG: 1, B: 1, I: 1, CODE: 1, SMALL: 1, LABEL: 1, MARK: 1, SUP: 1, SUB: 1, U: 1, ABBR: 1, TIME: 1 };
+  var PINPOINT_SKIP_SELECTOR = 'script,style,noscript,[data-plannotator-vim-ui],.annotation-highlight';
+  var SEMANTIC_BLOCK_SELECTOR = 'h1,h2,h3,h4,h5,h6,p,li,pre,blockquote,figcaption,table,button,[data-annotate],svg g';
+  var SEMANTIC_GROUP_SELECTOR = 'section,article,aside,nav,header,footer,ul,ol,figure,main';
+  var SEMANTIC_INLINE_SELECTOR = 'a,em,strong,b,i,code,small,label,mark,sup,sub,u,abbr,time';
+  var semanticTargetKeys = new WeakMap();
+  var semanticTargetKeyCounter = 0;
 
-  function resolvePinpointEl(node) {
+  function semanticTargetKey(el) {
+    var existing = semanticTargetKeys.get(el);
+    if (existing) return existing;
+    semanticTargetKeyCounter += 1;
+    var key = 'html-target-' + semanticTargetKeyCounter;
+    semanticTargetKeys.set(el, key);
+    return key;
+  }
+
+  function semanticLabel(el) {
+    return PINPOINT_LABELS[el.tagName] || el.tagName.toLowerCase();
+  }
+
+  function buildSemanticTargetGraph() {
+    var targets = [];
+    var blocks = [];
+    var byElement = new Map();
+
+    function add(el, kind, parent) {
+      if (!el || byElement.has(el) || el.closest(PINPOINT_SKIP_SELECTOR)) return null;
+      if (!el.textContent || !el.textContent.trim()) return null;
+      var target = {
+        key: semanticTargetKey(el),
+        element: el,
+        kind: kind,
+        parentKey: parent ? parent.key : null,
+        label: semanticLabel(el)
+      };
+      targets.push(target);
+      byElement.set(el, target);
+      return target;
+    }
+
+    function addInlineDescendants(root, parent) {
+      var inlineElements = Array.prototype.slice.call(root.querySelectorAll(SEMANTIC_INLINE_SELECTOR));
+      for (var inlineIndex = 0; inlineIndex < inlineElements.length; inlineIndex++) {
+        var inlineEl = inlineElements[inlineIndex];
+        var ancestorEl = inlineEl.parentElement && inlineEl.parentElement.closest(SEMANTIC_INLINE_SELECTOR);
+        var inlineParent = ancestorEl && root.contains(ancestorEl)
+          ? byElement.get(ancestorEl) || parent
+          : parent;
+        add(inlineEl, 'inline', inlineParent);
+      }
+    }
+
+    var groupElements = Array.prototype.slice.call(document.querySelectorAll(SEMANTIC_GROUP_SELECTOR));
+    for (var groupIndex = 0; groupIndex < groupElements.length; groupIndex++) {
+      var groupEl = groupElements[groupIndex];
+      var containingGroupEl = groupEl.parentElement && groupEl.parentElement.closest(SEMANTIC_GROUP_SELECTOR);
+      add(groupEl, 'group', containingGroupEl ? byElement.get(containingGroupEl) || null : null);
+    }
+
+    var blockElements = Array.prototype.slice.call(document.querySelectorAll(SEMANTIC_BLOCK_SELECTOR));
+    for (var blockIndex = 0; blockIndex < blockElements.length; blockIndex++) {
+      var blockEl = blockElements[blockIndex];
+      if (blockEl.closest(PINPOINT_SKIP_SELECTOR)) continue;
+      var containingBlock = blockEl.parentElement && blockEl.parentElement.closest(SEMANTIC_BLOCK_SELECTOR);
+      if (containingBlock) continue;
+      var parentGroupEl = blockEl.parentElement && blockEl.parentElement.closest(SEMANTIC_GROUP_SELECTOR);
+      var parentGroup = parentGroupEl ? byElement.get(parentGroupEl) : null;
+      var kind = blockEl.tagName === 'TABLE'
+        ? 'table'
+        : blockEl.tagName === 'PRE'
+          ? 'code'
+          : 'block';
+      var blockTarget = add(blockEl, kind, parentGroup || null);
+      if (!blockTarget) continue;
+      blocks.push(blockTarget);
+
+      if (blockEl.tagName === 'TABLE') {
+        var rows = Array.prototype.slice.call(blockEl.rows || []);
+        for (var rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+          var rowTarget = add(rows[rowIndex], 'row', blockTarget);
+          if (!rowTarget) continue;
+          var cells = Array.prototype.slice.call(rows[rowIndex].cells || []);
+          for (var cellIndex = 0; cellIndex < cells.length; cellIndex++) {
+            var cellTarget = add(cells[cellIndex], 'cell', rowTarget);
+            if (cellTarget) {
+              cellTarget.rowIndex = rowIndex;
+              cellTarget.columnIndex = cellIndex;
+              addInlineDescendants(cells[cellIndex], cellTarget);
+            }
+          }
+        }
+      } else {
+        addInlineDescendants(blockEl, blockTarget);
+      }
+    }
+
+    return {
+      targets: targets,
+      blocks: blocks,
+      byElement: byElement
+    };
+  }
+
+  function semanticChildren(graph, target) {
+    return graph.targets.filter(function(candidate) {
+      return candidate.parentKey === target.key;
+    });
+  }
+
+  function semanticParent(graph, target) {
+    if (!target || !target.parentKey) return null;
+    for (var i = 0; i < graph.targets.length; i++) {
+      if (graph.targets[i].key === target.parentKey) return graph.targets[i];
+    }
+    return null;
+  }
+
+  function semanticSibling(graph, target, delta) {
+    var parent = semanticParent(graph, target);
+    if (!parent) return target;
+    var siblings = semanticChildren(graph, parent);
+    var index = siblings.indexOf(target);
+    if (index < 0) return target;
+    var nextIndex = Math.max(0, Math.min(siblings.length - 1, index + delta));
+    return siblings[nextIndex] || target;
+  }
+
+  function semanticOwningBlock(graph, target) {
+    var current = target;
+    while (current && graph.blocks.indexOf(current) < 0) {
+      current = semanticParent(graph, current);
+    }
+    return current || target;
+  }
+
+  function resolveSemanticTarget(graph, node) {
     var el = node;
-    while (el && el.nodeType === 3) el = el.parentNode; // text node -> parent
-    if (!el || el.nodeType !== 1) return null;
-    // SVG: a click on a shape/text leaf (rect, path, text) resolves to the whole
-    // node group, so clicking anywhere on an SVG node — not just its label — picks it.
+    while (el && el.nodeType === 3) el = el.parentNode;
+    if (
+      !el
+      || el.nodeType !== 1
+      || el === document.documentElement
+      || el === document.body
+      || el.closest(PINPOINT_SKIP_SELECTOR)
+    ) return null;
+
     if (el.ownerSVGElement && el.closest) {
-      var g = el.closest('g');
-      if (g && g.textContent && g.textContent.trim()) el = g;
+      var svgGroup = el.closest('g');
+      if (svgGroup && graph.byElement.has(svgGroup)) return graph.byElement.get(svgGroup);
     }
-    if (PINPOINT_SKIP[el.tagName]) return null;
-    // Climb out of inline elements to their containing block.
-    while (el.parentElement && PINPOINT_INLINE[el.tagName] && !PINPOINT_SKIP[el.parentElement.tagName]) {
-      el = el.parentElement;
+
+    var inline = el.closest && el.closest(SEMANTIC_INLINE_SELECTOR);
+    if (inline && graph.byElement.has(inline)) return graph.byElement.get(inline);
+    var cell = el.closest && el.closest('td,th');
+    if (cell && graph.byElement.has(cell)) return graph.byElement.get(cell);
+
+    var current = el;
+    while (current && current !== document.body) {
+      if (graph.byElement.has(current)) return graph.byElement.get(current);
+      current = current.parentElement;
     }
-    if (PINPOINT_SKIP[el.tagName]) return null;
-    if (!el.textContent || !el.textContent.trim()) return null; // need text to annotate
-    return el;
+    return null;
   }
 
   // Floating label naming the element under the cursor (like the markdown overlay).
@@ -263,9 +512,25 @@ export const BRIDGE_SCRIPT = `(function() {
   }
   function hidePinpointLabel() { if (pinpointLabelEl) pinpointLabelEl.style.display = 'none'; }
 
+  var pointerSemanticGraph = null;
+  var pointerSemanticGraphRaf = 0;
+  function graphForPointerFrame() {
+    if (!pointerSemanticGraph) pointerSemanticGraph = buildSemanticTargetGraph();
+    if (!pointerSemanticGraphRaf) {
+      pointerSemanticGraphRaf = requestAnimationFrame(function() {
+        pointerSemanticGraph = null;
+        pointerSemanticGraphRaf = 0;
+      });
+    }
+    return pointerSemanticGraph;
+  }
+
   document.addEventListener('mousemove', function(e) {
     if (currentInputMethod !== 'pinpoint') return;
-    var el = resolvePinpointEl(e.target);
+    if (vimEnabled && vimPhase !== 'inactive') return;
+    var pointerGraph = graphForPointerFrame();
+    var pointerTarget = resolveSemanticTarget(pointerGraph, e.target);
+    var el = pointerTarget && pointerTarget.element;
     if (el !== pinpointHover) {
       if (pinpointHover) pinpointHover.classList.remove('plannotator-pinpoint-hover');
       pinpointHover = el;
@@ -284,8 +549,8 @@ export const BRIDGE_SCRIPT = `(function() {
   // Pop the toolbar for a whole element: select its text if possible (so a <mark>
   // can wrap it), else post its text + box directly so the toolbar still anchors
   // (e.g. an SVG node, whose <text> doesn't select like HTML text).
-  function annotateElement(el) {
-    if (!el) return;
+  function annotateElement(el, modeOverride) {
+    if (!el) return false;
     if (pinpointHover) { pinpointHover.classList.remove('plannotator-pinpoint-hover'); pinpointHover = null; }
     hidePinpointLabel();
     // SVG content can't hold an HTML <mark> wrapper — wrapping an SVG <text> in a
@@ -303,22 +568,26 @@ export const BRIDGE_SCRIPT = `(function() {
         txt = (sel.toString() || '').trim();
       } catch (ex) {}
     }
-    if (txt) { handleSelection(); return; }
+    if (txt) return handleSelection(modeOverride);
     var elText = (el.textContent || '').trim();
-    if (!elText) return;
+    if (!elText) return false;
     var r = el.getBoundingClientRect();
     pendingSelection = { element: true };
     pendingRange = null;
     skipNextClear = true; // don't let this click's mouseup clear the toolbar we just opened
     parent.postMessage({ type: PREFIX + 'selection', text: elText,
+      modeOverride: modeOverride || undefined,
       rect: { top: r.top, left: r.left, width: r.width, height: r.height } }, '*');
+    return true;
   }
 
   document.addEventListener('click', function(e) {
     if (currentInputMethod !== 'pinpoint') return;
     // Existing marks are handled by the mark-click listener.
     if (e.target && e.target.closest && e.target.closest('.annotation-highlight[data-bind-id]')) return;
-    var el = resolvePinpointEl(e.target);
+    var clickGraph = buildSemanticTargetGraph();
+    var clickTarget = resolveSemanticTarget(clickGraph, e.target);
+    var el = clickTarget && clickTarget.element;
     if (!el) return;
     // Suppress the page's own behavior (links, buttons) — we're annotating.
     e.preventDefault();
@@ -352,12 +621,856 @@ export const BRIDGE_SCRIPT = `(function() {
     }
   });
 
+  // --- Optional Vim navigation ---
+  // The bridge owns iframe-local ranges and focus. The parent only enables the
+  // feature and receives the same selection messages used by pointer input.
+  function isVimEditableTarget(node) {
+    var el = node && node.nodeType === 1 ? node : node && node.parentElement;
+    if (!el || !el.closest) return false;
+    return !!el.closest('button,input,textarea,select,a[href],summary,[contenteditable]:not([contenteditable="false"]),[role="button"],[role="link"],[role="textbox"],[role="dialog"],[data-plannotator-vim-ui]');
+  }
+
+  function prepareVimFocusOwner() {
+    if (!document.body) return;
+    document.body.setAttribute('data-plannotator-vim-focus-owner', '');
+    if (!document.body.hasAttribute('tabindex')) {
+      document.body.setAttribute('tabindex', '-1');
+      vimAddedBodyTabIndex = true;
+    }
+  }
+
+  function ensureVimFocus() {
+    prepareVimFocusOwner();
+    if (!document.body) return;
+    try { document.body.focus({ preventScroll: true }); } catch (ex) {
+      try { document.body.focus(); } catch (ignore) {}
+    }
+  }
+
+  function getVimTextNodes() {
+    if (!document.body) return [];
+    var nodes = [];
+    var walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
+      acceptNode: function(node) {
+        var parentEl = node.parentElement;
+        if (!parentEl || !node.data || !node.data.length) return NodeFilter.FILTER_REJECT;
+        if (parentEl.closest('script,style,noscript,input,textarea,select,button,[contenteditable]:not([contenteditable="false"]),[data-plannotator-vim-ui]')) {
+          return NodeFilter.FILTER_REJECT;
+        }
+        return NodeFilter.FILTER_ACCEPT;
+      }
+    });
+    while (walker.nextNode()) nodes.push(walker.currentNode);
+    return nodes;
+  }
+
+  function nearestVisibleTextNode() {
+    var nodes = getVimTextNodes();
+    if (!nodes.length) return null;
+    var centerY = window.innerHeight / 2;
+    var best = nodes[0];
+    var bestDistance = Infinity;
+    for (var i = 0; i < nodes.length; i++) {
+      var range = document.createRange();
+      range.selectNodeContents(nodes[i]);
+      var rect = range.getBoundingClientRect();
+      if (!rect.height && !rect.width) continue;
+      var distance = Math.abs((rect.top + rect.bottom) / 2 - centerY);
+      if (distance < bestDistance) {
+        best = nodes[i];
+        bestDistance = distance;
+      }
+    }
+    return best;
+  }
+
+  function setCollapsedSelection(node, offset) {
+    if (!node) return false;
+    var selection = window.getSelection();
+    if (!selection) return false;
+    var range = document.createRange();
+    range.setStart(node, Math.max(0, Math.min(offset || 0, node.length || 0)));
+    range.collapse(true);
+    selection.removeAllRanges();
+    selection.addRange(range);
+    return true;
+  }
+
+  function ensureVimTextCursor() {
+    var selection = window.getSelection();
+    if (selection && selection.rangeCount && selection.focusNode && document.body.contains(selection.focusNode)) {
+      return true;
+    }
+    return setCollapsedSelection(nearestVisibleTextNode(), 0);
+  }
+
+  function currentVimPreciseTarget() {
+    var graph = buildSemanticTargetGraph();
+    var target = currentVimSemanticTarget(graph);
+    return target && (target.kind === 'inline' || target.kind === 'row' || target.kind === 'cell')
+      ? target.element
+      : null;
+  }
+
+  function setVimSelectionFocus(selection, node, offset) {
+    if (vimPhase === 'visual' && selection.anchorNode) {
+      selection.setBaseAndExtent(
+        selection.anchorNode,
+        selection.anchorOffset,
+        node,
+        offset
+      );
+      return true;
+    }
+    return setCollapsedSelection(node, offset);
+  }
+
+  function clampVimSelectionToTarget(selection, target, direction) {
+    if (!target || !selection) return false;
+    if (selection.focusNode && target.contains(selection.focusNode)) return true;
+    var nodes = getVimTextNodes().filter(function(node) { return target.contains(node); });
+    if (!nodes.length) return false;
+    var boundaryNode = direction === 'backward' ? nodes[0] : nodes[nodes.length - 1];
+    var boundaryOffset = direction === 'backward' ? 0 : boundaryNode.length;
+    return setVimSelectionFocus(selection, boundaryNode, boundaryOffset);
+  }
+
+  function syncVimTargetToSelection(selection) {
+    if (!selection || !selection.focusNode) return;
+    var graph = buildSemanticTargetGraph();
+    var resolved = resolveSemanticTarget(graph, selection.focusNode);
+    if (resolved) vimPinpointEl = semanticOwningBlock(graph, resolved).element;
+  }
+
+  function modifyVimSelection(direction, granularity) {
+    if (!ensureVimTextCursor()) return false;
+    var selection = window.getSelection();
+    if (!selection || typeof selection.modify !== 'function') return false;
+    var preciseTarget = currentVimPreciseTarget();
+    selection.modify(vimPhase === 'visual' ? 'extend' : 'move', direction, granularity);
+    if (preciseTarget) clampVimSelectionToTarget(selection, preciseTarget, direction);
+    else syncVimTargetToSelection(selection);
+    updateVimUi();
+    return true;
+  }
+
+  function vimTextPointForOffset(nodes, offset) {
+    var remaining = Math.max(0, offset);
+    for (var i = 0; i < nodes.length; i++) {
+      if (remaining <= nodes[i].length) return { node: nodes[i], offset: remaining };
+      remaining -= nodes[i].length;
+    }
+    var last = nodes[nodes.length - 1];
+    return last ? { node: last, offset: last.length } : null;
+  }
+
+  function vimTextOffsetForPoint(nodes, node, offset) {
+    var total = 0;
+    for (var i = 0; i < nodes.length; i++) {
+      if (nodes[i] === node) return total + Math.max(0, Math.min(offset, nodes[i].length));
+      total += nodes[i].length;
+    }
+    return null;
+  }
+
+  function moveVimWord(motion) {
+    if (!ensureVimTextCursor()) return false;
+    var selection = window.getSelection();
+    var preciseTarget = currentVimPreciseTarget();
+    var textTarget = preciseTarget || currentVimBlock();
+    if (!selection || !selection.focusNode || !textTarget || !Intl.Segmenter) {
+      return modifyVimSelection(motion === 'backward' ? 'backward' : 'forward', 'word');
+    }
+    var nodes = getVimTextNodes().filter(function(node) { return textTarget.contains(node); });
+    var focusOffset = vimTextOffsetForPoint(nodes, selection.focusNode, selection.focusOffset);
+    if (focusOffset === null) return false;
+    var text = nodes.map(function(node) { return node.data; }).join('');
+    var words = Array.from(new Intl.Segmenter(undefined, { granularity: 'word' }).segment(text))
+      .filter(function(segment) { return segment.isWordLike; });
+    var targetOffset = null;
+    if (motion === 'backward') {
+      for (var i = words.length - 1; i >= 0; i--) {
+        if (words[i].index < focusOffset) { targetOffset = words[i].index; break; }
+      }
+    } else if (motion === 'end') {
+      for (var j = 0; j < words.length; j++) {
+        var end = words[j].index + words[j].segment.length;
+        if (end > focusOffset) { targetOffset = end; break; }
+      }
+    } else {
+      for (var k = 0; k < words.length; k++) {
+        if (words[k].index > focusOffset) { targetOffset = words[k].index; break; }
+      }
+    }
+    if (targetOffset === null) {
+      if (preciseTarget) {
+        var boundaryNode = motion === 'backward' ? nodes[0] : nodes[nodes.length - 1];
+        var boundaryOffset = motion === 'backward' ? 0 : boundaryNode.length;
+        var movedToBoundary = setVimSelectionFocus(
+          selection,
+          boundaryNode,
+          boundaryOffset
+        );
+        updateVimUi();
+        return movedToBoundary;
+      }
+      return modifyVimSelection(motion === 'backward' ? 'backward' : 'forward', 'word');
+    }
+    var point = vimTextPointForOffset(nodes, targetOffset);
+    if (!point) return false;
+    setVimSelectionFocus(selection, point.node, point.offset);
+    updateVimUi();
+    return true;
+  }
+
+  function currentVimBlock() {
+    var graph = buildSemanticTargetGraph();
+    var selection = window.getSelection();
+    var node = selection && selection.focusNode;
+    var resolved = resolveSemanticTarget(graph, node);
+    if (resolved && (vimPhase === 'text' || vimPhase === 'visual')) {
+      return semanticOwningBlock(graph, resolved).element;
+    }
+    var semantic = currentVimSemanticTarget(graph);
+    return semantic ? semanticOwningBlock(graph, semantic).element : null;
+  }
+
+  function selectVimBlock(block, resetAnchor) {
+    if (!block) return false;
+    if (resetAnchor !== false) vimVisualBlockAnchorEl = block;
+    var range = document.createRange();
+    range.selectNodeContents(block);
+    var selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+    return true;
+  }
+
+  function vimBlocks() {
+    return buildSemanticTargetGraph().blocks.map(function(target) {
+      return target.element;
+    });
+  }
+
+  function moveVimVisualBlock(delta) {
+    var blocks = vimBlocks();
+    if (!blocks.length) return false;
+    var current = currentVimBlock();
+    var index = blocks.indexOf(current);
+    if (index < 0) index = 0;
+    var nextIndex = Math.max(0, Math.min(blocks.length - 1, index + delta));
+    var next = blocks[nextIndex];
+    var anchor = vimVisualBlockAnchorEl || current || next;
+    var anchorIndex = blocks.indexOf(anchor);
+    if (anchorIndex < 0) {
+      anchor = next;
+      anchorIndex = nextIndex;
+      vimVisualBlockAnchorEl = anchor;
+    }
+    var selection = window.getSelection();
+    if (!selection) return false;
+    var anchorTexts = getVimTextNodes().filter(function(node) { return anchor.contains(node); });
+    var nextTexts = getVimTextNodes().filter(function(node) { return next.contains(node); });
+    if (!anchorTexts.length || !nextTexts.length) return false;
+    if (nextIndex >= anchorIndex) {
+      selection.setBaseAndExtent(
+        anchorTexts[0],
+        0,
+        nextTexts[nextTexts.length - 1],
+        nextTexts[nextTexts.length - 1].length
+      );
+    } else {
+      selection.setBaseAndExtent(
+        anchorTexts[anchorTexts.length - 1],
+        anchorTexts[anchorTexts.length - 1].length,
+        nextTexts[0],
+        0
+      );
+    }
+    vimPinpointEl = next;
+    next.scrollIntoView({ block: 'nearest' });
+    updateVimUi();
+    return true;
+  }
+
+  function moveVimDocumentBoundary(end) {
+    var nodes = getVimTextNodes();
+    if (!nodes.length) return false;
+    var node = end ? nodes[nodes.length - 1] : nodes[0];
+    var offset = end ? node.length : 0;
+    var selection = window.getSelection();
+    if (!selection) return false;
+    if (vimPhase !== 'visual' || !selection.anchorNode) {
+      setCollapsedSelection(node, offset);
+    } else {
+      selection.setBaseAndExtent(selection.anchorNode, selection.anchorOffset, node, offset);
+    }
+    node.parentElement && node.parentElement.scrollIntoView({ block: 'nearest' });
+    updateVimUi();
+    return true;
+  }
+
+  function currentVimSemanticTarget(graph) {
+    return vimPinpointEl ? graph.byElement.get(vimPinpointEl) || null : null;
+  }
+
+  function semanticVimPhase(target) {
+    return target && (target.kind === 'inline' || target.kind === 'row' || target.kind === 'cell')
+      ? 'inline'
+      : 'block';
+  }
+
+  function setVimPinpointTarget(target) {
+    if (pinpointHover) {
+      pinpointHover.classList.remove('plannotator-pinpoint-hover');
+      pinpointHover = null;
+    }
+    if (vimPinpointEl) vimPinpointEl.classList.remove('plannotator-pinpoint-hover');
+    vimVisualBlockAnchorEl = null;
+    vimPinpointEl = target ? target.element : null;
+    if (vimPinpointEl) {
+      vimPhase = semanticVimPhase(target);
+      window.getSelection().removeAllRanges();
+      vimPinpointEl.classList.add('plannotator-pinpoint-hover');
+      vimPinpointEl.scrollIntoView({ block: 'nearest' });
+      var r = vimPinpointEl.getBoundingClientRect();
+      var lbl = getPinpointLabelEl();
+      lbl.textContent = target.label;
+      lbl.style.display = 'block';
+      lbl.style.top = Math.max(2, r.top - 22) + 'px';
+      lbl.style.left = Math.max(2, r.left) + 'px';
+    } else {
+      hidePinpointLabel();
+    }
+    updateVimUi();
+  }
+
+  function initialVimPinpointTarget() {
+    var graph = buildSemanticTargetGraph();
+    if (!graph.blocks.length) return null;
+    var centerY = window.innerHeight / 2;
+    var blocks = graph.blocks.slice();
+    blocks.sort(function(a, b) {
+      var ar = a.element.getBoundingClientRect();
+      var br = b.element.getBoundingClientRect();
+      return Math.abs((ar.top + ar.bottom) / 2 - centerY) - Math.abs((br.top + br.bottom) / 2 - centerY);
+    });
+    return blocks[0];
+  }
+
+  function moveVimPinpoint(delta, blocksOnly) {
+    var graph = buildSemanticTargetGraph();
+    if (!graph.blocks.length) return false;
+    var current = currentVimSemanticTarget(graph) || initialVimPinpointTarget();
+    if (!current) return false;
+
+    if (vimPhase === 'inline' && !blocksOnly) {
+      setVimPinpointTarget(semanticSibling(graph, current, delta));
+      return true;
+    }
+
+    var block = semanticOwningBlock(graph, current);
+    var index = graph.blocks.indexOf(block);
+    if (index < 0) index = 0;
+    var nextIndex = Math.max(0, Math.min(graph.blocks.length - 1, index + delta));
+    setVimPinpointTarget(graph.blocks[nextIndex]);
+    return true;
+  }
+
+  function refineVimPinpoint(inward) {
+    var graph = buildSemanticTargetGraph();
+    var current = currentVimSemanticTarget(graph);
+    if (!current) {
+      current = initialVimPinpointTarget();
+      if (current) setVimPinpointTarget(current);
+    }
+    if (!current) return false;
+
+    if (!inward) {
+      var parent = semanticParent(graph, current);
+      if (parent) {
+        setVimPinpointTarget(parent);
+        return true;
+      }
+      return true;
+    }
+
+    var child = semanticChildren(graph, current)[0];
+    if (child) {
+      setVimPinpointTarget(child);
+      return true;
+    }
+    enterVimTextTarget(current);
+    return true;
+  }
+
+  function enterVimTextTarget(target) {
+    if (!target || !target.element) return false;
+    var nodes = getVimTextNodes().filter(function(node) {
+      return target.element.contains(node);
+    });
+    if (!nodes.length) return false;
+    if (vimPinpointEl) vimPinpointEl.classList.remove('plannotator-pinpoint-hover');
+    hidePinpointLabel();
+    vimVisualBlockAnchorEl = null;
+    vimPinpointEl = target.element;
+    vimPhase = 'text';
+    setCollapsedSelection(nodes[0], 0);
+    updateVimUi();
+    return true;
+  }
+
+  function resetVimSemanticNavigation() {
+    if (!vimEnabled) return;
+    window.getSelection().removeAllRanges();
+    setVimPinpointTarget(initialVimPinpointTarget());
+  }
+
+  function restoreVimSemanticTarget() {
+    if (!vimEnabled) return;
+    if (vimPhase === 'action' && restoreVimActionState()) return;
+    var graph = buildSemanticTargetGraph();
+    var target = currentVimSemanticTarget(graph) || initialVimPinpointTarget();
+    if (target) setVimPinpointTarget(target);
+    else {
+      vimPinpointEl = null;
+      vimPhase = 'inactive';
+      hidePinpointLabel();
+      updateVimUi();
+    }
+  }
+
+  function rememberVimActionState() {
+    var selection = window.getSelection();
+    var range = selection && selection.rangeCount
+      ? selection.getRangeAt(0).cloneRange()
+      : null;
+    vimActionReturn = {
+      phase: vimPhase,
+      pinpointEl: vimPinpointEl,
+      visualBlockAnchorEl: vimVisualBlockAnchorEl,
+      range: range
+    };
+  }
+
+  function beginVimAction(mode) {
+    if (mode === 'redline' && vimActionReturn) {
+      if (vimActionReturn.phase === 'visual') {
+        vimActionReturn.phase = 'text';
+        if (vimActionReturn.range) vimActionReturn.range.collapse(false);
+      } else if (vimActionReturn.phase === 'visual-block') {
+        var graph = buildSemanticTargetGraph();
+        var target = vimActionReturn.pinpointEl && graph.byElement.get(vimActionReturn.pinpointEl);
+        vimActionReturn.phase = semanticVimPhase(target);
+        vimActionReturn.visualBlockAnchorEl = null;
+        vimActionReturn.range = null;
+      }
+    }
+    vimPhase = 'action';
+    updateVimUi();
+  }
+
+  function restoreVimActionState() {
+    if (!vimActionReturn) return false;
+    var saved = vimActionReturn;
+    vimActionReturn = null;
+    vimPinpointEl = saved.pinpointEl;
+    vimVisualBlockAnchorEl = saved.visualBlockAnchorEl;
+
+    if (saved.phase === 'block' || saved.phase === 'inline') {
+      var graph = buildSemanticTargetGraph();
+      var target = vimPinpointEl && graph.byElement.get(vimPinpointEl);
+      if (target) {
+        setVimPinpointTarget(target);
+        return true;
+      }
+    }
+
+    if (vimPinpointEl) vimPinpointEl.classList.remove('plannotator-pinpoint-hover');
+    hidePinpointLabel();
+    vimPhase = saved.phase;
+    var selection = window.getSelection();
+    if (selection) {
+      selection.removeAllRanges();
+      if (saved.range) {
+        try { selection.addRange(saved.range); } catch (ex) {}
+      }
+    }
+    updateVimUi();
+    return true;
+  }
+
+  function getVimCursorEl() {
+    var cursor = document.querySelector('[data-plannotator-vim-cursor]');
+    if (!cursor) {
+      cursor = document.createElement('div');
+      cursor.setAttribute('data-plannotator-vim-cursor', '');
+      cursor.setAttribute('data-plannotator-vim-ui', '');
+      document.body.appendChild(cursor);
+    }
+    return cursor;
+  }
+
+  function getVimBadgeEl() {
+    var badge = document.querySelector('[data-plannotator-vim-badge]');
+    if (!badge) {
+      badge = document.createElement('div');
+      badge.setAttribute('data-plannotator-vim-badge', '');
+      badge.setAttribute('data-plannotator-vim-ui', '');
+      document.body.appendChild(badge);
+    }
+    return badge;
+  }
+
+  function updateVimUi() {
+    if (!vimEnabled) return;
+    var badge = getVimBadgeEl();
+    var cursor = getVimCursorEl();
+    if (vimPhase === 'inactive') {
+      badge.style.display = 'none';
+      cursor.style.display = 'none';
+      return;
+    }
+    badge.style.display = 'block';
+    var phaseLabel = vimPhase === 'text' ? 'NORMAL' : vimPhase.toUpperCase().replace('-', ' ');
+    badge.textContent = phaseLabel + ' · ' + (currentInputMethod === 'pinpoint' ? 'PINPOINT' : 'SELECT');
+    if (vimPhase !== 'text') {
+      cursor.style.display = 'none';
+      return;
+    }
+    var selection = window.getSelection();
+    if (!selection || !selection.focusNode) {
+      cursor.style.display = 'none';
+      return;
+    }
+    var range = document.createRange();
+    try {
+      range.setStart(selection.focusNode, selection.focusOffset);
+      range.collapse(true);
+      var rect = range.getClientRects()[0] || range.getBoundingClientRect();
+      cursor.style.display = 'block';
+      cursor.style.left = rect.left + 'px';
+      cursor.style.top = rect.top + 'px';
+      cursor.style.height = (rect.height || 16) + 'px';
+    } catch (ex) {
+      cursor.style.display = 'none';
+    }
+  }
+
+  function toggleVimHelp() {
+    vimHelpOpen = !vimHelpOpen;
+    var existing = document.querySelector('[data-plannotator-vim-help]');
+    if (!vimHelpOpen) {
+      if (existing) existing.remove();
+      return;
+    }
+    if (existing) return;
+    var help = document.createElement('div');
+    help.setAttribute('data-plannotator-vim-help', '');
+    help.setAttribute('data-plannotator-vim-ui', '');
+    help.innerHTML = '<div><strong>Vim controls</strong><p><kbd>j k · gg G</kbd> move between blocks or refined siblings · <kbd>h l · Esc</kbd> move out, refine, or back out · <kbd>v / V</kbd> select text or whole blocks · <kbd>h j k l · w b e · 0 $</kbd> move after entering text · <kbd>Enter</kbd> active annotation · <kbd>Space · c d m t y</kbd> actions · <kbd>?</kbd> help</p></div>';
+    help.addEventListener('mousedown', function(e) {
+      if (e.target === help) toggleVimHelp();
+    });
+    document.body.appendChild(help);
+  }
+
+  function clearVimUi() {
+    var nodes = document.querySelectorAll('[data-plannotator-vim-cursor],[data-plannotator-vim-badge],[data-plannotator-vim-help]');
+    for (var i = 0; i < nodes.length; i++) nodes[i].remove();
+    if (vimPinpointEl) vimPinpointEl.classList.remove('plannotator-pinpoint-hover');
+    vimVisualBlockAnchorEl = null;
+    vimActionReturn = null;
+    hidePinpointLabel();
+    vimHelpOpen = false;
+    if (vimAddedBodyTabIndex && document.body) {
+      document.body.removeAttribute('tabindex');
+      vimAddedBodyTabIndex = false;
+    }
+    if (document.body) document.body.removeAttribute('data-plannotator-vim-focus-owner');
+  }
+
+  function copyVimText(text) {
+    if (!text) return;
+    var textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.style.cssText = 'position:fixed;opacity:0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand('copy');
+    textarea.remove();
+  }
+
+  function vimActionMode(key) {
+    // The iframe is an intentionally dependency-free sandbox. Keep these
+    // command keys aligned with plan-review/vimSelection.shortcuts.ts, whose
+    // scope owns the user-facing registry and parent-document dispatch.
+    if (key === 'c') return 'comment';
+    if (key === 'd') return 'redline';
+    if (key === 't') return 'quickLabel';
+    if (key === 'm' || key === ' ' || key === 'Space' || key === 'Spacebar') return 'selection';
+    return null;
+  }
+
+  function handleVimKeydown(e) {
+    if (!vimEnabled || isVimEditableTarget(e.target) || e.isComposing) return false;
+    if (e.metaKey || e.ctrlKey || e.altKey) return false;
+
+    var key = e.key;
+    var handled = false;
+
+    if (vimHelpOpen) {
+      if (key === '?' || key === 'Escape') {
+        toggleVimHelp();
+        handled = true;
+      }
+    } else if (key === '?') {
+      toggleVimHelp();
+      handled = true;
+    } else if (key === 'Escape') {
+      if (pendingSelection) {
+        parent.postMessage({ type: PREFIX + 'selection-clear' }, '*');
+        pendingSelection = null;
+        pendingRange = null;
+        restoreVimSemanticTarget();
+        handled = true;
+      } else if (vimPhase === 'visual') {
+        var visualSelection = window.getSelection();
+        if (visualSelection && visualSelection.focusNode) {
+          setCollapsedSelection(visualSelection.focusNode, visualSelection.focusOffset);
+        }
+        vimPhase = 'text';
+        updateVimUi();
+        handled = true;
+      } else if (vimPhase === 'text' || vimPhase === 'visual-block' || vimPhase === 'action') {
+        restoreVimSemanticTarget();
+        handled = true;
+      } else if (vimPhase === 'inline') {
+        var escapeGraph = buildSemanticTargetGraph();
+        var escapeTarget = currentVimSemanticTarget(escapeGraph);
+        var escapeParent = escapeTarget && semanticParent(escapeGraph, escapeTarget);
+        if (escapeParent) setVimPinpointTarget(escapeParent);
+        else {
+          if (vimPinpointEl) vimPinpointEl.classList.remove('plannotator-pinpoint-hover');
+          vimPinpointEl = null;
+          vimPhase = 'inactive';
+          hidePinpointLabel();
+          updateVimUi();
+        }
+        handled = true;
+      } else if (vimPhase === 'block') {
+        if (vimPinpointEl) vimPinpointEl.classList.remove('plannotator-pinpoint-hover');
+        vimPinpointEl = null;
+        vimPhase = 'inactive';
+        hidePinpointLabel();
+        window.getSelection().removeAllRanges();
+        updateVimUi();
+        handled = true;
+      }
+    } else if (pendingSelection) {
+      // The parent toolbar/comment/label UI owns keys until it resolves.
+      return false;
+    } else if (key === 'g') {
+      if (vimPendingG) {
+        clearTimeout(vimPendingGTimer);
+        vimPendingG = false;
+        if (vimPhase === 'text' || vimPhase === 'visual') moveVimDocumentBoundary(false);
+        else {
+          var firstGraph = buildSemanticTargetGraph();
+          if (firstGraph.blocks.length) setVimPinpointTarget(firstGraph.blocks[0]);
+        }
+      } else {
+        vimPendingG = true;
+        vimPendingGTimer = setTimeout(function() { vimPendingG = false; }, 500);
+      }
+      handled = true;
+    } else {
+      if (vimPendingG) {
+        clearTimeout(vimPendingGTimer);
+        vimPendingG = false;
+      }
+
+      if (vimPhase === 'inactive') {
+        setVimPinpointTarget(initialVimPinpointTarget());
+      } else if (vimPhase === 'block' || vimPhase === 'inline') {
+        var currentGraph = buildSemanticTargetGraph();
+        if (!currentVimSemanticTarget(currentGraph)) {
+          setVimPinpointTarget(initialVimPinpointTarget());
+        }
+      }
+
+      if (vimPhase === 'block' || vimPhase === 'inline') {
+        if (key === 'j') handled = moveVimPinpoint(1, false);
+        else if (key === 'k') handled = moveVimPinpoint(-1, false);
+        else if (key === '{') handled = moveVimPinpoint(-1, true);
+        else if (key === '}') handled = moveVimPinpoint(1, true);
+        else if (key === 'h' || key === 'H') handled = refineVimPinpoint(false);
+        else if (key === 'l') handled = refineVimPinpoint(true);
+        else if (key === 'G') {
+          var lastGraph = buildSemanticTargetGraph();
+          if (lastGraph.blocks.length) {
+            setVimPinpointTarget(lastGraph.blocks[lastGraph.blocks.length - 1]);
+            handled = true;
+          }
+        } else if (key === 'v') {
+          var visualGraph = buildSemanticTargetGraph();
+          var visualTarget = currentVimSemanticTarget(visualGraph);
+          if (visualTarget && enterVimTextTarget(visualTarget)) {
+            vimPhase = 'visual';
+            updateVimUi();
+            handled = true;
+          }
+        } else if (key === 'V') {
+          var blockGraph = buildSemanticTargetGraph();
+          var blockTarget = currentVimSemanticTarget(blockGraph);
+          if (blockTarget) {
+            var owningBlock = semanticOwningBlock(blockGraph, blockTarget);
+            if (vimPinpointEl) vimPinpointEl.classList.remove('plannotator-pinpoint-hover');
+            hidePinpointLabel();
+            vimPinpointEl = owningBlock.element;
+            vimPhase = 'visual-block';
+            handled = selectVimBlock(owningBlock.element, true);
+            updateVimUi();
+          }
+        } else if (key === 'y') {
+          copyVimText(vimPinpointEl && vimPinpointEl.textContent || '');
+          handled = !!vimPinpointEl;
+        } else if (key === 'Enter' || vimActionMode(key)) {
+          var semanticActionMode = key === 'Enter' ? vimActiveMode : vimActionMode(key);
+          rememberVimActionState();
+          var semanticActionStarted = vimPinpointEl
+            ? annotateElement(vimPinpointEl, key === 'Enter' ? undefined : semanticActionMode)
+            : false;
+          if (semanticActionStarted) {
+            beginVimAction(semanticActionMode);
+          } else {
+            vimActionReturn = null;
+          }
+          handled = semanticActionStarted;
+        }
+      } else if (vimPhase === 'text' || vimPhase === 'visual') {
+        ensureVimTextCursor();
+        var selection = window.getSelection();
+        if (key === 'v') {
+          vimPhase = vimPhase === 'visual' ? 'text' : 'visual';
+          if (vimPhase === 'text' && selection && selection.focusNode) {
+            setCollapsedSelection(selection.focusNode, selection.focusOffset);
+          }
+          updateVimUi();
+          handled = true;
+        } else if (key === 'V') {
+          var currentBlock = currentVimBlock();
+          if (currentBlock) {
+            if (vimPinpointEl) vimPinpointEl.classList.remove('plannotator-pinpoint-hover');
+            vimPinpointEl = currentBlock;
+            vimPhase = 'visual-block';
+            selectVimBlock(currentBlock, true);
+            handled = true;
+          }
+          updateVimUi();
+        } else if (key === 'o' && selection && !selection.isCollapsed) {
+          selection.setBaseAndExtent(selection.focusNode, selection.focusOffset, selection.anchorNode, selection.anchorOffset);
+          updateVimUi();
+          handled = true;
+        } else if (key === 'G') {
+          handled = moveVimDocumentBoundary(true);
+        } else if (key === 'h') handled = modifyVimSelection('backward', 'character');
+        else if (key === 'l') handled = modifyVimSelection('forward', 'character');
+        else if (key === 'j') handled = modifyVimSelection('forward', 'line');
+        else if (key === 'k') handled = modifyVimSelection('backward', 'line');
+        else if (key === 'w') handled = moveVimWord('forward');
+        else if (key === 'b') handled = moveVimWord('backward');
+        else if (key === 'e') handled = moveVimWord('end');
+        else if (key === '0') handled = modifyVimSelection('backward', 'lineboundary');
+        else if (key === '$') handled = modifyVimSelection('forward', 'lineboundary');
+        else if (key === '{') handled = modifyVimSelection('backward', 'paragraph');
+        else if (key === '}') handled = modifyVimSelection('forward', 'paragraph');
+        else if (key === 'y' && selection && !selection.isCollapsed) {
+          copyVimText(selection.toString());
+          setCollapsedSelection(selection.focusNode, selection.focusOffset);
+          vimPhase = 'text';
+          updateVimUi();
+          handled = true;
+        } else if ((key === 'Enter' || vimActionMode(key)) && selection && !selection.isCollapsed) {
+          var textActionMode = key === 'Enter' ? vimActiveMode : vimActionMode(key);
+          rememberVimActionState();
+          var textActionStarted = handleSelection(key === 'Enter' ? undefined : textActionMode);
+          if (textActionStarted) {
+            beginVimAction(textActionMode);
+          } else {
+            vimActionReturn = null;
+          }
+          handled = textActionStarted;
+        }
+      } else if (vimPhase === 'visual-block') {
+        var blockSelection = window.getSelection();
+        if (key === 'j' || key === 'k') {
+          handled = moveVimVisualBlock(key === 'j' ? 1 : -1);
+        } else if (key === 'V') {
+          restoreVimSemanticTarget();
+          handled = true;
+        } else if (key === 'o' && blockSelection && !blockSelection.isCollapsed) {
+          blockSelection.setBaseAndExtent(
+            blockSelection.focusNode,
+            blockSelection.focusOffset,
+            blockSelection.anchorNode,
+            blockSelection.anchorOffset
+          );
+          var previousBlockAnchor = vimVisualBlockAnchorEl;
+          vimVisualBlockAnchorEl = vimPinpointEl;
+          if (previousBlockAnchor) vimPinpointEl = previousBlockAnchor;
+          handled = true;
+        } else if (key === 'y' && blockSelection && !blockSelection.isCollapsed) {
+          copyVimText(blockSelection.toString());
+          restoreVimSemanticTarget();
+          handled = true;
+        } else if ((key === 'Enter' || vimActionMode(key)) && blockSelection && !blockSelection.isCollapsed) {
+          var blockActionMode = key === 'Enter' ? vimActiveMode : vimActionMode(key);
+          rememberVimActionState();
+          var blockActionStarted = handleSelection(key === 'Enter' ? undefined : blockActionMode);
+          if (blockActionStarted) {
+            beginVimAction(blockActionMode);
+          } else {
+            vimActionReturn = null;
+          }
+          handled = blockActionStarted;
+        }
+      }
+    }
+
+    if (handled) {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+    }
+    return handled;
+  }
+
+  document.addEventListener('keydown', handleVimKeydown, true);
+
+  // Pointer input exits the keyboard-owned semantic state without synthesizing
+  // focus or consuming the pointer event. Drag selection and Pinpoint clicking
+  // then continue through their existing handlers.
+  document.addEventListener('mousedown', function(e) {
+    if (!vimEnabled || isVimEditableTarget(e.target)) return;
+    if (pinpointHover) {
+      pinpointHover.classList.remove('plannotator-pinpoint-hover');
+      pinpointHover = null;
+    }
+    if (vimPinpointEl) vimPinpointEl.classList.remove('plannotator-pinpoint-hover');
+    vimPinpointEl = null;
+    vimVisualBlockAnchorEl = null;
+    vimPhase = 'inactive';
+    hidePinpointLabel();
+    updateVimUi();
+  }, true);
+
   // --- Type-to-comment ---
   // While a selection is pending, focus is inside this iframe, so the parent's
   // toolbar keydown listener never sees the keystroke. Forward a single printable
   // char to the parent so it can open a comment pre-filled with it.
   document.addEventListener('keydown', function(e) {
     if (!pendingSelection) return;
+    if (isVimEditableTarget(e.target)) return;
     if (e.metaKey || e.ctrlKey || e.altKey) return;
     if (!e.key || e.key.length !== 1) return; // single printable char only
     e.preventDefault();

--- a/packages/ui/components/html-viewer/bridge-script.ts
+++ b/packages/ui/components/html-viewer/bridge-script.ts
@@ -146,6 +146,7 @@ export const BRIDGE_SCRIPT = `(function() {
   var currentInputMethod = 'drag'; // 'drag' = text selection, 'pinpoint' = click an element
   var pinpointHover = null;
   var vimEnabled = false;
+  var vimHudEnabled = false;
   var vimPhase = 'inactive';
   var vimActiveMode = 'selection';
   var vimPinpointEl = null;
@@ -304,6 +305,7 @@ export const BRIDGE_SCRIPT = `(function() {
     else if (type === PREFIX + 'set-vim-mode') {
       var wasVimEnabled = vimEnabled;
       vimEnabled = e.data.enabled === true;
+      vimHudEnabled = e.data.hudEnabled === true;
       vimActiveMode = e.data.mode === 'comment'
         || e.data.mode === 'redline'
         || e.data.mode === 'quickLabel'
@@ -1124,16 +1126,25 @@ export const BRIDGE_SCRIPT = `(function() {
 
   function updateVimUi() {
     if (!vimEnabled) return;
-    var badge = getVimBadgeEl();
+    if (vimHudEnabled) {
+      parent.postMessage({
+        type: PREFIX + 'vim-state',
+        phase: vimPhase
+      }, '*');
+    }
+    var badge = document.querySelector('[data-plannotator-vim-badge]');
+    if (!vimHudEnabled && !badge) badge = getVimBadgeEl();
     var cursor = getVimCursorEl();
     if (vimPhase === 'inactive') {
-      badge.style.display = 'none';
+      if (badge) badge.style.display = 'none';
       cursor.style.display = 'none';
       return;
     }
-    badge.style.display = 'block';
+    if (badge) badge.style.display = vimHudEnabled ? 'none' : 'block';
     var phaseLabel = vimPhase === 'text' ? 'NORMAL' : vimPhase.toUpperCase().replace('-', ' ');
-    badge.textContent = phaseLabel + ' · ' + (currentInputMethod === 'pinpoint' ? 'PINPOINT' : 'SELECT');
+    if (badge) {
+      badge.textContent = phaseLabel + ' · ' + (currentInputMethod === 'pinpoint' ? 'PINPOINT' : 'SELECT');
+    }
     if (vimPhase !== 'text') {
       cursor.style.display = 'none';
       return;
@@ -1212,12 +1223,43 @@ export const BRIDGE_SCRIPT = `(function() {
     return null;
   }
 
+  function vimActionIdForKey(key) {
+    if (key === 'j') return 'moveDown';
+    if (key === 'k') return 'moveUp';
+    if (key === 'G') return 'documentEnd';
+    if (key === 'h' || key === 'H') return 'moveOut';
+    if (key === 'l') return 'refine';
+    if (key === 'v') return 'visual';
+    if (key === 'V') return 'visualBlock';
+    if (key === 'w') return 'wordForward';
+    if (key === 'b') return 'wordBackward';
+    if (key === 'e') return 'wordEnd';
+    if (key === '0') return 'lineStart';
+    if (key === '$') return 'lineEnd';
+    if (key === '{') return 'previousTextBlock';
+    if (key === '}') return 'nextTextBlock';
+    if (key === 'o') return 'swapSelectionEnds';
+    if (key === 'Enter') return 'activeAnnotation';
+    if (key === ' ' || key === 'Space' || key === 'Spacebar') return 'annotationMenu';
+    if (key === 'c') return 'comment';
+    if (key === 'd') return 'redline';
+    if (key === 'm') return 'markup';
+    if (key === 't') return 'label';
+    if (key === 'y') return 'copy';
+    if (key === 'Escape') return 'cancel';
+    if (key === '?') return 'help';
+    return null;
+  }
+
   function handleVimKeydown(e) {
     if (!vimEnabled || isVimEditableTarget(e.target) || e.isComposing) return false;
     if (e.metaKey || e.ctrlKey || e.altKey) return false;
 
     var key = e.key;
     var handled = false;
+    var hudKey = key;
+    var vimCommandContext = vimPhase;
+    var vimActionId = key === 'g' ? null : vimActionIdForKey(key);
 
     if (vimHelpOpen) {
       if (key === '?' || key === 'Escape') {
@@ -1274,6 +1316,8 @@ export const BRIDGE_SCRIPT = `(function() {
       if (vimPendingG) {
         clearTimeout(vimPendingGTimer);
         vimPendingG = false;
+        vimActionId = 'documentStart';
+        hudKey = 'gg';
         if (vimPhase === 'text' || vimPhase === 'visual') moveVimDocumentBoundary(false);
         else {
           var firstGraph = buildSemanticTargetGraph();
@@ -1439,6 +1483,14 @@ export const BRIDGE_SCRIPT = `(function() {
     }
 
     if (handled) {
+      if (vimHudEnabled && vimActionId) {
+        parent.postMessage({
+          type: PREFIX + 'vim-command',
+          actionId: vimActionId,
+          key: hudKey,
+          context: vimCommandContext
+        }, '*');
+      }
       e.preventDefault();
       e.stopImmediatePropagation();
     }

--- a/packages/ui/components/html-viewer/bridge-script.ts
+++ b/packages/ui/components/html-viewer/bridge-script.ts
@@ -61,6 +61,99 @@ body[data-plannotator-vim-focus-owner]:focus {
   background: var(--pn-focus-highlight, #4493f8);
   pointer-events: none;
 }
+[data-plannotator-vim-reticle] {
+  position: fixed;
+  z-index: 2147483645;
+  inset: 0;
+  overflow: visible;
+  pointer-events: none;
+}
+[data-plannotator-vim-reticle] [data-vim-reticle-fill],
+[data-plannotator-vim-reticle] [data-vim-reticle-corner],
+[data-plannotator-vim-reticle] [data-vim-reticle-label] {
+  position: absolute;
+  top: 0;
+  left: 0;
+  will-change: transform;
+  transition: transform 90ms cubic-bezier(.22,1,.36,1);
+}
+[data-plannotator-vim-reticle] [data-vim-reticle-fill] {
+  width: 100px;
+  height: 100px;
+  transform-origin: 0 0;
+  border-radius: 8px;
+  background: rgba(167,139,250,.045);
+  box-shadow:
+    inset 0 0 0 1px rgba(196,181,253,.16),
+    0 0 42px rgba(139,92,246,.12);
+}
+[data-plannotator-vim-reticle] [data-vim-reticle-corner] {
+  width: 28px;
+  height: 28px;
+  border-color: #c4b5fd;
+  filter:
+    drop-shadow(0 0 6px rgba(167,139,250,.92))
+    drop-shadow(0 0 18px rgba(124,58,237,.42));
+}
+[data-plannotator-vim-reticle] [data-vim-reticle-corner="top-left"] {
+  border-top: 3px solid;
+  border-left: 3px solid;
+  border-top-left-radius: 8px;
+}
+[data-plannotator-vim-reticle] [data-vim-reticle-corner="top-right"] {
+  border-top: 3px solid;
+  border-right: 3px solid;
+  border-top-right-radius: 8px;
+}
+[data-plannotator-vim-reticle] [data-vim-reticle-corner="bottom-left"] {
+  border-bottom: 3px solid;
+  border-left: 3px solid;
+  border-bottom-left-radius: 8px;
+}
+[data-plannotator-vim-reticle] [data-vim-reticle-corner="bottom-right"] {
+  border-right: 3px solid;
+  border-bottom: 3px solid;
+  border-bottom-right-radius: 8px;
+}
+[data-plannotator-vim-reticle] [data-vim-reticle-label] {
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 118px;
+  height: 30px;
+  max-width: min(280px, calc(100vw - 24px));
+  padding: 0 11px;
+  overflow: hidden;
+  border: 1px solid rgba(216,206,255,.42);
+  border-radius: 9px;
+  color: #f6f2ff;
+  background: rgba(18,14,28,.84);
+  box-shadow:
+    0 10px 28px rgba(0,0,0,.42),
+    0 0 20px rgba(139,92,246,.18);
+  backdrop-filter: blur(10px);
+  font: 700 10px/1 ui-monospace, SFMono-Regular, Menlo, monospace;
+  letter-spacing: .13em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+[data-plannotator-vim-reticle] [data-vim-reticle-label]::before {
+  width: 7px;
+  height: 7px;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: #c4b5fd;
+  box-shadow: 0 0 12px rgba(167,139,250,.94);
+  content: "";
+}
+@media (prefers-reduced-motion: reduce) {
+  [data-plannotator-vim-reticle] [data-vim-reticle-fill],
+  [data-plannotator-vim-reticle] [data-vim-reticle-corner],
+  [data-plannotator-vim-reticle] [data-vim-reticle-label] {
+    transition: none;
+  }
+}
 [data-plannotator-vim-badge] {
   position: fixed;
   z-index: 2147483647;
@@ -77,31 +170,6 @@ body[data-plannotator-vim-focus-owner]:focus {
   letter-spacing: .04em;
   pointer-events: none;
 }
-[data-plannotator-vim-help] {
-  position: fixed;
-  z-index: 2147483647;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 20px;
-  background: color-mix(in srgb, var(--pn-background, #111) 68%, transparent);
-  backdrop-filter: blur(8px);
-}
-[data-plannotator-vim-help] > div {
-  width: min(480px, 100%);
-  padding: 18px;
-  border: 1px solid color-mix(in srgb, var(--pn-foreground, #eee) 18%, transparent);
-  border-radius: 12px;
-  background: var(--pn-background, #111);
-  color: var(--pn-foreground, #eee);
-  box-shadow: 0 18px 60px rgba(0,0,0,.35);
-  font: 12px/1.55 system-ui, sans-serif;
-}
-[data-plannotator-vim-help] kbd {
-  color: var(--pn-focus-highlight, #4493f8);
-  font: 700 11px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
-}
 `;
 
 export const BRIDGE_SCRIPT = `(function() {
@@ -113,7 +181,16 @@ export const BRIDGE_SCRIPT = `(function() {
   // root, and its class list is never touched.
   window.addEventListener('message', function(e) {
     if (e.source !== parent) return;
-    if (!e.data || e.data.type !== PREFIX + 'theme') return;
+    if (!e.data) return;
+    if (e.data.type === PREFIX + 'set-vim-help') {
+      vimHelpOpen = !!e.data.open;
+      parent.postMessage({
+        type: PREFIX + 'vim-help',
+        open: vimHelpOpen
+      }, '*');
+      return;
+    }
+    if (e.data.type !== PREFIX + 'theme') return;
     var root = document.documentElement;
     var tokens = e.data.tokens || {};
     var hostTheme = !!e.data.hostTheme;
@@ -156,6 +233,9 @@ export const BRIDGE_SCRIPT = `(function() {
   var vimHelpOpen = false;
   var vimAddedBodyTabIndex = false;
   var vimActionReturn = null;
+  var vimLastActionId = null;
+  var vimLastActionContext = 'inactive';
+  var vimLastPostedPhase = null;
   // A plain click on an element-annotation target opens the toolbar, but the same
   // click's mouseup schedules a handleSelection() that would see an empty selection
   // and immediately clear it. This flag suppresses that one trailing clear.
@@ -304,8 +384,10 @@ export const BRIDGE_SCRIPT = `(function() {
 
     else if (type === PREFIX + 'set-vim-mode') {
       var wasVimEnabled = vimEnabled;
+      var wasVimHudEnabled = vimHudEnabled;
       vimEnabled = e.data.enabled === true;
       vimHudEnabled = e.data.hudEnabled === true;
+      if (wasVimHudEnabled !== vimHudEnabled) vimLastPostedPhase = null;
       vimActiveMode = e.data.mode === 'comment'
         || e.data.mode === 'redline'
         || e.data.mode === 'quickLabel'
@@ -649,10 +731,11 @@ export const BRIDGE_SCRIPT = `(function() {
     }
   }
 
-  function getVimTextNodes() {
-    if (!document.body) return [];
+  function getVimTextNodes(root) {
+    var scope = root || document.body;
+    if (!scope) return [];
     var nodes = [];
-    var walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
+    var walker = document.createTreeWalker(scope, NodeFilter.SHOW_TEXT, {
       acceptNode: function(node) {
         var parentEl = node.parentElement;
         if (!parentEl || !node.data || !node.data.length) return NodeFilter.FILTER_REJECT;
@@ -730,7 +813,7 @@ export const BRIDGE_SCRIPT = `(function() {
   function clampVimSelectionToTarget(selection, target, direction) {
     if (!target || !selection) return false;
     if (selection.focusNode && target.contains(selection.focusNode)) return true;
-    var nodes = getVimTextNodes().filter(function(node) { return target.contains(node); });
+    var nodes = getVimTextNodes(target);
     if (!nodes.length) return false;
     var boundaryNode = direction === 'backward' ? nodes[0] : nodes[nodes.length - 1];
     var boundaryOffset = direction === 'backward' ? 0 : boundaryNode.length;
@@ -783,7 +866,7 @@ export const BRIDGE_SCRIPT = `(function() {
     if (!selection || !selection.focusNode || !textTarget || !Intl.Segmenter) {
       return modifyVimSelection(motion === 'backward' ? 'backward' : 'forward', 'word');
     }
-    var nodes = getVimTextNodes().filter(function(node) { return textTarget.contains(node); });
+    var nodes = getVimTextNodes(textTarget);
     var focusOffset = vimTextOffsetForPoint(nodes, selection.focusNode, selection.focusOffset);
     if (focusOffset === null) return false;
     var text = nodes.map(function(node) { return node.data; }).join('');
@@ -871,8 +954,8 @@ export const BRIDGE_SCRIPT = `(function() {
     }
     var selection = window.getSelection();
     if (!selection) return false;
-    var anchorTexts = getVimTextNodes().filter(function(node) { return anchor.contains(node); });
-    var nextTexts = getVimTextNodes().filter(function(node) { return next.contains(node); });
+    var anchorTexts = getVimTextNodes(anchor);
+    var nextTexts = getVimTextNodes(next);
     if (!anchorTexts.length || !nextTexts.length) return false;
     if (nextIndex >= anchorIndex) {
       selection.setBaseAndExtent(
@@ -933,14 +1016,18 @@ export const BRIDGE_SCRIPT = `(function() {
     if (vimPinpointEl) {
       vimPhase = semanticVimPhase(target);
       window.getSelection().removeAllRanges();
-      vimPinpointEl.classList.add('plannotator-pinpoint-hover');
       vimPinpointEl.scrollIntoView({ block: 'nearest' });
-      var r = vimPinpointEl.getBoundingClientRect();
-      var lbl = getPinpointLabelEl();
-      lbl.textContent = target.label;
-      lbl.style.display = 'block';
-      lbl.style.top = Math.max(2, r.top - 22) + 'px';
-      lbl.style.left = Math.max(2, r.left) + 'px';
+      if (vimHudEnabled) {
+        hidePinpointLabel();
+      } else {
+        vimPinpointEl.classList.add('plannotator-pinpoint-hover');
+        var r = vimPinpointEl.getBoundingClientRect();
+        var lbl = getPinpointLabelEl();
+        lbl.textContent = target.label;
+        lbl.style.display = 'block';
+        lbl.style.top = Math.max(2, r.top - 22) + 'px';
+        lbl.style.left = Math.max(2, r.left) + 'px';
+      }
     } else {
       hidePinpointLabel();
     }
@@ -1008,9 +1095,7 @@ export const BRIDGE_SCRIPT = `(function() {
 
   function enterVimTextTarget(target) {
     if (!target || !target.element) return false;
-    var nodes = getVimTextNodes().filter(function(node) {
-      return target.element.contains(node);
-    });
+    var nodes = getVimTextNodes(target.element);
     if (!nodes.length) return false;
     if (vimPinpointEl) vimPinpointEl.classList.remove('plannotator-pinpoint-hover');
     hidePinpointLabel();
@@ -1124,9 +1209,213 @@ export const BRIDGE_SCRIPT = `(function() {
     return badge;
   }
 
+  function getVimReticleEl() {
+    var reticle = document.querySelector('[data-plannotator-vim-reticle]');
+    if (reticle) return reticle;
+    reticle = document.createElement('div');
+    reticle.setAttribute('data-plannotator-vim-reticle', '');
+    reticle.setAttribute('data-plannotator-vim-ui', '');
+    reticle.innerHTML = [
+      '<div data-vim-reticle-fill></div>',
+      '<div data-vim-reticle-corner="top-left"></div>',
+      '<div data-vim-reticle-corner="top-right"></div>',
+      '<div data-vim-reticle-corner="bottom-left"></div>',
+      '<div data-vim-reticle-corner="bottom-right"></div>',
+      '<div data-vim-reticle-label></div>'
+    ].join('');
+    document.body.appendChild(reticle);
+    return reticle;
+  }
+
+  function hideVimReticle() {
+    var reticle = document.querySelector('[data-plannotator-vim-reticle]');
+    if (reticle) reticle.style.display = 'none';
+  }
+
+  function vimRangeRect(range) {
+    if (!range) return null;
+    var rects = [];
+    if (typeof range.getClientRects === 'function') {
+      try {
+        var rangeRects = range.getClientRects();
+        for (var rangeRectIndex = 0; rangeRectIndex < rangeRects.length; rangeRectIndex++) {
+          rects.push(rangeRects[rangeRectIndex]);
+        }
+      } catch (ex) {}
+    }
+    var visible = rects.filter(function(rect) {
+      return rect.width > 0 || rect.height > 0;
+    });
+    if (!visible.length) {
+      if (typeof range.getBoundingClientRect !== 'function') return null;
+      try {
+        return range.getBoundingClientRect();
+      } catch (ex) {
+        return null;
+      }
+    }
+    var left = Math.min.apply(null, visible.map(function(rect) { return rect.left; }));
+    var top = Math.min.apply(null, visible.map(function(rect) { return rect.top; }));
+    var right = Math.max.apply(null, visible.map(function(rect) { return rect.right; }));
+    var bottom = Math.max.apply(null, visible.map(function(rect) { return rect.bottom; }));
+    return { left: left, top: top, width: right - left, height: bottom - top };
+  }
+
+  function vimReticleSemanticDescriptor(target) {
+    if (!target) return 'TARGET';
+    if (target.kind === 'code') return 'CODE';
+    if (target.kind === 'math') return 'FORMULA';
+    if (target.kind === 'table') return 'TABLE';
+    if (target.kind === 'row') return 'ROW';
+    if (target.kind === 'cell') return 'CELL';
+    return String(target.label || target.kind).split(':')[0].toUpperCase();
+  }
+
+  function vimReticleCursorDescriptor() {
+    if (vimLastActionId === 'moveDown') return 'NEXT LINE';
+    if (vimLastActionId === 'moveUp') return 'PREVIOUS LINE';
+    if (vimLastActionId === 'previousTextBlock') return 'PREVIOUS BLOCK';
+    if (vimLastActionId === 'nextTextBlock') return 'NEXT BLOCK';
+    if (vimLastActionId === 'swapSelectionEnds') return 'SWAPPED ENDS';
+    if (vimLastActionId === 'lineStart') return 'LINE START';
+    if (vimLastActionId === 'lineEnd') return 'LINE END';
+    if (vimLastActionId === 'wordForward') return 'NEXT WORD';
+    if (vimLastActionId === 'wordBackward') return 'PREVIOUS WORD';
+    if (vimLastActionId === 'wordEnd') return 'WORD END';
+    if (vimLastActionId === 'previousTextBlock') return 'PREVIOUS TEXT';
+    if (vimLastActionId === 'nextTextBlock') return 'NEXT TEXT';
+    if (vimLastActionId === 'documentStart') return 'DOCUMENT START';
+    if (vimLastActionId === 'documentEnd') return 'DOCUMENT END';
+    if (vimLastActionId === 'moveOut') {
+      return vimLastActionContext === 'text' || vimLastActionContext === 'visual'
+        ? 'PREVIOUS CHARACTER'
+        : 'TEXT';
+    }
+    if (vimLastActionId === 'refine') {
+      return vimLastActionContext === 'text' || vimLastActionContext === 'visual'
+        ? 'NEXT CHARACTER'
+        : 'INLINE TEXT';
+    }
+    return 'TEXT';
+  }
+
+  function vimReticleVisualDescriptor(blockSelection) {
+    if (blockSelection) return 'BLOCK RANGE';
+    if (vimLastActionId === 'visual') return 'RANGE START';
+    if (vimLastActionId === 'wordForward') return 'NEXT WORD';
+    if (vimLastActionId === 'wordBackward') return 'PREVIOUS WORD';
+    if (vimLastActionId === 'wordEnd') return 'EXACT TOKEN';
+    if (vimLastActionId === 'lineStart') return 'TO LINE START';
+    if (vimLastActionId === 'lineEnd') return 'TO LINE END';
+    if (vimLastActionId === 'moveDown') return 'NEXT LINE';
+    if (vimLastActionId === 'moveUp') return 'PREVIOUS LINE';
+    return 'RANGE';
+  }
+
+  function vimReticleTarget() {
+    var phase = vimPhase;
+    var pinpointEl = vimPinpointEl;
+    var savedRange = null;
+    if (phase === 'action' && vimActionReturn) {
+      phase = vimActionReturn.phase;
+      pinpointEl = vimActionReturn.pinpointEl;
+      savedRange = vimActionReturn.range;
+    }
+
+    if (phase === 'block' || phase === 'inline') {
+      if (!pinpointEl) return null;
+      var graph = buildSemanticTargetGraph();
+      var target = graph.byElement.get(pinpointEl) || null;
+      return {
+        phase: phase,
+        compact: false,
+        rect: pinpointEl.getBoundingClientRect(),
+        label: (phase === 'inline' ? 'INLINE' : 'BLOCK')
+          + ' · ' + vimReticleSemanticDescriptor(target)
+      };
+    }
+
+    var selection = window.getSelection();
+    var range = savedRange;
+    if (!range && selection && selection.rangeCount) {
+      range = selection.getRangeAt(0);
+    }
+    if (!range) return null;
+
+    if (phase === 'text') {
+      var caretRange = range.cloneRange();
+      caretRange.collapse(false);
+      var caretRect = vimRangeRect(caretRange);
+      if (!caretRect) return null;
+      if (!caretRect.height) caretRect.height = 16;
+      if (!caretRect.width) caretRect.width = 1;
+      return {
+        phase: phase,
+        compact: true,
+        rect: caretRect,
+        label: 'CURSOR · ' + vimReticleCursorDescriptor()
+      };
+    }
+
+    if (phase === 'visual' || phase === 'visual-block') {
+      return {
+        phase: phase,
+        compact: false,
+        rect: vimRangeRect(range),
+        label: 'VISUAL · ' + vimReticleVisualDescriptor(phase === 'visual-block')
+      };
+    }
+    return null;
+  }
+
+  function updateVimReticle() {
+    if (!vimHudEnabled || vimPhase === 'inactive') {
+      hideVimReticle();
+      return;
+    }
+    var target = vimReticleTarget();
+    if (!target || !target.rect) {
+      hideVimReticle();
+      return;
+    }
+
+    var rect = target.rect;
+    var paddingX = target.compact ? 10 : 5;
+    var paddingY = target.compact ? 6 : 4;
+    var width = Math.max(44, rect.width + paddingX * 2);
+    var height = Math.max(32, rect.height + paddingY * 2);
+    var left = Math.max(0, rect.left + rect.width / 2 - width / 2);
+    var top = Math.max(0, rect.top + rect.height / 2 - height / 2);
+    var cornerSize = 28;
+    var cornerRight = Math.max(0, width - cornerSize);
+    var cornerBottom = Math.max(0, height - cornerSize);
+    var labelTop = top - 36 >= 4 ? top - 36 : top + height + 6;
+    var reticle = getVimReticleEl();
+    var fill = reticle.querySelector('[data-vim-reticle-fill]');
+    var label = reticle.querySelector('[data-vim-reticle-label]');
+    var topLeft = reticle.querySelector('[data-vim-reticle-corner="top-left"]');
+    var topRight = reticle.querySelector('[data-vim-reticle-corner="top-right"]');
+    var bottomLeft = reticle.querySelector('[data-vim-reticle-corner="bottom-left"]');
+    var bottomRight = reticle.querySelector('[data-vim-reticle-corner="bottom-right"]');
+
+    reticle.style.display = 'block';
+    reticle.setAttribute('data-vim-target-phase', target.phase);
+    reticle.setAttribute('data-vim-target-label', target.label);
+    fill.style.transform = 'translate3d(' + left + 'px,' + top + 'px,0) scale('
+      + (width / 100) + ',' + (height / 100) + ')';
+    topLeft.style.transform = 'translate3d(' + left + 'px,' + top + 'px,0)';
+    topRight.style.transform = 'translate3d(' + (left + cornerRight) + 'px,' + top + 'px,0)';
+    bottomLeft.style.transform = 'translate3d(' + left + 'px,' + (top + cornerBottom) + 'px,0)';
+    bottomRight.style.transform = 'translate3d(' + (left + cornerRight) + 'px,'
+      + (top + cornerBottom) + 'px,0)';
+    label.textContent = target.label;
+    label.style.transform = 'translate3d(' + left + 'px,' + labelTop + 'px,0)';
+  }
+
   function updateVimUi() {
     if (!vimEnabled) return;
-    if (vimHudEnabled) {
+    if (vimHudEnabled && vimLastPostedPhase !== vimPhase) {
+      vimLastPostedPhase = vimPhase;
       parent.postMessage({
         type: PREFIX + 'vim-state',
         phase: vimPhase
@@ -1138,7 +1427,18 @@ export const BRIDGE_SCRIPT = `(function() {
     if (vimPhase === 'inactive') {
       if (badge) badge.style.display = 'none';
       cursor.style.display = 'none';
+      hideVimReticle();
       return;
+    }
+    if (vimHudEnabled) {
+      if (vimPinpointEl) vimPinpointEl.classList.remove('plannotator-pinpoint-hover');
+      hidePinpointLabel();
+      updateVimReticle();
+    } else {
+      hideVimReticle();
+      if (vimPinpointEl && (vimPhase === 'block' || vimPhase === 'inline')) {
+        vimPinpointEl.classList.add('plannotator-pinpoint-hover');
+      }
     }
     if (badge) badge.style.display = vimHudEnabled ? 'none' : 'block';
     var phaseLabel = vimPhase === 'text' ? 'NORMAL' : vimPhase.toUpperCase().replace('-', ' ');
@@ -1168,26 +1468,27 @@ export const BRIDGE_SCRIPT = `(function() {
     }
   }
 
+  var vimUiRaf = 0;
+  function scheduleVimUiUpdate() {
+    if (!vimEnabled || vimPhase === 'inactive' || vimUiRaf) return;
+    vimUiRaf = requestAnimationFrame(function() {
+      vimUiRaf = 0;
+      updateVimUi();
+    });
+  }
+  window.addEventListener('resize', scheduleVimUiUpdate, { passive: true });
+  window.addEventListener('scroll', scheduleVimUiUpdate, { passive: true, capture: true });
+
   function toggleVimHelp() {
     vimHelpOpen = !vimHelpOpen;
-    var existing = document.querySelector('[data-plannotator-vim-help]');
-    if (!vimHelpOpen) {
-      if (existing) existing.remove();
-      return;
-    }
-    if (existing) return;
-    var help = document.createElement('div');
-    help.setAttribute('data-plannotator-vim-help', '');
-    help.setAttribute('data-plannotator-vim-ui', '');
-    help.innerHTML = '<div><strong>Vim controls</strong><p><kbd>j k · gg G</kbd> move between blocks or refined siblings · <kbd>h l · Esc</kbd> move out, refine, or back out · <kbd>v / V</kbd> select text or whole blocks · <kbd>h j k l · w b e · 0 $</kbd> move after entering text · <kbd>Enter</kbd> active annotation · <kbd>Space · c d m t y</kbd> actions · <kbd>?</kbd> help</p></div>';
-    help.addEventListener('mousedown', function(e) {
-      if (e.target === help) toggleVimHelp();
-    });
-    document.body.appendChild(help);
+    parent.postMessage({
+      type: PREFIX + 'vim-help',
+      open: vimHelpOpen
+    }, '*');
   }
 
   function clearVimUi() {
-    var nodes = document.querySelectorAll('[data-plannotator-vim-cursor],[data-plannotator-vim-badge],[data-plannotator-vim-help]');
+    var nodes = document.querySelectorAll('[data-plannotator-vim-cursor],[data-plannotator-vim-badge],[data-plannotator-vim-reticle]');
     for (var i = 0; i < nodes.length; i++) nodes[i].remove();
     if (vimPinpointEl) vimPinpointEl.classList.remove('plannotator-pinpoint-hover');
     vimVisualBlockAnchorEl = null;
@@ -1484,6 +1785,9 @@ export const BRIDGE_SCRIPT = `(function() {
 
     if (handled) {
       if (vimHudEnabled && vimActionId) {
+        vimLastActionId = vimActionId;
+        vimLastActionContext = vimCommandContext;
+        updateVimReticle();
         parent.postMessage({
           type: PREFIX + 'vim-command',
           actionId: vimActionId,
@@ -1670,7 +1974,10 @@ export const BRIDGE_SCRIPT = `(function() {
 
   function onReady() {
     if (typeof ResizeObserver !== 'undefined' && document.body) {
-      new ResizeObserver(postResize).observe(document.body);
+      new ResizeObserver(function() {
+        postResize();
+        scheduleVimUiUpdate();
+      }).observe(document.body);
     }
     parent.postMessage({ type: PREFIX + 'ready' }, '*');
   }

--- a/packages/ui/components/html-viewer/bridge-script.ts
+++ b/packages/ui/components/html-viewer/bridge-script.ts
@@ -321,7 +321,15 @@ export const BRIDGE_SCRIPT = `(function() {
         // Text selections wrap a <mark>; element pinpoints (e.g. SVG nodes) carry
         // no range, so there's no inline mark to apply — the annotation is still
         // captured on the parent side from the posted text.
-        if (pendingSelection.startContainerPath) applyMark(id, annType, pendingSelection);
+        if (pendingSelection.startContainerPath) {
+          applyMark(id, annType, pendingSelection);
+          if (
+            vimActionReturn
+            && (vimActionReturn.phase === 'visual' || vimActionReturn.phase === 'visual-block')
+          ) {
+            vimActionReturn.range = committedMarkRange(id) || vimActionReturn.range;
+          }
+        }
         pendingSelection = null;
         pendingRange = null;
         window.getSelection().removeAllRanges();
@@ -1140,6 +1148,21 @@ export const BRIDGE_SCRIPT = `(function() {
     };
   }
 
+  function committedMarkRange(id) {
+    var marks = document.querySelectorAll('[data-bind-id="' + id + '"]');
+    if (!marks.length) return null;
+    var first = marks[0];
+    var last = marks[marks.length - 1];
+    var range = document.createRange();
+    try {
+      range.setStart(first, 0);
+      range.setEnd(last, last.childNodes.length);
+      return range;
+    } catch (ex) {
+      return null;
+    }
+  }
+
   function beginVimAction(mode) {
     if (mode === 'redline' && vimActionReturn) {
       if (vimActionReturn.phase === 'visual') {
@@ -1504,13 +1527,10 @@ export const BRIDGE_SCRIPT = `(function() {
 
   function copyVimText(text) {
     if (!text) return;
-    var textarea = document.createElement('textarea');
-    textarea.value = text;
-    textarea.style.cssText = 'position:fixed;opacity:0';
-    document.body.appendChild(textarea);
-    textarea.select();
-    document.execCommand('copy');
-    textarea.remove();
+    parent.postMessage({
+      type: PREFIX + 'vim-copy',
+      text: text
+    }, '*');
   }
 
   function vimActionMode(key) {

--- a/packages/ui/components/html-viewer/srcdoc.test.ts
+++ b/packages/ui/components/html-viewer/srcdoc.test.ts
@@ -89,6 +89,11 @@ describe("viewer CSS/script namespace", () => {
   test("annotation CSS reads only --pn- variables", () => {
     expect(ANNOTATION_HIGHLIGHT_CSS).toContain("var(--pn-");
     expect(/var\(--(?!pn-)/.test(ANNOTATION_HIGHLIGHT_CSS)).toBe(false);
+    expect(ANNOTATION_HIGHLIGHT_CSS).toContain("[data-plannotator-vim-reticle]");
+    expect(ANNOTATION_HIGHLIGHT_CSS).toContain("@media (prefers-reduced-motion: reduce)");
+    expect(BRIDGE_SCRIPT).toContain("return 'PREVIOUS BLOCK'");
+    expect(BRIDGE_SCRIPT).toContain("return 'NEXT BLOCK'");
+    expect(BRIDGE_SCRIPT).toContain("return 'SWAPPED ENDS'");
   });
 
   test("bridge script reads only --pn- variables and guards bare writes", () => {
@@ -124,6 +129,13 @@ describe("hasHostThemeOptIn", () => {
 // opted in to host theming. Requires DOM_TESTS=1 (happy-dom preload).
 const hasDom = typeof document !== "undefined";
 describe.if(hasDom)("bridge theme handler (DOM)", () => {
+  function bridgeMessageData(event: MessageEvent): Record<string, unknown> | null {
+    if (!event.data || typeof event.data !== "object") return null;
+    return event.data instanceof Object
+      ? Object.fromEntries(Object.entries(event.data))
+      : null;
+  }
+
   beforeAll(() => {
     new Function(BRIDGE_SCRIPT)();
   });
@@ -217,13 +229,8 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
 
     const bridgeMessages: Array<Record<string, unknown>> = [];
     const capture = (event: MessageEvent) => {
-      if (
-        event.data
-        && typeof event.data === "object"
-        && (event.data as { type?: string }).type === "plannotator-bridge-selection"
-      ) {
-        bridgeMessages.push(event.data as Record<string, unknown>);
-      }
+      const data = bridgeMessageData(event);
+      if (data?.type === "plannotator-bridge-selection") bridgeMessages.push(data);
     };
     window.addEventListener("message", capture);
     const comment = new KeyboardEvent("keydown", {
@@ -484,13 +491,17 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.innerHTML = "<h1>First block</h1><p>Second block</p>";
     const hudMessages: Array<Record<string, unknown>> = [];
     const capture = (event: MessageEvent) => {
+      const data = bridgeMessageData(event);
       if (
-        event.data
-        && typeof event.data === "object"
-        && ["plannotator-bridge-vim-command", "plannotator-bridge-vim-state"]
-          .includes((event.data as { type?: string }).type ?? "")
+        data
+        && [
+          "plannotator-bridge-vim-command",
+          "plannotator-bridge-vim-state",
+          "plannotator-bridge-vim-help",
+        ]
+          .includes(typeof data.type === "string" ? data.type : "")
       ) {
-        hudMessages.push(event.data as Record<string, unknown>);
+        hudMessages.push(data);
       }
     };
     window.addEventListener("message", capture);
@@ -531,7 +542,6 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       cancelable: true,
     }));
     await new Promise<void>((resolve) => setTimeout(resolve, 0));
-    window.removeEventListener("message", capture);
 
     expect(document.querySelector("[data-plannotator-vim-badge]")).toBeNull();
     expect(hudMessages).toContainEqual({
@@ -544,11 +554,60 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       key: "j",
       context: "block",
     });
+    const reticle = document.querySelector<HTMLElement>(
+      "[data-plannotator-vim-reticle]",
+    );
+    expect(reticle).not.toBeNull();
+    expect(reticle?.dataset.vimTargetPhase).toBe("block");
+    expect(reticle?.dataset.vimTargetLabel).toBe("BLOCK · PARAGRAPH");
+    expect(reticle?.querySelectorAll("[data-vim-reticle-corner]")).toHaveLength(4);
+    expect(document.querySelector(".plannotator-pinpoint-hover")).toBeNull();
+
+    document.body.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "?",
+      bubbles: true,
+      cancelable: true,
+    }));
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    expect(hudMessages).toContainEqual({
+      type: "plannotator-bridge-vim-help",
+      open: true,
+    });
+    expect(document.querySelector("[data-plannotator-vim-help]")).toBeNull();
+
+    postBridge({
+      type: "plannotator-bridge-set-vim-help",
+      open: false,
+    });
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    expect(hudMessages).toContainEqual({
+      type: "plannotator-bridge-vim-help",
+      open: false,
+    });
+
+    document.body.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "l",
+      bubbles: true,
+      cancelable: true,
+    }));
+    expect(reticle?.dataset.vimTargetPhase).toBe("text");
+    expect(reticle?.dataset.vimTargetLabel).toBe("CURSOR · INLINE TEXT");
+
+    for (const key of ["v", "e"]) {
+      document.body.dispatchEvent(new KeyboardEvent("keydown", {
+        key,
+        bubbles: true,
+        cancelable: true,
+      }));
+    }
+    expect(reticle?.dataset.vimTargetPhase).toBe("visual");
+    expect(reticle?.dataset.vimTargetLabel).toBe("VISUAL · EXACT TOKEN");
 
     postBridge({
       type: "plannotator-bridge-set-vim-mode",
       enabled: false,
     });
+    window.removeEventListener("message", capture);
     document.body.replaceChildren();
   });
 });

--- a/packages/ui/components/html-viewer/srcdoc.test.ts
+++ b/packages/ui/components/html-viewer/srcdoc.test.ts
@@ -217,6 +217,16 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     expect(document.querySelector("[data-plannotator-vim-badge]")?.textContent)
       .toBe("BLOCK · PINPOINT");
 
+    const tab = new KeyboardEvent("keydown", {
+      key: "Tab",
+      bubbles: true,
+      cancelable: true,
+    });
+    document.body.dispatchEvent(tab);
+    expect(tab.defaultPrevented).toBe(false);
+    expect(document.querySelector(".plannotator-pinpoint-hover")?.textContent)
+      .toBe("Keyboard document");
+
     const move = new KeyboardEvent("keydown", {
       key: "j",
       bubbles: true,
@@ -608,6 +618,144 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       enabled: false,
     });
     window.removeEventListener("message", capture);
+    document.body.replaceChildren();
+  });
+
+  test("routes Vim yank text to the trusted parent without sandbox clipboard access", async () => {
+    document.body.innerHTML = "<h1>Keyboard review fixture</h1><p>After</p>";
+    const copyMessages: Array<Record<string, unknown>> = [];
+    const capture = (event: MessageEvent) => {
+      const data = bridgeMessageData(event);
+      if (data?.type === "plannotator-bridge-vim-copy") {
+        copyMessages.push(data);
+      }
+    };
+    window.addEventListener("message", capture);
+
+    postBridge({
+      type: "plannotator-bridge-set-vim-mode",
+      enabled: true,
+      hudEnabled: true,
+    });
+    postBridge({ type: "plannotator-bridge-focus-vim" });
+    for (const key of ["V", "y"]) {
+      document.body.dispatchEvent(new KeyboardEvent("keydown", {
+        key,
+        bubbles: true,
+        cancelable: true,
+      }));
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    window.removeEventListener("message", capture);
+
+    expect(copyMessages).toContainEqual({
+      type: "plannotator-bridge-vim-copy",
+      text: "Keyboard review fixture",
+    });
+    const reticle = document.querySelector<HTMLElement>(
+      "[data-plannotator-vim-reticle]",
+    );
+    expect(reticle?.dataset.vimTargetPhase).toBe("block");
+    expect(reticle?.dataset.vimTargetLabel).toBe("BLOCK · HEADING");
+
+    postBridge({
+      type: "plannotator-bridge-set-vim-mode",
+      enabled: false,
+    });
+    document.body.replaceChildren();
+  });
+
+  test("restores the committed Visual range after annotation markup mutates the DOM", () => {
+    postBridge({
+      type: "plannotator-bridge-set-vim-mode",
+      enabled: false,
+    });
+    document.body.innerHTML = "<p>Alpha bravo charlie</p>";
+    postBridge({
+      type: "plannotator-bridge-set-input-method",
+      method: "drag",
+    });
+    postBridge({
+      type: "plannotator-bridge-set-vim-mode",
+      enabled: true,
+      hudEnabled: false,
+    });
+    postBridge({ type: "plannotator-bridge-focus-vim" });
+
+    for (const key of ["v", "w", "c"]) {
+      document.body.dispatchEvent(new KeyboardEvent("keydown", {
+        key,
+        bubbles: true,
+        cancelable: true,
+      }));
+    }
+    expect(document.querySelector("[data-plannotator-vim-badge]")?.textContent)
+      .toBe("ACTION · SELECT");
+
+    postBridge({
+      type: "plannotator-bridge-create-mark",
+      id: "vim-committed-range",
+      annotationType: "comment",
+    });
+
+    expect(document.querySelector("[data-plannotator-vim-badge]")?.textContent)
+      .toBe("VISUAL · SELECT");
+    expect(window.getSelection()?.toString()).toBe("Alpha ");
+    expect(
+      document.querySelector('[data-bind-id="vim-committed-range"]')?.textContent,
+    ).toBe("Alpha ");
+
+    postBridge({
+      type: "plannotator-bridge-set-vim-mode",
+      enabled: false,
+    });
+    document.body.replaceChildren();
+  });
+
+  test("restores a whole-block Visual range after annotation markup mutates the DOM", () => {
+    postBridge({
+      type: "plannotator-bridge-set-vim-mode",
+      enabled: false,
+    });
+    document.body.innerHTML = "<p>Whole block target</p><p>After</p>";
+    postBridge({
+      type: "plannotator-bridge-set-input-method",
+      method: "drag",
+    });
+    postBridge({
+      type: "plannotator-bridge-set-vim-mode",
+      enabled: true,
+      hudEnabled: false,
+    });
+    postBridge({ type: "plannotator-bridge-focus-vim" });
+
+    for (const key of ["V", "c"]) {
+      document.body.dispatchEvent(new KeyboardEvent("keydown", {
+        key,
+        bubbles: true,
+        cancelable: true,
+      }));
+    }
+    expect(document.querySelector("[data-plannotator-vim-badge]")?.textContent)
+      .toBe("ACTION · SELECT");
+
+    postBridge({
+      type: "plannotator-bridge-create-mark",
+      id: "vim-committed-block-range",
+      annotationType: "comment",
+    });
+
+    expect(document.querySelector("[data-plannotator-vim-badge]")?.textContent)
+      .toBe("VISUAL BLOCK · SELECT");
+    expect(window.getSelection()?.toString()).toBe("Whole block target");
+    expect(
+      document.querySelector('[data-bind-id="vim-committed-block-range"]')?.textContent,
+    ).toBe("Whole block target");
+
+    postBridge({
+      type: "plannotator-bridge-set-vim-mode",
+      enabled: false,
+    });
     document.body.replaceChildren();
   });
 });

--- a/packages/ui/components/html-viewer/srcdoc.test.ts
+++ b/packages/ui/components/html-viewer/srcdoc.test.ts
@@ -11,7 +11,7 @@
  * These tests are the mutation guard: reintroducing any bare-token injection
  * for non-opted-in documents must go red here.
  */
-import { describe, expect, test } from "bun:test";
+import { beforeAll, describe, expect, test } from "bun:test";
 import { ANNOTATION_HIGHLIGHT_CSS, BRIDGE_SCRIPT } from "./bridge-script";
 import {
   DIFF_HIGHLIGHT_CSS,
@@ -124,19 +124,24 @@ describe("hasHostThemeOptIn", () => {
 // opted in to host theming. Requires DOM_TESTS=1 (happy-dom preload).
 const hasDom = typeof document !== "undefined";
 describe.if(hasDom)("bridge theme handler (DOM)", () => {
-  function postTheme(data: Record<string, unknown>) {
+  beforeAll(() => {
+    new Function(BRIDGE_SCRIPT)();
+  });
+
+  function postBridge(data: Record<string, unknown>) {
     window.dispatchEvent(
       new MessageEvent("message", {
-        data: { type: "plannotator-bridge-theme", ...data },
+        data,
+        source: window,
       }),
     );
   }
 
   test("author root only receives --pn-* on theme flip; opt-in restores bare push", () => {
-    new Function(BRIDGE_SCRIPT)();
     const root = document.documentElement;
 
-    postTheme({
+    postBridge({
+      type: "plannotator-bridge-theme",
       tokens: { "--pn-muted": "red", "--muted": "blue" },
       isLight: true,
       hostTheme: false,
@@ -145,7 +150,8 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     expect(root.style.getPropertyValue("--muted")).toBe("");
     expect(root.classList.contains("light")).toBe(false);
 
-    postTheme({
+    postBridge({
+      type: "plannotator-bridge-theme",
       tokens: { "--pn-muted": "red", "--muted": "blue" },
       isLight: true,
       hostTheme: true,
@@ -156,6 +162,322 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     root.style.removeProperty("--pn-muted");
     root.style.removeProperty("--muted");
     root.classList.remove("light");
+  });
+
+  test("Vim navigation is block-first, focus-safe, and posts through the normal selection protocol", async () => {
+    document.body.innerHTML = [
+      "<h1>Keyboard document</h1>",
+      "<p>First paragraph</p>",
+      "<p>Second paragraph</p>",
+      '<a href="#destination">Native link</a>',
+      '<input value="native typing">',
+    ].join("");
+
+    postBridge({
+      type: "plannotator-bridge-set-input-method",
+      method: "pinpoint",
+    });
+    postBridge({
+      type: "plannotator-bridge-set-vim-mode",
+      enabled: false,
+    });
+
+    const disabledMove = new KeyboardEvent("keydown", {
+      key: "j",
+      bubbles: true,
+      cancelable: true,
+    });
+    document.body.dispatchEvent(disabledMove);
+    expect(disabledMove.defaultPrevented).toBe(false);
+    expect(document.querySelector("[data-plannotator-vim-badge]")).toBeNull();
+
+    postBridge({
+      type: "plannotator-bridge-set-vim-mode",
+      enabled: true,
+    });
+    postBridge({
+      type: "plannotator-bridge-focus-vim",
+    });
+    expect(document.body.getAttribute("tabindex")).toBe("-1");
+    expect(document.body.hasAttribute("data-plannotator-vim-focus-owner")).toBe(true);
+    const initial = document.querySelector(".plannotator-pinpoint-hover");
+    expect(initial?.textContent).toBe("Keyboard document");
+    expect(document.querySelector("[data-plannotator-vim-badge]")?.textContent)
+      .toBe("BLOCK · PINPOINT");
+
+    const move = new KeyboardEvent("keydown", {
+      key: "j",
+      bubbles: true,
+      cancelable: true,
+    });
+    document.body.dispatchEvent(move);
+    expect(move.defaultPrevented).toBe(true);
+    expect(document.querySelector(".plannotator-pinpoint-hover")?.textContent)
+      .toBe("First paragraph");
+
+    const bridgeMessages: Array<Record<string, unknown>> = [];
+    const capture = (event: MessageEvent) => {
+      if (
+        event.data
+        && typeof event.data === "object"
+        && (event.data as { type?: string }).type === "plannotator-bridge-selection"
+      ) {
+        bridgeMessages.push(event.data as Record<string, unknown>);
+      }
+    };
+    window.addEventListener("message", capture);
+    const comment = new KeyboardEvent("keydown", {
+      key: "c",
+      bubbles: true,
+      cancelable: true,
+    });
+    document.body.dispatchEvent(comment);
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    window.removeEventListener("message", capture);
+    expect(comment.defaultPrevented).toBe(true);
+    expect(bridgeMessages.at(-1)).toMatchObject({
+      type: "plannotator-bridge-selection",
+      text: "First paragraph",
+      modeOverride: "comment",
+    });
+
+    const input = document.querySelector<HTMLInputElement>("input");
+    if (!input) throw new Error("Missing bridge input fixture");
+    const typing = new KeyboardEvent("keydown", {
+      key: "d",
+      bubbles: true,
+      cancelable: true,
+    });
+    input.dispatchEvent(typing);
+    expect(typing.defaultPrevented).toBe(false);
+
+    const link = document.querySelector<HTMLAnchorElement>("a");
+    if (!link) throw new Error("Missing bridge link fixture");
+    const activateLink = new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+    });
+    link.dispatchEvent(activateLink);
+    expect(activateLink.defaultPrevented).toBe(false);
+
+    postBridge({
+      type: "plannotator-bridge-cancel-selection",
+    });
+    document.body.innerHTML = [
+      "<table><tbody>",
+      "<tr><td>A1</td><td>A2</td></tr>",
+      "<tr><td>B1</td><td>B2</td></tr>",
+      "</tbody></table>",
+      "<p>After table</p>",
+    ].join("");
+    postBridge({
+      type: "plannotator-bridge-set-input-method",
+      method: "pinpoint",
+    });
+    for (const key of ["l", "l"]) {
+      document.body.dispatchEvent(new KeyboardEvent("keydown", {
+        key,
+        bubbles: true,
+        cancelable: true,
+      }));
+    }
+    const a1 = document.querySelector(".plannotator-pinpoint-hover");
+    expect(a1?.tagName).toBe("TD");
+    expect(a1?.textContent).toBe("A1");
+    document.body.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "j",
+      bubbles: true,
+      cancelable: true,
+    }));
+    expect(document.querySelector(".plannotator-pinpoint-hover")?.textContent).toBe("A2");
+    document.body.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "h",
+      bubbles: true,
+      cancelable: true,
+    }));
+    expect(document.querySelector(".plannotator-pinpoint-hover")?.tagName).toBe("TR");
+    document.body.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "j",
+      bubbles: true,
+      cancelable: true,
+    }));
+    expect(document.querySelector(".plannotator-pinpoint-hover")?.textContent).toBe("B1B2");
+    document.body.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "h",
+      bubbles: true,
+      cancelable: true,
+    }));
+    expect(document.querySelector(".plannotator-pinpoint-hover")?.tagName).toBe("TABLE");
+    document.body.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "j",
+      bubbles: true,
+      cancelable: true,
+    }));
+    expect(document.querySelector(".plannotator-pinpoint-hover")?.textContent)
+      .toBe("After table");
+
+    postBridge({
+      type: "plannotator-bridge-set-vim-mode",
+      enabled: false,
+    });
+    document.body.innerHTML = "<p>Alpha <strong>bravo</strong> charlie</p>";
+    postBridge({
+      type: "plannotator-bridge-set-vim-mode",
+      enabled: true,
+    });
+    postBridge({
+      type: "plannotator-bridge-focus-vim",
+    });
+    document.body.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "l",
+      bubbles: true,
+      cancelable: true,
+    }));
+    expect(document.querySelector(".plannotator-pinpoint-hover")?.tagName).toBe("STRONG");
+    document.body.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "v",
+      bubbles: true,
+      cancelable: true,
+    }));
+    for (const key of ["w", "e"]) {
+      document.body.dispatchEvent(new KeyboardEvent("keydown", {
+        key,
+        bubbles: true,
+        cancelable: true,
+      }));
+      expect(window.getSelection()?.toString()).toBe("bravo");
+    }
+
+    postBridge({
+      type: "plannotator-bridge-set-vim-mode",
+      enabled: false,
+    });
+    document.body.innerHTML = "<p>Alpha bravo charlie</p>";
+    postBridge({
+      type: "plannotator-bridge-set-input-method",
+      method: "drag",
+    });
+    postBridge({
+      type: "plannotator-bridge-set-vim-mode",
+      enabled: true,
+    });
+    postBridge({
+      type: "plannotator-bridge-focus-vim",
+    });
+    const visual = new KeyboardEvent("keydown", {
+      key: "v",
+      bubbles: true,
+      cancelable: true,
+    });
+    document.body.dispatchEvent(visual);
+    const word = new KeyboardEvent("keydown", {
+      key: "w",
+      bubbles: true,
+      cancelable: true,
+    });
+    document.body.dispatchEvent(word);
+    expect(window.getSelection()?.toString()).toBe("Alpha ");
+    const action = new KeyboardEvent("keydown", {
+      key: " ",
+      bubbles: true,
+      cancelable: true,
+    });
+    document.body.dispatchEvent(action);
+    expect(document.querySelector("[data-plannotator-vim-badge]")?.textContent)
+      .toBe("ACTION · SELECT");
+
+    postBridge({
+      type: "plannotator-bridge-cancel-selection",
+    });
+    expect(document.querySelector("[data-plannotator-vim-badge]")?.textContent)
+      .toBe("VISUAL · SELECT");
+    expect(window.getSelection()?.toString()).toBe("Alpha ");
+
+    postBridge({
+      type: "plannotator-bridge-set-vim-mode",
+      enabled: false,
+    });
+    document.body.innerHTML = "<p>Collapsed text target</p>";
+    postBridge({
+      type: "plannotator-bridge-set-vim-mode",
+      enabled: true,
+    });
+    postBridge({
+      type: "plannotator-bridge-focus-vim",
+    });
+    document.body.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "l",
+      bubbles: true,
+      cancelable: true,
+    }));
+    const collapsedAction = new KeyboardEvent("keydown", {
+      key: "c",
+      bubbles: true,
+      cancelable: true,
+    });
+    document.body.dispatchEvent(collapsedAction);
+    expect(collapsedAction.defaultPrevented).toBe(false);
+    const collapsedCopy = new KeyboardEvent("keydown", {
+      key: "y",
+      bubbles: true,
+      cancelable: true,
+    });
+    document.body.dispatchEvent(collapsedCopy);
+    expect(collapsedCopy.defaultPrevented).toBe(false);
+    expect(document.querySelector("[data-plannotator-vim-badge]")?.textContent)
+      .toBe("NORMAL · SELECT");
+    document.body.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "Escape",
+      bubbles: true,
+      cancelable: true,
+    }));
+    document.body.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "Escape",
+      bubbles: true,
+      cancelable: true,
+    }));
+    const inactiveEscape = new KeyboardEvent("keydown", {
+      key: "Escape",
+      bubbles: true,
+      cancelable: true,
+    });
+    document.body.dispatchEvent(inactiveEscape);
+    expect(inactiveEscape.defaultPrevented).toBe(false);
+
+    postBridge({
+      type: "plannotator-bridge-set-vim-mode",
+      enabled: false,
+    });
+    document.body.innerHTML = "<p>Block one</p><p>Block two</p>";
+    postBridge({
+      type: "plannotator-bridge-set-vim-mode",
+      enabled: true,
+    });
+    postBridge({
+      type: "plannotator-bridge-focus-vim",
+    });
+    for (const key of ["V", "j"]) {
+      document.body.dispatchEvent(new KeyboardEvent("keydown", {
+        key,
+        bubbles: true,
+        cancelable: true,
+      }));
+    }
+    expect(window.getSelection()?.toString()).toContain("Block two");
+    document.body.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "k",
+      bubbles: true,
+      cancelable: true,
+    }));
+    expect(window.getSelection()?.toString()).toBe("Block one");
+
+    postBridge({
+      type: "plannotator-bridge-set-vim-mode",
+      enabled: false,
+    });
+    expect(document.body.hasAttribute("tabindex")).toBe(false);
+    document.body.replaceChildren();
   });
 });
 

--- a/packages/ui/components/html-viewer/srcdoc.test.ts
+++ b/packages/ui/components/html-viewer/srcdoc.test.ts
@@ -479,6 +479,78 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     expect(document.body.hasAttribute("tabindex")).toBe(false);
     document.body.replaceChildren();
   });
+
+  test("Vim HUD mode suppresses the iframe badge and emits handled command DTOs", async () => {
+    document.body.innerHTML = "<h1>First block</h1><p>Second block</p>";
+    const hudMessages: Array<Record<string, unknown>> = [];
+    const capture = (event: MessageEvent) => {
+      if (
+        event.data
+        && typeof event.data === "object"
+        && ["plannotator-bridge-vim-command", "plannotator-bridge-vim-state"]
+          .includes((event.data as { type?: string }).type ?? "")
+      ) {
+        hudMessages.push(event.data as Record<string, unknown>);
+      }
+    };
+    window.addEventListener("message", capture);
+
+    postBridge({
+      type: "plannotator-bridge-set-vim-mode",
+      enabled: true,
+      hudEnabled: false,
+    });
+    postBridge({ type: "plannotator-bridge-focus-vim" });
+    document.body.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "j",
+      bubbles: true,
+      cancelable: true,
+    }));
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    expect(hudMessages).toEqual([]);
+    expect(document.querySelector("[data-plannotator-vim-badge]")).not.toBeNull();
+
+    postBridge({
+      type: "plannotator-bridge-set-vim-mode",
+      enabled: false,
+    });
+    document.body.innerHTML = "<h1>First block</h1><p>Second block</p>";
+    postBridge({
+      type: "plannotator-bridge-set-input-method",
+      method: "pinpoint",
+    });
+    postBridge({
+      type: "plannotator-bridge-set-vim-mode",
+      enabled: true,
+      hudEnabled: true,
+    });
+    postBridge({ type: "plannotator-bridge-focus-vim" });
+    document.body.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "j",
+      bubbles: true,
+      cancelable: true,
+    }));
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    window.removeEventListener("message", capture);
+
+    expect(document.querySelector("[data-plannotator-vim-badge]")).toBeNull();
+    expect(hudMessages).toContainEqual({
+      type: "plannotator-bridge-vim-state",
+      phase: "block",
+    });
+    expect(hudMessages).toContainEqual({
+      type: "plannotator-bridge-vim-command",
+      actionId: "moveDown",
+      key: "j",
+      context: "block",
+    });
+
+    postBridge({
+      type: "plannotator-bridge-set-vim-mode",
+      enabled: false,
+    });
+    document.body.replaceChildren();
+  });
 });
 
 describe("injectIntoHead", () => {

--- a/packages/ui/components/html-viewer/useHtmlAnnotation.ts
+++ b/packages/ui/components/html-viewer/useHtmlAnnotation.ts
@@ -21,21 +21,26 @@ function nextHtmlAnnId(): string {
 interface BridgeSelectionMessage {
   type: `${typeof PREFIX}selection`;
   text: string;
-  rect: { top: number; left: number; width: number; height: number };
+  rect: BridgeRect;
+  modeOverride?: EditorMode;
 }
 
-interface BridgeMarkClickMessage {
-  type: `${typeof PREFIX}mark-click`;
-  id: string;
-}
-
-interface BridgeResizeMessage {
-  type: `${typeof PREFIX}resize`;
+interface BridgeRect {
+  top: number;
+  left: number;
+  width: number;
   height: number;
 }
 
-type BridgeMessage = BridgeSelectionMessage | BridgeMarkClickMessage | BridgeResizeMessage | { type: string };
+type BridgeMessage =
+  | BridgeSelectionMessage
+  | { type: `${typeof PREFIX}selection-clear` }
+  | { type: `${typeof PREFIX}selection-rect`; rect: BridgeRect }
+  | { type: `${typeof PREFIX}keytype`; key: string }
+  | { type: `${typeof PREFIX}mark-click`; id: string }
+  | { type: `${typeof PREFIX}resize`; height: number };
 
+/** Dependencies and callbacks for the sandboxed HTML annotation bridge. */
 export interface UseHtmlAnnotationOptions {
   iframeRef: RefObject<HTMLIFrameElement | null>;
   annotations: Annotation[];
@@ -50,6 +55,73 @@ function postToIframe(iframe: HTMLIFrameElement | null, msg: Record<string, unkn
   iframe?.contentWindow?.postMessage(msg, "*");
 }
 
+function parseEditorMode(value: unknown): EditorMode | undefined {
+  return value === "selection"
+    || value === "comment"
+    || value === "redline"
+    || value === "quickLabel"
+    ? value
+    : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parseBridgeRect(value: unknown): BridgeRect | null {
+  if (!isRecord(value)) return null;
+  const { top, left, width, height } = value;
+  return typeof top === "number" && Number.isFinite(top)
+    && typeof left === "number" && Number.isFinite(left)
+    && typeof width === "number" && Number.isFinite(width)
+    && typeof height === "number" && Number.isFinite(height)
+    ? { top, left, width, height }
+    : null;
+}
+
+function parseBridgeMessage(value: unknown): BridgeMessage | null {
+  if (!isRecord(value) || typeof value.type !== "string") return null;
+
+  switch (value.type) {
+    case `${PREFIX}selection`: {
+      const rect = parseBridgeRect(value.rect);
+      if (typeof value.text !== "string" || !rect) return null;
+      return {
+        type: value.type,
+        text: value.text,
+        rect,
+        modeOverride: parseEditorMode(value.modeOverride),
+      };
+    }
+    case `${PREFIX}selection-clear`:
+      return { type: value.type };
+    case `${PREFIX}selection-rect`: {
+      const rect = parseBridgeRect(value.rect);
+      return rect ? { type: value.type, rect } : null;
+    }
+    case `${PREFIX}keytype`:
+      return typeof value.key === "string"
+        ? { type: value.type, key: value.key }
+        : null;
+    case `${PREFIX}mark-click`:
+      return typeof value.id === "string"
+        ? { type: value.type, id: value.id }
+        : null;
+    case `${PREFIX}resize`:
+      return typeof value.height === "number" && Number.isFinite(value.height)
+        ? { type: value.type, height: value.height }
+        : null;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Adapt source-validated iframe messages to the existing annotation UI.
+ *
+ * Malformed bridge payloads are ignored; annotations are posted back through
+ * the iframe protocol and reported through the supplied callbacks.
+ */
 export function useHtmlAnnotation({
   iframeRef,
   onAddAnnotation,
@@ -57,7 +129,10 @@ export function useHtmlAnnotation({
   selectedAnnotationId,
   mode,
   onResize,
-}: UseHtmlAnnotationOptions): Omit<UseAnnotationHighlighterReturn, "highlighterRef"> {
+}: UseHtmlAnnotationOptions): Omit<
+  UseAnnotationHighlighterReturn,
+  "highlighterRef" | "highlightRange" | "highlightMathElement"
+> {
   const [toolbarState, setToolbarState] = useState<ToolbarState | null>(null);
   const [commentPopover, setCommentPopover] = useState<CommentPopoverState | null>(null);
   const [quickLabelPicker, setQuickLabelPicker] = useState<QuickLabelPickerState | null>(null);
@@ -115,18 +190,19 @@ export function useHtmlAnnotation({
   );
 
   useEffect(() => {
-    function handler(e: MessageEvent<BridgeMessage>) {
-      if (!e.data || typeof e.data.type !== "string" || !e.data.type.startsWith(PREFIX)) return;
+    function handler(e: MessageEvent<unknown>) {
+      if (e.source !== iframeRef.current?.contentWindow) return;
+      const message = parseBridgeMessage(e.data);
+      if (!message) return;
 
-      const type = e.data.type;
+      const type = message.type;
 
       if (type === `${PREFIX}selection`) {
-        const msg = e.data as BridgeSelectionMessage;
-        pendingTextRef.current = msg.text;
-        const anchor = positionAnchor(msg.rect);
+        pendingTextRef.current = message.text;
+        const anchor = positionAnchor(message.rect);
         if (!anchor) return;
 
-        const currentMode = modeRef.current;
+        const currentMode = message.modeOverride ?? modeRef.current;
 
         if (currentMode === "redline") {
           const id = nextHtmlAnnId();
@@ -137,7 +213,7 @@ export function useHtmlAnnotation({
             startOffset: 0,
             endOffset: 0,
             type: AnnotationType.DELETION,
-            originalText: msg.text,
+            originalText: message.text,
             author: getIdentity(),
             createdA: Date.now(),
           });
@@ -148,8 +224,8 @@ export function useHtmlAnnotation({
           iframeRef.current?.blur();
           setCommentPopover({
             anchorEl: anchor,
-            contextText: msg.text,
-            selectedText: msg.text,
+            contextText: message.text,
+            selectedText: message.text,
           });
         } else if (currentMode === "quickLabel") {
           setQuickLabelPicker({
@@ -160,7 +236,7 @@ export function useHtmlAnnotation({
           setToolbarState({
             element: anchor,
             source: null,
-            selectionText: msg.text,
+            selectionText: message.text,
           });
         }
       }
@@ -182,7 +258,7 @@ export function useHtmlAnnotation({
         const iframe = iframeRef.current;
         const anchor = anchorRef.current;
         if (!iframe || !anchor) return;
-        const r = (e.data as unknown as { rect: { top: number; left: number; width: number; height: number } }).rect;
+        const r = message.rect;
         const iframeRect = iframe.getBoundingClientRect();
         anchor.style.top = `${iframeRect.top + r.top}px`;
         anchor.style.left = `${iframeRect.left + r.left + r.width / 2}px`;
@@ -194,7 +270,7 @@ export function useHtmlAnnotation({
         // markdown path, where AnnotationToolbar owns this keydown). Open a comment
         // pre-filled with the typed char.
         if (!toolbarStateRef.current) return;
-        const key = (e.data as { key?: string }).key;
+        const key = message.key;
         const text = pendingTextRef.current;
         if (!key || !text) return;
         const anchor = anchorRef.current ?? getOrCreateAnchor();
@@ -206,13 +282,11 @@ export function useHtmlAnnotation({
       }
 
       if (type === `${PREFIX}mark-click`) {
-        const msg = e.data as BridgeMarkClickMessage;
-        onSelectRef.current?.(msg.id);
+        onSelectRef.current?.(message.id);
       }
 
       if (type === `${PREFIX}resize`) {
-        const msg = e.data as BridgeResizeMessage;
-        onResize?.(msg.height);
+        onResize?.(message.height);
       }
     }
 
@@ -304,14 +378,16 @@ export function useHtmlAnnotation({
   );
 
   const handleCommentClose = useCallback(() => {
+    postToIframe(iframeRef.current, { type: `${PREFIX}cancel-selection` });
     setCommentPopover(null);
     pendingTextRef.current = "";
-  }, []);
+  }, [iframeRef]);
 
   const handleToolbarClose = useCallback(() => {
+    postToIframe(iframeRef.current, { type: `${PREFIX}cancel-selection` });
     setToolbarState(null);
     pendingTextRef.current = "";
-  }, []);
+  }, [iframeRef]);
 
   const applyQuickLabel = useCallback(
     (label: QuickLabel, clearState: () => void) => {
@@ -349,9 +425,10 @@ export function useHtmlAnnotation({
   );
 
   const handleQuickLabelPickerDismiss = useCallback(() => {
+    postToIframe(iframeRef.current, { type: `${PREFIX}cancel-selection` });
     setQuickLabelPicker(null);
     pendingTextRef.current = "";
-  }, []);
+  }, [iframeRef]);
 
   const removeHighlight = useCallback(
     (id: string) => {

--- a/packages/ui/config/settings.ts
+++ b/packages/ui/config/settings.ts
@@ -55,7 +55,7 @@ export const SETTINGS = {
   vimModeEnabled: {
     // Vim bindings deliberately default OFF. Unmodified letter keys must remain
     // inert for existing users until they explicitly opt into modal document
-    // navigation from Settings > Shortcuts.
+    // navigation from Settings > Vim.
     defaultValue: false as boolean,
     fromCookie: () => {
       const value = storage.getItem('plannotator-vim-mode-enabled');

--- a/packages/ui/config/settings.ts
+++ b/packages/ui/config/settings.ts
@@ -79,6 +79,19 @@ export const SETTINGS = {
     serverKey: undefined, fromServer: undefined, toServer: undefined,
   },
 
+  vimHudKeyPanelEnabled: {
+    // Preserve the existing full HUD for current users while allowing the
+    // bottom-right key panel to be hidden independently from the reticle.
+    defaultValue: true as boolean,
+    fromCookie: () => {
+      const value = storage.getItem('plannotator-vim-hud-key-panel-enabled');
+      return value === 'true' ? true : value === 'false' ? false : undefined;
+    },
+    toCookie: (value: boolean) =>
+      storage.setItem('plannotator-vim-hud-key-panel-enabled', String(value)),
+    serverKey: undefined, fromServer: undefined, toServer: undefined,
+  },
+
   // --- Diff display options (namespaced under diffOptions in config.json) ---
 
   // Which left-panel view a code review OPENS in. 'sections' = the git-status

--- a/packages/ui/config/settings.ts
+++ b/packages/ui/config/settings.ts
@@ -28,6 +28,7 @@ export interface SettingDef<T> {
   toServer?: (value: T) => Record<string, unknown>;
 }
 
+/** Typed registry of persisted UI settings and their storage codecs. */
 export const SETTINGS = {
   displayName: {
     defaultValue: () => generateIdentity(),
@@ -48,6 +49,20 @@ export const SETTINGS = {
       return v === 'true' ? true : v === 'false' ? false : undefined;
     },
     toCookie: (v: boolean) => storage.setItem('plannotator-grid-enabled', String(v)),
+    serverKey: undefined, fromServer: undefined, toServer: undefined,
+  },
+
+  vimModeEnabled: {
+    // Vim bindings deliberately default OFF. Unmodified letter keys must remain
+    // inert for existing users until they explicitly opt into modal document
+    // navigation from Settings > Shortcuts.
+    defaultValue: false as boolean,
+    fromCookie: () => {
+      const value = storage.getItem('plannotator-vim-mode-enabled');
+      return value === 'true' ? true : value === 'false' ? false : undefined;
+    },
+    toCookie: (value: boolean) =>
+      storage.setItem('plannotator-vim-mode-enabled', String(value)),
     serverKey: undefined, fromServer: undefined, toServer: undefined,
   },
 

--- a/packages/ui/config/settings.ts
+++ b/packages/ui/config/settings.ts
@@ -66,6 +66,19 @@ export const SETTINGS = {
     serverKey: undefined, fromServer: undefined, toServer: undefined,
   },
 
+  vimHudEnabled: {
+    // The larger command HUD is an optional presentation layer on top of Vim
+    // controls. It has no effect while Vim mode itself is disabled.
+    defaultValue: false as boolean,
+    fromCookie: () => {
+      const value = storage.getItem('plannotator-vim-hud-enabled');
+      return value === 'true' ? true : value === 'false' ? false : undefined;
+    },
+    toCookie: (value: boolean) =>
+      storage.setItem('plannotator-vim-hud-enabled', String(value)),
+    serverKey: undefined, fromServer: undefined, toServer: undefined,
+  },
+
   // --- Diff display options (namespaced under diffOptions in config.json) ---
 
   // Which left-panel view a code review OPENS in. 'sections' = the git-status

--- a/packages/ui/config/vimModeSetting.test.ts
+++ b/packages/ui/config/vimModeSetting.test.ts
@@ -17,6 +17,8 @@ describe('Vim mode setting', () => {
 
     expect(SETTINGS.vimModeEnabled.defaultValue).toBe(false);
     expect(SETTINGS.vimModeEnabled.fromCookie()).toBeUndefined();
+    expect(SETTINGS.vimHudEnabled.defaultValue).toBe(false);
+    expect(SETTINGS.vimHudEnabled.fromCookie()).toBeUndefined();
   });
 
   test('round-trips only explicit boolean values', () => {
@@ -37,5 +39,16 @@ describe('Vim mode setting', () => {
 
     values.set('plannotator-vim-mode-enabled', 'unexpected');
     expect(SETTINGS.vimModeEnabled.fromCookie()).toBeUndefined();
+
+    SETTINGS.vimHudEnabled.toCookie(true);
+    expect(values.get('plannotator-vim-hud-enabled')).toBe('true');
+    expect(SETTINGS.vimHudEnabled.fromCookie()).toBe(true);
+
+    SETTINGS.vimHudEnabled.toCookie(false);
+    expect(values.get('plannotator-vim-hud-enabled')).toBe('false');
+    expect(SETTINGS.vimHudEnabled.fromCookie()).toBe(false);
+
+    values.set('plannotator-vim-hud-enabled', 'unexpected');
+    expect(SETTINGS.vimHudEnabled.fromCookie()).toBeUndefined();
   });
 });

--- a/packages/ui/config/vimModeSetting.test.ts
+++ b/packages/ui/config/vimModeSetting.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { resetStorageBackend, setStorageBackend } from '../utils/storage';
+import { SETTINGS } from './settings';
+
+afterEach(() => {
+  resetStorageBackend();
+});
+
+describe('Vim mode setting', () => {
+  test('is opt-in and defaults to disabled when no preference exists', () => {
+    const values = new Map<string, string>();
+    setStorageBackend({
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, value) => { values.set(key, value); },
+      removeItem: (key) => { values.delete(key); },
+    });
+
+    expect(SETTINGS.vimModeEnabled.defaultValue).toBe(false);
+    expect(SETTINGS.vimModeEnabled.fromCookie()).toBeUndefined();
+  });
+
+  test('round-trips only explicit boolean values', () => {
+    const values = new Map<string, string>();
+    setStorageBackend({
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, value) => { values.set(key, value); },
+      removeItem: (key) => { values.delete(key); },
+    });
+
+    SETTINGS.vimModeEnabled.toCookie(true);
+    expect(values.get('plannotator-vim-mode-enabled')).toBe('true');
+    expect(SETTINGS.vimModeEnabled.fromCookie()).toBe(true);
+
+    SETTINGS.vimModeEnabled.toCookie(false);
+    expect(values.get('plannotator-vim-mode-enabled')).toBe('false');
+    expect(SETTINGS.vimModeEnabled.fromCookie()).toBe(false);
+
+    values.set('plannotator-vim-mode-enabled', 'unexpected');
+    expect(SETTINGS.vimModeEnabled.fromCookie()).toBeUndefined();
+  });
+});

--- a/packages/ui/config/vimModeSetting.test.ts
+++ b/packages/ui/config/vimModeSetting.test.ts
@@ -19,6 +19,8 @@ describe('Vim mode setting', () => {
     expect(SETTINGS.vimModeEnabled.fromCookie()).toBeUndefined();
     expect(SETTINGS.vimHudEnabled.defaultValue).toBe(false);
     expect(SETTINGS.vimHudEnabled.fromCookie()).toBeUndefined();
+    expect(SETTINGS.vimHudKeyPanelEnabled.defaultValue).toBe(true);
+    expect(SETTINGS.vimHudKeyPanelEnabled.fromCookie()).toBeUndefined();
   });
 
   test('round-trips only explicit boolean values', () => {
@@ -50,5 +52,16 @@ describe('Vim mode setting', () => {
 
     values.set('plannotator-vim-hud-enabled', 'unexpected');
     expect(SETTINGS.vimHudEnabled.fromCookie()).toBeUndefined();
+
+    SETTINGS.vimHudKeyPanelEnabled.toCookie(false);
+    expect(values.get('plannotator-vim-hud-key-panel-enabled')).toBe('false');
+    expect(SETTINGS.vimHudKeyPanelEnabled.fromCookie()).toBe(false);
+
+    SETTINGS.vimHudKeyPanelEnabled.toCookie(true);
+    expect(values.get('plannotator-vim-hud-key-panel-enabled')).toBe('true');
+    expect(SETTINGS.vimHudKeyPanelEnabled.fromCookie()).toBe(true);
+
+    values.set('plannotator-vim-hud-key-panel-enabled', 'unexpected');
+    expect(SETTINGS.vimHudKeyPanelEnabled.fromCookie()).toBeUndefined();
   });
 });

--- a/packages/ui/hooks/useAnnotationHighlighter.test.tsx
+++ b/packages/ui/hooks/useAnnotationHighlighter.test.tsx
@@ -61,6 +61,16 @@ function Harness({
       >
         trigger
       </button>
+      <button
+        data-testid="trigger-keyboard-range"
+        onClick={() => {
+          const selection = window.getSelection();
+          if (!selection || selection.rangeCount === 0) return;
+          hook.highlightRange(selection.getRangeAt(0), 'redline');
+        }}
+      >
+        trigger keyboard
+      </button>
     </div>
   );
 }
@@ -97,6 +107,61 @@ function SelectionProbeHarness({
 }
 
 describe('useAnnotationHighlighter math annotations', () => {
+  test.skipIf(!hasDom)('keyboard ranges create the same annotation as the pointer range seam', async () => {
+    const runRange = async (triggerTestId: string) => {
+      const host = document.createElement('div');
+      document.body.appendChild(host);
+      const root = createRoot(host);
+      const annotations: Annotation[] = [];
+
+      await act(async () => {
+        root.render(<Harness mode="redline" onAdd={(ann) => annotations.push(ann)} />);
+      });
+
+      const before = host.querySelector<HTMLElement>('[data-testid="text-before"]');
+      if (!before?.firstChild) throw new Error('Missing selection fixture text');
+      const range = document.createRange();
+      range.setStart(before.firstChild, 0);
+      range.setEnd(before.firstChild, 'Formula'.length);
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+
+      const trigger = host.querySelector<HTMLButtonElement>(
+        `[data-testid="${triggerTestId}"]`,
+      );
+      if (!trigger) throw new Error(`Missing ${triggerTestId}`);
+      await act(async () => {
+        trigger.click();
+      });
+
+      const annotation = annotations[0];
+      act(() => root.unmount());
+      host.remove();
+      if (!annotation) throw new Error('Range did not create an annotation');
+      return annotation;
+    };
+
+    const pointer = await runRange('trigger-range');
+    const keyboard = await runRange('trigger-keyboard-range');
+    const comparable = (annotation: Annotation) => ({
+      type: annotation.type,
+      blockId: annotation.blockId,
+      startOffset: annotation.startOffset,
+      endOffset: annotation.endOffset,
+      originalText: annotation.originalText,
+    });
+
+    expect(comparable(keyboard)).toEqual(comparable(pointer));
+    expect(comparable(keyboard)).toEqual({
+      type: AnnotationType.DELETION,
+      blockId: 'block-1',
+      startOffset: 0,
+      endOffset: 'Formula'.length,
+      originalText: 'Formula',
+    });
+  });
+
   test.skipIf(!hasDom)('redline mode annotates an inline formula as a whole math target', async () => {
     const host = document.createElement('div');
     document.body.appendChild(host);

--- a/packages/ui/hooks/useAnnotationHighlighter.ts
+++ b/packages/ui/hooks/useAnnotationHighlighter.ts
@@ -244,6 +244,7 @@ export interface UseAnnotationHighlighterOptions {
   onRestoreMismatch?: (annotation: Annotation, restoredText: string) => void;
 }
 
+/** Annotation UI state and mutation commands owned by one rendered document. */
 export interface UseAnnotationHighlighterReturn {
   highlighterRef: RefObject<Highlighter | null>;
 
@@ -259,12 +260,22 @@ export interface UseAnnotationHighlighterReturn {
   handleCommentClose: () => void;
   handleFloatingQuickLabel: (label: QuickLabel) => void;
   handleQuickLabelPickerDismiss: () => void;
+  /** Paint a caller-created DOM range through the same pipeline as pointer selection. */
+  highlightRange: (range: Range, modeOverride?: EditorMode) => void;
+  /** Annotate one rendered formula through the same path as a pointer click. */
+  highlightMathElement: (element: HTMLElement, modeOverride?: EditorMode) => void;
 
   removeHighlight: (id: string) => void;
   clearAllHighlights: () => void;
   applyAnnotations: (annotations: Annotation[]) => void;
 }
 
+/**
+ * Own pointer and caller-supplied range annotations for a Markdown container.
+ *
+ * Highlight restoration failures are reported through `onRestoreMismatch`
+ * when verification is enabled; malformed or stale ranges are ignored.
+ */
 export function useAnnotationHighlighter({
   containerRef,
   annotations,
@@ -283,6 +294,7 @@ export function useAnnotationHighlighter({
   const pendingSourceRef = useRef<any>(null);
   const pendingMathTargetsRef = useRef<MathAnnotationTarget[]>([]);
   const pendingMathElementRef = useRef<HTMLElement | null>(null);
+  const pendingModeOverrideRef = useRef<EditorMode | null>(null);
   const justCreatedIdRef = useRef<string | null>(null);
   const lastMousePosRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
   const mouseDownMathRef = useRef<HTMLElement | null>(null);
@@ -834,10 +846,13 @@ export function useAnnotationHighlighter({
           setCommentPopover(null);
           setQuickLabelPicker(null);
 
-          if (modeRef.current === 'redline') {
+          const effectiveMode = pendingModeOverrideRef.current ?? modeRef.current;
+          pendingModeOverrideRef.current = null;
+
+          if (effectiveMode === 'redline') {
             createAnnotationFromSource(highlighter, source, AnnotationType.DELETION);
             window.getSelection()?.removeAllRanges();
-          } else if (modeRef.current === 'comment') {
+          } else if (effectiveMode === 'comment') {
             pendingSourceRef.current = source;
             setCommentPopover({
               anchorEl: doms[0] as HTMLElement,
@@ -845,7 +860,7 @@ export function useAnnotationHighlighter({
               selectedText: source.text,
               source,
             });
-          } else if (modeRef.current === 'quickLabel') {
+          } else if (effectiveMode === 'quickLabel') {
             pendingSourceRef.current = source;
             setQuickLabelPicker({
               anchorEl: doms[0] as HTMLElement,
@@ -985,6 +1000,86 @@ export function useAnnotationHighlighter({
       highlighter.dispose();
     };
   }, [clearPendingSelection, enabled]);
+
+  const highlightRange = useCallback((range: Range, modeOverride?: EditorMode) => {
+    const highlighter = highlighterRef.current;
+    const container = containerRef.current;
+    if (!highlighter || !container || range.collapsed) return;
+    if (!container.contains(range.commonAncestorContainer)) return;
+
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range.cloneRange());
+    pendingModeOverrideRef.current = modeOverride ?? null;
+
+    try {
+      highlighter.fromRange(range);
+    } finally {
+      pendingModeOverrideRef.current = null;
+      selection?.removeAllRanges();
+    }
+  }, [containerRef]);
+
+  const highlightMathElement = useCallback((
+    element: HTMLElement,
+    modeOverride?: EditorMode,
+  ) => {
+    const container = containerRef.current;
+    const mathElement = closestMathElement(element, container);
+    if (!container || !mathElement) return;
+
+    const effectiveMode = modeOverride ?? modeRef.current;
+    const existingId = mathElement.dataset.bindId;
+    if (existingId && effectiveMode !== 'redline') {
+      onSelectAnnotationRef.current?.(existingId);
+      return;
+    }
+
+    const source = mathSourceFromElement(mathElement);
+    if (!source) return;
+
+    const highlighter = highlighterRef.current;
+    if (pendingSourceRef.current && highlighter && !isMathAnnotationSource(pendingSourceRef.current)) {
+      highlighter.remove(pendingSourceRef.current.id);
+    }
+    clearPendingSelection();
+    setToolbarState(null);
+    setCommentPopover(null);
+    setQuickLabelPicker(null);
+
+    if (effectiveMode === 'redline') {
+      createAnnotationFromMathSource(source, AnnotationType.DELETION);
+      return;
+    }
+
+    pendingSourceRef.current = source;
+    showPendingMathPreview(source);
+
+    if (effectiveMode === 'comment') {
+      setCommentPopover({
+        anchorEl: source.element,
+        contextText: source.text.slice(0, 80),
+        selectedText: source.text,
+        source,
+      });
+      return;
+    }
+
+    if (effectiveMode === 'quickLabel') {
+      setQuickLabelPicker({
+        anchorEl: source.element,
+        cursorHint: lastMousePosRef.current,
+        source,
+      });
+      return;
+    }
+
+    setToolbarState({
+      element: source.element,
+      source,
+      selectionText: source.text,
+    });
+  }, [clearPendingSelection, containerRef, showPendingMathPreview]);
 
   // Apply CSS classes to existing annotations
   useEffect(() => {
@@ -1201,6 +1296,8 @@ export function useAnnotationHighlighter({
     handleCommentClose,
     handleFloatingQuickLabel,
     handleQuickLabelPickerDismiss,
+    highlightRange,
+    highlightMathElement,
     removeHighlight,
     clearAllHighlights,
     applyAnnotations: applyAnnotationsInternal,

--- a/packages/ui/hooks/usePinpoint.ts
+++ b/packages/ui/hooks/usePinpoint.ts
@@ -1,4 +1,10 @@
-import { useEffect, useState, type RefObject } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from 'react';
 import type { InputMethod } from '../types';
 import {
   buildSemanticTargetGraph,
@@ -23,6 +29,8 @@ export interface UsePinpointOptions {
 export interface UsePinpointReturn {
   /** Live target from the canonical semantic graph under the pointer. */
   hoverTarget: SemanticTarget | null;
+  /** Release pointer-owned feedback so keyboard navigation can take over. */
+  clearHover: () => void;
 }
 
 /**
@@ -39,25 +47,27 @@ export function usePinpoint({
   onCodeBlockClick,
 }: UsePinpointOptions): UsePinpointReturn {
   const [hoverTarget, setHoverTarget] = useState<SemanticTarget | null>(null);
+  const hoverElementRef = useRef<HTMLElement | null>(null);
 
   const isActive = inputMethod === 'pinpoint' && enabled;
+  const clearHover = useCallback(() => {
+    hoverElementRef.current?.removeAttribute('data-pinpoint-hover');
+    hoverElementRef.current = null;
+    setHoverTarget(null);
+  }, []);
 
   // Clear hover when deactivated
   useEffect(() => {
     if (!isActive) {
-      setHoverTarget((prev) => {
-        if (prev) prev.element.removeAttribute('data-pinpoint-hover');
-        return null;
-      });
+      clearHover();
     }
-  }, [isActive]);
+  }, [clearHover, isActive]);
 
   // Mousemove / touchstart — resolve target and update hover state
   useEffect(() => {
     const container = containerRef.current;
     if (!isActive || !container) return;
 
-    let prevElement: HTMLElement | null = null;
     let graph = buildSemanticTargetGraph(container);
     let graphIsDirty = false;
     const liveGraph = () => {
@@ -80,18 +90,14 @@ export function usePinpoint({
       );
 
       if (resolved) {
-        if (resolved.element !== prevElement) {
-          prevElement?.removeAttribute('data-pinpoint-hover');
+        if (resolved.element !== hoverElementRef.current) {
+          hoverElementRef.current?.removeAttribute('data-pinpoint-hover');
           resolved.element.setAttribute('data-pinpoint-hover', '');
-          prevElement = resolved.element;
+          hoverElementRef.current = resolved.element;
           setHoverTarget(resolved);
         }
       } else {
-        if (prevElement) {
-          prevElement.removeAttribute('data-pinpoint-hover');
-          prevElement = null;
-          setHoverTarget(null);
-        }
+        clearHover();
       }
     };
 
@@ -107,9 +113,7 @@ export function usePinpoint({
     };
 
     const handleMouseLeave = () => {
-      prevElement?.removeAttribute('data-pinpoint-hover');
-      prevElement = null;
-      setHoverTarget(null);
+      clearHover();
     };
 
     container.addEventListener('mousemove', handleMouseMove);
@@ -118,12 +122,13 @@ export function usePinpoint({
 
     return () => {
       observer.disconnect();
-      prevElement?.removeAttribute('data-pinpoint-hover');
+      hoverElementRef.current?.removeAttribute('data-pinpoint-hover');
+      hoverElementRef.current = null;
       container.removeEventListener('mousemove', handleMouseMove);
       container.removeEventListener('mouseleave', handleMouseLeave);
       container.removeEventListener('touchstart', handleTouchStart);
     };
-  }, [isActive, containerRef]);
+  }, [clearHover, isActive, containerRef]);
 
   // Click — create Range and trigger web-highlighter
   useEffect(() => {
@@ -174,5 +179,5 @@ export function usePinpoint({
     };
   }, [isActive, containerRef, onCodeBlockClick, onSelectRange]);
 
-  return { hoverTarget };
+  return { hoverTarget, clearHover };
 }

--- a/packages/ui/hooks/usePinpoint.ts
+++ b/packages/ui/hooks/usePinpoint.ts
@@ -1,30 +1,44 @@
 import { useEffect, useState, type RefObject } from 'react';
-import type Highlighter from '@plannotator/web-highlighter';
 import type { InputMethod } from '../types';
-import { resolvePinpointTarget } from '../utils/blockTargeting';
+import {
+  buildSemanticTargetGraph,
+  createSemanticTargetRange,
+  resolveSemanticTargetAtPoint,
+  type SemanticTarget,
+} from '../utils/blockTargeting';
 
+/** Inputs for pointer Pinpoint targeting within one rendered document. */
 export interface UsePinpointOptions {
   containerRef: RefObject<HTMLElement | null>;
-  highlighterRef: RefObject<Highlighter | null>;
   inputMethod: InputMethod;
   /** Disable when toolbar/popover/diff is active */
   enabled: boolean;
+  /** Submit a text range through the shared annotation pipeline. */
+  onSelectRange: (range: Range) => void;
   /** Handle code block clicks (needs special annotation path) */
   onCodeBlockClick: (blockId: string, element: HTMLElement) => void;
 }
 
+/** Live pointer-owned state returned by `usePinpoint`. */
 export interface UsePinpointReturn {
-  hoverTarget: { element: HTMLElement; label: string } | null;
+  /** Live target from the canonical semantic graph under the pointer. */
+  hoverTarget: SemanticTarget | null;
 }
 
+/**
+ * Resolve pointer hover and clicks through the canonical semantic target graph.
+ *
+ * The hook mutates only its transient hover marker and removes it when disabled
+ * or unmounted.
+ */
 export function usePinpoint({
   containerRef,
-  highlighterRef,
   inputMethod,
   enabled,
+  onSelectRange,
   onCodeBlockClick,
 }: UsePinpointOptions): UsePinpointReturn {
-  const [hoverTarget, setHoverTarget] = useState<{ element: HTMLElement; label: string } | null>(null);
+  const [hoverTarget, setHoverTarget] = useState<SemanticTarget | null>(null);
 
   const isActive = inputMethod === 'pinpoint' && enabled;
 
@@ -44,16 +58,33 @@ export function usePinpoint({
     if (!isActive || !container) return;
 
     let prevElement: HTMLElement | null = null;
+    let graph = buildSemanticTargetGraph(container);
+    let graphIsDirty = false;
+    const liveGraph = () => {
+      if (graphIsDirty) {
+        graph = buildSemanticTargetGraph(container);
+        graphIsDirty = false;
+      }
+      return graph;
+    };
+    const observer = new MutationObserver(() => {
+      graphIsDirty = true;
+    });
+    observer.observe(container, { childList: true, subtree: true });
 
     const updateHover = (clientX: number, clientY: number, target: HTMLElement) => {
-      const resolved = resolvePinpointTarget(target, container, { clientX, clientY });
+      const resolved = resolveSemanticTargetAtPoint(
+        liveGraph(),
+        target,
+        { clientX, clientY },
+      );
 
       if (resolved) {
         if (resolved.element !== prevElement) {
           prevElement?.removeAttribute('data-pinpoint-hover');
           resolved.element.setAttribute('data-pinpoint-hover', '');
           prevElement = resolved.element;
-          setHoverTarget({ element: resolved.element, label: resolved.label });
+          setHoverTarget(resolved);
         }
       } else {
         if (prevElement) {
@@ -86,6 +117,7 @@ export function usePinpoint({
     container.addEventListener('touchstart', handleTouchStart, { passive: true });
 
     return () => {
+      observer.disconnect();
       prevElement?.removeAttribute('data-pinpoint-hover');
       container.removeEventListener('mousemove', handleMouseMove);
       container.removeEventListener('mouseleave', handleMouseLeave);
@@ -99,15 +131,12 @@ export function usePinpoint({
     if (!isActive || !container) return;
 
     const handleClick = (e: MouseEvent) => {
-      // Read highlighter at click time, not effect setup time.
-      // On remount (e.g. after exiting plan diff), the highlighter init effect
-      // may not have run yet when this effect sets up, but it will be ready by
-      // the time the user clicks.
-      const highlighter = highlighterRef.current;
-      if (!highlighter) return;
-
       const target = e.target as HTMLElement;
-      const resolved = resolvePinpointTarget(target, container, { clientX: e.clientX, clientY: e.clientY });
+      const resolved = resolveSemanticTargetAtPoint(
+        buildSemanticTargetGraph(container),
+        target,
+        { clientX: e.clientX, clientY: e.clientY },
+      );
       if (!resolved) return;
 
       // Prevent link navigation in pinpoint mode
@@ -120,7 +149,7 @@ export function usePinpoint({
       resolved.element.removeAttribute('data-pinpoint-hover');
       setHoverTarget(null);
 
-      if (resolved.isCodeBlock) {
+      if (resolved.kind === 'code') {
         // Route to existing code block annotation path
         const codeBlockContainer = container.querySelector(`[data-block-id="${resolved.blockId}"]`) as HTMLElement;
         if (codeBlockContainer) {
@@ -131,19 +160,10 @@ export function usePinpoint({
 
       // Create a text-level Range spanning the target element's content.
       // web-highlighter needs ranges anchored to text nodes, not elements.
-      const range = createTextRange(resolved.element);
+      const range = createSemanticTargetRange(resolved);
       if (!range) return;
 
-      // Set browser selection so web-highlighter's mouseup handler picks it up
-      const sel = window.getSelection();
-      sel?.removeAllRanges();
-      sel?.addRange(range);
-
-      // Drive web-highlighter programmatically — fires CREATE event
-      highlighter.fromRange(range);
-
-      // Clean up browser selection
-      window.getSelection()?.removeAllRanges();
+      onSelectRange(range);
     };
 
     // Use capture phase so we get the click before links navigate
@@ -152,31 +172,7 @@ export function usePinpoint({
     return () => {
       container.removeEventListener('click', handleClick, true);
     };
-  }, [isActive, containerRef, highlighterRef, onCodeBlockClick]);
+  }, [isActive, containerRef, onCodeBlockClick, onSelectRange]);
 
   return { hoverTarget };
-}
-
-/**
- * Create a Range anchored to text nodes (not elements).
- * web-highlighter's painter expects text-node-level ranges.
- */
-function createTextRange(element: HTMLElement): Range | null {
-  const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT, null);
-
-  let firstNode: Text | null = null;
-  let lastNode: Text | null = null;
-
-  let node: Text | null;
-  while ((node = walker.nextNode() as Text | null)) {
-    if (!firstNode) firstNode = node;
-    lastNode = node;
-  }
-
-  if (!firstNode || !lastNode) return null;
-
-  const range = document.createRange();
-  range.setStart(firstNode, 0);
-  range.setEnd(lastNode, lastNode.length);
-  return range;
 }

--- a/packages/ui/hooks/useVimDocumentFocus.test.tsx
+++ b/packages/ui/hooks/useVimDocumentFocus.test.tsx
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import React, { act, useCallback, useRef } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  requestVimDocumentFocus,
+  useVimDocumentFocus,
+} from './useVimDocumentFocus';
+
+const hasDom = typeof document !== 'undefined';
+let root: Root | null = null;
+let host: HTMLElement | null = null;
+
+interface HarnessProps {
+  readonly enabled?: boolean;
+  readonly blocked?: boolean;
+}
+
+function Harness({ enabled = true, blocked = false }: HarnessProps) {
+  const documentRef = useRef<HTMLButtonElement>(null);
+  const focusDocument = useCallback((): boolean => {
+    const documentButton = documentRef.current;
+    if (!documentButton) return false;
+    if (window.document.activeElement === documentButton) return false;
+    documentButton.focus();
+    return window.document.activeElement === documentButton;
+  }, []);
+
+  useVimDocumentFocus({ enabled, blocked, focusDocument });
+
+  return <button ref={documentRef}>Document surface</button>;
+}
+
+async function mountHarness(props: HarnessProps = {}): Promise<HTMLButtonElement> {
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  root = createRoot(host);
+  await act(async () => root?.render(<Harness {...props} />));
+  const documentButton = host.querySelector<HTMLButtonElement>('button');
+  if (!documentButton) throw new Error('Document focus surface did not render');
+  return documentButton;
+}
+
+function escape(target: Element): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
+  target.dispatchEvent(event);
+  return event;
+}
+
+describe('useVimDocumentFocus', () => {
+  afterEach(async () => {
+    const mountedRoot = root;
+    if (mountedRoot) await act(async () => mountedRoot.unmount());
+    root = null;
+    host?.remove();
+    host = null;
+    if (hasDom) document.body.replaceChildren();
+  });
+
+  test.skipIf(!hasDom)('takes initial focus only when the page is neutral', async () => {
+    const documentButton = await mountHarness();
+    expect(document.activeElement).toBe(documentButton);
+
+    await act(async () => root?.unmount());
+    root = null;
+    host?.remove();
+    host = null;
+
+    const existingInput = document.createElement('input');
+    document.body.appendChild(existingInput);
+    existingInput.focus();
+    await mountHarness();
+    expect(document.activeElement).toBe(existingInput);
+  });
+
+  test.skipIf(!hasDom)('returns from app chrome on Escape without taking editable or modal focus', async () => {
+    const documentButton = await mountHarness();
+    const chromeButton = document.createElement('button');
+    chromeButton.textContent = 'App control';
+    document.body.appendChild(chromeButton);
+    chromeButton.focus();
+
+    const chromeEscape = escape(chromeButton);
+    expect(document.activeElement).toBe(documentButton);
+    expect(chromeEscape.defaultPrevented).toBe(true);
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+    expect(escape(input).defaultPrevented).toBe(false);
+    expect(document.activeElement).toBe(input);
+
+    const overlay = document.createElement('div');
+    overlay.className = 'fixed inset-0';
+    const dialogButton = document.createElement('button');
+    overlay.appendChild(dialogButton);
+    document.body.appendChild(overlay);
+    dialogButton.focus();
+    expect(escape(dialogButton).defaultPrevented).toBe(false);
+    expect(document.activeElement).toBe(dialogButton);
+  });
+
+  test.skipIf(!hasDom)('stays inert while the document controller is blocked', async () => {
+    await mountHarness({ blocked: true });
+    const chromeButton = document.createElement('button');
+    document.body.appendChild(chromeButton);
+    chromeButton.focus();
+
+    expect(escape(chromeButton).defaultPrevented).toBe(false);
+    expect(document.activeElement).toBe(chromeButton);
+  });
+
+  test.skipIf(!hasDom)('accepts an explicit handoff after an owned UI closes', async () => {
+    const documentButton = await mountHarness();
+    const chromeButton = document.createElement('button');
+    document.body.appendChild(chromeButton);
+    chromeButton.focus();
+
+    requestVimDocumentFocus();
+
+    expect(document.activeElement).toBe(documentButton);
+  });
+});

--- a/packages/ui/hooks/useVimDocumentFocus.ts
+++ b/packages/ui/hooks/useVimDocumentFocus.ts
@@ -1,0 +1,116 @@
+import { useEffect, useRef } from 'react';
+
+const VIM_DOCUMENT_FOCUS_REQUEST = 'plannotator:vim-document-focus-request';
+
+const EDITABLE_FOCUS_SELECTOR = [
+  'input',
+  'textarea',
+  'select',
+  '[contenteditable]:not([contenteditable="false"])',
+  '[role="textbox"]',
+  '[role="combobox"]',
+].join(',');
+
+const BLOCKING_OVERLAY_SELECTOR = [
+  '[role="dialog"]',
+  '[aria-modal="true"]',
+  // Some legacy Plannotator modals predate explicit dialog semantics. Keep
+  // Vim from focusing the obscured document underneath those full-screen
+  // overlays while they are brought onto the shared dialog primitive.
+  '.fixed.inset-0',
+].join(',');
+
+/** Inputs for restoring keyboard ownership to a Vim-enabled document. */
+export interface UseVimDocumentFocusOptions {
+  readonly enabled: boolean;
+  readonly blocked: boolean;
+  /** Focus the owning document surface and report whether focus moved to it. */
+  readonly focusDocument: () => boolean;
+}
+
+function pageFocusIsNeutral(): boolean {
+  return document.activeElement === document.body || document.activeElement === null;
+}
+
+function hasBlockingOverlay(): boolean {
+  return document.querySelector(BLOCKING_OVERLAY_SELECTOR) !== null;
+}
+
+function targetOwnsTextInput(target: EventTarget | null): boolean {
+  return target instanceof Element && target.closest(EDITABLE_FOCUS_SELECTOR) !== null;
+}
+
+/** Ask the active Vim document to reclaim focus after an owned UI closes. */
+export function requestVimDocumentFocus(): void {
+  document.dispatchEvent(new Event(VIM_DOCUMENT_FOCUS_REQUEST, { cancelable: true }));
+}
+
+/**
+ * Give an enabled Vim document initial keyboard ownership and let Escape from
+ * neutral app chrome return to it.
+ *
+ * Editable controls and overlays retain first ownership of Escape. The hook
+ * only prevents the event after focus actually moves back to the document.
+ */
+export function useVimDocumentFocus({
+  enabled,
+  blocked,
+  focusDocument,
+}: UseVimDocumentFocusOptions): void {
+  const autoFocusAttemptedRef = useRef(false);
+
+  useEffect(() => {
+    if (!enabled) {
+      autoFocusAttemptedRef.current = false;
+      return;
+    }
+    if (autoFocusAttemptedRef.current) return;
+    autoFocusAttemptedRef.current = true;
+    if (blocked || !pageFocusIsNeutral() || hasBlockingOverlay()) return;
+    focusDocument();
+  }, [blocked, enabled, focusDocument]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleFocusRequest = (event: Event) => {
+      if (
+        !event.defaultPrevented
+        && !blocked
+        && !hasBlockingOverlay()
+        && focusDocument()
+      ) {
+        // One visible document owns each request when a host renders multiple
+        // Viewer instances.
+        event.preventDefault();
+      }
+    };
+    const handleEscape = (event: KeyboardEvent) => {
+      if (
+        event.key !== 'Escape'
+        || event.defaultPrevented
+        || event.isComposing
+        || event.ctrlKey
+        || event.metaKey
+        || event.altKey
+        || event.shiftKey
+        || blocked
+        || targetOwnsTextInput(event.target)
+        || hasBlockingOverlay()
+      ) {
+        return;
+      }
+
+      if (focusDocument()) {
+        event.preventDefault();
+      }
+    };
+
+    document.addEventListener(VIM_DOCUMENT_FOCUS_REQUEST, handleFocusRequest);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener(VIM_DOCUMENT_FOCUS_REQUEST, handleFocusRequest);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [blocked, enabled, focusDocument]);
+}

--- a/packages/ui/hooks/useVimSelection.test.tsx
+++ b/packages/ui/hooks/useVimSelection.test.tsx
@@ -1,0 +1,309 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import React, { useRef } from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { EditorMode } from '../types';
+
+const hasDom = typeof document !== 'undefined';
+const hookModule = hasDom ? await import('./useVimSelection') : null;
+
+interface VimHarnessProps {
+  enabled: boolean;
+  blocked?: boolean;
+  onRange: (text: string, mode?: EditorMode) => void;
+}
+
+function VimHarness({ enabled, blocked = false, onRange }: VimHarnessProps) {
+  if (!hookModule) throw new Error('DOM test environment is not registered');
+  const articleRef = useRef<HTMLElement | null>(null);
+  const vim = hookModule.useVimSelection({
+    containerRef: articleRef,
+    enabled,
+    blocked,
+    activeMode: 'selection',
+    onHighlightRange: (range, mode) => onRange(range.toString(), mode),
+    onCodeBlockAction: (_blockId, element, mode) =>
+      onRange(element.textContent?.trim() ?? '', mode),
+    onMathAction: (element, mode) => onRange(element.textContent?.trim() ?? '', mode),
+  });
+
+  return (
+    <article
+      ref={articleRef}
+      tabIndex={enabled ? 0 : undefined}
+      data-phase={vim.state.phase}
+      data-target-key={vim.activeTarget?.key ?? ''}
+      onFocus={vim.onFocus}
+      onBlur={vim.onBlur}
+      onMouseDown={vim.onMouseDown}
+    >
+      <p data-block-id="intro">Alpha <strong>bravo</strong> charlie</p>
+      <div data-block-id="matrix">
+        <table>
+          <tbody>
+            <tr><td>A1</td><td>A2</td></tr>
+            <tr><td>B1</td><td>B2</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div data-block-id="code"><pre><code className="hljs">const x = 1;</code></pre></div>
+      <a data-testid="native-link" href="#destination">Native link</a>
+      <input data-testid="native-input" defaultValue="typing stays native" />
+    </article>
+  );
+}
+
+function keydown(target: HTMLElement, key: string): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    shiftKey: /^[A-Z]$/.test(key) || ['?', '{', '}', '$'].includes(key),
+    bubbles: true,
+    cancelable: true,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
+
+function mountHarness(props: VimHarnessProps): { article: HTMLElement; root: Root; host: HTMLElement } {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  const root = createRoot(host);
+  act(() => {
+    root.render(<VimHarness {...props} />);
+  });
+  const article = host.querySelector<HTMLElement>('article');
+  if (!article) throw new Error('Vim harness did not render');
+  return { article, root, host };
+}
+
+afterEach(() => {
+  if (hasDom) {
+    document.body.replaceChildren();
+    window.getSelection()?.removeAllRanges();
+  }
+});
+
+describe.if(hasDom)('useVimSelection', () => {
+  test('is completely inert when the opt-in setting is disabled', () => {
+    const actions: string[] = [];
+    const { article, root } = mountHarness({
+      enabled: false,
+      onRange: (text) => actions.push(text),
+    });
+
+    article.focus();
+    const visual = keydown(article, 'v');
+    const deleteAction = keydown(article, 'd');
+
+    expect(visual.defaultPrevented).toBe(false);
+    expect(deleteAction.defaultPrevented).toBe(false);
+    expect(article.dataset.phase).toBe('inactive');
+    expect(actions).toEqual([]);
+    act(() => root.unmount());
+  });
+
+  test('creates a Visual range and routes an action through the shared range callback', () => {
+    const actions: Array<{ text: string; mode?: EditorMode }> = [];
+    const { article, root } = mountHarness({
+      enabled: true,
+      onRange: (text, mode) => actions.push({ text, mode }),
+    });
+
+    act(() => article.focus());
+    act(() => { keydown(article, 'v'); });
+    act(() => { keydown(article, 'w'); });
+    expect(article.dataset.phase).toBe('visual');
+    expect(window.getSelection()?.toString()).toBe('Alpha ');
+
+    let actionEvent: KeyboardEvent | null = null;
+    act(() => { actionEvent = keydown(article, 'd'); });
+    expect(actionEvent?.defaultPrevented).toBe(true);
+    expect(actions).toEqual([{ text: 'Alpha ', mode: 'redline' }]);
+    expect(article.dataset.phase).toBe('text');
+    act(() => root.unmount());
+  });
+
+  test('enters Action state for the existing annotation toolbar without stealing its keys', () => {
+    const actions: Array<{ text: string; mode?: EditorMode }> = [];
+    const props: VimHarnessProps = {
+      enabled: true,
+      onRange: (text, mode) => actions.push({ text, mode }),
+    };
+    const { article, root } = mountHarness(props);
+
+    act(() => article.focus());
+    act(() => { keydown(article, 'v'); });
+    act(() => { keydown(article, 'w'); });
+    act(() => { keydown(article, ' '); });
+    expect(actions).toEqual([{ text: 'Alpha ', mode: 'selection' }]);
+    expect(article.dataset.phase).toBe('action');
+
+    const toolbarKey = keydown(article, 'x');
+    expect(toolbarKey.defaultPrevented).toBe(false);
+    let escape: KeyboardEvent | null = null;
+    act(() => { escape = keydown(article, 'Escape'); });
+    expect(escape.defaultPrevented).toBe(false);
+    expect(article.dataset.phase).toBe('action');
+
+    act(() => root.render(<VimHarness {...props} blocked />));
+    act(() => root.render(<VimHarness {...props} />));
+    expect(article.dataset.phase).toBe('visual');
+    expect(window.getSelection()?.toString()).toBe('Alpha ');
+    act(() => root.unmount());
+  });
+
+  test('does not restore stale document focus after the action UI closes elsewhere', () => {
+    const props: VimHarnessProps = {
+      enabled: true,
+      onRange: () => {},
+    };
+    const { article, root } = mountHarness(props);
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+
+    act(() => article.focus());
+    act(() => { keydown(article, 'v'); });
+    act(() => { keydown(article, 'w'); });
+    act(() => { keydown(article, 'c'); });
+    expect(article.dataset.phase).toBe('action');
+
+    act(() => root.render(<VimHarness {...props} blocked />));
+    act(() => outside.focus());
+    act(() => root.render(<VimHarness {...props} />));
+    expect(document.activeElement).toBe(outside);
+
+    // A later, unrelated blocked transition must not consume the old action's
+    // focus-restoration request after focus has intentionally moved elsewhere.
+    act(() => outside.blur());
+    act(() => root.render(<VimHarness {...props} blocked />));
+    act(() => root.render(<VimHarness {...props} />));
+    expect(document.activeElement).not.toBe(article);
+
+    act(() => root.unmount());
+    outside.remove();
+  });
+
+  test('starts with block focus, refines through inline to text, and preserves controls', () => {
+    const actions: Array<{ text: string; mode?: EditorMode }> = [];
+    const { article, root, host } = mountHarness({
+      enabled: true,
+      onRange: (text, mode) => actions.push({ text, mode }),
+    });
+
+    act(() => article.focus());
+    expect(article.dataset.phase).toBe('block');
+    expect(article.dataset.targetKey).toBe('intro:block');
+    act(() => { keydown(article, 'l'); });
+    expect(article.dataset.phase).toBe('inline');
+    expect(article.dataset.targetKey).toBe('intro:inline:0');
+    act(() => { keydown(article, 'l'); });
+    expect(article.dataset.phase).toBe('text');
+    act(() => { keydown(article, 'Escape'); });
+    expect(article.dataset.phase).toBe('inline');
+    act(() => { keydown(article, 'c'); });
+    expect(actions).toEqual([{ text: 'bravo', mode: 'comment' }]);
+    expect(article.dataset.phase).toBe('action');
+
+    const input = host.querySelector<HTMLInputElement>('[data-testid="native-input"]');
+    if (!input) throw new Error('Missing native input');
+    input.focus();
+    const inputEvent = keydown(input, 'd');
+    expect(inputEvent.defaultPrevented).toBe(false);
+    expect(actions).toHaveLength(1);
+
+    const link = host.querySelector<HTMLAnchorElement>('[data-testid="native-link"]');
+    if (!link) throw new Error('Missing native link');
+    link.focus();
+    const linkEvent = keydown(link, 'Enter');
+    expect(linkEvent.defaultPrevented).toBe(false);
+    expect(actions).toHaveLength(1);
+    act(() => root.unmount());
+  });
+
+  test('walks blocks with j/k and extends a whole-block Visual selection', () => {
+    const actions: Array<{ text: string; mode?: EditorMode }> = [];
+    const { article, root } = mountHarness({
+      enabled: true,
+      onRange: (text, mode) => actions.push({ text, mode }),
+    });
+
+    act(() => article.focus());
+    expect(article.dataset.targetKey).toBe('intro:block');
+    act(() => { keydown(article, 'j'); });
+    expect(article.dataset.targetKey).toBe('matrix:table');
+    act(() => { keydown(article, 'k'); });
+    expect(article.dataset.targetKey).toBe('intro:block');
+    act(() => { keydown(article, 'G'); });
+    expect(article.dataset.targetKey).toBe('code:code');
+    act(() => {
+      keydown(article, 'g');
+      keydown(article, 'g');
+    });
+    expect(article.dataset.targetKey).toBe('intro:block');
+
+    act(() => { keydown(article, 'V'); });
+    expect(article.dataset.phase).toBe('visual-block');
+    expect(window.getSelection()?.toString()).toContain('Alpha');
+    act(() => { keydown(article, 'j'); });
+    expect(window.getSelection()?.toString()).toContain('B2');
+    act(() => { keydown(article, 'd'); });
+    expect(actions).toHaveLength(1);
+    expect(actions[0]?.mode).toBe('redline');
+    expect(actions[0]?.text).toContain('Alpha');
+    expect(actions[0]?.text).toContain('B2');
+    act(() => root.unmount());
+  });
+
+  test('moves through semantic siblings before refining or returning to block order', () => {
+    const { article, root } = mountHarness({
+      enabled: true,
+      onRange: () => {},
+    });
+
+    act(() => article.focus());
+    act(() => { keydown(article, 'j'); });
+    expect(article.dataset.targetKey).toBe('matrix:table');
+    act(() => { keydown(article, 'l'); });
+    expect(article.dataset.targetKey).toBe('matrix:row:0');
+    act(() => { keydown(article, 'j'); });
+    expect(article.dataset.targetKey).toBe('matrix:row:1');
+    act(() => { keydown(article, 'l'); });
+    expect(article.dataset.targetKey).toBe('matrix:cell:1:0');
+    act(() => { keydown(article, 'j'); });
+    expect(article.dataset.targetKey).toBe('matrix:cell:1:1');
+    act(() => { keydown(article, 'v'); });
+    act(() => { keydown(article, 'w'); });
+    expect(window.getSelection()?.toString()).toBe('B2');
+    act(() => { keydown(article, 'Escape'); });
+    act(() => { keydown(article, 'Escape'); });
+    act(() => { keydown(article, 'h'); });
+    expect(article.dataset.targetKey).toBe('matrix:row:1');
+    act(() => root.unmount());
+  });
+
+  test('does not action a collapsed text cursor and does not consume Escape when inactive', () => {
+    const actions: string[] = [];
+    const { article, root } = mountHarness({
+      enabled: true,
+      onRange: (text) => actions.push(text),
+    });
+
+    act(() => article.focus());
+    act(() => { keydown(article, 'l'); });
+    act(() => { keydown(article, 'l'); });
+    expect(article.dataset.phase).toBe('text');
+    const collapsedAction = keydown(article, 'c');
+    expect(collapsedAction.defaultPrevented).toBe(false);
+    const collapsedCopy = keydown(article, 'y');
+    expect(collapsedCopy.defaultPrevented).toBe(false);
+    expect(actions).toEqual([]);
+
+    act(() => { keydown(article, 'Escape'); });
+    act(() => { keydown(article, 'Escape'); });
+    act(() => { keydown(article, 'Escape'); });
+    expect(article.dataset.phase).toBe('inactive');
+    const inactiveEscape = keydown(article, 'Escape');
+    expect(inactiveEscape.defaultPrevented).toBe(false);
+    act(() => root.unmount());
+  });
+});

--- a/packages/ui/hooks/useVimSelection.test.tsx
+++ b/packages/ui/hooks/useVimSelection.test.tsx
@@ -175,6 +175,88 @@ describe.if(hasDom)('useVimSelection', () => {
     act(() => root.unmount());
   });
 
+  test('opens the annotation toolbar with both m and Space overrides', () => {
+    const actions: Array<{ text: string; mode?: EditorMode }> = [];
+    const first = mountHarness({
+      enabled: true,
+      onRange: (text, mode) => actions.push({ text, mode }),
+    });
+
+    act(() => first.article.focus());
+    let markupEvent: KeyboardEvent | null = null;
+    act(() => { markupEvent = keydown(first.article, 'm'); });
+    expect(markupEvent?.defaultPrevented).toBe(true);
+    expect(actions).toEqual([{ text: 'Alpha bravo charlie', mode: 'selection' }]);
+    expect(first.article.dataset.phase).toBe('action');
+    act(() => first.root.unmount());
+    first.host.remove();
+
+    const second = mountHarness({
+      enabled: true,
+      onRange: (text, mode) => actions.push({ text, mode }),
+    });
+    act(() => second.article.focus());
+    let menuEvent: KeyboardEvent | null = null;
+    act(() => { menuEvent = keydown(second.article, ' '); });
+    expect(menuEvent?.defaultPrevented).toBe(true);
+    expect(actions).toEqual([
+      { text: 'Alpha bravo charlie', mode: 'selection' },
+      { text: 'Alpha bravo charlie', mode: 'selection' },
+    ]);
+    expect(second.article.dataset.phase).toBe('action');
+    act(() => second.root.unmount());
+  });
+
+  test('copies a Visual selection, collapses it, and keeps document focus', async () => {
+    const copied: string[] = [];
+    const clipboardDescriptor = Object.getOwnPropertyDescriptor(
+      navigator,
+      'clipboard',
+    );
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: async (text: string) => {
+          copied.push(text);
+        },
+      },
+    });
+    const { article, root } = mountHarness({
+      enabled: true,
+      onRange: () => {},
+    });
+
+    try {
+      act(() => article.focus());
+      act(() => { keydown(article, 'v'); });
+      act(() => { keydown(article, 'w'); });
+      expect(window.getSelection()?.toString()).toBe('Alpha ');
+
+      let copyEvent: KeyboardEvent | null = null;
+      await act(async () => {
+        copyEvent = keydown(article, 'y');
+        await Promise.resolve();
+      });
+
+      expect(copyEvent?.defaultPrevented).toBe(true);
+      expect(copied).toEqual(['Alpha ']);
+      expect(article.dataset.phase).toBe('text');
+      expect(document.activeElement).toBe(article);
+      expect(window.getSelection()?.isCollapsed).toBe(true);
+    } finally {
+      act(() => root.unmount());
+      if (clipboardDescriptor) {
+        Object.defineProperty(
+          navigator,
+          'clipboard',
+          clipboardDescriptor,
+        );
+      } else {
+        delete (navigator as Navigator & { clipboard?: Clipboard }).clipboard;
+      }
+    }
+  });
+
   test('does not restore stale document focus after the action UI closes elsewhere', () => {
     const props: VimHarnessProps = {
       enabled: true,
@@ -215,6 +297,9 @@ describe.if(hasDom)('useVimSelection', () => {
 
     act(() => article.focus());
     expect(article.dataset.phase).toBe('block');
+    expect(article.dataset.targetKey).toBe('intro:block');
+    const tab = keydown(article, 'Tab');
+    expect(tab.defaultPrevented).toBe(false);
     expect(article.dataset.targetKey).toBe('intro:block');
     act(() => { keydown(article, 'l'); });
     expect(article.dataset.phase).toBe('inline');

--- a/packages/ui/hooks/useVimSelection.test.tsx
+++ b/packages/ui/hooks/useVimSelection.test.tsx
@@ -9,16 +9,23 @@ const hookModule = hasDom ? await import('./useVimSelection') : null;
 
 interface VimHarnessProps {
   enabled: boolean;
+  hudEnabled?: boolean;
   blocked?: boolean;
   onRange: (text: string, mode?: EditorMode) => void;
 }
 
-function VimHarness({ enabled, blocked = false, onRange }: VimHarnessProps) {
+function VimHarness({
+  enabled,
+  hudEnabled = false,
+  blocked = false,
+  onRange,
+}: VimHarnessProps) {
   if (!hookModule) throw new Error('DOM test environment is not registered');
   const articleRef = useRef<HTMLElement | null>(null);
   const vim = hookModule.useVimSelection({
     containerRef: articleRef,
     enabled,
+    hudEnabled,
     blocked,
     activeMode: 'selection',
     onHighlightRange: (range, mode) => onRange(range.toString(), mode),
@@ -33,6 +40,8 @@ function VimHarness({ enabled, blocked = false, onRange }: VimHarnessProps) {
       tabIndex={enabled ? 0 : undefined}
       data-phase={vim.state.phase}
       data-target-key={vim.activeTarget?.key ?? ''}
+      data-hud-key={vim.hudCommand?.key ?? ''}
+      data-hud-command={vim.hudCommand?.description ?? ''}
       onFocus={vim.onFocus}
       onBlur={vim.onBlur}
       onMouseDown={vim.onMouseDown}
@@ -99,6 +108,20 @@ describe.if(hasDom)('useVimSelection', () => {
     expect(deleteAction.defaultPrevented).toBe(false);
     expect(article.dataset.phase).toBe('inactive');
     expect(actions).toEqual([]);
+    act(() => root.unmount());
+  });
+
+  test('does not retain handled commands when the optional HUD is disabled', () => {
+    const { article, root } = mountHarness({
+      enabled: true,
+      hudEnabled: false,
+      onRange: () => {},
+    });
+
+    act(() => article.focus());
+    act(() => { keydown(article, 'j'); });
+    expect(article.dataset.phase).toBe('block');
+    expect(article.dataset.hudKey).toBe('');
     act(() => root.unmount());
   });
 
@@ -224,6 +247,7 @@ describe.if(hasDom)('useVimSelection', () => {
     const actions: Array<{ text: string; mode?: EditorMode }> = [];
     const { article, root } = mountHarness({
       enabled: true,
+      hudEnabled: true,
       onRange: (text, mode) => actions.push({ text, mode }),
     });
 
@@ -231,21 +255,28 @@ describe.if(hasDom)('useVimSelection', () => {
     expect(article.dataset.targetKey).toBe('intro:block');
     act(() => { keydown(article, 'j'); });
     expect(article.dataset.targetKey).toBe('matrix:table');
+    expect(article.dataset.hudKey).toBe('j');
+    expect(article.dataset.hudCommand).toBe('Next block');
     act(() => { keydown(article, 'k'); });
     expect(article.dataset.targetKey).toBe('intro:block');
+    expect(article.dataset.hudCommand).toBe('Previous block');
     act(() => { keydown(article, 'G'); });
     expect(article.dataset.targetKey).toBe('code:code');
+    expect(article.dataset.hudCommand).toBe('End of document');
     act(() => {
       keydown(article, 'g');
       keydown(article, 'g');
     });
     expect(article.dataset.targetKey).toBe('intro:block');
+    expect(article.dataset.hudKey).toBe('gg');
+    expect(article.dataset.hudCommand).toBe('Start of document');
 
     act(() => { keydown(article, 'V'); });
     expect(article.dataset.phase).toBe('visual-block');
     expect(window.getSelection()?.toString()).toContain('Alpha');
     act(() => { keydown(article, 'j'); });
     expect(window.getSelection()?.toString()).toContain('B2');
+    expect(article.dataset.hudCommand).toBe('Extend to next block');
     act(() => { keydown(article, 'd'); });
     expect(actions).toHaveLength(1);
     expect(actions[0]?.mode).toBe('redline');

--- a/packages/ui/hooks/useVimSelection.ts
+++ b/packages/ui/hooks/useVimSelection.ts
@@ -7,7 +7,10 @@ import {
   type MouseEvent as ReactMouseEvent,
   type RefObject,
 } from 'react';
-import { useVimSelectionShortcuts } from '../shortcuts';
+import {
+  useVimSelectionShortcuts,
+  type VimSelectionActionId,
+} from '../shortcuts';
 import type { EditorMode } from '../types';
 import {
   buildSemanticTargetGraph,
@@ -21,6 +24,10 @@ import {
   type SemanticTargetGraph,
 } from '../utils/blockTargeting';
 import { isDocumentKeyboardControl } from '../utils/domSelection';
+import {
+  createVimHudCommand,
+  type VimHudCommand,
+} from '../utils/vimHud';
 import {
   applyNativeTextSelection,
   createInitialVimSelectionState,
@@ -44,6 +51,7 @@ import {
 export interface UseVimSelectionOptions {
   readonly containerRef: RefObject<HTMLElement | null>;
   readonly enabled: boolean;
+  readonly hudEnabled: boolean;
   readonly blocked: boolean;
   readonly activeMode: EditorMode;
   /** Identity that changes when the rendered document is replaced. */
@@ -62,6 +70,7 @@ export interface UseVimSelectionReturn {
   readonly state: VimSelectionState;
   readonly focused: boolean;
   readonly helpOpen: boolean;
+  readonly hudCommand: VimHudCommand | null;
   readonly activeTarget: SemanticTarget | null;
   readonly onFocus: (event: ReactFocusEvent<HTMLElement>) => void;
   readonly onBlur: (event: ReactFocusEvent<HTMLElement>) => void;
@@ -231,6 +240,7 @@ function applyVisualBlockSelection(
 export function useVimSelection({
   containerRef,
   enabled,
+  hudEnabled,
   blocked,
   activeMode,
   contentVersion,
@@ -244,6 +254,8 @@ export function useVimSelection({
   const stateRef = useRef(state);
   const [focused, setFocused] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
+  const [hudCommand, setHudCommand] = useState<VimHudCommand | null>(null);
+  const hudSequenceRef = useRef(0);
   const restoreFocusRef = useRef(false);
   const wasBlockedRef = useRef(blocked);
   const pointerFocusRef = useRef(false);
@@ -283,6 +295,7 @@ export function useVimSelection({
       setState(createInitialVimSelectionState());
       setFocused(false);
       setHelpOpen(false);
+      setHudCommand(null);
       window.getSelection()?.removeAllRanges();
       return;
     }
@@ -303,6 +316,10 @@ export function useVimSelection({
     initializeSemanticNavigation,
     setState,
   ]);
+
+  useEffect(() => {
+    setHudCommand(null);
+  }, [contentVersion, hudEnabled]);
 
   useEffect(() => {
     const wasBlocked = wasBlockedRef.current;
@@ -823,7 +840,25 @@ export function useVimSelection({
     && !event.altKey
   ), [blocked, enabled, focused]);
 
-  const onKeyDown = useCallback((event: KeyboardEvent) => {
+  const recordHudCommand = useCallback((
+    actionId: VimSelectionActionId,
+    event: KeyboardEvent,
+    context: VimSelectionState['phase'],
+  ) => {
+    if (!hudEnabled) return;
+    hudSequenceRef.current += 1;
+    setHudCommand(createVimHudCommand(
+      hudSequenceRef.current,
+      actionId,
+      event.key,
+      context,
+    ));
+  }, [hudEnabled]);
+
+  const onKeyDown = useCallback((
+    event: KeyboardEvent,
+    actionId: VimSelectionActionId,
+  ) => {
     if (!canHandleShortcut(event)) return;
 
     if (stateRef.current.phase === 'action') {
@@ -834,6 +869,7 @@ export function useVimSelection({
     if (!container) return;
     const graph = buildSemanticTargetGraph(container);
     const key = event.key;
+    const context = stateRef.current.phase;
     let handled = false;
 
     if (helpOpen) {
@@ -868,6 +904,7 @@ export function useVimSelection({
     }
 
     if (handled) {
+      recordHudCommand(actionId, event, context);
       event.preventDefault();
       event.stopPropagation();
     }
@@ -881,47 +918,53 @@ export function useVimSelection({
     helpOpen,
     initializeSemanticNavigation,
     jumpToDocumentBlock,
+    recordHudCommand,
   ]);
 
   const onDocumentStart = useCallback((event: KeyboardEvent) => {
     if (!canHandleShortcut(event) || stateRef.current.phase === 'action') return;
     const container = containerRef.current;
     if (!container) return;
+    const context = stateRef.current.phase;
     if (jumpToDocumentBlock(buildSemanticTargetGraph(container), false)) {
+      recordHudCommand('documentStart', event, context);
       event.preventDefault();
       event.stopPropagation();
     }
-  }, [canHandleShortcut, containerRef, jumpToDocumentBlock]);
+  }, [canHandleShortcut, containerRef, jumpToDocumentBlock, recordHudCommand]);
 
-  const shortcutHandler = { when: canHandleShortcut, handle: onKeyDown };
+  const shortcutHandler = (actionId: VimSelectionActionId) => ({
+    when: canHandleShortcut,
+    handle: (event: KeyboardEvent) => onKeyDown(event, actionId),
+  });
   useVimSelectionShortcuts({
     target: containerRef.current,
     handlers: {
-      moveDown: shortcutHandler,
-      moveUp: shortcutHandler,
+      moveDown: shortcutHandler('moveDown'),
+      moveUp: shortcutHandler('moveUp'),
       documentStart: { when: canHandleShortcut, handle: onDocumentStart },
-      documentEnd: shortcutHandler,
-      moveOut: shortcutHandler,
-      refine: shortcutHandler,
-      visual: shortcutHandler,
-      visualBlock: shortcutHandler,
-      wordForward: shortcutHandler,
-      wordBackward: shortcutHandler,
-      wordEnd: shortcutHandler,
-      lineStart: shortcutHandler,
-      lineEnd: shortcutHandler,
-      previousTextBlock: shortcutHandler,
-      nextTextBlock: shortcutHandler,
-      swapSelectionEnds: shortcutHandler,
-      activeAnnotation: shortcutHandler,
-      annotationMenu: shortcutHandler,
-      comment: shortcutHandler,
-      redline: shortcutHandler,
-      markup: shortcutHandler,
-      label: shortcutHandler,
-      copy: shortcutHandler,
-      cancel: shortcutHandler,
-      help: shortcutHandler,
+      documentEnd: shortcutHandler('documentEnd'),
+      moveOut: shortcutHandler('moveOut'),
+      refine: shortcutHandler('refine'),
+      visual: shortcutHandler('visual'),
+      visualBlock: shortcutHandler('visualBlock'),
+      wordForward: shortcutHandler('wordForward'),
+      wordBackward: shortcutHandler('wordBackward'),
+      wordEnd: shortcutHandler('wordEnd'),
+      lineStart: shortcutHandler('lineStart'),
+      lineEnd: shortcutHandler('lineEnd'),
+      previousTextBlock: shortcutHandler('previousTextBlock'),
+      nextTextBlock: shortcutHandler('nextTextBlock'),
+      swapSelectionEnds: shortcutHandler('swapSelectionEnds'),
+      activeAnnotation: shortcutHandler('activeAnnotation'),
+      annotationMenu: shortcutHandler('annotationMenu'),
+      comment: shortcutHandler('comment'),
+      redline: shortcutHandler('redline'),
+      markup: shortcutHandler('markup'),
+      label: shortcutHandler('label'),
+      copy: shortcutHandler('copy'),
+      cancel: shortcutHandler('cancel'),
+      help: shortcutHandler('help'),
     },
   });
 
@@ -949,6 +992,7 @@ export function useVimSelection({
     state,
     focused,
     helpOpen,
+    hudCommand,
     activeTarget,
     onFocus,
     onBlur,

--- a/packages/ui/hooks/useVimSelection.ts
+++ b/packages/ui/hooks/useVimSelection.ts
@@ -23,6 +23,7 @@ import {
   type SemanticTarget,
   type SemanticTargetGraph,
 } from '../utils/blockTargeting';
+import { copyTextPreservingFocus } from '../utils/clipboard';
 import { isDocumentKeyboardControl } from '../utils/domSelection';
 import {
   createVimHudCommand,
@@ -64,6 +65,8 @@ export interface UseVimSelectionOptions {
     modeOverride?: EditorMode,
   ) => void;
   readonly onMathAction: (element: HTMLElement, modeOverride?: EditorMode) => void;
+  /** Clear pointer-owned feedback after a handled keyboard command. */
+  readonly onHandledCommand?: () => void;
 }
 
 /** State and event handlers rendered by the Markdown Viewer. */
@@ -88,16 +91,6 @@ function selectionModeForAction(key: string): EditorMode | null {
     return 'selection';
   }
   return null;
-}
-
-function copyText(text: string): void {
-  const textarea = document.createElement('textarea');
-  textarea.style.cssText = 'position:fixed;opacity:0;pointer-events:none';
-  textarea.value = text;
-  document.body.appendChild(textarea);
-  textarea.select();
-  document.execCommand('copy');
-  textarea.remove();
 }
 
 function motionFromTextKey(key: string): VimTextMotion | null {
@@ -249,6 +242,7 @@ export function useVimSelection({
   onHighlightRange,
   onCodeBlockAction,
   onMathAction,
+  onHandledCommand,
 }: UseVimSelectionOptions): UseVimSelectionReturn {
   const [state, setStateValue] = useState<VimSelectionState>(
     createInitialVimSelectionState,
@@ -529,8 +523,8 @@ export function useVimSelection({
     if (current.phase === 'visual') {
       const range = selectedTextRange(graph.container, current);
       if (!range) return false;
-      copyText(range.toString());
-      setState({
+      copyTextPreservingFocus(range.toString(), graph.container);
+      updateTextState(graph, {
         phase: 'text',
         targetKey: current.targetKey,
         cursor: current.cursor,
@@ -540,16 +534,19 @@ export function useVimSelection({
     if (current.phase === 'visual-block') {
       const range = visualBlockRange(graph, current);
       if (!range) return false;
-      copyText(range.toString());
+      copyTextPreservingFocus(range.toString(), graph.container);
       const target = resolveSemanticTarget(graph, current.targetKey);
-      if (target) setState(semanticStateForTarget(target));
+      if (target) setSemanticTarget(target);
       return true;
     }
     const target = resolveSemanticTarget(graph, current.targetKey);
     if (!target) return false;
-    copyText(target.element.textContent?.trim() ?? '');
+    copyTextPreservingFocus(
+      target.element.textContent?.trim() ?? '',
+      graph.container,
+    );
     return true;
-  }, [setState]);
+  }, [setSemanticTarget, updateTextState]);
 
   const handleSemanticKey = useCallback((
     graph: SemanticTargetGraph,
@@ -907,6 +904,7 @@ export function useVimSelection({
     }
 
     if (handled) {
+      onHandledCommand?.();
       recordHudCommand(actionId, event, context);
       event.preventDefault();
       event.stopPropagation();
@@ -921,6 +919,7 @@ export function useVimSelection({
     helpOpen,
     initializeSemanticNavigation,
     jumpToDocumentBlock,
+    onHandledCommand,
     recordHudCommand,
   ]);
 
@@ -930,11 +929,18 @@ export function useVimSelection({
     if (!container) return;
     const context = stateRef.current.phase;
     if (jumpToDocumentBlock(buildSemanticTargetGraph(container), false)) {
+      onHandledCommand?.();
       recordHudCommand('documentStart', event, context);
       event.preventDefault();
       event.stopPropagation();
     }
-  }, [canHandleShortcut, containerRef, jumpToDocumentBlock, recordHudCommand]);
+  }, [
+    canHandleShortcut,
+    containerRef,
+    jumpToDocumentBlock,
+    onHandledCommand,
+    recordHudCommand,
+  ]);
 
   const shortcutHandler = (actionId: VimSelectionActionId) => ({
     when: canHandleShortcut,

--- a/packages/ui/hooks/useVimSelection.ts
+++ b/packages/ui/hooks/useVimSelection.ts
@@ -46,6 +46,7 @@ import {
   type VimVisualBlockState,
   type VimVisualState,
 } from '../utils/vimNavigation';
+import { useVimDocumentFocus } from './useVimDocumentFocus';
 
 /** Inputs required by the Markdown semantic Vim controller. */
 export interface UseVimSelectionOptions {
@@ -990,6 +991,21 @@ export function useVimSelection({
     if (containerRef.current === document.activeElement) return;
     setFocused(false);
   }, [containerRef]);
+
+  const focusDocument = useCallback((): boolean => {
+    const container = containerRef.current;
+    if (!enabled || !container) return false;
+    if (document.activeElement === container) return false;
+    restoringFocusRef.current = stateRef.current.phase !== 'inactive';
+    container.focus({ preventScroll: true });
+    return document.activeElement === container;
+  }, [containerRef, enabled]);
+
+  useVimDocumentFocus({
+    enabled,
+    blocked,
+    focusDocument,
+  });
 
   const onMouseDown = useCallback((event: ReactMouseEvent<HTMLElement>) => {
     if (!enabled || isDocumentKeyboardControl(event.target)) return;

--- a/packages/ui/hooks/useVimSelection.ts
+++ b/packages/ui/hooks/useVimSelection.ts
@@ -75,7 +75,8 @@ export interface UseVimSelectionReturn {
   readonly onFocus: (event: ReactFocusEvent<HTMLElement>) => void;
   readonly onBlur: (event: ReactFocusEvent<HTMLElement>) => void;
   readonly onMouseDown: (event: ReactMouseEvent<HTMLElement>) => void;
-  readonly closeHelp: () => void;
+  readonly onHelpOpenChange: (open: boolean) => void;
+  readonly onHudFocusLeave: () => void;
 }
 
 function selectionModeForAction(key: string): EditorMode | null {
@@ -266,14 +267,15 @@ export function useVimSelection({
     setStateValue(next);
   }, []);
 
-  const liveGraph = containerRef.current
-    ? buildSemanticTargetGraph(containerRef.current)
-    : null;
-  const activeTarget = liveGraph && (
+  const needsLiveTarget = enabled && (
     state.phase === 'block'
     || state.phase === 'inline'
     || state.phase === 'action'
-  )
+  );
+  const liveGraph = needsLiveTarget && containerRef.current
+    ? buildSemanticTargetGraph(containerRef.current)
+    : null;
+  const activeTarget = liveGraph
     ? resolveSemanticTarget(liveGraph, targetKeyForState(state))
     : null;
 
@@ -975,8 +977,19 @@ export function useVimSelection({
 
   const onBlur = useCallback((event: ReactFocusEvent<HTMLElement>) => {
     if (event.relatedTarget instanceof Node && event.currentTarget.contains(event.relatedTarget)) return;
+    if (
+      event.relatedTarget instanceof Element
+      && event.relatedTarget.closest('[data-vim-key-hud]')
+    ) {
+      return;
+    }
     setFocused(false);
   }, []);
+
+  const onHudFocusLeave = useCallback(() => {
+    if (containerRef.current === document.activeElement) return;
+    setFocused(false);
+  }, [containerRef]);
 
   const onMouseDown = useCallback((event: ReactMouseEvent<HTMLElement>) => {
     if (!enabled || isDocumentKeyboardControl(event.target)) return;
@@ -997,6 +1010,7 @@ export function useVimSelection({
     onFocus,
     onBlur,
     onMouseDown,
-    closeHelp: () => setHelpOpen(false),
+    onHelpOpenChange: setHelpOpen,
+    onHudFocusLeave,
   };
 }

--- a/packages/ui/hooks/useVimSelection.ts
+++ b/packages/ui/hooks/useVimSelection.ts
@@ -1,0 +1,958 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type FocusEvent as ReactFocusEvent,
+  type MouseEvent as ReactMouseEvent,
+  type RefObject,
+} from 'react';
+import { useVimSelectionShortcuts } from '../shortcuts';
+import type { EditorMode } from '../types';
+import {
+  buildSemanticTargetGraph,
+  createSemanticTargetRange,
+  findInitialSemanticTarget,
+  getOwningBlockTarget,
+  getSemanticTargetChildren,
+  moveSemanticTarget,
+  resolveSemanticTarget,
+  type SemanticTarget,
+  type SemanticTargetGraph,
+} from '../utils/blockTargeting';
+import { isDocumentKeyboardControl } from '../utils/domSelection';
+import {
+  applyNativeTextSelection,
+  createInitialVimSelectionState,
+  createRangeBetweenTextPositions,
+  getTextElementBounds,
+  moveTextPosition,
+  resolveTextPosition,
+  serializeTextPosition,
+  type VimBlockState,
+  type VimInlineState,
+  type VimRestorableState,
+  type VimSelectionState,
+  type VimTextMotion,
+  type VimTextPosition,
+  type VimTextState,
+  type VimVisualBlockState,
+  type VimVisualState,
+} from '../utils/vimNavigation';
+
+/** Inputs required by the Markdown semantic Vim controller. */
+export interface UseVimSelectionOptions {
+  readonly containerRef: RefObject<HTMLElement | null>;
+  readonly enabled: boolean;
+  readonly blocked: boolean;
+  readonly activeMode: EditorMode;
+  /** Identity that changes when the rendered document is replaced. */
+  readonly contentVersion?: unknown;
+  readonly onHighlightRange: (range: Range, modeOverride?: EditorMode) => void;
+  readonly onCodeBlockAction: (
+    blockId: string,
+    element: HTMLElement,
+    modeOverride?: EditorMode,
+  ) => void;
+  readonly onMathAction: (element: HTMLElement, modeOverride?: EditorMode) => void;
+}
+
+/** State and event handlers rendered by the Markdown Viewer. */
+export interface UseVimSelectionReturn {
+  readonly state: VimSelectionState;
+  readonly focused: boolean;
+  readonly helpOpen: boolean;
+  readonly activeTarget: SemanticTarget | null;
+  readonly onFocus: (event: ReactFocusEvent<HTMLElement>) => void;
+  readonly onBlur: (event: ReactFocusEvent<HTMLElement>) => void;
+  readonly onMouseDown: (event: ReactMouseEvent<HTMLElement>) => void;
+  readonly closeHelp: () => void;
+}
+
+function selectionModeForAction(key: string): EditorMode | null {
+  if (key === 'c') return 'comment';
+  if (key === 'd') return 'redline';
+  if (key === 't') return 'quickLabel';
+  if (key === 'm' || key === ' ' || key === 'Space' || key === 'Spacebar') {
+    return 'selection';
+  }
+  return null;
+}
+
+function copyText(text: string): void {
+  const textarea = document.createElement('textarea');
+  textarea.style.cssText = 'position:fixed;opacity:0;pointer-events:none';
+  textarea.value = text;
+  document.body.appendChild(textarea);
+  textarea.select();
+  document.execCommand('copy');
+  textarea.remove();
+}
+
+function motionFromTextKey(key: string): VimTextMotion | null {
+  if (key === 'h') return 'left';
+  if (key === 'l') return 'right';
+  if (key === 'w') return 'word-forward';
+  if (key === 'b') return 'word-backward';
+  if (key === 'e') return 'word-end';
+  if (key === '{') return 'block-backward';
+  if (key === '}') return 'block-forward';
+  return null;
+}
+
+function semanticStateForTarget(target: SemanticTarget): VimBlockState | VimInlineState {
+  return target.kind === 'inline' || target.kind === 'row' || target.kind === 'cell'
+    ? { phase: 'inline', targetKey: target.key }
+    : { phase: 'block', targetKey: target.key };
+}
+
+function targetKeyForState(state: VimSelectionState): string | null {
+  switch (state.phase) {
+    case 'inactive':
+      return null;
+    case 'action':
+      return state.returnTo.targetKey;
+    case 'block':
+    case 'inline':
+    case 'text':
+    case 'visual':
+    case 'visual-block':
+      return state.targetKey;
+  }
+}
+
+function targetKeyForPosition(
+  graph: SemanticTargetGraph,
+  currentTargetKey: string,
+  position: VimTextPosition,
+): string {
+  const current = resolveSemanticTarget(graph, currentTargetKey);
+  if (current?.blockId === position.blockId) return currentTargetKey;
+  return graph.blockKeys
+    .map((key) => resolveSemanticTarget(graph, key))
+    .find((target) => target?.blockId === position.blockId)
+    ?.key ?? currentTargetKey;
+}
+
+function clampPositionToSemanticTarget(
+  graph: SemanticTargetGraph,
+  targetKey: string,
+  position: VimTextPosition,
+  direction: 'forward' | 'backward',
+): VimTextPosition {
+  const target = resolveSemanticTarget(graph, targetKey);
+  if (!target || (target.kind !== 'inline' && target.kind !== 'row' && target.kind !== 'cell')) {
+    return position;
+  }
+  const bounds = getTextElementBounds(graph.container, target.element);
+  if (!bounds) return position;
+  if (position.blockId !== bounds.start.blockId) {
+    return direction === 'forward' ? bounds.end : bounds.start;
+  }
+  if (position.textOffset <= bounds.start.textOffset) return bounds.start;
+  if (position.textOffset >= bounds.end.textOffset) return bounds.end;
+  return {
+    blockId: position.blockId,
+    textOffset: position.textOffset,
+    affinity: position.affinity,
+  };
+}
+
+function moveWithNativeSelection(
+  container: HTMLElement,
+  state: VimTextState | VimVisualState,
+  direction: 'forward' | 'backward',
+  granularity: 'line' | 'lineboundary',
+): VimTextPosition | null {
+  const anchor = state.phase === 'visual' ? state.anchor : null;
+  const selection = applyNativeTextSelection(container, state.cursor, anchor);
+  if (!selection || typeof selection.modify !== 'function') return null;
+  selection.modify(state.phase === 'text' ? 'move' : 'extend', direction, granularity);
+  if (!selection.focusNode) return null;
+  return serializeTextPosition(container, selection.focusNode, selection.focusOffset);
+}
+
+function selectedTextRange(
+  container: HTMLElement,
+  state: VimVisualState,
+): Range | null {
+  const range = createRangeBetweenTextPositions(container, state.anchor, state.cursor);
+  return range && !range.collapsed ? range : null;
+}
+
+function visualBlockPoints(
+  graph: SemanticTargetGraph,
+  state: VimVisualBlockState,
+): { anchor: VimTextPosition; cursor: VimTextPosition } | null {
+  const anchorTarget = resolveSemanticTarget(graph, state.anchorTargetKey);
+  const cursorTarget = resolveSemanticTarget(graph, state.targetKey);
+  if (!anchorTarget || !cursorTarget) return null;
+  const anchorBounds = getTextElementBounds(graph.container, anchorTarget.element);
+  const cursorBounds = getTextElementBounds(graph.container, cursorTarget.element);
+  if (!anchorBounds || !cursorBounds) return null;
+
+  const anchorIndex = graph.blockKeys.indexOf(anchorTarget.key);
+  const cursorIndex = graph.blockKeys.indexOf(cursorTarget.key);
+  return cursorIndex >= anchorIndex
+    ? { anchor: anchorBounds.start, cursor: cursorBounds.end }
+    : { anchor: anchorBounds.end, cursor: cursorBounds.start };
+}
+
+function visualBlockRange(
+  graph: SemanticTargetGraph,
+  state: VimVisualBlockState,
+): Range | null {
+  const points = visualBlockPoints(graph, state);
+  if (!points) return null;
+  const range = createRangeBetweenTextPositions(
+    graph.container,
+    points.anchor,
+    points.cursor,
+  );
+  return range && !range.collapsed ? range : null;
+}
+
+function applyVisualBlockSelection(
+  graph: SemanticTargetGraph,
+  state: VimVisualBlockState,
+): void {
+  const points = visualBlockPoints(graph, state);
+  if (points) applyNativeTextSelection(graph.container, points.cursor, points.anchor);
+}
+
+/**
+ * Own semantic block navigation and precise text selection while the rendered
+ * document has focus.
+ *
+ * The shortcut listener is attached only to the rendered document element.
+ * Disabling the opt-in setting makes it inert, and native controls inside the
+ * document retain their own keys.
+ */
+export function useVimSelection({
+  containerRef,
+  enabled,
+  blocked,
+  activeMode,
+  contentVersion,
+  onHighlightRange,
+  onCodeBlockAction,
+  onMathAction,
+}: UseVimSelectionOptions): UseVimSelectionReturn {
+  const [state, setStateValue] = useState<VimSelectionState>(
+    createInitialVimSelectionState,
+  );
+  const stateRef = useRef(state);
+  const [focused, setFocused] = useState(false);
+  const [helpOpen, setHelpOpen] = useState(false);
+  const restoreFocusRef = useRef(false);
+  const wasBlockedRef = useRef(blocked);
+  const pointerFocusRef = useRef(false);
+  const restoringFocusRef = useRef(false);
+
+  const setState = useCallback((next: VimSelectionState) => {
+    stateRef.current = next;
+    setStateValue(next);
+  }, []);
+
+  const liveGraph = containerRef.current
+    ? buildSemanticTargetGraph(containerRef.current)
+    : null;
+  const activeTarget = liveGraph && (
+    state.phase === 'block'
+    || state.phase === 'inline'
+    || state.phase === 'action'
+  )
+    ? resolveSemanticTarget(liveGraph, targetKeyForState(state))
+    : null;
+
+  const initializeSemanticNavigation = useCallback((): VimBlockState | null => {
+    const container = containerRef.current;
+    if (!container) return null;
+    const graph = buildSemanticTargetGraph(container);
+    const initial = findInitialSemanticTarget(graph);
+    if (!initial) return null;
+    const next: VimBlockState = { phase: 'block', targetKey: initial.key };
+    setState(next);
+    window.getSelection()?.removeAllRanges();
+    initial.element.scrollIntoView({ block: 'nearest' });
+    return next;
+  }, [containerRef, setState]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setState(createInitialVimSelectionState());
+      setFocused(false);
+      setHelpOpen(false);
+      window.getSelection()?.removeAllRanges();
+      return;
+    }
+    if (!focused) return;
+    if (restoringFocusRef.current) {
+      restoringFocusRef.current = false;
+      return;
+    }
+    if (pointerFocusRef.current) {
+      pointerFocusRef.current = false;
+      return;
+    }
+    initializeSemanticNavigation();
+  }, [
+    contentVersion,
+    enabled,
+    focused,
+    initializeSemanticNavigation,
+    setState,
+  ]);
+
+  useEffect(() => {
+    const wasBlocked = wasBlockedRef.current;
+    wasBlockedRef.current = blocked;
+    if (wasBlocked && !blocked && stateRef.current.phase === 'action') {
+      const returnTo = stateRef.current.returnTo;
+      setState(returnTo);
+      const container = containerRef.current;
+      if (container) {
+        const graph = buildSemanticTargetGraph(container);
+        if (returnTo.phase === 'text' || returnTo.phase === 'visual') {
+          applyNativeTextSelection(
+            graph.container,
+            returnTo.cursor,
+            returnTo.phase === 'visual' ? returnTo.anchor : null,
+          );
+        } else if (returnTo.phase === 'visual-block') {
+          applyVisualBlockSelection(graph, returnTo);
+        }
+      }
+    }
+    if (wasBlocked && !blocked) {
+      const shouldRestoreFocus = restoreFocusRef.current;
+      restoreFocusRef.current = false;
+      if (
+        shouldRestoreFocus
+        && enabled
+        && (document.activeElement === document.body || document.activeElement === null)
+      ) {
+        const container = containerRef.current;
+        if (container) {
+          restoringFocusRef.current = true;
+          container.focus({ preventScroll: true });
+        }
+      }
+    }
+  }, [blocked, containerRef, enabled, setState]);
+
+  const setSemanticTarget = useCallback((target: SemanticTarget) => {
+    setState(semanticStateForTarget(target));
+    window.getSelection()?.removeAllRanges();
+    target.element.scrollIntoView({ block: 'nearest' });
+  }, [setState]);
+
+  const updateTextState = useCallback((
+    graph: SemanticTargetGraph,
+    next: VimTextState | VimVisualState,
+  ) => {
+    const targetKey = targetKeyForPosition(graph, next.targetKey, next.cursor);
+    const normalized = { ...next, targetKey };
+    setState(normalized);
+    applyNativeTextSelection(
+      graph.container,
+      normalized.cursor,
+      normalized.phase === 'visual' ? normalized.anchor : null,
+    );
+    resolveTextPosition(graph.container, normalized.cursor)
+      ?.node.parentElement
+      ?.scrollIntoView({ block: 'nearest' });
+  }, [setState]);
+
+  const enterTextAtTarget = useCallback((
+    graph: SemanticTargetGraph,
+    target: SemanticTarget,
+  ): boolean => {
+    const bounds = getTextElementBounds(graph.container, target.element);
+    if (!bounds) return false;
+    updateTextState(graph, {
+      phase: 'text',
+      targetKey: target.key,
+      cursor: bounds.start,
+    });
+    return true;
+  }, [updateTextState]);
+
+  const enterVisualAtTarget = useCallback((
+    graph: SemanticTargetGraph,
+    target: SemanticTarget,
+  ): boolean => {
+    const bounds = getTextElementBounds(graph.container, target.element);
+    if (!bounds) return false;
+    updateTextState(graph, {
+      phase: 'visual',
+      targetKey: target.key,
+      anchor: bounds.start,
+      cursor: bounds.start,
+    });
+    return true;
+  }, [updateTextState]);
+
+  const enterVisualBlock = useCallback((
+    graph: SemanticTargetGraph,
+    target: SemanticTarget,
+  ): boolean => {
+    const block = getOwningBlockTarget(graph, target);
+    const next: VimVisualBlockState = {
+      phase: 'visual-block',
+      anchorTargetKey: block.key,
+      targetKey: block.key,
+    };
+    if (!getTextElementBounds(graph.container, block.element)) return false;
+    setState(next);
+    applyVisualBlockSelection(graph, next);
+    block.element.scrollIntoView({ block: 'nearest' });
+    return true;
+  }, [setState]);
+
+  const runTargetAction = useCallback((
+    target: SemanticTarget,
+    returnTo: VimBlockState | VimInlineState,
+    modeOverride?: EditorMode,
+  ): boolean => {
+    const effectiveMode = modeOverride ?? activeMode;
+    const beginAction = () => {
+      restoreFocusRef.current = effectiveMode !== 'redline';
+      setState(
+        effectiveMode !== 'redline'
+          ? { phase: 'action', returnTo }
+          : returnTo,
+      );
+    };
+
+    if (target.kind === 'code') {
+      beginAction();
+      onCodeBlockAction(target.blockId, target.element, modeOverride);
+      return true;
+    }
+    if (target.kind === 'math') {
+      beginAction();
+      onMathAction(target.element, modeOverride);
+      return true;
+    }
+    const range = createSemanticTargetRange(target);
+    if (!range) return false;
+    beginAction();
+    onHighlightRange(range, modeOverride);
+    return true;
+  }, [
+    activeMode,
+    onCodeBlockAction,
+    onHighlightRange,
+    onMathAction,
+    setState,
+  ]);
+
+  const runRangeAction = useCallback((
+    graph: SemanticTargetGraph,
+    range: Range,
+    returnTo: VimVisualState | VimVisualBlockState,
+    modeOverride?: EditorMode,
+  ): boolean => {
+    const effectiveMode = modeOverride ?? activeMode;
+    const immediateReturn: VimRestorableState = returnTo.phase === 'visual'
+      ? {
+          phase: 'text' as const,
+          targetKey: returnTo.targetKey,
+          cursor: returnTo.cursor,
+        }
+      : (() => {
+          const target = resolveSemanticTarget(graph, returnTo.targetKey);
+          return target ? semanticStateForTarget(target) : returnTo;
+        })();
+    restoreFocusRef.current = effectiveMode !== 'redline';
+    setState(
+      effectiveMode !== 'redline'
+        ? { phase: 'action', returnTo }
+        : immediateReturn,
+    );
+    onHighlightRange(range, modeOverride);
+    return true;
+  }, [activeMode, onHighlightRange, setState]);
+
+  const actionForCurrentState = useCallback((
+    graph: SemanticTargetGraph,
+    current: VimRestorableState,
+    modeOverride?: EditorMode,
+  ): boolean => {
+    if (current.phase === 'visual') {
+      const range = selectedTextRange(graph.container, current);
+      return range
+        ? runRangeAction(graph, range, current, modeOverride)
+        : false;
+    }
+    if (current.phase === 'visual-block') {
+      const range = visualBlockRange(graph, current);
+      return range
+        ? runRangeAction(graph, range, current, modeOverride)
+        : false;
+    }
+
+    const target = resolveSemanticTarget(graph, current.targetKey);
+    if (!target) return false;
+    return runTargetAction(
+      target,
+      semanticStateForTarget(target),
+      modeOverride,
+    );
+  }, [runRangeAction, runTargetAction]);
+
+  const copyCurrentState = useCallback((
+    graph: SemanticTargetGraph,
+    current: VimRestorableState,
+  ): boolean => {
+    if (current.phase === 'visual') {
+      const range = selectedTextRange(graph.container, current);
+      if (!range) return false;
+      copyText(range.toString());
+      setState({
+        phase: 'text',
+        targetKey: current.targetKey,
+        cursor: current.cursor,
+      });
+      return true;
+    }
+    if (current.phase === 'visual-block') {
+      const range = visualBlockRange(graph, current);
+      if (!range) return false;
+      copyText(range.toString());
+      const target = resolveSemanticTarget(graph, current.targetKey);
+      if (target) setState(semanticStateForTarget(target));
+      return true;
+    }
+    const target = resolveSemanticTarget(graph, current.targetKey);
+    if (!target) return false;
+    copyText(target.element.textContent?.trim() ?? '');
+    return true;
+  }, [setState]);
+
+  const handleSemanticKey = useCallback((
+    graph: SemanticTargetGraph,
+    current: VimBlockState | VimInlineState,
+    key: string,
+  ): boolean => {
+    const target = resolveSemanticTarget(graph, current.targetKey);
+    if (!target) return false;
+
+    if (key === 'j' || key === 'k' || key === '{' || key === '}') {
+      const previous = key === 'k' || key === '{';
+      setSemanticTarget(moveSemanticTarget(
+        graph,
+        target,
+        current.phase === 'inline' && (key === 'j' || key === 'k')
+          ? previous
+            ? 'previous-sibling'
+            : 'next-sibling'
+          : previous
+            ? 'previous-block'
+            : 'next-block',
+      ));
+      return true;
+    }
+    if (key === 'h' || key === 'H') {
+      const parent = moveSemanticTarget(graph, target, 'parent');
+      if (parent.key !== target.key) setSemanticTarget(parent);
+      return true;
+    }
+    if (key === 'l') {
+      const child = getSemanticTargetChildren(graph, target)[0];
+      if (!child) return enterTextAtTarget(graph, target);
+      setSemanticTarget(child);
+      return true;
+    }
+    if (key === 'v') return enterVisualAtTarget(graph, target);
+    if (key === 'V') return enterVisualBlock(graph, target);
+    if (key === 'Enter') return actionForCurrentState(graph, current);
+    if (key === 'y') return copyCurrentState(graph, current);
+    const actionMode = selectionModeForAction(key);
+    return actionMode
+      ? actionForCurrentState(graph, current, actionMode)
+      : false;
+  }, [
+    actionForCurrentState,
+    copyCurrentState,
+    enterTextAtTarget,
+    enterVisualAtTarget,
+    enterVisualBlock,
+    setSemanticTarget,
+  ]);
+
+  const handleTextKey = useCallback((
+    graph: SemanticTargetGraph,
+    current: VimTextState | VimVisualState,
+    key: string,
+  ): boolean => {
+    if (key === 'v') {
+      if (current.phase === 'visual') {
+        updateTextState(graph, {
+          phase: 'text',
+          targetKey: current.targetKey,
+          cursor: current.cursor,
+        });
+      } else {
+        updateTextState(graph, {
+          phase: 'visual',
+          targetKey: current.targetKey,
+          cursor: current.cursor,
+          anchor: current.cursor,
+        });
+      }
+      return true;
+    }
+    if (key === 'V') {
+      const target = resolveSemanticTarget(graph, current.targetKey);
+      return target ? enterVisualBlock(graph, target) : false;
+    }
+    if (key === 'o' && current.phase === 'visual') {
+      updateTextState(graph, {
+        ...current,
+        anchor: current.cursor,
+        cursor: current.anchor,
+      });
+      return true;
+    }
+    if (key === 'Enter') {
+      return current.phase === 'visual'
+        ? actionForCurrentState(graph, current)
+        : false;
+    }
+    if (key === 'y') {
+      return current.phase === 'visual'
+        ? copyCurrentState(graph, current)
+        : false;
+    }
+    const actionMode = selectionModeForAction(key);
+    if (actionMode) {
+      return current.phase === 'visual'
+        ? actionForCurrentState(graph, current, actionMode)
+        : false;
+    }
+    if (key === 'G') {
+      updateTextState(graph, {
+        ...current,
+        cursor: moveTextPosition(graph.container, current.cursor, 'document-end'),
+      });
+      return true;
+    }
+    if (key === 'j' || key === 'k' || key === '0' || key === '$') {
+      const direction = key === 'j' || key === '$' ? 'forward' : 'backward';
+      const granularity = key === 'j' || key === 'k' ? 'line' : 'lineboundary';
+      const nativePosition = moveWithNativeSelection(
+        graph.container,
+        current,
+        direction,
+        granularity,
+      );
+      const fallback: VimTextMotion = key === 'j'
+        ? 'block-forward'
+        : key === 'k'
+          ? 'block-backward'
+          : key === '0'
+            ? 'line-start'
+            : 'line-end';
+      updateTextState(graph, {
+        ...current,
+        cursor: clampPositionToSemanticTarget(
+          graph,
+          current.targetKey,
+          nativePosition
+            ?? moveTextPosition(graph.container, current.cursor, fallback),
+          direction,
+        ),
+      });
+      return true;
+    }
+    const motion = motionFromTextKey(key);
+    if (!motion) return false;
+    const nextPosition = moveTextPosition(graph.container, current.cursor, motion);
+    updateTextState(graph, {
+      ...current,
+      cursor: motion === 'block-backward' || motion === 'block-forward'
+        ? nextPosition
+        : clampPositionToSemanticTarget(
+            graph,
+            current.targetKey,
+            nextPosition,
+            motion === 'left' || motion === 'word-backward' ? 'backward' : 'forward',
+          ),
+    });
+    return true;
+  }, [
+    actionForCurrentState,
+    copyCurrentState,
+    enterVisualBlock,
+    updateTextState,
+  ]);
+
+  const handleVisualBlockKey = useCallback((
+    graph: SemanticTargetGraph,
+    current: VimVisualBlockState,
+    key: string,
+  ): boolean => {
+    if (key === 'V') {
+      const target = resolveSemanticTarget(graph, current.targetKey);
+      if (target) setSemanticTarget(target);
+      return true;
+    }
+    if (key === 'j' || key === 'k') {
+      const target = resolveSemanticTarget(graph, current.targetKey);
+      if (!target) return false;
+      const next = moveSemanticTarget(
+        graph,
+        target,
+        key === 'j' ? 'next-block' : 'previous-block',
+      );
+      const nextState: VimVisualBlockState = {
+        ...current,
+        targetKey: getOwningBlockTarget(graph, next).key,
+      };
+      setState(nextState);
+      applyVisualBlockSelection(graph, nextState);
+      next.element.scrollIntoView({ block: 'nearest' });
+      return true;
+    }
+    if (key === 'o') {
+      const next: VimVisualBlockState = {
+        phase: 'visual-block',
+        anchorTargetKey: current.targetKey,
+        targetKey: current.anchorTargetKey,
+      };
+      setState(next);
+      applyVisualBlockSelection(graph, next);
+      return true;
+    }
+    if (key === 'Enter') return actionForCurrentState(graph, current);
+    if (key === 'y') return copyCurrentState(graph, current);
+    const actionMode = selectionModeForAction(key);
+    return actionMode
+      ? actionForCurrentState(graph, current, actionMode)
+      : false;
+  }, [
+    actionForCurrentState,
+    copyCurrentState,
+    setSemanticTarget,
+    setState,
+  ]);
+
+  const escapeCurrentState = useCallback((
+    graph: SemanticTargetGraph,
+    current: VimSelectionState,
+  ) => {
+    switch (current.phase) {
+      case 'inactive':
+        return;
+      case 'action':
+        setState(current.returnTo);
+        return;
+      case 'visual':
+        updateTextState(graph, {
+          phase: 'text',
+          targetKey: current.targetKey,
+          cursor: current.cursor,
+        });
+        return;
+      case 'text': {
+        const target = resolveSemanticTarget(graph, current.targetKey);
+        if (target) setSemanticTarget(target);
+        return;
+      }
+      case 'visual-block': {
+        const target = resolveSemanticTarget(graph, current.targetKey);
+        if (target) setSemanticTarget(target);
+        return;
+      }
+      case 'inline': {
+        const target = resolveSemanticTarget(graph, current.targetKey);
+        const parent = target
+          ? moveSemanticTarget(graph, target, 'parent')
+          : null;
+        if (parent && parent.key !== target?.key) {
+          setSemanticTarget(parent);
+        } else {
+          setState(createInitialVimSelectionState());
+          window.getSelection()?.removeAllRanges();
+        }
+        return;
+      }
+      case 'block':
+        setState(createInitialVimSelectionState());
+        window.getSelection()?.removeAllRanges();
+    }
+  }, [setSemanticTarget, setState, updateTextState]);
+
+  const jumpToDocumentBlock = useCallback((
+    graph: SemanticTargetGraph,
+    end: boolean,
+  ): boolean => {
+    const current = stateRef.current;
+    if (current.phase === 'text' || current.phase === 'visual') {
+      updateTextState(graph, {
+        ...current,
+        cursor: moveTextPosition(
+          graph.container,
+          current.cursor,
+          end ? 'document-end' : 'document-start',
+        ),
+      });
+      return true;
+    }
+    const currentTarget = resolveSemanticTarget(graph, targetKeyForState(current))
+      ?? findInitialSemanticTarget(graph);
+    if (!currentTarget) return false;
+    setSemanticTarget(moveSemanticTarget(
+      graph,
+      currentTarget,
+      end ? 'last-block' : 'first-block',
+    ));
+    return true;
+  }, [setSemanticTarget, updateTextState]);
+
+  const canHandleShortcut = useCallback((event: KeyboardEvent) => (
+    enabled
+    && !blocked
+    && focused
+    && !event.isComposing
+    && !isDocumentKeyboardControl(event.target)
+    && !event.ctrlKey
+    && !event.metaKey
+    && !event.altKey
+  ), [blocked, enabled, focused]);
+
+  const onKeyDown = useCallback((event: KeyboardEvent) => {
+    if (!canHandleShortcut(event)) return;
+
+    if (stateRef.current.phase === 'action') {
+      return;
+    }
+
+    const container = containerRef.current;
+    if (!container) return;
+    const graph = buildSemanticTargetGraph(container);
+    const key = event.key;
+    let handled = false;
+
+    if (helpOpen) {
+      if (key === 'Escape' || key === '?') {
+        setHelpOpen(false);
+        handled = true;
+      }
+    } else if (key === '?') {
+      setHelpOpen(true);
+      handled = true;
+    } else if (key === 'Escape') {
+      if (stateRef.current.phase !== 'inactive') {
+        escapeCurrentState(graph, stateRef.current);
+        handled = true;
+      }
+    } else {
+      let current = stateRef.current;
+      if (current.phase === 'inactive') {
+        current = initializeSemanticNavigation()
+          ?? createInitialVimSelectionState();
+      }
+
+      if (key === 'G') {
+        handled = jumpToDocumentBlock(graph, true);
+      } else if (current.phase === 'block' || current.phase === 'inline') {
+        handled = handleSemanticKey(graph, current, key);
+      } else if (current.phase === 'text' || current.phase === 'visual') {
+        handled = handleTextKey(graph, current, key);
+      } else if (current.phase === 'visual-block') {
+        handled = handleVisualBlockKey(graph, current, key);
+      }
+    }
+
+    if (handled) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  }, [
+    canHandleShortcut,
+    containerRef,
+    escapeCurrentState,
+    handleSemanticKey,
+    handleTextKey,
+    handleVisualBlockKey,
+    helpOpen,
+    initializeSemanticNavigation,
+    jumpToDocumentBlock,
+  ]);
+
+  const onDocumentStart = useCallback((event: KeyboardEvent) => {
+    if (!canHandleShortcut(event) || stateRef.current.phase === 'action') return;
+    const container = containerRef.current;
+    if (!container) return;
+    if (jumpToDocumentBlock(buildSemanticTargetGraph(container), false)) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  }, [canHandleShortcut, containerRef, jumpToDocumentBlock]);
+
+  const shortcutHandler = { when: canHandleShortcut, handle: onKeyDown };
+  useVimSelectionShortcuts({
+    target: containerRef.current,
+    handlers: {
+      moveDown: shortcutHandler,
+      moveUp: shortcutHandler,
+      documentStart: { when: canHandleShortcut, handle: onDocumentStart },
+      documentEnd: shortcutHandler,
+      moveOut: shortcutHandler,
+      refine: shortcutHandler,
+      visual: shortcutHandler,
+      visualBlock: shortcutHandler,
+      wordForward: shortcutHandler,
+      wordBackward: shortcutHandler,
+      wordEnd: shortcutHandler,
+      lineStart: shortcutHandler,
+      lineEnd: shortcutHandler,
+      previousTextBlock: shortcutHandler,
+      nextTextBlock: shortcutHandler,
+      swapSelectionEnds: shortcutHandler,
+      activeAnnotation: shortcutHandler,
+      annotationMenu: shortcutHandler,
+      comment: shortcutHandler,
+      redline: shortcutHandler,
+      markup: shortcutHandler,
+      label: shortcutHandler,
+      copy: shortcutHandler,
+      cancel: shortcutHandler,
+      help: shortcutHandler,
+    },
+  });
+
+  const onFocus = useCallback((event: ReactFocusEvent<HTMLElement>) => {
+    if (!enabled || event.target !== event.currentTarget) return;
+    setFocused(true);
+  }, [enabled]);
+
+  const onBlur = useCallback((event: ReactFocusEvent<HTMLElement>) => {
+    if (event.relatedTarget instanceof Node && event.currentTarget.contains(event.relatedTarget)) return;
+    setFocused(false);
+  }, []);
+
+  const onMouseDown = useCallback((event: ReactMouseEvent<HTMLElement>) => {
+    if (!enabled || isDocumentKeyboardControl(event.target)) return;
+    setState(createInitialVimSelectionState());
+    window.getSelection()?.removeAllRanges();
+    if (document.activeElement !== event.currentTarget) {
+      pointerFocusRef.current = true;
+      event.currentTarget.focus({ preventScroll: true });
+    }
+  }, [enabled, setState]);
+
+  return {
+    state,
+    focused,
+    helpOpen,
+    activeTarget,
+    onFocus,
+    onBlur,
+    onMouseDown,
+    closeHelp: () => setHelpOpen(false),
+  };
+}

--- a/packages/ui/shortcuts.test.ts
+++ b/packages/ui/shortcuts.test.ts
@@ -75,6 +75,9 @@ describe('shortcuts', () => {
       'Actions',
       'Input Method',
       'Annotations',
+      'Vim Document Navigation',
+      'Vim Text Navigation',
+      'Vim Annotation Actions',
       'Image Annotator',
     ]);
 
@@ -83,6 +86,9 @@ describe('shortcuts', () => {
       'Sidebar',
       'Input Method',
       'Annotations',
+      'Vim Document Navigation',
+      'Vim Text Navigation',
+      'Vim Annotation Actions',
       'Image Annotator',
     ]);
 
@@ -114,12 +120,16 @@ describe('shortcuts', () => {
     const quickLabelEvent = { key: '3', ctrlKey: false, metaKey: false, shiftKey: false, altKey: true, code: 'Digit3' } as KeyboardEvent;
     const macOptionQuickLabelEvent = { key: '£', ctrlKey: false, metaKey: false, shiftKey: false, altKey: true, code: 'Digit3' } as KeyboardEvent;
     const wrongEvent = { key: 'Enter', ctrlKey: false, metaKey: false, shiftKey: false, altKey: true, code: 'Enter' } as KeyboardEvent;
+    const spaceEvent = { key: ' ', ctrlKey: false, metaKey: false, shiftKey: false, altKey: false, code: 'Space' } as KeyboardEvent;
+    const questionEvent = { key: '?', ctrlKey: false, metaKey: false, shiftKey: true, altKey: false, code: 'Slash' } as KeyboardEvent;
 
     expect(matchesShortcutBinding(submitEvent, 'Mod+Enter')).toBe(true);
     expect(matchesShortcutBinding(reverseSearchEvent, 'Shift+F3')).toBe(true);
     expect(matchesShortcutBinding(typeEvent, 'A-Z')).toBe(true);
     expect(matchesShortcutBinding(quickLabelEvent, 'Alt+1-0')).toBe(true);
     expect(matchesShortcutBinding(macOptionQuickLabelEvent, 'Alt+1-0')).toBe(true);
+    expect(matchesShortcutBinding(spaceEvent, 'Space')).toBe(true);
+    expect(matchesShortcutBinding(questionEvent, '?')).toBe(true);
     expect(matchesShortcutBinding(wrongEvent, 'Mod+Enter')).toBe(false);
   });
 

--- a/packages/ui/shortcuts.test.ts
+++ b/packages/ui/shortcuts.test.ts
@@ -120,8 +120,22 @@ describe('shortcuts', () => {
     const quickLabelEvent = { key: '3', ctrlKey: false, metaKey: false, shiftKey: false, altKey: true, code: 'Digit3' } as KeyboardEvent;
     const macOptionQuickLabelEvent = { key: '£', ctrlKey: false, metaKey: false, shiftKey: false, altKey: true, code: 'Digit3' } as KeyboardEvent;
     const wrongEvent = { key: 'Enter', ctrlKey: false, metaKey: false, shiftKey: false, altKey: true, code: 'Enter' } as KeyboardEvent;
-    const spaceEvent = { key: ' ', ctrlKey: false, metaKey: false, shiftKey: false, altKey: false, code: 'Space' } as KeyboardEvent;
-    const questionEvent = { key: '?', ctrlKey: false, metaKey: false, shiftKey: true, altKey: false, code: 'Slash' } as KeyboardEvent;
+    const spaceEvent = {
+      key: ' ',
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      altKey: false,
+      code: 'Space',
+    };
+    const questionEvent = {
+      key: '?',
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: true,
+      altKey: false,
+      code: 'Slash',
+    };
 
     expect(matchesShortcutBinding(submitEvent, 'Mod+Enter')).toBe(true);
     expect(matchesShortcutBinding(reverseSearchEvent, 'Shift+F3')).toBe(true);

--- a/packages/ui/shortcuts/core.ts
+++ b/packages/ui/shortcuts/core.ts
@@ -46,12 +46,6 @@ const NAMED_TOKENS = new Set([
   'Enter',
   'Escape',
   'Tab',
-  // TODO(migration): `matchesKeyToken` does not currently match `Space` —
-  // pressing Spacebar produces `event.key === ' '` (length 1), which the
-  // matcher uppercases to `' '` and then compares to the literal `'Space'`,
-  // always failing. Add a special case in `matchesKeyToken` (e.g.
-  // `if (token === 'Space') return event.key === ' ' || event.code === 'Space'`)
-  // before any scope binds Space.
   'Space',
   'Backspace',
   'Delete',
@@ -70,6 +64,10 @@ const NAMED_TOKENS = new Set([
   '.',
   '[',
   ']',
+  '{',
+  '}',
+  '?',
+  '$',
 ]);
 
 for (let n = 1; n <= 12; n += 1) {
@@ -77,6 +75,7 @@ for (let n = 1; n <= 12; n += 1) {
 }
 
 const MODIFIER_TOKENS = new Set(['Mod', 'Shift', 'Alt']);
+const SHIFTED_LITERAL_TOKENS = new Set(['{', '}', '?', '$']);
 
 export function defineShortcutScope<TAction extends string>(scope: ShortcutScopeDefinition<TAction>): ShortcutScopeDefinition<TAction> {
   return scope;
@@ -351,6 +350,10 @@ function matchesKeyToken(event: KeyboardEvent, token: string): boolean {
   const key = event.key.length === 1 ? event.key.toUpperCase() : event.key;
   const shortcutDigit = getShortcutDigit(event);
 
+  if (token === 'Space') {
+    return event.key === ' ' || event.key === 'Spacebar' || event.code === 'Space';
+  }
+
   if (token === 'A-Z') {
     return /^[A-Z]$/.test(key);
   }
@@ -370,6 +373,12 @@ function matchesKeyToken(event: KeyboardEvent, token: string): boolean {
   return key === token;
 }
 
+/**
+ * Match a keyboard event against one normalized, single-press binding.
+ *
+ * Sequential and hold bindings deliberately return false; their timing
+ * semantics are handled by the shortcut runtime's dedicated paths.
+ */
 export function matchesShortcutBinding(event: KeyboardEvent, binding: string): boolean {
   if (binding.includes(' ') || binding.includes('hold')) {
     return false;
@@ -385,13 +394,24 @@ export function matchesShortcutBinding(event: KeyboardEvent, binding: string): b
   if (keyTokens.length !== 1) return false;
 
   const keyToken = keyTokens[0];
-  const shiftMatches = requiresShift === event.shiftKey || (!requiresShift && keyToken === 'A-Z' && event.shiftKey);
+  const shiftMatches = requiresShift === event.shiftKey
+    || (!requiresShift && keyToken === 'A-Z' && event.shiftKey)
+    || (!requiresShift && SHIFTED_LITERAL_TOKENS.has(keyToken) && event.key === keyToken);
 
   if (requiresMod !== (event.metaKey || event.ctrlKey)) return false;
   if (!shiftMatches) return false;
   if (requiresAlt !== event.altKey) return false;
 
   return matchesKeyToken(event, keyToken);
+}
+
+/**
+ * Match one key group from a sequential binding such as `G G`.
+ *
+ * The group uses the same normalized syntax as an ordinary one-press binding.
+ */
+export function matchesShortcutBindingGroup(event: KeyboardEvent, group: string): boolean {
+  return matchesShortcutBinding(event, group);
 }
 
 export function getMatchingShortcutBindingIndex(event: KeyboardEvent, bindings: string[]): number {

--- a/packages/ui/shortcuts/core.ts
+++ b/packages/ui/shortcuts/core.ts
@@ -76,6 +76,10 @@ for (let n = 1; n <= 12; n += 1) {
 
 const MODIFIER_TOKENS = new Set(['Mod', 'Shift', 'Alt']);
 const SHIFTED_LITERAL_TOKENS = new Set(['{', '}', '?', '$']);
+type ShortcutKeyEvent = Pick<
+  KeyboardEvent,
+  'key' | 'code' | 'metaKey' | 'ctrlKey' | 'shiftKey' | 'altKey'
+>;
 
 export function defineShortcutScope<TAction extends string>(scope: ShortcutScopeDefinition<TAction>): ShortcutScopeDefinition<TAction> {
   return scope;
@@ -114,7 +118,7 @@ export function parseDoubleTapBinding(binding: string): string | null {
  * Check if a KeyboardEvent matches a named key token (for sequential/stateful matching).
  * Unlike `matchesShortcutBinding`, this matches a single key identity without modifier checks.
  */
-export function matchesKeyName(event: KeyboardEvent, keyName: string): boolean {
+export function matchesKeyName(event: ShortcutKeyEvent, keyName: string): boolean {
   if (keyName === 'Alt') return event.key === 'Alt';
   if (keyName === 'Shift') return event.key === 'Shift';
   if (keyName === 'Mod') return event.key === 'Meta' || event.key === 'Control';
@@ -332,13 +336,13 @@ export function formatShortcutBindingsText(
   return bindings.map(binding => formatShortcutBindingText(binding, platform)).join(' or ');
 }
 
-function getDigitCode(event: KeyboardEvent): string | null {
+function getDigitCode(event: ShortcutKeyEvent): string | null {
   const code = typeof event.code === 'string' ? event.code : '';
   const match = code.match(/^Digit([0-9])$/);
   return match ? match[1] : null;
 }
 
-export function getShortcutDigit(event: KeyboardEvent): number | null {
+export function getShortcutDigit(event: ShortcutKeyEvent): number | null {
   const parsed = Number.parseInt(event.key, 10);
   if (!Number.isNaN(parsed)) return parsed;
 
@@ -346,7 +350,7 @@ export function getShortcutDigit(event: KeyboardEvent): number | null {
   return digitCode === null ? null : Number.parseInt(digitCode, 10);
 }
 
-function matchesKeyToken(event: KeyboardEvent, token: string): boolean {
+function matchesKeyToken(event: ShortcutKeyEvent, token: string): boolean {
   const key = event.key.length === 1 ? event.key.toUpperCase() : event.key;
   const shortcutDigit = getShortcutDigit(event);
 
@@ -379,7 +383,7 @@ function matchesKeyToken(event: KeyboardEvent, token: string): boolean {
  * Sequential and hold bindings deliberately return false; their timing
  * semantics are handled by the shortcut runtime's dedicated paths.
  */
-export function matchesShortcutBinding(event: KeyboardEvent, binding: string): boolean {
+export function matchesShortcutBinding(event: ShortcutKeyEvent, binding: string): boolean {
   if (binding.includes(' ') || binding.includes('hold')) {
     return false;
   }
@@ -410,10 +414,10 @@ export function matchesShortcutBinding(event: KeyboardEvent, binding: string): b
  *
  * The group uses the same normalized syntax as an ordinary one-press binding.
  */
-export function matchesShortcutBindingGroup(event: KeyboardEvent, group: string): boolean {
+export function matchesShortcutBindingGroup(event: ShortcutKeyEvent, group: string): boolean {
   return matchesShortcutBinding(event, group);
 }
 
-export function getMatchingShortcutBindingIndex(event: KeyboardEvent, bindings: string[]): number {
+export function getMatchingShortcutBindingIndex(event: ShortcutKeyEvent, bindings: string[]): number {
   return bindings.findIndex(binding => matchesShortcutBinding(event, binding));
 }

--- a/packages/ui/shortcuts/index.ts
+++ b/packages/ui/shortcuts/index.ts
@@ -8,6 +8,10 @@ export { commentPopoverShortcuts } from './plan-review/commentPopover.shortcuts'
 export { imageAnnotatorShortcuts, useImageAnnotatorShortcuts } from './plan-review/imageAnnotator.shortcuts';
 export { inputMethodShortcuts } from './plan-review/inputMethod.shortcuts';
 export { viewerShortcuts, useViewerShortcuts } from './plan-review/viewer.shortcuts';
+export {
+  vimSelectionShortcuts,
+  useVimSelectionShortcuts,
+} from './plan-review/vimSelection.shortcuts';
 export { goalSetupShortcuts, useGoalSetupShortcuts } from './plan-review/goalSetup.shortcuts';
 export { annotateSidebarShortcuts, useAnnotateSidebarShortcuts } from './plan-review/sidebar.shortcuts';
 

--- a/packages/ui/shortcuts/index.ts
+++ b/packages/ui/shortcuts/index.ts
@@ -9,8 +9,14 @@ export { imageAnnotatorShortcuts, useImageAnnotatorShortcuts } from './plan-revi
 export { inputMethodShortcuts } from './plan-review/inputMethod.shortcuts';
 export { viewerShortcuts, useViewerShortcuts } from './plan-review/viewer.shortcuts';
 export {
+  describeVimSelectionAction,
+  isVimSelectionActionId,
   vimSelectionShortcuts,
   useVimSelectionShortcuts,
+} from './plan-review/vimSelection.shortcuts';
+export type {
+  VimSelectionActionId,
+  VimSelectionHudContext,
 } from './plan-review/vimSelection.shortcuts';
 export { goalSetupShortcuts, useGoalSetupShortcuts } from './plan-review/goalSetup.shortcuts';
 export { annotateSidebarShortcuts, useAnnotateSidebarShortcuts } from './plan-review/sidebar.shortcuts';

--- a/packages/ui/shortcuts/plan-review/vimSelection.shortcuts.ts
+++ b/packages/ui/shortcuts/plan-review/vimSelection.shortcuts.ts
@@ -166,5 +166,86 @@ export const vimSelectionShortcuts = defineShortcutScope({
   },
 });
 
+/** Stable action identifiers emitted by the Vim selection shortcut scope. */
+export type VimSelectionActionId = keyof typeof vimSelectionShortcuts.shortcuts;
+
+/** Vim navigation state used to make HUD command descriptions contextual. */
+export type VimSelectionHudContext =
+  | 'inactive'
+  | 'block'
+  | 'inline'
+  | 'text'
+  | 'visual'
+  | 'visual-block'
+  | 'action';
+
+/**
+ * Return the user-facing HUD description for a handled Vim action.
+ *
+ * Contextual movement keys keep one registered shortcut while accurately
+ * describing whether they moved by document structure, line, or character.
+ */
+export function describeVimSelectionAction(
+  actionId: VimSelectionActionId,
+  context: VimSelectionHudContext,
+): string {
+  switch (actionId) {
+    case 'moveDown':
+      if (context === 'inline') return 'Next semantic sibling';
+      if (context === 'text' || context === 'visual') return 'Next line';
+      if (context === 'visual-block') return 'Extend to next block';
+      return 'Next block';
+    case 'moveUp':
+      if (context === 'inline') return 'Previous semantic sibling';
+      if (context === 'text' || context === 'visual') return 'Previous line';
+      if (context === 'visual-block') return 'Extend to previous block';
+      return 'Previous block';
+    case 'moveOut':
+      return context === 'text' || context === 'visual'
+        ? 'Move left one character'
+        : 'Move to containing target';
+    case 'refine':
+      return context === 'text' || context === 'visual'
+        ? 'Move right one character'
+        : 'Refine into child or text';
+    case 'visual':
+      return context === 'visual'
+        ? 'Return to Normal mode'
+        : 'Start Visual selection';
+    case 'visualBlock':
+      return context === 'visual-block'
+        ? 'Return to block navigation'
+        : 'Select the whole block';
+    case 'documentStart':
+    case 'documentEnd':
+    case 'wordForward':
+    case 'wordBackward':
+    case 'wordEnd':
+    case 'lineStart':
+    case 'lineEnd':
+    case 'previousTextBlock':
+    case 'nextTextBlock':
+    case 'swapSelectionEnds':
+    case 'activeAnnotation':
+    case 'annotationMenu':
+    case 'comment':
+    case 'redline':
+    case 'markup':
+    case 'label':
+    case 'copy':
+    case 'cancel':
+    case 'help':
+      return vimSelectionShortcuts.shortcuts[actionId].description;
+  }
+}
+
+/** Parse an unknown bridge value into a registered Vim action identifier. */
+export function isVimSelectionActionId(
+  value: unknown,
+): value is VimSelectionActionId {
+  return typeof value === 'string'
+    && Object.prototype.hasOwnProperty.call(vimSelectionShortcuts.shortcuts, value);
+}
+
 /** Bind Vim selection handlers to the opted-in document focus surface. */
 export const useVimSelectionShortcuts = createShortcutScopeHook(vimSelectionShortcuts);

--- a/packages/ui/shortcuts/plan-review/vimSelection.shortcuts.ts
+++ b/packages/ui/shortcuts/plan-review/vimSelection.shortcuts.ts
@@ -1,0 +1,170 @@
+import { defineShortcutScope } from '../core';
+import { createShortcutScopeHook } from '../runtime';
+
+/**
+ * Modal document-navigation commands shared by plan review and annotate mode.
+ *
+ * The bindings are active only while the opted-in document focus surface owns
+ * focus; native controls and annotation composers remain outside this scope.
+ */
+export const vimSelectionShortcuts = defineShortcutScope({
+  id: 'vim-selection',
+  title: 'Vim selection',
+  shortcuts: {
+    moveDown: {
+      description: 'Next block or semantic sibling',
+      bindings: ['J'],
+      section: 'Vim Document Navigation',
+      displayOrder: 10,
+    },
+    moveUp: {
+      description: 'Previous block or semantic sibling',
+      bindings: ['K'],
+      section: 'Vim Document Navigation',
+      displayOrder: 20,
+    },
+    documentStart: {
+      description: 'Start of document',
+      bindings: ['G G'],
+      section: 'Vim Document Navigation',
+      displayOrder: 30,
+      preventDefault: true,
+    },
+    documentEnd: {
+      description: 'End of document',
+      bindings: ['Shift+G'],
+      section: 'Vim Document Navigation',
+      displayOrder: 40,
+    },
+    moveOut: {
+      description: 'Move to containing target',
+      bindings: ['H'],
+      section: 'Vim Document Navigation',
+      displayOrder: 50,
+    },
+    refine: {
+      description: 'Refine into child or text',
+      bindings: ['L'],
+      section: 'Vim Document Navigation',
+      displayOrder: 60,
+    },
+    visual: {
+      description: 'Toggle precise Visual selection',
+      bindings: ['V'],
+      section: 'Vim Document Navigation',
+      displayOrder: 70,
+    },
+    visualBlock: {
+      description: 'Toggle whole-block Visual selection',
+      bindings: ['Shift+V'],
+      section: 'Vim Document Navigation',
+      hint: 'Use j / k to extend by whole blocks.',
+      displayOrder: 80,
+    },
+    wordForward: {
+      description: 'Move to next word',
+      bindings: ['W'],
+      section: 'Vim Text Navigation',
+      displayOrder: 90,
+    },
+    wordBackward: {
+      description: 'Move to previous word',
+      bindings: ['B'],
+      section: 'Vim Text Navigation',
+      displayOrder: 100,
+    },
+    wordEnd: {
+      description: 'Move to end of word',
+      bindings: ['E'],
+      section: 'Vim Text Navigation',
+      displayOrder: 110,
+    },
+    lineStart: {
+      description: 'Move to start of line',
+      bindings: ['0'],
+      section: 'Vim Text Navigation',
+      displayOrder: 120,
+    },
+    lineEnd: {
+      description: 'Move to end of line',
+      bindings: ['$'],
+      section: 'Vim Text Navigation',
+      displayOrder: 130,
+    },
+    previousTextBlock: {
+      description: 'Move to previous text block',
+      bindings: ['{'],
+      section: 'Vim Text Navigation',
+      displayOrder: 140,
+    },
+    nextTextBlock: {
+      description: 'Move to next text block',
+      bindings: ['}'],
+      section: 'Vim Text Navigation',
+      displayOrder: 150,
+    },
+    swapSelectionEnds: {
+      description: 'Swap selection ends',
+      bindings: ['O'],
+      section: 'Vim Text Navigation',
+      displayOrder: 160,
+    },
+    activeAnnotation: {
+      description: 'Use active annotation mode',
+      bindings: ['Enter'],
+      section: 'Vim Annotation Actions',
+      displayOrder: 170,
+    },
+    annotationMenu: {
+      description: 'Open annotation actions',
+      bindings: ['Space'],
+      section: 'Vim Annotation Actions',
+      displayOrder: 180,
+    },
+    comment: {
+      description: 'Comment selection or target',
+      bindings: ['C'],
+      section: 'Vim Annotation Actions',
+      displayOrder: 190,
+    },
+    redline: {
+      description: 'Redline selection or target',
+      bindings: ['D'],
+      section: 'Vim Annotation Actions',
+      displayOrder: 200,
+    },
+    markup: {
+      description: 'Markup selection or target',
+      bindings: ['M'],
+      section: 'Vim Annotation Actions',
+      displayOrder: 210,
+    },
+    label: {
+      description: 'Label selection or target',
+      bindings: ['T'],
+      section: 'Vim Annotation Actions',
+      displayOrder: 220,
+    },
+    copy: {
+      description: 'Copy selection or target',
+      bindings: ['Y'],
+      section: 'Vim Annotation Actions',
+      displayOrder: 230,
+    },
+    cancel: {
+      description: 'Cancel current Vim state',
+      bindings: ['Escape'],
+      section: 'Vim Annotation Actions',
+      displayOrder: 240,
+    },
+    help: {
+      description: 'Show contextual help',
+      bindings: ['?'],
+      section: 'Vim Annotation Actions',
+      displayOrder: 250,
+    },
+  },
+});
+
+/** Bind Vim selection handlers to the opted-in document focus surface. */
+export const useVimSelectionShortcuts = createShortcutScopeHook(vimSelectionShortcuts);

--- a/packages/ui/shortcuts/plan-review/vimSelection.shortcuts.ts
+++ b/packages/ui/shortcuts/plan-review/vimSelection.shortcuts.ts
@@ -158,7 +158,7 @@ export const vimSelectionShortcuts = defineShortcutScope({
       displayOrder: 240,
     },
     help: {
-      description: 'Show contextual help',
+      description: 'Toggle key map',
       bindings: ['?'],
       section: 'Vim Annotation Actions',
       displayOrder: 250,

--- a/packages/ui/shortcuts/runtime.ts
+++ b/packages/ui/shortcuts/runtime.ts
@@ -1,6 +1,11 @@
 import { useEffect, useRef } from 'react';
 import type { ShortcutDefinition, ShortcutScopeDefinition } from './core';
-import { matchesKeyName, matchesShortcutBinding, parseDoubleTapBinding } from './core';
+import {
+  matchesKeyName,
+  matchesShortcutBinding,
+  matchesShortcutBindingGroup,
+  parseDoubleTapBinding,
+} from './core';
 
 type ShortcutActionId<TScope extends ShortcutScopeDefinition<any>> = keyof TScope['shortcuts'] & string;
 
@@ -24,12 +29,36 @@ export interface UseShortcutScopeOptions<TScope extends ShortcutScopeDefinition<
   stopOnMatch?: boolean;
 }
 
+interface ShortcutSequenceCandidate {
+  readonly actionId: string;
+  readonly groups: readonly string[];
+  readonly nextIndex: number;
+}
+
+interface ShortcutSequenceState {
+  readonly candidates: readonly ShortcutSequenceCandidate[];
+  readonly expiresAt: number;
+}
+
+const SHORTCUT_SEQUENCE_WINDOW_MS = 500;
+
 function normalizeShortcutHandler(handler: ShortcutHandler): ShortcutHandlerConfig {
   if (typeof handler === 'function') {
     return { handle: handler };
   }
 
   return handler;
+}
+
+function getShortcutEntries<TScope extends ShortcutScopeDefinition<any>>(
+  scope: TScope,
+): Array<[ShortcutActionId<TScope>, ShortcutDefinition]> {
+  // SAFETY: ShortcutScopeDefinition constrains every own value in `shortcuts`
+  // to ShortcutDefinition; Object.entries preserves those own keys and values.
+  return Object.entries(scope.shortcuts) as Array<[
+    ShortcutActionId<TScope>,
+    ShortcutDefinition,
+  ]>;
 }
 
 // TODO(migration): no cross-scope arbitration. When two scopes bind the
@@ -48,10 +77,7 @@ export function dispatchShortcutEvent<TScope extends ShortcutScopeDefinition<any
   const stopOnMatch = options?.stopOnMatch ?? true;
   let handled = false;
 
-  for (const [actionId, shortcut] of Object.entries(scope.shortcuts) as Array<[
-    ShortcutActionId<TScope>,
-    ShortcutDefinition,
-  ]>) {
+  for (const [actionId, shortcut] of getShortcutEntries(scope)) {
     const handler = handlers[actionId];
     if (!handler) continue;
     if (!shortcut.bindings.some(binding => matchesShortcutBinding(event, binding))) continue;
@@ -84,6 +110,14 @@ function getEventTarget(target: ShortcutEventTarget): EventTarget | null {
   return target;
 }
 
+/**
+ * Attach a registry scope to a keyboard event target.
+ *
+ * Ordinary bindings dispatch immediately. Non-modifier sequential bindings
+ * advance within a 500 ms window, suppress their prefix keystrokes, and reset
+ * after a match, timeout, or unrelated key. Handlers are read through a ref so
+ * listener lifetime follows only the scope, target, and dispatch options.
+ */
 export function useShortcutScope<TScope extends ShortcutScopeDefinition<any>>({
   scope,
   handlers,
@@ -91,6 +125,7 @@ export function useShortcutScope<TScope extends ShortcutScopeDefinition<any>>({
   stopOnMatch = true,
 }: UseShortcutScopeOptions<TScope>) {
   const handlersRef = useRef(handlers);
+  const sequenceRef = useRef<ShortcutSequenceState | null>(null);
 
   useEffect(() => {
     handlersRef.current = handlers;
@@ -101,12 +136,79 @@ export function useShortcutScope<TScope extends ShortcutScopeDefinition<any>>({
     if (!eventTarget || !('addEventListener' in eventTarget)) return;
 
     const handleKeyDown = (event: Event) => {
-      dispatchShortcutEvent(scope, handlersRef.current, event as KeyboardEvent, { stopOnMatch });
+      if (!(event instanceof KeyboardEvent)) return;
+      const keyboardEvent = event;
+      if (dispatchShortcutEvent(scope, handlersRef.current, keyboardEvent, { stopOnMatch })) {
+        sequenceRef.current = null;
+        return;
+      }
+
+      const now = Date.now();
+      const active = sequenceRef.current && sequenceRef.current.expiresAt >= now
+        ? sequenceRef.current.candidates
+        : [];
+      const advanced: ShortcutSequenceCandidate[] = [];
+
+      for (const candidate of active) {
+        const group = candidate.groups[candidate.nextIndex];
+        if (!group || !matchesShortcutBindingGroup(keyboardEvent, group)) continue;
+        if (candidate.nextIndex === candidate.groups.length - 1) {
+          const shortcut = scope.shortcuts[candidate.actionId];
+          const handler = handlersRef.current[candidate.actionId];
+          if (!shortcut || !handler) continue;
+          const { when, handle } = normalizeShortcutHandler(handler);
+          if (when && !when(keyboardEvent)) continue;
+          if (shortcut.preventDefault) keyboardEvent.preventDefault();
+          handle(keyboardEvent);
+          sequenceRef.current = null;
+          return;
+        }
+        advanced.push({ ...candidate, nextIndex: candidate.nextIndex + 1 });
+      }
+
+      if (advanced.length > 0) {
+        sequenceRef.current = {
+          candidates: advanced,
+          expiresAt: now + SHORTCUT_SEQUENCE_WINDOW_MS,
+        };
+        keyboardEvent.preventDefault();
+        return;
+      }
+
+      const started: ShortcutSequenceCandidate[] = [];
+      for (const [actionId, shortcut] of getShortcutEntries(scope)) {
+        const handler = handlersRef.current[actionId];
+        if (!handler) continue;
+        const { when } = normalizeShortcutHandler(handler);
+        if (when && !when(keyboardEvent)) continue;
+
+        for (const binding of shortcut.bindings) {
+          const groups = binding.trim().split(/\s+/).filter(Boolean);
+          const doubleTapKey = parseDoubleTapBinding(binding);
+          if (
+            groups.length < 2
+            || groups.includes('hold')
+            || (doubleTapKey !== null && ['Alt', 'Shift', 'Mod'].includes(doubleTapKey))
+            || !matchesShortcutBindingGroup(keyboardEvent, groups[0] ?? '')
+          ) {
+            continue;
+          }
+          started.push({ actionId, groups, nextIndex: 1 });
+        }
+      }
+
+      sequenceRef.current = started.length > 0
+        ? {
+            candidates: started,
+            expiresAt: now + SHORTCUT_SEQUENCE_WINDOW_MS,
+          }
+        : null;
+      if (started.length > 0) keyboardEvent.preventDefault();
     };
 
-    eventTarget.addEventListener('keydown', handleKeyDown as EventListener);
+    eventTarget.addEventListener('keydown', handleKeyDown);
     return () => {
-      eventTarget.removeEventListener('keydown', handleKeyDown as EventListener);
+      eventTarget.removeEventListener('keydown', handleKeyDown);
     };
   }, [scope, stopOnMatch, target]);
 }
@@ -165,10 +267,7 @@ export function useDoubleTapShortcuts<TScope extends ShortcutScopeDefinition<any
   useEffect(() => {
     // Pre-parse which actions have double-tap bindings
     const doubleTapActions: Array<{ actionId: ShortcutActionId<TScope>; keyName: string; preventDefault: boolean }> = [];
-    for (const [actionId, shortcut] of Object.entries(scope.shortcuts) as Array<[
-      ShortcutActionId<TScope>,
-      ShortcutDefinition,
-    ]>) {
+    for (const [actionId, shortcut] of getShortcutEntries(scope)) {
       for (const binding of shortcut.bindings) {
         const keyName = parseDoubleTapBinding(binding);
         if (keyName) {

--- a/packages/ui/theme.css
+++ b/packages/ui/theme.css
@@ -56,6 +56,487 @@
 @import "./themes/neutral.css";
 @import "./print.css";
 
+/* Live Vim HUD target — mirrors the four-corner treatment used in the
+ * product demo while measuring the real semantic target/caret/range. */
+.vim-target-reticle {
+  position: absolute;
+  inset: 0;
+  z-index: 23;
+  overflow: visible;
+  pointer-events: none;
+}
+
+.vim-target-reticle__fill,
+.vim-target-reticle__corner,
+.vim-target-reticle__label {
+  position: absolute;
+  top: 0;
+  left: 0;
+  will-change: transform;
+  transition: transform 90ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.vim-target-reticle__fill {
+  width: 100px;
+  height: 100px;
+  transform-origin: 0 0;
+  border-radius: 8px;
+  background: rgba(167, 139, 250, 0.045);
+  box-shadow:
+    inset 0 0 0 1px rgba(196, 181, 253, 0.16),
+    0 0 42px rgba(139, 92, 246, 0.12);
+}
+
+.vim-target-reticle__corner {
+  width: 28px;
+  height: 28px;
+  border-color: #c4b5fd;
+  filter:
+    drop-shadow(0 0 6px rgba(167, 139, 250, 0.92))
+    drop-shadow(0 0 18px rgba(124, 58, 237, 0.42));
+}
+
+.vim-target-reticle__corner--top-left {
+  border-top: 3px solid;
+  border-left: 3px solid;
+  border-top-left-radius: 8px;
+}
+
+.vim-target-reticle__corner--top-right {
+  border-top: 3px solid;
+  border-right: 3px solid;
+  border-top-right-radius: 8px;
+}
+
+.vim-target-reticle__corner--bottom-left {
+  border-bottom: 3px solid;
+  border-left: 3px solid;
+  border-bottom-left-radius: 8px;
+}
+
+.vim-target-reticle__corner--bottom-right {
+  border-right: 3px solid;
+  border-bottom: 3px solid;
+  border-bottom-right-radius: 8px;
+}
+
+.vim-target-reticle__label {
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 118px;
+  height: 30px;
+  max-width: min(280px, calc(100vw - 24px));
+  padding: 0 11px;
+  overflow: hidden;
+  border: 1px solid rgba(216, 206, 255, 0.42);
+  border-radius: 9px;
+  color: #f6f2ff;
+  background: rgba(18, 14, 28, 0.84);
+  box-shadow:
+    0 10px 28px rgba(0, 0, 0, 0.42),
+    0 0 20px rgba(139, 92, 246, 0.18);
+  backdrop-filter: blur(10px);
+  font: 700 10px/1 var(--font-mono), ui-monospace, SFMono-Regular, Menlo, monospace;
+  letter-spacing: 0.13em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.vim-target-reticle__label-dot {
+  width: 7px;
+  height: 7px;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: #c4b5fd;
+  box-shadow: 0 0 12px rgba(167, 139, 250, 0.94);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vim-target-reticle__fill,
+  .vim-target-reticle__corner,
+  .vim-target-reticle__label {
+    transition: none;
+  }
+}
+
+.vim-key-hud__map-toggle {
+  transition:
+    color 120ms ease,
+    background-color 120ms ease,
+    border-color 120ms ease,
+    transform 120ms ease-out;
+  touch-action: manipulation;
+}
+
+.vim-key-hud__map-toggle:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.82);
+  outline-offset: 2px;
+}
+
+.vim-key-hud__map-toggle:active {
+  transform: scale(0.97);
+}
+
+.vim-key-hud__map-columns {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 9px;
+}
+
+.vim-key-hud__map-scroll {
+  scrollbar-color: rgba(196, 181, 253, 0.24) transparent;
+  scrollbar-width: thin;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .vim-key-hud__map-toggle:hover {
+    border-color: rgba(196, 181, 253, 0.34) !important;
+    color: #e1d8ef !important;
+    background: rgba(167, 139, 250, 0.16) !important;
+  }
+}
+
+@media (max-width: 760px) {
+  .vim-key-hud__map-columns {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vim-key-hud__map-toggle {
+    transition: none;
+  }
+}
+
+/* First-run Vim announcement. The preview reuses the live HUD's violet
+ * glass, illuminated keycap, and four-corner targeting vocabulary. */
+.vim-announcement-backdrop {
+  animation: vim-announcement-backdrop-in 160ms ease-out both;
+}
+
+.vim-announcement-dialog {
+  animation: vim-announcement-dialog-in 200ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.vim-announcement-switch {
+  transition:
+    border-color 140ms ease,
+    background-color 140ms ease;
+  touch-action: manipulation;
+}
+
+.vim-announcement-secondary-action {
+  transition:
+    color 140ms ease,
+    background-color 140ms ease;
+}
+
+.vim-announcement-primary-action {
+  transition: opacity 140ms ease;
+}
+
+.vim-announcement-switch__track {
+  position: relative;
+  width: 42px;
+  height: 24px;
+  flex: 0 0 auto;
+  border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--muted) 75%, transparent);
+  transition:
+    border-color 160ms ease,
+    background-color 160ms ease;
+}
+
+.vim-announcement-switch__thumb {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  background: var(--muted-foreground);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.28);
+  transform: translate3d(0, 0, 0);
+  transition:
+    background-color 160ms ease,
+    transform 180ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.vim-announcement-switch__track--checked {
+  border-color: color-mix(in srgb, var(--primary) 72%, transparent);
+  background: color-mix(in srgb, var(--primary) 58%, transparent);
+}
+
+.vim-announcement-switch__track--checked .vim-announcement-switch__thumb {
+  background: var(--primary-foreground);
+  transform: translate3d(18px, 0, 0);
+}
+
+.vim-announcement-step {
+  animation: vim-announcement-step 14s linear infinite both;
+}
+
+.vim-announcement-step--1 { animation-delay: 0s; }
+.vim-announcement-step--2 { animation-delay: -12s; }
+.vim-announcement-step--3 { animation-delay: -10s; }
+.vim-announcement-step--4 { animation-delay: -8s; }
+.vim-announcement-step--5 { animation-delay: -6s; }
+.vim-announcement-step--6 { animation-delay: -4s; }
+.vim-announcement-step--7 { animation-delay: -2s; }
+
+.vim-announcement-showcase[data-playing="false"] .vim-announcement-step,
+.vim-announcement-showcase[data-playing="false"] .vim-announcement-code-selection {
+  animation-play-state: paused;
+}
+
+.vim-announcement-showcase__canvas {
+  transform-origin: top left;
+}
+
+.vim-announcement-reticle {
+  position: absolute;
+  z-index: 12;
+  border-radius: 8px;
+  background: rgba(167, 139, 250, 0.045);
+  box-shadow:
+    inset 0 0 0 1px rgba(196, 181, 253, 0.16),
+    0 0 42px rgba(139, 92, 246, 0.14);
+  pointer-events: none;
+}
+
+.vim-announcement-reticle--block {
+  inset: -5px;
+}
+
+.vim-announcement-reticle--inline {
+  inset: -3px -8px;
+}
+
+.vim-announcement-reticle--cursor-start {
+  top: 50%;
+  left: -22px;
+  width: 44px;
+  height: 32px;
+  margin-top: -16px;
+}
+
+.vim-announcement-reticle--selection {
+  top: 50%;
+  left: 50%;
+  width: 44px;
+  height: 32px;
+  margin-top: -16px;
+  margin-left: -22px;
+}
+
+.vim-announcement-reticle__corner {
+  position: absolute;
+  width: 24px;
+  height: 24px;
+  border-color: #c4b5fd;
+  filter:
+    drop-shadow(0 0 6px rgba(167, 139, 250, 0.92))
+    drop-shadow(0 0 18px rgba(124, 58, 237, 0.42));
+}
+
+.vim-announcement-reticle__corner--top-left {
+  top: 0;
+  left: 0;
+  border-top: 3px solid;
+  border-left: 3px solid;
+  border-top-left-radius: 8px;
+}
+
+.vim-announcement-reticle__corner--top-right {
+  top: 0;
+  right: 0;
+  border-top: 3px solid;
+  border-right: 3px solid;
+  border-top-right-radius: 8px;
+}
+
+.vim-announcement-reticle__corner--bottom-left {
+  bottom: 0;
+  left: 0;
+  border-bottom: 3px solid;
+  border-left: 3px solid;
+  border-bottom-left-radius: 8px;
+}
+
+.vim-announcement-reticle__corner--bottom-right {
+  right: 0;
+  bottom: 0;
+  border-right: 3px solid;
+  border-bottom: 3px solid;
+  border-bottom-right-radius: 8px;
+}
+
+.vim-announcement-reticle__label {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 0;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  height: 27px;
+  max-width: 250px;
+  padding: 0 9px;
+  overflow: hidden;
+  border: 1px solid rgba(216, 206, 255, 0.38);
+  border-radius: 8px;
+  color: #f6f2ff;
+  background: rgba(18, 14, 28, 0.82);
+  box-shadow:
+    0 8px 24px rgba(0, 0, 0, 0.38),
+    0 0 18px rgba(139, 92, 246, 0.18);
+  backdrop-filter: blur(9px);
+  font: 800 8px/1 var(--font-mono), ui-monospace, SFMono-Regular, Menlo, monospace;
+  letter-spacing: 0.12em;
+  white-space: nowrap;
+}
+
+.vim-announcement-reticle--cursor-start .vim-announcement-reticle__label {
+  top: calc(100% + 6px);
+  bottom: auto;
+}
+
+.vim-announcement-reticle__dot {
+  width: 6px;
+  height: 6px;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: #c4b5fd;
+  box-shadow: 0 0 10px rgba(167, 139, 250, 0.94);
+}
+
+.vim-announcement-code-selection {
+  animation: vim-announcement-selection 14s linear infinite both;
+}
+
+.vim-announcement-comment {
+  position: absolute;
+  top: calc(100% + 24px);
+  left: -18px;
+  z-index: 14;
+  width: 194px;
+  padding: 9px 11px;
+  border: 1px solid rgba(196, 181, 253, 0.28);
+  border-radius: 9px;
+  color: #f5f0ff;
+  background: rgba(27, 23, 38, 0.9);
+  box-shadow:
+    0 12px 30px rgba(0, 0, 0, 0.42),
+    0 0 24px rgba(139, 92, 246, 0.14);
+  backdrop-filter: blur(10px);
+}
+
+@keyframes vim-announcement-backdrop-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes vim-announcement-dialog-in {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 8px, 0) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+}
+
+@keyframes vim-announcement-step {
+  0%,
+  11% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  14%,
+  96% {
+    opacity: 0;
+    transform: scale(0.985);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes vim-announcement-selection {
+  0%,
+  70% {
+    color: #d2a8ff;
+    background: transparent;
+    box-shadow: none;
+  }
+  72%,
+  100% {
+    color: #f5f0ff;
+    background: rgba(139, 92, 246, 0.48);
+    box-shadow: 0 0 12px rgba(139, 92, 246, 0.24);
+  }
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .vim-announcement-switch:hover {
+    border-color: color-mix(in srgb, var(--primary) 35%, var(--border));
+    background: color-mix(in srgb, var(--muted) 48%, transparent);
+  }
+
+  .vim-announcement-secondary-action:hover {
+    color: var(--foreground);
+    background: var(--muted);
+  }
+
+  .vim-announcement-primary-action:hover {
+    opacity: 0.9;
+  }
+}
+
+@media (max-width: 820px) {
+  .vim-announcement-showcase__canvas {
+    width: calc(100% / 0.81);
+    height: calc(100% / 0.81);
+    transform: scale(0.81);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vim-announcement-backdrop,
+  .vim-announcement-dialog,
+  .vim-announcement-step,
+  .vim-announcement-code-selection {
+    animation: none;
+  }
+
+  .vim-announcement-switch,
+  .vim-announcement-switch__track,
+  .vim-announcement-switch__thumb,
+  .vim-announcement-secondary-action,
+  .vim-announcement-primary-action {
+    transition: none;
+  }
+
+  .vim-announcement-step {
+    opacity: 0;
+  }
+
+  .vim-announcement-step--6 {
+    opacity: 1;
+    transform: none;
+  }
+
+  .vim-announcement-code-selection {
+    color: #f5f0ff;
+    background: rgba(139, 92, 246, 0.48);
+    box-shadow: 0 0 12px rgba(139, 92, 246, 0.24);
+  }
+}
+
 /* Tailwind bridge — maps CSS vars to utility classes */
 @theme inline {
   --color-background: var(--background);

--- a/packages/ui/utils/blockTargeting.ts
+++ b/packages/ui/utils/blockTargeting.ts
@@ -1,11 +1,12 @@
 /**
- * Block Targeting — resolves which element to annotate in pinpoint mode.
+ * Semantic document targeting shared by pointer Pinpoint and Vim navigation.
  *
- * Walks from the element under the cursor upward through the block tree
- * to find the most specific targetable element (inline, cell, or block).
+ * The graph is rebuilt from the live rendered document whenever a consumer
+ * needs it. Callers persist stable keys, never DOM nodes, across renders.
  */
+import { createTextRange } from './domSelection';
 
-/** Elements that should never be targeted */
+/** Elements that never participate in document targeting. */
 const SKIP_SELECTORS = [
   '.annotation-toolbar',
   '.annotation-highlight',
@@ -14,227 +15,510 @@ const SKIP_SELECTORS = [
   '[data-pinpoint-ignore]',
 ].join(',');
 
-/** Inline elements that are individually targetable within a block */
-const INLINE_TARGETS = new Set(['STRONG', 'EM', 'A']);
-
-/** Table cell elements */
-const CELL_TARGETS = new Set(['TD', 'TH']);
-
-export interface PinpointTarget {
-  /** The DOM element to highlight and select */
-  element: HTMLElement;
-  /** The data-block-id of the parent block */
-  blockId: string;
-  /** Human-readable label for the hover tooltip */
-  label: string;
-  /** Whether this is a code block (needs special annotation path) */
-  isCodeBlock: boolean;
-}
-
-/** Edge-zone threshold for table hover (px). Covers the outermost cell padding
- *  area (cells have px-3/py-2 = 12px/8px padding) so you need to aim at actual
- *  text content to target a specific cell. */
+const INLINE_TARGET_SELECTOR = 'strong,em,a,code:not(.hljs)';
 const TABLE_EDGE_ZONE = 22;
 
+/** The semantic kind of a document target. */
+export type SemanticTargetKind =
+  | 'group'
+  | 'block'
+  | 'inline'
+  | 'table'
+  | 'row'
+  | 'cell'
+  | 'code'
+  | 'math';
+
+/** A stable semantic target resolved to its current live DOM element. */
+export interface SemanticTarget {
+  readonly key: string;
+  readonly blockId: string;
+  readonly element: HTMLElement;
+  readonly label: string;
+  readonly kind: SemanticTargetKind;
+  readonly parentKey: string | null;
+  readonly rowIndex?: number;
+  readonly columnIndex?: number;
+}
+
 /**
- * Given a mousemove/click target element, find the best annotation target
- * within the viewer container. Optionally accepts mouse coordinates for
- * edge-zone detection (tables).
+ * One projection of the rendered document used by pointer hit-testing,
+ * keyboard traversal, hierarchy refinement, overlays, and annotation actions.
  */
-export function resolvePinpointTarget(
-  target: HTMLElement,
-  container: HTMLElement,
-  mousePos?: { clientX: number; clientY: number },
-): PinpointTarget | null {
-  // Skip toolbar, buttons, existing annotations
-  if (target.closest(SKIP_SELECTORS)) return null;
-  if (!container.contains(target)) return null;
-
-  // Group detection: cursor is in the gap/gutter of a list group wrapper
-  const groupEl = target.closest('[data-pinpoint-group]') as HTMLElement | null;
-  if (groupEl && container.contains(groupEl) && !target.closest('[data-block-id]')) {
-    const groupType = groupEl.getAttribute('data-pinpoint-group');
-    const label = groupType === 'list' ? 'list' : groupType === 'blockquote' ? 'blockquote group' : 'group';
-    return { element: groupEl, blockId: '', label, isCodeBlock: false };
-  }
-
-  // Find the parent block
-  const blockEl = target.closest('[data-block-id]') as HTMLElement | null;
-  if (!blockEl || !container.contains(blockEl)) return null;
-
-  const blockId = blockEl.getAttribute('data-block-id')!;
-
-  // Skip hr (no text content)
-  if (blockEl.tagName === 'HR') return null;
-
-  // Code block detection: pre > code.hljs
-  const codeEl = blockEl.querySelector('pre > code.hljs');
-  if (codeEl && (target === codeEl || codeEl.contains(target) || target.closest('pre'))) {
-    return {
-      element: blockEl,
-      blockId,
-      label: getCodeBlockLabel(blockEl),
-      isCodeBlock: true,
-    };
-  }
-
-  // Table edge-zone detection: edges target whole table or row
-  const tableEl = blockEl.querySelector('table');
-  if (tableEl && mousePos) {
-    const tableRect = tableEl.getBoundingClientRect();
-    const nearLeft = mousePos.clientX - tableRect.left < TABLE_EDGE_ZONE;
-    const nearRight = tableRect.right - mousePos.clientX < TABLE_EDGE_ZONE;
-    const nearTop = mousePos.clientY - tableRect.top < TABLE_EDGE_ZONE;
-    const nearBottom = tableRect.bottom - mousePos.clientY < TABLE_EDGE_ZONE;
-
-    // Top/bottom edge → whole table
-    if (nearTop || nearBottom) {
-      return { element: blockEl, blockId, label: 'table', isCodeBlock: false };
-    }
-
-    // Left/right edge → the row at this Y position
-    if (nearLeft || nearRight) {
-      const row = findRowAtY(tableEl, mousePos.clientY);
-      if (row) {
-        return { element: row, blockId, label: getRowLabel(row), isCodeBlock: false };
-      }
-      return { element: blockEl, blockId, label: 'table', isCodeBlock: false };
-    }
-  }
-
-  // Inline code (not inside a code block) — target the <code> element
-  if (target.tagName === 'CODE' && !target.classList.contains('hljs')) {
-    const text = target.textContent?.trim() || '';
-    if (text) {
-      return {
-        element: target,
-        blockId,
-        label: `code: \`${truncate(text, 30)}\``,
-        isCodeBlock: false,
-      };
-    }
-  }
-
-  // Inline elements: strong, em, a
-  if (INLINE_TARGETS.has(target.tagName)) {
-    const text = target.textContent?.trim() || '';
-    if (text) {
-      return {
-        element: target,
-        blockId,
-        label: getInlineLabel(target, text),
-        isCodeBlock: false,
-      };
-    }
-  }
-
-  // Table cells (only reached when cursor is deep inside, not near edge)
-  if (CELL_TARGETS.has(target.tagName)) {
-    return {
-      element: target,
-      blockId,
-      label: 'table cell',
-      isCodeBlock: false,
-    };
-  }
-  // Check if inside a table cell
-  const cell = target.closest('td, th') as HTMLElement | null;
-  if (cell && blockEl.contains(cell)) {
-    return {
-      element: cell,
-      blockId,
-      label: 'table cell',
-      isCodeBlock: false,
-    };
-  }
-
-  // List item — target the content span (second child), not the bullet
-  if (blockEl.querySelector('.select-none')) {
-    // This is a list item with a bullet. Find the content span.
-    const contentSpan = blockEl.children[1] as HTMLElement | undefined;
-    if (contentSpan && (contentSpan === target || contentSpan.contains(target))) {
-      return {
-        element: contentSpan,
-        blockId,
-        label: getListItemLabel(contentSpan),
-        isCodeBlock: false,
-      };
-    }
-    // Clicked on the bullet area — still target the content span
-    if (contentSpan) {
-      return {
-        element: contentSpan,
-        blockId,
-        label: getListItemLabel(contentSpan),
-        isCodeBlock: false,
-      };
-    }
-  }
-
-  // Fall back to the full block
-  return {
-    element: blockEl,
-    blockId,
-    label: getBlockLabel(blockEl),
-    isCodeBlock: false,
-  };
+export interface SemanticTargetGraph {
+  readonly container: HTMLElement;
+  readonly targets: readonly SemanticTarget[];
+  readonly byKey: ReadonlyMap<string, SemanticTarget>;
+  readonly byElement: ReadonlyMap<HTMLElement, SemanticTarget>;
+  /** One entry per rendered Markdown block, in document order. */
+  readonly blockKeys: readonly string[];
 }
 
-function getInlineLabel(el: HTMLElement, text: string): string {
-  switch (el.tagName) {
-    case 'STRONG': return `bold: "${truncate(text, 30)}"`;
-    case 'EM': return `italic: "${truncate(text, 30)}"`;
-    case 'A': return `link: "${truncate(text, 25)}"`;
-    default: return truncate(text, 30);
-  }
+/** Motions available while navigating the semantic target graph. */
+export type SemanticTargetMotion =
+  | 'previous-block'
+  | 'next-block'
+  | 'previous-sibling'
+  | 'next-sibling'
+  | 'parent'
+  | 'child'
+  | 'first-block'
+  | 'last-block';
+
+/** Pointer coordinates used for table edge-zone targeting. */
+export interface SemanticPointerPosition {
+  readonly clientX: number;
+  readonly clientY: number;
 }
 
-function getBlockLabel(el: HTMLElement): string {
-  const tag = el.tagName.toLowerCase();
-  const text = el.textContent?.trim() || '';
+function getBlockElements(container: HTMLElement): HTMLElement[] {
+  const seen = new Set<string>();
+  const result: HTMLElement[] = [];
 
-  if (el.querySelector('table')) return 'table';
-  if (el.dataset.blockType === 'heading' || /^h[1-6]$/.test(tag)) {
-    return `heading: "${truncate(text, 35)}"`;
-  }
-  if (tag === 'blockquote') return `blockquote: "${truncate(text, 30)}"`;
-  if (tag === 'p') return text ? `paragraph: "${truncate(text, 35)}"` : 'paragraph';
-  return truncate(text, 35) || tag;
-}
+  container.querySelectorAll<HTMLElement>('[data-block-id]').forEach((element) => {
+    const blockId = element.dataset.blockId;
+    if (!blockId || seen.has(blockId) || element.tagName === 'HR') return;
+    seen.add(blockId);
+    result.push(element);
+  });
 
-function getListItemLabel(contentSpan: HTMLElement): string {
-  const text = contentSpan.textContent?.trim() || '';
-  return text ? `list item: "${truncate(text, 30)}"` : 'list item';
-}
-
-function getCodeBlockLabel(blockEl: HTMLElement): string {
-  const codeEl = blockEl.querySelector('code');
-  const lang = codeEl?.className?.match(/language-(\S+)/)?.[1];
-  return lang ? `code block (${lang})` : 'code block';
-}
-
-/** Find the table row whose bounding box contains the given Y coordinate */
-function findRowAtY(tableEl: HTMLTableElement, clientY: number): HTMLTableRowElement | null {
-  const rows = tableEl.querySelectorAll('tr');
-  for (const row of rows) {
-    const rect = row.getBoundingClientRect();
-    if (clientY >= rect.top && clientY <= rect.bottom) {
-      return row;
-    }
-  }
-  return null;
-}
-
-/** Human-readable label for a table row */
-function getRowLabel(row: HTMLTableRowElement): string {
-  // Header row
-  if (row.querySelector('th')) return 'table header row';
-  // Body row — use first cell text as hint
-  const firstCell = row.querySelector('td');
-  const text = firstCell?.textContent?.trim() || '';
-  return text ? `row: "${truncate(text, 25)}"` : 'table row';
+  return result;
 }
 
 function truncate(text: string, max: number): string {
-  return text.length > max ? text.slice(0, max) + '...' : text;
+  return text.length > max ? `${text.slice(0, max)}...` : text;
+}
+
+function inlineLabel(element: HTMLElement): string {
+  const text = element.textContent?.trim() ?? '';
+  const excerpt = truncate(text, 30);
+  if (element.tagName === 'STRONG') return `bold: "${excerpt}"`;
+  if (element.tagName === 'EM') return `italic: "${excerpt}"`;
+  if (element.tagName === 'A') return `link: "${truncate(text, 25)}"`;
+  return element.tagName === 'CODE' ? `code: \`${excerpt}\`` : excerpt;
+}
+
+function blockLabel(element: HTMLElement, listItem: boolean): string {
+  const text = element.textContent?.trim() ?? '';
+  const tag = element.tagName.toLowerCase();
+  if (listItem) {
+    return text ? `list item: "${truncate(text, 30)}"` : 'list item';
+  }
+  if (element.dataset.blockType === 'heading' || /^h[1-6]$/.test(tag)) {
+    return `heading: "${truncate(text, 35)}"`;
+  }
+  if (tag === 'blockquote') return `blockquote: "${truncate(text, 30)}"`;
+  return text ? `paragraph: "${truncate(text, 35)}"` : tag;
+}
+
+function codeBlockLabel(block: HTMLElement): string {
+  const code = block.querySelector('code');
+  const language = code?.className.match(/language-(\S+)/)?.[1];
+  return language ? `code block (${language})` : 'code block';
+}
+
+function groupKey(group: HTMLElement): string {
+  const type = group.dataset.pinpointGroup ?? 'group';
+  const ids = Array.from(group.querySelectorAll<HTMLElement>('[data-block-id]'))
+    .map((element) => element.dataset.blockId)
+    .filter((id): id is string => Boolean(id));
+  return `group:${type}:${ids[0] ?? 'empty'}:${ids.at(-1) ?? 'empty'}`;
+}
+
+function groupLabel(group: HTMLElement): string {
+  if (group.dataset.pinpointGroup === 'list') return 'list';
+  if (group.dataset.pinpointGroup === 'blockquote') return 'blockquote group';
+  return 'group';
+}
+
+function listContentElement(block: HTMLElement): HTMLElement | null {
+  if (!block.querySelector('.select-none')) return null;
+  return block.children[1] instanceof HTMLElement ? block.children[1] : null;
+}
+
+function addInlineTargets(
+  targets: SemanticTarget[],
+  byElement: Map<HTMLElement, SemanticTarget>,
+  blockId: string,
+  parent: SemanticTarget,
+  root: HTMLElement,
+  keyPrefix: string,
+): void {
+  const elements = Array.from(root.querySelectorAll<HTMLElement>(INLINE_TARGET_SELECTOR))
+    .filter((element) => element.textContent?.trim() && !element.closest(SKIP_SELECTORS));
+
+  elements.forEach((element, index) => {
+    const ancestorElement = element.parentElement?.closest<HTMLElement>(INLINE_TARGET_SELECTOR);
+    const semanticParent = ancestorElement && root.contains(ancestorElement)
+      ? byElement.get(ancestorElement) ?? parent
+      : parent;
+    const target: SemanticTarget = {
+      key: `${keyPrefix}:inline:${index}`,
+      blockId,
+      element,
+      label: inlineLabel(element),
+      kind: 'inline',
+      parentKey: semanticParent.key,
+    };
+    targets.push(target);
+    byElement.set(element, target);
+  });
+}
+
+/**
+ * Build the canonical semantic target graph for a rendered Markdown document.
+ *
+ * Each `[data-block-id]` contributes exactly one block-navigation entry.
+ * Groups, table rows/cells, and inline formatting become hierarchy nodes.
+ */
+export function buildSemanticTargetGraph(container: HTMLElement): SemanticTargetGraph {
+  const targets: SemanticTarget[] = [];
+  const byElement = new Map<HTMLElement, SemanticTarget>();
+  const blockKeys: string[] = [];
+  const groupTargets = new Map<HTMLElement, SemanticTarget>();
+
+  container.querySelectorAll<HTMLElement>('[data-pinpoint-group]').forEach((group) => {
+    const firstBlockId = group.querySelector<HTMLElement>('[data-block-id]')?.dataset.blockId;
+    const target: SemanticTarget = {
+      key: groupKey(group),
+      blockId: firstBlockId ?? '',
+      element: group,
+      label: groupLabel(group),
+      kind: 'group',
+      parentKey: null,
+    };
+    targets.push(target);
+    byElement.set(group, target);
+    groupTargets.set(group, target);
+  });
+
+  for (const block of getBlockElements(container)) {
+    const blockId = block.dataset.blockId;
+    if (!blockId) continue;
+
+    const group = block.closest<HTMLElement>('[data-pinpoint-group]');
+    const parentKey = group ? groupTargets.get(group)?.key ?? null : null;
+    const codeElement = block.querySelector<HTMLElement>('pre > code.hljs');
+    const mathElement = block.matches('.math-annotatable,[data-math-tex]')
+      ? block
+      : block.querySelector<HTMLElement>('.math-annotatable,[data-math-tex]');
+    const table = block.querySelector<HTMLTableElement>('table');
+
+    if (codeElement) {
+      const target: SemanticTarget = {
+        key: `${blockId}:code`,
+        blockId,
+        element: block,
+        label: codeBlockLabel(block),
+        kind: 'code',
+        parentKey,
+      };
+      targets.push(target);
+      byElement.set(block, target);
+      blockKeys.push(target.key);
+      continue;
+    }
+
+    if (mathElement) {
+      const target: SemanticTarget = {
+        key: `${blockId}:math`,
+        blockId,
+        element: mathElement,
+        label: 'formula',
+        kind: 'math',
+        parentKey,
+      };
+      targets.push(target);
+      byElement.set(mathElement, target);
+      blockKeys.push(target.key);
+      continue;
+    }
+
+    if (table) {
+      const tableTarget: SemanticTarget = {
+        key: `${blockId}:table`,
+        blockId,
+        element: block,
+        label: 'table',
+        kind: 'table',
+        parentKey,
+      };
+      targets.push(tableTarget);
+      byElement.set(block, tableTarget);
+      blockKeys.push(tableTarget.key);
+
+      Array.from(table.rows).forEach((row, rowIndex) => {
+        const rowTarget: SemanticTarget = {
+          key: `${blockId}:row:${rowIndex}`,
+          blockId,
+          element: row,
+          label: rowIndex === 0 ? 'table header row' : `table row ${rowIndex}`,
+          kind: 'row',
+          parentKey: tableTarget.key,
+          rowIndex,
+        };
+        targets.push(rowTarget);
+        byElement.set(row, rowTarget);
+
+        Array.from(row.cells).forEach((cell, columnIndex) => {
+          const cellTarget: SemanticTarget = {
+            key: `${blockId}:cell:${rowIndex}:${columnIndex}`,
+            blockId,
+            element: cell,
+            label: `table cell ${rowIndex + 1}, ${columnIndex + 1}`,
+            kind: 'cell',
+            parentKey: rowTarget.key,
+            rowIndex,
+            columnIndex,
+          };
+          targets.push(cellTarget);
+          byElement.set(cell, cellTarget);
+          addInlineTargets(
+            targets,
+            byElement,
+            blockId,
+            cellTarget,
+            cell,
+            cellTarget.key,
+          );
+        });
+      });
+      continue;
+    }
+
+    const listContent = listContentElement(block);
+    const primaryElement = listContent ?? block;
+    const blockTarget: SemanticTarget = {
+      key: `${blockId}:block`,
+      blockId,
+      element: primaryElement,
+      label: blockLabel(primaryElement, listContent !== null),
+      kind: 'block',
+      parentKey,
+    };
+    targets.push(blockTarget);
+    byElement.set(primaryElement, blockTarget);
+    blockKeys.push(blockTarget.key);
+    addInlineTargets(targets, byElement, blockId, blockTarget, primaryElement, blockId);
+  }
+
+  return {
+    container,
+    targets,
+    byKey: new Map(targets.map((target) => [target.key, target])),
+    byElement,
+    blockKeys,
+  };
+}
+
+/** Resolve a stable target key against a freshly built graph. */
+export function resolveSemanticTarget(
+  graph: SemanticTargetGraph,
+  key: string | null,
+): SemanticTarget | null {
+  return key ? graph.byKey.get(key) ?? null : null;
+}
+
+/**
+ * Create the annotation range owned by a semantic target.
+ *
+ * Code and math targets use their existing specialized annotation paths;
+ * every text-bearing graph node resolves through this one range seam.
+ */
+export function createSemanticTargetRange(target: SemanticTarget): Range | null {
+  return target.kind === 'code' || target.kind === 'math'
+    ? null
+    : createTextRange(target.element);
+}
+
+/** Return the direct semantic children of a target in document order. */
+export function getSemanticTargetChildren(
+  graph: SemanticTargetGraph,
+  target: SemanticTarget,
+): readonly SemanticTarget[] {
+  return graph.targets.filter((candidate) => candidate.parentKey === target.key);
+}
+
+/** Return the block-navigation target that owns a nested semantic target. */
+export function getOwningBlockTarget(
+  graph: SemanticTargetGraph,
+  target: SemanticTarget,
+): SemanticTarget {
+  let current = target;
+  while (!graph.blockKeys.includes(current.key) && current.parentKey) {
+    const parent = resolveSemanticTarget(graph, current.parentKey);
+    if (!parent) break;
+    current = parent;
+  }
+  if (graph.blockKeys.includes(current.key)) return current;
+  return graph.blockKeys
+    .map((key) => resolveSemanticTarget(graph, key))
+    .find((candidate) => candidate?.blockId === target.blockId)
+    ?? target;
+}
+
+/** Pick the block nearest the visible center of the document viewport. */
+export function findInitialSemanticTarget(
+  graph: SemanticTargetGraph,
+): SemanticTarget | null {
+  const viewport = graph.container.closest<HTMLElement>('[data-overlayscrollbars-viewport]');
+  const viewportRect = (viewport ?? graph.container).getBoundingClientRect();
+  const centerY = viewportRect.top + viewportRect.height / 2;
+  return graph.blockKeys
+    .map((key) => resolveSemanticTarget(graph, key))
+    .filter((target): target is SemanticTarget => target !== null)
+    .sort((left, right) => {
+      const leftRect = left.element.getBoundingClientRect();
+      const rightRect = right.element.getBoundingClientRect();
+      return Math.abs((leftRect.top + leftRect.bottom) / 2 - centerY)
+        - Math.abs((rightRect.top + rightRect.bottom) / 2 - centerY);
+    })[0] ?? null;
+}
+
+/**
+ * Move through block order, sibling order, or one hierarchy level.
+ */
+export function moveSemanticTarget(
+  graph: SemanticTargetGraph,
+  current: SemanticTarget,
+  motion: SemanticTargetMotion,
+): SemanticTarget {
+  if (motion === 'parent') {
+    return resolveSemanticTarget(graph, current.parentKey) ?? current;
+  }
+  if (motion === 'child') {
+    return getSemanticTargetChildren(graph, current)[0] ?? current;
+  }
+  if (motion === 'first-block') {
+    return resolveSemanticTarget(graph, graph.blockKeys[0] ?? null) ?? current;
+  }
+  if (motion === 'last-block') {
+    return resolveSemanticTarget(graph, graph.blockKeys.at(-1) ?? null) ?? current;
+  }
+  if (motion === 'previous-sibling' || motion === 'next-sibling') {
+    if (!current.parentKey) return current;
+    const parent = resolveSemanticTarget(graph, current.parentKey);
+    if (!parent) return current;
+    const siblings = getSemanticTargetChildren(graph, parent);
+    const index = siblings.findIndex((candidate) => candidate.key === current.key);
+    if (index < 0) return current;
+    const delta = motion === 'previous-sibling' ? -1 : 1;
+    const nextIndex = Math.max(0, Math.min(siblings.length - 1, index + delta));
+    return siblings[nextIndex] ?? current;
+  }
+
+  const delta: -1 | 1 = motion === 'previous-block' ? -1 : 1;
+  const block = getOwningBlockTarget(graph, current);
+  const index = graph.blockKeys.indexOf(block.key);
+  if (index < 0) return current;
+  const nextIndex = Math.max(0, Math.min(graph.blockKeys.length - 1, index + delta));
+  return resolveSemanticTarget(graph, graph.blockKeys[nextIndex] ?? null) ?? current;
+}
+
+function targetForBlock(graph: SemanticTargetGraph, block: HTMLElement): SemanticTarget | null {
+  const blockId = block.dataset.blockId;
+  if (!blockId) return null;
+  return graph.blockKeys
+    .map((key) => resolveSemanticTarget(graph, key))
+    .find((target) => target?.blockId === blockId)
+    ?? null;
+}
+
+function rowAtY(table: HTMLTableElement, clientY: number): HTMLTableRowElement | null {
+  return Array.from(table.rows).find((row) => {
+    const rect = row.getBoundingClientRect();
+    return clientY >= rect.top && clientY <= rect.bottom;
+  }) ?? null;
+}
+
+/**
+ * Resolve the pointer's semantic target from the same graph used by keyboard
+ * navigation. Table edge zones select table/row scope; content selects cells.
+ */
+export function resolveSemanticTargetAtPoint(
+  graph: SemanticTargetGraph,
+  pointerTarget: HTMLElement,
+  pointer?: SemanticPointerPosition,
+): SemanticTarget | null {
+  if (pointerTarget.closest(SKIP_SELECTORS)) return null;
+  if (!graph.container.contains(pointerTarget)) return null;
+
+  const group = pointerTarget.closest<HTMLElement>('[data-pinpoint-group]');
+  if (group && !pointerTarget.closest('[data-block-id]')) {
+    return graph.byElement.get(group) ?? null;
+  }
+
+  const block = pointerTarget.closest<HTMLElement>('[data-block-id]');
+  if (!block || !graph.container.contains(block) || block.tagName === 'HR') return null;
+  const blockTarget = targetForBlock(graph, block);
+  if (!blockTarget) return null;
+
+  const code = block.querySelector<HTMLElement>('pre > code.hljs');
+  if (
+    code
+    && (pointerTarget === code || code.contains(pointerTarget) || pointerTarget.closest('pre'))
+  ) {
+    return blockTarget;
+  }
+
+  const table = block.querySelector<HTMLTableElement>('table');
+  if (table && pointer) {
+    const rect = table.getBoundingClientRect();
+    const nearHorizontalEdge = pointer.clientX - rect.left < TABLE_EDGE_ZONE
+      || rect.right - pointer.clientX < TABLE_EDGE_ZONE;
+    const nearVerticalEdge = pointer.clientY - rect.top < TABLE_EDGE_ZONE
+      || rect.bottom - pointer.clientY < TABLE_EDGE_ZONE;
+    if (nearVerticalEdge) return blockTarget;
+    if (nearHorizontalEdge) {
+      const row = rowAtY(table, pointer.clientY);
+      return row ? graph.byElement.get(row) ?? blockTarget : blockTarget;
+    }
+  }
+
+  const inline = pointerTarget.closest<HTMLElement>(INLINE_TARGET_SELECTOR);
+  if (inline && block.contains(inline)) {
+    const inlineTarget = graph.byElement.get(inline);
+    if (inlineTarget) return inlineTarget;
+  }
+
+  const cell = pointerTarget.closest<HTMLTableCellElement>('td,th');
+  if (cell && block.contains(cell)) {
+    return graph.byElement.get(cell) ?? blockTarget;
+  }
+
+  return blockTarget;
+}
+
+/**
+ * Backward-compatible pointer result used by existing Pinpoint consumers.
+ *
+ * New code should retain the semantic target itself so pointer and keyboard
+ * paths share its stable key and hierarchy.
+ */
+export interface PinpointTarget {
+  readonly element: HTMLElement;
+  readonly blockId: string;
+  readonly label: string;
+  readonly isCodeBlock: boolean;
+}
+
+/** Resolve a pointer target through the canonical semantic graph. */
+export function resolvePinpointTarget(
+  target: HTMLElement,
+  container: HTMLElement,
+  pointer?: SemanticPointerPosition,
+): PinpointTarget | null {
+  const semantic = resolveSemanticTargetAtPoint(
+    buildSemanticTargetGraph(container),
+    target,
+    pointer,
+  );
+  return semantic
+    ? {
+        element: semantic.element,
+        blockId: semantic.blockId,
+        label: semantic.label,
+        isCodeBlock: semantic.kind === 'code',
+      }
+    : null;
 }

--- a/packages/ui/utils/clipboard.ts
+++ b/packages/ui/utils/clipboard.ts
@@ -1,0 +1,73 @@
+function copyTextWithFallback(text: string, focusOwner: HTMLElement): void {
+  const activeElement = document.activeElement instanceof HTMLElement
+    ? document.activeElement
+    : null;
+  const selection = window.getSelection();
+  const savedRanges = selection
+    ? Array.from({ length: selection.rangeCount }, (_, index) =>
+        selection.getRangeAt(index).cloneRange())
+    : [];
+  let copied = false;
+
+  const handleCopy = (event: ClipboardEvent) => {
+    event.preventDefault();
+    event.clipboardData?.setData('text/plain', text);
+    copied = true;
+  };
+  document.addEventListener('copy', handleCopy);
+  try {
+    copied = document.execCommand('copy') || copied;
+  } catch {
+    copied = false;
+  } finally {
+    document.removeEventListener('copy', handleCopy);
+  }
+
+  if (!copied) {
+    const textarea = document.createElement('textarea');
+    textarea.style.cssText = 'position:fixed;opacity:0;pointer-events:none';
+    textarea.value = text;
+    document.body.appendChild(textarea);
+    textarea.select();
+    try {
+      document.execCommand('copy');
+    } catch {
+      // Clipboard access can be denied by the embedding browser. The caller
+      // still regains the same document focus and selection below.
+    }
+    textarea.remove();
+  }
+
+  if (activeElement?.isConnected) {
+    activeElement.focus({ preventScroll: true });
+  } else if (focusOwner.isConnected) {
+    focusOwner.focus({ preventScroll: true });
+  }
+  if (selection && savedRanges.length > 0) {
+    selection.removeAllRanges();
+    savedRanges.forEach((range) => selection.addRange(range));
+  }
+}
+
+/**
+ * Copy text without stealing focus or discarding the host document's native
+ * selection. Falls back to the copy event for restricted browser contexts.
+ */
+export function copyTextPreservingFocus(
+  text: string,
+  focusOwner: HTMLElement,
+): void {
+  try {
+    const clipboardWrite = navigator.clipboard?.writeText(text);
+    if (clipboardWrite) {
+      void clipboardWrite.catch(() => {
+        copyTextWithFallback(text, focusOwner);
+      });
+      return;
+    }
+  } catch {
+    // Fall through when a browser exposes Clipboard but rejects access
+    // synchronously (for example, in a restricted embedded document).
+  }
+  copyTextWithFallback(text, focusOwner);
+}

--- a/packages/ui/utils/domSelection.ts
+++ b/packages/ui/utils/domSelection.ts
@@ -1,0 +1,84 @@
+/** Elements whose text must not become part of a document annotation range. */
+const NON_ANNOTATABLE_SELECTOR = [
+  'button',
+  'input',
+  'textarea',
+  'select',
+  'script',
+  'style',
+  '[contenteditable]:not([contenteditable="false"])',
+  '[data-pinpoint-ignore]',
+  '.select-none',
+  '.annotation-toolbar',
+  '.katex',
+].join(',');
+
+const DOCUMENT_KEYBOARD_CONTROL_SELECTOR = [
+  'button',
+  'input',
+  'textarea',
+  'select',
+  'a[href]',
+  'summary',
+  '[contenteditable]:not([contenteditable="false"])',
+  '[role="button"]',
+  '[role="link"]',
+  '[role="textbox"]',
+  '[role="dialog"]',
+].join(',');
+
+/**
+ * Return the annotatable text nodes under an element in document order.
+ * Existing highlight wrappers remain eligible so Vim selections can overlap
+ * annotations just like pointer selections.
+ */
+export function getAnnotatableTextNodes(element: Element): Text[] {
+  const nodes: Text[] = [];
+  const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT, {
+    acceptNode(node) {
+      const parent = node.parentElement;
+      if (!parent || parent.closest(NON_ANNOTATABLE_SELECTOR)) {
+        return NodeFilter.FILTER_REJECT;
+      }
+      return node.textContent?.length
+        ? NodeFilter.FILTER_ACCEPT
+        : NodeFilter.FILTER_REJECT;
+    },
+  });
+
+  let node = walker.nextNode();
+  while (node) {
+    if (node instanceof Text) nodes.push(node);
+    node = walker.nextNode();
+  }
+  return nodes;
+}
+
+/**
+ * Return whether a keyboard event originated in an editable or interactive
+ * control that must retain ownership of ordinary typing keys.
+ */
+export function isDocumentKeyboardControl(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  return target.matches(DOCUMENT_KEYBOARD_CONTROL_SELECTOR)
+    || target.closest(DOCUMENT_KEYBOARD_CONTROL_SELECTOR) !== null
+    || (target instanceof HTMLElement && target.isContentEditable);
+}
+
+/**
+ * Create a text-node-anchored range spanning an element's annotatable text.
+ * Web-highlighter cannot paint element-node endpoints, so callers share this
+ * conversion instead of synthesizing subtly different ranges.
+ */
+export function createTextRange(element: HTMLElement): Range | null {
+  const nodes = getAnnotatableTextNodes(element);
+  const firstNode = nodes[0];
+  const lastNode = nodes[nodes.length - 1];
+
+  if (!firstNode || !lastNode) return null;
+
+  const range = document.createRange();
+  range.setStart(firstNode, 0);
+  range.setEnd(lastNode, lastNode.length);
+  return range;
+}

--- a/packages/ui/utils/vimHud.test.ts
+++ b/packages/ui/utils/vimHud.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, test } from 'bun:test';
-import { createVimHudCommand, getVimHudPhase } from './vimHud';
+import { vimSelectionShortcuts } from '../shortcuts/plan-review/vimSelection.shortcuts';
+import {
+  createVimHudCommand,
+  getVimHudLegendGroups,
+  getVimHudPhase,
+  isVimHudLegendGroupActive,
+} from './vimHud';
 
 describe('Vim HUD command projection', () => {
   test('normalizes multi-key and named keys for the video keycaps', () => {
     expect(createVimHudCommand(1, 'documentStart', 'g', 'block')).toMatchObject({
       key: 'gg',
       description: 'Start of document',
+      context: 'block',
     });
     expect(createVimHudCommand(2, 'cancel', 'Escape', 'visual')).toMatchObject({
       key: 'esc',
@@ -25,5 +32,40 @@ describe('Vim HUD command projection', () => {
     expect(getVimHudPhase('text', 'refine')).toBe('TEXT');
     expect(getVimHudPhase('visual', 'wordEnd')).toBe('VISUAL');
     expect(getVimHudPhase('action', 'comment')).toBe('ACTION');
+  });
+
+  test('maps every registered Vim action into the expanded learning legend', () => {
+    const groups = getVimHudLegendGroups();
+    const legendActionIds = new Set(
+      groups.flatMap((group) => group.items.map((item) => item.actionId)),
+    );
+
+    expect([...legendActionIds].sort().join(',')).toBe(
+      Object.keys(vimSelectionShortcuts.shortcuts).sort().join(','),
+    );
+    expect(groups.find((group) => group.id === 'structure')?.items)
+      .toContainEqual(expect.objectContaining({
+        actionId: 'documentStart',
+        key: 'gg',
+      }));
+    expect(groups.find((group) => group.id === 'text')?.items)
+      .toContainEqual(expect.objectContaining({
+        actionId: 'moveDown',
+        key: 'j',
+        description: 'Next line',
+      }));
+    expect(groups.find((group) => group.id === 'annotation')?.items)
+      .toContainEqual(expect.objectContaining({
+        actionId: 'annotationMenu',
+        key: 'space',
+      }));
+  });
+
+  test('highlights the legend group for the current navigation level', () => {
+    expect(isVimHudLegendGroupActive('structure', 'BLOCK')).toBe(true);
+    expect(isVimHudLegendGroupActive('text', 'WORD')).toBe(true);
+    expect(isVimHudLegendGroupActive('selection', 'VISUAL')).toBe(true);
+    expect(isVimHudLegendGroupActive('annotation', 'ACTION')).toBe(true);
+    expect(isVimHudLegendGroupActive('control', 'BLOCK')).toBe(false);
   });
 });

--- a/packages/ui/utils/vimHud.test.ts
+++ b/packages/ui/utils/vimHud.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test';
+import { createVimHudCommand, getVimHudPhase } from './vimHud';
+
+describe('Vim HUD command projection', () => {
+  test('normalizes multi-key and named keys for the video keycaps', () => {
+    expect(createVimHudCommand(1, 'documentStart', 'g', 'block')).toMatchObject({
+      key: 'gg',
+      description: 'Start of document',
+    });
+    expect(createVimHudCommand(2, 'cancel', 'Escape', 'visual')).toMatchObject({
+      key: 'esc',
+      description: 'Cancel current Vim state',
+    });
+    expect(createVimHudCommand(3, 'annotationMenu', ' ', 'visual')).toMatchObject({
+      key: 'space',
+      description: 'Open annotation actions',
+    });
+  });
+
+  test('distinguishes structural, line, word, visual, and action phases', () => {
+    expect(getVimHudPhase('block', 'moveDown')).toBe('BLOCK');
+    expect(getVimHudPhase('inline', 'moveDown')).toBe('INLINE');
+    expect(getVimHudPhase('text', 'moveDown')).toBe('LINE');
+    expect(getVimHudPhase('text', 'wordForward')).toBe('WORD');
+    expect(getVimHudPhase('text', 'refine')).toBe('TEXT');
+    expect(getVimHudPhase('visual', 'wordEnd')).toBe('VISUAL');
+    expect(getVimHudPhase('action', 'comment')).toBe('ACTION');
+  });
+});

--- a/packages/ui/utils/vimHud.ts
+++ b/packages/ui/utils/vimHud.ts
@@ -1,5 +1,6 @@
 import {
   describeVimSelectionAction,
+  vimSelectionShortcuts,
   type VimSelectionActionId,
   type VimSelectionHudContext,
 } from '../shortcuts/plan-review/vimSelection.shortcuts';
@@ -20,7 +21,104 @@ export interface VimHudCommand {
   readonly actionId: VimSelectionActionId;
   readonly key: string;
   readonly description: string;
+  readonly context: VimSelectionHudContext;
 }
+
+/** Stable section identifiers used by the expanded Vim HUD key map. */
+export type VimHudLegendGroupId =
+  | 'structure'
+  | 'text'
+  | 'selection'
+  | 'annotation'
+  | 'control';
+
+/** One registered Vim command projected into the expanded HUD key map. */
+export interface VimHudLegendItem {
+  readonly actionId: VimSelectionActionId;
+  readonly key: string;
+  readonly description: string;
+}
+
+/** One learnable command family rendered in the expanded HUD key map. */
+export interface VimHudLegendGroup {
+  readonly id: VimHudLegendGroupId;
+  readonly title: string;
+  readonly description: string;
+  readonly items: readonly VimHudLegendItem[];
+}
+
+interface VimHudLegendGroupSpec {
+  readonly id: VimHudLegendGroupId;
+  readonly title: string;
+  readonly description: string;
+  readonly context: VimSelectionHudContext;
+  readonly actionIds: readonly VimSelectionActionId[];
+}
+
+const VIM_HUD_LEGEND_GROUP_SPECS: readonly VimHudLegendGroupSpec[] = [
+  {
+    id: 'structure',
+    title: 'Document',
+    description: 'Move by blocks and semantic structure',
+    context: 'block',
+    actionIds: [
+      'moveDown',
+      'moveUp',
+      'documentStart',
+      'documentEnd',
+      'moveOut',
+      'refine',
+    ],
+  },
+  {
+    id: 'text',
+    title: 'Text',
+    description: 'Move by characters, lines, words, and paragraphs',
+    context: 'text',
+    actionIds: [
+      'moveOut',
+      'refine',
+      'moveDown',
+      'moveUp',
+      'wordForward',
+      'wordBackward',
+      'wordEnd',
+      'lineStart',
+      'lineEnd',
+      'previousTextBlock',
+      'nextTextBlock',
+    ],
+  },
+  {
+    id: 'selection',
+    title: 'Select',
+    description: 'Grow an exact or whole-block selection',
+    context: 'block',
+    actionIds: ['visual', 'visualBlock', 'swapSelectionEnds'],
+  },
+  {
+    id: 'annotation',
+    title: 'Annotate',
+    description: 'Act on the current target or selection',
+    context: 'block',
+    actionIds: [
+      'activeAnnotation',
+      'annotationMenu',
+      'comment',
+      'redline',
+      'markup',
+      'label',
+      'copy',
+    ],
+  },
+  {
+    id: 'control',
+    title: 'Control',
+    description: 'Back out or show this key map',
+    context: 'block',
+    actionIds: ['cancel', 'help'],
+  },
+];
 
 function normalizeVimHudKey(
   actionId: VimSelectionActionId,
@@ -31,6 +129,19 @@ function normalizeVimHudKey(
   if (rawKey === 'Enter') return 'enter';
   if (rawKey === ' ' || rawKey === 'Space' || rawKey === 'Spacebar') return 'space';
   return rawKey;
+}
+
+function formatVimLegendKey(
+  actionId: VimSelectionActionId,
+  binding: string,
+): string {
+  if (actionId === 'documentStart') return 'gg';
+  if (actionId === 'documentEnd') return 'G';
+  if (actionId === 'visualBlock') return 'V';
+  if (binding === 'Escape') return 'esc';
+  if (binding === 'Enter') return 'enter';
+  if (binding === 'Space') return 'space';
+  return binding.length === 1 ? binding.toLowerCase() : binding;
 }
 
 /**
@@ -47,7 +158,53 @@ export function createVimHudCommand(
     actionId,
     key: normalizeVimHudKey(actionId, rawKey),
     description: describeVimSelectionAction(actionId, context),
+    context,
   };
+}
+
+/**
+ * Project the registered Vim shortcut scope into learnable HUD groups.
+ *
+ * Movement actions intentionally appear in both Document and Text with
+ * contextual descriptions because the same Vim keys change granularity after
+ * the user refines into text.
+ */
+export function getVimHudLegendGroups(): readonly VimHudLegendGroup[] {
+  return VIM_HUD_LEGEND_GROUP_SPECS.map((group) => ({
+    id: group.id,
+    title: group.title,
+    description: group.description,
+    items: group.actionIds.map((actionId) => {
+      const shortcut = vimSelectionShortcuts.shortcuts[actionId];
+      return {
+        actionId,
+        key: formatVimLegendKey(actionId, shortcut.bindings[0] ?? ''),
+        description: describeVimSelectionAction(actionId, group.context),
+      };
+    }),
+  }));
+}
+
+/**
+ * Return whether a legend group represents the HUD's current movement level.
+ */
+export function isVimHudLegendGroupActive(
+  groupId: VimHudLegendGroupId,
+  phase: VimHudPhase,
+): boolean {
+  switch (phase) {
+    case 'BLOCK':
+    case 'INLINE':
+      return groupId === 'structure';
+    case 'LINE':
+    case 'WORD':
+    case 'TEXT':
+      return groupId === 'text';
+    case 'VISUAL':
+      return groupId === 'selection';
+    case 'ACTION':
+      return groupId === 'annotation';
+  }
 }
 
 /**

--- a/packages/ui/utils/vimHud.ts
+++ b/packages/ui/utils/vimHud.ts
@@ -1,0 +1,106 @@
+import {
+  describeVimSelectionAction,
+  type VimSelectionActionId,
+  type VimSelectionHudContext,
+} from '../shortcuts/plan-review/vimSelection.shortcuts';
+
+/** Semantic label displayed in the Vim key HUD. */
+export type VimHudPhase =
+  | 'BLOCK'
+  | 'INLINE'
+  | 'LINE'
+  | 'WORD'
+  | 'TEXT'
+  | 'VISUAL'
+  | 'ACTION';
+
+/** One successfully handled Vim command rendered by the key HUD. */
+export interface VimHudCommand {
+  readonly sequence: number;
+  readonly actionId: VimSelectionActionId;
+  readonly key: string;
+  readonly description: string;
+}
+
+function normalizeVimHudKey(
+  actionId: VimSelectionActionId,
+  rawKey: string,
+): string {
+  if (actionId === 'documentStart') return 'gg';
+  if (rawKey === 'Escape') return 'esc';
+  if (rawKey === 'Enter') return 'enter';
+  if (rawKey === ' ' || rawKey === 'Space' || rawKey === 'Spacebar') return 'space';
+  return rawKey;
+}
+
+/**
+ * Build immutable HUD feedback from a command that the Vim controller handled.
+ */
+export function createVimHudCommand(
+  sequence: number,
+  actionId: VimSelectionActionId,
+  rawKey: string,
+  context: VimSelectionHudContext,
+): VimHudCommand {
+  return {
+    sequence,
+    actionId,
+    key: normalizeVimHudKey(actionId, rawKey),
+    description: describeVimSelectionAction(actionId, context),
+  };
+}
+
+/**
+ * Project live Vim navigation state and the latest motion into the video HUD's
+ * semantic phase vocabulary.
+ */
+export function getVimHudPhase(
+  state: VimSelectionHudContext,
+  actionId?: VimSelectionActionId,
+): VimHudPhase {
+  switch (state) {
+    case 'action':
+      return 'ACTION';
+    case 'visual':
+    case 'visual-block':
+      return 'VISUAL';
+    case 'inline':
+      return 'INLINE';
+    case 'block':
+    case 'inactive':
+      return 'BLOCK';
+    case 'text':
+      switch (actionId) {
+        case 'moveDown':
+        case 'moveUp':
+        case 'lineStart':
+        case 'lineEnd':
+          return 'LINE';
+        case 'wordForward':
+        case 'wordBackward':
+        case 'wordEnd':
+          return 'WORD';
+        case 'previousTextBlock':
+        case 'nextTextBlock':
+          return 'BLOCK';
+        case 'documentStart':
+        case 'documentEnd':
+        case 'moveOut':
+        case 'refine':
+        case 'visual':
+        case 'visualBlock':
+        case 'swapSelectionEnds':
+        case 'activeAnnotation':
+        case 'annotationMenu':
+        case 'comment':
+        case 'redline':
+        case 'markup':
+        case 'label':
+        case 'copy':
+        case 'cancel':
+        case 'help':
+        case undefined:
+          return 'TEXT';
+      }
+  }
+}

--- a/packages/ui/utils/vimModeAnnouncement.test.ts
+++ b/packages/ui/utils/vimModeAnnouncement.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { resetStorageBackend, setStorageBackend } from './storage';
+import {
+  markVimModeAnnouncementSeen,
+  needsVimModeAnnouncement,
+} from './vimModeAnnouncement';
+
+const STORAGE_KEY = 'plannotator-vim-mode-announcement-seen';
+let stored: Map<string, string>;
+
+describe('Vim mode announcement persistence', () => {
+  beforeEach(() => {
+    stored = new Map();
+    setStorageBackend({
+      getItem: key => stored.get(key) ?? null,
+      setItem: (key, value) => {
+        stored.set(key, value);
+      },
+      removeItem: key => {
+        stored.delete(key);
+      },
+    });
+  });
+
+  afterEach(() => {
+    resetStorageBackend();
+  });
+
+  test('is needed until the current announcement is marked seen', () => {
+    expect(needsVimModeAnnouncement()).toBe(true);
+
+    markVimModeAnnouncementSeen();
+
+    expect(stored.get(STORAGE_KEY)).toBe('2');
+    expect(needsVimModeAnnouncement()).toBe(false);
+  });
+
+  test('shows again when a stored announcement version is stale', () => {
+    stored.set(STORAGE_KEY, '1');
+    expect(needsVimModeAnnouncement()).toBe(true);
+  });
+});

--- a/packages/ui/utils/vimModeAnnouncement.ts
+++ b/packages/ui/utils/vimModeAnnouncement.ts
@@ -1,0 +1,23 @@
+/**
+ * Tracks whether the user has seen the Vim controls announcement.
+ *
+ * Cookie-backed storage keeps the dismissal across Plannotator's random
+ * localhost ports while still honoring host-provided storage backends.
+ */
+
+import { storage } from './storage';
+
+const STORAGE_KEY = 'plannotator-vim-mode-announcement-seen';
+// v2 is the full interactive introduction with the live settings and HUD
+// showcase. Earlier development builds used v1 for a smaller notice.
+const CURRENT_VERSION = '2';
+
+/** Return whether the current announcement version has not been dismissed. */
+export function needsVimModeAnnouncement(): boolean {
+  return storage.getItem(STORAGE_KEY) !== CURRENT_VERSION;
+}
+
+/** Persist dismissal of the current announcement version in shared UI storage. */
+export function markVimModeAnnouncementSeen(): void {
+  storage.setItem(STORAGE_KEY, CURRENT_VERSION);
+}

--- a/packages/ui/utils/vimNavigation.test.ts
+++ b/packages/ui/utils/vimNavigation.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+const hasDom = typeof document !== 'undefined';
+const navigationModule = hasDom ? await import('./vimNavigation') : null;
+const targetingModule = hasDom ? await import('./blockTargeting') : null;
+
+function navigation() {
+  if (!navigationModule) throw new Error('DOM test environment is not registered');
+  return navigationModule;
+}
+
+function targeting() {
+  if (!targetingModule) throw new Error('DOM test environment is not registered');
+  return targetingModule;
+}
+
+function createDocumentFixture(): HTMLElement {
+  const container = document.createElement('article');
+  container.innerHTML = [
+    '<li data-block-id="intro"><span class="select-none">1.</span>',
+    '<div>Alpha <strong>bravo</strong> 👩🏽‍💻.</div></li>',
+    '<div data-block-id="matrix"><table>',
+    '<thead><tr><th>A1</th><th>A2</th></tr></thead>',
+    '<tbody><tr><td>B1</td><td>B2</td></tr><tr><td>C1</td><td>C2</td></tr></tbody>',
+    '</table></div>',
+    '<div data-block-id="code"><pre><code class="hljs">const answer = 42;</code></pre></div>',
+    '<p data-block-id="outro">Charlie delta</p>',
+  ].join('');
+  document.body.appendChild(container);
+  return container;
+}
+
+function targetByKey(
+  targets: readonly import('./blockTargeting').SemanticTarget[],
+  key: string,
+) {
+  const target = targets.find((candidate) => candidate.key === key);
+  if (!target) throw new Error(`Missing Pinpoint target ${key}`);
+  return target;
+}
+
+afterEach(() => {
+  if (hasDom) {
+    document.body.replaceChildren();
+    window.getSelection()?.removeAllRanges();
+  }
+});
+
+describe.if(hasDom)('Vim text navigation', () => {
+  test('uses durable block-relative offsets across highlight DOM mutations', () => {
+    const { resolveTextPosition, serializeTextPosition } = navigation();
+    const container = createDocumentFixture();
+    const original = resolveTextPosition(container, { blockId: 'intro', textOffset: 8 });
+    expect(original?.node.data).toBe('bravo');
+    expect(original?.offset).toBe(2);
+
+    const intro = container.querySelector<HTMLElement>('[data-block-id="intro"]');
+    if (!intro) throw new Error('Missing intro block');
+    intro.innerHTML = [
+      '<span class="select-none">1.</span>',
+      '<div>Alpha <mark>bravo</mark> 👩🏽‍💻.</div>',
+    ].join('');
+
+    const restored = resolveTextPosition(container, { blockId: 'intro', textOffset: 8 });
+    expect(restored?.node.data).toBe('bravo');
+    expect(restored?.offset).toBe(2);
+    expect(restored && serializeTextPosition(container, restored.node, restored.offset)).toEqual({
+      blockId: 'intro',
+      textOffset: 8,
+    });
+  });
+
+  test('serializes an element endpoint after its final child as the text end', () => {
+    const { serializeTextPosition } = navigation();
+    const container = createDocumentFixture();
+    const intro = container.querySelector<HTMLElement>('[data-block-id="intro"] > div');
+    if (!intro) throw new Error('Missing intro content');
+
+    expect(serializeTextPosition(
+      container,
+      intro,
+      intro.childNodes.length,
+    )).toEqual({
+      blockId: 'intro',
+      textOffset: 'Alpha bravo 👩🏽‍💻.'.length,
+    });
+  });
+
+  test('moves by words, grapheme clusters, blocks, and document bounds', () => {
+    const { moveTextPosition } = navigation();
+    const container = createDocumentFixture();
+
+    expect(moveTextPosition(container, { blockId: 'intro', textOffset: 0 }, 'word-forward'))
+      .toEqual({ blockId: 'intro', textOffset: 'Alpha '.length });
+    expect(moveTextPosition(
+      container,
+      { blockId: 'intro', textOffset: 'Alpha bravo '.length },
+      'right',
+    )).toEqual({
+      blockId: 'intro',
+      textOffset: 'Alpha bravo 👩🏽‍💻'.length,
+    });
+    expect(moveTextPosition(container, { blockId: 'intro', textOffset: 0 }, 'block-forward'))
+      .toEqual({ blockId: 'matrix', textOffset: 0 });
+    expect(moveTextPosition(container, { blockId: 'matrix', textOffset: 0 }, 'document-end'))
+      .toEqual({ blockId: 'outro', textOffset: 'Charlie delta'.length });
+  });
+
+  test('creates forward ranges even after swapping selection ends', () => {
+    const { createRangeBetweenTextPositions } = navigation();
+    const container = createDocumentFixture();
+    const range = createRangeBetweenTextPositions(
+      container,
+      { blockId: 'outro', textOffset: 'Charlie'.length },
+      { blockId: 'intro', textOffset: 'Alpha '.length },
+    );
+
+    expect(range?.toString()).toContain('bravo');
+    expect(range?.toString()).toContain('Charlie');
+    expect(range?.collapsed).toBe(false);
+  });
+});
+
+describe.if(hasDom)('canonical semantic target graph', () => {
+  test('enumerates semantic targets without list markers or toolbar text', () => {
+    const { buildSemanticTargetGraph } = targeting();
+    const container = createDocumentFixture();
+    const targets = buildSemanticTargetGraph(container).targets;
+
+    expect(targetByKey(targets, 'intro:block').element.textContent).toContain('Alpha');
+    expect(targetByKey(targets, 'intro:block').element.textContent).not.toContain('1.');
+    expect(targetByKey(targets, 'intro:inline:0').label).toContain('bold');
+    expect(targetByKey(targets, 'matrix:table').kind).toBe('table');
+    expect(targetByKey(targets, 'matrix:cell:2:1').element.textContent).toBe('C2');
+    expect(targetByKey(targets, 'code:code').kind).toBe('code');
+  });
+
+  test('uses hierarchy refinement with explicit sibling and block motions', () => {
+    const { buildSemanticTargetGraph, moveSemanticTarget } = targeting();
+    const container = createDocumentFixture();
+    const graph = buildSemanticTargetGraph(container);
+    const targets = graph.targets;
+    const intro = targetByKey(targets, 'intro:block');
+    const inline = moveSemanticTarget(graph, intro, 'child');
+    expect(inline.key).toBe('intro:inline:0');
+    expect(moveSemanticTarget(graph, inline, 'parent').key).toBe('intro:block');
+
+    const table = targetByKey(targets, 'matrix:table');
+    const row = moveSemanticTarget(graph, table, 'child');
+    const a1 = moveSemanticTarget(graph, row, 'child');
+    expect(row.key).toBe('matrix:row:0');
+    expect(a1.key).toBe('matrix:cell:0:0');
+    expect(moveSemanticTarget(graph, a1, 'next-sibling').key).toBe('matrix:cell:0:1');
+    expect(moveSemanticTarget(graph, row, 'next-sibling').key).toBe('matrix:row:1');
+    expect(moveSemanticTarget(graph, a1, 'next-block').key).toBe('code:code');
+    expect(moveSemanticTarget(
+      graph,
+      targetByKey(targets, 'matrix:cell:1:1'),
+      'previous-block',
+    ).key).toBe('intro:block');
+    expect(moveSemanticTarget(graph, a1, 'parent').key).toBe('matrix:row:0');
+    expect(moveSemanticTarget(graph, row, 'parent').key).toBe('matrix:table');
+  });
+
+  test('j/k and gg/G traverse top-level semantic targets', () => {
+    const { buildSemanticTargetGraph, moveSemanticTarget } = targeting();
+    const container = createDocumentFixture();
+    const graph = buildSemanticTargetGraph(container);
+    const targets = graph.targets;
+    const intro = targetByKey(targets, 'intro:block');
+
+    expect(moveSemanticTarget(graph, intro, 'next-block').key).toBe('matrix:table');
+    expect(moveSemanticTarget(graph, intro, 'last-block').key).toBe('outro:block');
+    expect(moveSemanticTarget(
+      graph,
+      targetByKey(targets, 'outro:block'),
+      'first-block',
+    ).key).toBe('intro:block');
+  });
+
+  test('pointer hit-testing resolves nodes from the keyboard navigation graph', () => {
+    const {
+      buildSemanticTargetGraph,
+      createSemanticTargetRange,
+      resolveSemanticTargetAtPoint,
+    } = targeting();
+    const container = createDocumentFixture();
+    const graph = buildSemanticTargetGraph(container);
+    const strong = container.querySelector<HTMLElement>('strong');
+    const intro = container.querySelector<HTMLElement>('[data-block-id="intro"]');
+    if (!strong || !intro) throw new Error('Missing semantic fixture nodes');
+
+    const inlineTarget = resolveSemanticTargetAtPoint(graph, strong);
+    expect(inlineTarget?.key).toBe('intro:inline:0');
+    expect(resolveSemanticTargetAtPoint(graph, intro)?.key).toBe('intro:block');
+    expect(inlineTarget).toBe(graph.byKey.get('intro:inline:0'));
+    expect(inlineTarget && createSemanticTargetRange(inlineTarget)?.toString())
+      .toBe('bravo');
+  });
+
+  test('preserves nested inline hierarchy while exposing top-level inline siblings', () => {
+    const { buildSemanticTargetGraph, moveSemanticTarget } = targeting();
+    const container = createDocumentFixture();
+    const intro = container.querySelector<HTMLElement>('[data-block-id="intro"] > div');
+    if (!intro) throw new Error('Missing intro content');
+    intro.innerHTML = '<strong>outer <em>inner</em></strong><code>next</code>';
+
+    const graph = buildSemanticTargetGraph(container);
+    const block = targetByKey(graph.targets, 'intro:block');
+    const strong = moveSemanticTarget(graph, block, 'child');
+    const nested = moveSemanticTarget(graph, strong, 'child');
+    const sibling = moveSemanticTarget(graph, strong, 'next-sibling');
+
+    expect(strong.element.tagName).toBe('STRONG');
+    expect(nested.element.tagName).toBe('EM');
+    expect(sibling.element.tagName).toBe('CODE');
+  });
+
+  test('resolves semantic bounds to the intended side of adjacent table cells', () => {
+    const { buildSemanticTargetGraph } = targeting();
+    const {
+      createRangeBetweenTextPositions,
+      getTextElementBounds,
+    } = navigation();
+    const container = createDocumentFixture();
+    const graph = buildSemanticTargetGraph(container);
+    const cell = targetByKey(graph.targets, 'matrix:cell:1:1');
+    const bounds = getTextElementBounds(container, cell.element);
+    if (!bounds) throw new Error('Missing table-cell text bounds');
+
+    expect(createRangeBetweenTextPositions(container, bounds.start, bounds.end)?.toString())
+      .toBe('B2');
+  });
+});

--- a/packages/ui/utils/vimNavigation.ts
+++ b/packages/ui/utils/vimNavigation.ts
@@ -379,9 +379,16 @@ export function moveTextPosition(
   position: VimTextPosition,
   motion: VimTextMotion,
 ): VimTextPosition {
+  const currentBlock = findBlock(container, position.blockId);
+  if (!currentBlock) return findInitialTextPosition(container) ?? position;
+  const currentText = getBlockText(currentBlock);
+  const nextOffset = moveWithinBlock(currentText, position.textOffset, motion);
+  if (nextOffset !== null) {
+    return { blockId: position.blockId, textOffset: nextOffset };
+  }
+
   const blocks = getBlockElements(container).filter((block) => getBlockText(block).length > 0);
   if (blocks.length === 0) return position;
-
   if (motion === 'document-start') {
     return getPositionAtBlockBoundary(blocks[0], 'start') ?? position;
   }
@@ -389,20 +396,12 @@ export function moveTextPosition(
     return getPositionAtBlockBoundary(blocks[blocks.length - 1], 'end') ?? position;
   }
 
-  const blockIndex = blocks.findIndex((block) => block.dataset.blockId === position.blockId);
+  const blockIndex = blocks.indexOf(currentBlock);
   if (blockIndex < 0) return findInitialTextPosition(container) ?? position;
-
   if (motion === 'block-backward' || motion === 'block-forward') {
     const delta = motion === 'block-backward' ? -1 : 1;
     const nextBlock = blocks[Math.max(0, Math.min(blocks.length - 1, blockIndex + delta))];
     return getPositionAtBlockBoundary(nextBlock, 'start') ?? position;
-  }
-
-  const currentBlock = blocks[blockIndex];
-  const currentText = getBlockText(currentBlock);
-  const nextOffset = moveWithinBlock(currentText, position.textOffset, motion);
-  if (nextOffset !== null) {
-    return { blockId: position.blockId, textOffset: nextOffset };
   }
 
   const direction = motion === 'left' || motion === 'word-backward' ? -1 : 1;

--- a/packages/ui/utils/vimNavigation.ts
+++ b/packages/ui/utils/vimNavigation.ts
@@ -1,0 +1,412 @@
+import { getAnnotatableTextNodes } from './domSelection';
+
+/** A durable cursor location measured within one rendered Markdown block. */
+export interface VimTextPosition {
+  readonly blockId: string;
+  readonly textOffset: number;
+  /**
+   * Resolve an offset shared by adjacent text nodes toward the next or previous
+   * node. Omitted positions preserve the historical backward affinity.
+   */
+  readonly affinity?: 'forward' | 'backward';
+}
+
+/** Text movement commands understood by the Markdown Vim adapter. */
+export type VimTextMotion =
+  | 'left'
+  | 'right'
+  | 'word-forward'
+  | 'word-backward'
+  | 'word-end'
+  | 'line-start'
+  | 'line-end'
+  | 'block-backward'
+  | 'block-forward'
+  | 'document-start'
+  | 'document-end';
+
+/** Block-level keyboard navigation with no browser text selection. */
+export interface VimBlockState {
+  readonly phase: 'block';
+  readonly targetKey: string;
+}
+
+/** A refined semantic child such as inline code, a table row, or a cell. */
+export interface VimInlineState {
+  readonly phase: 'inline';
+  readonly targetKey: string;
+}
+
+/** A collapsed text cursor inside the current semantic target. */
+export interface VimTextState {
+  readonly phase: 'text';
+  readonly targetKey: string;
+  readonly cursor: VimTextPosition;
+}
+
+/** A characterwise browser selection anchored inside rendered text. */
+export interface VimVisualState {
+  readonly phase: 'visual';
+  readonly targetKey: string;
+  readonly cursor: VimTextPosition;
+  readonly anchor: VimTextPosition;
+}
+
+/** A whole-block selection extending through block-navigation order. */
+export interface VimVisualBlockState {
+  readonly phase: 'visual-block';
+  readonly targetKey: string;
+  readonly anchorTargetKey: string;
+}
+
+/** Any Vim state that can be restored after an annotation UI closes. */
+export type VimRestorableState =
+  | VimBlockState
+  | VimInlineState
+  | VimTextState
+  | VimVisualState
+  | VimVisualBlockState;
+
+/** Annotation UI owns the keyboard while this state is active. */
+export interface VimActionState {
+  readonly phase: 'action';
+  readonly returnTo: VimRestorableState;
+}
+
+/**
+ * Complete Vim navigation state.
+ *
+ * The discriminated union prevents semantic focus, text cursors, and visual
+ * anchors from existing in contradictory combinations.
+ */
+export type VimSelectionState =
+  | { readonly phase: 'inactive' }
+  | VimRestorableState
+  | VimActionState;
+
+/** Return a fresh state with no semantic or text target. */
+export function createInitialVimSelectionState(): { readonly phase: 'inactive' } {
+  return { phase: 'inactive' };
+}
+
+function getBlockElements(container: HTMLElement): HTMLElement[] {
+  const seen = new Set<string>();
+  const result: HTMLElement[] = [];
+
+  container.querySelectorAll<HTMLElement>('[data-block-id]').forEach((element) => {
+    const blockId = element.dataset.blockId;
+    if (!blockId || seen.has(blockId) || element.tagName === 'HR') return;
+    seen.add(blockId);
+    result.push(element);
+  });
+
+  return result;
+}
+
+function getBlockText(block: HTMLElement): string {
+  return getAnnotatableTextNodes(block).map((node) => node.data).join('');
+}
+
+function getPositionAtBlockBoundary(
+  block: HTMLElement,
+  boundary: 'start' | 'end',
+): VimTextPosition | null {
+  const blockId = block.dataset.blockId;
+  if (!blockId) return null;
+  const textLength = getBlockText(block).length;
+  if (textLength === 0) return null;
+  return {
+    blockId,
+    textOffset: boundary === 'start' ? 0 : textLength,
+  };
+}
+
+function findBlock(container: HTMLElement, blockId: string): HTMLElement | null {
+  for (const element of getBlockElements(container)) {
+    if (element.dataset.blockId === blockId) return element;
+  }
+  return null;
+}
+
+function getViewportCenterY(container: HTMLElement): number {
+  const viewport = container.closest<HTMLElement>('[data-overlayscrollbars-viewport]');
+  const rect = (viewport ?? container).getBoundingClientRect();
+  return rect.top + rect.height / 2;
+}
+
+/** Pick the first text cursor nearest the visible center of the document. */
+export function findInitialTextPosition(container: HTMLElement): VimTextPosition | null {
+  const centerY = getViewportCenterY(container);
+  const candidates = getBlockElements(container)
+    .map((block) => ({ block, position: getPositionAtBlockBoundary(block, 'start') }))
+    .filter((candidate): candidate is { block: HTMLElement; position: VimTextPosition } =>
+      candidate.position !== null,
+    );
+
+  candidates.sort((left, right) => {
+    const leftRect = left.block.getBoundingClientRect();
+    const rightRect = right.block.getBoundingClientRect();
+    const leftDistance = Math.abs((leftRect.top + leftRect.bottom) / 2 - centerY);
+    const rightDistance = Math.abs((rightRect.top + rightRect.bottom) / 2 - centerY);
+    return leftDistance - rightDistance;
+  });
+
+  return candidates[0]?.position ?? null;
+}
+
+/** Resolve a logical Vim position into a live text-node DOM point. */
+export function resolveTextPosition(
+  container: HTMLElement,
+  position: VimTextPosition,
+): { node: Text; offset: number } | null {
+  const block = findBlock(container, position.blockId);
+  if (!block) return null;
+
+  const nodes = getAnnotatableTextNodes(block);
+  if (nodes.length === 0) return null;
+
+  let remaining = Math.max(0, position.textOffset);
+  for (const [index, node] of nodes.entries()) {
+    if (remaining < node.length) {
+      return { node, offset: remaining };
+    }
+    if (remaining === node.length) {
+      if (position.affinity === 'forward' && index < nodes.length - 1) {
+        remaining = 0;
+        continue;
+      }
+      return { node, offset: remaining };
+    }
+    remaining -= node.length;
+  }
+
+  const lastNode = nodes[nodes.length - 1];
+  return { node: lastNode, offset: lastNode.length };
+}
+
+function normalizeDomPoint(
+  node: Node,
+  offset: number,
+): { node: Text; offset: number } | null {
+  if (node instanceof Text) {
+    return { node, offset: Math.max(0, Math.min(offset, node.length)) };
+  }
+  if (!(node instanceof Element)) return null;
+
+  // A DOM point whose offset equals `childNodes.length` sits after the final
+  // child. Treating it as the start of that child moves a line/document-end
+  // cursor backward when Selection.modify() returns an element endpoint.
+  const childAtOffset = offset < node.childNodes.length
+    ? node.childNodes[Math.max(0, offset)]
+    : undefined;
+  if (childAtOffset) {
+    const nextWalker = document.createTreeWalker(childAtOffset, NodeFilter.SHOW_TEXT);
+    const nextCandidate = childAtOffset instanceof Text
+      ? childAtOffset
+      : nextWalker.nextNode();
+    const nextText = nextCandidate instanceof Text ? nextCandidate : null;
+    if (nextText) return { node: nextText, offset: 0 };
+  }
+
+  const previousChild = node.childNodes[Math.max(0, offset - 1)];
+  if (!previousChild) return null;
+  const previousTexts = previousChild instanceof Text
+    ? [previousChild]
+    : previousChild instanceof Element
+      ? getAnnotatableTextNodes(previousChild)
+      : [];
+  const previousText = previousTexts[previousTexts.length - 1];
+  return previousText ? { node: previousText, offset: previousText.length } : null;
+}
+
+/** Serialize a live DOM selection point back into a durable block-relative position. */
+export function serializeTextPosition(
+  container: HTMLElement,
+  node: Node,
+  offset: number,
+): VimTextPosition | null {
+  const point = normalizeDomPoint(node, offset);
+  if (!point) return null;
+
+  const block = point.node.parentElement?.closest<HTMLElement>('[data-block-id]');
+  const blockId = block?.dataset.blockId;
+  if (!block || !blockId || !container.contains(block)) return null;
+
+  let textOffset = 0;
+  for (const textNode of getAnnotatableTextNodes(block)) {
+    if (textNode === point.node) {
+      return {
+        blockId,
+        textOffset: textOffset + Math.max(0, Math.min(point.offset, textNode.length)),
+      };
+    }
+    textOffset += textNode.length;
+  }
+  return null;
+}
+
+function compareTextPositions(
+  container: HTMLElement,
+  left: VimTextPosition,
+  right: VimTextPosition,
+): number {
+  if (left.blockId === right.blockId) return left.textOffset - right.textOffset;
+  const blocks = getBlockElements(container);
+  const leftIndex = blocks.findIndex((block) => block.dataset.blockId === left.blockId);
+  const rightIndex = blocks.findIndex((block) => block.dataset.blockId === right.blockId);
+  return leftIndex - rightIndex;
+}
+
+/** Build a live range between two logical positions regardless of selection direction. */
+export function createRangeBetweenTextPositions(
+  container: HTMLElement,
+  anchor: VimTextPosition,
+  cursor: VimTextPosition,
+): Range | null {
+  const anchorPoint = resolveTextPosition(container, anchor);
+  const cursorPoint = resolveTextPosition(container, cursor);
+  if (!anchorPoint || !cursorPoint) return null;
+
+  const anchorFirst = compareTextPositions(container, anchor, cursor) <= 0;
+  const start = anchorFirst ? anchorPoint : cursorPoint;
+  const end = anchorFirst ? cursorPoint : anchorPoint;
+  const range = document.createRange();
+  range.setStart(start.node, start.offset);
+  range.setEnd(end.node, end.offset);
+  return range;
+}
+
+/**
+ * Return durable text bounds for a semantic target element.
+ *
+ * Bounds may span multiple Markdown blocks for group targets.
+ */
+export function getTextElementBounds(
+  container: HTMLElement,
+  element: HTMLElement,
+): { start: VimTextPosition; end: VimTextPosition } | null {
+  const nodes = getAnnotatableTextNodes(element);
+  const first = nodes[0];
+  const last = nodes.at(-1);
+  if (!first || !last) return null;
+  const start = serializeTextPosition(container, first, 0);
+  const end = serializeTextPosition(container, last, last.length);
+  return start && end
+    ? {
+        start: { ...start, affinity: 'forward' },
+        end: { ...end, affinity: 'backward' },
+      }
+    : null;
+}
+
+/** Show a logical cursor or visual range through the browser Selection API. */
+export function applyNativeTextSelection(
+  container: HTMLElement,
+  cursor: VimTextPosition,
+  anchor: VimTextPosition | null,
+): Selection | null {
+  const cursorPoint = resolveTextPosition(container, cursor);
+  if (!cursorPoint) return null;
+
+  const selection = window.getSelection();
+  selection?.removeAllRanges();
+  if (!selection) return null;
+
+  if (!anchor) {
+    const range = document.createRange();
+    range.setStart(cursorPoint.node, cursorPoint.offset);
+    range.collapse(true);
+    selection.addRange(range);
+    return selection;
+  }
+
+  const anchorPoint = resolveTextPosition(container, anchor);
+  if (!anchorPoint) return null;
+  selection.setBaseAndExtent(
+    anchorPoint.node,
+    anchorPoint.offset,
+    cursorPoint.node,
+    cursorPoint.offset,
+  );
+  return selection;
+}
+
+function segmentBoundaries(text: string, granularity: 'grapheme' | 'word'): number[] {
+  const segmenter = new Intl.Segmenter(undefined, { granularity });
+  return Array.from(segmenter.segment(text), (segment) => segment.index);
+}
+
+function moveWithinBlock(
+  text: string,
+  offset: number,
+  motion: VimTextMotion,
+): number | null {
+  const safeOffset = Math.max(0, Math.min(offset, text.length));
+
+  if (motion === 'left' || motion === 'right') {
+    const boundaries = [...segmentBoundaries(text, 'grapheme'), text.length];
+    if (motion === 'left') {
+      return boundaries.filter((boundary) => boundary < safeOffset).at(-1) ?? null;
+    }
+    return boundaries.find((boundary) => boundary > safeOffset) ?? null;
+  }
+
+  if (
+    motion === 'word-forward'
+    || motion === 'word-backward'
+    || motion === 'word-end'
+  ) {
+    const segmenter = new Intl.Segmenter(undefined, { granularity: 'word' });
+    const words = Array.from(segmenter.segment(text)).filter((segment) => segment.isWordLike);
+    if (motion === 'word-backward') {
+      return words.filter((word) => word.index < safeOffset).at(-1)?.index ?? null;
+    }
+    if (motion === 'word-end') {
+      const word = words.find((candidate) => candidate.index + candidate.segment.length > safeOffset);
+      return word ? word.index + word.segment.length : null;
+    }
+    return words.find((word) => word.index > safeOffset)?.index ?? null;
+  }
+
+  if (motion === 'line-start') return 0;
+  if (motion === 'line-end') return text.length;
+  return null;
+}
+
+/** Move a logical text cursor without retaining stale DOM-node references. */
+export function moveTextPosition(
+  container: HTMLElement,
+  position: VimTextPosition,
+  motion: VimTextMotion,
+): VimTextPosition {
+  const blocks = getBlockElements(container).filter((block) => getBlockText(block).length > 0);
+  if (blocks.length === 0) return position;
+
+  if (motion === 'document-start') {
+    return getPositionAtBlockBoundary(blocks[0], 'start') ?? position;
+  }
+  if (motion === 'document-end') {
+    return getPositionAtBlockBoundary(blocks[blocks.length - 1], 'end') ?? position;
+  }
+
+  const blockIndex = blocks.findIndex((block) => block.dataset.blockId === position.blockId);
+  if (blockIndex < 0) return findInitialTextPosition(container) ?? position;
+
+  if (motion === 'block-backward' || motion === 'block-forward') {
+    const delta = motion === 'block-backward' ? -1 : 1;
+    const nextBlock = blocks[Math.max(0, Math.min(blocks.length - 1, blockIndex + delta))];
+    return getPositionAtBlockBoundary(nextBlock, 'start') ?? position;
+  }
+
+  const currentBlock = blocks[blockIndex];
+  const currentText = getBlockText(currentBlock);
+  const nextOffset = moveWithinBlock(currentText, position.textOffset, motion);
+  if (nextOffset !== null) {
+    return { blockId: position.blockId, textOffset: nextOffset };
+  }
+
+  const direction = motion === 'left' || motion === 'word-backward' ? -1 : 1;
+  const adjacent = blocks[blockIndex + direction];
+  if (!adjacent) return position;
+  return getPositionAtBlockBoundary(adjacent, direction < 0 ? 'end' : 'start') ?? position;
+}

--- a/packages/ui/utils/vimReticle.test.ts
+++ b/packages/ui/utils/vimReticle.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { SemanticTarget } from './blockTargeting';
+import { createVimHudCommand } from './vimHud';
+import { getVimReticleLabel } from './vimReticle';
+
+function target(
+  kind: SemanticTarget['kind'],
+  label: string,
+): Pick<SemanticTarget, 'kind' | 'label'> {
+  return { kind, label };
+}
+
+describe('Vim HUD reticle labels', () => {
+  test('names semantic targets without leaking their full text', () => {
+    expect(getVimReticleLabel(
+      { phase: 'block', targetKey: 'target' },
+      target('block', 'heading: "Implementation plan"'),
+      null,
+    )).toBe('BLOCK · HEADING');
+    expect(getVimReticleLabel(
+      { phase: 'inline', targetKey: 'target' },
+      target('inline', 'bold: "production-grade"'),
+      null,
+    )).toBe('INLINE · BOLD');
+  });
+
+  test('describes caret and Visual motions using their handled context', () => {
+    expect(getVimReticleLabel(
+      {
+        phase: 'text',
+        targetKey: 'target',
+        cursor: { blockId: 'block', textOffset: 0 },
+      },
+      null,
+      createVimHudCommand(1, 'refine', 'l', 'block'),
+    )).toBe('CURSOR · INLINE TEXT');
+    expect(getVimReticleLabel(
+      {
+        phase: 'visual',
+        targetKey: 'target',
+        anchor: { blockId: 'block', textOffset: 0 },
+        cursor: { blockId: 'block', textOffset: 4 },
+      },
+      null,
+      createVimHudCommand(2, 'wordEnd', 'e', 'visual'),
+    )).toBe('VISUAL · EXACT TOKEN');
+  });
+
+  test('keeps motion compositor-only and disables it for reduced motion', () => {
+    const themeCss = readFileSync(resolve(import.meta.dir, '../theme.css'), 'utf8');
+    const reticleCss = themeCss.slice(themeCss.indexOf('.vim-target-reticle'));
+    expect(reticleCss).toContain('transition: transform');
+    expect(reticleCss).not.toMatch(/transition:\s*(top|left|width|height)/);
+    expect(reticleCss).toContain('@media (prefers-reduced-motion: reduce)');
+    expect(reticleCss).toContain('transition: none');
+  });
+});

--- a/packages/ui/utils/vimReticle.ts
+++ b/packages/ui/utils/vimReticle.ts
@@ -1,0 +1,88 @@
+import type { SemanticTarget } from './blockTargeting';
+import type { VimRestorableState } from './vimNavigation';
+import type { VimHudCommand } from './vimHud';
+
+const CURSOR_DESCRIPTORS: Partial<
+  Record<VimHudCommand['actionId'], string>
+> = {
+  moveDown: 'NEXT LINE',
+  moveUp: 'PREVIOUS LINE',
+  lineStart: 'LINE START',
+  lineEnd: 'LINE END',
+  wordForward: 'NEXT WORD',
+  wordBackward: 'PREVIOUS WORD',
+  wordEnd: 'WORD END',
+  previousTextBlock: 'PREVIOUS TEXT',
+  nextTextBlock: 'NEXT TEXT',
+  documentStart: 'DOCUMENT START',
+  documentEnd: 'DOCUMENT END',
+};
+
+const VISUAL_DESCRIPTORS: Partial<
+  Record<VimHudCommand['actionId'], string>
+> = {
+  visual: 'RANGE START',
+  visualBlock: 'BLOCK RANGE',
+  wordForward: 'NEXT WORD',
+  wordBackward: 'PREVIOUS WORD',
+  wordEnd: 'EXACT TOKEN',
+  lineStart: 'TO LINE START',
+  lineEnd: 'TO LINE END',
+  moveDown: 'NEXT LINE',
+  moveUp: 'PREVIOUS LINE',
+  previousTextBlock: 'PREVIOUS BLOCK',
+  nextTextBlock: 'NEXT BLOCK',
+  swapSelectionEnds: 'SWAPPED ENDS',
+};
+
+type VimReticleSemanticTarget = Pick<SemanticTarget, 'kind' | 'label'>;
+
+function semanticDescriptor(target: VimReticleSemanticTarget): string {
+  switch (target.kind) {
+    case 'code':
+      return 'CODE';
+    case 'math':
+      return 'FORMULA';
+    case 'table':
+      return 'TABLE';
+    case 'row':
+      return 'ROW';
+    case 'cell':
+      return 'CELL';
+    case 'group':
+      return target.label.toUpperCase();
+    case 'inline':
+    case 'block':
+      return (target.label.split(':')[0] || target.kind).toUpperCase();
+  }
+}
+
+function cursorDescriptor(command: VimHudCommand | null): string {
+  if (!command) return 'TEXT';
+  if (command.actionId === 'moveOut' || command.actionId === 'refine') {
+    const characterMotion = command.context === 'text' || command.context === 'visual';
+    if (command.actionId === 'moveOut') {
+      return characterMotion ? 'PREVIOUS CHARACTER' : 'TEXT';
+    }
+    return characterMotion ? 'NEXT CHARACTER' : 'INLINE TEXT';
+  }
+  return CURSOR_DESCRIPTORS[command.actionId] ?? 'TEXT';
+}
+
+/** Build the concise target label shared with the approved Vim demo. */
+export function getVimReticleLabel(
+  state: VimRestorableState,
+  target: VimReticleSemanticTarget | null,
+  command: VimHudCommand | null,
+): string {
+  if (state.phase === 'text') return `CURSOR · ${cursorDescriptor(command)}`;
+  if (state.phase === 'visual') {
+    return `VISUAL · ${
+      command ? VISUAL_DESCRIPTORS[command.actionId] ?? 'RANGE' : 'RANGE'
+    }`;
+  }
+  if (state.phase === 'visual-block') return 'VISUAL · BLOCK RANGE';
+  return `${state.phase === 'inline' ? 'INLINE' : 'BLOCK'} · ${
+    target ? semanticDescriptor(target) : 'TARGET'
+  }`;
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -23,6 +23,11 @@ These are local-only scripts for launching Plannotator UI flows with fixture dat
 
 See [UI-TESTING.md](../docs/UI-TESTING.md) for detailed UI testing documentation.
 
+The end-to-end, user-centered Vim controls matrix lives in
+[manual/vim-ux-smoke.md](manual/vim-ux-smoke.md). It covers real Markdown and
+raw-HTML navigation, selection, annotation, focus recovery, HUD behavior, and
+native-control compatibility.
+
 ## Integration & Utility Tests (`manual/local/`)
 
 These scripts test integrations, releases, and provide utilities.

--- a/tests/manual/vim-ux-smoke.md
+++ b/tests/manual/vim-ux-smoke.md
@@ -1,0 +1,268 @@
+# Vim controls UX smoke test
+
+This smoke test evaluates Vim controls as a reviewer experiences them. It is
+not a key-by-key implementation checklist: each journey starts from a realistic
+user intent and verifies focus, movement, selection, annotation, recovery, and
+feedback together.
+
+Run the complete matrix against both renderer paths:
+
+- Markdown in the plan or annotate application.
+- Raw HTML through the sandboxed HTML viewer, using
+  `tests/test-fixtures/vim-ux-smoke.html`.
+- Select and Pinpoint input methods.
+- Vim HUD with the Key panel both visible and hidden.
+
+## Launch
+
+Build and run the real plan application:
+
+```bash
+bun run build:hook
+bun run dev:hook -- --host 127.0.0.1
+```
+
+Run the raw-HTML fixture through the real annotate server:
+
+```bash
+PLANNOTATOR_REMOTE=1 \
+PLANNOTATOR_PORT=3019 \
+PLANNOTATOR_AI=disabled \
+PLANNOTATOR_SHARE=disabled \
+bun apps/hook/server/index.ts annotate tests/test-fixtures/vim-ux-smoke.html
+```
+
+Enable **Settings → Vim → Vim controls**. Enable **Vim HUD** when a
+scenario asks for visible targeting feedback.
+
+## Journey 1: start reviewing without hunting for focus
+
+**User intent:** open a document and immediately start moving through it.
+
+1. Open a neutral document with Vim controls enabled.
+2. Without clicking the document, press `j`, `k`, `gg`, and `G`.
+3. Focus an app control, then press `Escape`.
+4. Press `j` again.
+
+Expected:
+
+- The document takes focus automatically once it is ready.
+- The first target is a real semantic block, never the whole document.
+- `j` and `k` move one visible block at a time.
+- `gg` and `G` jump to the first and last blocks.
+- `Escape` returns from neutral app chrome to the document.
+- No document-sized browser focus ring appears.
+- An open dialog, composer, picker, or editor keeps first ownership of
+  `Escape`; focus returns only after that layer closes.
+
+## Journey 2: scan by document structure
+
+**User intent:** skim a long plan at paragraph granularity, then inspect one
+structured area.
+
+1. Move over headings, paragraphs, lists, code blocks, and tables with `j` and
+   `k`.
+2. Stop on a paragraph containing bold, code, or a link and press `l`.
+3. Use `j` and `k` to move across inline siblings; press `h` to return.
+4. Stop on a table, press `l` into rows, move between rows, press `l` into
+   cells, move between cells, and use `h` to climb back out.
+
+Expected:
+
+- Block movement follows the rendered reading order.
+- A code block is one block; its lines and tokens are not separate block
+  targets until the user enters text.
+- Refinement follows meaningful hierarchy:
+  `table → row → cell → text` and `paragraph → inline target → text`.
+- `j` and `k` move among siblings at the current level.
+- `h` climbs one semantic level without unexpectedly changing position.
+- Select and Pinpoint resolve the same visible targets.
+
+## Journey 3: navigate exact text efficiently
+
+**User intent:** reach a variable, value, or sentence fragment without stepping
+through every character.
+
+1. Refine into text with `l`.
+2. Use `w`, `b`, and `e` across prose and source code.
+3. Use `0` and `$` to jump to line boundaries.
+4. Use `j` and `k` to move by visual line.
+5. Use `{` and `}` to jump between text blocks.
+6. Use `h` and `l` for final character adjustments.
+
+Expected:
+
+- Word motions skip whole words/tokens rather than advancing one character.
+- Line and paragraph motions make long-distance navigation visibly faster.
+- Source-code identifiers, numeric values, punctuation, and prose are all
+  reachable.
+- The caret sits at the text edge; it does not bisect a highlighted token.
+- The viewport scrolls only as needed to keep the active target visible and
+  does not jitter between keys.
+
+## Journey 4: select exactly what should be discussed
+
+**User intent:** select a phrase, one code value, or several complete blocks.
+
+1. From text, press `v`, extend with text motions, and select a prose phrase.
+2. Repeat for a code identifier and a numeric value such as `3` or `1_500`.
+3. Press `o` to swap the fixed and moving ends and refine the other edge.
+4. Press `V` on a paragraph or code block.
+5. Extend the whole-block selection with `j` and shrink it with `k`.
+6. Press `V` again to return to the current semantic block.
+
+Expected:
+
+- Visual selection matches the exact visible characters, including code.
+- Highlight geometry begins and ends on the selected glyphs.
+- `o` changes which edge moves without changing the selected text.
+- Whole-block Visual selects only the intended block range—not unrelated
+  bullets, numbers, or neighboring blocks.
+- The HUD reticle follows the active range and labels exact text versus whole
+  blocks correctly.
+
+## Journey 5: annotate without losing the target
+
+**User intent:** comment, redline, label, or mark up the current target and
+continue reviewing.
+
+Run each action from a semantic block and from an exact Visual range:
+
+- `c`: open a comment.
+- `d`: create a redline.
+- `t`: open quick labels and choose one with its numeric shortcut.
+- `m` or `Space`: open the shared annotation toolbar.
+- `Enter`: apply the currently selected toolbar mode.
+
+Expected:
+
+- Every action uses the same toolbar, composer, highlighter, annotation model,
+  and sidebar entry as pointer selection.
+- The composer receives all typed characters—including `j`, `k`, and `gg`;
+  document navigation freezes while it owns focus.
+- `Command+Enter` saves the comment.
+- `Escape` cancels only the open action, restores document focus, and restores
+  the exact source range.
+- Saving also restores the exact range, even after highlight markup changes
+  the DOM.
+- Redline applies immediately and returns to a coherent text or block state.
+- No comment composer opens merely from rapid navigation over a code block.
+
+## Journey 6: copy and continue
+
+**User intent:** copy an exact phrase or complete block, then keep reviewing.
+
+1. Make a Visual selection and press `y`.
+2. Paste into a native text field.
+3. Select a complete block with `V`, press `y`, and paste again.
+
+Expected:
+
+- Clipboard text exactly matches the visible selection.
+- Visual yank collapses to a text caret; whole-block yank returns to block
+  navigation.
+- Document focus remains active and the next Vim key works immediately.
+- Raw HTML copies through the validated parent bridge without adding
+  `allow-same-origin` or clipboard permission to the sandbox.
+
+## Journey 7: learn from the HUD without surrendering space
+
+**User intent:** use the target reticle while choosing how much key guidance is
+visible.
+
+1. Enable Vim HUD and navigate through block, inline, text, Visual, and action
+   states.
+2. Hide the bottom-right Key panel with its close control.
+3. Continue navigating.
+4. Press `?`, inspect the complete key map, and press `?` again.
+5. Disable and re-enable **Settings → Vim → Key panel**.
+
+Expected:
+
+- The four-corner reticle remains visible when the Key panel is hidden.
+- Reticle geometry encloses the current semantic block, caret, or exact range.
+- The persistent panel reports only handled keys; typed composer text never
+  appears in it.
+- `?` temporarily opens a complete, contextual command map even when the panel
+  is hidden.
+- Closing the map returns to reticle-only HUD.
+- Key panel preference persists independently from Vim controls and Vim HUD.
+
+## Journey 8: leave Vim safely
+
+**User intent:** interact with normal web controls or turn Vim off without
+surprises.
+
+1. Press `Tab` and `Shift+Tab`.
+2. Type in a native input or textarea.
+3. Activate a native link or button with `Enter`.
+4. Disable Vim controls in Settings and type the Vim command keys in the
+   document.
+5. Re-enable Vim controls and close Settings.
+
+Expected:
+
+- Tab navigation is never consumed by Vim.
+- Inputs, textareas, contenteditable regions, dialogs, and embedded editors
+  retain native typing.
+- Native links and buttons retain native activation.
+- With Vim disabled, no unmodified Vim key is consumed and the document does
+  not become a focus surface.
+- Re-enabling restores automatic document focus while preserving the separate
+  HUD and Key panel preferences.
+
+## Journey 9: stress the race-prone path
+
+**User intent:** navigate quickly like an experienced reviewer.
+
+1. Hold or rapidly repeat `j` and `k` across prose, tables, and code.
+2. Mix `gg`, `G`, word, line, and block jumps at typing speed.
+3. Open and cancel several comments in succession.
+4. Save a comment, immediately navigate, then create a different annotation.
+
+Expected:
+
+- Only explicitly invoked actions open UI.
+- Navigation keys never leak into a comment composer that was not requested.
+- A previous selection cannot reopen a composer after its action completes.
+- Focus and reticle state never trail the visible target.
+- The page does not oscillate, jump, or blur while following the target.
+
+## 2026-07-26 run record
+
+The complete matrix was run in the real application on macOS/Chromium against
+the standalone Markdown plan and the production-built raw-HTML annotate server.
+
+| Area | Markdown | Raw HTML | Evidence |
+| --- | --- | --- | --- |
+| Automatic focus and Escape recovery | Pass | Pass | Real app |
+| Block, document, hierarchy, and sibling movement | Pass | Pass | Real app + DOM integration |
+| Word, token, line, and text-block motion | Pass | Pass | Real app |
+| Exact Visual and whole-block Visual selection | Pass | Pass | Real app + DOM integration |
+| Comment save/cancel and focus restoration | Pass | Pass | Real app + DOM integration |
+| Redline, label, active-mode Enter | Pass | Pass | Real app |
+| Shared toolbar via `m` / `Space` | Pass | Pass | Full Viewer and bridge integration tests |
+| Rapid `j` / `k` over code without phantom composer | Pass | Pass | Real app |
+| Yank, paste, and post-yank focus | Pass | Pass | Real app + clipboard bridge tests |
+| Select/Pinpoint target parity | Pass | Pass | Real app + integration tests |
+| HUD reticle, hidden panel, and temporary `?` map | Pass | Pass | Real app + integration tests |
+| Native controls, Tab, and disabled-mode compatibility | Pass | Pass | DOM integration |
+| Settings persistence and independent HUD controls | Pass | Pass | Real app + settings tests |
+
+Three real defects were found and fixed during the run:
+
+1. Raw-HTML comment markup replaced the selected text nodes, leaving Visual
+   state pointed at a stale range after save. The bridge now restores a range
+   over the committed annotation marks.
+2. Raw-HTML `y` could not write from the opaque-origin sandbox. It now sends a
+   bounded, source-validated copy message to the focused parent viewer, which
+   performs the same focus-preserving copy used by Markdown.
+3. With Vim auto-focus active, the keyboard block overlay could visually mask
+   a nested pointer Pinpoint target. Pointer hover now owns the classic
+   Pinpoint overlay until the next handled Vim command, then ownership returns
+   immediately to the keyboard target.
+
+The in-app automation driver does not synthesize `m` and `Space` identically
+to physical browser input on every macOS layout. Those two commands are covered
+through the real `Viewer`/highlighter integration and raw bridge DOM tests,
+which assert the shared annotation toolbar opens with the correct range.

--- a/tests/test-fixtures/vim-ux-smoke.html
+++ b/tests/test-fixtures/vim-ux-smoke.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Vim UX smoke fixture</title>
+  <style>
+    body {
+      max-width: 760px;
+      margin: 0 auto;
+      padding: 48px 32px;
+      font: 17px/1.6 system-ui, sans-serif;
+      color: #d9dce5;
+      background: #171923;
+    }
+    code, pre {
+      font-family: ui-monospace, monospace;
+    }
+    pre {
+      padding: 20px;
+      border-radius: 12px;
+      background: #222633;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    th, td {
+      padding: 8px 12px;
+      border: 1px solid #3b4050;
+      text-align: left;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Keyboard review fixture</h1>
+    <p>
+      Reviewers can move by <strong>document structure</strong>, refine into
+      exact words, and annotate without reaching for the mouse.
+    </p>
+    <section>
+      <h2>Runtime policy</h2>
+      <pre><code>const retryLimit = 3;
+const timeoutMs = 1_500;
+const endpoint = "wss://example.test";</code></pre>
+      <p>The retry limit should stay conservative during rollout.</p>
+    </section>
+    <table>
+      <thead>
+        <tr><th>Setting</th><th>Value</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>retryLimit</td><td>3</td></tr>
+        <tr><td>timeoutMs</td><td>1,500 ms</td></tr>
+      </tbody>
+    </table>
+    <label>
+      Native note
+      <input value="Typing here must stay native">
+    </label>
+    <button type="button">Native action</button>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- add opt-in, default-off Vim keyboard navigation for plan and annotate documents
- share one semantic target graph between Pinpoint and keyboard navigation across blocks, inline targets, tables, code, and exact text ranges
- add an optional video-faithful HUD with a live four-corner reticle, handled-key history, contextual key map, and independently hideable Key panel
- support Markdown and sandboxed raw HTML, including document, block, sibling, word/token, line, Visual, Visual-block, annotation, and copy workflows
- keep native controls, dialogs, composers, pointer Pinpoint, reduced motion, and disabled-mode behavior intact
- announce Vim mode through the existing launch-dialog chain and expose it in a dedicated Settings panel

## UX smoke test

- added the durable user-journey matrix and run record at [tests/manual/vim-ux-smoke.md](tests/manual/vim-ux-smoke.md)
- ran real Markdown and production-built raw-HTML sessions across Select, Pinpoint, HUD, hidden Key panel, navigation, exact selection, comment, redline, label, shared toolbar, active-mode Enter, copy/paste, focus recovery, native controls, and rapid-input races
- fixed three defects found by the run: raw Visual range restoration after mark insertion, raw sandbox yank, and pointer/keyboard Pinpoint overlay ownership

## Verification

- `bun test` — 2,412 pass, 176 skip, 0 fail
- `DOM_TESTS=1 bun test packages/ui` — 565 pass, 0 fail
- `bun run typecheck`
- `bun run build`
- `git diff --check`
- live macOS/Chromium QA against the real Markdown app and production-built raw-HTML annotate server

## Review

- self-review covered focus lifecycles, clipboard bridge boundaries, DOM mutation restoration, pointer/keyboard ownership, test isolation, and evidence accuracy
- bridge regression coverage rejects wrong sources, disabled/unfocused copies, malformed or oversized payloads, and proves both exact Visual and whole-block Visual restoration
- rebased cleanly onto current `origin/main` (`9a450a69`) and reran every gate after the rebase