### PR TITLE
fix(hook): read annotate-last from Claude Code's transcript tree, not file order

### DIFF
--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -1213,7 +1213,12 @@ if (args[0] === "sessions") {
         console.error(`[DEBUG] ${label}: ${paths.length ? paths.join(", ") : "(none)"}`);
       }
       for (const logPath of paths) {
-        const recent = getRecentRenderedMessages(logPath, RECENT_MESSAGES_LIMIT);
+        // Claude Code transcripts are trees: `/rewind` re-parents the next
+        // message rather than truncating, so a file-order read returns
+        // orphaned messages. Follow the id chain instead.
+        const recent = getRecentRenderedMessages(logPath, RECENT_MESSAGES_LIMIT, {
+          activeBranchOnly: true,
+        });
         if (recent.length > 0) {
           recentMessages = recent;
           lastMessage = recent[0];

--- a/apps/hook/server/session-log.test.ts
+++ b/apps/hook/server/session-log.test.ts
@@ -14,6 +14,7 @@ import {
   findAnchorIndex,
   extractLastRenderedMessage,
   extractRecentRenderedMessages,
+  resolveActiveBranchIndices,
   findDroidSessionLogsForCwd,
   resolveDroidSessionLogForCwd,
   projectSlugFromCwd,
@@ -167,8 +168,63 @@ function queueOp(): string {
   });
 }
 
+/** Bookkeeping entry with no id at all — Claude Code often writes these last. */
+function lastPromptEntry(lastPrompt: string, leafUuid: string): string {
+  return JSON.stringify({ type: "last-prompt", lastPrompt, leafUuid });
+}
+
+/**
+ * Link fixture lines into one parent chain, the way Claude Code records a
+ * conversation. The individual helpers assign random `parentUuid`s, which would
+ * otherwise leave every entry an orphan and make branch resolution untestable.
+ * Entries with no `uuid` (bookkeeping types) are passed through untouched.
+ */
+function linkChain(lines: string[], parentUuid: string | null = null): string[] {
+  let previous = parentUuid;
+  return lines.map((line) => {
+    const entry = JSON.parse(line);
+    if (typeof entry.uuid !== "string") {
+      return JSON.stringify(entry);
+    }
+    entry.parentUuid = previous;
+    previous = entry.uuid;
+    return JSON.stringify(entry);
+  });
+}
+
+/** Last `uuid` in a set of already-linked lines. */
+function tailUuid(lines: string[]): string {
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const entry = JSON.parse(lines[i]);
+    if (typeof entry.uuid === "string") {
+      return entry.uuid;
+    }
+  }
+  throw new Error("no id-bearing entry in lines");
+}
+
 function buildLog(...lines: string[]): string {
-  return lines.join("\n");
+  return linkChain(lines).join("\n");
+}
+
+/**
+ * A log recording a `/rewind`. `kept` runs to the rewind target, `abandoned` is
+ * orphaned by the rewind but stays in the file, and `resumed` re-parents back to
+ * the target. File order stays kept → abandoned → resumed, because the
+ * transcript is append-only and the rewind itself writes nothing.
+ */
+function buildRewoundLog(opts: {
+  kept: string[];
+  abandoned: string[];
+  resumed: string[];
+}): string {
+  const kept = linkChain(opts.kept);
+  const forkPoint = tailUuid(kept);
+  return [
+    ...kept,
+    ...linkChain(opts.abandoned, forkPoint),
+    ...linkChain(opts.resumed, forkPoint),
+  ].join("\n");
 }
 
 function droidMessage(
@@ -736,6 +792,132 @@ describe("extractRecentRenderedMessages (picker)", () => {
     const entries = parseSessionLog(log);
     const result = extractRecentRenderedMessages(entries, entries.length, 5);
     expect(result.map((m) => m.text)).toEqual(["World", "Hello"]);
+  });
+});
+
+describe("resolveActiveBranchIndices", () => {
+  test("a linear log puts every id-bearing entry on the branch", () => {
+    const log = buildLog(
+      userPrompt("first"),
+      assistantText("msg_1", "First response"),
+      userPrompt("second"),
+      assistantText("msg_2", "Second response"),
+    );
+    const entries = parseSessionLog(log);
+    expect(resolveActiveBranchIndices(entries)).toEqual(new Set([0, 1, 2, 3]));
+  });
+
+  test("a rewind drops the orphaned entries", () => {
+    const log = buildRewoundLog({
+      kept: [userPrompt("keep me"), assistantText("msg_keep", "Kept")],
+      abandoned: [userPrompt("rewound away"), assistantText("msg_gone", "Orphaned")],
+      resumed: [userPrompt("after rewind")],
+    });
+    const entries = parseSessionLog(log);
+    // Lines 2 and 3 are the abandoned branch; they stay in the file but are
+    // not part of the conversation any more.
+    expect(resolveActiveBranchIndices(entries)).toEqual(new Set([0, 1, 4]));
+  });
+
+  test("walks back from a tail that carries no id", () => {
+    // Claude Code frequently writes a `last-prompt` entry as the final line.
+    const linked = linkChain([
+      userPrompt("first"),
+      assistantText("msg_1", "Response"),
+    ]);
+    const log = [...linked, lastPromptEntry("first", tailUuid(linked))].join("\n");
+    const entries = parseSessionLog(log);
+    expect(resolveActiveBranchIndices(entries)).toEqual(new Set([0, 1]));
+  });
+
+  test("null when entries carry no ids at all", () => {
+    const entries = parseSessionLog(
+      [
+        JSON.stringify({ type: "user", message: { role: "user", content: "hi" } }),
+        JSON.stringify({
+          type: "assistant",
+          message: { id: "m", role: "assistant", content: [{ type: "text", text: "yo" }] },
+        }),
+      ].join("\n"),
+    );
+    expect(resolveActiveBranchIndices(entries)).toBeNull();
+  });
+
+  test("null when the chain dead-ends instead of reaching the root", () => {
+    // Unlinked lines: each helper assigns a random parentUuid that matches
+    // nothing in the file. A partial walk must not be mistaken for a branch.
+    const log = [userPrompt("first"), assistantText("msg_1", "Response")].join("\n");
+    const entries = parseSessionLog(log);
+    expect(resolveActiveBranchIndices(entries)).toBeNull();
+  });
+
+  test("null on a cycle", () => {
+    const a = JSON.stringify({ type: "user", message: { role: "user", content: "a" }, uuid: "u-a", parentUuid: "u-b" });
+    const b = JSON.stringify({ type: "user", message: { role: "user", content: "b" }, uuid: "u-b", parentUuid: "u-a" });
+    expect(resolveActiveBranchIndices(parseSessionLog([a, b].join("\n")))).toBeNull();
+  });
+
+  test("empty log → null", () => {
+    expect(resolveActiveBranchIndices([])).toBeNull();
+  });
+});
+
+describe("extractRecentRenderedMessages — after a rewind", () => {
+  const rewoundLog = () =>
+    buildRewoundLog({
+      kept: [
+        userPrompt("are the remotes named weirdly?"),
+        assistantText("msg_target", "They're inverted from the GitHub convention."),
+      ],
+      abandoned: [
+        userPrompt("nah, use the standard convention"),
+        assistantText("msg_orphan", "Pushed. All three are on 68c1291c."),
+      ],
+      resumed: [userPrompt("/plannotator-last")],
+    });
+
+  test("the default pick is the live message, not the orphan", () => {
+    const entries = parseSessionLog(rewoundLog());
+    const result = extractRecentRenderedMessages(entries, entries.length, 25, {
+      branchIndices: resolveActiveBranchIndices(entries),
+    });
+    expect(result[0].messageId).toBe("msg_target");
+    expect(result.map((m) => m.messageId)).not.toContain("msg_orphan");
+  });
+
+  test("orphaned messages are absent from the picker list", () => {
+    const entries = parseSessionLog(rewoundLog());
+    const result = extractRecentRenderedMessages(entries, entries.length, 25, {
+      branchIndices: resolveActiveBranchIndices(entries),
+    });
+    expect(result).toHaveLength(1);
+  });
+
+  test("without branchIndices the orphan still wins (unchanged file-order read)", () => {
+    // Documents the behavior the Droid path keeps, and the bug this fixes.
+    const entries = parseSessionLog(rewoundLog());
+    const result = extractRecentRenderedMessages(entries, entries.length, 25);
+    expect(result[0].messageId).toBe("msg_orphan");
+  });
+
+  test("line numbers still point at real file positions", () => {
+    const entries = parseSessionLog(rewoundLog());
+    const result = extractRecentRenderedMessages(entries, entries.length, 25, {
+      branchIndices: resolveActiveBranchIndices(entries),
+    });
+    // msg_target is file line 2 (index 1), even though lines 3-4 were skipped.
+    expect(result[0].lineNumbers).toEqual([2]);
+  });
+
+  test("an untrustworthy chain degrades to the file-order read", () => {
+    // resolveActiveBranchIndices returns null here; passing it through must not
+    // filter everything out.
+    const log = [userPrompt("first"), assistantText("msg_1", "Response")].join("\n");
+    const entries = parseSessionLog(log);
+    const result = extractRecentRenderedMessages(entries, entries.length, 25, {
+      branchIndices: resolveActiveBranchIndices(entries),
+    });
+    expect(result.map((m) => m.messageId)).toEqual(["msg_1"]);
   });
 });
 

--- a/apps/hook/server/session-log.test.ts
+++ b/apps/hook/server/session-log.test.ts
@@ -14,6 +14,7 @@ import {
   findAnchorIndex,
   extractLastRenderedMessage,
   extractRecentRenderedMessages,
+  getRecentRenderedMessages,
   resolveActiveBranchIndices,
   findDroidSessionLogsForCwd,
   resolveDroidSessionLogForCwd,
@@ -918,6 +919,74 @@ describe("extractRecentRenderedMessages — after a rewind", () => {
       branchIndices: resolveActiveBranchIndices(entries),
     });
     expect(result.map((m) => m.messageId)).toEqual(["msg_1"]);
+  });
+});
+
+describe("getRecentRenderedMessages — after a /compact", () => {
+  // A compact boundary is written with `parentUuid: null`, so it is a tree
+  // root: the active branch stops there and pre-compaction entries are cut.
+  const compactedLog = () => {
+    const preCompact = linkChain([
+      userPrompt("early question"),
+      assistantText("msg_pre", "Pre-compaction answer"),
+    ]);
+    const boundary = JSON.stringify({
+      type: "system",
+      subtype: "compact_boundary",
+      uuid: "u-compact",
+      parentUuid: null,
+    });
+    const postPrompt = JSON.stringify({
+      type: "user",
+      message: { role: "user", content: "/plannotator-last" },
+      uuid: "u-after",
+      parentUuid: "u-compact",
+    });
+    return [...preCompact, boundary, postPrompt].join("\n");
+  };
+
+  test("the active branch stops at the compact boundary", () => {
+    const entries = parseSessionLog(compactedLog());
+    expect(resolveActiveBranchIndices(entries)).toEqual(new Set([2, 3]));
+  });
+
+  test("an empty active branch falls back to the file-order read", () => {
+    // Right after a compaction the branch holds no assistant messages. An
+    // empty result must not escape: callers treat it as "wrong log file" and
+    // walk off to an older session. Fail open to the file-order read instead.
+    const dir = join(tmpdir(), `plannotator-compact-test-${process.pid}`);
+    mkdirSync(dir, { recursive: true });
+    const logPath = join(dir, "session.jsonl");
+    try {
+      writeFileSync(logPath, compactedLog());
+      const result = getRecentRenderedMessages(logPath, 25, {
+        activeBranchOnly: true,
+      });
+      expect(result.map((m) => m.messageId)).toEqual(["msg_pre"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a post-compaction assistant message is preferred once one exists", () => {
+    // Once the compacted conversation has its own assistant message, the
+    // branch read stands on its own and the pre-compaction orphan stays out.
+    const log = [
+      compactedLog(),
+      linkChain([assistantText("msg_post", "Post-compaction answer")], "u-after").join("\n"),
+    ].join("\n");
+    const dir = join(tmpdir(), `plannotator-compact-test2-${process.pid}`);
+    mkdirSync(dir, { recursive: true });
+    const logPath = join(dir, "session.jsonl");
+    try {
+      writeFileSync(logPath, log);
+      const result = getRecentRenderedMessages(logPath, 25, {
+        activeBranchOnly: true,
+      });
+      expect(result.map((m) => m.messageId)).toEqual(["msg_post"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/apps/hook/server/session-log.ts
+++ b/apps/hook/server/session-log.ts
@@ -45,6 +45,10 @@ export function normalizeCwdForCompare(cwd: string): string {
 export interface SessionLogEntry {
   type: string;
   id?: string;
+  /** Entry identity. Bookkeeping types (`last-prompt`, `ai-title`, `mode`) have none. */
+  uuid?: string;
+  /** The entry this one follows. `null` on the root entry. */
+  parentUuid?: string | null;
   visibility?: string;
   message?: {
     id?: string;
@@ -715,13 +719,74 @@ export function getLastRenderedMessage(
 }
 
 /**
+ * Resolve the entries that are actually part of the live conversation.
+ *
+ * Claude Code's transcript is append-only and tree-shaped: every entry records
+ * the entry it follows in `parentUuid`. `/rewind` writes nothing at all — the
+ * next message simply re-parents to an earlier entry, orphaning everything
+ * that came after it. So file order and the live conversation diverge, and
+ * reading the file bottom-up returns messages the user can no longer see.
+ *
+ * Walks `parentUuid` from the newest entry that has a `uuid` back to the root.
+ * The newest entry is not necessarily the last line: bookkeeping types
+ * (`last-prompt`, `ai-title`, `mode`, `file-history-snapshot`) carry no ids and
+ * are frequently written last.
+ *
+ * Returns a set of indices into `entries`, so callers keep reporting real file
+ * positions. Returns null when the chain can't be trusted — no ids at all, or a
+ * walk that dead-ends instead of reaching the root — so callers can fall back
+ * to a linear scan rather than returning nothing. Measured against 311 local
+ * transcripts, every one reaches the root with no dangling parents or cycles.
+ */
+export function resolveActiveBranchIndices(
+  entries: SessionLogEntry[],
+): Set<number> | null {
+  const indexByUuid = new Map<string, number>();
+  let cursor = -1;
+  for (let i = 0; i < entries.length; i++) {
+    const uuid = entries[i]?.uuid;
+    if (typeof uuid === "string" && uuid) {
+      indexByUuid.set(uuid, i);
+      cursor = i;
+    }
+  }
+  if (cursor === -1) {
+    return null;
+  }
+
+  const branch = new Set<number>();
+  for (;;) {
+    // A cycle would spin forever; treat a revisit as an untrustworthy chain.
+    if (branch.has(cursor)) {
+      return null;
+    }
+    branch.add(cursor);
+
+    const parentUuid = entries[cursor]?.parentUuid;
+    if (parentUuid === null || parentUuid === undefined) {
+      return branch;
+    }
+    if (typeof parentUuid !== "string") {
+      return null;
+    }
+    const parentIndex = indexByUuid.get(parentUuid);
+    if (parentIndex === undefined) {
+      return null;
+    }
+    cursor = parentIndex;
+  }
+}
+
+/**
  * Extract up to `limit` of the most recent rendered assistant messages.
  *
  * Returned newest-first. Unlike `extractLastRenderedMessage`, this does not
  * stop at turn boundaries (human prompts) — picker UIs want a flat list of
- * recent assistant bubbles. Necessary for the rewind case: after `/rewind`,
- * the message at the bottom of the terminal isn't the newest transcript
- * entry, so the user needs to pick from a list.
+ * recent assistant bubbles.
+ *
+ * Pass `branchIndices` (from `resolveActiveBranchIndices`) to skip entries that
+ * a `/rewind` orphaned. Without it, entries are read in file order, which after
+ * a rewind includes messages no longer in the conversation.
  *
  * Chunks of a single API message (same message.id) are concatenated.
  */
@@ -729,8 +794,10 @@ export function extractRecentRenderedMessages(
   entries: SessionLogEntry[],
   beforeIndex: number,
   limit: number,
+  opts: { branchIndices?: Set<number> | null } = {},
 ): RenderedMessage[] {
   if (limit <= 0) return [];
+  const { branchIndices } = opts;
 
   // Map preserves insertion order — we walk backward, so first key inserted is
   // newest. Each bucket collects the chunks of one API message (same message.id).
@@ -742,6 +809,7 @@ export function extractRecentRenderedMessages(
   for (let i = beforeIndex - 1; i >= 0; i--) {
     const entry = entries[i];
     if (!entry) continue;
+    if (branchIndices && !branchIndices.has(i)) continue;
 
     if (entry.type === "progress" || entry.type === "system") continue;
     if (entry.type === "file-history-snapshot") continue;
@@ -778,15 +846,26 @@ export function extractRecentRenderedMessages(
 
 /**
  * High-level: read up to `limit` recent assistant messages from a session log.
+ *
+ * `activeBranchOnly` restricts the read to the live conversation branch, so a
+ * `/rewind` doesn't surface orphaned messages. Only meaningful for transcripts
+ * that carry `uuid`/`parentUuid` (Claude Code); an untrustworthy or absent
+ * chain silently degrades to a plain file-order read.
  */
 export function getRecentRenderedMessages(
   logPath: string,
   limit: number,
+  opts: { activeBranchOnly?: boolean } = {},
 ): RenderedMessage[] {
   try {
     const content = readFileSync(logPath, "utf-8");
     const entries = parseSessionLog(content);
-    return extractRecentRenderedMessages(entries, entries.length, limit);
+    const branchIndices = opts.activeBranchOnly
+      ? resolveActiveBranchIndices(entries)
+      : null;
+    return extractRecentRenderedMessages(entries, entries.length, limit, {
+      branchIndices,
+    });
   } catch {
     return [];
   }

--- a/apps/hook/server/session-log.ts
+++ b/apps/hook/server/session-log.ts
@@ -851,6 +851,13 @@ export function extractRecentRenderedMessages(
  * `/rewind` doesn't surface orphaned messages. Only meaningful for transcripts
  * that carry `uuid`/`parentUuid` (Claude Code); an untrustworthy or absent
  * chain silently degrades to a plain file-order read.
+ *
+ * A `/compact` boundary is also a tree root (`parentUuid: null`), so right
+ * after a compaction the active branch may contain no assistant messages at
+ * all. An empty filtered result falls back to the file-order read: callers
+ * treat "no messages" as "wrong log file" and would walk off to an older
+ * session, which is strictly worse than offering the pre-compaction messages
+ * the user just watched scroll by.
  */
 export function getRecentRenderedMessages(
   logPath: string,
@@ -863,9 +870,15 @@ export function getRecentRenderedMessages(
     const branchIndices = opts.activeBranchOnly
       ? resolveActiveBranchIndices(entries)
       : null;
-    return extractRecentRenderedMessages(entries, entries.length, limit, {
+    const messages = extractRecentRenderedMessages(entries, entries.length, limit, {
       branchIndices,
     });
+    if (messages.length === 0 && branchIndices) {
+      // Fail open, never fail empty: an empty active branch (fresh /compact)
+      // must not make this log look like the wrong file.
+      return extractRecentRenderedMessages(entries, entries.length, limit);
+    }
+    return messages;
   } catch {
     return [];
   }


### PR DESCRIPTION
## The bug

Claude Code session logs are append-only and tree-shaped. Every entry records the entry it follows in `parentUuid`, and `/rewind` writes nothing of its own: the next committed message simply re-parents to the rewind target, and every entry that followed that target stays in the file, permanently orphaned.

`extractRecentRenderedMessages` scanned bottom-up in file order, so orphaned messages continued to appear in the `annotate-last` message picker despite no longer being part of the conversation.

## The fix

`resolveActiveBranchIndices` walks `parentUuid` from the newest id-bearing entry back to the root.

- It returns indices rather than a filtered array, so callers continue to report real file line numbers (`lineNumbers` derives from the loop index).
- It returns `null` for any chain that cannot be trusted (no ids present, a dangling parent, a cycle), allowing callers to degrade to the previous file-order read rather than returning nothing.
- The newest entry is not necessarily the last line. `last-prompt`, `ai-title`, `mode` and `file-history-snapshot` carry no ids and are frequently written last.

The behavior is opted into at the Claude Code call site only. Droid's call site, Codex and Copilot (separate parsers), and Pi, OpenCode and Amp (live APIs, no transcript reads) are all unaffected. Both new parameters default to off.

## Scope of the behavior change

Verification against a corpus of real session logs showed every chain resolving cleanly to the root, with no dangling parents or cycles, and the default selection unchanged in every transcript containing a message.

The default not moving is expected rather than evidence that the change is inert. A committed rewind's new branch is always the newest region of the file, so file order and the tree already agree on the most recent message. The user-visible improvement is in the picker, which no longer offers messages that have left the conversation.

## Out of scope: the uncommitted rewind

This does not address the case of rewinding and then immediately running `/plannotator-last`, which cannot be fixed by reading alone. The skill invokes the binary through `` !`plannotator annotate-last $ARGUMENTS` ``, and Claude Code cannot write the invoking message until that command returns, because the message is incomplete until the substitution has been filled. At read time the rewind is therefore absent from disk entirely.

Session logs confirm the ordering: the invocation's transcript entry is timestamped well after the command has run and the annotate window has closed. A rewind that is never followed by a message also does not survive quitting and resuming the session, so no external process can observe one.

## Rationale for the current scope

Switching the skill from the substitution to a Bash-tool invocation would fix the default, since Claude Code writes the message before running tools. That was deliberately left out here: it alters every invocation rather than only rewinds, and it adds a model round-trip for a comparatively rare situation. Reading the tree correctly stands on its own as a bug fix, and it is the prerequisite in either design. With it in place, the rewind case can be covered by a personal skill that invokes `plannotator annotate-last` through the Bash tool, leaving shipped behavior unchanged for everyone else.

## Tests

Fixtures previously assigned random `parentUuid` values, which left every entry an orphan and made branch resolution untestable. `buildLog` now links fixture lines into a single chain, and `buildRewoundLog` models a fork. No existing assertion depends on id values.

New coverage: a linear log, a rewind, a tail carrying no id, a log with no ids at all, a dangling parent, a cycle, line-number preservation after filtering, and the fallback to a file-order read.
