### PR TITLE
fix(amp,droid): surface Approve-with-Notes feedback instead of dropping it

### DIFF
--- a/apps/amp-plugin/plannotator.test.ts
+++ b/apps/amp-plugin/plannotator.test.ts
@@ -63,6 +63,48 @@ describe("Amp Plannotator plugin helpers", () => {
     );
   });
 
+  // #1137: approved decisions carrying Approve-with-Notes feedback (#1092)
+  // were silently dropped — formatAnnotationFeedback returned null for
+  // anything that was not "annotated".
+  test("surfaces approved-with-notes feedback for message annotations", () => {
+    const result = formatAnnotationFeedback(
+      { decision: "approved", feedback: "Ship it, but rename the flag before GA." },
+      { kind: "message" },
+    );
+
+    expect(result).toBe(
+      "# Approved with Notes\n\nThe artifact is approved. The notes below are non-blocking guidance, not a request for another revision.\n\nShip it, but rename the flag before GA.\n\nDo not revise or reopen the artifact solely because of these notes unless the user explicitly requests it. Carry the notes into subsequent work where applicable.",
+    );
+  });
+
+  test("surfaces approved-with-notes feedback with the file context", () => {
+    const result = formatAnnotationFeedback(
+      { decision: "approved", feedback: "Fine as-is; consider splitting later." },
+      { kind: "file", filePath: "docs/plan.md" },
+    );
+
+    expect(result).toContain("# Approved with Notes");
+    expect(result).toContain("File: docs/plan.md\n\nFine as-is; consider splitting later.");
+  });
+
+  test("keeps note-less and dismissed decisions silent", () => {
+    expect(
+      formatAnnotationFeedback({ decision: "approved" }, { kind: "message" }),
+    ).toBeNull();
+    expect(
+      formatAnnotationFeedback(
+        { decision: "approved", feedback: "   " },
+        { kind: "message" },
+      ),
+    ).toBeNull();
+    expect(
+      formatAnnotationFeedback(
+        { decision: "dismissed", feedback: "should never surface" },
+        { kind: "message" },
+      ),
+    ).toBeNull();
+  });
+
   test("detects non-action outputs", () => {
     expect(isNoActionFeedback("Review session closed without feedback.")).toBe(true);
     expect(isNoActionFeedback("Code review completed — no changes requested.")).toBe(false);

--- a/apps/amp-plugin/plannotator.ts
+++ b/apps/amp-plugin/plannotator.ts
@@ -16,6 +16,10 @@ const DEFAULT_ANNOTATE_FILE_FEEDBACK_PROMPT =
   "# Markdown Annotations\n\n{{fileHeader}}: {{filePath}}\n\n{{feedback}}\n\nPlease address the annotation feedback above.";
 const DEFAULT_ANNOTATE_MESSAGE_FEEDBACK_PROMPT =
   "# Message Annotations\n\n{{feedback}}\n\nPlease address the annotation feedback above.";
+// Mirrors DEFAULT_ANNOTATE_APPROVED_WITH_NOTES_PROMPT in packages/shared/prompts.ts,
+// which this self-contained plugin cannot import. Keep the two in sync.
+const DEFAULT_ANNOTATE_APPROVED_WITH_NOTES_PROMPT =
+  "# Approved with Notes\n\nThe artifact is approved. The notes below are non-blocking guidance, not a request for another revision.\n\n{{contextBlock}}{{feedback}}\n\nDo not revise or reopen the artifact solely because of these notes unless the user explicitly requests it. Carry the notes into subsequent work where applicable.";
 
 type CommandContext = PluginCommandContext;
 type ReadyResult = "ready" | "exited" | "timeout";
@@ -198,12 +202,29 @@ export function formatAnnotationFeedback(
   decision: AnnotateDecision,
   options: { kind: "file"; filePath: string } | { kind: "message" },
 ): string | null {
-  if (decision.decision !== "annotated") return null;
+  // Approved-with-notes carries reviewer guidance in `feedback` (#1092); only
+  // dismissed decisions and note-less approvals have nothing to surface.
+  if (decision.decision !== "annotated" && decision.decision !== "approved") return null;
 
   const feedback = decision.feedback?.trim();
   if (!feedback || isNoActionFeedback(feedback)) return null;
 
   const config = loadPlannotatorConfig();
+
+  if (decision.decision === "approved") {
+    const template = getConfiguredPrompt(
+      config,
+      "approvedWithNotes",
+      DEFAULT_ANNOTATE_APPROVED_WITH_NOTES_PROMPT,
+    );
+    const context = options.kind === "file" ? `File: ${options.filePath}` : "";
+    return resolveTemplate(template, {
+      context,
+      contextBlock: context ? `${context}\n\n` : "",
+      feedback,
+    });
+  }
+
   if (options.kind === "file") {
     const template = getConfiguredPrompt(config, "fileFeedback", DEFAULT_ANNOTATE_FILE_FEEDBACK_PROMPT);
     return resolveTemplate(template, {
@@ -341,7 +362,14 @@ async function handleAnnotateResult(
 
   const decision = parseAnnotateDecision(result.stdout);
   if (decision?.decision === "approved") {
-    await ctx.ui.notify("Approved.");
+    // Approve-with-Notes (#1092): surface the reviewer's notes instead of
+    // silently dropping them. A note-less approval keeps the old behavior.
+    const feedback = formatAnnotationFeedback(decision, options);
+    if (feedback) {
+      await appendFeedback(ctx, feedback);
+    } else {
+      await ctx.ui.notify("Approved.");
+    }
     return;
   }
   if (decision?.decision === "dismissed") {
@@ -890,9 +918,11 @@ type PromptConfig = {
     annotate?: {
       fileFeedback?: unknown;
       messageFeedback?: unknown;
+      approvedWithNotes?: unknown;
       runtimes?: Partial<Record<typeof RUNTIME, {
         fileFeedback?: unknown;
         messageFeedback?: unknown;
+        approvedWithNotes?: unknown;
       }>>;
     };
   };
@@ -938,7 +968,7 @@ export function getPlannotatorDataDir(): string {
 
 function getConfiguredPrompt(
   config: PromptConfig,
-  key: "fileFeedback" | "messageFeedback",
+  key: "fileFeedback" | "messageFeedback" | "approvedWithNotes",
   fallback: string,
 ): string {
   const annotate = config.prompts?.annotate;

--- a/apps/droid-plugin/lib/run-plannotator.js
+++ b/apps/droid-plugin/lib/run-plannotator.js
@@ -90,7 +90,18 @@ function emitAnnotateDecision(rawOutput, heading) {
     const parsed = JSON.parse(output);
     if (parsed && typeof parsed === "object") {
       if (parsed.decision === "approved") {
-        process.stdout.write("Approved.\n");
+        // Approve-with-Notes (#1092): `approved` may carry reviewer notes in
+        // `feedback`. Only a note-less approval is a plain "Approved."
+        const feedback = typeof parsed.feedback === "string" ? parsed.feedback.trim() : "";
+        if (!feedback) {
+          process.stdout.write("Approved.\n");
+          return;
+        }
+        // Mirrors DEFAULT_ANNOTATE_APPROVED_WITH_NOTES_PROMPT in
+        // packages/shared/prompts.ts. Keep the two in sync.
+        process.stdout.write(
+          `# Approved with Notes\n\nThe artifact is approved. The notes below are non-blocking guidance, not a request for another revision.\n\n${feedback}\n\nDo not revise or reopen the artifact solely because of these notes unless the user explicitly requests it. Carry the notes into subsequent work where applicable.\n`,
+        );
         return;
       }
 

--- a/apps/droid-plugin/lib/run-plannotator.test.js
+++ b/apps/droid-plugin/lib/run-plannotator.test.js
@@ -1,0 +1,74 @@
+const { afterEach, beforeEach, describe, expect, test } = require("bun:test");
+const { emitAnnotateDecision } = require("./run-plannotator");
+
+// #1137: approved decisions carrying Approve-with-Notes feedback (#1092) were
+// collapsed to a bare "Approved." and the reviewer's notes were silently
+// dropped. These tests pin the full decision -> stdout contract.
+describe("emitAnnotateDecision", () => {
+  let written;
+  let originalWrite;
+
+  beforeEach(() => {
+    written = [];
+    originalWrite = process.stdout.write;
+    process.stdout.write = (chunk) => {
+      written.push(String(chunk));
+      return true;
+    };
+  });
+
+  afterEach(() => {
+    process.stdout.write = originalWrite;
+  });
+
+  const output = () => written.join("");
+
+  test("plain approval still prints Approved.", () => {
+    emitAnnotateDecision('{"decision":"approved"}', "Markdown Annotations");
+    expect(output()).toBe("Approved.\n");
+  });
+
+  test("approved-with-notes surfaces the feedback instead of dropping it", () => {
+    emitAnnotateDecision(
+      JSON.stringify({
+        decision: "approved",
+        feedback: "Ship it, but rename the flag before GA.",
+      }),
+      "Markdown Annotations",
+    );
+
+    expect(output()).toBe(
+      "# Approved with Notes\n\nThe artifact is approved. The notes below are non-blocking guidance, not a request for another revision.\n\nShip it, but rename the flag before GA.\n\nDo not revise or reopen the artifact solely because of these notes unless the user explicitly requests it. Carry the notes into subsequent work where applicable.\n",
+    );
+  });
+
+  test("approved with blank feedback prints Approved.", () => {
+    emitAnnotateDecision('{"decision":"approved","feedback":"   "}', "Markdown Annotations");
+    expect(output()).toBe("Approved.\n");
+  });
+
+  test("dismissed decision closes the session", () => {
+    emitAnnotateDecision('{"decision":"dismissed"}', "Markdown Annotations");
+    expect(output()).toBe("Annotation session closed.\n");
+  });
+
+  test("annotated decision wraps feedback under the heading", () => {
+    emitAnnotateDecision(
+      '{"decision":"annotated","feedback":"Comment: tighten this section."}',
+      "Markdown Annotations",
+    );
+    expect(output()).toBe(
+      "# Markdown Annotations\n\nComment: tighten this section.\n\nPlease address the annotation feedback above.\n",
+    );
+  });
+
+  test("empty output closes the session", () => {
+    emitAnnotateDecision("", "Markdown Annotations");
+    expect(output()).toBe("Annotation session closed.\n");
+  });
+
+  test("non-JSON output falls back to raw passthrough", () => {
+    emitAnnotateDecision("plain text feedback", "Markdown Annotations");
+    expect(output()).toBe("plain text feedback\n");
+  });
+});


### PR DESCRIPTION
Fixes #1137 — Amp and Droid collapsed every `decision: "approved"` to a bare "Approved.", silently dropping the `feedback` field that Approve with Notes (#1092) attaches.

## Root cause

There were actually **three** drop sites, one more than the issue lists:

1. `apps/droid-plugin/lib/run-plannotator.js` — `emitAnnotateDecision`'s approved branch printed `"Approved.\n"` and returned, never reading `parsed.feedback` (the `annotated` branch right below it handles feedback properly).
2. `apps/amp-plugin/plannotator.ts` — `formatAnnotationFeedback` opened with `if (decision.decision !== "annotated") return null;`, so approved decisions could never format.
3. `apps/amp-plugin/plannotator.ts` — `handleAnnotateResult` **also** early-returned `ctx.ui.notify("Approved.")` before `formatAnnotationFeedback` was ever called, so fixing (2) alone would not have fixed Amp.

## Change

Both adapters now surface approved-with-notes feedback using the same prompt text as `DEFAULT_ANNOTATE_APPROVED_WITH_NOTES_PROMPT` in `packages/shared/prompts.ts` (the wording the OpenCode and Pi adapters already emit via `getAnnotateApprovedWithNotesPrompt`). Since the Amp plugin and the Droid `lib/` are self-contained and don't import `packages/shared`, the text is mirrored locally with a keep-in-sync comment, the same pattern the Amp plugin already uses for its `fileFeedback` / `messageFeedback` defaults.

- **Amp**: `formatAnnotationFeedback` handles `approved` + feedback (file annotations get a `File: <path>` context line, matching `buildAnnotatePromptFromBridgeOutcome` in the OpenCode adapter); `handleAnnotateResult` appends the formatted notes to the thread, and only note-less approvals keep the plain `"Approved."` notify. The config override key is `approvedWithNotes` under `prompts.annotate` (and `prompts.annotate.runtimes.amp`), matching the shared prompt config shape.
- **Droid**: `emitAnnotateDecision` emits the approved-with-notes block when feedback is present; blank/absent feedback still prints `"Approved.\n"`.

Deliberately preserved: `dismissed` stays silent even if a `feedback` field is somehow present, and raw-output fallback for non-JSON stdout is untouched.

## Tests

- Amp (`plannotator.test.ts`, +3): message-kind approved-with-notes formats the full prompt; file-kind includes the `File:` context; note-less / blank / dismissed all stay `null`.
- Droid (`run-plannotator.test.js`, **new file**, 7 tests): pins the whole decision→stdout contract — plain approved, approved-with-notes, blank-feedback approved, dismissed, annotated, empty output, non-JSON passthrough.

## Verification (Windows, bun 1.3.13)

```
# with the fix
bun test apps/amp-plugin/plannotator.test.ts apps/droid-plugin/lib/run-plannotator.test.js
  27 pass, 0 fail   (17 pre-existing + 3 new amp + 7 new droid)

# negative control: revert ONLY the two source files, keep the tests
  24 pass, 3 fail   (exactly the three approved-with-notes tests)
```

Full `bun test` on this branch: **2283 pass / 72 fail / 14 errors** across 225 files, vs pristine `main` on the same machine: **2274 pass / 71 fail / 14 errors** across 224 files — the delta is exactly the 10 added tests (9 pass; the one extra "fail", `commit-history.test.ts` "pages with before and reports hasMore honestly", is unrelated to these files and **passes in isolation** on this branch, so it appears load-flaky on this box). The ~71 baseline failures are pre-existing Windows-environment failures (workspace/symlink-heavy suites), identical either side.

`bun run typecheck` doesn't cover `apps/amp-plugin` (no tsconfig there and it's not in the script's project list), so as a proxy I ran the same standalone `tsc --strict` invocation over `plannotator.ts` on both pristine and this branch: **37 errors both sides, byte-identical sets** (all pre-existing module-resolution noise from checking the file outside its build context — nothing introduced).

Not verified live: I don't have Amp or Droid (Factory) installed, so this is exercised through the exported helpers/unit contract rather than an end-to-end annotate session.
