### PR TITLE
feat(ui): add "Enter sends" composer keymap setting

### DIFF
--- a/packages/core/config-types.ts
+++ b/packages/core/config-types.ts
@@ -1,6 +1,12 @@
 export type DefaultDiffType = 'since-base' | 'uncommitted' | 'unstaged' | 'staged' | 'merge-base' | 'all';
 export type DiffLineBgIntensity = 'subtle' | 'normal' | 'strong';
 
+/**
+ * Which keystroke submits a text composer (comment editors, AI chat inputs).
+ * 'enter' additionally frees Mod+Enter for Ask AI on composers that offer it.
+ */
+export type ComposerSubmitKey = 'mod-enter' | 'enter';
+
 export interface DiffOptions {
   diffStyle?: 'split' | 'unified';
   overflow?: 'scroll' | 'wrap';

--- a/packages/review-editor/components/AITab.tsx
+++ b/packages/review-editor/components/AITab.tsx
@@ -9,7 +9,7 @@ import { CountBadge } from './CountBadge';
 import { CopyButton } from './CopyButton';
 import { PermissionCard } from './PermissionCard';
 import { AIConfigBar } from './AIConfigBar';
-import { submitHint } from '@plannotator/ui/utils/platform';
+import { useComposerKeys, useComposerSubmitHint } from '@plannotator/ui/hooks/useComposerKeys';
 import { OverlayScrollArea } from '@plannotator/ui/components/OverlayScrollArea';
 import type { AIProviderOption } from '@plannotator/ui/utils/aiProvider';
 
@@ -294,6 +294,11 @@ const GeneralInput: React.FC<{
   onStop?: () => void;
 }> = ({ value, onChange, onSubmit, disabled, isStreaming, onStop }) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const handleKeyDown = useComposerKeys({
+    onSubmit,
+    canSubmit: !disabled && value.trim().length > 0,
+  });
+  const submitHint = useComposerSubmitHint();
 
   const autoResize = useCallback(() => {
     const el = textareaRef.current;
@@ -317,12 +322,7 @@ const GeneralInput: React.FC<{
           className="flex-1 px-2.5 py-1.5 bg-muted rounded-md text-xs text-foreground placeholder:text-muted-foreground/50 resize-none focus:outline-none focus:ring-1 focus:ring-primary/50 leading-relaxed"
           style={{ maxHeight: 120 }}
           disabled={disabled}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !e.nativeEvent.isComposing && !disabled) {
-              e.preventDefault();
-              onSubmit();
-            }
-          }}
+          onKeyDown={handleKeyDown}
         />
         {isStreaming && onStop ? (
           <button

--- a/packages/review-editor/components/AnnotationToolbar.tsx
+++ b/packages/review-editor/components/AnnotationToolbar.tsx
@@ -9,6 +9,7 @@ import { ConventionalLabelPicker, type LabelDef } from './ConventionalLabelPicke
 import type { ConventionalLabel, ConventionalDecoration } from '@plannotator/ui/types';
 import type { AIChatEntry } from '../hooks/useAIChat';
 import { useDraggable } from '@plannotator/ui/hooks/useDraggable';
+import { useComposerKeys } from '@plannotator/ui/hooks/useComposerKeys';
 
 interface AnnotationToolbarProps {
   toolbarState: ToolbarState;
@@ -105,6 +106,14 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
     onCancel(); // close the whole toolbar
   };
 
+  const askAIFromComment = aiAvailable && !isEditing && !!onAskAI && commentText.trim().length > 0;
+  const handleCommentKeyDown = useComposerKeys({
+    onSubmit,
+    onAskAI: askAIFromComment ? handleAskAIClick : undefined,
+    onCancel: () => onDismiss(),
+    canSubmit: commentText.trim().length > 0 || suggestedCode.trim().length > 0,
+  });
+
   const content = (
     <div
       ref={toolbarRef}
@@ -180,13 +189,7 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
             className="w-full min-h-[4.5rem] max-h-[calc(100vh-16rem)] px-3 py-2 bg-muted rounded-lg text-xs leading-6 resize-y border-0 focus:outline-none focus:ring-1 focus:ring-primary/50 placeholder:text-muted-foreground"
             rows={3}
             autoFocus
-            onKeyDown={(e) => {
-              if (e.key === 'Escape') {
-                onDismiss();
-              } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !e.nativeEvent.isComposing) {
-                onSubmit();
-              }
-            }}
+            onKeyDown={handleCommentKeyDown}
           />
 
           {/* Optional suggested code section */}

--- a/packages/review-editor/components/AskAIInput.tsx
+++ b/packages/review-editor/components/AskAIInput.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { formatLineRange } from '../utils/formatLineRange';
 import { SparklesIcon } from '@plannotator/ui/components/SparklesIcon';
 import type { AIChatEntry } from '../hooks/useAIChat';
-import { submitHint } from '@plannotator/ui/utils/platform';
+import { useComposerKeys, useComposerSubmitHint } from '@plannotator/ui/hooks/useComposerKeys';
 
 interface AskAIInputProps {
   lineStart: number;
@@ -41,6 +41,13 @@ export const AskAIInput: React.FC<AskAIInputProps> = ({
     setQuestion('');
   };
 
+  const handleKeyDown = useComposerKeys({
+    onSubmit: handleSubmit,
+    onCancel: () => onCancel(),
+    canSubmit: !isLoading && question.trim().length > 0,
+  });
+  const submitHint = useComposerSubmitHint();
+
   return (
     <div className="w-80">
       <div className="flex items-center justify-between mb-2" {...dragHandleProps}>
@@ -67,13 +74,7 @@ export const AskAIInput: React.FC<AskAIInputProps> = ({
         rows={2}
         autoFocus
         disabled={isLoading}
-        onKeyDown={(e) => {
-          if (e.key === 'Escape') {
-            onCancel();
-          } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !e.nativeEvent.isComposing) {
-            handleSubmit();
-          }
-        }}
+        onKeyDown={handleKeyDown}
       />
 
       <div className="flex items-center gap-2 mt-2">

--- a/packages/review-editor/components/ExpandedCommentDialog.tsx
+++ b/packages/review-editor/components/ExpandedCommentDialog.tsx
@@ -1,7 +1,8 @@
 import React, { useRef } from 'react';
 import { Dialog } from '@base-ui/react/dialog';
 import { SparklesIcon } from '@plannotator/ui/components/SparklesIcon';
-import { useReviewAnnotationToolbarShortcuts } from '@plannotator/ui/shortcuts';
+import { matchesShortcutBinding, useReviewAnnotationToolbarShortcuts } from '@plannotator/ui/shortcuts';
+import { useComposerKeys } from '@plannotator/ui/hooks/useComposerKeys';
 
 interface ExpandedCommentDialogProps {
   title: string;
@@ -33,17 +34,11 @@ export const ExpandedCommentDialog: React.FC<ExpandedCommentDialogProps> = ({
   const askAIEnabled = aiAvailable && !!onAskAI && commentText.trim().length > 0;
   const submitLabel = isEditing ? 'Update' : 'Add Comment';
 
+  // Submit/Ask AI run off the popup's own keydown (see handleKeyDown below) so
+  // they follow the composer keymap; Escape stays document-level.
   useReviewAnnotationToolbarShortcuts({
     target: 'document',
     handlers: {
-      submitComment: {
-        when: (event) => canSubmit && !event.isComposing && event.target instanceof Node && !!dialogRef.current?.contains(event.target),
-        handle: (event) => {
-          event.preventDefault();
-          event.stopPropagation();
-          onSubmit();
-        },
-      },
       cancel: {
         when: (event) => event.target instanceof Node && !!dialogRef.current?.contains(event.target),
         handle: (event) => {
@@ -58,6 +53,24 @@ export const ExpandedCommentDialog: React.FC<ExpandedCommentDialogProps> = ({
   const handleAskAI = () => {
     if (!askAIEnabled) return;
     onAskAI?.(commentText.trim());
+  };
+
+  const composerKeys = useComposerKeys({
+    onSubmit,
+    onAskAI: askAIEnabled ? handleAskAI : undefined,
+    canSubmit,
+  });
+
+  // Bound to the popup rather than the textarea so Mod+Enter is swallowed
+  // wherever focus sits, keeping it away from the window listener that submits
+  // the whole review. Only the textarea drives the composer keymap though -
+  // under "Enter sends", Enter on a focused button must still press it.
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    if (event.target === textareaRef.current) {
+      composerKeys(event);
+      return;
+    }
+    if (matchesShortcutBinding(event.nativeEvent, 'Mod+Enter')) event.stopPropagation();
   };
 
   return (
@@ -80,6 +93,7 @@ export const ExpandedCommentDialog: React.FC<ExpandedCommentDialogProps> = ({
             return textarea;
           }}
           finalFocus={false}
+          onKeyDown={handleKeyDown}
           className="fixed left-1/2 top-1/2 z-[2000] w-[calc(100vw-2rem)] max-w-2xl h-[min(36rem,85dvh)] max-h-[calc(100dvh-2rem)] -translate-x-1/2 -translate-y-1/2 overflow-hidden bg-popover border border-border rounded-xl shadow-2xl flex flex-col"
         >
           <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border/50">

--- a/packages/review-editor/components/ExpandedCommentDialog.tsx
+++ b/packages/review-editor/components/ExpandedCommentDialog.tsx
@@ -61,16 +61,16 @@ export const ExpandedCommentDialog: React.FC<ExpandedCommentDialogProps> = ({
     canSubmit,
   });
 
-  // Bound to the popup rather than the textarea so Mod+Enter is swallowed
-  // wherever focus sits, keeping it away from the window listener that submits
-  // the whole review. Only the textarea drives the composer keymap though -
-  // under "Enter sends", Enter on a focused button must still press it.
+  // Bound to the popup rather than the textarea so Mod+Enter keeps working
+  // wherever focus sits inside the dialog.
   const handleKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
-    if (event.target === textareaRef.current) {
-      composerKeys(event);
-      return;
-    }
-    if (matchesShortcutBinding(event.nativeEvent, 'Mod+Enter')) event.stopPropagation();
+    const isModEnter = matchesShortcutBinding(event.nativeEvent, 'Mod+Enter');
+    // The textarea gets the whole keymap. Elsewhere only Mod+Enter runs: under
+    // "Enter sends", bare Enter on a focused button must press that button.
+    if (event.target === textareaRef.current || isModEnter) composerKeys(event);
+    // Mod+Enter must never reach the window listener that submits the whole
+    // review while this dialog is open, even when the composer declined it.
+    if (isModEnter) event.stopPropagation();
   };
 
   return (

--- a/packages/review-editor/components/FileCommentBanner.tsx
+++ b/packages/review-editor/components/FileCommentBanner.tsx
@@ -1,6 +1,7 @@
 import React, { useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { CodeAnnotation } from '@plannotator/ui/types';
 import { sanitizeBlockHtml } from '@plannotator/ui/utils/sanitizeHtml';
+import { useComposerKeys } from '@plannotator/ui/hooks/useComposerKeys';
 import { CommentMeta } from './CommentMeta';
 import { CommentActions } from './CommentActions';
 import { FileNameChip } from './FileNameChip';
@@ -71,6 +72,12 @@ export const FileCommentCard: React.FC<{
     setIsEditing(false);
   };
 
+  const handleEditKeyDown = useComposerKeys({
+    onSubmit: saveEdit,
+    onCancel: (e) => { e.preventDefault(); setIsEditing(false); },
+    canSubmit: draft.trim().length > 0,
+  });
+
   return (
     <div
       className={`review-comment group${isSelected ? ' is-selected' : ''}`}
@@ -108,10 +115,7 @@ export const FileCommentCard: React.FC<{
             autoFocus
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Escape') { e.preventDefault(); setIsEditing(false); }
-              else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); saveEdit(); }
-            }}
+            onKeyDown={handleEditKeyDown}
             className="w-full min-h-[80px] resize-y rounded border border-border bg-background p-2 text-xs leading-relaxed focus:outline-none focus:ring-1 focus:ring-primary/40"
             placeholder="File comment (markdown supported)…"
           />

--- a/packages/ui/components/AnnotationPanel.tsx
+++ b/packages/ui/components/AnnotationPanel.tsx
@@ -3,6 +3,7 @@ import { AnnotationType, type Annotation, type Block, type CodeAnnotation, type 
 import { isCurrentUser } from '../utils/identity';
 import { ImageThumbnail } from './ImageThumbnail';
 import { EditorAnnotationCard } from './EditorAnnotationCard';
+import { useComposerKeys } from '../hooks/useComposerKeys';
 import { useIsMobile } from '../hooks/useIsMobile';
 import { OverlayScrollArea } from './OverlayScrollArea';
 import { Button } from './ui/button';
@@ -468,15 +469,14 @@ const AnnotationCard: React.FC<{
     setIsEditing(false);
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !e.nativeEvent.isComposing) {
-      e.preventDefault();
-      handleSaveEdit();
-    } else if (e.key === 'Escape') {
+  const handleKeyDown = useComposerKeys({
+    onSubmit: handleSaveEdit,
+    onCancel: (e) => {
       e.preventDefault();
       handleCancelEdit();
-    }
-  };
+    },
+    canSubmit: editText.trim().length > 0,
+  });
 
   const typeColor = TYPE_COLOR[annotation.type] ?? 'text-muted-foreground';
   const typeLabel = TYPE_LABEL[annotation.type] ?? 'Note';
@@ -656,6 +656,15 @@ const CodeAnnotationCard: React.FC<{
     setEditText(annotation.text || '');
   };
 
+  const handleEditKeyDown = useComposerKeys({
+    onSubmit: handleSaveEdit,
+    onCancel: (e) => {
+      e.preventDefault();
+      handleCancelEdit();
+    },
+    canSubmit: editText.trim().length > 0,
+  });
+
   return (
     <div
       data-annotation-id={annotation.id}
@@ -720,15 +729,7 @@ const CodeAnnotationCard: React.FC<{
             ref={textareaRef}
             value={editText}
             onChange={(e) => setEditText(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !e.nativeEvent.isComposing) {
-                e.preventDefault();
-                handleSaveEdit();
-              } else if (e.key === 'Escape') {
-                e.preventDefault();
-                handleCancelEdit();
-              }
-            }}
+            onKeyDown={handleEditKeyDown}
             placeholder="Add your comment..."
             aria-label="Annotation comment"
             className="w-full resize-none rounded-lg border border-border/50 bg-card px-2.5 py-2 text-base leading-relaxed text-foreground outline-none transition-colors placeholder:text-muted-foreground/50 focus:border-primary/40 focus:ring-1 focus:ring-primary/20"

--- a/packages/ui/components/CodeFilePopout.tsx
+++ b/packages/ui/components/CodeFilePopout.tsx
@@ -5,6 +5,7 @@ import { PopoutDialog } from './PopoutDialog';
 import { useTheme } from './ThemeProvider';
 import { CommentPopover } from './CommentPopover';
 import { ImageThumbnail } from './ImageThumbnail';
+import { useComposerKeys } from '../hooks/useComposerKeys';
 import type { CodeAnnotation, ImageAttachment } from '../types';
 
 export interface CodeFileAnnotationInput {
@@ -161,6 +162,16 @@ const CodeInlineAnnotation: React.FC<{
     setIsEditing(false);
   };
 
+  const handleEditKeyDown = useComposerKeys({
+    onSubmit: save,
+    onCancel: (e) => {
+      e.preventDefault();
+      setIsEditing(false);
+      setEditText(annotation.text ?? '');
+    },
+    canSubmit: editText.trim().length > 0,
+  });
+
   return (
     <div
       data-code-annotation-id={annotation.id}
@@ -221,16 +232,7 @@ const CodeInlineAnnotation: React.FC<{
             value={editText}
             onChange={(e) => setEditText(e.target.value)}
             onClick={(e) => e.stopPropagation()}
-            onKeyDown={(e) => {
-              if (e.key === 'Escape') {
-                e.preventDefault();
-                setIsEditing(false);
-                setEditText(annotation.text ?? '');
-              } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !e.nativeEvent.isComposing) {
-                e.preventDefault();
-                save();
-              }
-            }}
+            onKeyDown={handleEditKeyDown}
             rows={Math.min(editText.split('\n').length + 1, 8)}
             className="w-full resize-none rounded border border-border bg-background px-2 py-1.5 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
           />

--- a/packages/ui/components/CommentPopover.tsx
+++ b/packages/ui/components/CommentPopover.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import type { ImageAttachment } from '../types';
 import { AttachmentsButton } from './AttachmentsButton';
-import { submitHint } from '../utils/platform';
+import { useComposerAskAIHint, useComposerKeys, useComposerSubmitHint } from '../hooks/useComposerKeys';
 import { useDraggable } from '../hooks/useDraggable';
 import { SparklesIcon } from './SparklesIcon';
 import { hasUnsavedCommentContent } from '../utils/commentContent';
@@ -235,21 +235,14 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
     onClose();
   }, [allowImages, askAIContext, contextText, draftKey, isGlobal, onAskAI, onClose, onDraftChange, text]);
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Escape') {
-      e.stopPropagation();
-      if (mode === 'dialog') {
-        setMode('popover');
-      } else {
-        onClose();
-      }
-      return;
+  const handleCancelKey = useCallback((e: React.KeyboardEvent<HTMLElement>) => {
+    e.stopPropagation();
+    if (mode === 'dialog') {
+      setMode('popover');
+    } else {
+      onClose();
     }
-    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !e.nativeEvent.isComposing) {
-      e.preventDefault();
-      handleSubmit();
-    }
-  };
+  }, [mode, onClose]);
 
   const headerLabel = isGlobal
     ? 'Global Comment'
@@ -261,6 +254,15 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
     hasUnsavedContent ||
     (allowEmptySubmit && initialText.trim().length > 0);
   const canAskAI = !!onAskAI && !askAIDisabled && text.trim().length > 0;
+
+  const handleKeyDown = useComposerKeys({
+    onSubmit: handleSubmit,
+    onAskAI: canAskAI ? handleAskAI : undefined,
+    onCancel: handleCancelKey,
+    canSubmit,
+  });
+  const submitHint = useComposerSubmitHint();
+  const askAIHint = useComposerAskAIHint();
 
   if (mode === 'dialog') {
     return createPortal(
@@ -340,6 +342,7 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
                 >
                   <SparklesIcon className="w-3 h-3" />
                   Ask AI
+                  {askAIHint && <span className="text-[10px] font-normal opacity-60">{askAIHint}</span>}
                 </button>
               )}
             </div>
@@ -462,6 +465,7 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
             >
               <SparklesIcon className="w-3 h-3" />
               Ask AI
+              {askAIHint && <span className="text-[10px] font-normal opacity-60">{askAIHint}</span>}
             </button>
           )}
         </div>

--- a/packages/ui/components/KeyboardShortcuts.tsx
+++ b/packages/ui/components/KeyboardShortcuts.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import type { ComposerSubmitKey } from '@plannotator/core/config-types';
+import { useConfigValue } from '../config';
 import {
   formatShortcutBindingTokens,
   listScopeShortcuts,
@@ -84,16 +86,28 @@ const inputMethodShortcuts: ShortcutSection = {
   ],
 };
 
-const annotationShortcuts: ShortcutSection = {
+/** Composer rows for the active submit key, shared by the annotation sections. */
+function composerRows(submitKey: ComposerSubmitKey): Shortcut[] {
+  if (submitKey === 'enter') {
+    return [
+      { keys: [enter], desc: 'Submit comment' },
+      { keys: [shiftKey, enter], desc: 'New line' },
+      { keys: [modKey, enter], desc: 'Ask AI', hint: 'Sends the typed comment to AI. Submits instead where Ask AI is unavailable.' },
+    ];
+  }
+  return [{ keys: [modKey, enter], desc: 'Submit comment' }];
+}
+
+const annotationShortcuts = (submitKey: ComposerSubmitKey): ShortcutSection => ({
   title: 'Annotations',
   shortcuts: [
     { keys: ['a-z'], desc: 'Start typing comment', hint: 'When the annotation toolbar is open, any letter key opens the comment editor with that character' },
     { keys: [altKey, '1-0'], desc: 'Apply quick label', hint: 'Instantly applies the Nth preset label (0 = 10th). When the label picker is open, bare digits also work.' },
-    { keys: [modKey, enter], desc: 'Submit comment' },
+    ...composerRows(submitKey),
     { keys: [modKey, 'C'], desc: 'Copy selected text' },
     { keys: ['Esc'], desc: 'Close toolbar / Cancel' },
   ],
-};
+});
 
 const imageAnnotatorShortcuts: ShortcutSection = {
   title: 'Image Annotator',
@@ -107,9 +121,9 @@ const imageAnnotatorShortcuts: ShortcutSection = {
   ],
 };
 
-const sharedPlanEditorShortcuts: ShortcutSection[] = [
+const sharedPlanEditorShortcuts = (submitKey: ComposerSubmitKey): ShortcutSection[] => [
   inputMethodShortcuts,
-  annotationShortcuts,
+  annotationShortcuts(submitKey),
   imageAnnotatorShortcuts,
 ];
 
@@ -159,18 +173,18 @@ const annotateSidebarShortcuts: ShortcutSection = {
   ],
 };
 
-const planShortcuts: ShortcutSection[] = [
+const planShortcuts = (submitKey: ComposerSubmitKey): ShortcutSection[] => [
   planActionShortcuts,
-  ...sharedPlanEditorShortcuts,
+  ...sharedPlanEditorShortcuts(submitKey),
 ];
 
-const annotateShortcuts: ShortcutSection[] = [
+const annotateShortcuts = (submitKey: ComposerSubmitKey): ShortcutSection[] => [
   annotateActionShortcuts,
   annotateSidebarShortcuts,
-  ...sharedPlanEditorShortcuts,
+  ...sharedPlanEditorShortcuts(submitKey),
 ];
 
-const reviewShortcuts: ShortcutSection[] = [
+const reviewShortcuts = (submitKey: ComposerSubmitKey): ShortcutSection[] => [
   {
     title: 'Actions',
     shortcuts: [
@@ -205,7 +219,7 @@ const reviewShortcuts: ShortcutSection[] = [
   {
     title: 'Annotations',
     shortcuts: [
-      { keys: [modKey, enter], desc: 'Submit comment' },
+      ...composerRows(submitKey),
       { keys: ['Tab'], desc: 'Indent in editor' },
       { keys: ['Esc'], desc: 'Close toolbar / Cancel' },
     ],
@@ -219,11 +233,12 @@ export const KeyboardShortcuts: React.FC<{
   mode: 'plan' | 'annotate' | 'review';
   vimModeEnabled?: boolean;
 }> = ({ mode, vimModeEnabled = false }) => {
+  const submitKey = useConfigValue('composerSubmitKey');
   const baseSections = mode === 'review'
-    ? reviewShortcuts
+    ? reviewShortcuts(submitKey)
     : mode === 'annotate'
-      ? annotateShortcuts
-      : planShortcuts;
+      ? annotateShortcuts(submitKey)
+      : planShortcuts(submitKey);
   const sections = vimModeEnabled && mode !== 'review'
     ? [...vimShortcuts, ...baseSections]
     : baseSections;

--- a/packages/ui/components/Settings.tsx
+++ b/packages/ui/components/Settings.tsx
@@ -802,6 +802,8 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
   const [fileBrowserSettings, setFileBrowserSettings] = useState<FileBrowserSettings>({ enabled: false, directories: [] });
   const [newDirPath, setNewDirPath] = useState('');
 
+  const composerSubmitKey = useConfigValue('composerSubmitKey');
+
   // Fetch available agents for OpenCode
   const { agents: availableAgents, validateAgent, getAgentWarning } = useAgents(origin ?? null, agentSurface);
 
@@ -1852,7 +1854,17 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
 
                 {/* === SHORTCUTS TAB === */}
                 {activeTab === 'shortcuts' && (
-                  <KeyboardShortcuts mode={mode} vimModeEnabled={vimModeEnabled} />
+                  <div className="space-y-4">
+                    {/* Composer submit key — the reference table below rerenders from it. */}
+                    <ToggleSwitch
+                      checked={composerSubmitKey === 'enter'}
+                      onChange={(v) => configStore.set('composerSubmitKey', v ? 'enter' : 'mod-enter')}
+                      label="Enter sends"
+                      description={`Enter submits comments and AI messages, ${isMac ? 'Shift+Return' : 'Shift+Enter'} inserts a new line, ${modKey}+Enter asks AI. Off: ${modKey}+Enter submits.`}
+                    />
+                    <div className="border-t border-border" />
+                    <KeyboardShortcuts mode={mode} vimModeEnabled={vimModeEnabled} />
+                  </div>
                 )}
 
                 {/* === COMMENTS TAB === */}

--- a/packages/ui/components/ai/DocumentAIChatPanel.tsx
+++ b/packages/ui/components/ai/DocumentAIChatPanel.tsx
@@ -5,7 +5,7 @@ import { formatRelativeTime, renderChatMarkdown } from '../../utils/aiChatFormat
 import { OverlayScrollArea } from '../OverlayScrollArea';
 import { SparklesIcon } from '../SparklesIcon';
 import { AIProviderBar } from './AIProviderBar';
-import { submitHint } from '../../utils/platform';
+import { useComposerKeys, useComposerSubmitHint } from '../../hooks/useComposerKeys';
 
 interface DocumentAIChatPanelProps {
   messages: AIChatEntry[];
@@ -256,6 +256,11 @@ const GeneralInput: React.FC<{
   onStop?: () => void;
 }> = ({ value, onChange, onSubmit, disabled, isStreaming, onStop }) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const handleKeyDown = useComposerKeys({
+    onSubmit,
+    canSubmit: !disabled && value.trim().length > 0,
+  });
+  const submitHint = useComposerSubmitHint();
 
   useEffect(() => {
     const el = textareaRef.current;
@@ -276,12 +281,7 @@ const GeneralInput: React.FC<{
           className="flex-1 px-2.5 py-1.5 bg-muted rounded-md text-xs text-foreground placeholder:text-muted-foreground/50 resize-none focus:outline-none focus:ring-1 focus:ring-primary/50 leading-relaxed"
           style={{ maxHeight: 120 }}
           disabled={disabled}
-          onKeyDown={(event) => {
-            if (event.key === 'Enter' && (event.metaKey || event.ctrlKey) && !event.nativeEvent.isComposing && !disabled) {
-              event.preventDefault();
-              onSubmit();
-            }
-          }}
+          onKeyDown={handleKeyDown}
         />
         {isStreaming && onStop ? (
           <button

--- a/packages/ui/config/settings.ts
+++ b/packages/ui/config/settings.ts
@@ -9,7 +9,7 @@
  * Add new settings here. Cookie-only settings omit serverKey.
  */
 
-import type { DiffLineBgIntensity } from '@plannotator/core/config-types';
+import type { ComposerSubmitKey, DiffLineBgIntensity } from '@plannotator/core/config-types';
 import { storage } from '../utils/storage';
 import { generateIdentity } from '../utils/generateIdentity';
 
@@ -302,6 +302,16 @@ export const SETTINGS = {
       return isDiffLineBgIntensity(v) ? v : undefined;
     },
     toServer: (v: DiffLineBgIntensity) => ({ diffOptions: { lineBgIntensity: v } }),
+  },
+  /** Submit keystroke for comment editors and AI chat inputs. See utils/composerKeymap. */
+  composerSubmitKey: {
+    defaultValue: 'mod-enter' as ComposerSubmitKey,
+    fromCookie: () => {
+      const v = storage.getItem('plannotator-composer-submit-key');
+      return v === 'enter' || v === 'mod-enter' ? v : undefined;
+    },
+    toCookie: (v: ComposerSubmitKey) => storage.setItem('plannotator-composer-submit-key', v),
+    serverKey: undefined, fromServer: undefined, toServer: undefined,
   },
   conventionalComments: {
     defaultValue: false as boolean,

--- a/packages/ui/hooks/useComposerKeys.ts
+++ b/packages/ui/hooks/useComposerKeys.ts
@@ -1,0 +1,69 @@
+import { useCallback } from 'react';
+import type React from 'react';
+import { useConfigValue } from '../config';
+import {
+  COMPOSER_KEYMAPS,
+  composerAskAIHint,
+  composerSubmitHint,
+  resolveComposerIntent,
+} from '../utils/composerKeymap';
+
+export interface ComposerKeyOptions {
+  onSubmit: () => void;
+  /** Omit on composers without an Ask AI action — Mod+Enter then submits. */
+  onAskAI?: () => void;
+  /** Escape, passed through un-defaulted so each surface keeps its own semantics. */
+  onCancel?: (event: React.KeyboardEvent<HTMLElement>) => void;
+  canSubmit: boolean;
+}
+
+/**
+ * Keydown handler for a text composer, honoring the `composerSubmitKey` setting.
+ *
+ * A React handler rather than a `useShortcutScope` window listener: composers
+ * are portaled and nested (popover inside viewer inside app), and the shortcut
+ * engine has no cross-scope arbitration — see the note in shortcuts/runtime.ts.
+ */
+export function useComposerKeys({
+  onSubmit,
+  onAskAI,
+  onCancel,
+  canSubmit,
+}: ComposerKeyOptions): (event: React.KeyboardEvent<HTMLElement>) => void {
+  const submitKey = useConfigValue('composerSubmitKey');
+
+  return useCallback(
+    (event: React.KeyboardEvent<HTMLElement>) => {
+      if (event.key === 'Escape') {
+        onCancel?.(event);
+        return;
+      }
+
+      const intent = resolveComposerIntent(event.nativeEvent, COMPOSER_KEYMAPS[submitKey], {
+        canSubmit,
+        canAskAI: !!onAskAI,
+      });
+      if (!intent) return;
+
+      // The composer consumed the key: keep it away from the app-level
+      // Mod+Enter that approves the plan / sends the review. Those listeners
+      // skip INPUT and TEXTAREA targets, but a composer bound to a container
+      // also sees keys pressed on its buttons.
+      event.preventDefault();
+      event.stopPropagation();
+      if (intent === 'askAI') onAskAI?.();
+      else onSubmit();
+    },
+    [canSubmit, onAskAI, onCancel, onSubmit, submitKey],
+  );
+}
+
+/** Keycap hint for the active submit key, e.g. `⌘↵` or `↵`. */
+export function useComposerSubmitHint(): string {
+  return composerSubmitHint(useConfigValue('composerSubmitKey'));
+}
+
+/** Keycap hint for Ask AI, or null while the active keymap leaves it unbound. */
+export function useComposerAskAIHint(): string | null {
+  return composerAskAIHint(useConfigValue('composerSubmitKey'));
+}

--- a/packages/ui/shortcuts/code-review/ai.shortcuts.ts
+++ b/packages/ui/shortcuts/code-review/ai.shortcuts.ts
@@ -9,7 +9,7 @@ export const reviewAiShortcuts = defineShortcutScope({
       description: 'Send message',
       bindings: ['Mod+Enter'],
       section: 'AI Assistant',
-      hint: 'Available in the AI tab and the Ask AI inline input.',
+      hint: 'Available in the AI tab and the Ask AI inline input. With "Enter sends" enabled in Settings, Enter sends and Shift+Enter inserts a new line.',
       displayOrder: 10,
     },
     cancel: {

--- a/packages/ui/shortcuts/code-review/annotationToolbar.shortcuts.ts
+++ b/packages/ui/shortcuts/code-review/annotationToolbar.shortcuts.ts
@@ -9,6 +9,7 @@ export const reviewAnnotationToolbarShortcuts = defineShortcutScope({
       description: 'Submit comment',
       bindings: ['Mod+Enter'],
       section: 'Annotations',
+      hint: 'With "Enter sends" enabled in Settings, Enter submits, Shift+Enter inserts a new line, and Mod+Enter asks AI.',
       displayOrder: 10,
     },
     indentSuggestedCode: {

--- a/packages/ui/shortcuts/plan-review/commentPopover.shortcuts.ts
+++ b/packages/ui/shortcuts/plan-review/commentPopover.shortcuts.ts
@@ -8,6 +8,7 @@ export const commentPopoverShortcuts = defineShortcutScope({
       description: 'Submit comment',
       bindings: ['Mod+Enter'],
       section: 'Annotations',
+      hint: 'With "Enter sends" enabled in Settings, Enter submits, Shift+Enter inserts a new line, and Mod+Enter asks AI.',
       displayOrder: 30,
     },
     cancel: {

--- a/packages/ui/utils/composerKeymap.test.ts
+++ b/packages/ui/utils/composerKeymap.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'bun:test';
+import { COMPOSER_KEYMAPS, composerAskAIHint, resolveComposerIntent } from './composerKeymap';
+
+function keyEvent(overrides: Partial<KeyboardEvent> & { key: string }): KeyboardEvent {
+  return {
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    altKey: false,
+    isComposing: false,
+    keyCode: 13,
+    code: 'Enter',
+    ...overrides,
+  } as KeyboardEvent;
+}
+
+const ENTER = keyEvent({ key: 'Enter' });
+const MOD_ENTER = keyEvent({ key: 'Enter', metaKey: true });
+const SHIFT_ENTER = keyEvent({ key: 'Enter', shiftKey: true });
+
+const READY = { canSubmit: true, canAskAI: true };
+const NO_AI = { canSubmit: true, canAskAI: false };
+
+describe('resolveComposerIntent', () => {
+  describe("'mod-enter' keymap", () => {
+    const keymap = COMPOSER_KEYMAPS['mod-enter'];
+
+    it('submits on Mod+Enter and leaves Enter to the textarea', () => {
+      expect(resolveComposerIntent(MOD_ENTER, keymap, READY)).toBe('submit');
+      expect(resolveComposerIntent(ENTER, keymap, READY)).toBeNull();
+      expect(resolveComposerIntent(SHIFT_ENTER, keymap, READY)).toBeNull();
+    });
+
+    it('never asks AI, even where Ask AI is available', () => {
+      expect(resolveComposerIntent(MOD_ENTER, keymap, READY)).toBe('submit');
+    });
+  });
+
+  describe("'enter' keymap", () => {
+    const keymap = COMPOSER_KEYMAPS.enter;
+
+    it('submits on Enter and asks AI on Mod+Enter', () => {
+      expect(resolveComposerIntent(ENTER, keymap, READY)).toBe('submit');
+      expect(resolveComposerIntent(MOD_ENTER, keymap, READY)).toBe('askAI');
+    });
+
+    it('leaves Shift+Enter to the textarea for a newline', () => {
+      expect(resolveComposerIntent(SHIFT_ENTER, keymap, READY)).toBeNull();
+    });
+
+    it('falls back to submit on Mod+Enter where Ask AI is unavailable', () => {
+      expect(resolveComposerIntent(MOD_ENTER, keymap, NO_AI)).toBe('submit');
+    });
+
+    it('yields to the textarea while the composer cannot submit', () => {
+      const empty = { canSubmit: false, canAskAI: false };
+      expect(resolveComposerIntent(ENTER, keymap, empty)).toBeNull();
+      expect(resolveComposerIntent(MOD_ENTER, keymap, empty)).toBeNull();
+    });
+
+    it('still asks AI while the composer cannot submit but AI is available', () => {
+      expect(resolveComposerIntent(MOD_ENTER, keymap, { canSubmit: false, canAskAI: true })).toBe('askAI');
+    });
+  });
+
+  it('hints Ask AI only where the keymap binds it', () => {
+    expect(composerAskAIHint('mod-enter')).toBeNull();
+    expect(composerAskAIHint('enter')).toBeTruthy();
+  });
+
+  it('ignores Enter that commits an IME candidate', () => {
+    const keymap = COMPOSER_KEYMAPS.enter;
+    expect(resolveComposerIntent(keyEvent({ key: 'Enter', isComposing: true }), keymap, READY)).toBeNull();
+    expect(resolveComposerIntent(keyEvent({ key: 'Enter', keyCode: 229 }), keymap, READY)).toBeNull();
+  });
+});

--- a/packages/ui/utils/composerKeymap.ts
+++ b/packages/ui/utils/composerKeymap.ts
@@ -1,0 +1,78 @@
+/**
+ * Keymap for text composers — comment editors and AI chat inputs.
+ *
+ * Two modes, selected by the `composerSubmitKey` setting:
+ *   'mod-enter' — Mod+Enter submits (Enter inserts a newline).
+ *   'enter'     — Enter submits, Shift+Enter inserts a newline, and Mod+Enter
+ *                 asks AI on composers that offer it.
+ *
+ * Bindings are written in the shortcut-registry language and matched with the
+ * registry matcher, so there is one place that decides what "Mod+Enter" means.
+ */
+
+import type { ComposerSubmitKey } from '@plannotator/core/config-types';
+import { matchesShortcutBinding } from '../shortcuts/core';
+import { isMac, submitHint } from './platform';
+
+export interface ComposerKeymap {
+  submit: string;
+  /** null on keymaps where the submit key leaves no room for a second action. */
+  askAI: string | null;
+  /** Explicit newline binding, for hints and help text. Bare Enter otherwise. */
+  newline: string | null;
+}
+
+export type ComposerIntent = 'submit' | 'askAI';
+
+export const COMPOSER_KEYMAPS: Record<ComposerSubmitKey, ComposerKeymap> = {
+  'mod-enter': { submit: 'Mod+Enter', askAI: null, newline: null },
+  enter: { submit: 'Enter', askAI: 'Mod+Enter', newline: 'Shift+Enter' },
+};
+
+export interface ComposerCapabilities {
+  /** False while the composer is empty, disabled, or mid-stream. */
+  canSubmit: boolean;
+  /** False on composers without an Ask AI action, or when AI is unavailable. */
+  canAskAI: boolean;
+}
+
+/**
+ * Returns the action a keystroke asks for, or null to leave the event to the
+ * textarea. A null return is what makes Shift+Enter (and Enter while the
+ * composer can't submit) insert a newline: the caller must not preventDefault.
+ */
+export function resolveComposerIntent(
+  event: KeyboardEvent,
+  keymap: ComposerKeymap,
+  caps: ComposerCapabilities,
+): ComposerIntent | null {
+  // An IME candidate is committed with Enter. Under the 'enter' keymap that is
+  // the same keystroke as submit, so this guard decides whether CJK input works.
+  if (event.isComposing || event.keyCode === 229) return null;
+
+  if (keymap.askAI && matchesShortcutBinding(event, keymap.askAI)) {
+    if (caps.canAskAI) return 'askAI';
+    // Ask AI unbound here: fall back to submit rather than dead-ending the
+    // keystroke users already have in their fingers.
+    return caps.canSubmit ? 'submit' : null;
+  }
+
+  if (matchesShortcutBinding(event, keymap.submit)) {
+    return caps.canSubmit ? 'submit' : null;
+  }
+
+  return null;
+}
+
+/** Compact keycap hint for the submit action, e.g. `⌘↵` or `↵`. */
+export function composerSubmitHint(key: ComposerSubmitKey): string {
+  return key === 'enter' ? (isMac ? '↵' : 'Enter') : submitHint;
+}
+
+/**
+ * Compact keycap hint for the Ask AI action, or null where the keymap leaves it
+ * unbound. `submitHint` renders Mod+Enter, the only Ask AI binding in the table.
+ */
+export function composerAskAIHint(key: ComposerSubmitKey): string | null {
+  return COMPOSER_KEYMAPS[key].askAI ? submitHint : null;
+}


### PR DESCRIPTION
## feat(ui): "Enter sends" composer keymap setting

Adds an opt-in setting that makes **Enter** submit comments and AI messages, **Shift+Enter** insert a newline, and **Mod+Enter** ask AI. Default is unchanged (`Mod+Enter` submits), so nobody's muscle memory moves without opting in.

Toggle lives in **Settings → Shortcuts → "Enter sends"**, directly above the shortcut reference table, which rerenders from the same value.

### Behavior

| Keystroke | Off (default) | On |
|---|---|---|
| `Enter` | newline | submit |
| `Shift+Enter` | newline | newline |
| `Mod+Enter` | submit | Ask AI (submits where Ask AI is unavailable) |

Applies to every text composer, so the two halves of the app stay consistent: plan-review comment popover (dialog + inline), annotation panel cards, code-file popout, document AI chat; code-review annotation toolbar, expanded comment dialog, file comment banner, Ask AI input, AI tab.

### Two intentional changes that apply with the setting off

Routing every composer through one resolver tightened two loose behaviors. Both are deliberate, and both ship in the default keymap:

1. **Empty edits no longer submit.** Four edit cards (annotation card, code annotation card, code-file popout, file comment banner) used to accept `Mod+Enter` on a cleared textarea, saving an empty comment and closing the editor. The shared handler gates submit on non-empty trimmed text, so that keystroke is now a no-op. Clearing a comment to delete it was never the intended gesture.
2. **Extra modifiers no longer submit.** The old per-site checks were `Enter && (metaKey || ctrlKey)`, which also fired on `Cmd+Shift+Enter` and `Cmd+Alt+Enter`. The registry matcher requires exact modifiers, so those combinations do nothing in a composer now. (The review toolbar's suggested-code textarea kept its hardcoded check and still accepts them.)

### Implementation

- `packages/core/config-types.ts` - `ComposerSubmitKey = 'mod-enter' | 'enter'`.
- `packages/ui/utils/composerKeymap.ts` - keymap table plus a pure `resolveComposerIntent(event, keymap, caps)` resolver. Bindings are written in the shortcut-registry language and matched with `matchesShortcutBinding`, so one place decides what "Mod+Enter" means. Returning `null` (rather than a "newline" intent) is what lets Shift+Enter and Enter-while-empty fall through to the textarea: the caller must not `preventDefault`.
- `packages/ui/hooks/useComposerKeys.ts` - the React handler each composer wires up, plus `useComposerSubmitHint` / `useComposerAskAIHint` keycaps. A local handler rather than a `useShortcutScope` window listener because composers are portaled and nested and the shortcut engine has no cross-scope arbitration.
- `packages/ui/config/settings.ts` - `composerSubmitKey`, cookie-only, default `'mod-enter'`.
- `KeyboardShortcuts.tsx` - reference sections became functions of the active submit key, so the help table tells the truth in both modes.

### Notes

- **IME**: with Enter submitting, `isComposing` / `keyCode === 229` decides whether CJK input works at all. Guarded in the resolver and covered by tests.
- **Expanded comment dialog**: the handler sits on the popup rather than the textarea, so `Mod+Enter` keeps working with focus anywhere in the dialog, as before. Bare `Enter` only drives the keymap from the textarea, otherwise it would `preventDefault` the activation of a focused Collapse/Close/Ask AI button. `Mod+Enter` is also stopped from propagating, so it can't reach the window listener that submits the whole review while the dialog is open.
- **Suggested-code textarea** in the review toolbar deliberately stays on hardcoded `Mod+Enter` - Enter is a newline in a code block.
- `ToggleSwitch` gained `shrink-0` + `gap-4`: a long description used to squeeze the track below its width and push the thumb outside it.

### Testing

- New unit tests for the resolver (9 cases: both keymaps, Shift+Enter passthrough, Ask AI fallback, `canSubmit` gating, IME guards).
- Full `bun test` and all 7 `typecheck` projects match the pre-change baseline.
- Manually exercised in a compiled binary: plan review and code review, both keymap modes.