### PR TITLE
fix(review): surface partial GitLab comment submissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,7 @@ jobs:
           packages/ui/components/MarkdownEditor.extensions.test.tsx
           packages/ui/components/sidebar/FileBrowser.test.ts
           packages/editor/editableDocumentsHook.test.tsx
+          packages/review-editor/components/ReviewSubmissionDialog.ui.test.tsx
           packages/review-editor/hooks/useReviewSearch.test.tsx
           packages/ui/components/AnnotationPanel.props.test.tsx
           packages/ui/components/Viewer.consumer.test.tsx

--- a/apps/pi-extension/server/pr.ts
+++ b/apps/pi-extension/server/pr.ts
@@ -9,6 +9,7 @@ import {
 	type PRMetadata,
 	type PRRef,
 	type PRReviewFileComment,
+	type PRReviewSubmissionResult,
 	type PRRuntime,
 	type PRStackTree,
 	type PRListItem,
@@ -85,13 +86,14 @@ export function fetchPRContext(ref: PRRef) {
 export function fetchPRFileContent(ref: PRRef, sha: string, filePath: string) {
 	return fetchPRFileContentCore(prRuntime, ref, sha, filePath);
 }
+/** Submit a review through the Pi Node.js command runtime. */
 export function submitPRReview(
 	ref: PRRef,
 	headSha: string,
 	action: "approve" | "comment",
 	body: string,
 	fileComments: PRReviewFileComment[],
-) {
+): Promise<PRReviewSubmissionResult> {
 	return submitPRReviewCore(
 		prRuntime,
 		ref,

--- a/apps/pi-extension/server/serverReview.ts
+++ b/apps/pi-extension/server/serverReview.ts
@@ -265,6 +265,8 @@ export async function startReviewServer(options: {
 	shareBaseUrl?: string;
 	pasteApiUrl?: string;
 	prMetadata?: PRMetadata;
+	/** Platform review writer override used by isolated runtime tests. */
+	prReviewSubmitter?: typeof submitPRReview;
 	/**
 	 * The initial layer patch is missing per-file content (platform APIs
 	 * withhold patches on very large PRs). Enables the local recompute upgrade
@@ -284,6 +286,7 @@ export async function startReviewServer(options: {
 }): Promise<ReviewServerResult> {
 	const gitUser = detectGitUser();
 	const aiEnabled = resolveAIEnabled();
+	const submitPlatformReview = options.prReviewSubmitter ?? submitPRReview;
 	let draftKey = contentHash(options.rawPatch);
 	let prMeta = options.prMetadata;
 	const isPRMode = !!prMeta;
@@ -2229,16 +2232,16 @@ export async function startReviewServer(options: {
 				}
 
 				console.error(`[pr-action] ${body.action} with ${fileComments.length} file comment(s), target=${targetUrl}, headSha=${targetHeadSha}`);
-				await submitPRReview(
+				const submission = await submitPlatformReview(
 					targetRef,
 					targetHeadSha,
 					body.action as "approve" | "comment",
 					body.body as string,
 					fileComments,
 				);
-				console.error(`[pr-action] Success`);
+				console.error(`[pr-action] ${submission.status === "complete" ? "Success" : "Partial success"}`);
 				prContextLive.refreshAfterWrite(targetUrl, targetRef);
-				json(res, { ok: true, prUrl: targetUrl });
+				json(res, { ok: true, prUrl: targetUrl, submission });
 			} catch (err) {
 				const message = err instanceof Error ? err.message : "Failed to submit PR review";
 				console.error(`[pr-action] Failed: ${message}`);

--- a/apps/pi-extension/serverReview-pr-action.test.ts
+++ b/apps/pi-extension/serverReview-pr-action.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type {
+  PRMetadata,
+  PRReviewFileComment,
+  PRReviewSubmissionResult,
+} from './generated/pr-types.ts';
+import { startReviewServer } from './server/serverReview.ts';
+
+const originalAI = process.env.PLANNOTATOR_AI;
+const originalDataDir = process.env.PLANNOTATOR_DATA_DIR;
+const originalPath = process.env.PATH;
+const originalPort = process.env.PLANNOTATOR_PORT;
+const tempDirs: string[] = [];
+
+const prMetadata: PRMetadata = {
+  platform: 'gitlab',
+  host: 'gitlab.invalid',
+  projectPath: 'acme/widgets',
+  iid: 7,
+  title: 'Reliable comments',
+  author: 'reviewer',
+  baseBranch: 'main',
+  headBranch: 'feature',
+  baseSha: 'base',
+  headSha: 'head',
+  url: 'https://gitlab.invalid/acme/widgets/-/merge_requests/7',
+};
+
+const fileComment: PRReviewFileComment = {
+  path: 'src/failing.ts',
+  line: 19,
+  side: 'RIGHT',
+  body: 'Handle this failure.',
+};
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  if (originalAI === undefined) delete process.env.PLANNOTATOR_AI;
+  else process.env.PLANNOTATOR_AI = originalAI;
+  if (originalDataDir === undefined) delete process.env.PLANNOTATOR_DATA_DIR;
+  else process.env.PLANNOTATOR_DATA_DIR = originalDataDir;
+  if (originalPath === undefined) delete process.env.PATH;
+  else process.env.PATH = originalPath;
+  if (originalPort === undefined) delete process.env.PLANNOTATOR_PORT;
+  else process.env.PLANNOTATOR_PORT = originalPort;
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('Pi /api/pr-action submission contract', () => {
+  test('preserves the actionable mixed-outcome response', async () => {
+    const partial: PRReviewSubmissionResult = {
+      status: 'partial',
+      postedFileCommentCount: 1,
+      failedFileComments: [{
+        comment: fileComment,
+        error: 'src/failing.ts:19: rejected',
+      }],
+      reviewBodyPosted: true,
+      approval: 'not-requested',
+      recoveryFile: '/tmp/failed-comments/review.json',
+      retry: {
+        action: 'comment',
+        fileComments: [fileComment],
+      },
+    };
+    process.env.PLANNOTATOR_AI = 'disabled';
+    process.env.PLANNOTATOR_DATA_DIR = makeTempDir('plannotator-pi-pr-action-data-');
+    process.env.PATH = makeTempDir('plannotator-pi-pr-action-path-');
+    delete process.env.PLANNOTATOR_PORT;
+
+    const server = await startReviewServer({
+      rawPatch: 'diff --git a/src/failing.ts b/src/failing.ts\n',
+      gitRef: 'MR !7',
+      htmlContent: '<!doctype html><html><body>review</body></html>',
+      prMetadata,
+      prReviewSubmitter: async () => partial,
+    });
+    try {
+      const response = await fetch(`${server.url}/api/pr-action`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'comment',
+          body: 'Overall review',
+          fileComments: [fileComment],
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        ok: true,
+        prUrl: prMetadata.url,
+        submission: partial,
+      });
+    } finally {
+      server.stop();
+    }
+  });
+});

--- a/apps/pi-extension/serverReview-pr-action.test.ts
+++ b/apps/pi-extension/serverReview-pr-action.test.ts
@@ -56,7 +56,70 @@ afterEach(() => {
   }
 });
 
+async function withReviewServer(
+  submit: () => Promise<PRReviewSubmissionResult>,
+  run: (url: string) => Promise<void>,
+): Promise<void> {
+  process.env.PLANNOTATOR_AI = 'disabled';
+  process.env.PLANNOTATOR_DATA_DIR = makeTempDir('plannotator-pi-pr-action-data-');
+  process.env.PATH = makeTempDir('plannotator-pi-pr-action-path-');
+  delete process.env.PLANNOTATOR_PORT;
+  const server = await startReviewServer({
+    rawPatch: 'diff --git a/src/failing.ts b/src/failing.ts\n',
+    gitRef: 'MR !7',
+    htmlContent: '<!doctype html><html><body>review</body></html>',
+    prMetadata,
+    prReviewSubmitter: async () => submit(),
+  });
+  try {
+    await run(server.url);
+  } finally {
+    server.stop();
+  }
+}
+
+async function postReview(url: string): Promise<Response> {
+  return fetch(`${url}/api/pr-action`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      action: 'comment',
+      body: 'Overall review',
+      fileComments: [fileComment],
+    }),
+  });
+}
+
 describe('Pi /api/pr-action submission contract', () => {
+  test('returns complete success', async () => {
+    await withReviewServer(
+      async () => ({ status: 'complete' }),
+      async (url) => {
+        const response = await postReview(url);
+        expect(response.status).toBe(200);
+        expect(await response.json()).toMatchObject({
+          ok: true,
+          submission: { status: 'complete' },
+        });
+      },
+    );
+  });
+
+  test('returns an all-failure as an error', async () => {
+    await withReviewServer(
+      async () => {
+        throw new Error('Failed to post inline comments');
+      },
+      async (url) => {
+        const response = await postReview(url);
+        expect(response.status).toBe(500);
+        expect(await response.json()).toEqual({
+          error: 'Failed to post inline comments',
+        });
+      },
+    );
+  });
+
   test('preserves the actionable mixed-outcome response', async () => {
     const partial: PRReviewSubmissionResult = {
       status: 'partial',
@@ -73,37 +136,17 @@ describe('Pi /api/pr-action submission contract', () => {
         fileComments: [fileComment],
       },
     };
-    process.env.PLANNOTATOR_AI = 'disabled';
-    process.env.PLANNOTATOR_DATA_DIR = makeTempDir('plannotator-pi-pr-action-data-');
-    process.env.PATH = makeTempDir('plannotator-pi-pr-action-path-');
-    delete process.env.PLANNOTATOR_PORT;
-
-    const server = await startReviewServer({
-      rawPatch: 'diff --git a/src/failing.ts b/src/failing.ts\n',
-      gitRef: 'MR !7',
-      htmlContent: '<!doctype html><html><body>review</body></html>',
-      prMetadata,
-      prReviewSubmitter: async () => partial,
-    });
-    try {
-      const response = await fetch(`${server.url}/api/pr-action`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          action: 'comment',
-          body: 'Overall review',
-          fileComments: [fileComment],
-        }),
-      });
-
-      expect(response.status).toBe(200);
-      expect(await response.json()).toMatchObject({
-        ok: true,
-        prUrl: prMetadata.url,
-        submission: partial,
-      });
-    } finally {
-      server.stop();
-    }
+    await withReviewServer(
+      async () => partial,
+      async (url) => {
+        const response = await postReview(url);
+        expect(response.status).toBe(200);
+        expect(await response.json()).toMatchObject({
+          ok: true,
+          prUrl: prMetadata.url,
+          submission: partial,
+        });
+      },
+    );
   });
 });

--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -68,7 +68,6 @@ import { exportReviewFeedback, buildProseFeedback, commitShaFromMode } from './u
 import { parseDiffToFiles } from './utils/diffParser';
 import {
   ReviewSubmissionDialog,
-  buildPRActionRequest,
   buildPlatformReviewBody,
   buildReviewSubmission,
   type ReviewSubmission,
@@ -113,9 +112,26 @@ import { DEMO_TOUR_ID } from './demoTour';
 import { GuideScreen } from './components/guide/GuideScreen';
 import { DEMO_GUIDE_ID } from './demoGuide';
 import { buildPRArtifacts } from './utils/prArtifacts';
-import { parsePRActionSuccess, readPRActionError } from './utils/prActionResponse';
+import {
+  submitPlatformReviewTargets,
+} from './utils/platformReviewSubmission';
+import {
+  loadReviewSubmissionRecovery,
+  restoreReviewSubmission,
+  saveReviewSubmissionRecovery,
+  type ReviewSubmissionRecovery,
+  type ReviewRecoveryStorage,
+} from './utils/reviewSubmissionRecovery';
 
 declare const __APP_VERSION__: string;
+
+function getReviewRecoveryStorage(): ReviewRecoveryStorage | null {
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
 
 interface DiffData {
   files: DiffFile[];
@@ -385,6 +401,11 @@ const ReviewApp: React.FC = () => {
   const [platformUser, setPlatformUser] = useState<string | null>(null);
   const [platformCommentDialog, setPlatformCommentDialog] = useState<{ action: 'approve' | 'comment'; plan: ReviewSubmission } | null>(null);
   const [platformGeneralComment, setPlatformGeneralComment] = useState('');
+  const [platformReviewRecovery, setPlatformReviewRecovery] = useState<{
+    rootPrUrl: string;
+    recovery: ReviewSubmissionRecovery;
+  } | null>(null);
+  const [platformRecoveryPersistsRefresh, setPlatformRecoveryPersistsRefresh] = useState(false);
   const [platformOpenPR, setPlatformOpenPR] = useState(() => {
     const platformSetting = storage.getItem('plannotator-platform-open-pr');
     if (platformSetting !== null) return platformSetting !== 'false';
@@ -2598,6 +2619,9 @@ const ReviewApp: React.FC = () => {
 
     try {
       if (!prMetadata) throw new Error('PR metadata unavailable');
+      if (plan.targets.some(target => target.status === 'blocked')) {
+        throw new Error(`Automatic retry is blocked until the ${mrLabel} is inspected.`);
+      }
 
       const bodyForTarget = (target: SubmissionTarget) => buildPlatformReviewBody(
         action,
@@ -2621,58 +2645,28 @@ const ReviewApp: React.FC = () => {
         }];
       }
 
-      const openUrls: string[] = [];
-      const results = await Promise.allSettled(
-        targets.map(async (target): Promise<SubmissionTarget> => {
-          if (target.status === 'success') return target;
-          try {
-            const prRes = await fetch('/api/pr-action', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify(buildPRActionRequest(
-                action,
-                bodyForTarget(target),
-                target,
-              )),
-            });
-            const rawResponse: unknown = await prRes.json();
-            if (!prRes.ok) {
-              return {
-                ...target,
-                status: 'failed',
-                error: readPRActionError(rawResponse) ?? 'Failed to submit',
-              };
-            }
-            const prData = parsePRActionSuccess(rawResponse);
-            if (!prData) {
-              return {
-                ...target,
-                status: 'failed',
-                error: 'Invalid response from review server',
-              };
-            }
-            if (prData.submission.status === 'partial') {
-              return {
-                ...target,
-                status: 'partial',
-                error: undefined,
-                partial: prData.submission,
-              };
-            }
-            if (prData.prUrl) openUrls.push(prData.prUrl);
-            return {
-              ...target,
-              status: 'success',
-              error: undefined,
-              partial: undefined,
-            };
-          } catch (err) {
-            return { ...target, status: 'failed', error: err instanceof Error ? err.message : 'Network error' };
-          }
-        }),
-      );
-      const updatedTargets = results.map((r, i) => r.status === 'fulfilled' ? r.value : { ...targets[i], status: 'failed' as const, error: 'Unexpected error' });
-      const allOk = updatedTargets.every(t => t.status === 'success');
+      const attempt = await submitPlatformReviewTargets({
+        targets,
+        action,
+        generalComment: generalComment ?? '',
+        bodyForTarget,
+      });
+      const updatedTargets = attempt.targets;
+      const allOk = attempt.allComplete;
+      const recovery = attempt.recovery;
+      const openUrls = attempt.openUrls;
+      setPlatformReviewRecovery(recovery
+        ? { rootPrUrl: prMetadata.url, recovery }
+        : null);
+      const recoveryStorage = getReviewRecoveryStorage();
+      const persistsRefresh = recoveryStorage
+        ? saveReviewSubmissionRecovery(
+          recoveryStorage,
+          prMetadata.url,
+          recovery,
+        )
+        : false;
+      setPlatformRecoveryPersistsRefresh(recovery !== null && persistsRefresh);
 
       if (!allOk) {
         setPlatformCommentDialog(prev => prev ? {
@@ -2725,9 +2719,35 @@ const ReviewApp: React.FC = () => {
     // inline review comments — seed them into the review body instead (quoted),
     // where the user can edit before submitting. Also means a review with only
     // prose notes still has something to post.
-    setPlatformGeneralComment(buildProseFeedback(visibleDescriptionAnnotations, visibleCommentAnnotations, prContext?.body));
+    const seededGeneralComment = buildProseFeedback(
+      visibleDescriptionAnnotations,
+      visibleCommentAnnotations,
+      prContext?.body,
+    );
+    const rootPrUrl = prMetadata?.url;
+    const inMemoryRecovery = rootPrUrl && platformReviewRecovery?.rootPrUrl === rootPrUrl
+      ? platformReviewRecovery.recovery
+      : null;
+    const recoveryStorage = getReviewRecoveryStorage();
+    const storedRecovery = rootPrUrl && recoveryStorage
+      ? loadReviewSubmissionRecovery(recoveryStorage, rootPrUrl)
+      : null;
+    const recovery = inMemoryRecovery ?? storedRecovery;
+    if (recovery) {
+      setPlatformReviewRecovery({ rootPrUrl: rootPrUrl ?? '', recovery });
+      if (storedRecovery) {
+        setPlatformRecoveryPersistsRefresh(true);
+      }
+      setPlatformGeneralComment(recovery.generalComment);
+      setPlatformCommentDialog({
+        action: recovery.action,
+        plan: restoreReviewSubmission(plan, recovery),
+      });
+      return;
+    }
+    setPlatformGeneralComment(seededGeneralComment);
     setPlatformCommentDialog({ action, plan });
-  }, [allAnnotations, visibleEditorAnnotations, files, prMetadata, visibleDescriptionAnnotations, visibleCommentAnnotations, prContext?.body]);
+  }, [allAnnotations, visibleEditorAnnotations, files, prMetadata, visibleDescriptionAnnotations, visibleCommentAnnotations, prContext?.body, platformReviewRecovery]);
 
   // Double-tap Option/Alt to toggle review destination (PR mode only)
   useEffect(() => {
@@ -2780,8 +2800,9 @@ const ReviewApp: React.FC = () => {
         if (submitted || isPlatformActioning) return;
         const isApproveAction = platformCommentDialog.action === 'approve';
         const hasTargets = platformCommentDialog.plan.targets.length > 0;
+        const retryBlocked = platformCommentDialog.plan.targets.some(target => target.status === 'blocked');
         const canSubmit = isApproveAction || hasTargets || platformGeneralComment.trim();
-        if (!canSubmit) return;
+        if (!canSubmit || retryBlocked) return;
         e.preventDefault();
         handlePlatformAction(platformCommentDialog.action, platformCommentDialog.plan, platformGeneralComment);
         return;
@@ -3844,6 +3865,7 @@ const ReviewApp: React.FC = () => {
           }}
           onCancel={() => setPlatformCommentDialog(null)}
           isSubmitting={isPlatformActioning}
+          recoveryPersistsRefresh={platformRecoveryPersistsRefresh}
           mrLabel={mrLabel}
           platformLabel={platformLabel}
         />

--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -68,6 +68,7 @@ import { exportReviewFeedback, buildProseFeedback, commitShaFromMode } from './u
 import { parseDiffToFiles } from './utils/diffParser';
 import {
   ReviewSubmissionDialog,
+  buildPRActionRequest,
   buildPlatformReviewBody,
   buildReviewSubmission,
   type ReviewSubmission,
@@ -112,6 +113,7 @@ import { DEMO_TOUR_ID } from './demoTour';
 import { GuideScreen } from './components/guide/GuideScreen';
 import { DEMO_GUIDE_ID } from './demoGuide';
 import { buildPRArtifacts } from './utils/prArtifacts';
+import { parsePRActionSuccess, readPRActionError } from './utils/prActionResponse';
 
 declare const __APP_VERSION__: string;
 
@@ -2627,19 +2629,43 @@ const ReviewApp: React.FC = () => {
             const prRes = await fetch('/api/pr-action', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({
+              body: JSON.stringify(buildPRActionRequest(
                 action,
-                body: bodyForTarget(target),
-                fileComments: target.fileComments,
-                targetPrUrl: target.prUrl || undefined,
-              }),
+                bodyForTarget(target),
+                target,
+              )),
             });
-            const prData = await prRes.json() as { ok?: boolean; prUrl?: string; error?: string };
-            if (!prRes.ok || prData.error) {
-              return { ...target, status: 'failed', error: prData.error ?? 'Failed to submit' };
+            const rawResponse: unknown = await prRes.json();
+            if (!prRes.ok) {
+              return {
+                ...target,
+                status: 'failed',
+                error: readPRActionError(rawResponse) ?? 'Failed to submit',
+              };
+            }
+            const prData = parsePRActionSuccess(rawResponse);
+            if (!prData) {
+              return {
+                ...target,
+                status: 'failed',
+                error: 'Invalid response from review server',
+              };
+            }
+            if (prData.submission.status === 'partial') {
+              return {
+                ...target,
+                status: 'partial',
+                error: undefined,
+                partial: prData.submission,
+              };
             }
             if (prData.prUrl) openUrls.push(prData.prUrl);
-            return { ...target, status: 'success' };
+            return {
+              ...target,
+              status: 'success',
+              error: undefined,
+              partial: undefined,
+            };
           } catch (err) {
             return { ...target, status: 'failed', error: err instanceof Error ? err.message : 'Network error' };
           }

--- a/packages/review-editor/components/ReviewSubmissionDialog.test.ts
+++ b/packages/review-editor/components/ReviewSubmissionDialog.test.ts
@@ -67,7 +67,7 @@ describe('buildPRActionRequest', () => {
   test('uses only the server-authorized retry after a partial submission', () => {
     const partialTarget: SubmissionTarget = {
       ...target,
-      status: 'failed',
+      status: 'partial',
       partial: {
         status: 'partial',
         postedFileCommentCount: 1,
@@ -90,5 +90,12 @@ describe('buildPRActionRequest', () => {
       fileComments: [inlineComment],
       targetPrUrl: target.prUrl,
     });
+  });
+
+  test('refuses a partial target without a server-authorized retry', () => {
+    expect(() => buildPRActionRequest('comment', 'Do not post', {
+      ...target,
+      status: 'partial',
+    })).toThrow('missing its server-authorized retry');
   });
 });

--- a/packages/review-editor/components/ReviewSubmissionDialog.test.ts
+++ b/packages/review-editor/components/ReviewSubmissionDialog.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import {
+  buildPRActionRequest,
   buildPlatformReviewBody,
   type SubmissionTarget,
 } from './ReviewSubmissionDialog';
@@ -38,5 +39,56 @@ describe('buildPlatformReviewBody', () => {
       fileComments: [inlineComment],
       fileScopedBody: '',
     })).toBe('');
+  });
+});
+
+describe('buildPRActionRequest', () => {
+  const target: SubmissionTarget = {
+    prUrl: 'https://gitlab.example/acme/widgets/-/merge_requests/7',
+    prNumber: 7,
+    prTitle: 'Reliable comments',
+    prRepo: 'acme/widgets',
+    fileComments: [inlineComment, { ...inlineComment, path: 'src/posted.ts', line: 30 }],
+    fileScopedBody: '',
+    fileCount: 2,
+    annotationCount: 2,
+    status: 'pending',
+  };
+
+  test('uses the complete original payload before any platform mutation', () => {
+    expect(buildPRActionRequest('comment', 'Overall review', target)).toEqual({
+      action: 'comment',
+      body: 'Overall review',
+      fileComments: target.fileComments,
+      targetPrUrl: target.prUrl,
+    });
+  });
+
+  test('uses only the server-authorized retry after a partial submission', () => {
+    const partialTarget: SubmissionTarget = {
+      ...target,
+      status: 'failed',
+      partial: {
+        status: 'partial',
+        postedFileCommentCount: 1,
+        failedFileComments: [{
+          comment: inlineComment,
+          error: 'rejected',
+        }],
+        reviewBodyPosted: true,
+        approval: 'succeeded',
+        retry: {
+          action: 'comment',
+          fileComments: [inlineComment],
+        },
+      },
+    };
+
+    expect(buildPRActionRequest('approve', 'Do not repost this', partialTarget)).toEqual({
+      action: 'comment',
+      body: '',
+      fileComments: [inlineComment],
+      targetPrUrl: target.prUrl,
+    });
   });
 });

--- a/packages/review-editor/components/ReviewSubmissionDialog.tsx
+++ b/packages/review-editor/components/ReviewSubmissionDialog.tsx
@@ -24,7 +24,7 @@ export interface SubmissionTarget {
   fileScopedBody: string;
   fileCount: number;
   annotationCount: number;
-  status: 'pending' | 'success' | 'partial' | 'failed';
+  status: 'pending' | 'success' | 'partial' | 'failed' | 'blocked';
   error?: string;
   partial?: PRReviewSubmissionPartial;
 }
@@ -61,6 +61,7 @@ interface ReviewSubmissionDialogProps {
   onConfirm: () => void;
   onCancel: () => void;
   isSubmitting: boolean;
+  recoveryPersistsRefresh: boolean;
   mrLabel: string;
   platformLabel: string;
 }
@@ -150,6 +151,9 @@ export function buildPRActionRequest(
   body: string,
   target: SubmissionTarget,
 ): PRActionRequest {
+  if (target.status === 'partial' && !target.partial) {
+    throw new Error('Partial review target is missing its server-authorized retry');
+  }
   const retry = target.partial?.retry;
   return {
     action: retry?.action ?? action,
@@ -300,6 +304,7 @@ export function ReviewSubmissionDialog({
   onConfirm,
   onCancel,
   isSubmitting,
+  recoveryPersistsRefresh,
   mrLabel,
   platformLabel,
 }: ReviewSubmissionDialogProps) {
@@ -310,7 +315,9 @@ export function ReviewSubmissionDialog({
   const hasTargets = submission.targets.length > 0;
   const allSucceeded = hasTargets && submission.targets.every(t => t.status === 'success');
   const hasFailed = submission.targets.some(t => t.status === 'failed');
-  const hasPartial = submission.targets.some(t => t.partial !== undefined);
+  const hasPartial = submission.targets.some(t => t.status === 'partial');
+  const hasBlocked = submission.targets.some(t => t.status === 'blocked');
+  const bodyLocked = hasPartial || hasBlocked;
 
   return (
     <div className="fixed inset-0 z-[100] flex items-center justify-center bg-background/80 backdrop-blur-sm p-4">
@@ -326,13 +333,23 @@ export function ReviewSubmissionDialog({
 
         {/* General comment */}
         <textarea
-          autoFocus
+          autoFocus={!bodyLocked}
           value={generalComment}
           onChange={e => onGeneralCommentChange(e.target.value)}
           placeholder="Leave a comment..."
           rows={3}
-          className="w-full rounded-md border border-border bg-background text-sm px-3 py-2 resize-none focus:outline-none focus:ring-1 focus:ring-primary mb-3"
+          disabled={bodyLocked}
+          aria-describedby={bodyLocked ? 'review-general-comment-lock' : undefined}
+          className="w-full rounded-md border border-border bg-background text-sm px-3 py-2 resize-none focus:outline-none focus:ring-1 focus:ring-primary disabled:cursor-not-allowed disabled:opacity-60"
         />
+        {bodyLocked && (
+          <div id="review-general-comment-lock" className="mt-1 mb-3 text-xs text-warning">
+            {hasBlocked
+              ? `General comment locked because ${platformLabel} may already have received it. Automatic retry is blocked until you inspect the ${mrLabel}.`
+              : 'General comment locked because it may already be posted. Safe retry never resends it.'}
+          </div>
+        )}
+        {!bodyLocked && <div className="mb-3" />}
 
         {/* Targets */}
         {submission.targets.length > 0 && (
@@ -359,6 +376,10 @@ export function ReviewSubmissionDialog({
                       <svg className="w-4 h-4 text-destructive" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                         <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
                       </svg>
+                    ) : target.status === 'blocked' ? (
+                      <svg className="w-4 h-4 text-warning" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v4m0 4h.01M10.3 3.6l-7.4 13A2 2 0 004.7 19h14.6a2 2 0 001.8-2.4l-7.4-13a2 2 0 00-3.4 0z" />
+                      </svg>
                     ) : (
                       <svg className="w-4 h-4 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                         <circle cx="12" cy="12" r="10" />
@@ -372,13 +393,16 @@ export function ReviewSubmissionDialog({
                     <div className="text-xs text-muted-foreground">
                       {target.annotationCount} comment{target.annotationCount !== 1 ? 's' : ''} across {target.fileCount} file{target.fileCount !== 1 ? 's' : ''}
                     </div>
-                    {target.status === 'failed' && target.error && (
+                    {(target.status === 'failed' || target.status === 'partial') && target.error && (
                       <div className="text-xs text-destructive mt-0.5">{target.error}</div>
                     )}
-                    {target.partial && (
+                    {target.status === 'partial' && target.partial && (
                       <div className="mt-2 rounded-md border border-warning/30 bg-warning/10 p-2 text-xs">
                         <div className="font-medium text-warning">
                           Review partially posted
+                        </div>
+                        <div className="mt-1 text-muted-foreground">
+                          This attempt posted {target.partial.postedFileCommentCount} inline comment{target.partial.postedFileCommentCount === 1 ? '' : 's'}{target.partial.reviewBodyPosted ? ' and the general comment' : ''}.
                         </div>
                         {target.partial.failedFileComments.length > 0 && (
                           <>
@@ -412,11 +436,42 @@ export function ReviewSubmissionDialog({
                             ? `Retry sends only the ${target.partial.retry.fileComments.length} unposted inline comment${target.partial.retry.fileComments.length === 1 ? '' : 's'}; posted comments and the general note are not sent again.`
                             : `Retry only repeats the ${mrLabel} approval; posted comments and the general note are not sent again.`}
                         </div>
+                        <div className="mt-1 text-muted-foreground">
+                          {recoveryPersistsRefresh
+                            ? 'You can close and reopen this dialog or refresh this tab; Plannotator keeps this narrowed retry in tab-scoped recovery storage.'
+                            : 'You can close and reopen this dialog on this page. Keep the page open because tab-scoped refresh recovery is unavailable.'}
+                        </div>
                         {target.partial.recoveryFile && (
                           <div className="mt-1 text-muted-foreground">
                             Recovery copy: <code className="break-all text-foreground">{target.partial.recoveryFile}</code>
                           </div>
                         )}
+                      </div>
+                    )}
+                    {target.status === 'blocked' && (
+                      <div className="mt-2 rounded-md border border-warning/30 bg-warning/10 p-2 text-xs">
+                        <div className="font-medium text-warning">Automatic retry blocked</div>
+                        <div className="mt-1 break-words text-muted-foreground">
+                          {target.error ?? `The ${mrLabel} may already contain part of this review. Inspect it before starting another submission.`}
+                        </div>
+                        {target.partial && target.partial.failedFileComments.length > 0 && (
+                          <CopyButton
+                            text={buildFailedCommentsMarkdown(target.partial)}
+                            variant="inline"
+                            label="Copy last known unposted comments"
+                            className="mt-1"
+                          />
+                        )}
+                        {target.partial?.recoveryFile && (
+                          <div className="mt-1 text-muted-foreground">
+                            Last recovery copy: <code className="break-all text-foreground">{target.partial.recoveryFile}</code>
+                          </div>
+                        )}
+                        <div className="mt-1 text-muted-foreground">
+                          {recoveryPersistsRefresh
+                            ? 'Closing or refreshing this tab keeps the block in tab-scoped recovery storage.'
+                            : 'Closing the dialog keeps this block on the current page. Keep the page open because tab-scoped refresh recovery is unavailable.'}
+                        </div>
                       </div>
                     )}
                   </div>
@@ -472,13 +527,13 @@ export function ReviewSubmissionDialog({
             disabled={isSubmitting}
             className="px-4 py-2 rounded-md text-sm font-medium bg-muted text-muted-foreground hover:bg-muted/80 disabled:opacity-50"
           >
-            Cancel
+            {hasPartial || hasBlocked ? 'Close' : 'Cancel'}
           </button>
           <button
             onClick={onConfirm}
-            disabled={isSubmitting || (!hasTargets && !isApprove && !generalComment.trim()) || allSucceeded}
+            disabled={isSubmitting || hasBlocked || (!hasTargets && !isApprove && !generalComment.trim()) || allSucceeded}
             className={`px-4 py-2 rounded-md text-sm font-medium transition-opacity ${
-              isSubmitting || (!hasTargets && !isApprove && !generalComment.trim()) || allSucceeded
+              isSubmitting || hasBlocked || (!hasTargets && !isApprove && !generalComment.trim()) || allSucceeded
                 ? 'opacity-50 cursor-not-allowed bg-muted text-muted-foreground'
                 : isApprove
                   ? 'bg-success text-success-foreground hover:opacity-90'
@@ -487,6 +542,8 @@ export function ReviewSubmissionDialog({
           >
             {isSubmitting
               ? 'Posting...'
+              : hasBlocked
+                ? 'Retry blocked'
               : hasPartial
                 ? 'Retry Unposted'
                 : hasFailed

--- a/packages/review-editor/components/ReviewSubmissionDialog.tsx
+++ b/packages/review-editor/components/ReviewSubmissionDialog.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { CodeAnnotation } from '@plannotator/ui/types';
+import type { PRReviewSubmissionPartial } from '@plannotator/shared/pr-types';
 import { CopyButton } from './CopyButton';
 import { exportReviewFeedback, formatConventionalPrefix } from '../utils/exportFeedback';
 
@@ -23,8 +24,9 @@ export interface SubmissionTarget {
   fileScopedBody: string;
   fileCount: number;
   annotationCount: number;
-  status: 'pending' | 'success' | 'failed';
+  status: 'pending' | 'success' | 'partial' | 'failed';
   error?: string;
+  partial?: PRReviewSubmissionPartial;
 }
 
 export interface OrphanedFindings {
@@ -36,6 +38,14 @@ export interface OrphanedFindings {
 export interface ReviewSubmission {
   targets: SubmissionTarget[];
   orphans: OrphanedFindings[];
+}
+
+/** Request body accepted by the review server's platform submission endpoint. */
+export interface PRActionRequest {
+  action: 'approve' | 'comment';
+  body: string;
+  fileComments: SubmissionTarget['fileComments'];
+  targetPrUrl?: string;
 }
 
 type ReviewPlatform = 'github' | 'gitlab';
@@ -96,6 +106,19 @@ function buildFileScopedBody(annotations: CodeAnnotation[]): string {
   return parts.join('\n\n');
 }
 
+function buildFailedCommentsMarkdown(
+  partial: PRReviewSubmissionPartial,
+): string {
+  return partial.failedFileComments
+    .map(({ comment, error }) => [
+      `### ${comment.path}:${comment.line}`,
+      comment.body,
+      '',
+      `Posting error: ${error}`,
+    ].join('\n'))
+    .join('\n\n');
+}
+
 /**
  * Build the top-level review body without adding product attribution.
  * GitHub requires a body for COMMENT reviews, so an inline-only review gets a
@@ -116,6 +139,24 @@ export function buildPlatformReviewBody(
     return 'See inline comments.';
   }
   return '';
+}
+
+/**
+ * Build either the original platform request or the exact retry-safe subset
+ * returned by the server after a partial GitLab submission.
+ */
+export function buildPRActionRequest(
+  action: 'approve' | 'comment',
+  body: string,
+  target: SubmissionTarget,
+): PRActionRequest {
+  const retry = target.partial?.retry;
+  return {
+    action: retry?.action ?? action,
+    body: retry ? '' : body,
+    fileComments: retry?.fileComments ?? target.fileComments,
+    ...(target.prUrl ? { targetPrUrl: target.prUrl } : {}),
+  };
 }
 
 export function buildReviewSubmission(
@@ -269,6 +310,7 @@ export function ReviewSubmissionDialog({
   const hasTargets = submission.targets.length > 0;
   const allSucceeded = hasTargets && submission.targets.every(t => t.status === 'success');
   const hasFailed = submission.targets.some(t => t.status === 'failed');
+  const hasPartial = submission.targets.some(t => t.partial !== undefined);
 
   return (
     <div className="fixed inset-0 z-[100] flex items-center justify-center bg-background/80 backdrop-blur-sm p-4">
@@ -309,6 +351,10 @@ export function ReviewSubmissionDialog({
                       <svg className="w-4 h-4 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                         <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
                       </svg>
+                    ) : target.status === 'partial' ? (
+                      <svg className="w-4 h-4 text-warning" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v4m0 4h.01M10.3 3.6l-7.4 13A2 2 0 004.7 19h14.6a2 2 0 001.8-2.4l-7.4-13a2 2 0 00-3.4 0z" />
+                      </svg>
                     ) : target.status === 'failed' ? (
                       <svg className="w-4 h-4 text-destructive" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                         <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -328,6 +374,50 @@ export function ReviewSubmissionDialog({
                     </div>
                     {target.status === 'failed' && target.error && (
                       <div className="text-xs text-destructive mt-0.5">{target.error}</div>
+                    )}
+                    {target.partial && (
+                      <div className="mt-2 rounded-md border border-warning/30 bg-warning/10 p-2 text-xs">
+                        <div className="font-medium text-warning">
+                          Review partially posted
+                        </div>
+                        {target.partial.failedFileComments.length > 0 && (
+                          <>
+                            <div className="mt-1 text-muted-foreground">
+                              {target.partial.failedFileComments.length} inline comment{target.partial.failedFileComments.length === 1 ? '' : 's'} failed:
+                            </div>
+                            <ul className="mt-1 space-y-1">
+                              {target.partial.failedFileComments.map(({ comment, error }) => (
+                                <li key={`${comment.path}:${comment.line}:${comment.body}`} className="min-w-0">
+                                  <div className="font-mono break-all">{comment.path}:{comment.line}</div>
+                                  <div className="truncate text-foreground" title={comment.body}>{comment.body}</div>
+                                  <div className="break-words text-destructive">{error}</div>
+                                </li>
+                              ))}
+                            </ul>
+                            <CopyButton
+                              text={buildFailedCommentsMarkdown(target.partial)}
+                              variant="inline"
+                              label="Copy failed comments"
+                              className="mt-1"
+                            />
+                          </>
+                        )}
+                        {target.partial.approval === 'failed' && (
+                          <div className="mt-1 text-destructive">
+                            {target.partial.approvalError ?? `Failed to approve ${mrLabel}.`}
+                          </div>
+                        )}
+                        <div className="mt-1 text-muted-foreground">
+                          {target.partial.retry.fileComments.length > 0
+                            ? `Retry sends only the ${target.partial.retry.fileComments.length} unposted inline comment${target.partial.retry.fileComments.length === 1 ? '' : 's'}; posted comments and the general note are not sent again.`
+                            : `Retry only repeats the ${mrLabel} approval; posted comments and the general note are not sent again.`}
+                        </div>
+                        {target.partial.recoveryFile && (
+                          <div className="mt-1 text-muted-foreground">
+                            Recovery copy: <code className="break-all text-foreground">{target.partial.recoveryFile}</code>
+                          </div>
+                        )}
+                      </div>
                     )}
                   </div>
                 </div>
@@ -397,11 +487,13 @@ export function ReviewSubmissionDialog({
           >
             {isSubmitting
               ? 'Posting...'
-              : hasFailed
-                ? 'Retry Failed'
-                : isApprove
-                  ? 'Approve'
-                  : 'Post Comments'}
+              : hasPartial
+                ? 'Retry Unposted'
+                : hasFailed
+                  ? 'Retry Failed'
+                  : isApprove
+                    ? 'Approve'
+                    : 'Post Comments'}
           </button>
         </div>
       </div>

--- a/packages/review-editor/components/ReviewSubmissionDialog.tsx
+++ b/packages/review-editor/components/ReviewSubmissionDialog.tsx
@@ -469,7 +469,7 @@ export function ReviewSubmissionDialog({
                         )}
                         <div className="mt-1 text-muted-foreground">
                           {recoveryPersistsRefresh
-                            ? 'Closing or refreshing this tab keeps the block in tab-scoped recovery storage.'
+                            ? 'Closing and reopening this dialog, or refreshing this tab, keeps the block in tab-scoped recovery storage.'
                             : 'Closing the dialog keeps this block on the current page. Keep the page open because tab-scoped refresh recovery is unavailable.'}
                         </div>
                       </div>

--- a/packages/review-editor/components/ReviewSubmissionDialog.ui.test.tsx
+++ b/packages/review-editor/components/ReviewSubmissionDialog.ui.test.tsx
@@ -31,7 +31,10 @@ const baseTarget: SubmissionTarget = {
 let root: Root | null = null;
 let host: HTMLElement | null = null;
 
-async function renderSubmission(submission: ReviewSubmission): Promise<void> {
+async function renderSubmission(
+  submission: ReviewSubmission,
+  generalComment = '',
+): Promise<void> {
   host = document.createElement('div');
   document.body.appendChild(host);
   await act(async () => {
@@ -41,13 +44,14 @@ async function renderSubmission(submission: ReviewSubmission): Promise<void> {
         isOpen
         action="comment"
         submission={submission}
-        generalComment=""
+        generalComment={generalComment}
         onGeneralCommentChange={() => {}}
         platformOpenPR={false}
         onPlatformOpenPRChange={() => {}}
         onConfirm={() => {}}
         onCancel={() => {}}
         isSubmitting={false}
+        recoveryPersistsRefresh
         mrLabel="MR"
         platformLabel="GitLab"
       />,
@@ -121,14 +125,20 @@ describe('ReviewSubmissionDialog submission outcomes', () => {
         },
       }],
       orphans: [],
-    });
+    }, 'Edited general comment');
 
     const content = document.body.textContent ?? '';
     expect(content).toContain('Review partially posted');
+    expect(content).toContain('This attempt posted 1 inline comment and the general comment');
     expect(content).toContain('src/failing.ts:19');
     expect(content).toContain('Handle this failure.');
     expect(content).toContain('Retry sends only the 1 unposted inline comment');
     expect(content).toContain('/tmp/plannotator/failed-comments/review.json');
+    expect(content).toContain('General comment locked because it may already be posted');
+    expect(content).toContain('refresh this tab');
+    const textarea = document.querySelector('textarea');
+    expect(textarea?.disabled).toBe(true);
+    expect(textarea?.value).toBe('Edited general comment');
     expect(actionButton()?.textContent).toContain('Retry Unposted');
     expect(actionButton()?.disabled).toBe(false);
   });

--- a/packages/review-editor/components/ReviewSubmissionDialog.ui.test.tsx
+++ b/packages/review-editor/components/ReviewSubmissionDialog.ui.test.tsx
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  ReviewSubmissionDialog,
+  type ReviewSubmission,
+  type SubmissionTarget,
+} from './ReviewSubmissionDialog';
+
+const hasDom = typeof document !== 'undefined';
+
+const failedComment = {
+  path: 'src/failing.ts',
+  line: 19,
+  side: 'RIGHT' as const,
+  body: 'Handle this failure.',
+};
+
+const baseTarget: SubmissionTarget = {
+  prUrl: 'https://gitlab.example/acme/widgets/-/merge_requests/7',
+  prNumber: 7,
+  prTitle: 'Make reviews reliable',
+  prRepo: 'acme/widgets',
+  fileComments: [failedComment],
+  fileScopedBody: '',
+  fileCount: 1,
+  annotationCount: 1,
+  status: 'pending',
+};
+
+let root: Root | null = null;
+let host: HTMLElement | null = null;
+
+async function renderSubmission(submission: ReviewSubmission): Promise<void> {
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  await act(async () => {
+    root = createRoot(host!);
+    root.render(
+      <ReviewSubmissionDialog
+        isOpen
+        action="comment"
+        submission={submission}
+        generalComment=""
+        onGeneralCommentChange={() => {}}
+        platformOpenPR={false}
+        onPlatformOpenPRChange={() => {}}
+        onConfirm={() => {}}
+        onCancel={() => {}}
+        isSubmitting={false}
+        mrLabel="MR"
+        platformLabel="GitLab"
+      />,
+    );
+  });
+}
+
+function actionButton(): HTMLButtonElement | null {
+  return Array.from(document.querySelectorAll('button')).find((button) =>
+    button.textContent?.includes('Post Comments') ||
+    button.textContent?.includes('Retry Failed') ||
+    button.textContent?.includes('Retry Unposted')
+  ) ?? null;
+}
+
+afterEach(async () => {
+  if (root !== null) {
+    await act(async () => root?.unmount());
+    root = null;
+  }
+  host?.remove();
+  host = null;
+  if (hasDom) document.body.innerHTML = '';
+});
+
+describe('ReviewSubmissionDialog submission outcomes', () => {
+  test.skipIf(!hasDom)('renders all-success as complete and disables another submission', async () => {
+    await renderSubmission({
+      targets: [{ ...baseTarget, status: 'success' }],
+      orphans: [],
+    });
+
+    expect(document.body.textContent).toContain('acme/widgets#7');
+    expect(actionButton()?.disabled).toBe(true);
+  });
+
+  test.skipIf(!hasDom)('renders all-failure with its error and a retry action', async () => {
+    await renderSubmission({
+      targets: [{
+        ...baseTarget,
+        status: 'failed',
+        error: 'Failed to post inline comments',
+      }],
+      orphans: [],
+    });
+
+    expect(document.body.textContent).toContain('Failed to post inline comments');
+    expect(actionButton()?.textContent).toContain('Retry Failed');
+    expect(actionButton()?.disabled).toBe(false);
+  });
+
+  test.skipIf(!hasDom)('renders mixed results with exact recovery and safe retry guidance', async () => {
+    await renderSubmission({
+      targets: [{
+        ...baseTarget,
+        status: 'partial',
+        partial: {
+          status: 'partial',
+          postedFileCommentCount: 1,
+          failedFileComments: [{
+            comment: failedComment,
+            error: 'src/failing.ts:19: rejected',
+          }],
+          reviewBodyPosted: true,
+          approval: 'not-requested',
+          recoveryFile: '/tmp/plannotator/failed-comments/review.json',
+          retry: {
+            action: 'comment',
+            fileComments: [failedComment],
+          },
+        },
+      }],
+      orphans: [],
+    });
+
+    const content = document.body.textContent ?? '';
+    expect(content).toContain('Review partially posted');
+    expect(content).toContain('src/failing.ts:19');
+    expect(content).toContain('Handle this failure.');
+    expect(content).toContain('Retry sends only the 1 unposted inline comment');
+    expect(content).toContain('/tmp/plannotator/failed-comments/review.json');
+    expect(actionButton()?.textContent).toContain('Retry Unposted');
+    expect(actionButton()?.disabled).toBe(false);
+  });
+});

--- a/packages/review-editor/utils/platformReviewSubmission.test.ts
+++ b/packages/review-editor/utils/platformReviewSubmission.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, test } from 'bun:test';
+import type { PRReviewSubmissionPartial } from '@plannotator/shared/pr-types';
+import type {
+  ReviewSubmission,
+  SubmissionTarget,
+} from '../components/ReviewSubmissionDialog';
+import {
+  submitPlatformReviewTarget,
+  submitPlatformReviewTargets,
+} from './platformReviewSubmission';
+import {
+  buildReviewSubmissionRecovery,
+  loadReviewSubmissionRecovery,
+  restoreReviewSubmission,
+  saveReviewSubmissionRecovery,
+  type ReviewRecoveryStorage,
+} from './reviewSubmissionRecovery';
+
+const comments = [
+  { path: 'src/one.ts', line: 10, side: 'RIGHT' as const, body: 'One' },
+  { path: 'src/two.ts', line: 20, side: 'RIGHT' as const, body: 'Two' },
+  { path: 'src/three.ts', line: 30, side: 'LEFT' as const, body: 'Three' },
+];
+
+const baseTarget: SubmissionTarget = {
+  prUrl: 'https://gitlab.example/acme/widgets/-/merge_requests/7',
+  prNumber: 7,
+  prTitle: 'Reliable retry',
+  prRepo: 'acme/widgets',
+  fileComments: comments,
+  fileScopedBody: '',
+  fileCount: 3,
+  annotationCount: 3,
+  status: 'pending',
+};
+
+class MemoryStorage implements ReviewRecoveryStorage {
+  private readonly values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+
+  corruptAll(value: string): void {
+    for (const key of this.values.keys()) this.values.set(key, value);
+  }
+}
+
+function partial(
+  failedComments: typeof comments,
+  postedFileCommentCount: number,
+): PRReviewSubmissionPartial {
+  return {
+    status: 'partial',
+    postedFileCommentCount,
+    failedFileComments: failedComments.map((comment) => ({
+      comment,
+      error: `${comment.path}:${comment.line}: rejected`,
+    })),
+    reviewBodyPosted: postedFileCommentCount > 0,
+    approval: 'not-requested',
+    retry: { action: 'comment', fileComments: failedComments },
+  };
+}
+
+function successResponse(submission: object): Response {
+  return Response.json({ ok: true, submission });
+}
+
+describe('platform review retry safety', () => {
+  test('partial → close/reopen → retry stays narrowed across retry-of-a-retry', async () => {
+    const requests: unknown[] = [];
+    const responses = [
+      successResponse(partial([comments[1], comments[2]], 1)),
+      successResponse({ status: 'complete' }),
+      successResponse(partial([comments[2]], 1)),
+      successResponse({ status: 'complete' }),
+    ];
+    const fetchReview = async (_input: string, init: RequestInit): Promise<Response> => {
+      if (typeof init.body !== 'string') throw new Error('Expected JSON request body');
+      const request: unknown = JSON.parse(init.body);
+      requests.push(request);
+      const response = responses.shift();
+      if (!response) throw new Error('Unexpected extra request');
+      return response;
+    };
+
+    const completedSibling: SubmissionTarget = {
+      ...baseTarget,
+      prUrl: 'https://gitlab.example/acme/widgets/-/merge_requests/8',
+      prNumber: 8,
+      status: 'pending',
+    };
+    const first = await submitPlatformReviewTargets({
+      targets: [baseTarget, completedSibling],
+      action: 'comment',
+      generalComment: 'Overall review',
+      bodyForTarget: () => 'Overall review',
+      fetchReview,
+    });
+    expect(first.targets[0].status).toBe('partial');
+    expect(first.targets[1].status).toBe('success');
+
+    const storage = new MemoryStorage();
+    const recovery = first.recovery;
+    expect(recovery).not.toBeNull();
+    saveReviewSubmissionRecovery(storage, baseTarget.prUrl, recovery);
+
+    // Simulate Cancel/Close by discarding the dialog plan, then rebuilding it.
+    const freshPlan: ReviewSubmission = {
+      targets: [
+        { ...baseTarget, status: 'pending' },
+        completedSibling,
+      ],
+      orphans: [],
+    };
+    const reloaded = loadReviewSubmissionRecovery(storage, baseTarget.prUrl);
+    if (!reloaded) throw new Error('Expected persisted recovery');
+    const reopened = restoreReviewSubmission(freshPlan, reloaded);
+    expect(reopened.targets[0].status).toBe('partial');
+    expect(reopened.targets[1].status).toBe('success');
+
+    const second = await submitPlatformReviewTargets({
+      targets: reopened.targets,
+      action: reloaded.action,
+      generalComment: 'Overall review',
+      bodyForTarget: () => 'This edit must not be posted',
+      fetchReview,
+    });
+    expect(second.targets[0].status).toBe('partial');
+    expect(second.targets[1].status).toBe('success');
+
+    const third = await submitPlatformReviewTargets({
+      targets: second.targets,
+      action: 'comment',
+      generalComment: 'Overall review',
+      bodyForTarget: () => 'Still must not be posted',
+      fetchReview,
+    });
+    expect(third.allComplete).toBe(true);
+    expect(requests).toEqual([
+      {
+        action: 'comment',
+        body: 'Overall review',
+        fileComments: comments,
+        targetPrUrl: baseTarget.prUrl,
+      },
+      {
+        action: 'comment',
+        body: 'Overall review',
+        fileComments: comments,
+        targetPrUrl: completedSibling.prUrl,
+      },
+      {
+        action: 'comment',
+        body: '',
+        fileComments: [comments[1], comments[2]],
+        targetPrUrl: baseTarget.prUrl,
+      },
+      {
+        action: 'comment',
+        body: '',
+        fileComments: [comments[2]],
+        targetPrUrl: baseTarget.prUrl,
+      },
+    ]);
+  });
+
+  test('a server-confirmed retry failure preserves the partial state', async () => {
+    const narrowed = partial([comments[2]], 2);
+    const result = await submitPlatformReviewTarget({
+      target: { ...baseTarget, status: 'partial', partial: narrowed },
+      action: 'comment',
+      body: 'Ignored',
+      fetchReview: async () => Response.json(
+        { error: 'Retry failed before posting' },
+        { status: 500 },
+      ),
+    });
+
+    expect(result.target).toMatchObject({
+      status: 'partial',
+      partial: narrowed,
+      error: 'Retry failed before posting',
+    });
+  });
+
+  test('an unrecognized success blocks replay and survives reopen', async () => {
+    let fetchCount = 0;
+    const ambiguous = await submitPlatformReviewTarget({
+      target: baseTarget,
+      action: 'comment',
+      body: 'Overall review',
+      fetchReview: async () => {
+        fetchCount += 1;
+        return Response.json({ ok: true, submission: { status: 'newer-version' } });
+      },
+    });
+    expect(ambiguous.target.status).toBe('blocked');
+
+    const storage = new MemoryStorage();
+    const recovery = buildReviewSubmissionRecovery(
+      'comment',
+      'Overall review',
+      [ambiguous.target],
+    );
+    saveReviewSubmissionRecovery(storage, baseTarget.prUrl, recovery);
+    const reloaded = loadReviewSubmissionRecovery(storage, baseTarget.prUrl);
+    if (!reloaded) throw new Error('Expected blocked recovery');
+    const reopened = restoreReviewSubmission(
+      { targets: [baseTarget], orphans: [] },
+      reloaded,
+    );
+    expect(reopened.targets[0].status).toBe('blocked');
+
+    await submitPlatformReviewTarget({
+      target: reopened.targets[0],
+      action: 'comment',
+      body: 'Must not post',
+      fetchReview: async () => {
+        fetchCount += 1;
+        return successResponse({ status: 'complete' });
+      },
+    });
+    expect(fetchCount).toBe(1);
+  });
+
+  test('an unreadable saved retry blocks a broad replay after refresh', () => {
+    const storage = new MemoryStorage();
+    const recoveryToCorrupt = buildReviewSubmissionRecovery(
+      'comment',
+      'Overall review',
+      [{ ...baseTarget, status: 'success' }],
+    );
+    saveReviewSubmissionRecovery(
+      storage,
+      baseTarget.prUrl,
+      recoveryToCorrupt,
+    );
+    storage.corruptAll('{not-json');
+
+    const recovery = loadReviewSubmissionRecovery(storage, baseTarget.prUrl);
+    if (!recovery) throw new Error('Expected corrupt recovery to fail closed');
+    const reopened = restoreReviewSubmission(
+      { targets: [baseTarget], orphans: [] },
+      recovery,
+    );
+
+    expect(reopened.targets[0]).toMatchObject({
+      status: 'blocked',
+      error: expect.stringContaining('could not read its retry contract'),
+    });
+  });
+});

--- a/packages/review-editor/utils/platformReviewSubmission.ts
+++ b/packages/review-editor/utils/platformReviewSubmission.ts
@@ -1,0 +1,169 @@
+import type { SubmissionTarget } from '../components/ReviewSubmissionDialog';
+import { buildPRActionRequest } from '../components/ReviewSubmissionDialog';
+import { parsePRActionSuccess, readPRActionError } from './prActionResponse';
+import {
+  buildReviewSubmissionRecovery,
+  type ReviewSubmissionRecovery,
+} from './reviewSubmissionRecovery';
+
+const UNKNOWN_RESULT_ERROR =
+  'The platform may have accepted part of this review, but Plannotator could not confirm the result. Automatic retry is blocked to avoid duplicate comments. Inspect the pull request or merge request before starting another review.';
+
+/** Fetch-compatible capability used to submit one platform review target. */
+export type PlatformReviewFetch = (
+  input: string,
+  init: RequestInit,
+) => Promise<Response>;
+
+/** Caller-visible result of submitting one target through `/api/pr-action`. */
+export interface PlatformReviewTargetResult {
+  target: SubmissionTarget;
+  prUrl?: string;
+}
+
+/** Result of one complete multi-target platform submission attempt. */
+export interface PlatformReviewAttemptResult {
+  targets: SubmissionTarget[];
+  allComplete: boolean;
+  recovery: ReviewSubmissionRecovery | null;
+  openUrls: string[];
+}
+
+/**
+ * Preserve an existing narrowed retry after a server-confirmed safe failure.
+ * A first-attempt failure has no known mutation and remains broadly retryable.
+ */
+export function markPlatformReviewSafeFailure(
+  target: SubmissionTarget,
+  error: string,
+): SubmissionTarget {
+  return target.partial
+    ? { ...target, status: 'partial', error }
+    : { ...target, status: 'failed', error, partial: undefined };
+}
+
+/** Block replay when the platform may have mutated but no result was confirmed. */
+export function markPlatformReviewAmbiguous(
+  target: SubmissionTarget,
+  error = UNKNOWN_RESULT_ERROR,
+): SubmissionTarget {
+  return { ...target, status: 'blocked', error };
+}
+
+/**
+ * Submit one platform target and translate the HTTP boundary into a retry-safe
+ * target state. Network loss and unrecognized 2xx payloads block automatic
+ * replay because the remote mutation outcome is unknowable.
+ */
+export async function submitPlatformReviewTarget(options: {
+  target: SubmissionTarget;
+  action: 'approve' | 'comment';
+  body: string;
+  fetchReview?: PlatformReviewFetch;
+}): Promise<PlatformReviewTargetResult> {
+  const { target, action, body, fetchReview = fetch } = options;
+  if (target.status === 'success' || target.status === 'blocked') {
+    return { target };
+  }
+
+  let response: Response;
+  try {
+    response = await fetchReview('/api/pr-action', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(buildPRActionRequest(action, body, target)),
+    });
+  } catch {
+    return { target: markPlatformReviewAmbiguous(target) };
+  }
+
+  let rawResponse: unknown;
+  try {
+    rawResponse = await response.json();
+  } catch {
+    return {
+      target: response.ok
+        ? markPlatformReviewAmbiguous(target)
+        : markPlatformReviewSafeFailure(target, 'Failed to submit review'),
+    };
+  }
+
+  if (!response.ok) {
+    return {
+      target: markPlatformReviewSafeFailure(
+        target,
+        readPRActionError(rawResponse) ?? 'Failed to submit review',
+      ),
+    };
+  }
+
+  const parsed = parsePRActionSuccess(rawResponse);
+  if (!parsed) {
+    return { target: markPlatformReviewAmbiguous(target) };
+  }
+  if (parsed.submission.status === 'partial') {
+    return {
+      target: {
+        ...target,
+        status: 'partial',
+        error: undefined,
+        partial: parsed.submission,
+      },
+      ...(parsed.prUrl ? { prUrl: parsed.prUrl } : {}),
+    };
+  }
+  return {
+    target: {
+      ...target,
+      status: 'success',
+      error: undefined,
+      partial: undefined,
+    },
+    ...(parsed.prUrl ? { prUrl: parsed.prUrl } : {}),
+  };
+}
+
+/**
+ * Execute the multi-target submission step used by `handlePlatformAction` and
+ * derive the exact progress record that must survive dialog close or refresh.
+ */
+export async function submitPlatformReviewTargets(options: {
+  targets: SubmissionTarget[];
+  action: 'approve' | 'comment';
+  generalComment: string;
+  bodyForTarget: (target: SubmissionTarget) => string;
+  fetchReview?: PlatformReviewFetch;
+}): Promise<PlatformReviewAttemptResult> {
+  const {
+    targets,
+    action,
+    generalComment,
+    bodyForTarget,
+    fetchReview,
+  } = options;
+  const results = await Promise.allSettled(
+    targets.map(async (target) => submitPlatformReviewTarget({
+      target,
+      action,
+      body: bodyForTarget(target),
+      ...(fetchReview ? { fetchReview } : {}),
+    })),
+  );
+  const openUrls: string[] = [];
+  const updatedTargets = results.map((result, index) => {
+    if (result.status === 'rejected') {
+      return markPlatformReviewAmbiguous(targets[index]);
+    }
+    if (result.value.prUrl) openUrls.push(result.value.prUrl);
+    return result.value.target;
+  });
+  const allComplete = updatedTargets.every((target) => target.status === 'success');
+  return {
+    targets: updatedTargets,
+    allComplete,
+    recovery: allComplete
+      ? null
+      : buildReviewSubmissionRecovery(action, generalComment, updatedTargets),
+    openUrls,
+  };
+}

--- a/packages/review-editor/utils/prActionResponse.test.ts
+++ b/packages/review-editor/utils/prActionResponse.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'bun:test';
+import { parsePRActionSuccess, readPRActionError } from './prActionResponse';
+
+const failedComment = {
+  path: 'src/failing.ts',
+  line: 19,
+  side: 'RIGHT' as const,
+  body: 'Handle this failure.',
+};
+
+describe('parsePRActionSuccess', () => {
+  test('parses an all-success response', () => {
+    expect(parsePRActionSuccess({
+      ok: true,
+      prUrl: 'https://gitlab.example/acme/widgets/-/merge_requests/7',
+      submission: { status: 'complete' },
+    })).toEqual({
+      prUrl: 'https://gitlab.example/acme/widgets/-/merge_requests/7',
+      submission: { status: 'complete' },
+    });
+  });
+
+  test('rejects an all-failure error response', () => {
+    const response = {
+      error: 'Failed to post inline comments: src/failing.ts:19',
+    };
+
+    expect(parsePRActionSuccess(response)).toBeNull();
+    expect(readPRActionError(response)).toBe(response.error);
+  });
+
+  test('parses a mixed response with its exact retry contract', () => {
+    const response = {
+      ok: true,
+      submission: {
+        status: 'partial',
+        postedFileCommentCount: 1,
+        failedFileComments: [
+          {
+            comment: failedComment,
+            error: 'src/failing.ts:19: rejected',
+          },
+        ],
+        reviewBodyPosted: true,
+        approval: 'not-requested',
+        recoveryFile: '/tmp/plannotator/failed-comments/review.json',
+        retry: {
+          action: 'comment',
+          fileComments: [failedComment],
+        },
+      },
+    };
+
+    expect(parsePRActionSuccess(response)).toEqual({
+      submission: response.submission,
+    });
+  });
+
+  test('rejects a partial response that could cause an unsafe broad retry', () => {
+    expect(parsePRActionSuccess({
+      ok: true,
+      submission: {
+        status: 'partial',
+        postedFileCommentCount: 1,
+        failedFileComments: [],
+        reviewBodyPosted: true,
+        approval: 'not-requested',
+      },
+    })).toBeNull();
+  });
+
+  test('rejects a retry payload that includes an already-posted comment', () => {
+    expect(parsePRActionSuccess({
+      ok: true,
+      submission: {
+        status: 'partial',
+        postedFileCommentCount: 1,
+        failedFileComments: [{
+          comment: failedComment,
+          error: 'rejected',
+        }],
+        reviewBodyPosted: true,
+        approval: 'not-requested',
+        retry: {
+          action: 'comment',
+          fileComments: [
+            failedComment,
+            { ...failedComment, path: 'src/already-posted.ts' },
+          ],
+        },
+      },
+    })).toBeNull();
+  });
+});

--- a/packages/review-editor/utils/prActionResponse.ts
+++ b/packages/review-editor/utils/prActionResponse.ts
@@ -1,0 +1,186 @@
+import type {
+  PRReviewCommentFailure,
+  PRReviewFileComment,
+  PRReviewRetry,
+  PRReviewSubmissionPartial,
+  PRReviewSubmissionResult,
+} from '@plannotator/shared/pr-types';
+
+/** Parsed success payload returned by the review server's platform endpoint. */
+export interface PRActionSuccess {
+  prUrl?: string;
+  submission: PRReviewSubmissionResult;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function optionalString(value: unknown): string | undefined | null {
+  if (value === undefined) return undefined;
+  return typeof value === 'string' ? value : null;
+}
+
+function parseFileComment(value: unknown): PRReviewFileComment | null {
+  if (!isRecord(value)) return null;
+  if (
+    typeof value.path !== 'string' ||
+    typeof value.line !== 'number' ||
+    !Number.isInteger(value.line) ||
+    (value.side !== 'LEFT' && value.side !== 'RIGHT') ||
+    typeof value.body !== 'string'
+  ) {
+    return null;
+  }
+
+  const startLine = value.start_line;
+  const startSide = value.start_side;
+  if (
+    (startLine !== undefined && (
+      typeof startLine !== 'number' ||
+      !Number.isInteger(startLine)
+    )) ||
+    (startSide !== undefined && startSide !== 'LEFT' && startSide !== 'RIGHT')
+  ) {
+    return null;
+  }
+
+  return {
+    path: value.path,
+    line: value.line,
+    side: value.side,
+    body: value.body,
+    ...(startLine !== undefined ? { start_line: startLine } : {}),
+    ...(startSide !== undefined ? { start_side: startSide } : {}),
+  };
+}
+
+function parseRetry(value: unknown): PRReviewRetry | null {
+  if (
+    !isRecord(value) ||
+    (value.action !== 'approve' && value.action !== 'comment') ||
+    !Array.isArray(value.fileComments)
+  ) {
+    return null;
+  }
+  const fileComments = value.fileComments.map(parseFileComment);
+  if (fileComments.some((comment) => comment === null)) return null;
+  return {
+    action: value.action,
+    fileComments: fileComments.filter(
+      (comment): comment is PRReviewFileComment => comment !== null,
+    ),
+  };
+}
+
+function parseCommentFailure(value: unknown): PRReviewCommentFailure | null {
+  if (!isRecord(value) || typeof value.error !== 'string') return null;
+  const comment = parseFileComment(value.comment);
+  return comment ? { comment, error: value.error } : null;
+}
+
+function sameFileComment(
+  left: PRReviewFileComment,
+  right: PRReviewFileComment,
+): boolean {
+  return (
+    left.path === right.path &&
+    left.line === right.line &&
+    left.side === right.side &&
+    left.body === right.body &&
+    left.start_line === right.start_line &&
+    left.start_side === right.start_side
+  );
+}
+
+function parsePartialSubmission(
+  value: Record<string, unknown>,
+): PRReviewSubmissionPartial | null {
+  if (
+    typeof value.postedFileCommentCount !== 'number' ||
+    !Number.isInteger(value.postedFileCommentCount) ||
+    value.postedFileCommentCount < 0 ||
+    !Array.isArray(value.failedFileComments) ||
+    typeof value.reviewBodyPosted !== 'boolean' ||
+    (
+      value.approval !== 'not-requested' &&
+      value.approval !== 'succeeded' &&
+      value.approval !== 'failed'
+    )
+  ) {
+    return null;
+  }
+
+  const failedFileComments = value.failedFileComments.map(parseCommentFailure);
+  if (failedFileComments.some((failure) => failure === null)) return null;
+  const retry = parseRetry(value.retry);
+  const approvalError = optionalString(value.approvalError);
+  const recoveryFile = optionalString(value.recoveryFile);
+  if (!retry || approvalError === null || recoveryFile === null) return null;
+  const failures = failedFileComments.filter(
+    (failure): failure is PRReviewCommentFailure => failure !== null,
+  );
+  const retryMatchesFailures =
+    retry.fileComments.length === failures.length &&
+    retry.fileComments.every((comment, index) =>
+      sameFileComment(comment, failures[index].comment)
+    );
+  const retryActionMatchesApproval =
+    value.approval === 'failed'
+      ? retry.action === 'approve' && approvalError !== undefined
+      : retry.action === 'comment' && approvalError === undefined;
+  if (
+    !retryMatchesFailures ||
+    !retryActionMatchesApproval ||
+    (failures.length === 0 && value.approval !== 'failed')
+  ) {
+    return null;
+  }
+
+  return {
+    status: 'partial',
+    postedFileCommentCount: value.postedFileCommentCount,
+    failedFileComments: failures,
+    reviewBodyPosted: value.reviewBodyPosted,
+    approval: value.approval,
+    ...(approvalError !== undefined ? { approvalError } : {}),
+    ...(recoveryFile !== undefined ? { recoveryFile } : {}),
+    retry,
+  };
+}
+
+/**
+ * Parse the success response from `/api/pr-action`.
+ *
+ * Returns `null` when the payload does not satisfy the current API contract.
+ */
+export function parsePRActionSuccess(value: unknown): PRActionSuccess | null {
+  if (!isRecord(value) || value.ok !== true || !isRecord(value.submission)) {
+    return null;
+  }
+  const prUrl = optionalString(value.prUrl);
+  if (prUrl === null) return null;
+
+  let submission: PRReviewSubmissionResult;
+  if (value.submission.status === 'complete') {
+    submission = { status: 'complete' };
+  } else if (value.submission.status === 'partial') {
+    const partial = parsePartialSubmission(value.submission);
+    if (!partial) return null;
+    submission = partial;
+  } else {
+    return null;
+  }
+
+  return {
+    ...(prUrl !== undefined ? { prUrl } : {}),
+    submission,
+  };
+}
+
+/** Read a safe server error message from an unsuccessful platform response. */
+export function readPRActionError(value: unknown): string | undefined {
+  return isRecord(value) && typeof value.error === 'string'
+    ? value.error
+    : undefined;
+}

--- a/packages/review-editor/utils/prActionResponse.ts
+++ b/packages/review-editor/utils/prActionResponse.ts
@@ -93,7 +93,8 @@ function sameFileComment(
   );
 }
 
-function parsePartialSubmission(
+/** Parse one server-issued partial submission and its exact retry contract. */
+export function parsePRReviewSubmissionPartial(
   value: Record<string, unknown>,
 ): PRReviewSubmissionPartial | null {
   if (
@@ -165,7 +166,7 @@ export function parsePRActionSuccess(value: unknown): PRActionSuccess | null {
   if (value.submission.status === 'complete') {
     submission = { status: 'complete' };
   } else if (value.submission.status === 'partial') {
-    const partial = parsePartialSubmission(value.submission);
+    const partial = parsePRReviewSubmissionPartial(value.submission);
     if (!partial) return null;
     submission = partial;
   } else {

--- a/packages/review-editor/utils/reviewSubmissionRecovery.ts
+++ b/packages/review-editor/utils/reviewSubmissionRecovery.ts
@@ -1,0 +1,288 @@
+import type { PRReviewSubmissionPartial } from '@plannotator/shared/pr-types';
+import type {
+  ReviewSubmission,
+  SubmissionTarget,
+} from '../components/ReviewSubmissionDialog';
+import { parsePRReviewSubmissionPartial } from './prActionResponse';
+
+const STORAGE_KEY_PREFIX = 'plannotator-pr-review-recovery-v1:';
+
+/** Minimal session-storage capability used by review recovery. */
+export interface ReviewRecoveryStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+interface RetainedTargetBase {
+  prUrl: string;
+  prNumber: number;
+  prTitle: string;
+  prRepo: string;
+  fileCount: number;
+  annotationCount: number;
+}
+
+type RetainedSubmissionTarget =
+  | (RetainedTargetBase & { status: 'success' })
+  | (RetainedTargetBase & {
+      status: 'partial';
+      partial: PRReviewSubmissionPartial;
+      error?: string;
+    })
+  | (RetainedTargetBase & {
+      status: 'blocked';
+      error: string;
+      partial?: PRReviewSubmissionPartial;
+    });
+
+/** Retry-safe progress retained for one root PR review within a browser tab. */
+export interface ReviewSubmissionRecovery {
+  action: 'approve' | 'comment';
+  generalComment: string;
+  targets: RetainedSubmissionTarget[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function parseNonNegativeInteger(value: unknown): number | null {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0
+    ? value
+    : null;
+}
+
+function parseRetainedTarget(value: unknown): RetainedSubmissionTarget | null {
+  if (!isRecord(value)) return null;
+  const prNumber = parseNonNegativeInteger(value.prNumber);
+  const fileCount = parseNonNegativeInteger(value.fileCount);
+  const annotationCount = parseNonNegativeInteger(value.annotationCount);
+  if (
+    typeof value.prUrl !== 'string' ||
+    typeof value.prTitle !== 'string' ||
+    typeof value.prRepo !== 'string' ||
+    prNumber === null ||
+    fileCount === null ||
+    annotationCount === null
+  ) {
+    return null;
+  }
+
+  const base: RetainedTargetBase = {
+    prUrl: value.prUrl,
+    prNumber,
+    prTitle: value.prTitle,
+    prRepo: value.prRepo,
+    fileCount,
+    annotationCount,
+  };
+  if (value.status === 'success') return { ...base, status: 'success' };
+  if (value.status === 'blocked' && typeof value.error === 'string') {
+    if (value.partial === undefined) {
+      return { ...base, status: 'blocked', error: value.error };
+    }
+    if (!isRecord(value.partial)) return null;
+    const partial = parsePRReviewSubmissionPartial(value.partial);
+    return partial
+      ? { ...base, status: 'blocked', error: value.error, partial }
+      : null;
+  }
+  if (value.status !== 'partial' || !isRecord(value.partial)) return null;
+  const partial = parsePRReviewSubmissionPartial(value.partial);
+  if (!partial || (value.error !== undefined && typeof value.error !== 'string')) {
+    return null;
+  }
+  return {
+    ...base,
+    status: 'partial',
+    partial,
+    ...(typeof value.error === 'string' ? { error: value.error } : {}),
+  };
+}
+
+function parseRecovery(value: unknown): ReviewSubmissionRecovery | null {
+  if (
+    !isRecord(value) ||
+    (value.action !== 'approve' && value.action !== 'comment') ||
+    typeof value.generalComment !== 'string' ||
+    !Array.isArray(value.targets)
+  ) {
+    return null;
+  }
+  const targets = value.targets.map(parseRetainedTarget);
+  if (targets.some((target) => target === null)) return null;
+  return {
+    action: value.action,
+    generalComment: value.generalComment,
+    targets: targets.filter(
+      (target): target is RetainedSubmissionTarget => target !== null,
+    ),
+  };
+}
+
+function storageKey(rootPrUrl: string): string {
+  return `${STORAGE_KEY_PREFIX}${encodeURIComponent(rootPrUrl)}`;
+}
+
+function blockedCorruptRecovery(rootPrUrl: string): ReviewSubmissionRecovery {
+  return {
+    action: 'comment',
+    generalComment: '',
+    targets: [{
+      prUrl: rootPrUrl,
+      prNumber: 0,
+      prTitle: 'Saved retry state unavailable',
+      prRepo: 'Platform review',
+      fileCount: 0,
+      annotationCount: 0,
+      status: 'blocked',
+      error: 'Plannotator found saved review progress but could not read its retry contract. Automatic replay is blocked to avoid duplicate comments; inspect the platform review before starting again.',
+    }],
+  };
+}
+
+/** Load retry-safe progress for one root PR URL from tab-scoped storage. */
+export function loadReviewSubmissionRecovery(
+  storage: ReviewRecoveryStorage,
+  rootPrUrl: string,
+): ReviewSubmissionRecovery | null {
+  try {
+    const raw = storage.getItem(storageKey(rootPrUrl));
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed) || parsed.version !== 1) {
+      return blockedCorruptRecovery(rootPrUrl);
+    }
+    return parseRecovery(parsed.recovery) ?? blockedCorruptRecovery(rootPrUrl);
+  } catch {
+    return blockedCorruptRecovery(rootPrUrl);
+  }
+}
+
+/**
+ * Persist or clear retry-safe progress for one root PR URL.
+ * Returns whether tab-scoped refresh recovery is available.
+ */
+export function saveReviewSubmissionRecovery(
+  storage: ReviewRecoveryStorage,
+  rootPrUrl: string,
+  recovery: ReviewSubmissionRecovery | null,
+): boolean {
+  try {
+    if (recovery && recovery.targets.length > 0) {
+      storage.setItem(
+        storageKey(rootPrUrl),
+        JSON.stringify({ version: 1, recovery }),
+      );
+    } else {
+      storage.removeItem(storageKey(rootPrUrl));
+    }
+    return true;
+  } catch {
+    // A storage failure must not broaden a live in-memory retry. The dialog
+    // still retains its current target state until the tab is refreshed.
+    return false;
+  }
+}
+
+/**
+ * Retain only states that prove a remote mutation or make replay ambiguous.
+ * Plain failures are omitted because the original request is safe to retry.
+ */
+export function buildReviewSubmissionRecovery(
+  action: 'approve' | 'comment',
+  generalComment: string,
+  targets: SubmissionTarget[],
+): ReviewSubmissionRecovery | null {
+  const retainedTargets = targets.flatMap((target): RetainedSubmissionTarget[] => {
+    const base: RetainedTargetBase = {
+      prUrl: target.prUrl,
+      prNumber: target.prNumber,
+      prTitle: target.prTitle,
+      prRepo: target.prRepo,
+      fileCount: target.fileCount,
+      annotationCount: target.annotationCount,
+    };
+    if (target.status === 'success') return [{ ...base, status: 'success' }];
+    if (target.status === 'blocked') {
+      return [{
+        ...base,
+        status: 'blocked',
+        error: target.error ?? 'Retry blocked because the platform result is ambiguous.',
+        ...(target.partial ? { partial: target.partial } : {}),
+      }];
+    }
+    if (target.status === 'partial' && target.partial) {
+      return [{
+        ...base,
+        status: 'partial',
+        partial: target.partial,
+        ...(target.error ? { error: target.error } : {}),
+      }];
+    }
+    return [];
+  });
+  return retainedTargets.length > 0
+    ? { action, generalComment, targets: retainedTargets }
+    : null;
+}
+
+function restoreTarget(
+  freshTarget: SubmissionTarget | undefined,
+  retained: RetainedSubmissionTarget,
+): SubmissionTarget {
+  const base: SubmissionTarget = freshTarget ?? {
+    prUrl: retained.prUrl,
+    prNumber: retained.prNumber,
+    prTitle: retained.prTitle,
+    prRepo: retained.prRepo,
+    fileComments: retained.status === 'partial'
+      ? retained.partial.retry.fileComments
+      : [],
+    fileScopedBody: '',
+    fileCount: retained.fileCount,
+    annotationCount: retained.annotationCount,
+    status: 'pending',
+  };
+  if (retained.status === 'success') {
+    return { ...base, status: 'success', error: undefined, partial: undefined };
+  }
+  if (retained.status === 'blocked') {
+    return {
+      ...base,
+      status: 'blocked',
+      error: retained.error,
+      partial: retained.partial,
+    };
+  }
+  return {
+    ...base,
+    status: 'partial',
+    partial: retained.partial,
+    error: retained.error,
+  };
+}
+
+/** Merge retained progress into a freshly rebuilt annotation submission. */
+export function restoreReviewSubmission(
+  freshSubmission: ReviewSubmission,
+  recovery: ReviewSubmissionRecovery,
+): ReviewSubmission {
+  const freshByUrl = new Map(
+    freshSubmission.targets.map((target) => [target.prUrl, target]),
+  );
+  const retainedByUrl = new Map(
+    recovery.targets.map((target) => [target.prUrl, target]),
+  );
+  const restoredTargets = freshSubmission.targets.map((target) => {
+    const retained = retainedByUrl.get(target.prUrl);
+    return retained ? restoreTarget(target, retained) : target;
+  });
+  for (const retained of recovery.targets) {
+    if (!freshByUrl.has(retained.prUrl)) {
+      restoredTargets.push(restoreTarget(undefined, retained));
+    }
+  }
+  return { ...freshSubmission, targets: restoredTargets };
+}

--- a/packages/server/pr.ts
+++ b/packages/server/pr.ts
@@ -11,6 +11,7 @@ import type {
   PRContext,
   PRRuntime,
   PRReviewFileComment,
+  PRReviewSubmissionResult,
   PRStackTree,
   PRListItem,
 } from "@plannotator/shared/pr-types";
@@ -37,7 +38,7 @@ import {
   fetchPRList as fetchPRListCore,
 } from "@plannotator/shared/pr-provider";
 
-export type { PRRef, PRMetadata, PRContext, PRReviewFileComment, PRStackTree, PRListItem } from "@plannotator/shared/pr-types";
+export type { PRRef, PRMetadata, PRContext, PRReviewFileComment, PRReviewSubmissionResult, PRStackTree, PRListItem } from "@plannotator/shared/pr-types";
 export { prRefFromMetadata, isSameProject, getPlatformLabel, getMRLabel, getMRNumberLabel, getDisplayRepo, getCliName, getCliInstallUrl } from "@plannotator/shared/pr-types";
 export type { GithubPRMetadata } from "@plannotator/shared/pr-types";
 
@@ -110,13 +111,14 @@ export function fetchPRFileContent(
   return fetchPRFileContentCore(runtime, ref, sha, filePath);
 }
 
+/** Submit a review through the Bun command runtime. */
 export function submitPRReview(
   ref: PRRef,
   headSha: string,
   action: "approve" | "comment",
   body: string,
   fileComments: PRReviewFileComment[],
-): Promise<void> {
+): Promise<PRReviewSubmissionResult> {
   return submitPRReviewCore(runtime, ref, headSha, action, body, fileComments);
 }
 

--- a/packages/server/review-pr-action.test.ts
+++ b/packages/server/review-pr-action.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type {
+  PRMetadata,
+  PRReviewFileComment,
+  PRReviewSubmissionResult,
+} from '@plannotator/shared/pr-types';
+import { startReviewServer } from './review';
+
+const originalAI = process.env.PLANNOTATOR_AI;
+const originalDataDir = process.env.PLANNOTATOR_DATA_DIR;
+const originalPath = process.env.PATH;
+const tempDirs: string[] = [];
+
+const prMetadata: PRMetadata = {
+  platform: 'gitlab',
+  host: 'gitlab.invalid',
+  projectPath: 'acme/widgets',
+  iid: 7,
+  title: 'Reliable comments',
+  author: 'reviewer',
+  baseBranch: 'main',
+  headBranch: 'feature',
+  baseSha: 'base',
+  headSha: 'head',
+  url: 'https://gitlab.invalid/acme/widgets/-/merge_requests/7',
+};
+
+const fileComment: PRReviewFileComment = {
+  path: 'src/failing.ts',
+  line: 19,
+  side: 'RIGHT',
+  body: 'Handle this failure.',
+};
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function withReviewServer(
+  submit: () => Promise<PRReviewSubmissionResult>,
+  run: (url: string) => Promise<void>,
+): Promise<void> {
+  process.env.PLANNOTATOR_AI = 'disabled';
+  process.env.PLANNOTATOR_DATA_DIR = makeTempDir('plannotator-pr-action-data-');
+  process.env.PATH = makeTempDir('plannotator-pr-action-path-');
+  const server = await startReviewServer({
+    rawPatch: 'diff --git a/src/failing.ts b/src/failing.ts\n',
+    gitRef: 'MR !7',
+    htmlContent: '<!doctype html><html><body>review</body></html>',
+    prMetadata,
+    prReviewSubmitter: async () => submit(),
+  });
+  try {
+    await run(server.url);
+  } finally {
+    server.stop();
+  }
+}
+
+async function postReview(url: string): Promise<Response> {
+  return fetch(`${url}/api/pr-action`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      action: 'comment',
+      body: 'Overall review',
+      fileComments: [fileComment],
+    }),
+  });
+}
+
+afterEach(() => {
+  if (originalAI === undefined) delete process.env.PLANNOTATOR_AI;
+  else process.env.PLANNOTATOR_AI = originalAI;
+  if (originalDataDir === undefined) delete process.env.PLANNOTATOR_DATA_DIR;
+  else process.env.PLANNOTATOR_DATA_DIR = originalDataDir;
+  if (originalPath === undefined) delete process.env.PATH;
+  else process.env.PATH = originalPath;
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('Bun /api/pr-action submission contract', () => {
+  test('returns complete success', async () => {
+    await withReviewServer(
+      async () => ({ status: 'complete' }),
+      async (url) => {
+        const response = await postReview(url);
+        expect(response.status).toBe(200);
+        expect(await response.json()).toMatchObject({
+          ok: true,
+          submission: { status: 'complete' },
+        });
+      },
+    );
+  });
+
+  test('returns an all-failure as an error', async () => {
+    await withReviewServer(
+      async () => {
+        throw new Error('Failed to post inline comments');
+      },
+      async (url) => {
+        const response = await postReview(url);
+        expect(response.status).toBe(500);
+        expect(await response.json()).toEqual({
+          error: 'Failed to post inline comments',
+        });
+      },
+    );
+  });
+
+  test('returns mixed outcomes as actionable partial success', async () => {
+    const partial: PRReviewSubmissionResult = {
+      status: 'partial',
+      postedFileCommentCount: 1,
+      failedFileComments: [{
+        comment: fileComment,
+        error: 'src/failing.ts:19: rejected',
+      }],
+      reviewBodyPosted: true,
+      approval: 'not-requested',
+      recoveryFile: '/tmp/failed-comments/review.json',
+      retry: {
+        action: 'comment',
+        fileComments: [fileComment],
+      },
+    };
+    await withReviewServer(
+      async () => partial,
+      async (url) => {
+        const response = await postReview(url);
+        expect(response.status).toBe(200);
+        expect(await response.json()).toMatchObject({
+          ok: true,
+          prUrl: prMetadata.url,
+          submission: partial,
+        });
+      },
+    );
+  });
+});

--- a/packages/server/review.ts
+++ b/packages/server/review.ts
@@ -168,6 +168,8 @@ export interface ReviewServerOptions {
   opencodeClient?: OpencodeClient;
   /** PR metadata when reviewing a pull request (PR mode) */
   prMetadata?: PRMetadata;
+  /** Platform review writer override used by isolated runtime tests. */
+  prReviewSubmitter?: typeof submitPRReview;
   /**
    * The initial layer patch is missing per-file content (platform APIs
    * withhold patches on very large PRs). Enables the local recompute upgrade
@@ -215,6 +217,7 @@ export async function startReviewServer(
   options: ReviewServerOptions
 ): Promise<ReviewServerResult> {
   const { htmlContent, origin, gitContext, sharingEnabled = true, shareBaseUrl, onReady } = options;
+  const submitPlatformReview = options.prReviewSubmitter ?? submitPRReview;
   const aiEnabled = resolveAIEnabled();
 
   let prMetadata = options.prMetadata;
@@ -2786,7 +2789,7 @@ export async function startReviewServer(
 
               console.error(`[pr-action] ${body.action} with ${body.fileComments.length} file comment(s), target=${targetUrl}, headSha=${targetHeadSha}`);
 
-              await submitPRReview(
+              const submission = await submitPlatformReview(
                 targetRef,
                 targetHeadSha,
                 body.action,
@@ -2794,9 +2797,9 @@ export async function startReviewServer(
                 body.fileComments,
               );
 
-              console.error(`[pr-action] Success`);
+              console.error(`[pr-action] ${submission.status === "complete" ? "Success" : "Partial success"}`);
               prContextLive.refreshAfterWrite(targetUrl, targetRef);
-              return Response.json({ ok: true, prUrl: targetUrl });
+              return Response.json({ ok: true, prUrl: targetUrl, submission });
             } catch (err) {
               const message =
                 err instanceof Error ? err.message : "Failed to submit PR review";

--- a/packages/shared/pr-github.ts
+++ b/packages/shared/pr-github.ts
@@ -4,7 +4,7 @@
  * All functions use the `gh` CLI via the PRRuntime abstraction.
  */
 
-import type { PRRuntime, PRMetadata, PRContext, PRReviewThread, PRThreadComment, PRReviewFileComment, CommandResult, PRStackTree, PRStackNode, PRListItem } from "./pr-types";
+import type { PRRuntime, PRMetadata, PRContext, PRReviewThread, PRThreadComment, PRReviewFileComment, PRReviewSubmissionResult, CommandResult, PRStackTree, PRStackNode, PRListItem } from "./pr-types";
 import { encodeApiFilePath } from "./pr-types";
 import { parsePaginatedArray } from "./cli-pagination";
 
@@ -642,6 +642,12 @@ export async function markGhFilesViewed(
 
 // --- Submit PR Review ---
 
+/**
+ * Submit one atomic GitHub review.
+ *
+ * GitHub either accepts the complete review or this rejects before reporting
+ * success, so no narrowed retry result is needed.
+ */
 export async function submitGhPRReview(
   runtime: PRRuntime,
   ref: GhPRRef,
@@ -649,7 +655,7 @@ export async function submitGhPRReview(
   action: "approve" | "comment",
   body: string,
   fileComments: PRReviewFileComment[],
-): Promise<void> {
+): Promise<PRReviewSubmissionResult> {
   const payload = JSON.stringify({
     commit_id: headSha,
     body,
@@ -675,6 +681,8 @@ export async function submitGhPRReview(
     const message = result.stderr.trim() || result.stdout.trim() || `exit code ${result.exitCode}`;
     throw new Error(`Failed to submit PR review: ${message}`);
   }
+
+  return { status: "complete" };
 }
 
 // --- Stack Tree (GraphQL) ---

--- a/packages/shared/pr-gitlab.test.ts
+++ b/packages/shared/pr-gitlab.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, spyOn, test } from "bun:test";
-import { fetchGlMR, fetchGlMRContext, parsePaginatedArray } from "./pr-gitlab";
-import type { PRRuntime } from "./pr-types";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fetchGlMR, fetchGlMRContext, parsePaginatedArray, submitGlMRReview } from "./pr-gitlab";
+import type { PRReviewFileComment, PRRuntime } from "./pr-types";
 
 describe("fetchGlMR", () => {
   test("uses GitLab raw diffs so binary markers and collapsed files are preserved", async () => {
@@ -479,5 +482,191 @@ describe("parsePaginatedArray", () => {
 
   test("does not split on bracket characters inside strings", () => {
     expect(parsePaginatedArray<{ s: string }>('[{"s":"a][b"}]')).toEqual([{ s: "a][b" }]);
+  });
+});
+
+describe("submitGlMRReview", () => {
+  const comments: PRReviewFileComment[] = [
+    {
+      path: "src/first.ts",
+      line: 12,
+      side: "RIGHT",
+      body: "First finding",
+    },
+    {
+      path: "src/second.ts",
+      line: 27,
+      side: "LEFT",
+      body: "Second finding",
+    },
+  ];
+
+  function makeSubmissionRuntime(
+    discussionFailures: ReadonlySet<string>,
+  ): { runtime: PRRuntime; postedBodies: string[] } {
+    const postedBodies: string[] = [];
+    return {
+      postedBodies,
+      runtime: {
+        async runCommand(_command, args) {
+          const endpoint = args[1] ?? "";
+          if (endpoint === "projects/g%2Fp/merge_requests/1") {
+            return {
+              stdout: JSON.stringify({
+                diff_refs: {
+                  base_sha: "base",
+                  start_sha: "start",
+                  head_sha: "head",
+                },
+              }),
+              stderr: "",
+              exitCode: 0,
+            };
+          }
+          return { stdout: "", stderr: `unexpected endpoint: ${endpoint}`, exitCode: 1 };
+        },
+        async runCommandWithInput(_command, args, input) {
+          const endpoint = args[1] ?? "";
+          const payload = JSON.parse(input) as { body?: string };
+          if (payload.body) postedBodies.push(payload.body);
+          if (endpoint.endsWith("/notes")) {
+            return { stdout: "{}", stderr: "", exitCode: 0 };
+          }
+          if (endpoint.endsWith("/discussions")) {
+            return discussionFailures.has(payload.body ?? "")
+              ? { stdout: "", stderr: `rejected ${payload.body}`, exitCode: 1 }
+              : { stdout: "{}", stderr: "", exitCode: 0 };
+          }
+          return { stdout: "", stderr: `unexpected endpoint: ${endpoint}`, exitCode: 1 };
+        },
+      },
+    };
+  }
+
+  async function withFailedCommentDataDir<T>(run: (dir: string) => Promise<T>): Promise<T> {
+    const original = process.env.PLANNOTATOR_DATA_DIR;
+    const dir = mkdtempSync(join(tmpdir(), "plannotator-gitlab-submit-"));
+    process.env.PLANNOTATOR_DATA_DIR = dir;
+    try {
+      return await run(dir);
+    } finally {
+      if (original === undefined) delete process.env.PLANNOTATOR_DATA_DIR;
+      else process.env.PLANNOTATOR_DATA_DIR = original;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  test("reports complete when every inline discussion is posted", async () => {
+    const { runtime } = makeSubmissionRuntime(new Set());
+
+    await expect(
+      submitGlMRReview(runtime, REF, "head", "comment", "", comments),
+    ).resolves.toEqual({ status: "complete" });
+  });
+
+  test("throws when every inline discussion fails before anything is posted", async () => {
+    await withFailedCommentDataDir(async () => {
+      const { runtime } = makeSubmissionRuntime(new Set(["First finding", "Second finding"]));
+
+      await expect(
+        submitGlMRReview(runtime, REF, "head", "comment", "", comments),
+      ).rejects.toThrow("Failed to post inline comments");
+    });
+  });
+
+  test("reports all inline failures as partial when the review body already posted", async () => {
+    await withFailedCommentDataDir(async () => {
+      const { runtime } = makeSubmissionRuntime(new Set(["First finding", "Second finding"]));
+
+      const result = await submitGlMRReview(
+        runtime,
+        REF,
+        "head",
+        "comment",
+        "Already posted body",
+        comments,
+      );
+
+      expect(result).toMatchObject({
+        status: "partial",
+        postedFileCommentCount: 0,
+        reviewBodyPosted: true,
+        failedFileComments: [
+          { comment: comments[0] },
+          { comment: comments[1] },
+        ],
+        retry: {
+          action: "comment",
+          fileComments: comments,
+        },
+      });
+    });
+  });
+
+  test("reports mixed outcomes with exact failed comments and a durable recovery file", async () => {
+    await withFailedCommentDataDir(async () => {
+      const { runtime, postedBodies } = makeSubmissionRuntime(new Set(["Second finding"]));
+
+      const result = await submitGlMRReview(
+        runtime,
+        REF,
+        "head",
+        "comment",
+        "Overall review",
+        comments,
+      );
+
+      expect(result).toMatchObject({
+        status: "partial",
+        postedFileCommentCount: 1,
+        reviewBodyPosted: true,
+        approval: "not-requested",
+        failedFileComments: [
+          {
+            comment: comments[1],
+            error: "src/second.ts:27: rejected Second finding",
+          },
+        ],
+        retry: {
+          action: "comment",
+          fileComments: [comments[1]],
+        },
+      });
+      expect(result.status === "partial" ? result.recoveryFile : undefined).toBeString();
+      if (result.status !== "partial" || !result.recoveryFile) {
+        throw new Error("Expected a partial result with a recovery file");
+      }
+      const persisted = JSON.parse(readFileSync(result.recoveryFile, "utf-8")) as {
+        failedComments: PRReviewFileComment[];
+      };
+      expect(persisted.failedComments).toEqual([comments[1]]);
+      expect(postedBodies).toEqual(["Overall review", "First finding", "Second finding"]);
+    });
+  });
+
+  test("reports a failed approval as partial after inline comments have posted", async () => {
+    const { runtime } = makeSubmissionRuntime(new Set());
+
+    const result = await submitGlMRReview(
+      runtime,
+      REF,
+      "head",
+      "approve",
+      "",
+      comments,
+    );
+
+    expect(result).toMatchObject({
+      status: "partial",
+      postedFileCommentCount: 2,
+      failedFileComments: [],
+      reviewBodyPosted: false,
+      approval: "failed",
+      approvalError: "Failed to approve MR: unexpected endpoint: projects/g%2Fp/merge_requests/1/approve",
+      retry: {
+        action: "approve",
+        fileComments: [],
+      },
+    });
   });
 });

--- a/packages/shared/pr-gitlab.test.ts
+++ b/packages/shared/pr-gitlab.test.ts
@@ -503,6 +503,10 @@ describe("submitGlMRReview", () => {
 
   function makeSubmissionRuntime(
     discussionFailures: ReadonlySet<string>,
+    options: {
+      diffRefsReject?: boolean;
+      approvalReject?: boolean;
+    } = {},
   ): { runtime: PRRuntime; postedBodies: string[] } {
     const postedBodies: string[] = [];
     return {
@@ -511,6 +515,9 @@ describe("submitGlMRReview", () => {
         async runCommand(_command, args) {
           const endpoint = args[1] ?? "";
           if (endpoint === "projects/g%2Fp/merge_requests/1") {
+            if (options.diffRefsReject) {
+              throw new Error("spawn glab ENOENT");
+            }
             return {
               stdout: JSON.stringify({
                 diff_refs: {
@@ -536,6 +543,9 @@ describe("submitGlMRReview", () => {
             return discussionFailures.has(payload.body ?? "")
               ? { stdout: "", stderr: `rejected ${payload.body}`, exitCode: 1 }
               : { stdout: "{}", stderr: "", exitCode: 0 };
+          }
+          if (endpoint.endsWith("/approve") && options.approvalReject) {
+            throw new Error("spawn glab ENOENT");
           }
           return { stdout: "", stderr: `unexpected endpoint: ${endpoint}`, exitCode: 1 };
         },
@@ -644,6 +654,42 @@ describe("submitGlMRReview", () => {
     });
   });
 
+  test("turns a diff-ref spawn rejection after posting the body into a safe partial retry", async () => {
+    await withFailedCommentDataDir(async () => {
+      const { runtime } = makeSubmissionRuntime(new Set(), { diffRefsReject: true });
+
+      const result = await submitGlMRReview(
+        runtime,
+        REF,
+        "head",
+        "comment",
+        "Already posted body",
+        comments,
+      );
+
+      expect(result).toMatchObject({
+        status: "partial",
+        postedFileCommentCount: 0,
+        reviewBodyPosted: true,
+        failedFileComments: [
+          { comment: comments[0], error: expect.stringContaining("spawn glab ENOENT") },
+          { comment: comments[1], error: expect.stringContaining("spawn glab ENOENT") },
+        ],
+        retry: { action: "comment", fileComments: comments },
+      });
+    });
+  });
+
+  test("keeps a diff-ref spawn rejection retryable when no mutation occurred", async () => {
+    await withFailedCommentDataDir(async () => {
+      const { runtime } = makeSubmissionRuntime(new Set(), { diffRefsReject: true });
+
+      await expect(
+        submitGlMRReview(runtime, REF, "head", "comment", "", comments),
+      ).rejects.toThrow("Failed to post inline comments");
+    });
+  });
+
   test("reports a failed approval as partial after inline comments have posted", async () => {
     const { runtime } = makeSubmissionRuntime(new Set());
 
@@ -668,5 +714,38 @@ describe("submitGlMRReview", () => {
         fileComments: [],
       },
     });
+  });
+
+  test("reports repeated approval-only spawn failures consistently as partial", async () => {
+    const { runtime } = makeSubmissionRuntime(new Set(), { approvalReject: true });
+
+    const first = await submitGlMRReview(
+      runtime,
+      REF,
+      "head",
+      "approve",
+      "",
+      [],
+    );
+    const retry = await submitGlMRReview(
+      runtime,
+      REF,
+      "head",
+      "approve",
+      "",
+      [],
+    );
+
+    const expected = {
+      status: "partial",
+      postedFileCommentCount: 0,
+      failedFileComments: [],
+      reviewBodyPosted: false,
+      approval: "failed",
+      approvalError: "Failed to approve MR: spawn glab ENOENT",
+      retry: { action: "approve", fileComments: [] },
+    };
+    expect(first).toEqual(expected);
+    expect(retry).toEqual(expected);
   });
 });

--- a/packages/shared/pr-gitlab.ts
+++ b/packages/shared/pr-gitlab.ts
@@ -585,6 +585,7 @@ export async function submitGlMRReview(
   if (!runtime.runCommandWithInput) {
     throw new Error("Runtime does not support stdin input; cannot submit MR review");
   }
+  const runCommandWithInput = runtime.runCommandWithInput.bind(runtime);
 
   const encoded = encodeProject(ref.projectPath);
   const mrEndpoint = `projects/${encoded}/merge_requests/${ref.iid}`;
@@ -599,7 +600,7 @@ export async function submitGlMRReview(
   // 1. Post general body as a note (if non-empty)
   if (body && body.trim()) {
     const notePayload = JSON.stringify({ body: body.trim() });
-    const noteResult = await runtime.runCommandWithInput(
+    const noteResult = await runCommandWithInput(
       "glab",
       apiArgs(ref.host, `${mrEndpoint}/notes`, ["--method", "POST", "--input", "-", "-H", "Content-Type:application/json"]),
       notePayload,
@@ -614,81 +615,93 @@ export async function submitGlMRReview(
   // 2. Post inline file comments as discussions with position
   if (fileComments.length > 0) {
     // We need the MR's diff_refs for the position SHAs.
-    const mrResult = await runtime.runCommand(
-      "glab",
-      apiArgs(ref.host, mrEndpoint),
-    );
     let baseSha = headSha; // fallback
     let startSha = headSha;
-    if (mrResult.exitCode === 0 && mrResult.stdout.trim()) {
-      try {
-        const mrData = JSON.parse(mrResult.stdout) as { diff_refs?: { base_sha: string; start_sha: string; head_sha: string } };
-        if (mrData.diff_refs) {
-          baseSha = mrData.diff_refs.base_sha;
-          startSha = mrData.diff_refs.start_sha;
+    let diffRefsError: string | undefined;
+    try {
+      const mrResult = await runtime.runCommand(
+        "glab",
+        apiArgs(ref.host, mrEndpoint),
+      );
+      if (mrResult.exitCode === 0 && mrResult.stdout.trim()) {
+        try {
+          const mrData = JSON.parse(mrResult.stdout) as { diff_refs?: { base_sha: string; start_sha: string; head_sha: string } };
+          if (mrData.diff_refs) {
+            baseSha = mrData.diff_refs.base_sha;
+            startSha = mrData.diff_refs.start_sha;
+          }
+        } catch {
+          // Use fallbacks
         }
-      } catch {
-        // Use fallbacks
       }
+    } catch (error) {
+      diffRefsError = error instanceof Error ? error.message : String(error);
     }
 
-    // Submit comments in parallel
-    const results = await Promise.allSettled(
-      fileComments.map(async (comment) => {
-        const isOldSide = comment.side === "LEFT";
-        const position: Record<string, unknown> = {
-          position_type: "text",
-          base_sha: baseSha,
-          head_sha: headSha,
-          start_sha: startSha,
-          new_path: comment.path,
-          old_path: comment.path,
-        };
+    if (diffRefsError) {
+      failedFileComments = fileComments.map((comment) => ({
+        comment,
+        error: `${comment.path}:${comment.line}: Failed to prepare inline comment: ${diffRefsError}`,
+      }));
+    } else {
+      // Submit comments in parallel
+      const results = await Promise.allSettled(
+        fileComments.map(async (comment) => {
+          const isOldSide = comment.side === "LEFT";
+          const position: Record<string, unknown> = {
+            position_type: "text",
+            base_sha: baseSha,
+            head_sha: headSha,
+            start_sha: startSha,
+            new_path: comment.path,
+            old_path: comment.path,
+          };
 
-        if (isOldSide) {
-          position.old_line = comment.line;
-        } else {
-          position.new_line = comment.line;
-        }
+          if (isOldSide) {
+            position.old_line = comment.line;
+          } else {
+            position.new_line = comment.line;
+          }
 
-        // Multi-line range support
-        if (comment.start_line != null && comment.start_line !== comment.line) {
-          const startIsOld = (comment.start_side ?? comment.side) === "LEFT";
-          const startEntry: Record<string, unknown> = { type: startIsOld ? "old" : "new" };
-          if (startIsOld) startEntry.old_line = comment.start_line;
-          else startEntry.new_line = comment.start_line;
+          // Multi-line range support
+          if (comment.start_line != null && comment.start_line !== comment.line) {
+            const startIsOld = (comment.start_side ?? comment.side) === "LEFT";
+            const startEntry: Record<string, unknown> = { type: startIsOld ? "old" : "new" };
+            if (startIsOld) startEntry.old_line = comment.start_line;
+            else startEntry.new_line = comment.start_line;
 
-          const endEntry: Record<string, unknown> = { type: isOldSide ? "old" : "new" };
-          if (isOldSide) endEntry.old_line = comment.line;
-          else endEntry.new_line = comment.line;
+            const endEntry: Record<string, unknown> = { type: isOldSide ? "old" : "new" };
+            if (isOldSide) endEntry.old_line = comment.line;
+            else endEntry.new_line = comment.line;
 
-          position.line_range = { start: startEntry, end: endEntry };
-        }
+            position.line_range = { start: startEntry, end: endEntry };
+          }
 
-        const payload = JSON.stringify({ body: comment.body, position });
-        const res = await runtime.runCommandWithInput!(
-          "glab",
-          apiArgs(ref.host, `${mrEndpoint}/discussions`, ["--method", "POST", "--input", "-", "-H", "Content-Type:application/json"]),
-          payload,
-        );
+          const payload = JSON.stringify({ body: comment.body, position });
+          const res = await runCommandWithInput(
+            "glab",
+            apiArgs(ref.host, `${mrEndpoint}/discussions`, ["--method", "POST", "--input", "-", "-H", "Content-Type:application/json"]),
+            payload,
+          );
 
-        if (res.exitCode !== 0) {
-          const msg = res.stderr.trim() || res.stdout.trim() || `exit code ${res.exitCode}`;
-          throw new Error(`${comment.path}:${comment.line}: ${msg}`);
-        }
-      }),
-    );
+          if (res.exitCode !== 0) {
+            const msg = res.stderr.trim() || res.stdout.trim() || `exit code ${res.exitCode}`;
+            throw new Error(`${comment.path}:${comment.line}: ${msg}`);
+          }
+        }),
+      );
 
-    failedFileComments = results.flatMap((result, index) =>
-      result.status === "rejected"
-        ? [{
-            comment: fileComments[index],
-            error: result.reason instanceof Error
-              ? result.reason.message
-              : String(result.reason),
-          }]
-        : [],
-    );
+      failedFileComments = results.flatMap((result, index) =>
+        result.status === "rejected"
+          ? [{
+              comment: fileComments[index],
+              error: result.reason instanceof Error
+                ? result.reason.message
+                : String(result.reason),
+            }]
+          : [],
+      );
+    }
     const errors = failedFileComments.map((failure) => failure.error);
 
     if (errors.length > 0) {
@@ -731,23 +744,23 @@ export async function submitGlMRReview(
   let approval: "not-requested" | "succeeded" | "failed" = "not-requested";
   let approvalError: string | undefined;
   if (action === "approve") {
-    const approveResult = await runtime.runCommandWithInput(
-      "glab",
-      apiArgs(ref.host, `${mrEndpoint}/approve`, ["--method", "POST", "--input", "-", "-H", "Content-Type:application/json"]),
-      "{}",
-    );
-    if (approveResult.exitCode !== 0) {
-      const msg = approveResult.stderr.trim() || approveResult.stdout.trim() || `exit code ${approveResult.exitCode}`;
-      approval = "failed";
-      approvalError = `Failed to approve MR: ${msg}`;
-      const reviewAlreadyPosted =
-        reviewBodyPosted ||
-        fileComments.length - failedFileComments.length > 0;
-      if (!reviewAlreadyPosted) {
-        throw new Error(approvalError);
+    try {
+      const approveResult = await runCommandWithInput(
+        "glab",
+        apiArgs(ref.host, `${mrEndpoint}/approve`, ["--method", "POST", "--input", "-", "-H", "Content-Type:application/json"]),
+        "{}",
+      );
+      if (approveResult.exitCode !== 0) {
+        const msg = approveResult.stderr.trim() || approveResult.stdout.trim() || `exit code ${approveResult.exitCode}`;
+        approval = "failed";
+        approvalError = `Failed to approve MR: ${msg}`;
+      } else {
+        approval = "succeeded";
       }
-    } else {
-      approval = "succeeded";
+    } catch (error) {
+      approval = "failed";
+      const message = error instanceof Error ? error.message : String(error);
+      approvalError = `Failed to approve MR: ${message}`;
     }
   }
 

--- a/packages/shared/pr-gitlab.ts
+++ b/packages/shared/pr-gitlab.ts
@@ -7,7 +7,7 @@
 
 import { join } from "path";
 import { mkdirSync, writeFileSync } from "fs";
-import type { PRRuntime, PRMetadata, PRContext, PRReviewFileComment, CommandResult } from "./pr-types";
+import type { PRRuntime, PRMetadata, PRContext, PRReviewFileComment, PRReviewCommentFailure, PRReviewSubmissionResult, CommandResult } from "./pr-types";
 import { encodeApiFilePath } from "./pr-types";
 import { getPlannotatorDataDir } from "./data-dir";
 
@@ -567,6 +567,13 @@ export async function fetchGlFileContent(
 
 // --- Submit MR Review ---
 
+/**
+ * Submit a GitLab review across its separate note, discussion, and approval
+ * APIs.
+ *
+ * Returns a narrowed retry contract whenever GitLab accepts only part of the
+ * review. Throws only while replaying the original request is still safe.
+ */
 export async function submitGlMRReview(
   runtime: PRRuntime,
   ref: GlMRRef,
@@ -574,13 +581,16 @@ export async function submitGlMRReview(
   action: "approve" | "comment",
   body: string,
   fileComments: PRReviewFileComment[],
-): Promise<void> {
+): Promise<PRReviewSubmissionResult> {
   if (!runtime.runCommandWithInput) {
     throw new Error("Runtime does not support stdin input; cannot submit MR review");
   }
 
   const encoded = encodeProject(ref.projectPath);
   const mrEndpoint = `projects/${encoded}/merge_requests/${ref.iid}`;
+  let reviewBodyPosted = false;
+  let failedFileComments: PRReviewCommentFailure[] = [];
+  let recoveryFile: string | undefined;
 
   // Fetch base SHA for position context (needed for line comments)
   // We use the headSha passed in and derive baseSha from MR metadata
@@ -598,6 +608,7 @@ export async function submitGlMRReview(
       const msg = noteResult.stderr.trim() || noteResult.stdout.trim() || `exit code ${noteResult.exitCode}`;
       throw new Error(`Failed to post MR note: ${msg}`);
     }
+    reviewBodyPosted = true;
   }
 
   // 2. Post inline file comments as discussions with position
@@ -620,8 +631,6 @@ export async function submitGlMRReview(
         // Use fallbacks
       }
     }
-
-    const errors: string[] = [];
 
     // Submit comments in parallel
     const results = await Promise.allSettled(
@@ -670,22 +679,21 @@ export async function submitGlMRReview(
       }),
     );
 
-    for (const r of results) {
-      if (r.status === "rejected") {
-        errors.push(r.reason instanceof Error ? r.reason.message : String(r.reason));
-      }
-    }
+    failedFileComments = results.flatMap((result, index) =>
+      result.status === "rejected"
+        ? [{
+            comment: fileComments[index],
+            error: result.reason instanceof Error
+              ? result.reason.message
+              : String(result.reason),
+          }]
+        : [],
+    );
+    const errors = failedFileComments.map((failure) => failure.error);
 
     if (errors.length > 0) {
       // Persist unposted bodies to disk so the work survives transient GitLab errors.
-      // We keep the original throw-vs-warn split intentionally:
-      //  - all-fail → throw (nothing was posted, caller retries from clean state)
-      //  - partial-fail → warn only (some discussions + the MR note are already on
-      //    the server; throwing would have the client re-submit the whole review
-      //    and create duplicates).
-      const failed = results
-        .map((r, i) => (r.status === "rejected" ? fileComments[i] : null))
-        .filter((c): c is PRReviewFileComment => c !== null);
+      const failed = failedFileComments.map((failure) => failure.comment);
       let savedTo: string | null = null;
       try {
         const dir = join(getPlannotatorDataDir(), "failed-comments");
@@ -699,16 +707,20 @@ export async function submitGlMRReview(
       } catch (writeErr) {
         console.error(`[plannotator] Failed to persist unposted comments: ${writeErr instanceof Error ? writeErr.message : String(writeErr)}`);
       }
+      recoveryFile = savedTo ?? undefined;
       const suffix = savedTo ? ` (unposted bodies saved to ${savedTo})` : "";
 
-      if (errors.length === fileComments.length) {
-        // All failed — safe to throw, nothing was posted.
+      if (errors.length === fileComments.length && !reviewBodyPosted) {
+        // All failed and there was no review body — safe to throw because the
+        // MR was not mutated. The client can replay the original request.
         throw new Error(
           `Failed to post inline comments${suffix}:\n${errors.join("\n")}`,
         );
       }
-      // Partial failure — some comments and the MR note are already posted.
-      // Don't throw, or the UI will resubmit the whole review and duplicate them.
+
+      // Some part of the review already exists on GitLab. Keep processing an
+      // approval request, then return the exact safe retry instead of making
+      // callers infer that replaying the original review is safe.
       console.error(
         `[plannotator] ${errors.length}/${fileComments.length} inline comments failed${suffix}:\n${errors.join("\n")}`,
       );
@@ -716,6 +728,8 @@ export async function submitGlMRReview(
   }
 
   // 3. Approve if requested
+  let approval: "not-requested" | "succeeded" | "failed" = "not-requested";
+  let approvalError: string | undefined;
   if (action === "approve") {
     const approveResult = await runtime.runCommandWithInput(
       "glab",
@@ -724,7 +738,34 @@ export async function submitGlMRReview(
     );
     if (approveResult.exitCode !== 0) {
       const msg = approveResult.stderr.trim() || approveResult.stdout.trim() || `exit code ${approveResult.exitCode}`;
-      throw new Error(`Failed to approve MR: ${msg}`);
+      approval = "failed";
+      approvalError = `Failed to approve MR: ${msg}`;
+      const reviewAlreadyPosted =
+        reviewBodyPosted ||
+        fileComments.length - failedFileComments.length > 0;
+      if (!reviewAlreadyPosted) {
+        throw new Error(approvalError);
+      }
+    } else {
+      approval = "succeeded";
     }
   }
+
+  if (failedFileComments.length > 0 || approval === "failed") {
+    return {
+      status: "partial",
+      postedFileCommentCount: fileComments.length - failedFileComments.length,
+      failedFileComments,
+      reviewBodyPosted,
+      approval,
+      ...(approvalError ? { approvalError } : {}),
+      ...(recoveryFile ? { recoveryFile } : {}),
+      retry: {
+        action: approval === "failed" ? "approve" : "comment",
+        fileComments: failedFileComments.map((failure) => failure.comment),
+      },
+    };
+  }
+
+  return { status: "complete" };
 }

--- a/packages/shared/pr-provider.ts
+++ b/packages/shared/pr-provider.ts
@@ -13,7 +13,7 @@
 
 import { checkGhAuth, getGhUser, fetchGhPR, fetchGhPRContext, fetchGhPRFileContent, submitGhPRReview, fetchGhPRViewedFiles, markGhFilesViewed, fetchGhPRStack, fetchGhPRList } from "./pr-github";
 import { checkGlAuth, getGlUser, fetchGlMR, fetchGlMRContext, fetchGlFileContent, submitGlMRReview } from "./pr-gitlab";
-import type { PRRuntime, PRRef, PRMetadata, PRContext, PRReviewFileComment, PRStackTree, PRListItem } from "./pr-types";
+import type { PRRuntime, PRRef, PRMetadata, PRContext, PRReviewFileComment, PRReviewSubmissionResult, PRStackTree, PRListItem } from "./pr-types";
 
 // Re-export the browser-safe surface so server callers can keep using
 // pr-provider as a single facade. Browser code imports from pr-types
@@ -58,6 +58,7 @@ export async function fetchPRFileContent(
   return fetchGlFileContent(runtime, ref, sha, filePath);
 }
 
+/** Submit a platform review and preserve any provider-specific partial result. */
 export async function submitPRReview(
   runtime: PRRuntime,
   ref: PRRef,
@@ -65,7 +66,7 @@ export async function submitPRReview(
   action: "approve" | "comment",
   body: string,
   fileComments: PRReviewFileComment[],
-): Promise<void> {
+): Promise<PRReviewSubmissionResult> {
   if (ref.platform === "github") return submitGhPRReview(runtime, ref, headSha, action, body, fileComments);
   return submitGlMRReview(runtime, ref, headSha, action, body, fileComments);
 }

--- a/packages/shared/pr-types.ts
+++ b/packages/shared/pr-types.ts
@@ -185,6 +185,47 @@ export interface PRReviewFileComment {
   start_side?: "LEFT" | "RIGHT";
 }
 
+/** One inline comment that GitLab did not accept, paired with its safe error text. */
+export interface PRReviewCommentFailure {
+  comment: PRReviewFileComment;
+  error: string;
+}
+
+/**
+ * Exact mutation that is safe after a partial platform submission.
+ *
+ * The review body is intentionally absent because it may already be posted.
+ */
+export interface PRReviewRetry {
+  action: "approve" | "comment";
+  fileComments: PRReviewFileComment[];
+}
+
+/** A platform review for which every requested mutation completed. */
+export interface PRReviewSubmissionComplete {
+  status: "complete";
+}
+
+/**
+ * A GitLab review that mutated the MR but did not complete every requested
+ * mutation. Callers must use `retry` instead of replaying the original review.
+ */
+export interface PRReviewSubmissionPartial {
+  status: "partial";
+  postedFileCommentCount: number;
+  failedFileComments: PRReviewCommentFailure[];
+  reviewBodyPosted: boolean;
+  approval: "not-requested" | "succeeded" | "failed";
+  approvalError?: string;
+  recoveryFile?: string;
+  retry: PRReviewRetry;
+}
+
+/** Caller-visible result of posting a review to GitHub or GitLab. */
+export type PRReviewSubmissionResult =
+  | PRReviewSubmissionComplete
+  | PRReviewSubmissionPartial;
+
 export type PRDiffScope = "layer" | "full-stack";
 
 export interface PRDiffScopeOption {


### PR DESCRIPTION
## Summary

- Make GitLab multi-request review submissions distinguish complete, failed-before-mutation, and partial outcomes.
- Keep the submission dialog open for partial results and show the exact failed comments, errors, recovery-file path, and copy action.
- Retry only the server-authorized unposted subset or failed approval so already-posted notes and discussions are not duplicated.
- Preserve the same API behavior in the Bun and Pi review servers.

## Before and after

Before, GitLab inline discussions were posted independently. Mixed success was logged and failed comments were persisted, but the server returned ordinary success and the UI could report the review as complete.

After, successful requests return submission status complete. If GitLab accepts any mutation but rejects another, the server returns an actionable partial result containing the exact failures and safe retry payload. A total failure before any mutation remains an error, so replaying the original request is safe.

## Retry and idempotency semantics

- A partial retry omits the general review body.
- It contains exactly the failed inline comments and uses comment or approve according to the unfinished operation.
- Client response validation rejects malformed retry payloads that include already-posted comments.
- Failed comments continue to be persisted under the Plannotator data directory when possible, and the UI exposes the recovery path plus a copy action.
- If a retry attempt fails before making another mutation, the previous narrowed retry metadata remains available.

A process or network loss after GitLab accepts a mutation but before Plannotator receives the response is still ambiguous. This change does not add a durable cross-process idempotency ledger for that case.

## Runtime parity

The shared provider contract is returned unchanged through both the Bun and Pi server implementations. Focused route tests cover the Bun complete, failed, and mixed responses and the Pi mixed-response contract.

## Validation

- Focused provider, Bun/Pi route, response-parser, and retry-construction tests: 37 passed
- Opt-in rendered submission-dialog tests: 3 passed
- Root TypeScript typecheck: passed
- Review production build: passed
- Hook production build: passed
- Pi extension production build and vendoring: passed
- Branch diff check against current origin/main: passed