### PR TITLE
fix(ui): focus and select existing review search text

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,7 @@ jobs:
           packages/ui/components/MarkdownEditor.extensions.test.tsx
           packages/ui/components/sidebar/FileBrowser.test.ts
           packages/editor/editableDocumentsHook.test.tsx
+          packages/review-editor/hooks/useReviewSearch.test.tsx
           packages/ui/components/AnnotationPanel.props.test.tsx
           packages/ui/components/Viewer.consumer.test.tsx
           packages/ui/components/InlineMarkdown.seam.test.tsx

--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -34,7 +34,12 @@ import { useAIChat } from './hooks/useAIChat';
 import { toast, Toaster } from 'sonner';
 import { useCodeNav, type CodeNavRequest } from './hooks/useCodeNav';
 import { extractLinesFromPatch } from './utils/patchParser';
-import { isTypingTarget, useReviewSearch, type ReviewSearchMatch } from './hooks/useReviewSearch';
+import {
+  shouldHandleReviewSearchShortcut,
+  isTypingTarget,
+  useReviewSearch,
+  type ReviewSearchMatch,
+} from './hooks/useReviewSearch';
 import { useEditorAnnotations } from '@plannotator/ui/hooks/useEditorAnnotations';
 import { useExternalAnnotations } from '@plannotator/ui/hooks/useExternalAnnotations';
 import { useAgentJobs, jobMatchesReviewContext } from '@plannotator/ui/hooks/useAgentJobs';
@@ -1193,7 +1198,13 @@ const ReviewApp: React.FC = () => {
       // Bail while the guide takeover is open (file tree isn't rendered) and
       // don't intercept in the Commits view (its rail has no search input) —
       // in both cases capturing the key would mutate hidden state or no-op.
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'f' && !isTypingTarget(e.target)) {
+      // Let the same shortcut reselect the current query when search already
+      // has focus, while preserving native shortcuts in every other input.
+      if (
+        (e.metaKey || e.ctrlKey)
+        && e.key.toLowerCase() === 'f'
+        && shouldHandleReviewSearchShortcut(e.target, searchInputRef.current)
+      ) {
         if (guideOpen) return;
         if (hasSearchableFiles && !showCommitsPanel) {
           e.preventDefault();

--- a/packages/review-editor/hooks/useReviewSearch.test.tsx
+++ b/packages/review-editor/hooks/useReviewSearch.test.tsx
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  shouldHandleReviewSearchShortcut,
+  useReviewSearch,
+  type UseReviewSearchResult,
+} from './useReviewSearch';
+
+const hasDom = typeof document !== 'undefined';
+
+let host: HTMLDivElement | null = null;
+let root: Root | null = null;
+let latest: UseReviewSearchResult | null = null;
+
+function Harness() {
+  const search = useReviewSearch({
+    files: [],
+    activeFilePath: null,
+  });
+  latest = search;
+
+  return (
+    <input
+      ref={search.searchInputRef}
+      value={search.searchQuery}
+      onChange={event => search.handleSearchInputChange(event.target.value)}
+    />
+  );
+}
+
+async function mountHarness(): Promise<HTMLInputElement> {
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  root = createRoot(host);
+
+  await act(async () => {
+    root!.render(<Harness />);
+  });
+
+  const input = host.querySelector('input');
+  if (!input) throw new Error('search input did not render');
+  return input;
+}
+
+async function openSearch(): Promise<void> {
+  await act(async () => {
+    latest!.openSearch();
+    await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+  });
+}
+
+function fakeElement(tagName: string, isContentEditable = false): HTMLElement {
+  return { tagName, isContentEditable } as HTMLElement;
+}
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => {
+      root!.unmount();
+    });
+  }
+  host?.remove();
+  host = null;
+  root = null;
+  latest = null;
+});
+
+describe('useReviewSearch', () => {
+  test('handles shortcuts outside editable controls and inside the review search input', () => {
+    const searchInput = fakeElement('INPUT') as HTMLInputElement;
+
+    expect(shouldHandleReviewSearchShortcut(searchInput, searchInput)).toBe(true);
+    expect(shouldHandleReviewSearchShortcut(fakeElement('INPUT'), searchInput)).toBe(false);
+    expect(shouldHandleReviewSearchShortcut(fakeElement('TEXTAREA'), searchInput)).toBe(false);
+    expect(shouldHandleReviewSearchShortcut(fakeElement('DIV', true), searchInput)).toBe(false);
+    expect(shouldHandleReviewSearchShortcut(fakeElement('DIV'), searchInput)).toBe(true);
+  });
+
+  test.skipIf(!hasDom)('selects the existing query whenever search is opened again', async () => {
+    const input = await mountHarness();
+
+    await act(async () => {
+      latest!.handleSearchInputChange('firstFunction');
+    });
+
+    input.blur();
+    input.setSelectionRange(input.value.length, input.value.length);
+    await openSearch();
+
+    expect(document.activeElement).toBe(input);
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(input.value.length);
+
+    input.setSelectionRange(input.value.length, input.value.length);
+    await openSearch();
+
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(input.value.length);
+  });
+});

--- a/packages/review-editor/hooks/useReviewSearch.ts
+++ b/packages/review-editor/hooks/useReviewSearch.ts
@@ -20,6 +20,13 @@ export function isTypingTarget(target: EventTarget | null): boolean {
   return tagName === 'INPUT' || tagName === 'TEXTAREA' || element.isContentEditable;
 }
 
+export function shouldHandleReviewSearchShortcut(
+  target: EventTarget | null,
+  searchInput: HTMLInputElement | null,
+): boolean {
+  return !isTypingTarget(target) || target === searchInput;
+}
+
 interface UseReviewSearchOptions {
   files: ReviewSearchableDiffFile[];
   activeFilePath: string | null;
@@ -72,7 +79,12 @@ export function useReviewSearch({
 
   const openSearch = useCallback(() => {
     setIsSearchOpen(true);
-    requestAnimationFrame(() => searchInputRef.current?.focus());
+    requestAnimationFrame(() => {
+      const input = searchInputRef.current;
+      if (!input) return;
+      input.focus();
+      input.select();
+    });
   }, []);
 
   const closeSearch = useCallback(() => {


### PR DESCRIPTION
## Context

   A common workflow while reviewing a diff is:

   1. Notice a function, type, or variable that needs more context.
   2. Double click, copy its name.
   3. Press Cmd/Ctrl+F to open the review search.
   4. Paste the name and press Enter.
   5. Inspect its definition and usages, open a result, and continue reviewing.
   6. Repeat the same flow for the next symbol.

   The first search works naturally because the search field starts empty. After that, the previous query remains in the
 field. When Cmd/Ctrl+F is used again, the caret is at the end of the existing query, instead of selecting the entire text. Pasting another symbol can therefore append it to the previous query instead of replacing it.
 
See example below:

<img width="800" height="503" alt="CleanShot 2026-07-29 at 21 45 52" src="https://github.com/user-attachments/assets/5717b6a5-2e31-4676-90a6-32c94b4db33a" />

   ## Expected behavior

   Reopening search with Cmd/Ctrl+F should select the existing query so the next typed or pasted symbol replaces it immediately. Browsers, editors, IDEs, etc. do this.

<img width="800" height="528" alt="CleanShot 2026-07-29 at 21 49 22" src="https://github.com/user-attachments/assets/fb5a4058-b6d0-4ec3-8520-39fe5414156b" />

   ## Changes

   - Allow the review search shortcut when focus is already inside the review search input.
   - Continue preserving native Cmd/Ctrl+F behavior in every other input, textarea, and content-editable element.
   - Focus and select the complete existing query whenever review search is opened.
   - Add regression coverage for:
     - handling the shortcut outside editable controls;
     - handling it inside the review search input;
     - selecting the existing query on every search opening.
   - Include the new DOM regression test in CI.

   ## Scope

   This does not change search matching, indexing, result navigation, or shortcut availability. Existing guards for views without review search remain unchanged.

   ## Testing

   - TypeScript typecheck suite
   - `DOM_TESTS=1 bun test packages/review-editor/hooks/useReviewSearch.test.tsx`