### PR TITLE
feat(core): add Zed Preview as an Open In App target

### DIFF
--- a/packages/core/open-in-apps.ts
+++ b/packages/core/open-in-apps.ts
@@ -81,6 +81,16 @@ export const OPEN_IN_APPS: OpenInApp[] = [
     linux: { bin: 'zed' },
   },
   {
+    id: 'zed-preview',
+    label: 'Zed Preview',
+    kind: 'editor',
+    icon: 'zed',
+    // Preview installs as a separate app bundle only on macOS. Zed's Linux
+    // install script and Windows installer both expose the preview CLI as
+    // plain `zed`, so the 'zed' entry above already covers preview there.
+    mac: { appName: 'Zed Preview' },
+  },
+  {
     id: 'sublime-text',
     label: 'Sublime Text',
     kind: 'editor',


### PR DESCRIPTION
Adds a 'zed-preview' entry to the Open In App catalog (packages/core/open-in-apps.ts), next to the stable Zed entry.

Values:
- mac: appName 'Zed Preview' (separate app bundle, per the issue report; launched via argv 'open -a "Zed Preview"', so the space is safe, same as Sublime Text / Visual Studio Code)
- linux/win: intentionally omitted. Verified in Zed's install.sh and script/bundle-windows.ps1 that the preview channel installs its CLI as plain 'zed' on both platforms (Linux symlinks ~/.local/bin/zed into zed-preview.app; the Windows preview installer still ships bin\zed.exe), so the existing 'zed' entry already detects and launches preview there. Mac-only entries (TextMate, Xcode) are existing precedent.

Detection: the server filters the catalog to installed apps (isAppAvailable checks for the .app bundle on macOS), so this entry only appears in the picker when Zed Preview.app is actually present. No menu growth for anyone else. The Pi server vendors the catalog via vendor.sh at build time, so both runtimes pick it up.

Tested: bun run typecheck (includes vendor.sh + Pi extension) and the open-in / DocBadges tests pass.

Closes #1119

https://claude.ai/code/session_01H5KQWqXqjrPxyxUNso1QHS