### PR TITLE
feat(review): add Cmd/Ctrl+Shift+Y shortcut to copy feedback

### DIFF
--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -2842,6 +2842,27 @@ const ReviewApp: React.FC = () => {
     handleApprove, handleSendFeedback, handlePlatformAction
   ]);
 
+  // Cmd/Ctrl+Shift+Y keyboard shortcut to copy feedback, mirroring the
+  // Copy Feedback button in the header and the review sidebar.
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key.toLowerCase() !== 'y' || !(e.metaKey || e.ctrlKey) || !e.shiftKey) return;
+
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+      if (platformCommentDialog || showExportModal || showNoAnnotationsDialog || showApproveWarning || showExitWarning) return;
+
+      e.preventDefault();
+      handleCopyFeedback();
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [
+    platformCommentDialog, showExportModal, showNoAnnotationsDialog, showApproveWarning, showExitWarning,
+    handleCopyFeedback
+  ]);
+
   if (isLoading) {
     return (
       <ThemeProvider defaultTheme="dark">

--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -2525,10 +2525,12 @@ const ReviewApp: React.FC = () => {
     if (await copyTextToClipboard(feedbackMarkdown)) {
       setCopyFeedback('Feedback copied!');
       setTimeout(() => setCopyFeedback(null), 2000);
+      toast.success('Feedback copied');
     } else {
       console.error('Failed to copy');
       setCopyFeedback('Failed to copy');
       setTimeout(() => setCopyFeedback(null), 2000);
+      toast.error('Failed to copy');
     }
   }, [totalAnnotationCount, feedbackMarkdown]);
 
@@ -2843,13 +2845,11 @@ const ReviewApp: React.FC = () => {
   ]);
 
   // Cmd/Ctrl+Shift+Y keyboard shortcut to copy feedback, mirroring the
-  // Copy Feedback button in the header and the review sidebar.
+  // Copy Feedback button in the header.
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key.toLowerCase() !== 'y' || !(e.metaKey || e.ctrlKey) || !e.shiftKey) return;
+      if (!(e.metaKey || e.ctrlKey) || !e.shiftKey || e.altKey || e.key.toLowerCase() !== 'y' || isTypingTarget(e.target)) return;
 
-      const tag = (e.target as HTMLElement)?.tagName;
-      if (tag === 'INPUT' || tag === 'TEXTAREA') return;
       if (platformCommentDialog || showExportModal || showNoAnnotationsDialog || showApproveWarning || showExitWarning) return;
 
       e.preventDefault();

--- a/packages/review-editor/shortcuts.ts
+++ b/packages/review-editor/shortcuts.ts
@@ -23,6 +23,12 @@ export const reviewEditorShortcuts = defineShortcutScope({
       section: 'Actions',
       displayOrder: 10,
     },
+    copyFeedback: {
+      description: 'Copy feedback to clipboard',
+      bindings: ['Mod+Shift+Y'],
+      section: 'Actions',
+      displayOrder: 20,
+    },
     focusSearch: {
       description: 'Focus search',
       bindings: ['Mod+F'],

--- a/packages/ui/components/KeyboardShortcuts.tsx
+++ b/packages/ui/components/KeyboardShortcuts.tsx
@@ -175,6 +175,7 @@ const reviewShortcuts: ShortcutSection[] = [
     title: 'Actions',
     shortcuts: [
       { keys: [modKey, enter], desc: 'Approve / Send feedback' },
+      { keys: [modKey, shiftKey, 'Y'], desc: 'Copy feedback', hint: 'Copies the same feedback that gets submitted' },
       { keys: [altKey, altKey], desc: 'Toggle destination', hint: 'Double-tap to switch between GitHub and Agent in PR review mode' },
       { keys: [modKey, 'B'], desc: 'Toggle file tree' },
       { keys: [modKey, '.'], desc: 'Toggle sidebar' },


### PR DESCRIPTION
This change adds a keyboard shortcut to the code review UI. The shortcut is `Cmd/Ctrl+Shift+Y`. The shortcut copies the review feedback to the clipboard.

Before this change, the user must click two controls. First, the user clicks the comment icon in the header. Then the user clicks the **Copy Feedback** button.

## Method

The `handleCopyFeedback` callback is available already in `App.tsx`. A new effect connects the keys to that callback. The effect uses the same guards as the `Cmd/Ctrl+Enter` effect:

- The effect does not operate when the focus is in an input field or a text area.
- The effect does not operate when a dialog is open.

A new entry in `packages/review-editor/shortcuts.ts` declares the shortcut. Thus the Settings list shows the shortcut automatically.

## Key selection

`Mod+Shift+Y` is free in the code review registry. `Mod+Shift+C` is not free, because the browser uses those keys for the developer tools. Tell me if you prefer different keys or push a commit to update etc.

## Tests

`bun test` gives 2440 pass and 22 fail. The same 22 tests also fail on `main`. Thus these failures are not related to this change.
