### PR TITLE
fix(opencode): Fix hardcoding default `build` OpenCode agent when sending responses

### DIFF
--- a/apps/marketing/src/content/docs/commands/plan-review.md
+++ b/apps/marketing/src/content/docs/commands/plan-review.md
@@ -106,7 +106,7 @@ Images are stored as temporary files and referenced by name in the feedback sent
 
 ## Agent switching (OpenCode)
 
-OpenCode users can configure which agent receives the approved plan. By default, approved plans stay on the current agent. See [Agent switching settings](/docs/getting-started/ui-settings/#agent-switching).
+OpenCode users can configure which agent receives the approved plan. By default, approved plans are handed off to the build agent. See [Agent switching settings](/docs/getting-started/ui-settings/#agent-switching).
 
 If the configured agent isn't found in the current OpenCode session, Plannotator logs a warning and shows a warning toast, then omits the agent switch so the current/default OpenCode flow continues.
 

--- a/apps/marketing/src/content/docs/commands/plan-review.md
+++ b/apps/marketing/src/content/docs/commands/plan-review.md
@@ -106,7 +106,9 @@ Images are stored as temporary files and referenced by name in the feedback sent
 
 ## Agent switching (OpenCode)
 
-OpenCode users can configure which agent receives the approved plan. Set this in Settings — choose from available agents or enter a custom agent name. If the configured agent isn't found, Plannotator shows a warning before approval.
+OpenCode users can configure which agent receives the approved plan. By default, approved plans stay on the current agent. See [Agent switching settings](/docs/getting-started/ui-settings/#agent-switching).
+
+If the configured agent isn't found in the current OpenCode session, Plannotator logs a warning and shows a warning toast, then omits the agent switch so the current/default OpenCode flow continues.
 
 ## Server API
 

--- a/apps/marketing/src/content/docs/getting-started/ui-settings.md
+++ b/apps/marketing/src/content/docs/getting-started/ui-settings.md
@@ -42,9 +42,9 @@ Controls which agent to switch to after plan approval. The dropdown is populated
 
 | Option | Behavior |
 |--------|----------|
-| **Build** (default) | Switch to the build agent after approval |
+| **Build** | Switch to the build agent after approval |
 | **Custom** | Enter a custom agent name (shows a warning if the agent isn't found) |
-| **Disabled** | Stay on the current agent after approval |
+| **Disabled** (default) | Stay on the current agent after approval |
 
 ### Auto-close tab
 

--- a/apps/marketing/src/content/docs/getting-started/ui-settings.md
+++ b/apps/marketing/src/content/docs/getting-started/ui-settings.md
@@ -38,13 +38,15 @@ On first launch, Plannotator shows a one-time setup dialog for this setting. You
 
 > OpenCode only.
 
-Controls which agent to switch to after plan approval. The dropdown is populated dynamically from your OpenCode configuration.
+Controls which agent to switch to after plan approval or after sending code review feedback. The dropdown is populated dynamically from your OpenCode configuration.
 
 | Option | Behavior |
 |--------|----------|
-| **Build** | Switch to the build agent after approval |
+| **Build** | Switch to the build agent |
 | **Custom** | Enter a custom agent name (shows a warning if the agent isn't found) |
-| **Disabled** (default) | Stay on the current agent after approval |
+| **Disabled** | Stay on the current agent |
+
+Until you pick an option, the default differs by surface: plan approval hands off to the **build** agent, and review feedback stays on the current agent. Once you pick an option it applies to both.
 
 ### Auto-close tab
 

--- a/apps/marketing/src/content/docs/guides/opencode.md
+++ b/apps/marketing/src/content/docs/guides/opencode.md
@@ -145,13 +145,13 @@ This makes it possible to approve a plan while leaving minor suggestions that th
 
 ## Agent switching
 
-OpenCode supports multiple agents. Plannotator lets you choose which agent handles the approved plan:
+OpenCode supports multiple agents. By default, approved plans stay on your current agent (no switch). To hand off approved plans to another agent, configure [Agent switching settings](/docs/getting-started/ui-settings/#agent-switching):
 
 1. Open **Settings** (gear icon)
 2. Under "Agent Switch", select from available agents or enter a custom agent name
-3. On approval, the selected agent receives the plan
+3. On approval, the selected agent receives the plan (if Agent Switch is disabled, your current agent continues)
 
-If the configured agent isn't found in the current OpenCode session, Plannotator shows a warning before approval. You can approve anyway (the default agent will be used) or go back and change the setting.
+If the configured agent isn't found in the current OpenCode session, Plannotator logs a warning and shows a warning toast, then sends approval or feedback without switching agents.
 
 ## Slash commands
 

--- a/apps/marketing/src/content/docs/guides/opencode.md
+++ b/apps/marketing/src/content/docs/guides/opencode.md
@@ -145,7 +145,7 @@ This makes it possible to approve a plan while leaving minor suggestions that th
 
 ## Agent switching
 
-OpenCode supports multiple agents. By default, approved plans stay on your current agent (no switch). To hand off approved plans to another agent, configure [Agent switching settings](/docs/getting-started/ui-settings/#agent-switching):
+OpenCode supports multiple agents. By default, approved plans are handed off to the build agent, while code review feedback stays on your current agent. To change either, configure [Agent switching settings](/docs/getting-started/ui-settings/#agent-switching):
 
 1. Open **Settings** (gear icon)
 2. Under "Agent Switch", select from available agents or enter a custom agent name

--- a/apps/opencode-plugin/agent-switch.test.ts
+++ b/apps/opencode-plugin/agent-switch.test.ts
@@ -66,6 +66,27 @@ describe("OpenCode agent switch validation", () => {
     });
   });
 
+  test("names plan approval in the warning on the plan path", async () => {
+    const agents = mock(async () => ({ data: [{ name: "plan" }] }));
+    const log = mock(() => undefined);
+    const showToast = mock(() => undefined);
+    const client = {
+      app: { agents, log },
+      tui: { showToast },
+    };
+
+    await expect(resolveValidatedTargetAgent({
+      client,
+      targetAgent: "build",
+      delivery: "plan-approval",
+    })).resolves.toBeUndefined();
+
+    expect(log).toHaveBeenCalledWith({
+      level: "info",
+      message: '[Plannotator] Configured OpenCode agent "build" is not available; approving the plan without switching agents.',
+    });
+  });
+
   test("omits explicit agents when OpenCode agent lookup fails", async () => {
     const agents = mock(async () => {
       throw new Error("agents unavailable");

--- a/apps/opencode-plugin/agent-switch.test.ts
+++ b/apps/opencode-plugin/agent-switch.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, mock, test } from "bun:test";
+import { resolveTargetAgent, resolveValidatedTargetAgent } from "./agent-switch";
+
+describe("OpenCode agent switch validation", () => {
+  test("preserves no-agent defaults", () => {
+    expect(resolveTargetAgent(undefined)).toBeUndefined();
+    expect(resolveTargetAgent("disabled")).toBeUndefined();
+    expect(resolveTargetAgent("   ")).toBeUndefined();
+  });
+
+  test("normalizes no-agent defaults before validation", async () => {
+    const agents = mock(async () => ({ data: [{ name: "build" }] }));
+
+    await expect(resolveValidatedTargetAgent({
+      client: { app: { agents } },
+      targetAgent: "disabled",
+    })).resolves.toBeUndefined();
+
+    expect(agents).not.toHaveBeenCalled();
+  });
+
+  test("keeps explicit agents that OpenCode reports", async () => {
+    const agents = mock(async () => ({
+      data: [{ name: "plan" }, { name: "build" }],
+    }));
+    const showToast = mock(() => undefined);
+    const client = {
+      app: { agents },
+      tui: { showToast },
+    };
+
+    await expect(resolveValidatedTargetAgent({
+      client,
+      targetAgent: "build",
+      directory: "/repo",
+    })).resolves.toBe("build");
+
+    expect(agents).toHaveBeenCalledWith({ query: { directory: "/repo" } });
+    expect(showToast).not.toHaveBeenCalled();
+  });
+
+  test("omits invalid explicit agents and warns visibly", async () => {
+    const agents = mock(async () => ({ data: [{ name: "plan" }] }));
+    const log = mock(() => undefined);
+    const showToast = mock(() => undefined);
+    const client = {
+      app: { agents, log },
+      tui: { showToast },
+    };
+
+    await expect(resolveValidatedTargetAgent({
+      client,
+      targetAgent: "build",
+    })).resolves.toBeUndefined();
+
+    expect(log).toHaveBeenCalledWith({
+      level: "info",
+      message: '[Plannotator] Configured OpenCode agent "build" is not available; sending feedback without switching agents.',
+    });
+    expect(showToast).toHaveBeenCalledWith({
+      body: {
+        title: "Plannotator",
+        message: 'Configured OpenCode agent "build" is not available; sending feedback without switching agents.',
+        variant: "warning",
+      },
+    });
+  });
+
+  test("omits explicit agents when OpenCode agent lookup fails", async () => {
+    const agents = mock(async () => {
+      throw new Error("agents unavailable");
+    });
+    const showToast = mock(() => undefined);
+    const client = {
+      app: { agents },
+      tui: { showToast },
+    };
+
+    await expect(resolveValidatedTargetAgent({
+      client,
+      targetAgent: "build",
+    })).resolves.toBeUndefined();
+
+    expect(showToast).toHaveBeenCalled();
+  });
+});

--- a/apps/opencode-plugin/agent-switch.ts
+++ b/apps/opencode-plugin/agent-switch.ts
@@ -1,0 +1,64 @@
+export interface OpenCodeAgentLike {
+  name?: string;
+}
+
+interface OpenCodeClientLike {
+  app?: {
+    agents?: (input?: unknown) => Promise<{ data?: OpenCodeAgentLike[] }>;
+    log?: (entry: { level: "info" | "error"; message: string }) => unknown;
+  };
+  tui?: {
+    showToast?: (input: unknown) => unknown;
+  };
+}
+
+export function resolveTargetAgent(agentSwitch?: string): string | undefined {
+  const trimmed = agentSwitch?.trim();
+  return trimmed && trimmed !== "disabled" ? trimmed : undefined;
+}
+
+function warnAgentUnavailable(client: OpenCodeClientLike, targetAgent: string): void {
+  const message = `Configured OpenCode agent "${targetAgent}" is not available; sending feedback without switching agents.`;
+
+  try {
+    void client.app?.log?.({ level: "info", message: `[Plannotator] ${message}` });
+  } catch {
+    // OpenCode logging is best-effort.
+  }
+
+  try {
+    const result = client.tui?.showToast?.({
+      body: { title: "Plannotator", message, variant: "warning" },
+    });
+    if (result && typeof (result as Promise<unknown>).catch === "function") {
+      (result as Promise<unknown>).catch(() => {});
+    }
+  } catch {
+    // Toast delivery is best-effort.
+  }
+}
+
+export async function resolveValidatedTargetAgent(input: {
+  client: OpenCodeClientLike;
+  targetAgent?: string;
+  directory?: string;
+}): Promise<string | undefined> {
+  const targetAgent = resolveTargetAgent(input.targetAgent);
+  if (!targetAgent) return undefined;
+
+  try {
+    const response = await input.client.app?.agents?.({
+      query: { directory: input.directory },
+    });
+    const agents = response?.data ?? [];
+    if (agents.some((agent) => agent.name === targetAgent)) {
+      return targetAgent;
+    }
+  } catch {
+    // Treat validation failures as unavailable: better to omit the agent than
+    // send a stale/invalid target that OpenCode may reject.
+  }
+
+  warnAgentUnavailable(input.client, targetAgent);
+  return undefined;
+}

--- a/apps/opencode-plugin/agent-switch.ts
+++ b/apps/opencode-plugin/agent-switch.ts
@@ -12,13 +12,21 @@ interface OpenCodeClientLike {
   };
 }
 
+/** What the omitted agent switch would have applied to, used in the warning copy. */
+export type AgentSwitchDelivery = "feedback" | "plan-approval";
+
 export function resolveTargetAgent(agentSwitch?: string): string | undefined {
   const trimmed = agentSwitch?.trim();
   return trimmed && trimmed !== "disabled" ? trimmed : undefined;
 }
 
-function warnAgentUnavailable(client: OpenCodeClientLike, targetAgent: string): void {
-  const message = `Configured OpenCode agent "${targetAgent}" is not available; sending feedback without switching agents.`;
+function warnAgentUnavailable(
+  client: OpenCodeClientLike,
+  targetAgent: string,
+  delivery: AgentSwitchDelivery,
+): void {
+  const action = delivery === "plan-approval" ? "approving the plan" : "sending feedback";
+  const message = `Configured OpenCode agent "${targetAgent}" is not available; ${action} without switching agents.`;
 
   try {
     void client.app?.log?.({ level: "info", message: `[Plannotator] ${message}` });
@@ -42,6 +50,7 @@ export async function resolveValidatedTargetAgent(input: {
   client: OpenCodeClientLike;
   targetAgent?: string;
   directory?: string;
+  delivery?: AgentSwitchDelivery;
 }): Promise<string | undefined> {
   const targetAgent = resolveTargetAgent(input.targetAgent);
   if (!targetAgent) return undefined;
@@ -59,6 +68,6 @@ export async function resolveValidatedTargetAgent(input: {
     // send a stale/invalid target that OpenCode may reject.
   }
 
-  warnAgentUnavailable(input.client, targetAgent);
+  warnAgentUnavailable(input.client, targetAgent, input.delivery ?? "feedback");
   return undefined;
 }

--- a/apps/opencode-plugin/cli-bridge.test.ts
+++ b/apps/opencode-plugin/cli-bridge.test.ts
@@ -10,7 +10,7 @@ import {
   formatUserFacingCliStderrLine,
   getRecentAssistantMessages,
 } from "./cli-bridge";
-import { getReviewDeniedSuffix } from "@plannotator/shared/prompts";
+import { getReviewApprovedPrompt, getReviewDeniedSuffix } from "@plannotator/shared/prompts";
 
 describe("OpenCode CLI bridge helpers", () => {
   test("maps OpenCode sharing context into child CLI env", () => {
@@ -159,7 +159,7 @@ describe("OpenCode CLI bridge helpers", () => {
       agentSwitch: "build",
     });
     expect(approved.agent).toBe("build");
-    expect(approved.message).toContain("Code Review");
+    expect(approved.message).toBe(getReviewApprovedPrompt("opencode"));
 
     const localFeedback = buildReviewPromptFromBridgeOutcome({
       decision: "annotated",

--- a/apps/opencode-plugin/cli-bridge.ts
+++ b/apps/opencode-plugin/cli-bridge.ts
@@ -10,12 +10,17 @@ import {
   getReviewApprovedPrompt,
   getReviewDeniedSuffix,
 } from "@plannotator/shared/prompts";
+import { resolveTargetAgent, resolveValidatedTargetAgent } from "./agent-switch";
 
 type LogLevel = "info" | "error";
 
 interface OpenCodeClient {
   app?: {
     log?: (entry: { level: LogLevel; message: string }) => unknown;
+    agents?: (input?: unknown) => Promise<{ data?: OpenCodeBridgeAgent[] }>;
+  };
+  tui?: {
+    showToast?: (input: unknown) => unknown;
   };
   session?: {
     messages?: (input: unknown) => Promise<{ data?: any[] }>;
@@ -318,7 +323,7 @@ async function runPlannotatorCli(options: RunCliOptions): Promise<RunCliResult> 
   );
   const loggedUrls = new Set<string>();
   const toastedUrls = new Set<string>();
-  const cwd = options.cwd || process.cwd();
+  const cwd = options.cwd ?? process.cwd();
   const env = {
     ...process.env,
     ...options.extraEnv,
@@ -538,8 +543,7 @@ export function buildReviewPromptFromBridgeOutcome(outcome: CliReviewOutcome): {
 } {
   if (outcome.decision === "dismissed") return { message: null };
 
-  const shouldSwitchAgent = outcome.agentSwitch && outcome.agentSwitch !== "disabled";
-  const targetAgent = shouldSwitchAgent ? outcome.agentSwitch : undefined;
+  const targetAgent = resolveTargetAgent(outcome.agentSwitch);
 
   if (outcome.approved || outcome.decision === "approved") {
     return {
@@ -584,12 +588,14 @@ export async function handleCliCommand(input: {
   cwd?: string;
   bridge?: OpenCodeBridgeContext;
 }): Promise<void> {
+  const cwd = input.cwd ?? process.cwd();
+
   try {
     if (input.command === "plannotator-review") {
       const result = await runPlannotatorCli({
         client: input.client,
         args: ["opencode-review"],
-        cwd: input.cwd,
+        cwd,
         input: JSON.stringify({
           arguments: input.rawArgs,
           ...buildBridgePayload(input.bridge),
@@ -606,8 +612,13 @@ export async function handleCliCommand(input: {
       const outcome = parseLastJson<CliReviewOutcome>(result.stdout);
       const prompt = buildReviewPromptFromBridgeOutcome(outcome);
       if (prompt.message) {
+        const targetAgent = await resolveValidatedTargetAgent({
+          client: input.client,
+          targetAgent: prompt.agent,
+          directory: cwd,
+        });
         await injectSessionPrompt(input.client, input.sessionId, prompt.message, {
-          agent: prompt.agent,
+          agent: targetAgent,
         });
       }
       return;
@@ -623,7 +634,7 @@ export async function handleCliCommand(input: {
       const result = await runPlannotatorCli({
         client: input.client,
         args: buildAnnotateCliArgs(parsed),
-        cwd: input.cwd,
+        cwd,
         readyLabel: "annotation UI",
         bridge: input.bridge,
       });
@@ -639,7 +650,7 @@ export async function handleCliCommand(input: {
           input.client,
           input.sessionId,
           getAnnotateFileFeedbackPrompt("opencode", undefined, {
-            fileHeader: getAnnotateFileHeader(parsed.filePath, input.cwd),
+            fileHeader: getAnnotateFileHeader(parsed.filePath, cwd),
             filePath: parsed.filePath,
             feedback: outcome.feedback,
           }),
@@ -664,7 +675,7 @@ export async function handleCliCommand(input: {
       const result = await runPlannotatorCli({
         client: input.client,
         args: ["opencode-annotate-last"],
-        cwd: input.cwd,
+        cwd,
         input: JSON.stringify({
           gate: parsed.gate,
           recentMessages,

--- a/apps/opencode-plugin/commands.ts
+++ b/apps/opencode-plugin/commands.ts
@@ -31,6 +31,7 @@ import { urlToMarkdown, isConvertedSource } from "@plannotator/shared/url-to-mar
 import { buildLocalWorkspaceReview, type WorkspaceDiffType } from "@plannotator/server/review-workspace";
 import { statSync } from "fs";
 import path from "path";
+import { resolveValidatedTargetAgent } from "./agent-switch";
 
 /** Shared dependencies injected by the plugin */
 export interface CommandDeps {
@@ -172,8 +173,11 @@ export async function handleReviewCommand(
     const sessionId = event.properties?.sessionID;
 
     if (sessionId) {
-      const shouldSwitchAgent = result.agentSwitch && result.agentSwitch !== "disabled";
-      const targetAgent = result.agentSwitch || "build";
+      const targetAgent = await resolveValidatedTargetAgent({
+        client,
+        targetAgent: result.agentSwitch,
+        directory,
+      });
 
       // Append the verification-only suffix when the reviewer sent annotations to
       // act on (PR mode included). Platform PR actions post a status message
@@ -188,7 +192,7 @@ export async function handleReviewCommand(
         await client.session.prompt({
           path: { id: sessionId },
           body: {
-            ...(shouldSwitchAgent && { agent: targetAgent }),
+            ...(targetAgent && { agent: targetAgent }),
             parts: [{ type: "text", text: message }],
           },
         });

--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -60,6 +60,7 @@ import {
   type OpenCodeBridgeContext,
   type OpenCodePlanReviewResult,
 } from "./cli-bridge";
+import { resolveValidatedTargetAgent } from "./agent-switch";
 
 // Lazy-load HTML at first use instead of embedding in the bundle.
 // The two SPA files are ~20 MB combined — inlining them as string literals
@@ -682,12 +683,16 @@ Use /plannotator-last or /plannotator-annotate for manual review, or set workflo
             // Clean up backing file after approval
             try { unlinkSync(backingPath); } catch { /* already gone */ }
 
-            const shouldSwitchAgent = result.agentSwitch && result.agentSwitch !== 'disabled';
-            const targetAgent = result.agentSwitch || 'build';
-            const shouldStartImplementation = shouldSwitchAgent
-              && shouldStartImplementationForAgent(targetAgent, workflowOptions);
+            const targetAgent = await resolveValidatedTargetAgent({
+              client: ctx.client,
+              targetAgent: result.agentSwitch,
+              directory: ctx.directory,
+            });
+            const shouldStartImplementation = targetAgent
+              ? shouldStartImplementationForAgent(targetAgent, workflowOptions)
+              : false;
 
-            if (shouldSwitchAgent) {
+            if (targetAgent) {
               try {
                 await ctx.client.session.prompt({
                   path: { id: context.sessionID },

--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -687,6 +687,7 @@ Use /plannotator-last or /plannotator-annotate for manual review, or set workflo
               client: ctx.client,
               targetAgent: result.agentSwitch,
               directory: ctx.directory,
+              delivery: "plan-approval",
             });
             const shouldStartImplementation = targetAgent
               ? shouldStartImplementationForAgent(targetAgent, workflowOptions)

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -2679,7 +2679,7 @@ const App: React.FC = () => {
         body.permissionMode = permissionMode;
       }
 
-      const effectiveAgent = getEffectiveAgentName(getAgentSwitchSettings());
+      const effectiveAgent = getEffectiveAgentName(getAgentSwitchSettings('plan'));
       if (effectiveAgent) {
         body.agentSwitch = effectiveAgent;
       }

--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -2486,7 +2486,7 @@ const ReviewApp: React.FC = () => {
     }
     setIsSendingFeedback(true);
     try {
-      const agentSwitchSettings = getAgentSwitchSettings();
+      const agentSwitchSettings = getAgentSwitchSettings('review');
       const effectiveAgent = getEffectiveAgentName(agentSwitchSettings);
 
       const res = await fetch('/api/feedback', {
@@ -2630,7 +2630,7 @@ const ReviewApp: React.FC = () => {
         for (const url of openUrls) window.open(url, '_blank');
       }
 
-      const agentSwitchSettings = getAgentSwitchSettings();
+      const agentSwitchSettings = getAgentSwitchSettings('review');
       const effectiveAgent = getEffectiveAgentName(agentSwitchSettings);
       const prLinks = openUrls.join(', ');
       const statusMessage = action === 'approve'

--- a/packages/ui/components/ApproveDropdown.tsx
+++ b/packages/ui/components/ApproveDropdown.tsx
@@ -36,7 +36,7 @@ export const ApproveDropdown: React.FC<ApproveDropdownProps> = ({
   disabled = false,
   isLoading = false,
 }) => {
-  const [setting, setSetting] = useState<AgentSwitchSettings>(() => getAgentSwitchSettings());
+  const [setting, setSetting] = useState<AgentSwitchSettings>(() => getAgentSwitchSettings('plan'));
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 

--- a/packages/ui/components/Settings.tsx
+++ b/packages/ui/components/Settings.tsx
@@ -28,9 +28,11 @@ import {
 } from '../utils/octarine';
 import {
   getAgentSwitchSettings,
+  getAgentSwitchDefaults,
   saveAgentSwitchSettings,
   AGENT_OPTIONS,
   type AgentSwitchSettings,
+  type AgentSwitchSurface,
 } from '../utils/agentSwitch';
 import {
   getPlanSaveSettings,
@@ -678,7 +680,10 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
   const [vaultsLoading, setVaultsLoading] = useState(false);
   const [bear, setBear] = useState<BearSettings>({ enabled: false, customTags: '', tagPosition: 'append', autoSave: false });
   const [octarine, setOctarine] = useState<OctarineSettings>({ enabled: false, workspace: '', folder: 'plannotator', autoSave: false });
-  const [agent, setAgent] = useState<AgentSwitchSettings>({ switchTo: 'build' });
+  // The agent switch default depends on the surface: plan approval hands off to
+  // the build agent, review feedback stays on the current agent.
+  const agentSurface: AgentSwitchSurface = mode === 'review' ? 'review' : 'plan';
+  const [agent, setAgent] = useState<AgentSwitchSettings>(() => getAgentSwitchDefaults(agentSurface));
   const [planSave, setPlanSave] = useState<PlanSaveSettings>({ enabled: true, customPath: null });
   const [uiPrefs, setUiPrefs] = useState<UIPreferences>({ tocEnabled: true, stickyActionsEnabled: true, planWidth: 'compact' });
   const [permissionMode, setPermissionMode] = useState<PermissionMode>('bypassPermissions');
@@ -693,7 +698,7 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
   const [newDirPath, setNewDirPath] = useState('');
 
   // Fetch available agents for OpenCode
-  const { agents: availableAgents, validateAgent, getAgentWarning } = useAgents(origin ?? null);
+  const { agents: availableAgents, validateAgent, getAgentWarning } = useAgents(origin ?? null, agentSurface);
 
   const mainTabs = useMemo(() => {
     const t: { id: SettingsTab; label: string }[] = [{ id: 'general', label: 'General' }];
@@ -742,7 +747,7 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
       setObsidian(getObsidianSettings());
       setBear(getBearSettings());
       setOctarine(getOctarineSettings());
-      setAgent(getAgentSwitchSettings());
+      setAgent(getAgentSwitchSettings(agentSurface));
       setPlanSave(getPlanSaveSettings());
       setUiPrefs(getUIPreferences());
       setPermissionMode(getPermissionModeSettings().mode);

--- a/packages/ui/hooks/useAgents.ts
+++ b/packages/ui/hooks/useAgents.ts
@@ -4,7 +4,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import type { Origin } from '@plannotator/core/agents';
-import { getAgentSwitchSettings } from '../utils/agentSwitch';
+import { getAgentSwitchSettings, type AgentSwitchSurface } from '../utils/agentSwitch';
 
 export interface Agent {
   id: string;
@@ -25,7 +25,7 @@ export interface UseAgentsResult {
  * Fetch available agents from OpenCode API
  * Only fetches when origin is 'opencode'
  */
-export function useAgents(origin: Origin | null): UseAgentsResult {
+export function useAgents(origin: Origin | null, surface: AgentSwitchSurface = 'plan'): UseAgentsResult {
   const [agents, setAgents] = useState<Agent[]>([]);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -56,7 +56,7 @@ export function useAgents(origin: Origin | null): UseAgentsResult {
   const getAgentWarning = useCallback((): string | null => {
     if (agents.length === 0) return null; // Can't validate without agents
 
-    const settings = getAgentSwitchSettings();
+    const settings = getAgentSwitchSettings(surface);
 
     if (settings.switchTo === 'disabled') {
       return null;
@@ -79,7 +79,7 @@ export function useAgents(origin: Origin | null): UseAgentsResult {
     }
 
     return null;
-  }, [agents, validateAgent]);
+  }, [agents, validateAgent, surface]);
 
   return {
     agents,

--- a/packages/ui/utils/agentSwitch.test.ts
+++ b/packages/ui/utils/agentSwitch.test.ts
@@ -16,13 +16,32 @@ afterEach(() => {
 });
 
 describe("agent switch settings", () => {
-  test("defaults to no switch/current agent when unset", () => {
+  test("review feedback defaults to no switch/current agent when unset", () => {
     setStorageBackend(memoryStorage());
 
-    const settings = getAgentSwitchSettings();
+    const settings = getAgentSwitchSettings("review");
 
     expect(settings.switchTo).toBe("disabled");
     expect(getEffectiveAgentName(settings)).toBeUndefined();
+  });
+
+  test("plan approval defaults to the build hand-off when unset", () => {
+    setStorageBackend(memoryStorage());
+
+    const settings = getAgentSwitchSettings("plan");
+
+    expect(settings.switchTo).toBe("build");
+    expect(getEffectiveAgentName(settings)).toBe("build");
+    expect(getAgentSwitchSettings().switchTo).toBe("build");
+  });
+
+  test("an explicit choice overrides the surface default everywhere", () => {
+    setStorageBackend(memoryStorage());
+
+    saveAgentSwitchSettings({ switchTo: "disabled" });
+
+    expect(getAgentSwitchSettings("plan").switchTo).toBe("disabled");
+    expect(getAgentSwitchSettings("review").switchTo).toBe("disabled");
   });
 
   test("keeps an explicitly saved target agent", () => {
@@ -30,7 +49,7 @@ describe("agent switch settings", () => {
 
     saveAgentSwitchSettings({ switchTo: "build" });
 
-    const settings = getAgentSwitchSettings();
+    const settings = getAgentSwitchSettings("review");
     expect(settings.switchTo).toBe("build");
     expect(getEffectiveAgentName(settings)).toBe("build");
   });

--- a/packages/ui/utils/agentSwitch.test.ts
+++ b/packages/ui/utils/agentSwitch.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { resetStorageBackend, setStorageBackend, type StorageBackend } from "./storage";
+import { getAgentSwitchSettings, getEffectiveAgentName, saveAgentSwitchSettings } from "./agentSwitch";
+
+function memoryStorage(initial: Record<string, string> = {}): StorageBackend {
+  const values = new Map(Object.entries(initial));
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => { values.set(key, value); },
+    removeItem: (key) => { values.delete(key); },
+  };
+}
+
+afterEach(() => {
+  resetStorageBackend();
+});
+
+describe("agent switch settings", () => {
+  test("defaults to no switch/current agent when unset", () => {
+    setStorageBackend(memoryStorage());
+
+    const settings = getAgentSwitchSettings();
+
+    expect(settings.switchTo).toBe("disabled");
+    expect(getEffectiveAgentName(settings)).toBeUndefined();
+  });
+
+  test("keeps an explicitly saved target agent", () => {
+    setStorageBackend(memoryStorage());
+
+    saveAgentSwitchSettings({ switchTo: "build" });
+
+    const settings = getAgentSwitchSettings();
+    expect(settings.switchTo).toBe("build");
+    expect(getEffectiveAgentName(settings)).toBe("build");
+  });
+
+  test("does not emit custom as an agent when no custom name is set", () => {
+    expect(getEffectiveAgentName({ switchTo: "custom" })).toBeUndefined();
+  });
+});

--- a/packages/ui/utils/agentSwitch.ts
+++ b/packages/ui/utils/agentSwitch.ts
@@ -2,7 +2,7 @@
  * Agent Switch Settings Utility
  *
  * Manages settings for automatic agent switching after plan approval.
- * Supports built-in agents (build), disabled, or custom agent names.
+ * Supports discovered agents, disabled, or custom agent names.
  *
  * Uses cookies (not localStorage) because each hook invocation runs on a
  * random port, and localStorage is scoped by origin including port.
@@ -29,7 +29,7 @@ export const AGENT_OPTIONS: { value: string; label: string; description: string 
 ];
 
 const DEFAULT_SETTINGS: AgentSwitchSettings = {
-  switchTo: 'build',
+  switchTo: 'disabled',
 };
 
 /**
@@ -67,5 +67,8 @@ export function getEffectiveAgentName(settings: AgentSwitchSettings): string | u
   if (settings.switchTo === 'custom' && settings.customName) {
     return settings.customName;
   }
-  return settings.switchTo; // 'build' or fallback
+  if (settings.switchTo === 'custom') {
+    return undefined;
+  }
+  return settings.switchTo;
 }

--- a/packages/ui/utils/agentSwitch.ts
+++ b/packages/ui/utils/agentSwitch.ts
@@ -1,8 +1,13 @@
 /**
  * Agent Switch Settings Utility
  *
- * Manages settings for automatic agent switching after plan approval.
- * Supports discovered agents, disabled, or custom agent names.
+ * Manages settings for automatic agent switching after plan approval and after
+ * sending code review feedback. Supports discovered agents, disabled, or custom
+ * agent names.
+ *
+ * The stored value is shared across surfaces, but the default when nothing is
+ * stored is surface-specific: plan approval keeps its historical hand-off to the
+ * build agent, while review feedback stays on the current agent.
  *
  * Uses cookies (not localStorage) because each hook invocation runs on a
  * random port, and localStorage is scoped by origin including port.
@@ -28,14 +33,32 @@ export const AGENT_OPTIONS: { value: string; label: string; description: string 
   { value: 'disabled', label: 'Disabled', description: 'Stay on current agent after approval' },
 ];
 
-const DEFAULT_SETTINGS: AgentSwitchSettings = {
+/** UI surface asking for the setting — only affects the unset default. */
+export type AgentSwitchSurface = 'plan' | 'review';
+
+const PLAN_DEFAULT_SETTINGS: AgentSwitchSettings = {
+  switchTo: 'build',
+};
+
+const REVIEW_DEFAULT_SETTINGS: AgentSwitchSettings = {
   switchTo: 'disabled',
 };
 
 /**
- * Get current agent switch settings from storage
+ * Default used when the user has never picked an agent switch setting.
+ * Plan approval hands off to the build agent (historical behavior); review
+ * feedback stays on the current agent.
  */
-export function getAgentSwitchSettings(): AgentSwitchSettings {
+export function getAgentSwitchDefaults(surface: AgentSwitchSurface = 'plan'): AgentSwitchSettings {
+  return surface === 'review' ? REVIEW_DEFAULT_SETTINGS : PLAN_DEFAULT_SETTINGS;
+}
+
+/**
+ * Get current agent switch settings from storage.
+ * An explicit user choice applies to every surface; only the unset default
+ * varies by surface.
+ */
+export function getAgentSwitchSettings(surface: AgentSwitchSurface = 'plan'): AgentSwitchSettings {
   const stored = storage.getItem(STORAGE_KEY);
   const customName = storage.getItem(CUSTOM_NAME_KEY) || undefined;
 
@@ -43,7 +66,7 @@ export function getAgentSwitchSettings(): AgentSwitchSettings {
   if (stored) {
     return { switchTo: stored, customName };
   }
-  return DEFAULT_SETTINGS;
+  return getAgentSwitchDefaults(surface);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fixes #1123 by removing OpenCode's implicit fallback to `build` when agent switching is unset/disabled.
- Keeps execution on the current agent unless a valid explicit agent is configured.
- Prevents invalid/unavailable configured agents from being sent to OpenCode.

## What changed

- Updated OpenCode agent-switch behavior so default/disabled mode does **not** set an `agent` parameter.
- Added validation for explicitly configured agents via `client.app.agents()` before request submission.
- If a configured agent is invalid/unavailable, the agent override is omitted and surfaced as a warning (log + toast).
- Updated related docs and tests.

## Testing

- Unit tests
- Marketing docs builds
- Manual testing with local plugin build

## Demo/Screenshots

### Bug
#### Before
<img width="698" height="518" alt="before-01" src="https://github.com/user-attachments/assets/b7799f92-6c4c-4ee5-b09a-d2e9088f6536" />
<img width="481" height="65" alt="before-02" src="https://github.com/user-attachments/assets/acdfbd25-bc1d-4609-89a9-6d43d85ef792" />

#### After
<img width="686" height="496" alt="after-01" src="https://github.com/user-attachments/assets/1e6c282a-0583-44bf-b7c9-c066f6ed12ce" />

### New warning toast if user manually enters a invalid custom agent via Settings
<img width="680" height="546" alt="warning-settings-01" src="https://github.com/user-attachments/assets/550b0f14-d262-45f1-b1bb-f6b2397b64d7" />

<img width="1252" height="213" alt="warning-toast-01" src="https://github.com/user-attachments/assets/ec7ddafc-fbf7-48cb-ad9f-11b281c524ea" />
