### PR TITLE
feat(ai): add Claude Opus 5 and Fable 5 across providers and review agents

### DIFF
--- a/apps/marketing/src/content/docs/guides/ai-features.md
+++ b/apps/marketing/src/content/docs/guides/ai-features.md
@@ -18,9 +18,18 @@ Requires the `claude` CLI installed and authenticated. Uses Claude Code's full s
 
 **Models:**
 
-- Sonnet 4.6 (default)
+- Sonnet 5 (default)
+- Fable 5
+- Opus 5
+- Opus 4.8
+- Sonnet 4.6
+- Opus 4.7
 - Opus 4.6
 - Haiku 4.5
+
+Opus 4.8, Opus 4.7, Opus 4.6, and Sonnet 4.6 are also offered in `(1M)` context
+variants. The 5-series models use their 1M context window by default, so they
+have no separate variant.
 
 ### Codex (via Codex SDK)
 

--- a/packages/ai/ai.test.ts
+++ b/packages/ai/ai.test.ts
@@ -888,6 +888,32 @@ describe("resolveSDKModel", () => {
     expect(resolveSDKModel("claude-sonnet-4-6[1m]", bedrockEnv)).toBe(SONNET_ARN);
   });
 
+  // Opus 5 is a bare alias like every other picker entry: it must NOT be
+  // mistaken for a cloud identifier (no `arn:` / `anthropic.` prefix), and the
+  // family matcher must still route it to the configured Opus ARN on
+  // Bedrock/Vertex. A matcher that keyed on "opus-4" would silently drop it.
+  test("maps the bare Opus 5 alias to the configured Opus ARN", () => {
+    expect(resolveSDKModel("claude-opus-5", bedrockEnv)).toBe(OPUS_ARN);
+    expect(
+      resolveSDKModel("claude-opus-5", {
+        CLAUDE_CODE_USE_VERTEX: "true",
+        ANTHROPIC_DEFAULT_OPUS_MODEL: OPUS_ARN,
+      }),
+    ).toBe(OPUS_ARN);
+  });
+
+  test("off Bedrock/Vertex: returns the Opus 5 alias unchanged", () => {
+    expect(resolveSDKModel("claude-opus-5", {})).toBe("claude-opus-5");
+  });
+
+  // Fable has no ANTHROPIC_DEFAULT_*_MODEL env var of its own (Claude Code
+  // only defines OPUS/SONNET/HAIKU), so on Bedrock it falls through to
+  // ANTHROPIC_MODEL rather than matching a family. Pinned so the fallthrough
+  // stays deliberate rather than looking like a missed family branch.
+  test("falls back to ANTHROPIC_MODEL for the Fable alias on Bedrock", () => {
+    expect(resolveSDKModel("claude-fable-5", bedrockEnv)).toBe(OPUS_ARN);
+  });
+
   test("passes through an identifier that is already an ARN", () => {
     expect(resolveSDKModel(SONNET_ARN, bedrockEnv)).toBe(SONNET_ARN);
   });

--- a/packages/ai/providers/claude-agent-sdk.ts
+++ b/packages/ai/providers/claude-agent-sdk.ts
@@ -165,6 +165,7 @@ export class ClaudeAgentSDKProvider implements AIProvider {
   };
   readonly models = [
     { id: 'claude-fable-5', label: 'Fable 5' },
+    { id: 'claude-opus-5', label: 'Opus 5' },
     { id: 'claude-opus-4-8', label: 'Opus 4.8' },
     { id: 'claude-opus-4-8[1m]', label: 'Opus 4.8 (1M)' },
     { id: 'claude-sonnet-5', label: 'Sonnet 5', default: true },

--- a/packages/server/agent-review-message.test.ts
+++ b/packages/server/agent-review-message.test.ts
@@ -286,6 +286,16 @@ describe("getLocalDiffInstruction", () => {
 });
 
 describe("buildClaudeCommand", () => {
+  test("defaults to Opus 5 when the caller passes no model", () => {
+    const command = buildClaudeCommand("review").command;
+    expect(command[command.indexOf("--model") + 1]).toBe("claude-opus-5");
+  });
+
+  test("still honours an explicitly requested model", () => {
+    const command = buildClaudeCommand("review", "claude-sonnet-5").command;
+    expect(command[command.indexOf("--model") + 1]).toBe("claude-sonnet-5");
+  });
+
   test("allows read-only JJ commands", () => {
     const command = buildClaudeCommand("review").command;
     const allowedTools = command[command.indexOf("--allowedTools") + 1];

--- a/packages/server/claude-review.ts
+++ b/packages/server/claude-review.ts
@@ -217,7 +217,7 @@ export interface ClaudeCommandResult {
  * Build the `claude -p` command. Prompt is passed via stdin, not as a
  * positional arg — avoids quoting issues, argv limits, and variadic flag conflicts.
  */
-export function buildClaudeCommand(prompt: string, model: string = "claude-opus-4-7", effort?: string): ClaudeCommandResult {
+export function buildClaudeCommand(prompt: string, model: string = "claude-opus-5", effort?: string): ClaudeCommandResult {
   const allowedTools = [
     "Agent", "Read", "Glob", "Grep",
     // GitHub CLI

--- a/packages/ui/components/AgentsTab.test.ts
+++ b/packages/ui/components/AgentsTab.test.ts
@@ -1,7 +1,34 @@
 import { describe, expect, test } from "bun:test";
-import { CODEX_MODELS, codexReasoningOptions } from "./AgentsTab";
+import { CLAUDE_MODELS, CODEX_MODELS, TOUR_CLAUDE_MODELS, codexReasoningOptions } from "./AgentsTab";
 
 const catalogEntry = (value: string) => CODEX_MODELS.find((m) => m.value === value);
+
+describe("CLAUDE_MODELS catalog", () => {
+  test("offers the current 5-series flagships", () => {
+    for (const value of ["claude-fable-5", "claude-opus-5", "claude-sonnet-5"]) {
+      expect(CLAUDE_MODELS.some((m) => m.value === value)).toBe(true);
+    }
+    expect(CLAUDE_MODELS.find((m) => m.value === "claude-opus-5")?.label).toBe("Opus 5");
+  });
+
+  // The 5-series models are 1M-context by default, so they carry no `[1m]`
+  // variant — that suffix exists only to opt the older 4.x models into the
+  // larger window. Pinned so a future entry doesn't invent `claude-opus-5[1m]`.
+  test("5-series entries have no [1m] context variant", () => {
+    for (const { value } of CLAUDE_MODELS) {
+      if (/-5(\[|$)/.test(value)) expect(value).not.toContain("[1m]");
+    }
+  });
+
+  test("tour/guide catalog inherits every review model plus the latest aliases", () => {
+    for (const { value } of CLAUDE_MODELS) {
+      expect(TOUR_CLAUDE_MODELS.some((m) => m.value === value)).toBe(true);
+    }
+    for (const alias of ["sonnet", "opus", "fable"]) {
+      expect(TOUR_CLAUDE_MODELS.some((m) => m.value === alias)).toBe(true);
+    }
+  });
+});
 
 test("uses the canonical GPT-5.6 Sol model ID", () => {
   expect(catalogEntry("gpt-5.6-sol")?.label).toBe("GPT-5.6 Sol");

--- a/packages/ui/components/AgentsTab.tsx
+++ b/packages/ui/components/AgentsTab.tsx
@@ -30,6 +30,7 @@ export type { AgentLaunchParams } from '../hooks/useAgentJobs';
 
 export const CLAUDE_MODELS: Array<{ value: string; label: string }> = [
   { value: 'claude-fable-5', label: 'Fable 5' },
+  { value: 'claude-opus-5', label: 'Opus 5' },
   { value: 'claude-opus-4-8', label: 'Opus 4.8' },
   { value: 'claude-opus-4-8[1m]', label: 'Opus 4.8 (1M)' },
   { value: 'claude-sonnet-5', label: 'Sonnet 5' },

--- a/packages/ui/hooks/useAgentSettings.ts
+++ b/packages/ui/hooks/useAgentSettings.ts
@@ -16,7 +16,7 @@ const COOKIE_KEY = 'plannotator.agents';
 // would clobber writes exactly like before.
 const settingsListeners = new Set<(s: AgentSettingsState) => void>();
 
-export const DEFAULT_CLAUDE_MODEL = 'claude-opus-4-7';
+export const DEFAULT_CLAUDE_MODEL = 'claude-opus-5';
 export const DEFAULT_CLAUDE_EFFORT = 'high';
 // gpt-5.3-codex is deprecated (ChatGPT-account Codex rejects it outright) —
 // default to the current flagship everywhere.


### PR DESCRIPTION
## What this adds

`claude-opus-5` ("Opus 5") in both static Claude model catalogs:

| File | Surface |
|---|---|
| `packages/ai/providers/claude-agent-sdk.ts` | Ask AI model picker |
| `packages/ui/components/AgentsTab.tsx` (`CLAUDE_MODELS`) | Review-agent picker — `TOUR_CLAUDE_MODELS` spreads it, so Code Tour and Guided Review inherit it |

**Fable 5 was already present** in both lists, so this PR only adds Opus 5. Nothing else was needed for guides/tours/marker review: those pass the picked model straight through to the CLI and there is no server-side model allowlist anywhere in the repo.

### No `claude-opus-5[1m]` variant

The `[1m]` suffix exists to opt the **4.x** models into the larger context window. The 5-series models are 1M by default, which is why the existing `claude-fable-5` and `claude-sonnet-5` entries carry no variant either. Adding one would have been the odd entry out. `AgentsTab.test.ts` now pins that invariant so a future entry doesn't invent one.

### Matcher verification

`resolveSDKModel` (the Bedrock/Vertex mapper) matches on the substring `"opus"`, so `claude-opus-5` routes to `ANTHROPIC_DEFAULT_OPUS_MODEL` correctly — but a matcher keyed on `"opus-4"` would have silently dropped it, so there are now tests for the bare alias on both Bedrock and Vertex, plus off-cloud passthrough. Also pinned the pre-existing Fable fallthrough (Claude Code defines only `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL`, so Fable falls back to `ANTHROPIC_MODEL` — deliberate, not a missed branch).

## ⚠️ Behavior change — commit 2, revert if unwanted

**`c1442797` bumps the Claude review-agent default from `claude-opus-4-7` to `claude-opus-5`** in two places: `DEFAULT_CLAUDE_MODEL` (`useAgentSettings.ts`) and `buildClaudeCommand`'s default parameter (`claude-review.ts`).

Users with a saved cookie pick are unaffected; users who never picked move from Opus 4.7 to Opus 5. It's isolated in its own commit — `git revert c1442797` drops it and leaves the new models as options only.

**Not changed, deliberately:** Ask AI's `DEFAULT_MODEL` (already `claude-sonnet-5`), and the tour/guide Claude defaults (the `sonnet` latest-resolving alias) — those are latency-sensitive interactive surfaces where the cheaper tier is intentional.

## Two-runtime law

`claude-agent-sdk.ts`, `claude-review.ts`, and `marker-review.ts` are all **auto-vendored** into the Pi extension by `apps/pi-extension/vendor.sh` (which `bun run typecheck` invokes). `apps/pi-extension/generated/` is gitignored, so there is nothing to hand-mirror. Verified the vendored copy carries the new entry and that `apps/pi-extension` tests pass.

## Tests

| Suite | Result |
|---|---|
| `bun run typecheck` (incl. vendor.sh + pi-extension) | pass |
| `bun test packages/ai packages/ui packages/server` | 1015 pass / 0 fail |
| `bun test apps/pi-extension` | 137 pass / 0 fail |

<details>
<summary><b>Part A — full hardcoded-model-slug inventory (click to expand)</b></summary>

Swept `packages/`, `apps/`, `tests/`, marketing content and skills for every provider's slugs (`claude-*`, `gpt-*`, `o3/o4-*`, `gemini-*`, cursor/copilot/pi/opencode patterns), excluding `node_modules` and `dist`. **173 matching lines across 18 files.** No `gemini-*`, `o3/o4-*`, `grok`, `deepseek`, or `qwen` slugs exist anywhere in the repo.

### Sources of truth

| Provider | Single source of truth | Flows to |
|---|---|---|
| Claude — Ask AI | `packages/ai/providers/claude-agent-sdk.ts` → `models` array | `/api/ai/capabilities` → UI picker |
| Claude — review agents | `packages/ui/components/AgentsTab.tsx` → `CLAUDE_MODELS` | `TOUR_CLAUDE_MODELS` (tour + guide), `GuideEmptyState.tsx` |
| Codex | `packages/ui/utils/codexModels.ts` → `CODEX_MODELS` | re-exported through `AgentsTab.tsx`; efforts clamped in `useAgentSettings.ts` |
| Codex — Ask AI | `packages/ai/providers/codex-app-server.ts` → `models` array | `/api/ai/capabilities` |
| Cursor / Copilot / OpenCode / Pi | **none — discovered at runtime** (`agent models`, `copilot help config`, `opencode models`, Pi RPC) | capability payload; UI consts are fallbacks only |

There is **no server-side model allowlist** — model strings pass through to the spawned CLI verbatim. Adding a picker entry is therefore sufficient to make a model launchable everywhere.

### Claude slugs

| File:line | Slug | Role | Staleness |
|---|---|---|---|
| `packages/ai/providers/claude-agent-sdk.ts:58` | `claude-sonnet-5` | Ask AI default | current |
| `…claude-agent-sdk.ts:167-178` | fable-5, **opus-5 (added)**, opus-4-8(+1m), sonnet-5, sonnet-4-6(+1m), opus-4-7(+1m), opus-4-6(+1m), haiku-4-5 | picker entries | topped out at Opus 4.8 before this PR |
| `packages/ui/components/AgentsTab.tsx:32-42` | same set | picker entries | same |
| `packages/ui/hooks/useAgentSettings.ts:19` | `claude-opus-4-7` → **`claude-opus-5`** | review default | **was 2 generations stale** |
| `packages/server/claude-review.ts:220` | `claude-opus-4-7` → **`claude-opus-5`** | server default param | **was 2 generations stale** |
| `useAgentSettings.ts:26,32` | `sonnet` | tour/guide default (latest-resolving alias) | self-updating |
| `packages/server/marker-review.ts:780-781` | `claude-sonnet-5`, `gpt-5.5` | docstring example of `copilot help config` output | current |
| `packages/server/marker-review.test.ts:152-237` | `claude-sonnet-5`, `claude-opus-4-8-thinking-high` | copilot fixtures | fine — fixtures, not a catalog |
| `packages/ai/ai.test.ts:860-921` | sonnet-4-6, opus-4-8[1m], haiku-4-5, sonnet-4-5 ARNs | Bedrock ARN fixtures | fine — arbitrary ARN strings |
| `packages/ai/providers/pi-sdk.ts:293` | `anthropic/claude-haiku-4-5` | docstring format example | fine |

### Non-Claude slugs

| File:line | Slug(s) | Role | Staleness |
|---|---|---|---|
| `packages/ai/providers/codex-app-server.ts:48,530` | `gpt-5.6-sol` | Ask AI Codex default + only entry | current |
| `packages/ui/utils/codexModels.ts:32-46` | gpt-5.6-{sol,terra,luna}, 5.5, 5.4, 5.3-codex-spark, 5.2, 5.4-mini | Codex catalog | current; retirements documented inline |
| `useAgentSettings.ts:23,28,36` | `gpt-5.5` | Codex review/tour/guide defaults | current |
| `useAgentSettings.ts:206-215` | `gpt-5.6`→`gpt-5.6-sol`, `gpt-5.1-codex-mini`→`gpt-5.4-mini`; retired set | migration maps | current, actively maintained |
| `packages/server/marker-review.test.ts:88-126` | `gpt-5` | cursor `--model` fixture | fine — arbitrary string |
| `packages/server/fixtures/pi-insufficient-credits.ndjson` | `openai/gpt-5.5` | Pi error-stream fixture | fine |
| `tests/manual/local/*.sh:27,68,37` | `gpt-5.4-mini` | manual e2e script default | slightly stale, not shipped |

### Stale slugs found in docs (the riskiest items)

| File:line | Slug | Assessment |
|---|---|---|
| `apps/marketing/…/guides/ai-features.md:21-23` | Sonnet 4.6 / Opus 4.6 / Haiku 4.5 | **Riskiest — public-facing and 3 generations stale.** Predated Fable 5, Sonnet 5, Opus 4.7, Opus 4.8. **Fixed in this PR.** |
| `apps/marketing/…/guides/ai-features.md:31-36` | GPT-5.4 (default), 5.3 Codex, 5.2 Codex | **Stale** — the real default is `gpt-5.5`, and 5.3-codex/5.2-codex are retired. **Not fixed** — out of scope for a Claude PR; worth a follow-up. |
| `apps/marketing/…/reference/api-endpoints.md:53` | `claude-3-5-sonnet` | **Retired model (Oct 2025)** in a public API example. It's an `agentSwitch` JSON example, not a model catalog, so left alone — flagging for a docs pass. |
| `apps/pi-extension/README.md:101,116` + `config.test.ts:146` | `claude-sonnet-4-5` | Pi's own agent-config example, unrelated to Plannotator's pickers. Correctly left alone. |

### Checked and found to need nothing

- **Fast mode** is Codex-only in Plannotator (`fastMode` is only ever set from `codexFast`). There is no Claude fast-mode toggle to extend to Opus 5/4.8/4.7, so nothing to gate.
- **Guide / tour / marker review** carry no model catalogs — they take the model from settings and forward it.
- **Cursor / Copilot / OpenCode / Pi** catalogs are runtime-discovered; their in-repo consts are `Default`-only fallbacks.
- `packages/ui/utils/codexModels.ts` effort clamping is per-Codex-model and unaffected.

</details>
