### PR TITLE
feat(cli): add safe uninstall lifecycle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -471,6 +471,173 @@ jobs:
           # 4. terminal: exercises managed WebTUI runtime + compiled sidecar import.
           Test-AgentTerminal
 
+      - name: Smoke-test uninstall lifecycle
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          BINARY: artifacts/${{ matrix.binary }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          # This disposable GitHub-hosted VM is the real Windows QA boundary.
+          # The smoke temporarily adds one unique RUNNER_TEMP path to HKCU PATH,
+          # restores the original value in finally, and the VM is discarded.
+          $sourceBinary = (Resolve-Path $env:BINARY).Path
+          $runnerTemp = [System.IO.Path]::GetFullPath($env:RUNNER_TEMP)
+          $testRoot = [System.IO.Path]::GetFullPath((Join-Path $runnerTemp "plannotator-uninstall-$([System.Guid]::NewGuid().ToString('N'))"))
+          $expectedPrefix = $runnerTemp.TrimEnd('\') + '\'
+          if (-not $testRoot.StartsWith($expectedPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw "Refusing unsafe uninstall smoke root: $testRoot"
+          }
+
+          $environmentNames = @(
+            "USERPROFILE",
+            "LOCALAPPDATA",
+            "APPDATA",
+            "XDG_CONFIG_HOME",
+            "XDG_CACHE_HOME",
+            "CLAUDE_CONFIG_DIR",
+            "CODEX_HOME",
+            "FACTORY_CONFIG_DIR",
+            "COPILOT_HOME",
+            "PI_CODING_AGENT_DIR",
+            "PLANNOTATOR_DATA_DIR"
+          )
+          $savedEnvironment = @{}
+          foreach ($name in $environmentNames) {
+            $savedEnvironment[$name] = [System.Environment]::GetEnvironmentVariable($name, "Process")
+          }
+          $originalUserPath = [System.Environment]::GetEnvironmentVariable("Path", "User")
+
+          function Wait-UntilMissing {
+            param([string] $Path)
+            for ($i = 0; $i -lt 80; $i++) {
+              if (-not (Test-Path -LiteralPath $Path)) { return }
+              Start-Sleep -Milliseconds 250
+            }
+            throw "Timed out waiting for uninstall to remove $Path"
+          }
+
+          function Set-IsolatedUninstallEnvironment {
+            param([string] $CaseRoot)
+            $isolatedHome = Join-Path $CaseRoot "home"
+            $localAppData = Join-Path $isolatedHome "AppData\Local"
+            $values = @{
+              USERPROFILE = $isolatedHome
+              LOCALAPPDATA = $localAppData
+              APPDATA = (Join-Path $isolatedHome "AppData\Roaming")
+              XDG_CONFIG_HOME = (Join-Path $isolatedHome ".config")
+              XDG_CACHE_HOME = (Join-Path $isolatedHome ".cache")
+              CLAUDE_CONFIG_DIR = (Join-Path $isolatedHome ".claude")
+              CODEX_HOME = (Join-Path $isolatedHome ".codex")
+              FACTORY_CONFIG_DIR = (Join-Path $isolatedHome ".factory")
+              COPILOT_HOME = (Join-Path $isolatedHome ".copilot")
+              PI_CODING_AGENT_DIR = (Join-Path $isolatedHome ".pi\agent")
+              PLANNOTATOR_DATA_DIR = (Join-Path $isolatedHome ".plannotator")
+            }
+            foreach ($entry in $values.GetEnumerator()) {
+              [System.Environment]::SetEnvironmentVariable($entry.Key, $entry.Value, "Process")
+            }
+            return $values
+          }
+
+          function Add-TestUserPathEntry {
+            param([string] $InstallDirectory)
+            $current = [System.Environment]::GetEnvironmentVariable("Path", "User")
+            $next = if ([string]::IsNullOrWhiteSpace($current)) {
+              ";$InstallDirectory;"
+            } else {
+              "$current;;$InstallDirectory;"
+            }
+            [System.Environment]::SetEnvironmentVariable("Path", $next, "User")
+            if ([string]::IsNullOrWhiteSpace($current)) { return ";" }
+            return "$current;;"
+          }
+
+          function Assert-TestUserPathEntryRemoved {
+            param(
+              [string] $InstallDirectory,
+              [string] $ExpectedPath
+            )
+            $current = [System.Environment]::GetEnvironmentVariable("Path", "User")
+            $target = $InstallDirectory.Trim().TrimEnd('\')
+            $matches = @($current -split ';' | Where-Object {
+              $_ -and $_.Trim().TrimEnd('\') -ieq $target
+            })
+            if ($matches.Count -ne 0) {
+              throw "Uninstall left its user PATH entry behind: $InstallDirectory"
+            }
+            if ($current -cne $ExpectedPath) {
+              throw "Uninstall changed unrelated user PATH bytes. Expected '$ExpectedPath', got '$current'"
+            }
+          }
+
+          function Invoke-UninstallSmoke {
+            param(
+              [string] $Name,
+              [bool] $Purge
+            )
+            $caseRoot = Join-Path $testRoot $Name
+            $values = Set-IsolatedUninstallEnvironment $caseRoot
+            $installDirectory = Join-Path $values.LOCALAPPDATA "plannotator"
+            $testBinary = Join-Path $installDirectory "plannotator.exe"
+            $dataDirectory = $values.PLANNOTATOR_DATA_DIR
+
+            New-Item -ItemType Directory -Force -Path $installDirectory | Out-Null
+            Copy-Item -LiteralPath $sourceBinary -Destination $testBinary
+            New-Item -ItemType Directory -Force -Path (Join-Path $dataDirectory "plans") | Out-Null
+            New-Item -ItemType Directory -Force -Path (Join-Path $dataDirectory "vendor\sem\v-test") | Out-Null
+            New-Item -ItemType Directory -Force -Path (Join-Path $dataDirectory "vendor\agent-terminal\v-test") | Out-Null
+            Set-Content -LiteralPath (Join-Path $dataDirectory "plans\keep.md") -Value "# keep"
+            Set-Content -LiteralPath (Join-Path $dataDirectory "config.json") -Value '{}'
+            Set-Content -LiteralPath (Join-Path $dataDirectory "vendor\sem\v-test\sem.exe") -Value "fixture"
+            Set-Content -LiteralPath (Join-Path $dataDirectory "vendor\agent-terminal\v-test\server.js") -Value "fixture"
+            $expectedUserPath = Add-TestUserPathEntry $installDirectory
+
+            $arguments = @("uninstall", "--yes")
+            if ($Purge) { $arguments += "--purge" }
+            & $testBinary @arguments
+            if ($LASTEXITCODE -ne 0) {
+              throw "Uninstall smoke '$Name' exited $LASTEXITCODE"
+            }
+
+            Wait-UntilMissing $testBinary
+            Wait-UntilMissing $installDirectory
+            Assert-TestUserPathEntryRemoved $installDirectory $expectedUserPath
+
+            if ($Purge) {
+              if (Test-Path -LiteralPath $dataDirectory) {
+                throw "Purge smoke left the data directory behind: $dataDirectory"
+              }
+            } else {
+              if (-not (Test-Path -LiteralPath (Join-Path $dataDirectory "plans\keep.md"))) {
+                throw "Default uninstall removed preserved plan data"
+              }
+              if (-not (Test-Path -LiteralPath (Join-Path $dataDirectory "config.json"))) {
+                throw "Default uninstall removed preserved configuration"
+              }
+              if (Test-Path -LiteralPath (Join-Path $dataDirectory "vendor\sem")) {
+                throw "Default uninstall left the sem sidecar behind"
+              }
+              if (Test-Path -LiteralPath (Join-Path $dataDirectory "vendor\agent-terminal")) {
+                throw "Default uninstall left the agent-terminal runtime behind"
+              }
+            }
+          }
+
+          try {
+            Invoke-UninstallSmoke "preserve" $false
+            Invoke-UninstallSmoke "purge" $true
+            Write-Host "OK: Windows uninstall preserve-data, purge, PATH, and self-delete verified"
+          } finally {
+            [System.Environment]::SetEnvironmentVariable("Path", $originalUserPath, "User")
+            foreach ($name in $environmentNames) {
+              [System.Environment]::SetEnvironmentVariable($name, $savedEnvironment[$name], "Process")
+            }
+            if (Test-Path -LiteralPath $testRoot) {
+              Remove-Item -LiteralPath $testRoot -Recurse -Force
+            }
+          }
+
   pi-extension-ai-runtime-windows:
     needs: test
     # Exercises the Pi extension's Node/jiti server mirror on Windows with an

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,25 @@ jobs:
           packages/ui/components/DocBadges.test.tsx
           packages/editor/planDiffAutoExit.test.tsx
 
+  uninstall-windows:
+    # Run the filesystem and path logic under real Windows path semantics.
+    # The tests inject temporary homes and process boundaries, so this job
+    # never touches the runner's actual agent installations or user data.
+    name: Uninstall lifecycle (Windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run focused uninstall tests
+        run: bun test packages/server/uninstall.test.ts apps/hook/server/cli.test.ts
+
   pi-extension-ai-runtime-windows:
     # Exercises the Pi extension's Node/jiti server mirror on Windows with an
     # npm-style `pi` shim pair. This catches regressions where `where pi`

--- a/README.md
+++ b/README.md
@@ -244,10 +244,13 @@ The command covers the conventional macOS, Linux, WSL, and Windows binary
 locations; the managed `sem` sidecar and agent-terminal runtime; installer
 skills, commands, hooks, policies, caches, and recognizable Amp/Kiro files; and
 detected Claude Code, Copilot CLI, Droid, Pi, and VS Code installations through
-their host CLIs. Shared strict-JSON settings are edited surgically. Custom or
-unrecognized files, separately installed optional skills, project-local
-integrations, external plan-save locations, and non-strict JSON/JSONC configs
-are preserved (with a warning when manual cleanup may be needed).
+their host CLIs. Shared JSON and JSONC settings are edited surgically. Custom
+or unrecognized files, separately installed optional skills, project-local
+integrations, external plan-save locations, and invalid configs are preserved
+(with an error when manual cleanup is needed). If cleanup reports an error,
+the CLI remains available for a safe retry, and its Windows PATH entry is
+retained or restored when possible. If PATH restoration itself fails, the
+output gives the full CLI path for retry and asks for manual PATH repair.
 For safety, purge refuses filesystem roots, the home directory, the shared
 temporary directory, symlinked data directories, and non-directory data paths.
 If your dedicated data directory is symlinked, point `PLANNOTATOR_DATA_DIR` at

--- a/README.md
+++ b/README.md
@@ -217,6 +217,45 @@ Then finish the step for your agent:
 
 Full walkthroughs live in the [installation docs](https://docs.plannotator.ai/open-source/start/installation).
 
+### Uninstall
+
+The safe default removes recognized Plannotator-installed components and keeps
+your local plans, history, drafts, guides, and settings:
+
+```bash
+plannotator uninstall
+```
+
+Use `--purge` for a full removal of known local Plannotator data as well:
+
+```bash
+plannotator uninstall --purge
+```
+
+Purge requires typing `purge` at the prompt and explains that the data is
+local-only: it is not stored on a Plannotator server and cannot be recovered.
+For automation, pass `--yes` (or `-y`); non-interactive removal refuses to run
+without it. Use `--dry-run` to preview recognized work without making changes.
+These mechanics keep the ordinary confirmation default-negative, make the
+irreversible outcome require a stronger explicit word, and still give package
+managers and scripts a conventional non-interactive flag.
+
+The command covers the conventional macOS, Linux, WSL, and Windows binary
+locations; the managed `sem` sidecar and agent-terminal runtime; installer
+skills, commands, hooks, policies, caches, and recognizable Amp/Kiro files; and
+detected Claude Code, Copilot CLI, Droid, Pi, and VS Code installations through
+their host CLIs. Shared strict-JSON settings are edited surgically. Custom or
+unrecognized files, separately installed optional skills, project-local
+integrations, external plan-save locations, and non-strict JSON/JSONC configs
+are preserved (with a warning when manual cleanup may be needed).
+For safety, purge refuses filesystem roots, the home directory, the shared
+temporary directory, symlinked data directories, and non-directory data paths.
+If your dedicated data directory is symlinked, point `PLANNOTATOR_DATA_DIR` at
+its resolved target and retry.
+
+If you installed only the standalone Pi extension and do not have the
+`plannotator` CLI, use `pi remove npm:@plannotator/pi-extension`.
+
 <details>
 <summary>Claude Code: manual hook setup (without the plugin system)</summary>
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,10 @@ Purge requires typing `purge` at the prompt and explains that the data is
 local-only: it is not stored on a Plannotator server and cannot be recovered.
 For automation, pass `--yes` (or `-y`); non-interactive removal refuses to run
 without it. Use `--dry-run` to preview recognized work without making changes.
+If a broken or unavailable host blocks cleanup, `--skip-hosts` leaves host
+plugin managers and shared host configuration untouched so the remaining
+installer-owned components and binary can still be removed; clean up those
+host integrations manually afterward.
 These mechanics keep the ordinary confirmation default-negative, make the
 irreversible outcome require a stronger explicit word, and still give package
 managers and scripts a conventional non-interactive flag.
@@ -244,15 +248,20 @@ The command covers the conventional macOS, Linux, WSL, and Windows binary
 locations; the managed `sem` sidecar and agent-terminal runtime; installer
 skills, commands, hooks, policies, caches, and recognizable Amp/Kiro files; and
 detected Claude Code, Copilot CLI, Droid, Pi, and VS Code installations through
-their host CLIs. Shared JSON and JSONC settings are edited surgically. Custom
+their host CLIs. Shared JSONC settings are edited surgically, while strict JSON
+updates preserve the file's indentation, line endings, and trailing-newline
+style. Custom
 or unrecognized files, separately installed optional skills, project-local
 integrations, external plan-save locations, and invalid configs are preserved
-(with an error when manual cleanup is needed). If cleanup reports an error,
+(with an error only when the malformed content may contain a managed entry).
+If cleanup reports an error,
 the CLI remains available for a safe retry, and its Windows PATH entry is
 retained or restored when possible. If PATH restoration itself fails, the
 output gives the full CLI path for retry and asks for manual PATH repair.
 For safety, purge refuses filesystem roots, the home directory, the shared
 temporary directory, symlinked data directories, and non-directory data paths.
+Existing paths are compared by filesystem identity, so case aliases, symlinks,
+hardlinks, and bind mounts cannot bypass the root/home/ancestor checks.
 If your dedicated data directory is symlinked, point `PLANNOTATOR_DATA_DIR` at
 its resolved target and retry.
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ updates preserve the file's indentation, line endings, and trailing-newline
 style. Custom
 or unrecognized files, separately installed optional skills, project-local
 integrations, external plan-save locations, and invalid configs are preserved
-(with an error only when the malformed content may contain a managed entry).
+(malformed host config is a fail-safe error unless `--skip-hosts` is explicit).
 If cleanup reports an error,
 the CLI remains available for a safe retry, and its Windows PATH entry is
 retained or restored when possible. If PATH restoration itself fails, the
@@ -262,6 +262,9 @@ For safety, purge refuses filesystem roots, the home directory, the shared
 temporary directory, symlinked data directories, and non-directory data paths.
 Existing paths are compared by filesystem identity, so case aliases, symlinks,
 hardlinks, and bind mounts cannot bypass the root/home/ancestor checks.
+That identity and every containment guard are revalidated after awaited host
+commands, immediately before the synchronous data-removal block; a replaced
+data directory is refused without touching either the old or replacement data.
 If your dedicated data directory is symlinked, point `PLANNOTATOR_DATA_DIR` at
 its resolved target and retry.
 

--- a/apps/hook/server/cli.test.ts
+++ b/apps/hook/server/cli.test.ts
@@ -35,6 +35,7 @@ describe("CLI top-level help", () => {
     expect(output).toContain("plannotator copilot-last [--gate] [--json] [--hook]");
     expect(output).toContain("plannotator setup-goal <interview|facts>");
     expect(output).toContain("plannotator uninstall [--purge] [--yes]");
+    expect(output).toContain("[--skip-hosts]");
     expect(output).toContain("Run 'plannotator <command> --help' for command-specific usage.");
     expect(output).toContain("running 'plannotator' without arguments is for hook integration");
   });
@@ -119,6 +120,7 @@ describe("CLI subcommand help", () => {
     expect(formatSubcommandHelp("uninstall")).toContain(
       "not stored on a Plannotator server",
     );
+    expect(formatSubcommandHelp("uninstall")).toContain("--skip-hosts");
     // unknown key falls back to top-level help
     expect(formatSubcommandHelp("nope")).toBe(formatTopLevelHelp());
   });
@@ -130,16 +132,18 @@ describe("uninstall CLI options", () => {
       purge: false,
       yes: false,
       dryRun: false,
+      skipHosts: false,
     });
   });
 
   test("parses purge, automation, and preview flags", () => {
     expect(
-      parseUninstallOptions(["--dry-run", "--purge", "-y"]),
+      parseUninstallOptions(["--dry-run", "--purge", "-y", "--skip-hosts"]),
     ).toEqual({
       purge: true,
       yes: true,
       dryRun: true,
+      skipHosts: true,
     });
   });
 
@@ -153,6 +157,9 @@ describe("uninstall CLI options", () => {
     expect(() => parseUninstallOptions(["--yes", "-y"])).toThrow(
       "--yes/-y may only be specified once",
     );
+    expect(() =>
+      parseUninstallOptions(["--skip-hosts", "--skip-hosts"]),
+    ).toThrow("--skip-hosts may only be specified once");
   });
 
   test("uses a stronger confirmation for purge", () => {

--- a/apps/hook/server/cli.test.ts
+++ b/apps/hook/server/cli.test.ts
@@ -8,8 +8,10 @@ import {
   isInteractiveNoArgInvocation,
   isSubcommandHelpInvocation,
   isTopLevelHelpInvocation,
+  isUninstallConfirmationAccepted,
   isVersionInvocation,
   parseStrictAnnotateOptions,
+  parseUninstallOptions,
 } from "./cli";
 
 describe("CLI top-level help", () => {
@@ -32,6 +34,7 @@ describe("CLI top-level help", () => {
     expect(output).toContain("plannotator annotate-last [--stdin]");
     expect(output).toContain("plannotator copilot-last [--gate] [--json] [--hook]");
     expect(output).toContain("plannotator setup-goal <interview|facts>");
+    expect(output).toContain("plannotator uninstall [--purge] [--yes]");
     expect(output).toContain("Run 'plannotator <command> --help' for command-specific usage.");
     expect(output).toContain("running 'plannotator' without arguments is for hook integration");
   });
@@ -83,6 +86,7 @@ describe("CLI subcommand help", () => {
       "setup-goal",
       "archive",
       "sessions",
+      "uninstall",
       "improve-context",
     ]) {
       expect(isSubcommandHelpInvocation([sub, "--help"])).toBe(sub);
@@ -109,8 +113,54 @@ describe("CLI subcommand help", () => {
       "--require-approval",
     );
     expect(formatSubcommandHelp("sessions")).toContain("--open [N]");
+    expect(formatSubcommandHelp("uninstall")).toContain(
+      "Local plans, history, drafts",
+    );
+    expect(formatSubcommandHelp("uninstall")).toContain(
+      "not stored on a Plannotator server",
+    );
     // unknown key falls back to top-level help
     expect(formatSubcommandHelp("nope")).toBe(formatTopLevelHelp());
+  });
+});
+
+describe("uninstall CLI options", () => {
+  test("defaults to preserving data and requiring confirmation", () => {
+    expect(parseUninstallOptions([])).toEqual({
+      purge: false,
+      yes: false,
+      dryRun: false,
+    });
+  });
+
+  test("parses purge, automation, and preview flags", () => {
+    expect(
+      parseUninstallOptions(["--dry-run", "--purge", "-y"]),
+    ).toEqual({
+      purge: true,
+      yes: true,
+      dryRun: true,
+    });
+  });
+
+  test("rejects unknown and duplicate options", () => {
+    expect(() => parseUninstallOptions(["--force"])).toThrow(
+      "Unknown uninstall option",
+    );
+    expect(() => parseUninstallOptions(["--purge", "--purge"])).toThrow(
+      "--purge may only be specified once",
+    );
+    expect(() => parseUninstallOptions(["--yes", "-y"])).toThrow(
+      "--yes/-y may only be specified once",
+    );
+  });
+
+  test("uses a stronger confirmation for purge", () => {
+    expect(isUninstallConfirmationAccepted("yes", false)).toBe(true);
+    expect(isUninstallConfirmationAccepted("Y", false)).toBe(true);
+    expect(isUninstallConfirmationAccepted("", false)).toBe(false);
+    expect(isUninstallConfirmationAccepted("yes", true)).toBe(false);
+    expect(isUninstallConfirmationAccepted(" PURGE ", true)).toBe(true);
   });
 });
 
@@ -268,6 +318,7 @@ describe("interactive no-arg invocation", () => {
     expect(output).toContain("plannotator review");
     expect(output).toContain("plannotator setup-goal interview bundle.json --json");
     expect(output).toContain("plannotator sessions");
+    expect(output).toContain("plannotator uninstall");
     expect(output).toContain("Run 'plannotator --help' for top-level usage.");
   });
 });

--- a/apps/hook/server/cli.ts
+++ b/apps/hook/server/cli.ts
@@ -6,6 +6,54 @@ export interface ParsedStrictAnnotateOptions {
   remainingArgs: string[];
 }
 
+export interface ParsedUninstallOptions {
+  purge: boolean;
+  yes: boolean;
+  dryRun: boolean;
+}
+
+/**
+ * Parse the deliberately small, non-overlapping uninstall flag surface.
+ */
+export function parseUninstallOptions(
+  args: readonly string[],
+): ParsedUninstallOptions {
+  let purge = false;
+  let yes = false;
+  let dryRun = false;
+
+  for (const arg of args) {
+    if (arg === "--purge") {
+      if (purge) throw new Error("--purge may only be specified once");
+      purge = true;
+    } else if (arg === "--yes" || arg === "-y") {
+      if (yes) throw new Error("--yes/-y may only be specified once");
+      yes = true;
+    } else if (arg === "--dry-run") {
+      if (dryRun) throw new Error("--dry-run may only be specified once");
+      dryRun = true;
+    } else {
+      throw new Error(`Unknown uninstall option: ${arg}`);
+    }
+  }
+
+  return { purge, yes, dryRun };
+}
+
+/**
+ * Normal uninstall accepts y/yes. Purge intentionally requires an exact,
+ * explicit word so an accidental return key cannot destroy local data.
+ */
+export function isUninstallConfirmationAccepted(
+  answer: string,
+  purge: boolean,
+): boolean {
+  const normalized = answer.trim().toLowerCase();
+  return purge
+    ? normalized === "purge"
+    : normalized === "y" || normalized === "yes";
+}
+
 export function parseStrictAnnotateOptions(
   args: string[],
 ): ParsedStrictAnnotateOptions {
@@ -99,6 +147,7 @@ export function formatTopLevelHelp(): string {
     "  plannotator last",
     "  plannotator archive",
     "  plannotator sessions",
+    "  plannotator uninstall [--purge] [--yes] [--dry-run]",
     "  plannotator improve-context",
     "",
     "Run 'plannotator <command> --help' for command-specific usage.",
@@ -213,6 +262,21 @@ const SUBCOMMAND_HELP: Record<string, string> = {
     "  --open [N]    Reopen session #N (default 1) in the browser",
     "  --clean       Remove stale session entries",
   ].join("\n"),
+  uninstall: [
+    "Usage:",
+    "  plannotator uninstall [--purge] [--yes | -y] [--dry-run]",
+    "",
+    "Remove Plannotator-installed components. Local plans, history, drafts,",
+    "settings, and other Plannotator data are preserved by default.",
+    "",
+    "Options:",
+    "  --purge       Also permanently delete known local Plannotator data",
+    "  --yes, -y     Skip the interactive confirmation (required without a TTY)",
+    "  --dry-run     Preview recognized removal work without changing anything",
+    "",
+    "Purge data is local-only: it is not stored on a Plannotator server and",
+    "cannot be recovered after purge. Unrecognized custom files are preserved.",
+  ].join("\n"),
 };
 
 // Aliases share another subcommand's help text.
@@ -250,6 +314,7 @@ export function formatInteractiveNoArgClarification(): string {
     "  plannotator last",
     "  plannotator archive",
     "  plannotator sessions",
+    "  plannotator uninstall",
     "",
     "Run 'plannotator --help' for top-level usage.",
   ].join("\n");

--- a/apps/hook/server/cli.ts
+++ b/apps/hook/server/cli.ts
@@ -10,6 +10,7 @@ export interface ParsedUninstallOptions {
   purge: boolean;
   yes: boolean;
   dryRun: boolean;
+  skipHosts: boolean;
 }
 
 /**
@@ -21,6 +22,7 @@ export function parseUninstallOptions(
   let purge = false;
   let yes = false;
   let dryRun = false;
+  let skipHosts = false;
 
   for (const arg of args) {
     if (arg === "--purge") {
@@ -32,12 +34,15 @@ export function parseUninstallOptions(
     } else if (arg === "--dry-run") {
       if (dryRun) throw new Error("--dry-run may only be specified once");
       dryRun = true;
+    } else if (arg === "--skip-hosts") {
+      if (skipHosts) throw new Error("--skip-hosts may only be specified once");
+      skipHosts = true;
     } else {
       throw new Error(`Unknown uninstall option: ${arg}`);
     }
   }
 
-  return { purge, yes, dryRun };
+  return { purge, yes, dryRun, skipHosts };
 }
 
 /**
@@ -147,7 +152,7 @@ export function formatTopLevelHelp(): string {
     "  plannotator last",
     "  plannotator archive",
     "  plannotator sessions",
-    "  plannotator uninstall [--purge] [--yes] [--dry-run]",
+    "  plannotator uninstall [--purge] [--yes] [--dry-run] [--skip-hosts]",
     "  plannotator improve-context",
     "",
     "Run 'plannotator <command> --help' for command-specific usage.",
@@ -264,7 +269,7 @@ const SUBCOMMAND_HELP: Record<string, string> = {
   ].join("\n"),
   uninstall: [
     "Usage:",
-    "  plannotator uninstall [--purge] [--yes | -y] [--dry-run]",
+    "  plannotator uninstall [--purge] [--yes | -y] [--dry-run] [--skip-hosts]",
     "",
     "Remove Plannotator-installed components. Local plans, history, drafts,",
     "settings, and other Plannotator data are preserved by default.",
@@ -273,6 +278,8 @@ const SUBCOMMAND_HELP: Record<string, string> = {
     "  --purge       Also permanently delete known local Plannotator data",
     "  --yes, -y     Skip the interactive confirmation (required without a TTY)",
     "  --dry-run     Preview recognized removal work without changing anything",
+    "  --skip-hosts   Leave host plugin managers and shared host config untouched",
+    "                 (for recovery when a host install or config is broken)",
     "",
     "Purge data is local-only: it is not stored on a Plannotator server and",
     "cannot be recovered after purge. Unrecognized custom files are preserved.",

--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -1,7 +1,7 @@
 /**
  * Plannotator CLI for Claude Code, Droid, Codex, Gemini CLI, and Copilot CLI
  *
- * Supports twelve modes:
+ * Supports thirteen modes:
  *
  * 1. Plan Review (default, no args):
  *    - Spawned by Claude/Gemini/Codex hook entrypoints
@@ -56,6 +56,10 @@
  *    - Spawned by PreToolUse hook on EnterPlanMode
  *    - Reads improvement hook file from ~/.plannotator/hooks/
  *    - Returns additionalContext or silently passes through
+ *
+ * 13. Uninstall (`plannotator uninstall`):
+ *    - Removes recognized installer-owned components across supported hosts
+ *    - Preserves local data by default; `--purge` removes known local data
  *
  * Global flags:
  *   --help             - Show top-level usage information
@@ -112,6 +116,12 @@ import { registerSession, unregisterSession, listSessions } from "@plannotator/s
 import { openBrowser } from "@plannotator/server/browser";
 import { inlineHtmlLocalAssets } from "@plannotator/server/html-assets";
 import { installAgentTerminalRuntime } from "@plannotator/server/agent-terminal-runtime";
+import {
+  createDefaultUninstallEnvironment,
+  formatPurgeWarning,
+  formatUninstallResult,
+  runPlannotatorUninstall,
+} from "@plannotator/server/uninstall";
 import { detectProjectName } from "@plannotator/server/project";
 import { hostnameOrFallback } from "@plannotator/shared/project";
 import { readImprovementHook } from "@plannotator/shared/improvement-hooks";
@@ -144,6 +154,8 @@ import {
   isTopLevelHelpInvocation,
   isVersionInvocation,
   parseStrictAnnotateOptions,
+  isUninstallConfirmationAccepted,
+  parseUninstallOptions,
 } from "./cli";
 import { completeAnnotateCommand } from "./annotate-command";
 import {
@@ -154,6 +166,7 @@ import {
 } from "./strict-annotate-result";
 import path from "path";
 import { tmpdir } from "os";
+import { createInterface } from "node:readline/promises";
 import { buildLocalWorkspaceReview, type WorkspaceDiffType } from "@plannotator/server/review-workspace";
 import {
   createAnnotateOutcomeEmitter,
@@ -171,10 +184,11 @@ import reviewHtml from "../dist/review.html" with { type: "text" };
 const reviewHtmlContent = reviewHtml as unknown as string;
 
 // Check for subcommand
+const rawArgs = process.argv.slice(2);
 let parsedStrictAnnotateOptions;
 try {
   parsedStrictAnnotateOptions = parseStrictAnnotateOptions(
-    process.argv.slice(2),
+    rawArgs,
   );
 } catch (error) {
   console.error(error instanceof Error ? error.message : String(error));
@@ -270,6 +284,74 @@ const helpSubcommand = isSubcommandHelpInvocation(args);
 if (helpSubcommand) {
   console.log(formatSubcommandHelp(helpSubcommand));
   process.exit(0);
+}
+
+if (args[0] === "uninstall") {
+  let options: ReturnType<typeof parseUninstallOptions>;
+  try {
+    options = parseUninstallOptions(rawArgs.slice(1));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    console.error("Run 'plannotator uninstall --help' for usage.");
+    process.exit(1);
+  }
+
+  const environment = createDefaultUninstallEnvironment();
+
+  if (!options.dryRun && !options.yes) {
+    if (process.stdin.isTTY !== true || process.stdout.isTTY !== true) {
+      console.error(
+        "Uninstall requires confirmation. Re-run with --yes in a non-interactive shell.",
+      );
+      process.exit(1);
+    }
+
+    if (options.purge) {
+      console.error(formatPurgeWarning(environment.dataDir));
+    } else {
+      console.error(
+        `Local Plannotator data in ${environment.dataDir} will be preserved.`,
+      );
+    }
+
+    const prompt = options.purge
+      ? "Type 'purge' to permanently uninstall and delete local data: "
+      : "Remove Plannotator-installed components? [y/N] ";
+    const readline = createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    let answer = "";
+    try {
+      answer = await readline.question(prompt);
+    } finally {
+      readline.close();
+    }
+
+    if (!isUninstallConfirmationAccepted(answer, options.purge)) {
+      console.log("Uninstall cancelled.");
+      process.exit(0);
+    }
+  } else if (options.purge && !options.dryRun) {
+    console.error(formatPurgeWarning(environment.dataDir));
+  }
+
+  const result = await runPlannotatorUninstall(
+    { purge: options.purge, dryRun: options.dryRun },
+    environment,
+  );
+  const formatted = formatUninstallResult(result);
+  if (formatted) console.log(formatted);
+
+  if (options.dryRun) {
+    console.log("Dry run complete; no changes were made.");
+  } else if (options.purge && result.ok) {
+    console.log(`Known local Plannotator data was purged from ${result.dataDir}.`);
+  } else if (!options.purge) {
+    console.log(`Local Plannotator data was preserved in ${result.dataDir}.`);
+  }
+
+  process.exit(result.ok ? 0 : 1);
 }
 
 if (args[0] === "install-runtime") {

--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -337,7 +337,11 @@ if (args[0] === "uninstall") {
   }
 
   const result = await runPlannotatorUninstall(
-    { purge: options.purge, dryRun: options.dryRun },
+    {
+      purge: options.purge,
+      dryRun: options.dryRun,
+      skipHosts: options.skipHosts,
+    },
     environment,
   );
   const formatted = formatUninstallResult(result);

--- a/apps/marketing/src/content/docs/getting-started/installation.md
+++ b/apps/marketing/src/content/docs/getting-started/installation.md
@@ -114,8 +114,11 @@ recognized removal set without changing anything.
 The purge removes only known Plannotator entries from the configured data
 directory. Unknown top-level files are preserved rather than guessed at, and
 custom external plan-save paths or project-local integrations are never
-deleted. If a host plugin manager is unavailable or a shared JSONC file cannot
-be edited safely, the command reports the manual follow-up.
+deleted. If a host plugin manager is unavailable or a shared config cannot be
+edited safely, the command reports the follow-up and preserves the CLI and its
+Windows PATH entry so you can fix the problem and retry. If Windows PATH
+restoration itself fails, the CLI remains on disk and the output gives its full
+path for retry and manual PATH repair.
 Purge also refuses broad targets (filesystem roots, the home directory, or the
 shared temporary directory), symlinked data directories, and non-directory
 paths. For a symlinked dedicated directory, set `PLANNOTATOR_DATA_DIR` to its

--- a/apps/marketing/src/content/docs/getting-started/installation.md
+++ b/apps/marketing/src/content/docs/getting-started/installation.md
@@ -118,16 +118,19 @@ integrations manually afterward.
 The purge removes only known Plannotator entries from the configured data
 directory. Unknown top-level files are preserved rather than guessed at, and
 custom external plan-save paths or project-local integrations are never
-deleted. If a host plugin manager is unavailable or a shared config cannot be
-edited safely, the command reports the follow-up and preserves the CLI and its
-Windows PATH entry so you can fix the problem and retry. If Windows PATH
-restoration itself fails, the CLI remains on disk and the output gives its full
-path for retry and manual PATH repair.
+deleted. Malformed host config is treated as a fail-safe error unless
+`--skip-hosts` is explicit. If a host plugin manager is unavailable or a shared
+config cannot be edited safely, the command reports the follow-up and preserves
+the CLI and its Windows PATH entry so you can fix the problem and retry. If
+Windows PATH restoration itself fails, the CLI remains on disk and the output
+gives its full path for retry and manual PATH repair.
 Purge also refuses broad targets (filesystem roots, the home directory, or the
 shared temporary directory), symlinked data directories, and non-directory
 paths. Existing targets are compared by filesystem identity, so case aliases,
 symlinks, hardlinks, and bind mounts cannot bypass the root/home/ancestor
-checks. For a symlinked dedicated directory, set `PLANNOTATOR_DATA_DIR` to its
+checks. The identity and containment guards are revalidated after awaited host
+commands, immediately before data removal, so a swapped directory is refused.
+For a symlinked dedicated directory, set `PLANNOTATOR_DATA_DIR` to its
 resolved target and retry.
 
 Pi-only installations that do not include the `plannotator` CLI should use:

--- a/apps/marketing/src/content/docs/getting-started/installation.md
+++ b/apps/marketing/src/content/docs/getting-started/installation.md
@@ -110,6 +110,10 @@ local-only: it is not stored on a Plannotator server and cannot be recovered
 after purge. `--yes` (or `-y`) skips confirmation for automation, and is
 required when no interactive terminal is available. `--dry-run` previews the
 recognized removal set without changing anything.
+If a broken or unavailable host blocks cleanup, `--skip-hosts` leaves host
+plugin managers and shared host configuration untouched while removing the
+remaining installer-owned components and binary. Remove the skipped host
+integrations manually afterward.
 
 The purge removes only known Plannotator entries from the configured data
 directory. Unknown top-level files are preserved rather than guessed at, and
@@ -121,7 +125,9 @@ restoration itself fails, the CLI remains on disk and the output gives its full
 path for retry and manual PATH repair.
 Purge also refuses broad targets (filesystem roots, the home directory, or the
 shared temporary directory), symlinked data directories, and non-directory
-paths. For a symlinked dedicated directory, set `PLANNOTATOR_DATA_DIR` to its
+paths. Existing targets are compared by filesystem identity, so case aliases,
+symlinks, hardlinks, and bind mounts cannot bypass the root/home/ancestor
+checks. For a symlinked dedicated directory, set `PLANNOTATOR_DATA_DIR` to its
 resolved target and retry.
 
 Pi-only installations that do not include the `plannotator` CLI should use:

--- a/apps/marketing/src/content/docs/getting-started/installation.md
+++ b/apps/marketing/src/content/docs/getting-started/installation.md
@@ -83,6 +83,50 @@ For `curl … | bash` pipelines you can set `PLANNOTATOR_MINIMAL=1` in the envir
 
 </details>
 
+## Uninstall
+
+`plannotator uninstall` removes recognized installed components while
+preserving local Plannotator data by default:
+
+```bash
+plannotator uninstall
+```
+
+This removes the conventional binary, the managed `sem` and agent-terminal
+runtimes, installer-provided skills and commands, managed hook/config entries,
+recognizable global integrations, and detected host plugins. Shared settings
+are changed only when their Plannotator entries can be identified safely;
+custom files and separately installed optional skills are preserved.
+
+To remove known local plans, history, drafts, guides, settings, and other
+Plannotator data too, use:
+
+```bash
+plannotator uninstall --purge
+```
+
+Purge requires typing `purge` at the prompt. The CLI warns that this data is
+local-only: it is not stored on a Plannotator server and cannot be recovered
+after purge. `--yes` (or `-y`) skips confirmation for automation, and is
+required when no interactive terminal is available. `--dry-run` previews the
+recognized removal set without changing anything.
+
+The purge removes only known Plannotator entries from the configured data
+directory. Unknown top-level files are preserved rather than guessed at, and
+custom external plan-save paths or project-local integrations are never
+deleted. If a host plugin manager is unavailable or a shared JSONC file cannot
+be edited safely, the command reports the manual follow-up.
+Purge also refuses broad targets (filesystem roots, the home directory, or the
+shared temporary directory), symlinked data directories, and non-directory
+paths. For a symlinked dedicated directory, set `PLANNOTATOR_DATA_DIR` to its
+resolved target and retry.
+
+Pi-only installations that do not include the `plannotator` CLI should use:
+
+```bash
+pi remove npm:@plannotator/pi-extension
+```
+
 <details>
 <summary><strong>Installing behind a rate-limited IP</strong></summary>
 

--- a/apps/pi-extension/README.md
+++ b/apps/pi-extension/README.md
@@ -23,6 +23,17 @@ pi install ./plannotator/apps/pi-extension
 pi -e npm:@plannotator/pi-extension
 ```
 
+## Uninstall
+
+Remove a standalone Pi installation with:
+
+```bash
+pi remove npm:@plannotator/pi-extension
+```
+
+If Pi was configured by the full Plannotator installer, `plannotator uninstall`
+also detects and removes the extension through Pi.
+
 ## Build from source
 
 If installing from a local clone, build the HTML assets first:

--- a/bun.lock
+++ b/bun.lock
@@ -231,6 +231,7 @@
         "@plannotator/shared": "workspace:*",
         "@plannotator/webtui": "0.1.0",
         "chokidar": "^5.0.0",
+        "jsonc-parser": "^3.3.1",
       },
       "devDependencies": {
         "glimpseui": "^0.8.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -31,11 +31,12 @@
     "*.mjs"
   ],
   "dependencies": {
-    "chokidar": "^5.0.0",
     "@pierre/diffs": "1.2.8",
     "@plannotator/ai": "workspace:*",
     "@plannotator/shared": "workspace:*",
-    "@plannotator/webtui": "0.1.0"
+    "@plannotator/webtui": "0.1.0",
+    "chokidar": "^5.0.0",
+    "jsonc-parser": "^3.3.1"
   },
   "peerDependencies": {
     "bun": ">=1.0.0"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,6 +19,7 @@
     "./repo": "./repo.ts",
     "./review-workspace": "./review-workspace.ts",
     "./agent-terminal-runtime": "./agent-terminal-runtime.ts",
+    "./uninstall": "./uninstall.ts",
     "./share-url": "./share-url.ts",
     "./sessions": "./sessions.ts",
     "./project": "./project.ts",

--- a/packages/server/uninstall.test.ts
+++ b/packages/server/uninstall.test.ts
@@ -1,15 +1,20 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
   existsSync,
+  linkSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
+  readlinkSync,
   rmSync,
+  statSync,
   symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, parse } from "node:path";
 import {
   formatPurgeWarning,
   runPlannotatorUninstall,
@@ -28,11 +33,27 @@ type Fixture = {
   homeDir: string;
   dataDir: string;
   commandCalls: CommandCall[];
-  scheduledDeletes: Array<{ target: string; parent: string }>;
+  scheduledDeletes: Array<{ target: string; parent: string | null }>;
   environment: UninstallEnvironment;
 };
 
 const temporaryRoots: string[] = [];
+
+const supportsCaseVariantPaths = (() => {
+  const root = mkdtempSync(join(tmpdir(), "plannotator-case-probe-"));
+  try {
+    const exact = join(root, "case-probe");
+    const variant = join(root, "CASE-PROBE");
+    mkdirSync(exact);
+    const exactStat = statSync(exact, { bigint: true });
+    const variantStat = statSync(variant, { bigint: true });
+    return exactStat.dev === variantStat.dev && exactStat.ino === variantStat.ino;
+  } catch {
+    return false;
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+})();
 
 afterEach(() => {
   for (const root of temporaryRoots.splice(0)) {
@@ -46,6 +67,7 @@ describe("Windows self-delete worker", () => {
       "$target=$env:PLANNOTATOR_UNINSTALL_TARGET\nfor",
     );
     expect(WINDOWS_SELF_DELETE_SCRIPT).toContain("}\n$parent=");
+    expect(WINDOWS_SELF_DELETE_SCRIPT).toContain("if($parent){Remove-Item");
   });
 });
 
@@ -59,7 +81,7 @@ function createFixture(
   mkdirSync(dataDir, { recursive: true });
 
   const commandCalls: CommandCall[] = [];
-  const scheduledDeletes: Array<{ target: string; parent: string }> = [];
+  const scheduledDeletes: Array<{ target: string; parent: string | null }> = [];
   const environment: UninstallEnvironment = {
     platform: "linux",
     homeDir,
@@ -104,6 +126,29 @@ function writeJson(filePath: string, value: unknown): void {
 
 function readJson(filePath: string): Record<string, unknown> {
   return JSON.parse(readFileSync(filePath, "utf8")) as Record<string, unknown>;
+}
+
+function snapshotTree(root: string): string[] {
+  const snapshot: string[] = [];
+  const visit = (path: string, relativePath: string): void => {
+    const stat = lstatSync(path);
+    if (stat.isSymbolicLink()) {
+      snapshot.push(`link:${relativePath}:${readlinkSync(path)}`);
+      return;
+    }
+    if (stat.isDirectory()) {
+      snapshot.push(`dir:${relativePath}`);
+      for (const entry of readdirSync(path).sort()) {
+        visit(join(path, entry), join(relativePath, entry));
+      }
+      return;
+    }
+    snapshot.push(
+      `file:${relativePath}:${readFileSync(path).toString("base64")}`,
+    );
+  };
+  visit(root, ".");
+  return snapshot;
 }
 
 describe("default uninstall", () => {
@@ -416,6 +461,7 @@ describe("default uninstall", () => {
     writeJson(join(fixture.homeDir, ".claude", "settings.json"), {
       enabledPlugins: { "plannotator@plannotator": true },
     });
+    const before = snapshotTree(fixture.root);
 
     const result = await runPlannotatorUninstall(
       { purge: false, dryRun: true },
@@ -432,6 +478,7 @@ describe("default uninstall", () => {
     );
     expect(existsSync(binary)).toBe(true);
     expect(fixture.commandCalls).toEqual([]);
+    expect(snapshotTree(fixture.root)).toEqual(before);
   });
 
   test("removes OpenCode from JSONC while preserving comments and unrelated plugins", async () => {
@@ -500,7 +547,7 @@ describe("default uninstall", () => {
     expect(existsSync(binary)).toBe(true);
     expect(result.ok).toBe(false);
     expect(result.errors).toContain(
-      `Preserved ${configPath}: it is not valid JSON or JSONC, so the managed entry could not be removed safely.`,
+      `Preserved ${configPath}: it is not valid JSON or JSONC, and it may contain a managed Plannotator entry. Re-run with --skip-hosts to leave host integrations for manual cleanup.`,
     );
   });
 
@@ -544,6 +591,151 @@ describe("default uninstall", () => {
       },
       experimental: { plan: true },
     });
+  });
+
+  test("preserves strict JSON indentation, line endings, and trailing newline", async () => {
+    const fixture = createFixture();
+    const settingsPath = join(
+      fixture.homeDir,
+      ".gemini",
+      "settings.json",
+    );
+    const contents = [
+      "{",
+      '    "theme": "custom",',
+      '    "hooks": {',
+      '        "BeforeTool": [',
+      "            {",
+      '                "matcher": "exit_plan_mode",',
+      '                "hooks": [{ "type": "command", "command": "plannotator" }]',
+      "            }",
+      "        ]",
+      "    }",
+      "}",
+      "",
+    ].join("\r\n");
+    writeText(settingsPath, contents);
+
+    const result = await runPlannotatorUninstall(
+      { purge: false, dryRun: false },
+      fixture.environment,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(readFileSync(settingsPath, "utf8")).toBe(
+      ['{', '    "theme": "custom"', '}', ''].join("\r\n"),
+    );
+  });
+
+  test("removes a relocated Codex hook adopted by the installer", async () => {
+    const fixture = createFixture();
+    const hooksPath = join(fixture.homeDir, ".codex", "hooks.json");
+    writeJson(hooksPath, {
+      hooks: {
+        Stop: [
+          {
+            hooks: [
+              {
+                type: "command",
+                command: join(fixture.root, "relocated", "plannotator"),
+              },
+              {
+                type: "command",
+                command: join(fixture.root, "relocated", "plannotator-helper"),
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const result = await runPlannotatorUninstall(
+      { purge: false, dryRun: false },
+      fixture.environment,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(readJson(hooksPath)).toEqual({
+      hooks: {
+        Stop: [
+          {
+            hooks: [
+              {
+                type: "command",
+                command: join(fixture.root, "relocated", "plannotator-helper"),
+              },
+            ],
+          },
+        ],
+      },
+    });
+  });
+
+  test("does not let unrelated malformed Gemini settings block binary removal", async () => {
+    const fixture = createFixture();
+    const binary = join(fixture.homeDir, ".local", "bin", "plannotator");
+    const settingsPath = join(
+      fixture.homeDir,
+      ".gemini",
+      "settings.json",
+    );
+    const contents = '{ "theme": "custom" // comments are not strict JSON\n}';
+    writeText(binary);
+    writeText(settingsPath, contents);
+
+    const result = await runPlannotatorUninstall(
+      { purge: false, dryRun: false },
+      fixture.environment,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(existsSync(binary)).toBe(false);
+    expect(readFileSync(settingsPath, "utf8")).toBe(contents);
+    expect(result.warnings).toContain(
+      `Preserved ${settingsPath}: it is not strict JSON. No recognizable Plannotator entry was found, so uninstall continued.`,
+    );
+  });
+
+  test("fails safe for possibly managed malformed config unless hosts are skipped", async () => {
+    const fixture = createFixture();
+    const binary = join(fixture.homeDir, ".local", "bin", "plannotator");
+    const settingsPath = join(
+      fixture.homeDir,
+      ".gemini",
+      "settings.json",
+    );
+    const kiroAgentPath = join(
+      fixture.homeDir,
+      ".kiro",
+      "agents",
+      "plannotator.json",
+    );
+    const contents = '{ "command": "plannotator" // malformed managed hook\n}';
+    const kiroContents = '{ "name": "plannotator" // malformed agent\n}';
+    writeText(binary);
+    writeText(settingsPath, contents);
+    writeText(kiroAgentPath, kiroContents);
+
+    const blocked = await runPlannotatorUninstall(
+      { purge: false, dryRun: false },
+      fixture.environment,
+    );
+
+    expect(blocked.ok).toBe(false);
+    expect(existsSync(binary)).toBe(true);
+    expect(blocked.errors[0]).toContain("may contain a managed Plannotator entry");
+    expect(blocked.errors[0]).toContain("--skip-hosts");
+
+    const escaped = await runPlannotatorUninstall(
+      { purge: false, dryRun: false, skipHosts: true },
+      fixture.environment,
+    );
+
+    expect(escaped.ok).toBe(true);
+    expect(existsSync(binary)).toBe(false);
+    expect(readFileSync(settingsPath, "utf8")).toBe(contents);
+    expect(readFileSync(kiroAgentPath, "utf8")).toBe(kiroContents);
+    expect(escaped.warnings[0]).toContain("Skipped host plugin managers");
   });
 
   test("skips data-contained runtimes when the configured data root is broad", async () => {
@@ -698,6 +890,107 @@ describe("purge uninstall", () => {
     expect(existsSync(binary)).toBe(true);
   });
 
+  test.skipIf(!supportsCaseVariantPaths)(
+    "refuses a case-variant data-dir spelling that resolves to HOME",
+    async () => {
+      const fixture = createFixture();
+      const caseVariantHome = join(dirname(fixture.homeDir), "HOME");
+      const plan = join(fixture.homeDir, "plans", "must-survive.md");
+      const binary = join(
+        fixture.homeDir,
+        ".local",
+        "bin",
+        "plannotator",
+      );
+      writeText(plan, "local-only data");
+      writeText(binary);
+
+      const result = await runPlannotatorUninstall(
+        { purge: true, dryRun: false },
+        {
+          ...fixture.environment,
+          dataDir: caseVariantHome,
+        },
+      );
+
+      expect(result.ok).toBe(false);
+      expect(result.errors[0]).toContain("home directory");
+      expect(readFileSync(plan, "utf8")).toBe("local-only data");
+      expect(existsSync(binary)).toBe(true);
+    },
+  );
+
+  test("refuses filesystem-root, home-ancestor, and shared-temp targets", async () => {
+    const cases = [
+      {
+        name: "filesystem root",
+        configure: (fixture: Fixture) => ({
+          dataDir: parse(fixture.homeDir).root,
+        }),
+        expected: "filesystem root",
+      },
+      {
+        name: "home ancestor",
+        configure: (fixture: Fixture) => ({ dataDir: fixture.root }),
+        expected: "contains the home directory",
+      },
+      {
+        name: "shared temp",
+        configure: (fixture: Fixture) => {
+          const sharedTemp = join(fixture.root, "shared-temp");
+          mkdirSync(sharedTemp);
+          return { dataDir: sharedTemp, tempDir: sharedTemp };
+        },
+        expected: "shared temporary directory",
+      },
+    ] as const;
+
+    for (const safetyCase of cases) {
+      const fixture = createFixture();
+      const binary = join(
+        fixture.homeDir,
+        ".local",
+        "bin",
+        "plannotator",
+      );
+      writeText(binary);
+
+      const result = await runPlannotatorUninstall(
+        { purge: true, dryRun: false },
+        {
+          ...fixture.environment,
+          ...safetyCase.configure(fixture),
+        },
+      );
+
+      expect(result.ok, safetyCase.name).toBe(false);
+      expect(result.errors[0], safetyCase.name).toContain(safetyCase.expected);
+      expect(existsSync(binary), safetyCase.name).toBe(true);
+    }
+  });
+
+  test("unlinks owned symlinks and hardlinks without touching their targets", async () => {
+    const fixture = createFixture();
+    const externalDirectory = join(fixture.root, "external-directory");
+    const externalDirectoryFile = join(externalDirectory, "keep.md");
+    const externalFile = join(fixture.root, "external-config.json");
+    writeText(externalDirectoryFile, "keep directory target");
+    writeText(externalFile, "keep hardlink target");
+    symlinkSync(externalDirectory, join(fixture.dataDir, "plans"), "dir");
+    linkSync(externalFile, join(fixture.dataDir, "config.json"));
+
+    const result = await runPlannotatorUninstall(
+      { purge: true, dryRun: false },
+      fixture.environment,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(readFileSync(externalDirectoryFile, "utf8")).toBe(
+      "keep directory target",
+    );
+    expect(readFileSync(externalFile, "utf8")).toBe("keep hardlink target");
+  });
+
   test("refuses a symlinked purge target before removing any component", async () => {
     const fixture = createFixture();
     const target = join(fixture.root, "real-data");
@@ -780,6 +1073,14 @@ describe("host and platform integrations", () => {
     expect(result.warnings).toContain(
       "Preserved the Plannotator CLI and its Windows PATH entry so you can resolve the errors and retry uninstall.",
     );
+
+    const escaped = await runPlannotatorUninstall(
+      { purge: false, dryRun: false, skipHosts: true },
+      fixture.environment,
+    );
+    expect(escaped.ok).toBe(true);
+    expect(existsSync(binary)).toBe(false);
+    expect(escaped.warnings[0]).toContain("Skipped host plugin managers");
   });
 
   test("detects disabled Claude and Droid plugins from installation metadata", async () => {
@@ -949,6 +1250,34 @@ describe("host and platform integrations", () => {
     expect(fixture.commandCalls[0]?.env).toEqual({
       PLANNOTATOR_UNINSTALL_PATH: dirname(currentExe),
     });
+  });
+
+  test("never schedules removal of a shared parent for a legacy Windows exe", async () => {
+    const fixture = createFixture();
+    const localAppData = join(fixture.homeDir, "AppData", "Local");
+    const sharedBin = join(fixture.homeDir, ".local", "bin");
+    const currentExe = join(sharedBin, "plannotator.exe");
+    const unrelatedFile = join(sharedBin, "unrelated-tool.exe");
+    writeText(currentExe);
+    writeText(unrelatedFile);
+
+    const result = await runPlannotatorUninstall(
+      { purge: false, dryRun: false },
+      {
+        ...fixture.environment,
+        platform: "win32",
+        execPath: currentExe,
+        env: { LOCALAPPDATA: localAppData },
+        which: (command) =>
+          command === "powershell.exe" ? "C:\\Windows\\powershell.exe" : null,
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(fixture.scheduledDeletes).toEqual([
+      { target: currentExe, parent: null },
+    ]);
+    expect(existsSync(unrelatedFile)).toBe(true);
   });
 
   test("keeps the running Windows CLI when PATH cleanup fails", async () => {

--- a/packages/server/uninstall.test.ts
+++ b/packages/server/uninstall.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeAll, describe, expect, test } from "bun:test";
 import {
   existsSync,
   linkSync,
@@ -8,6 +8,7 @@ import {
   readFileSync,
   readdirSync,
   readlinkSync,
+  renameSync,
   rmSync,
   statSync,
   symlinkSync,
@@ -38,8 +39,9 @@ type Fixture = {
 };
 
 const temporaryRoots: string[] = [];
+let supportsCaseVariantPaths = false;
 
-const supportsCaseVariantPaths = (() => {
+function detectCaseVariantPathSupport(): boolean {
   const root = mkdtempSync(join(tmpdir(), "plannotator-case-probe-"));
   try {
     const exact = join(root, "case-probe");
@@ -53,7 +55,11 @@ const supportsCaseVariantPaths = (() => {
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
-})();
+}
+
+beforeAll(() => {
+  supportsCaseVariantPaths = detectCaseVariantPathSupport();
+});
 
 afterEach(() => {
   for (const root of temporaryRoots.splice(0)) {
@@ -362,7 +368,7 @@ describe("default uninstall", () => {
     });
 
     const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: false },
+      { purge: false, dryRun: false, skipHosts: false },
       fixture.environment,
     );
 
@@ -464,7 +470,7 @@ describe("default uninstall", () => {
     const before = snapshotTree(fixture.root);
 
     const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: true },
+      { purge: false, dryRun: true, skipHosts: false },
       {
         ...fixture.environment,
         which: () => "/fake/claude",
@@ -505,7 +511,7 @@ describe("default uninstall", () => {
     writeText(configPath, contents);
 
     const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: false },
+      { purge: false, dryRun: false, skipHosts: false },
       fixture.environment,
     );
 
@@ -539,7 +545,7 @@ describe("default uninstall", () => {
     writeText(configPath, contents);
 
     const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: false },
+      { purge: false, dryRun: false, skipHosts: false },
       fixture.environment,
     );
 
@@ -547,7 +553,7 @@ describe("default uninstall", () => {
     expect(existsSync(binary)).toBe(true);
     expect(result.ok).toBe(false);
     expect(result.errors).toContain(
-      `Preserved ${configPath}: it is not valid JSON or JSONC, and it may contain a managed Plannotator entry. Re-run with --skip-hosts to leave host integrations for manual cleanup.`,
+      `Preserved ${configPath}: it is not valid JSON or JSONC, so managed host entries cannot be classified safely. Re-run with --skip-hosts to leave host integrations for manual cleanup.`,
     );
   });
 
@@ -574,7 +580,7 @@ describe("default uninstall", () => {
     });
 
     await runPlannotatorUninstall(
-      { purge: false, dryRun: false },
+      { purge: false, dryRun: false, skipHosts: false },
       fixture.environment,
     );
 
@@ -617,7 +623,7 @@ describe("default uninstall", () => {
     writeText(settingsPath, contents);
 
     const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: false },
+      { purge: false, dryRun: false, skipHosts: false },
       fixture.environment,
     );
 
@@ -650,7 +656,7 @@ describe("default uninstall", () => {
     });
 
     const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: false },
+      { purge: false, dryRun: false, skipHosts: false },
       fixture.environment,
     );
 
@@ -671,7 +677,7 @@ describe("default uninstall", () => {
     });
   });
 
-  test("does not let unrelated malformed Gemini settings block binary removal", async () => {
+  test("requires an explicit host skip for unrelated malformed Gemini settings", async () => {
     const fixture = createFixture();
     const binary = join(fixture.homeDir, ".local", "bin", "plannotator");
     const settingsPath = join(
@@ -683,20 +689,28 @@ describe("default uninstall", () => {
     writeText(binary);
     writeText(settingsPath, contents);
 
-    const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: false },
+    const blocked = await runPlannotatorUninstall(
+      { purge: false, dryRun: false, skipHosts: false },
       fixture.environment,
     );
 
-    expect(result.ok).toBe(true);
+    expect(blocked.ok).toBe(false);
+    expect(existsSync(binary)).toBe(true);
+    expect(readFileSync(settingsPath, "utf8")).toBe(contents);
+    expect(blocked.errors).toContain(
+      `Preserved ${settingsPath}: it is not strict JSON, so managed host entries cannot be classified safely. Re-run with --skip-hosts to leave host integrations for manual cleanup.`,
+    );
+
+    const escaped = await runPlannotatorUninstall(
+      { purge: false, dryRun: false, skipHosts: true },
+      fixture.environment,
+    );
+    expect(escaped.ok).toBe(true);
     expect(existsSync(binary)).toBe(false);
     expect(readFileSync(settingsPath, "utf8")).toBe(contents);
-    expect(result.warnings).toContain(
-      `Preserved ${settingsPath}: it is not strict JSON. No recognizable Plannotator entry was found, so uninstall continued.`,
-    );
   });
 
-  test("fails safe for possibly managed malformed config unless hosts are skipped", async () => {
+  test("fails safe for escaped managed spellings in malformed host config", async () => {
     const fixture = createFixture();
     const binary = join(fixture.homeDir, ".local", "bin", "plannotator");
     const settingsPath = join(
@@ -710,20 +724,21 @@ describe("default uninstall", () => {
       "agents",
       "plannotator.json",
     );
-    const contents = '{ "command": "plannotator" // malformed managed hook\n}';
+    const contents = '{ "command": "pl\\u0061nnotator" // malformed managed hook\n}';
     const kiroContents = '{ "name": "plannotator" // malformed agent\n}';
     writeText(binary);
     writeText(settingsPath, contents);
     writeText(kiroAgentPath, kiroContents);
 
     const blocked = await runPlannotatorUninstall(
-      { purge: false, dryRun: false },
+      { purge: false, dryRun: false, skipHosts: false },
       fixture.environment,
     );
 
     expect(blocked.ok).toBe(false);
     expect(existsSync(binary)).toBe(true);
-    expect(blocked.errors[0]).toContain("may contain a managed Plannotator entry");
+    expect(contents.toLowerCase()).not.toContain("plannotator");
+    expect(blocked.errors[0]).toContain("cannot be classified safely");
     expect(blocked.errors[0]).toContain("--skip-hosts");
 
     const escaped = await runPlannotatorUninstall(
@@ -756,7 +771,7 @@ describe("default uninstall", () => {
     writeText(unrelatedVendorFile, "unrelated");
 
     const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: false },
+      { purge: false, dryRun: false, skipHosts: false },
       {
         ...fixture.environment,
         dataDir: fixture.homeDir,
@@ -778,7 +793,7 @@ describe("purge uninstall", () => {
     writeText(join(fixture.dataDir, "vendor", "sem", "v0.8.0", "sem"));
 
     const result = await runPlannotatorUninstall(
-      { purge: true, dryRun: true },
+      { purge: true, dryRun: true, skipHosts: false },
       fixture.environment,
     );
 
@@ -794,7 +809,7 @@ describe("purge uninstall", () => {
     mkdirSync(vendorDirectory, { recursive: true });
 
     const preview = await runPlannotatorUninstall(
-      { purge: true, dryRun: true },
+      { purge: true, dryRun: true, skipHosts: false },
       fixture.environment,
     );
     expect(preview.preserved).toContain(
@@ -802,7 +817,7 @@ describe("purge uninstall", () => {
     );
 
     const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: false },
+      { purge: false, dryRun: false, skipHosts: false },
       fixture.environment,
     );
 
@@ -827,7 +842,7 @@ describe("purge uninstall", () => {
     writeText(customPath, "not installer-owned");
 
     const result = await runPlannotatorUninstall(
-      { purge: true, dryRun: false },
+      { purge: true, dryRun: false, skipHosts: false },
       fixture.environment,
     );
 
@@ -850,7 +865,7 @@ describe("purge uninstall", () => {
     writeText(join(fixture.dataDir, "vendor", "sem", "v0.8.0", "sem"));
 
     const result = await runPlannotatorUninstall(
-      { purge: true, dryRun: false },
+      { purge: true, dryRun: false, skipHosts: false },
       fixture.environment,
     );
 
@@ -877,7 +892,7 @@ describe("purge uninstall", () => {
     writeText(binary);
 
     const result = await runPlannotatorUninstall(
-      { purge: true, dryRun: false },
+      { purge: true, dryRun: false, skipHosts: false },
       {
         ...fixture.environment,
         dataDir: fixture.homeDir,
@@ -890,9 +905,54 @@ describe("purge uninstall", () => {
     expect(existsSync(binary)).toBe(true);
   });
 
-  test.skipIf(!supportsCaseVariantPaths)(
+  test("refuses a data-directory swap after awaited host cleanup", async () => {
+    const fixture = createFixture();
+    const validatedDirectory = join(fixture.root, "validated-data");
+    const replacementTarget = join(fixture.root, "replacement-target");
+    const originalPlan = join(fixture.dataDir, "plans", "original.md");
+    const replacementPlan = join(replacementTarget, "plans", "must-survive.md");
+    const binary = join(
+      fixture.homeDir,
+      ".local",
+      "bin",
+      "plannotator",
+    );
+    writeText(originalPlan, "original data");
+    writeText(replacementPlan, "unrelated replacement data");
+    writeText(binary);
+    writeJson(join(fixture.homeDir, ".claude", "settings.json"), {
+      enabledPlugins: { "plannotator@plannotator": true },
+    });
+
+    const result = await runPlannotatorUninstall(
+      { purge: true, dryRun: false, skipHosts: false },
+      {
+        ...fixture.environment,
+        which: (command) => command === "claude" ? "/fake/claude" : null,
+        runCommand: async () => {
+          renameSync(fixture.dataDir, validatedDirectory);
+          symlinkSync(replacementTarget, fixture.dataDir, "dir");
+          return { exitCode: 0, timedOut: false };
+        },
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain(
+      `Refusing to remove managed paths under ${fixture.dataDir}: the data directory changed after initial validation (the data directory is a symlink; set PLANNOTATOR_DATA_DIR to its resolved target and retry).`,
+    );
+    expect(readFileSync(join(validatedDirectory, "plans", "original.md"), "utf8"))
+      .toBe("original data");
+    expect(readFileSync(replacementPlan, "utf8")).toBe(
+      "unrelated replacement data",
+    );
+    expect(existsSync(binary)).toBe(true);
+  });
+
+  test(
     "refuses a case-variant data-dir spelling that resolves to HOME",
     async () => {
+      if (!supportsCaseVariantPaths) return;
       const fixture = createFixture();
       const caseVariantHome = join(dirname(fixture.homeDir), "HOME");
       const plan = join(fixture.homeDir, "plans", "must-survive.md");
@@ -906,7 +966,7 @@ describe("purge uninstall", () => {
       writeText(binary);
 
       const result = await runPlannotatorUninstall(
-        { purge: true, dryRun: false },
+        { purge: true, dryRun: false, skipHosts: false },
         {
           ...fixture.environment,
           dataDir: caseVariantHome,
@@ -956,7 +1016,7 @@ describe("purge uninstall", () => {
       writeText(binary);
 
       const result = await runPlannotatorUninstall(
-        { purge: true, dryRun: false },
+        { purge: true, dryRun: false, skipHosts: false },
         {
           ...fixture.environment,
           ...safetyCase.configure(fixture),
@@ -980,7 +1040,7 @@ describe("purge uninstall", () => {
     linkSync(externalFile, join(fixture.dataDir, "config.json"));
 
     const result = await runPlannotatorUninstall(
-      { purge: true, dryRun: false },
+      { purge: true, dryRun: false, skipHosts: false },
       fixture.environment,
     );
 
@@ -1006,7 +1066,7 @@ describe("purge uninstall", () => {
     writeText(binary);
 
     const result = await runPlannotatorUninstall(
-      { purge: true, dryRun: false },
+      { purge: true, dryRun: false, skipHosts: false },
       {
         ...fixture.environment,
         dataDir: symlink,
@@ -1032,7 +1092,7 @@ describe("purge uninstall", () => {
     writeText(binary);
 
     const result = await runPlannotatorUninstall(
-      { purge: true, dryRun: false },
+      { purge: true, dryRun: false, skipHosts: false },
       {
         ...fixture.environment,
         dataDir: dataFile,
@@ -1060,7 +1120,7 @@ describe("host and platform integrations", () => {
     });
 
     const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: false },
+      { purge: false, dryRun: false, skipHosts: false },
       fixture.environment,
     );
 
@@ -1107,7 +1167,7 @@ describe("host and platform integrations", () => {
     );
 
     await runPlannotatorUninstall(
-      { purge: false, dryRun: false },
+      { purge: false, dryRun: false, skipHosts: false },
       {
         ...fixture.environment,
         which: (command) => `/fake/${command}`,
@@ -1159,7 +1219,7 @@ describe("host and platform integrations", () => {
     );
 
     await runPlannotatorUninstall(
-      { purge: false, dryRun: false },
+      { purge: false, dryRun: false, skipHosts: false },
       {
         ...fixture.environment,
         which: (command) => `/fake/${command}`,
@@ -1201,7 +1261,7 @@ describe("host and platform integrations", () => {
     });
 
     await runPlannotatorUninstall(
-      { purge: true, dryRun: false },
+      { purge: true, dryRun: false, skipHosts: false },
       {
         ...fixture.environment,
         which: (command) => `/fake/${command}`,
@@ -1226,7 +1286,7 @@ describe("host and platform integrations", () => {
     writeText(legacyExe);
 
     const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: false },
+      { purge: false, dryRun: false, skipHosts: false },
       {
         ...fixture.environment,
         platform: "win32",
@@ -1262,7 +1322,7 @@ describe("host and platform integrations", () => {
     writeText(unrelatedFile);
 
     const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: false },
+      { purge: false, dryRun: false, skipHosts: false },
       {
         ...fixture.environment,
         platform: "win32",
@@ -1287,7 +1347,7 @@ describe("host and platform integrations", () => {
     writeText(currentExe);
 
     const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: false },
+      { purge: false, dryRun: false, skipHosts: false },
       {
         ...fixture.environment,
         platform: "win32",
@@ -1313,7 +1373,7 @@ describe("host and platform integrations", () => {
     writeText(currentExe);
 
     const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: false },
+      { purge: false, dryRun: false, skipHosts: false },
       {
         ...fixture.environment,
         platform: "win32",
@@ -1344,7 +1404,7 @@ describe("host and platform integrations", () => {
     let commandCount = 0;
 
     const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: false },
+      { purge: false, dryRun: false, skipHosts: false },
       {
         ...fixture.environment,
         platform: "win32",

--- a/packages/server/uninstall.test.ts
+++ b/packages/server/uninstall.test.ts
@@ -1,0 +1,722 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  formatPurgeWarning,
+  runPlannotatorUninstall,
+  type UninstallEnvironment,
+} from "./uninstall";
+
+type CommandCall = {
+  command: string;
+  args: readonly string[];
+  env?: Readonly<Record<string, string>>;
+};
+
+type Fixture = {
+  root: string;
+  homeDir: string;
+  dataDir: string;
+  commandCalls: CommandCall[];
+  scheduledDeletes: Array<{ target: string; parent: string }>;
+  environment: UninstallEnvironment;
+};
+
+const temporaryRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function createFixture(
+  overrides: Partial<UninstallEnvironment> = {},
+): Fixture {
+  const root = mkdtempSync(join(tmpdir(), "plannotator-uninstall-test-"));
+  temporaryRoots.push(root);
+  const homeDir = join(root, "home");
+  const dataDir = join(homeDir, ".plannotator");
+  mkdirSync(dataDir, { recursive: true });
+
+  const commandCalls: CommandCall[] = [];
+  const scheduledDeletes: Array<{ target: string; parent: string }> = [];
+  const environment: UninstallEnvironment = {
+    platform: "linux",
+    homeDir,
+    tempDir: tmpdir(),
+    dataDir,
+    execPath: join(root, "running-plannotator"),
+    env: {},
+    which: () => null,
+    runCommand: async (command, args, env) => {
+      commandCalls.push({ command, args, env });
+      return { exitCode: 0, timedOut: false };
+    },
+    scheduleWindowsSelfDelete: async (target, parent) => {
+      scheduledDeletes.push({ target, parent });
+      return true;
+    },
+    ...overrides,
+  };
+
+  return {
+    root,
+    homeDir,
+    dataDir,
+    commandCalls,
+    scheduledDeletes,
+    environment,
+  };
+}
+
+function writeText(filePath: string, content = "owned"): void {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content, "utf8");
+}
+
+function writeJson(filePath: string, value: unknown): void {
+  writeText(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function readJson(filePath: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(filePath, "utf8")) as Record<string, unknown>;
+}
+
+describe("default uninstall", () => {
+  test("removes recognized installer components and preserves local data", async () => {
+    const fixture = createFixture();
+    const { homeDir, dataDir } = fixture;
+    const alternateConfig = join(fixture.root, "xdg-config");
+    fixture.environment = {
+      ...fixture.environment,
+      env: { XDG_CONFIG_HOME: alternateConfig },
+    };
+
+    const binary = join(homeDir, ".local", "bin", "plannotator");
+    writeText(binary);
+    writeText(join(dataDir, "plans", "approved.md"), "# plan");
+    writeJson(join(dataDir, "config.json"), { theme: "dark" });
+    writeText(join(dataDir, "vendor", "sem", "v0.7.0", "sem"));
+    writeText(
+      join(dataDir, "vendor", "agent-terminal", "webtui-0.0.9", "server.js"),
+    );
+    writeText(join(dataDir, "vendor", "other-tool", "keep.txt"));
+    writeText(join(dataDir, "install-prefs"), "full\n");
+    writeText(join(dataDir, "migrations", "legacy"));
+
+    for (const skill of [
+      "plannotator-review",
+      "plannotator-annotate",
+      "plannotator-last",
+    ]) {
+      writeText(join(homeDir, ".claude", "skills", skill, "SKILL.md"));
+      writeText(join(homeDir, ".agents", "skills", skill, "SKILL.md"));
+    }
+    writeText(
+      join(homeDir, ".agents", "skills", "plannotator-compound", "SKILL.md"),
+      "user-managed extra skill",
+    );
+    writeText(
+      join(homeDir, ".agents", "skills", "plannotator-archive", "SKILL.md"),
+    );
+    writeText(
+      join(homeDir, ".codex", "skills", "plannotator-archive", "SKILL.md"),
+    );
+    writeText(
+      join(homeDir, ".kiro", "skills", "plannotator-setup-goal", "SKILL.md"),
+    );
+
+    const claudeSettings = join(homeDir, ".claude", "settings.json");
+    writeJson(claudeSettings, {
+      theme: "dark",
+      hooks: {
+        PermissionRequest: [
+          {
+            matcher: "ExitPlanMode",
+            hooks: [
+              { type: "command", command: binary, timeout: 345600 },
+              { type: "command", command: "custom-review-hook" },
+            ],
+          },
+        ],
+        PreToolUse: [
+          {
+            matcher: "EnterPlanMode",
+            hooks: [
+              {
+                type: "command",
+                command: `${binary} improve-context`,
+                timeout: 10,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const codexHooks = join(homeDir, ".codex", "hooks.json");
+    writeJson(codexHooks, {
+      hooks: {
+        Stop: [
+          {
+            hooks: [
+              { type: "command", command: binary, timeout: 345600 },
+              { type: "command", command: "custom-stop-hook" },
+            ],
+          },
+        ],
+      },
+    });
+    const codexConfig = join(homeDir, ".codex", "config.toml");
+    writeText(codexConfig, "[features]\nhooks = true\n\nmodel = \"custom\"\n");
+
+    const geminiSettings = join(homeDir, ".gemini", "settings.json");
+    writeJson(geminiSettings, {
+      theme: "custom",
+      hooks: {
+        BeforeTool: [
+          {
+            matcher: "exit_plan_mode",
+            hooks: [
+              { type: "command", command: "plannotator", timeout: 345600 },
+              { type: "command", command: "custom-gemini-hook" },
+            ],
+          },
+        ],
+      },
+    });
+    writeText(join(homeDir, ".gemini", "policies", "plannotator.toml"));
+    writeText(
+      join(homeDir, ".gemini", "commands", "plannotator-review.toml"),
+    );
+
+    const conventionalOpenCode = join(
+      homeDir,
+      ".config",
+      "opencode",
+      "opencode.json",
+    );
+    writeJson(conventionalOpenCode, {
+      plugin: ["@plannotator/opencode@latest", "keep-plugin"],
+      theme: "keep",
+    });
+    writeText(
+      join(
+        alternateConfig,
+        "opencode",
+        "commands",
+        "plannotator-annotate.md",
+      ),
+    );
+
+    const recognizableAmp = [
+      'const CATEGORY = "Plannotator";',
+      "export default function plannotatorAmpPlugin() {}",
+      'const origin = "PLANNOTATOR_ORIGIN";',
+    ].join("\n");
+    writeText(
+      join(homeDir, ".config", "amp", "plugins", "plannotator.ts"),
+      recognizableAmp,
+    );
+    const customKiroAgent = join(
+      homeDir,
+      ".kiro",
+      "agents",
+      "plannotator.json",
+    );
+    writeJson(customKiroAgent, {
+      name: "plannotator",
+      description: "my custom agent",
+      prompt: "custom",
+    });
+
+    const result = await runPlannotatorUninstall(
+      { purge: false, dryRun: false },
+      fixture.environment,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(existsSync(binary)).toBe(false);
+    expect(existsSync(join(homeDir, ".claude", "skills", "plannotator-review"))).toBe(false);
+    expect(existsSync(join(homeDir, ".agents", "skills", "plannotator-compound"))).toBe(true);
+    expect(existsSync(join(homeDir, ".agents", "skills", "plannotator-archive"))).toBe(false);
+    expect(existsSync(join(homeDir, ".kiro", "skills", "plannotator-setup-goal"))).toBe(false);
+
+    expect(existsSync(join(dataDir, "plans", "approved.md"))).toBe(true);
+    expect(readJson(join(dataDir, "config.json"))).toEqual({ theme: "dark" });
+    expect(existsSync(join(dataDir, "vendor", "sem"))).toBe(false);
+    expect(existsSync(join(dataDir, "vendor", "agent-terminal"))).toBe(false);
+    expect(existsSync(join(dataDir, "vendor", "other-tool", "keep.txt"))).toBe(true);
+    expect(existsSync(join(dataDir, "install-prefs"))).toBe(true);
+    expect(existsSync(join(dataDir, "migrations"))).toBe(true);
+
+    expect(readJson(claudeSettings)).toEqual({
+      theme: "dark",
+      hooks: {
+        PermissionRequest: [
+          {
+            matcher: "ExitPlanMode",
+            hooks: [{ type: "command", command: "custom-review-hook" }],
+          },
+        ],
+      },
+    });
+    expect(readJson(codexHooks)).toEqual({
+      hooks: {
+        Stop: [
+          {
+            hooks: [
+              { type: "command", command: "custom-stop-hook" },
+            ],
+          },
+        ],
+      },
+    });
+    expect(readFileSync(codexConfig, "utf8")).toContain('model = "custom"');
+    expect(readJson(geminiSettings)).toEqual({
+      theme: "custom",
+      hooks: {
+        BeforeTool: [
+          {
+            matcher: "exit_plan_mode",
+            hooks: [
+              { type: "command", command: "custom-gemini-hook" },
+            ],
+          },
+        ],
+      },
+    });
+    expect(readJson(conventionalOpenCode)).toEqual({
+      plugin: ["keep-plugin"],
+      theme: "keep",
+    });
+    expect(
+      existsSync(
+        join(
+          alternateConfig,
+          "opencode",
+          "commands",
+          "plannotator-annotate.md",
+        ),
+      ),
+    ).toBe(false);
+    expect(
+      existsSync(
+        join(homeDir, ".config", "amp", "plugins", "plannotator.ts"),
+      ),
+    ).toBe(false);
+    expect(existsSync(customKiroAgent)).toBe(true);
+    expect(result.preserved).toContain(
+      `${customKiroAgent} (custom or unrecognized Kiro agent)`,
+    );
+    expect(fixture.commandCalls).toEqual([]);
+  });
+
+  test("dry-run reports work without mutating files or invoking hosts", async () => {
+    const fixture = createFixture();
+    const binary = join(
+      fixture.homeDir,
+      ".local",
+      "bin",
+      "plannotator",
+    );
+    writeText(binary);
+    writeJson(join(fixture.homeDir, ".claude", "settings.json"), {
+      enabledPlugins: { "plannotator@plannotator": true },
+    });
+
+    const result = await runPlannotatorUninstall(
+      { purge: false, dryRun: true },
+      {
+        ...fixture.environment,
+        which: () => "/fake/claude",
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.planned).toContain(binary);
+    expect(result.planned).toContain(
+      "Claude Code plugin plannotator@plannotator",
+    );
+    expect(existsSync(binary)).toBe(true);
+    expect(fixture.commandCalls).toEqual([]);
+  });
+
+  test("preserves non-strict shared config rather than rewriting it", async () => {
+    const fixture = createFixture();
+    const configPath = join(
+      fixture.homeDir,
+      ".config",
+      "opencode",
+      "opencode.jsonc",
+    );
+    const contents = '{\n  // custom JSONC\n  "plugin": ["@plannotator/opencode"]\n}\n';
+    writeText(configPath, contents);
+
+    const result = await runPlannotatorUninstall(
+      { purge: false, dryRun: false },
+      fixture.environment,
+    );
+
+    expect(readFileSync(configPath, "utf8")).toBe(contents);
+    expect(result.warnings).toContain(
+      `Preserved ${configPath}: it is not strict JSON, so managed entries could not be removed safely.`,
+    );
+  });
+
+  test("preserves a custom Gemini hook sharing the managed matcher", async () => {
+    const fixture = createFixture();
+    const settingsPath = join(
+      fixture.homeDir,
+      ".gemini",
+      "settings.json",
+    );
+    writeJson(settingsPath, {
+      hooks: {
+        BeforeTool: [
+          {
+            matcher: "exit_plan_mode",
+            hooks: [
+              { type: "command", command: "plannotator", timeout: 345600 },
+              { type: "command", command: "my-custom-plan-hook" },
+            ],
+          },
+        ],
+      },
+      experimental: { plan: true },
+    });
+
+    await runPlannotatorUninstall(
+      { purge: false, dryRun: false },
+      fixture.environment,
+    );
+
+    expect(readJson(settingsPath)).toEqual({
+      hooks: {
+        BeforeTool: [
+          {
+            matcher: "exit_plan_mode",
+            hooks: [
+              { type: "command", command: "my-custom-plan-hook" },
+            ],
+          },
+        ],
+      },
+      experimental: { plan: true },
+    });
+  });
+
+  test("skips data-contained runtimes when the configured data root is broad", async () => {
+    const fixture = createFixture();
+    const binary = join(
+      fixture.homeDir,
+      ".local",
+      "bin",
+      "plannotator",
+    );
+    const unrelatedVendorFile = join(
+      fixture.homeDir,
+      "vendor",
+      "sem",
+      "keep.txt",
+    );
+    writeText(binary);
+    writeText(unrelatedVendorFile, "unrelated");
+
+    const result = await runPlannotatorUninstall(
+      { purge: false, dryRun: false },
+      {
+        ...fixture.environment,
+        dataDir: fixture.homeDir,
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(existsSync(binary)).toBe(false);
+    expect(existsSync(unrelatedVendorFile)).toBe(true);
+    expect(result.warnings[0]).toContain(
+      "Preserved managed runtime paths",
+    );
+  });
+});
+
+describe("purge uninstall", () => {
+  test("removes known local data while preserving unknown top-level entries", async () => {
+    const fixture = createFixture();
+    writeText(join(fixture.dataDir, "plans", "approved.md"));
+    writeText(join(fixture.dataDir, "history", "repo", "001.md"));
+    writeJson(join(fixture.dataDir, "config.json"), { theme: "dark" });
+    writeText(join(fixture.dataDir, "vendor", "sem", "v0.8.0", "sem"));
+    const customPath = join(fixture.dataDir, "my-notes", "keep.md");
+    writeText(customPath, "not installer-owned");
+
+    const result = await runPlannotatorUninstall(
+      { purge: true, dryRun: false },
+      fixture.environment,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(existsSync(join(fixture.dataDir, "plans"))).toBe(false);
+    expect(existsSync(join(fixture.dataDir, "history"))).toBe(false);
+    expect(existsSync(join(fixture.dataDir, "config.json"))).toBe(false);
+    expect(existsSync(join(fixture.dataDir, "vendor"))).toBe(false);
+    expect(existsSync(customPath)).toBe(true);
+    expect(result.preserved).toContain(
+      `${join(fixture.dataDir, "my-notes")} (unrecognized custom entry)`,
+    );
+  });
+
+  test("removes the data directory when no custom entries remain", async () => {
+    const fixture = createFixture();
+    writeText(join(fixture.dataDir, "drafts", "draft.json"));
+
+    const result = await runPlannotatorUninstall(
+      { purge: true, dryRun: false },
+      fixture.environment,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(existsSync(fixture.dataDir)).toBe(false);
+  });
+
+  test("states that purged data is local-only and unrecoverable", () => {
+    const warning = formatPurgeWarning("/tmp/example-data");
+    expect(warning).toContain("permanently delete");
+    expect(warning).toContain("local-only");
+    expect(warning).toContain("not stored on a Plannotator server");
+    expect(warning).toContain("cannot be recovered");
+  });
+
+  test("refuses a broad purge before removing any component", async () => {
+    const fixture = createFixture();
+    const binary = join(
+      fixture.homeDir,
+      ".local",
+      "bin",
+      "plannotator",
+    );
+    writeText(binary);
+
+    const result = await runPlannotatorUninstall(
+      { purge: true, dryRun: false },
+      {
+        ...fixture.environment,
+        dataDir: fixture.homeDir,
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toContain("Refusing to purge");
+    expect(result.errors[0]).toContain("home directory");
+    expect(existsSync(binary)).toBe(true);
+  });
+
+  test("refuses a symlinked purge target before removing any component", async () => {
+    const fixture = createFixture();
+    const target = join(fixture.root, "real-data");
+    const symlink = join(fixture.root, "linked-data");
+    mkdirSync(target, { recursive: true });
+    symlinkSync(target, symlink, "dir");
+    const binary = join(
+      fixture.homeDir,
+      ".local",
+      "bin",
+      "plannotator",
+    );
+    writeText(binary);
+
+    const result = await runPlannotatorUninstall(
+      { purge: true, dryRun: false },
+      {
+        ...fixture.environment,
+        dataDir: symlink,
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toContain("Refusing to purge");
+    expect(result.errors[0]).toContain("data directory is a symlink");
+    expect(existsSync(binary)).toBe(true);
+  });
+
+  test("refuses a data path that is a file before removing any component", async () => {
+    const fixture = createFixture();
+    const dataFile = join(fixture.root, "not-a-directory");
+    writeText(dataFile);
+    const binary = join(
+      fixture.homeDir,
+      ".local",
+      "bin",
+      "plannotator",
+    );
+    writeText(binary);
+
+    const result = await runPlannotatorUninstall(
+      { purge: true, dryRun: false },
+      {
+        ...fixture.environment,
+        dataDir: dataFile,
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toContain("data path is not a directory");
+    expect(existsSync(binary)).toBe(true);
+  });
+});
+
+describe("host and platform integrations", () => {
+  test("returns a partial-failure status when a detected host is unavailable", async () => {
+    const fixture = createFixture();
+    const binary = join(
+      fixture.homeDir,
+      ".local",
+      "bin",
+      "plannotator",
+    );
+    writeText(binary);
+    writeJson(join(fixture.homeDir, ".factory", "settings.json"), {
+      enabledPlugins: { "plannotator@plannotator": true },
+    });
+
+    const result = await runPlannotatorUninstall(
+      { purge: false, dryRun: false },
+      fixture.environment,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toContain(
+      "Droid plugin plannotator@plannotator",
+    );
+    expect(result.errors[0]).toContain("was not removed");
+    expect(existsSync(binary)).toBe(false);
+  });
+
+  test("uses host plugin managers and preserves Claude plugin data by default", async () => {
+    const fixture = createFixture();
+    writeJson(join(fixture.homeDir, ".claude", "settings.json"), {
+      enabledPlugins: { "plannotator@plannotator": true },
+    });
+    writeJson(join(fixture.homeDir, ".copilot", "settings.json"), {
+      enabledPlugins: { "plannotator-copilot@plannotator": true },
+    });
+    writeJson(join(fixture.homeDir, ".factory", "settings.json"), {
+      enabledPlugins: { "plannotator@plannotator": true },
+    });
+    writeJson(join(fixture.homeDir, ".pi", "agent", "settings.json"), {
+      packages: [{ source: "npm:@plannotator/pi-extension@0.25.1" }],
+    });
+    writeText(
+      join(
+        fixture.homeDir,
+        ".vscode",
+        "extensions",
+        "backnotprop.plannotator-webview-0.25.1",
+        "package.json",
+      ),
+    );
+
+    await runPlannotatorUninstall(
+      { purge: false, dryRun: false },
+      {
+        ...fixture.environment,
+        which: (command) => `/fake/${command}`,
+      },
+    );
+
+    expect(fixture.commandCalls.map((call) => call.args)).toEqual([
+      [
+        "plugin",
+        "uninstall",
+        "plannotator@plannotator",
+        "--scope",
+        "user",
+        "--keep-data",
+        "--yes",
+      ],
+      [
+        "plugins",
+        "remove",
+        "plannotator-copilot@plannotator",
+        "--plugin",
+      ],
+      [
+        "plugin",
+        "uninstall",
+        "plannotator@plannotator",
+        "--scope",
+        "user",
+      ],
+      ["remove", "npm:@plannotator/pi-extension"],
+      ["--uninstall-extension", "backnotprop.plannotator-webview"],
+    ]);
+  });
+
+  test("allows Claude to remove its plugin data during purge", async () => {
+    const fixture = createFixture();
+    writeJson(join(fixture.homeDir, ".claude", "settings.json"), {
+      enabledPlugins: { "plannotator@plannotator": true },
+    });
+
+    await runPlannotatorUninstall(
+      { purge: true, dryRun: false },
+      {
+        ...fixture.environment,
+        which: (command) => `/fake/${command}`,
+      },
+    );
+
+    expect(fixture.commandCalls).toHaveLength(1);
+    expect(fixture.commandCalls[0]?.args).not.toContain("--keep-data");
+  });
+
+  test("removes Windows PATH registration and schedules the running exe", async () => {
+    const fixture = createFixture();
+    const localAppData = join(fixture.homeDir, "AppData", "Local");
+    const currentExe = join(localAppData, "plannotator", "plannotator.exe");
+    const legacyExe = join(
+      fixture.homeDir,
+      ".local",
+      "bin",
+      "plannotator.exe",
+    );
+    writeText(currentExe);
+    writeText(legacyExe);
+
+    const result = await runPlannotatorUninstall(
+      { purge: false, dryRun: false },
+      {
+        ...fixture.environment,
+        platform: "win32",
+        execPath: currentExe.toUpperCase(),
+        env: { LOCALAPPDATA: localAppData },
+        which: (command) =>
+          command === "powershell.exe" ? "C:\\Windows\\powershell.exe" : null,
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(existsSync(legacyExe)).toBe(false);
+    expect(existsSync(currentExe)).toBe(true);
+    expect(fixture.scheduledDeletes).toEqual([
+      {
+        target: currentExe,
+        parent: dirname(currentExe),
+      },
+    ]);
+    expect(fixture.commandCalls).toHaveLength(1);
+    expect(fixture.commandCalls[0]?.env).toEqual({
+      PLANNOTATOR_UNINSTALL_PATH: dirname(currentExe),
+    });
+  });
+});

--- a/packages/server/uninstall.test.ts
+++ b/packages/server/uninstall.test.ts
@@ -60,7 +60,11 @@ function createFixture(
     which: () => null,
     runCommand: async (command, args, env) => {
       commandCalls.push({ command, args, env });
-      return { exitCode: 0, timedOut: false };
+      return {
+        exitCode: 0,
+        timedOut: false,
+        stdout: JSON.stringify("C:\\Tools;C:\\Users\\fixture\\AppData\\Local\\plannotator;C:\\Windows;;"),
+      };
     },
     scheduleWindowsSelfDelete: async (target, parent) => {
       scheduledDeletes.push({ target, parent });
@@ -130,11 +134,73 @@ describe("default uninstall", () => {
       join(homeDir, ".agents", "skills", "plannotator-archive", "SKILL.md"),
     );
     writeText(
+      join(homeDir, ".claude", "skills", "core", "plannotator-review", "SKILL.md"),
+    );
+    const customStaleLayoutEntry = join(
+      homeDir,
+      ".claude",
+      "skills",
+      "core",
+      "my-custom-skill",
+      "SKILL.md",
+    );
+    writeText(customStaleLayoutEntry, "custom");
+    writeText(
       join(homeDir, ".codex", "skills", "plannotator-archive", "SKILL.md"),
     );
     writeText(
       join(homeDir, ".kiro", "skills", "plannotator-setup-goal", "SKILL.md"),
     );
+    const openCodePackageCache = join(
+      homeDir,
+      ".cache",
+      "opencode",
+      "node_modules",
+      "@plannotator",
+      "opencode",
+      "package.json",
+    );
+    const unrelatedScopedCache = join(
+      homeDir,
+      ".cache",
+      "opencode",
+      "node_modules",
+      "@plannotator",
+      "ui",
+      "package.json",
+    );
+    const unrelatedBunCache = join(
+      homeDir,
+      ".bun",
+      "install",
+      "cache",
+      "@plannotator",
+      "ui",
+      "package.json",
+    );
+    const bunOpenCodeVersionCache = join(
+      homeDir,
+      ".bun",
+      "install",
+      "cache",
+      "@plannotator",
+      "opencode@0.25.1@@@1",
+      "package.json",
+    );
+    const bunOpenCodeAliasCache = join(
+      homeDir,
+      ".bun",
+      "install",
+      "cache",
+      "@plannotator",
+      "opencode",
+      "0.25.1@@@1",
+    );
+    writeText(openCodePackageCache);
+    writeText(unrelatedScopedCache);
+    writeText(unrelatedBunCache);
+    writeText(bunOpenCodeVersionCache);
+    writeText(bunOpenCodeAliasCache);
 
     const claudeSettings = join(homeDir, ".claude", "settings.json");
     writeJson(claudeSettings, {
@@ -251,6 +317,12 @@ describe("default uninstall", () => {
     expect(existsSync(join(homeDir, ".agents", "skills", "plannotator-compound"))).toBe(true);
     expect(existsSync(join(homeDir, ".agents", "skills", "plannotator-archive"))).toBe(false);
     expect(existsSync(join(homeDir, ".kiro", "skills", "plannotator-setup-goal"))).toBe(false);
+    expect(existsSync(customStaleLayoutEntry)).toBe(true);
+    expect(existsSync(openCodePackageCache)).toBe(false);
+    expect(existsSync(unrelatedScopedCache)).toBe(true);
+    expect(existsSync(unrelatedBunCache)).toBe(true);
+    expect(existsSync(bunOpenCodeVersionCache)).toBe(false);
+    expect(existsSync(bunOpenCodeAliasCache)).toBe(false);
 
     expect(existsSync(join(dataDir, "plans", "approved.md"))).toBe(true);
     expect(readJson(join(dataDir, "config.json"))).toEqual({ theme: "dark" });
@@ -352,7 +424,7 @@ describe("default uninstall", () => {
     expect(fixture.commandCalls).toEqual([]);
   });
 
-  test("preserves non-strict shared config rather than rewriting it", async () => {
+  test("removes OpenCode from JSONC while preserving comments and unrelated plugins", async () => {
     const fixture = createFixture();
     const configPath = join(
       fixture.homeDir,
@@ -360,7 +432,53 @@ describe("default uninstall", () => {
       "opencode",
       "opencode.jsonc",
     );
-    const contents = '{\n  // custom JSONC\n  "plugin": ["@plannotator/opencode"]\n}\n';
+    const contents = [
+      "{",
+      "  // custom JSONC",
+      '  "plugin": [',
+      '    "@plannotator/opencode", // managed',
+      "    // keep this plugin because it configures the user's workflow",
+      '    "keep-plugin",',
+      '    ["@plannotator/opencode@0.25.1", { "enabled": true }],',
+      "  ],",
+      '  "theme": "keep",',
+      "}",
+      "",
+    ].join("\n");
+    writeText(configPath, contents);
+
+    const result = await runPlannotatorUninstall(
+      { purge: false, dryRun: false },
+      fixture.environment,
+    );
+
+    const updated = readFileSync(configPath, "utf8");
+    expect(updated).toContain("// custom JSONC");
+    expect(updated).toContain(
+      "// keep this plugin because it configures the user's workflow",
+    );
+    expect(updated).toContain('"keep-plugin"');
+    expect(updated).toContain('"theme": "keep"');
+    expect(updated).not.toContain("@plannotator/opencode");
+    expect(result.errors).toEqual([]);
+  });
+
+  test("preserves invalid OpenCode config rather than guessing", async () => {
+    const fixture = createFixture();
+    const binary = join(
+      fixture.homeDir,
+      ".local",
+      "bin",
+      "plannotator",
+    );
+    writeText(binary);
+    const configPath = join(
+      fixture.homeDir,
+      ".config",
+      "opencode",
+      "opencode.jsonc",
+    );
+    const contents = '{ "plugin": ["@plannotator/opencode", } broken';
     writeText(configPath, contents);
 
     const result = await runPlannotatorUninstall(
@@ -369,8 +487,10 @@ describe("default uninstall", () => {
     );
 
     expect(readFileSync(configPath, "utf8")).toBe(contents);
-    expect(result.warnings).toContain(
-      `Preserved ${configPath}: it is not strict JSON, so managed entries could not be removed safely.`,
+    expect(existsSync(binary)).toBe(true);
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain(
+      `Preserved ${configPath}: it is not valid JSON or JSONC, so the managed entry could not be removed safely.`,
     );
   });
 
@@ -451,12 +571,56 @@ describe("default uninstall", () => {
 });
 
 describe("purge uninstall", () => {
+  test("dry-run does not report a managed-only vendor directory as custom", async () => {
+    const fixture = createFixture();
+    writeText(join(fixture.dataDir, "vendor", "sem", "v0.8.0", "sem"));
+
+    const result = await runPlannotatorUninstall(
+      { purge: true, dryRun: true },
+      fixture.environment,
+    );
+
+    expect(result.planned).toContain(join(fixture.dataDir, "vendor"));
+    expect(result.preserved).not.toContain(
+      `${join(fixture.dataDir, "vendor")} (unrecognized custom entry)`,
+    );
+  });
+
+  test("preserves an empty vendor directory when no managed sidecar existed", async () => {
+    const fixture = createFixture();
+    const vendorDirectory = join(fixture.dataDir, "vendor");
+    mkdirSync(vendorDirectory, { recursive: true });
+
+    const preview = await runPlannotatorUninstall(
+      { purge: true, dryRun: true },
+      fixture.environment,
+    );
+    expect(preview.preserved).toContain(
+      `${vendorDirectory} (unrecognized custom entry)`,
+    );
+
+    const result = await runPlannotatorUninstall(
+      { purge: false, dryRun: false },
+      fixture.environment,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(existsSync(vendorDirectory)).toBe(true);
+  });
+
   test("removes known local data while preserving unknown top-level entries", async () => {
     const fixture = createFixture();
     writeText(join(fixture.dataDir, "plans", "approved.md"));
     writeText(join(fixture.dataDir, "history", "repo", "001.md"));
     writeJson(join(fixture.dataDir, "config.json"), { theme: "dark" });
     writeText(join(fixture.dataDir, "vendor", "sem", "v0.8.0", "sem"));
+    const customVendorPath = join(
+      fixture.dataDir,
+      "vendor",
+      "other-tool",
+      "keep.txt",
+    );
+    writeText(customVendorPath, "not installer-owned");
     const customPath = join(fixture.dataDir, "my-notes", "keep.md");
     writeText(customPath, "not installer-owned");
 
@@ -469,7 +633,8 @@ describe("purge uninstall", () => {
     expect(existsSync(join(fixture.dataDir, "plans"))).toBe(false);
     expect(existsSync(join(fixture.dataDir, "history"))).toBe(false);
     expect(existsSync(join(fixture.dataDir, "config.json"))).toBe(false);
-    expect(existsSync(join(fixture.dataDir, "vendor"))).toBe(false);
+    expect(existsSync(join(fixture.dataDir, "vendor", "sem"))).toBe(false);
+    expect(existsSync(customVendorPath)).toBe(true);
     expect(existsSync(customPath)).toBe(true);
     expect(result.preserved).toContain(
       `${join(fixture.dataDir, "my-notes")} (unrecognized custom entry)`,
@@ -479,6 +644,8 @@ describe("purge uninstall", () => {
   test("removes the data directory when no custom entries remain", async () => {
     const fixture = createFixture();
     writeText(join(fixture.dataDir, "drafts", "draft.json"));
+    writeText(join(fixture.dataDir, "active", "session", "plan.md"));
+    writeText(join(fixture.dataDir, "vendor", "sem", "v0.8.0", "sem"));
 
     const result = await runPlannotatorUninstall(
       { purge: true, dryRun: false },
@@ -599,7 +766,61 @@ describe("host and platform integrations", () => {
       "Droid plugin plannotator@plannotator",
     );
     expect(result.errors[0]).toContain("was not removed");
-    expect(existsSync(binary)).toBe(false);
+    expect(existsSync(binary)).toBe(true);
+    expect(result.warnings).toContain(
+      "Preserved the Plannotator CLI and its Windows PATH entry so you can resolve the errors and retry uninstall.",
+    );
+  });
+
+  test("detects disabled Claude and Droid plugins from installation metadata", async () => {
+    const fixture = createFixture();
+    writeJson(
+      join(fixture.homeDir, ".claude", "plugins", "installed_plugins.json"),
+      {
+        plugins: {
+          "plannotator@plannotator": [
+            { installPath: "/fake/claude/plannotator" },
+          ],
+        },
+      },
+    );
+    writeJson(
+      join(fixture.homeDir, ".factory", "plugins", "installed_plugins.json"),
+      {
+        plugins: {
+          "plannotator@plannotator": [
+            { installPath: "/fake/droid/plannotator" },
+          ],
+        },
+      },
+    );
+
+    await runPlannotatorUninstall(
+      { purge: false, dryRun: false },
+      {
+        ...fixture.environment,
+        which: (command) => `/fake/${command}`,
+      },
+    );
+
+    expect(fixture.commandCalls.map((call) => call.args)).toEqual([
+      [
+        "plugin",
+        "uninstall",
+        "plannotator@plannotator",
+        "--scope",
+        "user",
+        "--keep-data",
+        "--yes",
+      ],
+      [
+        "plugin",
+        "uninstall",
+        "plannotator@plannotator",
+        "--scope",
+        "user",
+      ],
+    ]);
   });
 
   test("uses host plugin managers and preserves Claude plugin data by default", async () => {
@@ -717,6 +938,114 @@ describe("host and platform integrations", () => {
     expect(fixture.commandCalls).toHaveLength(1);
     expect(fixture.commandCalls[0]?.env).toEqual({
       PLANNOTATOR_UNINSTALL_PATH: dirname(currentExe),
+    });
+  });
+
+  test("keeps the running Windows CLI when PATH cleanup fails", async () => {
+    const fixture = createFixture();
+    const localAppData = join(fixture.homeDir, "AppData", "Local");
+    const currentExe = join(localAppData, "plannotator", "plannotator.exe");
+    writeText(currentExe);
+
+    const result = await runPlannotatorUninstall(
+      { purge: false, dryRun: false },
+      {
+        ...fixture.environment,
+        platform: "win32",
+        execPath: currentExe,
+        env: { LOCALAPPDATA: localAppData },
+        which: () => "C:\\Windows\\powershell.exe",
+        runCommand: async () => ({ exitCode: 1, timedOut: false }),
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain(
+      `Could not remove ${dirname(currentExe)} from the Windows user PATH.`,
+    );
+    expect(existsSync(currentExe)).toBe(true);
+    expect(fixture.scheduledDeletes).toEqual([]);
+  });
+
+  test("restores Windows PATH when scheduling self-delete fails", async () => {
+    const fixture = createFixture();
+    const localAppData = join(fixture.homeDir, "AppData", "Local");
+    const currentExe = join(localAppData, "plannotator", "plannotator.exe");
+    writeText(currentExe);
+
+    const result = await runPlannotatorUninstall(
+      { purge: false, dryRun: false },
+      {
+        ...fixture.environment,
+        platform: "win32",
+        execPath: currentExe,
+        env: { LOCALAPPDATA: localAppData },
+        which: () => "C:\\Windows\\powershell.exe",
+        scheduleWindowsSelfDelete: async () => false,
+      },
+    );
+
+    const pathLabel = `Windows user PATH entry ${dirname(currentExe)}`;
+    expect(result.ok).toBe(false);
+    expect(existsSync(currentExe)).toBe(true);
+    expect(result.removed).not.toContain(pathLabel);
+    expect(result.preserved).toContain(`${pathLabel} (restored for retry)`);
+    expect(fixture.commandCalls).toHaveLength(2);
+    expect(fixture.commandCalls[1]?.env).toEqual({
+      PLANNOTATOR_UNINSTALL_ORIGINAL_PATH:
+        "C:\\Tools;C:\\Users\\fixture\\AppData\\Local\\plannotator;C:\\Windows;;",
+    });
+  });
+
+  test("reports the full CLI path when Windows PATH restoration also fails", async () => {
+    const fixture = createFixture();
+    const localAppData = join(fixture.homeDir, "AppData", "Local");
+    const currentExe = join(localAppData, "plannotator", "plannotator.exe");
+    writeText(currentExe);
+    let commandCount = 0;
+
+    const result = await runPlannotatorUninstall(
+      { purge: false, dryRun: false },
+      {
+        ...fixture.environment,
+        platform: "win32",
+        execPath: currentExe,
+        env: { LOCALAPPDATA: localAppData },
+        which: () => "C:\\Windows\\powershell.exe",
+        runCommand: async (command, args, env) => {
+          fixture.commandCalls.push({ command, args, env });
+          commandCount += 1;
+          return {
+            exitCode: commandCount === 1 ? 0 : 1,
+            timedOut: false,
+            stdout:
+              commandCount === 1
+                ? JSON.stringify(
+                    `C:\\Before;${dirname(currentExe)};C:\\After;;`,
+                  )
+                : undefined,
+          };
+        },
+        scheduleWindowsSelfDelete: async () => false,
+      },
+    );
+
+    const pathLabel = `Windows user PATH entry ${dirname(currentExe)}`;
+    expect(result.ok).toBe(false);
+    expect(existsSync(currentExe)).toBe(true);
+    expect(result.removed).toContain(pathLabel);
+    expect(result.errors).toContain(
+      `Could not restore ${dirname(currentExe)} to the Windows user PATH after self-delete scheduling failed.`,
+    );
+    expect(result.warnings).toContain(
+      `The Plannotator CLI remains at ${currentExe}, but its Windows PATH entry could not be restored. Run that full path to retry, then restore PATH manually if needed.`,
+    );
+    expect(result.warnings).not.toContain(
+      "Preserved the Plannotator CLI and its Windows PATH entry so you can resolve the errors and retry uninstall.",
+    );
+    expect(fixture.commandCalls[1]?.env).toEqual({
+      PLANNOTATOR_UNINSTALL_ORIGINAL_PATH:
+        `C:\\Before;${dirname(currentExe)};C:\\After;;`,
     });
   });
 });

--- a/packages/server/uninstall.test.ts
+++ b/packages/server/uninstall.test.ts
@@ -14,6 +14,7 @@ import {
   formatPurgeWarning,
   runPlannotatorUninstall,
   type UninstallEnvironment,
+  WINDOWS_SELF_DELETE_SCRIPT,
 } from "./uninstall";
 
 type CommandCall = {
@@ -37,6 +38,15 @@ afterEach(() => {
   for (const root of temporaryRoots.splice(0)) {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+describe("Windows self-delete worker", () => {
+  test("keeps PowerShell statements on separate lines", () => {
+    expect(WINDOWS_SELF_DELETE_SCRIPT).toContain(
+      "$target=$env:PLANNOTATOR_UNINSTALL_TARGET\nfor",
+    );
+    expect(WINDOWS_SELF_DELETE_SCRIPT).toContain("}\n$parent=");
+  });
 });
 
 function createFixture(

--- a/packages/server/uninstall.ts
+++ b/packages/server/uninstall.ts
@@ -25,11 +25,25 @@ import {
   resolve,
 } from "node:path";
 import { getPlannotatorDataDir } from "@plannotator/shared/data-dir";
+import {
+  applyEdits,
+  createScanner,
+  findNodeAtLocation,
+  parse as parseJsonc,
+  parseTree,
+  type ParseError,
+} from "jsonc-parser";
 
 const CORE_SKILLS = [
   "plannotator-review",
   "plannotator-annotate",
   "plannotator-last",
+] as const;
+
+const EXTRA_SKILLS = [
+  "plannotator-compound",
+  "plannotator-setup-goal",
+  "plannotator-visual-explainer",
 ] as const;
 
 const LEGACY_COMMAND_NAMES = [
@@ -60,13 +74,13 @@ const PURGE_OWNED_TOP_LEVEL = [
   "plans",
   "history",
   "drafts",
+  "active",
   "hooks",
   "compound",
   "sessions",
   "guides",
   "failed-comments",
   "semantic-diff",
-  "vendor",
   "migrations",
   "config.json",
   "install-prefs",
@@ -79,13 +93,21 @@ const PURGE_OWNED_TOP_LEVEL = [
 ] as const;
 
 const WINDOWS_PATH_SCRIPT = [
+  "$ErrorActionPreference='Stop'",
   "$p=[Environment]::GetEnvironmentVariable('Path','User')",
   "if($null -eq $p){exit 3}",
   "$t=$env:PLANNOTATOR_UNINSTALL_PATH.Trim().TrimEnd('\\')",
-  "$kept=@($p -split ';' | Where-Object { $_ -and $_.Trim().TrimEnd('\\') -ine $t })",
+  "$kept=@($p -split ';' | Where-Object { $_.Trim().TrimEnd('\\') -ine $t })",
   "$n=$kept -join ';'",
   "if($n -eq $p){exit 3}",
   "[Environment]::SetEnvironmentVariable('Path',$n,'User')",
+  "Write-Output (ConvertTo-Json -Compress -InputObject $p)",
+].join("; ");
+
+const WINDOWS_PATH_RESTORE_SCRIPT = [
+  "$ErrorActionPreference='Stop'",
+  "$original=$env:PLANNOTATOR_UNINSTALL_ORIGINAL_PATH",
+  "[Environment]::SetEnvironmentVariable('Path',$original,'User')",
 ].join("; ");
 
 const WINDOWS_SELF_DELETE_SCRIPT = [
@@ -105,6 +127,7 @@ type JsonRecord = Record<string, unknown>;
 export interface UninstallCommandResult {
   readonly exitCode: number;
   readonly timedOut: boolean;
+  readonly stdout?: string;
 }
 
 /**
@@ -249,8 +272,19 @@ export async function runPlannotatorUninstall(
     purgeLocalData(request, state);
   }
 
-  await removeWindowsPathEntry(request, environment, paths, state);
-  await removeBinaries(request, environment, paths, state);
+  if (state.errors.length === 0) {
+    await removeBinaries(request, environment, paths, state);
+  }
+  if (state.errors.length > 0) {
+    const hasSpecificRetryWarning = state.warnings.some((warning) =>
+      warning.startsWith("The Plannotator CLI remains at "),
+    );
+    if (!hasSpecificRetryWarning) {
+      state.warnings.push(
+        "Preserved the Plannotator CLI and its Windows PATH entry so you can resolve the errors and retry uninstall.",
+      );
+    }
+  }
 
   return {
     ...state,
@@ -347,6 +381,10 @@ async function removeHostPlugins(
         hasEnabledPlugin(
           join(paths.claudeDir, "settings.json"),
           "plannotator@plannotator",
+        ) ||
+        hasInstalledPlugin(
+          join(paths.claudeDir, "plugins", "installed_plugins.json"),
+          "plannotator@plannotator",
         ),
     },
     {
@@ -373,10 +411,15 @@ async function removeHostPlugins(
         "--scope",
         "user",
       ],
-      installed: hasEnabledPlugin(
-        join(paths.factoryDir, "settings.json"),
-        "plannotator@plannotator",
-      ),
+      installed:
+        hasEnabledPlugin(
+          join(paths.factoryDir, "settings.json"),
+          "plannotator@plannotator",
+        ) ||
+        hasInstalledPlugin(
+          join(paths.factoryDir, "plugins", "installed_plugins.json"),
+          "plannotator@plannotator",
+        ),
     },
     {
       label: "Pi extension npm:@plannotator/pi-extension",
@@ -509,13 +552,18 @@ function removeInstalledFiles(
     );
   }
 
-  for (const staleLayout of ["core", "extra"]) {
-    removePath(
-      join(paths.claudeDir, "skills", staleLayout),
-      request,
-      state,
-    );
-  }
+  cleanupStaleSkillLayout(
+    join(paths.claudeDir, "skills", "core"),
+    CORE_SKILLS,
+    request,
+    state,
+  );
+  cleanupStaleSkillLayout(
+    join(paths.claudeDir, "skills", "extra"),
+    EXTRA_SKILLS,
+    request,
+    state,
+  );
 
   for (const skill of STALE_CODEX_SKILLS) {
     removePath(join(paths.codexDir, "skills", skill), request, state);
@@ -576,14 +624,46 @@ function removeInstalledFiles(
   }
 
   for (const cachePath of [
-    join(paths.xdgCacheDir, "opencode", "node_modules", "@plannotator"),
-    join(paths.xdgCacheDir, "opencode", "packages", "@plannotator"),
-    join(environment.homeDir, ".cache", "opencode", "node_modules", "@plannotator"),
-    join(environment.homeDir, ".cache", "opencode", "packages", "@plannotator"),
-    join(environment.homeDir, ".bun", "install", "cache", "@plannotator"),
+    join(
+      paths.xdgCacheDir,
+      "opencode",
+      "node_modules",
+      "@plannotator",
+      "opencode",
+    ),
+    join(
+      paths.xdgCacheDir,
+      "opencode",
+      "packages",
+      "@plannotator",
+      "opencode",
+    ),
+    join(
+      environment.homeDir,
+      ".cache",
+      "opencode",
+      "node_modules",
+      "@plannotator",
+      "opencode",
+    ),
+    join(
+      environment.homeDir,
+      ".cache",
+      "opencode",
+      "packages",
+      "@plannotator",
+      "opencode",
+    ),
   ]) {
     removePath(cachePath, request, state);
   }
+
+  cleanupDirectoryEntriesWithPrefix(
+    join(environment.homeDir, ".bun", "install", "cache", "@plannotator"),
+    "opencode",
+    request,
+    state,
+  );
 }
 
 function removeInstallerData(
@@ -594,11 +674,21 @@ function removeInstallerData(
   // retained as local state in the default mode: the migration ledger is what
   // prevents a later reinstall from mistaking separately installed extras for
   // obsolete installer copies. Purge removes those files through its inventory.
-  for (const path of [
+  const sidecarPaths = [
     join(state.dataDir, "vendor", "sem"),
     join(state.dataDir, "vendor", "agent-terminal"),
-  ]) {
+  ];
+  const hadManagedSidecar = sidecarPaths.some(pathExists);
+  for (const path of sidecarPaths) {
     removePath(path, request, state);
+  }
+  if (hadManagedSidecar) {
+    removeEmptyOwnedParent(
+      join(state.dataDir, "vendor"),
+      ["sem", "agent-terminal"],
+      request,
+      state,
+    );
   }
 }
 
@@ -626,7 +716,17 @@ function purgeLocalData(
 
   if (request.dryRun) {
     const recognized = new Set<string>(PURGE_OWNED_TOP_LEVEL);
-    const customEntries = remaining.filter((name) => !recognized.has(name));
+    const customEntries = remaining.filter(
+      (name) =>
+        !recognized.has(name) &&
+        !(
+          name === "vendor" &&
+          directoryContainsOnly(
+            join(state.dataDir, "vendor"),
+            ["sem", "agent-terminal"],
+          )
+        ),
+    );
     if (customEntries.length === 0) {
       state.planned.push(state.dataDir);
       return;
@@ -664,23 +764,23 @@ async function removeWindowsPathEntry(
   environment: UninstallEnvironment,
   paths: ReturnType<typeof resolveOwnedPaths>,
   state: MutableUninstallResult,
-): Promise<void> {
-  if (environment.platform !== "win32") return;
+): Promise<string | null> {
+  if (environment.platform !== "win32") return null;
 
   const label = `Windows user PATH entry ${paths.windowsInstallDir}`;
   if (request.dryRun) {
     state.planned.push(label);
-    return;
+    return null;
   }
 
   const powershell =
     environment.which("powershell.exe") ||
     environment.which("pwsh.exe");
   if (!powershell) {
-    state.warnings.push(
+    state.errors.push(
       `Could not inspect the Windows user PATH; remove ${paths.windowsInstallDir} from PATH manually if present.`,
     );
-    return;
+    return null;
   }
 
   const result = await environment.runCommand(
@@ -690,11 +790,24 @@ async function removeWindowsPathEntry(
   );
   if (result.exitCode === 0) {
     state.removed.push(label);
+    try {
+      const originalPath: unknown = JSON.parse(result.stdout?.trim() ?? "");
+      if (typeof originalPath !== "string") throw new Error("not a string");
+      return originalPath;
+    } catch {
+      state.errors.push(
+        `Removed ${paths.windowsInstallDir} from the Windows user PATH but could not capture the original PATH for safe rollback.`,
+      );
+      state.warnings.push(
+        `The Plannotator CLI remains at ${environment.execPath}, but its Windows PATH entry was removed without a usable backup. Run that full path to retry, then restore PATH manually if needed.`,
+      );
+    }
   } else if (result.exitCode !== 3) {
-    state.warnings.push(
+    state.errors.push(
       `Could not remove ${paths.windowsInstallDir} from the Windows user PATH.`,
     );
   }
+  return null;
 }
 
 async function removeBinaries(
@@ -703,35 +816,92 @@ async function removeBinaries(
   paths: ReturnType<typeof resolveOwnedPaths>,
   state: MutableUninstallResult,
 ): Promise<void> {
-  for (const binaryPath of paths.binaryPaths) {
-    if (!pathExists(binaryPath)) continue;
+  const existingBinaryPaths = paths.binaryPaths.filter(pathExists);
+  const currentBinary = existingBinaryPaths.find((binaryPath) =>
+    samePath(binaryPath, environment.execPath, environment.platform),
+  );
+  const inactiveBinaries = existingBinaryPaths.filter(
+    (binaryPath) => binaryPath !== currentBinary,
+  );
 
+  for (const binaryPath of inactiveBinaries) {
     if (request.dryRun) {
       state.planned.push(binaryPath);
       continue;
     }
+    removePath(binaryPath, request, state);
+    if (state.errors.length > 0) return;
+  }
 
-    const isCurrentWindowsBinary =
-      environment.platform === "win32" &&
-      samePath(binaryPath, environment.execPath, "win32");
+  const originalWindowsPath = await removeWindowsPathEntry(
+    request,
+    environment,
+    paths,
+    state,
+  );
+  if (state.errors.length > 0 || !currentBinary) return;
 
-    if (isCurrentWindowsBinary) {
-      const scheduled = await environment.scheduleWindowsSelfDelete(
-        binaryPath,
-        dirname(binaryPath),
+  if (request.dryRun) {
+    state.planned.push(currentBinary);
+    return;
+  }
+
+  if (environment.platform === "win32") {
+    const scheduled = await environment.scheduleWindowsSelfDelete(
+      currentBinary,
+      dirname(currentBinary),
+    );
+    if (scheduled) {
+      state.removed.push(`${currentBinary} (scheduled after exit)`);
+    } else {
+      state.errors.push(
+        `Could not schedule removal of the running executable ${currentBinary}.`,
       );
-      if (scheduled) {
-        state.removed.push(`${binaryPath} (scheduled after exit)`);
-      } else {
-        state.errors.push(
-          `Could not schedule removal of the running executable ${binaryPath}.`,
+      if (originalWindowsPath !== null) {
+        await restoreWindowsPathEntry(
+          environment,
+          paths,
+          originalWindowsPath,
+          state,
         );
       }
-      continue;
     }
-
-    removePath(binaryPath, request, state);
+    return;
   }
+
+  removePath(currentBinary, request, state);
+}
+
+async function restoreWindowsPathEntry(
+  environment: UninstallEnvironment,
+  paths: ReturnType<typeof resolveOwnedPaths>,
+  originalPath: string,
+  state: MutableUninstallResult,
+): Promise<void> {
+  const powershell =
+    environment.which("powershell.exe") ||
+    environment.which("pwsh.exe");
+  if (!powershell) return;
+
+  const result = await environment.runCommand(
+    powershell,
+    ["-NoProfile", "-NonInteractive", "-Command", WINDOWS_PATH_RESTORE_SCRIPT],
+    { PLANNOTATOR_UNINSTALL_ORIGINAL_PATH: originalPath },
+  );
+  if (result.exitCode !== 0) {
+    state.errors.push(
+      `Could not restore ${paths.windowsInstallDir} to the Windows user PATH after self-delete scheduling failed.`,
+    );
+    state.warnings.push(
+      `The Plannotator CLI remains at ${environment.execPath}, but its Windows PATH entry could not be restored. Run that full path to retry, then restore PATH manually if needed.`,
+    );
+    return;
+  }
+
+  const label = `Windows user PATH entry ${paths.windowsInstallDir}`;
+  const removedIndex = state.removed.indexOf(label);
+  if (removedIndex >= 0) state.removed.splice(removedIndex, 1);
+  state.preserved.push(`${label} (restored for retry)`);
 }
 
 function cleanupHooksJson(
@@ -821,7 +991,7 @@ function cleanupCodexConfig(
   try {
     content = readFileSync(filePath, "utf8");
   } catch (error) {
-    state.warnings.push(`Could not inspect ${filePath}: ${formatError(error)}`);
+    state.errors.push(`Could not inspect ${filePath}: ${formatError(error)}`);
     return;
   }
 
@@ -908,21 +1078,113 @@ function cleanupOpenCodeConfig(
   request: UninstallRequest,
   state: MutableUninstallResult,
 ): void {
-  const parsed = readJsonRecord(filePath, state);
-  if (!parsed || !Array.isArray(parsed.plugin)) return;
+  if (!existsSync(filePath)) return;
 
-  const next = parsed.plugin.filter(
-    (entry) => !isPlannotatorOpenCodePlugin(entry),
-  );
-  if (next.length === parsed.plugin.length) return;
+  let content: string;
+  try {
+    content = readFileSync(filePath, "utf8");
+  } catch (error) {
+    state.errors.push(`Could not inspect ${filePath}: ${formatError(error)}`);
+    return;
+  }
+
+  const parseErrors: ParseError[] = [];
+  const parsedValue: unknown = parseJsonc(content, parseErrors, {
+    allowTrailingComma: true,
+    disallowComments: false,
+  });
+  const parsed = asRecord(parsedValue);
+  if (parseErrors.length > 0 || !parsed) {
+    state.errors.push(
+      `Preserved ${filePath}: it is not valid JSON or JSONC, so the managed entry could not be removed safely.`,
+    );
+    return;
+  }
+  if (!Array.isArray(parsed.plugin)) return;
+
+  const matchingIndexes = parsed.plugin
+    .map((entry, index) =>
+      isPlannotatorOpenCodePlugin(entry) ? index : -1,
+    )
+    .filter((index) => index >= 0)
+    .reverse();
+  if (matchingIndexes.length === 0) return;
 
   if (request.dryRun) {
     state.planned.push(`@plannotator/opencode entry in ${filePath}`);
     return;
   }
 
-  parsed.plugin = next;
-  writeJson(filePath, parsed, "@plannotator/opencode entry", state);
+  let updated = content;
+  for (const index of matchingIndexes) {
+    updated = removeJsoncArrayEntry(updated, ["plugin"], index);
+  }
+  writeTextUpdate(
+    filePath,
+    updated,
+    "@plannotator/opencode entry",
+    state,
+  );
+}
+
+function removeJsoncArrayEntry(
+  content: string,
+  path: (string | number)[],
+  index: number,
+): string {
+  const tree = parseTree(content, [], {
+    allowTrailingComma: true,
+    disallowComments: false,
+  });
+  const arrayNode = tree ? findNodeAtLocation(tree, path) : undefined;
+  const children = arrayNode?.type === "array" ? arrayNode.children : undefined;
+  const target = children?.[index];
+  if (!arrayNode || !children || !target) return content;
+
+  const targetEnd = target.offset + target.length;
+  const next = children[index + 1];
+  let commaOffset = findJsoncCommaOffset(
+    content,
+    targetEnd,
+    next?.offset ?? arrayNode.offset + arrayNode.length,
+  );
+  if (commaOffset === null && index > 0) {
+    const previous = children[index - 1];
+    if (previous) {
+      commaOffset = findJsoncCommaOffset(
+        content,
+        previous.offset + previous.length,
+        target.offset,
+      );
+    }
+  }
+
+  const edits = [
+    { offset: target.offset, length: target.length, content: "" },
+  ];
+  if (commaOffset !== null) {
+    edits.push({ offset: commaOffset, length: 1, content: "" });
+  }
+  return applyEdits(content, edits);
+}
+
+function findJsoncCommaOffset(
+  content: string,
+  start: number,
+  end: number,
+): number | null {
+  const segment = content.slice(start, end);
+  const scanner = createScanner(segment, false);
+  while (scanner.getPosition() < segment.length) {
+    scanner.scan();
+    if (
+      scanner.getTokenLength() === 1 &&
+      segment[scanner.getTokenOffset()] === ","
+    ) {
+      return start + scanner.getTokenOffset();
+    }
+  }
+  return null;
 }
 
 function cleanupRecognizableKiroAgent(
@@ -958,7 +1220,7 @@ function cleanupRecognizableAmpPlugin(
   try {
     content = readFileSync(filePath, "utf8");
   } catch (error) {
-    state.warnings.push(`Could not inspect ${filePath}: ${formatError(error)}`);
+    state.errors.push(`Could not inspect ${filePath}: ${formatError(error)}`);
     return;
   }
 
@@ -983,7 +1245,7 @@ function readJsonRecord(
   try {
     content = readFileSync(filePath, "utf8");
   } catch (error) {
-    state.warnings.push(`Could not inspect ${filePath}: ${formatError(error)}`);
+    state.errors.push(`Could not inspect ${filePath}: ${formatError(error)}`);
     return null;
   }
 
@@ -991,12 +1253,12 @@ function readJsonRecord(
     const parsed: unknown = JSON.parse(content);
     const record = asRecord(parsed);
     if (!record) {
-      state.warnings.push(`Preserved ${filePath}: expected a JSON object.`);
+      state.errors.push(`Preserved ${filePath}: expected a JSON object.`);
       return null;
     }
     return record;
   } catch {
-    state.warnings.push(
+    state.errors.push(
       `Preserved ${filePath}: it is not strict JSON, so managed entries could not be removed safely.`,
     );
     return null;
@@ -1015,6 +1277,128 @@ function writeJson(
   } catch (error) {
     state.errors.push(`Could not update ${filePath}: ${formatError(error)}`);
   }
+}
+
+function writeTextUpdate(
+  filePath: string,
+  content: string,
+  label: string,
+  state: MutableUninstallResult,
+): void {
+  try {
+    writeFileSync(filePath, content, "utf8");
+    state.removed.push(`${label} in ${filePath}`);
+  } catch (error) {
+    state.errors.push(`Could not update ${filePath}: ${formatError(error)}`);
+  }
+}
+
+function cleanupStaleSkillLayout(
+  directory: string,
+  managedSkills: readonly string[],
+  request: UninstallRequest,
+  state: MutableUninstallResult,
+): void {
+  let entries: string[];
+  try {
+    const stat = lstatSync(directory);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) {
+      state.preserved.push(`${directory} (custom or unrecognized skill layout)`);
+      return;
+    }
+    entries = readdirSync(directory);
+  } catch (error) {
+    if (isMissingPathError(error)) return;
+    state.errors.push(`Could not inspect ${directory}: ${formatError(error)}`);
+    return;
+  }
+
+  const managed = new Set(managedSkills);
+  const managedEntries = entries.filter((entry) => managed.has(entry));
+  if (managedEntries.length === 0) return;
+
+  for (const entry of managedEntries) {
+    removePath(join(directory, entry), request, state);
+  }
+
+  const customEntries = entries.filter((entry) => !managed.has(entry));
+  for (const entry of customEntries) {
+    state.preserved.push(
+      `${join(directory, entry)} (custom or unrecognized skill layout entry)`,
+    );
+  }
+
+  if (customEntries.length === 0) {
+    removeEmptyOwnedParent(directory, managedSkills, request, state);
+  }
+}
+
+function cleanupDirectoryEntriesWithPrefix(
+  directory: string,
+  prefix: string,
+  request: UninstallRequest,
+  state: MutableUninstallResult,
+): void {
+  let entries: string[];
+  try {
+    const stat = lstatSync(directory);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return;
+    entries = readdirSync(directory);
+  } catch (error) {
+    if (isMissingPathError(error)) return;
+    state.errors.push(`Could not inspect ${directory}: ${formatError(error)}`);
+    return;
+  }
+
+  for (const entry of entries) {
+    if (entry === prefix || entry.startsWith(`${prefix}@`)) {
+      removePath(join(directory, entry), request, state);
+    }
+  }
+}
+
+function directoryContainsOnly(
+  directory: string,
+  allowedEntries: readonly string[],
+): boolean {
+  try {
+    const stat = lstatSync(directory);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+    const allowed = new Set(allowedEntries);
+    const entries = readdirSync(directory);
+    return (
+      entries.length > 0 &&
+      entries.every((entry) => allowed.has(entry))
+    );
+  } catch {
+    return false;
+  }
+}
+
+function removeEmptyOwnedParent(
+  directory: string,
+  plannedChildren: readonly string[],
+  request: UninstallRequest,
+  state: MutableUninstallResult,
+): void {
+  let entries: string[];
+  try {
+    const stat = lstatSync(directory);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return;
+    entries = readdirSync(directory);
+  } catch (error) {
+    if (isMissingPathError(error)) return;
+    state.errors.push(`Could not inspect ${directory}: ${formatError(error)}`);
+    return;
+  }
+
+  if (request.dryRun) {
+    const planned = new Set(plannedChildren);
+    if (!entries.every((entry) => planned.has(entry))) return;
+  } else if (entries.length > 0) {
+    return;
+  }
+  removePath(directory, request, state);
 }
 
 function removePath(
@@ -1126,6 +1510,13 @@ function hasEnabledPlugin(filePath: string, pluginId: string): boolean {
   const parsed = tryReadJsonRecord(filePath);
   const enabled = parsed ? asRecord(parsed.enabledPlugins) : null;
   return enabled?.[pluginId] === true;
+}
+
+function hasInstalledPlugin(filePath: string, pluginId: string): boolean {
+  const parsed = tryReadJsonRecord(filePath);
+  const plugins = parsed ? asRecord(parsed.plugins) : null;
+  const installs = plugins?.[pluginId];
+  return Array.isArray(installs) && installs.length > 0;
 }
 
 function hasPiPackage(filePath: string): boolean {
@@ -1267,17 +1658,19 @@ async function defaultRunCommand(
   args: readonly string[],
   env?: Readonly<Record<string, string>>,
 ): Promise<UninstallCommandResult> {
-  let proc: Bun.Subprocess<"ignore", "ignore", "ignore">;
+  let proc: Bun.Subprocess<"ignore", "pipe", "ignore">;
   try {
     proc = Bun.spawn([command, ...args], {
       stdin: "ignore",
-      stdout: "ignore",
+      stdout: "pipe",
       stderr: "ignore",
       env: { ...process.env, ...env },
     });
   } catch {
     return { exitCode: 1, timedOut: false };
   }
+
+  const stdoutPromise = new Response(proc.stdout).text().catch(() => "");
 
   let timedOut = false;
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -1290,7 +1683,7 @@ async function defaultRunCommand(
   });
   const exitCode = await Promise.race([proc.exited, timeout]);
   if (timer) clearTimeout(timer);
-  return { exitCode, timedOut };
+  return { exitCode, timedOut, stdout: await stdoutPromise };
 }
 
 async function defaultScheduleWindowsSelfDelete(

--- a/packages/server/uninstall.ts
+++ b/packages/server/uninstall.ts
@@ -13,6 +13,7 @@ import {
   readdirSync,
   rmSync,
   statSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
@@ -1521,10 +1522,13 @@ function removePath(
   }
 
   try {
-    rmSync(path, {
-      recursive: stat.isDirectory() && !stat.isSymbolicLink(),
-      force: true,
-    });
+    if (stat.isDirectory() && !stat.isSymbolicLink()) {
+      rmSync(path, { recursive: true, force: true });
+    } else {
+      // Never route a symlink through recursive removal. Unlinking the directory
+      // entry also gives hardlinked files the intended target-preserving behavior.
+      unlinkSync(path);
+    }
     state.removed.push(path);
   } catch (error) {
     state.errors.push(`Could not remove ${path}: ${formatError(error)}`);

--- a/packages/server/uninstall.ts
+++ b/packages/server/uninstall.ts
@@ -12,10 +12,12 @@ import {
   readFileSync,
   readdirSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import {
+  basename,
   dirname,
   isAbsolute,
   join,
@@ -119,7 +121,7 @@ export const WINDOWS_SELF_DELETE_SCRIPT = [
   "  if(-not (Test-Path -LiteralPath $target)){break}",
   "}",
   "$parent=$env:PLANNOTATOR_UNINSTALL_PARENT",
-  "Remove-Item -LiteralPath $parent -Force -ErrorAction SilentlyContinue",
+  "if($parent){Remove-Item -LiteralPath $parent -Force -ErrorAction SilentlyContinue}",
 ].join("\n");
 
 const WINDOWS_SELF_DELETE_BOOTSTRAP_SCRIPT = [
@@ -158,7 +160,7 @@ export interface UninstallEnvironment {
   ) => Promise<UninstallCommandResult>;
   readonly scheduleWindowsSelfDelete: (
     target: string,
-    parent: string,
+    parent: string | null,
   ) => Promise<boolean>;
 }
 
@@ -166,6 +168,8 @@ export interface UninstallEnvironment {
 export interface UninstallRequest {
   readonly purge: boolean;
   readonly dryRun: boolean;
+  /** Leave host plugin managers and shared host configuration untouched. */
+  readonly skipHosts?: boolean;
 }
 
 /** Caller-visible record of completed, planned, preserved, and failed work. */
@@ -193,6 +197,18 @@ type HookCleanupSpec = {
   readonly matcher?: string;
   readonly suffix: "" | "improve-context";
 };
+
+type PathIdentity = {
+  readonly device: bigint;
+  readonly inode: bigint;
+};
+
+type PathIdentityResult =
+  | { readonly kind: "found"; readonly identity: PathIdentity }
+  | { readonly kind: "missing" }
+  | { readonly kind: "error" };
+
+type PathRelation = "same" | "different" | "unknown";
 
 /**
  * Build the real process boundary used by `plannotator uninstall`.
@@ -264,8 +280,14 @@ export async function runPlannotatorUninstall(
 
   const paths = resolveOwnedPaths(environment);
 
-  await removeHostPlugins(request, environment, paths, state);
-  removeHostConfigEntries(request, environment, paths, state);
+  if (request.skipHosts) {
+    state.warnings.push(
+      "Skipped host plugin managers and shared host configuration (--skip-hosts); remove any remaining host integrations manually.",
+    );
+  } else {
+    await removeHostPlugins(request, environment, paths, state);
+    removeHostConfigEntries(request, environment, paths, state);
+  }
   removeInstalledFiles(request, environment, paths, state);
   if (dataDirSafetyIssue) {
     state.warnings.push(
@@ -460,7 +482,7 @@ async function removeHostPlugins(
     const executable = environment.which(action.command);
     if (!executable) {
       state.errors.push(
-        `${action.label} was detected but ${action.command} is unavailable; it was not removed. Use the host's plugin manager manually.`,
+        `${action.label} was detected but ${action.command} is unavailable; it was not removed. Use the host's plugin manager manually, or re-run with --skip-hosts to leave host integrations for manual cleanup.`,
       );
       continue;
     }
@@ -470,7 +492,7 @@ async function removeHostPlugins(
       state.removed.push(action.label);
     } else {
       state.errors.push(
-        `${action.label} was not removed automatically (${result.timedOut ? "command timed out" : `exit ${result.exitCode}`}); use the host's plugin manager manually.`,
+        `${action.label} was not removed automatically (${result.timedOut ? "command timed out" : `exit ${result.exitCode}`}); use the host's plugin manager manually, or re-run with --skip-hosts to leave host integrations for manual cleanup.`,
       );
     }
   }
@@ -491,6 +513,7 @@ function removeHostConfigEntries(
     paths.binaryPaths,
     environment.platform,
     false,
+    false,
     "managed Claude Code hooks",
     request,
     state,
@@ -501,6 +524,7 @@ function removeHostConfigEntries(
     [{ event: "Stop", suffix: "" }],
     paths.binaryPaths,
     environment.platform,
+    true,
     true,
     "managed Codex Stop hook",
     request,
@@ -617,17 +641,19 @@ function removeInstalledFiles(
     state,
   );
 
-  cleanupRecognizableKiroAgent(
-    join(environment.homeDir, ".kiro", "agents", "plannotator.json"),
-    request,
-    state,
-  );
-  for (const configDir of paths.configDirs) {
-    cleanupRecognizableAmpPlugin(
-      join(configDir, "amp", "plugins", "plannotator.ts"),
+  if (!request.skipHosts) {
+    cleanupRecognizableKiroAgent(
+      join(environment.homeDir, ".kiro", "agents", "plannotator.json"),
       request,
       state,
     );
+    for (const configDir of paths.configDirs) {
+      cleanupRecognizableAmpPlugin(
+        join(configDir, "amp", "plugins", "plannotator.ts"),
+        request,
+        state,
+      );
+    }
   }
 
   for (const cachePath of [
@@ -825,7 +851,11 @@ async function removeBinaries(
 ): Promise<void> {
   const existingBinaryPaths = paths.binaryPaths.filter(pathExists);
   const currentBinary = existingBinaryPaths.find((binaryPath) =>
-    samePath(binaryPath, environment.execPath, environment.platform),
+    pathsReferToSameEntry(
+      binaryPath,
+      environment.execPath,
+      environment.platform,
+    ),
   );
   const inactiveBinaries = existingBinaryPaths.filter(
     (binaryPath) => binaryPath !== currentBinary,
@@ -856,7 +886,13 @@ async function removeBinaries(
   if (environment.platform === "win32") {
     const scheduled = await environment.scheduleWindowsSelfDelete(
       currentBinary,
-      dirname(currentBinary),
+      pathsReferToSameEntry(
+        dirname(currentBinary),
+        paths.windowsInstallDir,
+        environment.platform,
+      )
+        ? paths.windowsInstallDir
+        : null,
     );
     if (scheduled) {
       state.removed.push(`${currentBinary} (scheduled after exit)`);
@@ -916,6 +952,7 @@ function cleanupHooksJson(
   specs: readonly HookCleanupSpec[],
   binaryPaths: readonly string[],
   platform: NodeJS.Platform,
+  allowRelocatedBinary: boolean,
   removeWhenEmpty: boolean,
   label: string,
   request: UninstallRequest,
@@ -951,7 +988,14 @@ function cleanupHooksJson(
       }
 
       const nextHooks = hookEntries.filter(
-        (hook) => !isManagedHook(hook, binaryPaths, spec.suffix, platform),
+        (hook) =>
+          !isManagedHook(
+            hook,
+            binaryPaths,
+            spec.suffix,
+            platform,
+            allowRelocatedBinary,
+          ),
       );
       if (nextHooks.length === hookEntries.length) {
         nextEntries.push(value);
@@ -1102,8 +1146,11 @@ function cleanupOpenCodeConfig(
   });
   const parsed = asRecord(parsedValue);
   if (parseErrors.length > 0 || !parsed) {
-    state.errors.push(
-      `Preserved ${filePath}: it is not valid JSON or JSONC, so the managed entry could not be removed safely.`,
+    reportMalformedSharedConfig(
+      filePath,
+      content,
+      "it is not valid JSON or JSONC",
+      state,
     );
     return;
   }
@@ -1260,16 +1307,42 @@ function readJsonRecord(
     const parsed: unknown = JSON.parse(content);
     const record = asRecord(parsed);
     if (!record) {
-      state.errors.push(`Preserved ${filePath}: expected a JSON object.`);
+      reportMalformedSharedConfig(
+        filePath,
+        content,
+        "it is not a JSON object",
+        state,
+      );
       return null;
     }
     return record;
   } catch {
-    state.errors.push(
-      `Preserved ${filePath}: it is not strict JSON, so managed entries could not be removed safely.`,
+    reportMalformedSharedConfig(
+      filePath,
+      content,
+      "it is not strict JSON",
+      state,
     );
     return null;
   }
+}
+
+function reportMalformedSharedConfig(
+  filePath: string,
+  content: string,
+  reason: string,
+  state: MutableUninstallResult,
+): void {
+  const prefix = `Preserved ${filePath}: ${reason}`;
+  if (content.toLowerCase().includes("plannotator")) {
+    state.errors.push(
+      `${prefix}, and it may contain a managed Plannotator entry. Re-run with --skip-hosts to leave host integrations for manual cleanup.`,
+    );
+    return;
+  }
+  state.warnings.push(
+    `${prefix}. No recognizable Plannotator entry was found, so uninstall continued.`,
+  );
 }
 
 function writeJson(
@@ -1279,7 +1352,17 @@ function writeJson(
   state: MutableUninstallResult,
 ): void {
   try {
-    writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+    const original = readFileSync(filePath, "utf8");
+    const lineEnding = original.includes("\r\n") ? "\r\n" : "\n";
+    const indentation = original.match(/\r?\n([\t ]+)\S/)?.[1];
+    const trailingNewline = /\r?\n$/.test(original);
+    const serialized = JSON.stringify(value, null, indentation)
+      .replace(/\n/g, lineEnding);
+    writeFileSync(
+      filePath,
+      `${serialized}${trailingNewline ? lineEnding : ""}`,
+      "utf8",
+    );
     state.removed.push(`${label} in ${filePath}`);
   } catch (error) {
     state.errors.push(`Could not update ${filePath}: ${formatError(error)}`);
@@ -1443,6 +1526,7 @@ function isManagedHook(
   binaryPaths: readonly string[],
   suffix: "" | "improve-context",
   platform: NodeJS.Platform,
+  allowRelocatedBinary = false,
 ): boolean {
   const hook = asRecord(value);
   if (!hook || hook.type !== "command" || typeof hook.command !== "string") {
@@ -1461,7 +1545,29 @@ function isManagedHook(
       return true;
     }
   }
-  return false;
+  return allowRelocatedBinary && isRelocatedPlannotatorCommand(command, suffix);
+}
+
+function isRelocatedPlannotatorCommand(
+  command: string,
+  suffix: "" | "improve-context",
+): boolean {
+  const commandSuffix = suffix ? ` ${suffix}` : "";
+  if (commandSuffix && !command.endsWith(commandSuffix)) return false;
+
+  const executable = commandSuffix
+    ? command.slice(0, -commandSuffix.length).trim()
+    : command;
+  const unquoted =
+    executable.length >= 2 &&
+      executable.startsWith('"') &&
+      executable.endsWith('"')
+      ? executable.slice(1, -1)
+      : executable;
+  if (!isAbsolute(unquoted)) return false;
+
+  const executableName = basename(unquoted).toLowerCase();
+  return executableName === "plannotator" || executableName === "plannotator.exe";
 }
 
 function isGeminiInstallerTemplate(
@@ -1590,7 +1696,7 @@ function sameCommand(
     : normalizedLeft === normalizedRight;
 }
 
-function samePath(
+function sameLexicalPath(
   left: string,
   right: string,
   platform: NodeJS.Platform,
@@ -1600,6 +1706,55 @@ function samePath(
   return platform === "win32"
     ? normalizedLeft.toLowerCase() === normalizedRight.toLowerCase()
     : normalizedLeft === normalizedRight;
+}
+
+function pathsReferToSameEntry(
+  left: string,
+  right: string,
+  platform: NodeJS.Platform,
+): boolean {
+  return comparePathEntries(left, right, platform) === "same";
+}
+
+function comparePathEntries(
+  left: string,
+  right: string,
+  platform: NodeJS.Platform,
+): PathRelation {
+  // The lexical check is the conservative fallback for missing paths and also
+  // preserves Windows path semantics in cross-platform tests. Existing aliases
+  // are compared by filesystem identity so case, links, and mounts cannot hide
+  // that two spellings refer to the same entry.
+  if (sameLexicalPath(left, right, platform)) return "same";
+
+  const leftIdentity = readPathIdentity(left);
+  const rightIdentity = readPathIdentity(right);
+  if (leftIdentity.kind === "error" || rightIdentity.kind === "error") {
+    return "unknown";
+  }
+  if (leftIdentity.kind !== "found" || rightIdentity.kind !== "found") {
+    return "different";
+  }
+  return sameIdentity(leftIdentity.identity, rightIdentity.identity)
+    ? "same"
+    : "different";
+}
+
+function readPathIdentity(path: string): PathIdentityResult {
+  try {
+    const stat = statSync(path, { bigint: true });
+    return {
+      kind: "found",
+      identity: { device: stat.dev, inode: stat.ino },
+    };
+  } catch (error) {
+    if (isMissingPathError(error)) return { kind: "missing" };
+    return { kind: "error" };
+  }
+}
+
+function sameIdentity(left: PathIdentity, right: PathIdentity): boolean {
+  return left.device === right.device && left.inode === right.inode;
 }
 
 function uniquePaths(paths: readonly string[]): string[] {
@@ -1616,17 +1771,40 @@ function getDataDirSafetyIssue(
     return "the data directory is not absolute";
   }
   const root = parse(dataDir).root;
-  if (samePath(dataDir, root, platform)) {
+  const rootRelation = comparePathEntries(dataDir, root, platform);
+  if (rootRelation === "same") {
     return "the data directory is a filesystem root";
   }
-  if (samePath(dataDir, homeDir, platform)) {
+  if (rootRelation === "unknown") {
+    return "the data directory identity relative to the filesystem root could not be verified";
+  }
+
+  const homeRelation = comparePathEntries(dataDir, homeDir, platform);
+  if (homeRelation === "same") {
     return "the data directory is the home directory; choose a dedicated PLANNOTATOR_DATA_DIR";
   }
-  if (isAncestorOrSame(dataDir, homeDir, platform)) {
+  if (homeRelation === "unknown") {
+    return "the data directory identity relative to the home directory could not be verified";
+  }
+
+  const ancestorRelation = compareAncestorRelation(
+    dataDir,
+    homeDir,
+    platform,
+  );
+  if (ancestorRelation === "same") {
     return `the data directory contains the home directory ${homeDir}`;
   }
-  if (samePath(dataDir, tempDir, platform)) {
+  if (ancestorRelation === "unknown") {
+    return "whether the data directory contains the home directory could not be verified";
+  }
+
+  const tempRelation = comparePathEntries(dataDir, tempDir, platform);
+  if (tempRelation === "same") {
     return "the data directory is the shared temporary directory";
+  }
+  if (tempRelation === "unknown") {
+    return "the data directory identity relative to the shared temporary directory could not be verified";
   }
   return null;
 }
@@ -1647,17 +1825,42 @@ function inspectDataDir(dataDir: string): string | null {
   return null;
 }
 
-function isAncestorOrSame(
+function compareAncestorRelation(
   parent: string,
   child: string,
   platform: NodeJS.Platform,
-): boolean {
+): PathRelation {
   const resolvedParent = resolve(parent);
   const resolvedChild = resolve(child);
   const rel = platform === "win32"
     ? relative(resolvedParent.toLowerCase(), resolvedChild.toLowerCase())
     : relative(resolvedParent, resolvedChild);
-  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+  if (rel === "" || (!rel.startsWith("..") && !isAbsolute(rel))) {
+    return "same";
+  }
+
+  const parentIdentity = readPathIdentity(resolvedParent);
+  if (parentIdentity.kind === "error") return "unknown";
+  if (parentIdentity.kind === "missing") return "different";
+
+  // A string-relative check cannot recognize a case alias, bind mount, or
+  // symlinked parent. Walk the existing child's ancestors and compare their
+  // device/inode pairs with the proposed purge root instead.
+  let current = resolvedChild;
+  while (true) {
+    const currentIdentity = readPathIdentity(current);
+    if (currentIdentity.kind === "error") return "unknown";
+    if (
+      currentIdentity.kind === "found" &&
+      sameIdentity(parentIdentity.identity, currentIdentity.identity)
+    ) {
+      return "same";
+    }
+
+    const next = dirname(current);
+    if (next === current) return "different";
+    current = next;
+  }
 }
 
 async function defaultRunCommand(
@@ -1695,7 +1898,7 @@ async function defaultRunCommand(
 
 async function defaultScheduleWindowsSelfDelete(
   target: string,
-  parent: string,
+  parent: string | null,
 ): Promise<boolean> {
   const powershell = Bun.which("powershell.exe") || Bun.which("pwsh.exe");
   if (!powershell) return false;
@@ -1716,7 +1919,7 @@ async function defaultScheduleWindowsSelfDelete(
         env: {
           ...process.env,
           PLANNOTATOR_UNINSTALL_TARGET: target,
-          PLANNOTATOR_UNINSTALL_PARENT: parent,
+          PLANNOTATOR_UNINSTALL_PARENT: parent ?? "",
           PLANNOTATOR_UNINSTALL_DELETE_SCRIPT: Buffer.from(
             WINDOWS_SELF_DELETE_SCRIPT,
             "utf16le",

--- a/packages/server/uninstall.ts
+++ b/packages/server/uninstall.ts
@@ -110,7 +110,8 @@ const WINDOWS_PATH_RESTORE_SCRIPT = [
   "[Environment]::SetEnvironmentVariable('Path',$original,'User')",
 ].join("; ");
 
-const WINDOWS_SELF_DELETE_SCRIPT = [
+/** @internal Exported only so the Windows worker syntax can be regression-tested. */
+export const WINDOWS_SELF_DELETE_SCRIPT = [
   "$target=$env:PLANNOTATOR_UNINSTALL_TARGET",
   "for($i=0;$i -lt 40;$i++){",
   "  Start-Sleep -Milliseconds 250",
@@ -119,7 +120,7 @@ const WINDOWS_SELF_DELETE_SCRIPT = [
   "}",
   "$parent=$env:PLANNOTATOR_UNINSTALL_PARENT",
   "Remove-Item -LiteralPath $parent -Force -ErrorAction SilentlyContinue",
-].join(" ");
+].join("\n");
 
 const WINDOWS_SELF_DELETE_BOOTSTRAP_SCRIPT = [
   "$ErrorActionPreference='Stop'",

--- a/packages/server/uninstall.ts
+++ b/packages/server/uninstall.ts
@@ -169,7 +169,7 @@ export interface UninstallRequest {
   readonly purge: boolean;
   readonly dryRun: boolean;
   /** Leave host plugin managers and shared host configuration untouched. */
-  readonly skipHosts?: boolean;
+  readonly skipHosts: boolean;
 }
 
 /** Caller-visible record of completed, planned, preserved, and failed work. */
@@ -196,6 +196,11 @@ type HookCleanupSpec = {
   readonly event: string;
   readonly matcher?: string;
   readonly suffix: "" | "improve-context";
+};
+
+type HookCleanupPolicy = {
+  readonly allowRelocatedBinary: boolean;
+  readonly removeFileWhenEmpty: boolean;
 };
 
 type PathIdentity = {
@@ -260,6 +265,7 @@ export async function runPlannotatorUninstall(
     errors: [],
   };
 
+  const initialDataDirIdentity = readPathIdentity(state.dataDir);
   const dataDirSafetyIssue =
     getDataDirSafetyIssue(
       state.dataDir,
@@ -294,11 +300,23 @@ export async function runPlannotatorUninstall(
       `Preserved managed runtime paths under ${state.dataDir}: ${dataDirSafetyIssue}.`,
     );
   } else {
-    removeInstallerData(request, state);
-  }
-
-  if (request.purge) {
-    purgeLocalData(request, state);
+    const destructiveBoundaryIssue = getDataDirDestructiveBoundaryIssue(
+      state.dataDir,
+      resolve(environment.homeDir),
+      resolve(environment.tempDir),
+      environment.platform,
+      initialDataDirIdentity,
+    );
+    if (destructiveBoundaryIssue) {
+      state.errors.push(
+        `Refusing to remove managed paths under ${state.dataDir}: ${destructiveBoundaryIssue}.`,
+      );
+    } else {
+      // Keep this block synchronous: no host command or other awaited work may
+      // reopen a path-swap window after the destructive-boundary revalidation.
+      removeInstallerData(request, state);
+      if (request.purge) purgeLocalData(request, state);
+    }
   }
 
   if (state.errors.length === 0) {
@@ -512,8 +530,10 @@ function removeHostConfigEntries(
     ],
     paths.binaryPaths,
     environment.platform,
-    false,
-    false,
+    {
+      allowRelocatedBinary: false,
+      removeFileWhenEmpty: false,
+    },
     "managed Claude Code hooks",
     request,
     state,
@@ -524,8 +544,10 @@ function removeHostConfigEntries(
     [{ event: "Stop", suffix: "" }],
     paths.binaryPaths,
     environment.platform,
-    true,
-    true,
+    {
+      allowRelocatedBinary: true,
+      removeFileWhenEmpty: true,
+    },
     "managed Codex Stop hook",
     request,
     state,
@@ -952,8 +974,7 @@ function cleanupHooksJson(
   specs: readonly HookCleanupSpec[],
   binaryPaths: readonly string[],
   platform: NodeJS.Platform,
-  allowRelocatedBinary: boolean,
-  removeWhenEmpty: boolean,
+  policy: HookCleanupPolicy,
   label: string,
   request: UninstallRequest,
   state: MutableUninstallResult,
@@ -994,7 +1015,7 @@ function cleanupHooksJson(
             binaryPaths,
             spec.suffix,
             platform,
-            allowRelocatedBinary,
+            policy.allowRelocatedBinary,
           ),
       );
       if (nextHooks.length === hookEntries.length) {
@@ -1024,7 +1045,7 @@ function cleanupHooksJson(
     return;
   }
 
-  if (removeWhenEmpty && Object.keys(parsed).length === 0) {
+  if (policy.removeFileWhenEmpty && Object.keys(parsed).length === 0) {
     removePath(filePath, request, state);
     return;
   }
@@ -1148,7 +1169,6 @@ function cleanupOpenCodeConfig(
   if (parseErrors.length > 0 || !parsed) {
     reportMalformedSharedConfig(
       filePath,
-      content,
       "it is not valid JSON or JSONC",
       state,
     );
@@ -1309,7 +1329,6 @@ function readJsonRecord(
     if (!record) {
       reportMalformedSharedConfig(
         filePath,
-        content,
         "it is not a JSON object",
         state,
       );
@@ -1319,7 +1338,6 @@ function readJsonRecord(
   } catch {
     reportMalformedSharedConfig(
       filePath,
-      content,
       "it is not strict JSON",
       state,
     );
@@ -1329,19 +1347,11 @@ function readJsonRecord(
 
 function reportMalformedSharedConfig(
   filePath: string,
-  content: string,
   reason: string,
   state: MutableUninstallResult,
 ): void {
-  const prefix = `Preserved ${filePath}: ${reason}`;
-  if (content.toLowerCase().includes("plannotator")) {
-    state.errors.push(
-      `${prefix}, and it may contain a managed Plannotator entry. Re-run with --skip-hosts to leave host integrations for manual cleanup.`,
-    );
-    return;
-  }
-  state.warnings.push(
-    `${prefix}. No recognizable Plannotator entry was found, so uninstall continued.`,
+  state.errors.push(
+    `Preserved ${filePath}: ${reason}, so managed host entries cannot be classified safely. Re-run with --skip-hosts to leave host integrations for manual cleanup.`,
   );
 }
 
@@ -1805,6 +1815,40 @@ function getDataDirSafetyIssue(
   }
   if (tempRelation === "unknown") {
     return "the data directory identity relative to the shared temporary directory could not be verified";
+  }
+  return null;
+}
+
+function getDataDirDestructiveBoundaryIssue(
+  dataDir: string,
+  homeDir: string,
+  tempDir: string,
+  platform: NodeJS.Platform,
+  initialIdentity: PathIdentityResult,
+): string | null {
+  const currentSafetyIssue =
+    getDataDirSafetyIssue(dataDir, homeDir, tempDir, platform) ??
+    inspectDataDir(dataDir);
+  if (currentSafetyIssue) {
+    return `the data directory changed after initial validation (${currentSafetyIssue})`;
+  }
+
+  const currentIdentity = readPathIdentity(dataDir);
+  if (
+    initialIdentity.kind === "error" ||
+    currentIdentity.kind === "error"
+  ) {
+    return "the data directory identity could not be revalidated after host cleanup";
+  }
+  if (initialIdentity.kind !== currentIdentity.kind) {
+    return "the data directory changed after initial validation";
+  }
+  if (
+    initialIdentity.kind === "found" &&
+    currentIdentity.kind === "found" &&
+    !sameIdentity(initialIdentity.identity, currentIdentity.identity)
+  ) {
+    return "the data directory changed after initial validation";
   }
   return null;
 }

--- a/packages/server/uninstall.ts
+++ b/packages/server/uninstall.ts
@@ -1,0 +1,1350 @@
+/**
+ * Plannotator uninstall lifecycle.
+ *
+ * The uninstaller removes only product-owned paths and recognizable managed
+ * entries from shared host configuration. The default mode keeps local review
+ * data. Purge removes the known Plannotator data inventory while preserving
+ * unknown top-level entries rather than guessing that custom files are ours.
+ */
+import {
+  existsSync,
+  lstatSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import {
+  dirname,
+  isAbsolute,
+  join,
+  normalize,
+  parse,
+  relative,
+  resolve,
+} from "node:path";
+import { getPlannotatorDataDir } from "@plannotator/shared/data-dir";
+
+const CORE_SKILLS = [
+  "plannotator-review",
+  "plannotator-annotate",
+  "plannotator-last",
+] as const;
+
+const LEGACY_COMMAND_NAMES = [
+  ...CORE_SKILLS,
+  "plannotator-archive",
+] as const;
+
+const KIRO_SKILLS = [
+  "plannotator-review",
+  "plannotator-annotate",
+  "plannotator-setup-goal",
+  "plannotator-visual-explainer",
+  "plannotator-archive",
+] as const;
+
+const STALE_CODEX_SKILLS = [
+  ...CORE_SKILLS,
+  "plannotator-compound",
+  "plannotator-setup-goal",
+  "plannotator-archive",
+] as const;
+
+const STALE_SHARED_SKILLS = [
+  "plannotator-archive",
+] as const;
+
+const PURGE_OWNED_TOP_LEVEL = [
+  "plans",
+  "history",
+  "drafts",
+  "hooks",
+  "compound",
+  "sessions",
+  "guides",
+  "failed-comments",
+  "semantic-diff",
+  "vendor",
+  "migrations",
+  "config.json",
+  "install-prefs",
+  "review-skills.json",
+  "vscode-ipc.json",
+  "codex-review-debug.log",
+  "codex-review-schema.json",
+  "tour-schema.json",
+  "guide-schema.json",
+] as const;
+
+const WINDOWS_PATH_SCRIPT = [
+  "$p=[Environment]::GetEnvironmentVariable('Path','User')",
+  "if($null -eq $p){exit 3}",
+  "$t=$env:PLANNOTATOR_UNINSTALL_PATH.Trim().TrimEnd('\\')",
+  "$kept=@($p -split ';' | Where-Object { $_ -and $_.Trim().TrimEnd('\\') -ine $t })",
+  "$n=$kept -join ';'",
+  "if($n -eq $p){exit 3}",
+  "[Environment]::SetEnvironmentVariable('Path',$n,'User')",
+].join("; ");
+
+const WINDOWS_SELF_DELETE_SCRIPT = [
+  "$target=$env:PLANNOTATOR_UNINSTALL_TARGET",
+  "for($i=0;$i -lt 40;$i++){",
+  "  Start-Sleep -Milliseconds 250",
+  "  Remove-Item -LiteralPath $target -Force -ErrorAction SilentlyContinue",
+  "  if(-not (Test-Path -LiteralPath $target)){break}",
+  "}",
+  "$parent=$env:PLANNOTATOR_UNINSTALL_PARENT",
+  "Remove-Item -LiteralPath $parent -Force -ErrorAction SilentlyContinue",
+].join(" ");
+
+type JsonRecord = Record<string, unknown>;
+
+/** Result returned by a host CLI command invoked during uninstall. */
+export interface UninstallCommandResult {
+  readonly exitCode: number;
+  readonly timedOut: boolean;
+}
+
+/**
+ * Platform and process capabilities used by the uninstall application service.
+ *
+ * Tests provide this boundary explicitly so no test can discover or mutate the
+ * developer's real home directory, PATH, plugins, or agent installations.
+ */
+export interface UninstallEnvironment {
+  readonly platform: NodeJS.Platform;
+  readonly homeDir: string;
+  readonly tempDir: string;
+  readonly dataDir: string;
+  readonly execPath: string;
+  readonly env: Readonly<Record<string, string | undefined>>;
+  readonly which: (command: string) => string | null;
+  readonly runCommand: (
+    command: string,
+    args: readonly string[],
+    env?: Readonly<Record<string, string>>,
+  ) => Promise<UninstallCommandResult>;
+  readonly scheduleWindowsSelfDelete: (
+    target: string,
+    parent: string,
+  ) => Promise<boolean>;
+}
+
+/** Requested uninstall behavior after CLI confirmation has completed. */
+export interface UninstallRequest {
+  readonly purge: boolean;
+  readonly dryRun: boolean;
+}
+
+/** Caller-visible record of completed, planned, preserved, and failed work. */
+export interface UninstallResult {
+  readonly ok: boolean;
+  readonly dataDir: string;
+  readonly removed: readonly string[];
+  readonly planned: readonly string[];
+  readonly preserved: readonly string[];
+  readonly warnings: readonly string[];
+  readonly errors: readonly string[];
+}
+
+type MutableUninstallResult = {
+  dataDir: string;
+  removed: string[];
+  planned: string[];
+  preserved: string[];
+  warnings: string[];
+  errors: string[];
+};
+
+type HookCleanupSpec = {
+  readonly event: string;
+  readonly matcher?: string;
+  readonly suffix: "" | "improve-context";
+};
+
+/**
+ * Build the real process boundary used by `plannotator uninstall`.
+ *
+ * No filesystem mutation occurs until `runPlannotatorUninstall` is called.
+ */
+export function createDefaultUninstallEnvironment(): UninstallEnvironment {
+  const homeDir = homedir();
+  const env = process.env;
+
+  return {
+    platform: process.platform,
+    homeDir,
+    tempDir: tmpdir(),
+    dataDir: getPlannotatorDataDir(),
+    execPath: process.execPath,
+    env,
+    which: (command) => Bun.which(command),
+    runCommand: defaultRunCommand,
+    scheduleWindowsSelfDelete: defaultScheduleWindowsSelfDelete,
+  };
+}
+
+/**
+ * Explain the irreversible purge boundary in user-facing language.
+ */
+export function formatPurgeWarning(dataDir: string): string {
+  return [
+    `Purge will permanently delete Plannotator data in ${dataDir}.`,
+    "This data is local-only. It is not stored on a Plannotator server and cannot be recovered after purge.",
+  ].join("\n");
+}
+
+/**
+ * Remove Plannotator's conventional installation and recognizable host
+ * integrations. Expected filesystem and host-CLI failures are collected in
+ * the returned value so one stale integration cannot prevent other cleanup.
+ */
+export async function runPlannotatorUninstall(
+  request: UninstallRequest,
+  environment = createDefaultUninstallEnvironment(),
+): Promise<UninstallResult> {
+  const state: MutableUninstallResult = {
+    dataDir: resolve(environment.dataDir),
+    removed: [],
+    planned: [],
+    preserved: [],
+    warnings: [],
+    errors: [],
+  };
+
+  const dataDirSafetyIssue =
+    getDataDirSafetyIssue(
+      state.dataDir,
+      resolve(environment.homeDir),
+      resolve(environment.tempDir),
+      environment.platform,
+    ) ?? inspectDataDir(state.dataDir);
+
+  if (request.purge && dataDirSafetyIssue) {
+    return {
+      ...state,
+      ok: false,
+      errors: [
+        `Refusing to purge ${state.dataDir}: ${dataDirSafetyIssue}.`,
+      ],
+    };
+  }
+
+  const paths = resolveOwnedPaths(environment);
+
+  await removeHostPlugins(request, environment, paths, state);
+  removeHostConfigEntries(request, environment, paths, state);
+  removeInstalledFiles(request, environment, paths, state);
+  if (dataDirSafetyIssue) {
+    state.warnings.push(
+      `Preserved managed runtime paths under ${state.dataDir}: ${dataDirSafetyIssue}.`,
+    );
+  } else {
+    removeInstallerData(request, state);
+  }
+
+  if (request.purge) {
+    purgeLocalData(request, state);
+  }
+
+  await removeWindowsPathEntry(request, environment, paths, state);
+  await removeBinaries(request, environment, paths, state);
+
+  return {
+    ...state,
+    ok: state.errors.length === 0,
+  };
+}
+
+/**
+ * Format an uninstall result for terminal output without exposing host command
+ * stdout/stderr or unrelated configuration contents.
+ */
+export function formatUninstallResult(result: UninstallResult): string {
+  const lines: string[] = [];
+
+  if (result.removed.length > 0) {
+    lines.push("Removed:");
+    for (const item of result.removed) lines.push(`  - ${item}`);
+  }
+  if (result.planned.length > 0) {
+    lines.push("Would remove:");
+    for (const item of result.planned) lines.push(`  - ${item}`);
+  }
+  if (result.preserved.length > 0) {
+    lines.push("Preserved:");
+    for (const item of result.preserved) lines.push(`  - ${item}`);
+  }
+  if (result.warnings.length > 0) {
+    lines.push("Warnings:");
+    for (const item of result.warnings) lines.push(`  - ${item}`);
+  }
+  if (result.errors.length > 0) {
+    lines.push("Errors:");
+    for (const item of result.errors) lines.push(`  - ${item}`);
+  }
+
+  return lines.join("\n");
+}
+
+function resolveOwnedPaths(environment: UninstallEnvironment) {
+  const { homeDir, env } = environment;
+  const claudeDir = env.CLAUDE_CONFIG_DIR || join(homeDir, ".claude");
+  const codexDir = env.CODEX_HOME || join(homeDir, ".codex");
+  const factoryDir = env.FACTORY_CONFIG_DIR || join(homeDir, ".factory");
+  const copilotDir = env.COPILOT_HOME || join(homeDir, ".copilot");
+  const xdgConfigDir = env.XDG_CONFIG_HOME || join(homeDir, ".config");
+  const xdgCacheDir = env.XDG_CACHE_HOME || join(homeDir, ".cache");
+  const configDirs = uniquePaths([
+    xdgConfigDir,
+    join(homeDir, ".config"),
+  ]);
+  const localAppData = env.LOCALAPPDATA || join(homeDir, "AppData", "Local");
+  const unixInstallDir = join(homeDir, ".local", "bin");
+  const windowsInstallDir = join(localAppData, "plannotator");
+
+  const binaryPaths = uniquePaths([
+    join(unixInstallDir, "plannotator"),
+    join(unixInstallDir, "plannotator.exe"),
+    join(windowsInstallDir, "plannotator"),
+    join(windowsInstallDir, "plannotator.exe"),
+  ]);
+
+  return {
+    claudeDir,
+    codexDir,
+    factoryDir,
+    copilotDir,
+    configDirs,
+    xdgCacheDir,
+    windowsInstallDir,
+    binaryPaths,
+  };
+}
+
+async function removeHostPlugins(
+  request: UninstallRequest,
+  environment: UninstallEnvironment,
+  paths: ReturnType<typeof resolveOwnedPaths>,
+  state: MutableUninstallResult,
+): Promise<void> {
+  const actions = [
+    {
+      label: "Claude Code plugin plannotator@plannotator",
+      command: "claude",
+      args: [
+        "plugin",
+        "uninstall",
+        "plannotator@plannotator",
+        "--scope",
+        "user",
+        ...(request.purge ? [] : ["--keep-data"]),
+        "--yes",
+      ],
+      installed:
+        hasEnabledPlugin(
+          join(paths.claudeDir, "settings.json"),
+          "plannotator@plannotator",
+        ),
+    },
+    {
+      label: "GitHub Copilot CLI plugin plannotator-copilot@plannotator",
+      command: "copilot",
+      args: ["plugins", "remove", "plannotator-copilot@plannotator", "--plugin"],
+      installed:
+        hasEnabledPlugin(
+          join(paths.copilotDir, "settings.json"),
+          "plannotator-copilot@plannotator",
+        ) ||
+        hasDirectoryWithPrefix(
+          join(paths.copilotDir, "installed-plugins", "plannotator"),
+          "plannotator-copilot",
+        ),
+    },
+    {
+      label: "Droid plugin plannotator@plannotator",
+      command: "droid",
+      args: [
+        "plugin",
+        "uninstall",
+        "plannotator@plannotator",
+        "--scope",
+        "user",
+      ],
+      installed: hasEnabledPlugin(
+        join(paths.factoryDir, "settings.json"),
+        "plannotator@plannotator",
+      ),
+    },
+    {
+      label: "Pi extension npm:@plannotator/pi-extension",
+      command: "pi",
+      args: ["remove", "npm:@plannotator/pi-extension"],
+      installed: hasPiPackage(
+        join(
+          environment.env.PI_CODING_AGENT_DIR || join(environment.homeDir, ".pi", "agent"),
+          "settings.json",
+        ),
+      ),
+    },
+    {
+      label: "VS Code extension backnotprop.plannotator-webview",
+      command: "code",
+      args: ["--uninstall-extension", "backnotprop.plannotator-webview"],
+      installed: hasDirectoryWithPrefix(
+        join(environment.homeDir, ".vscode", "extensions"),
+        "backnotprop.plannotator-webview-",
+      ),
+    },
+  ] as const;
+
+  for (const action of actions) {
+    if (!action.installed) continue;
+    if (request.dryRun) {
+      state.planned.push(action.label);
+      continue;
+    }
+
+    const executable = environment.which(action.command);
+    if (!executable) {
+      state.errors.push(
+        `${action.label} was detected but ${action.command} is unavailable; it was not removed. Use the host's plugin manager manually.`,
+      );
+      continue;
+    }
+
+    const result = await environment.runCommand(executable, action.args);
+    if (result.exitCode === 0) {
+      state.removed.push(action.label);
+    } else {
+      state.errors.push(
+        `${action.label} was not removed automatically (${result.timedOut ? "command timed out" : `exit ${result.exitCode}`}); use the host's plugin manager manually.`,
+      );
+    }
+  }
+}
+
+function removeHostConfigEntries(
+  request: UninstallRequest,
+  environment: UninstallEnvironment,
+  paths: ReturnType<typeof resolveOwnedPaths>,
+  state: MutableUninstallResult,
+): void {
+  cleanupHooksJson(
+    join(paths.claudeDir, "settings.json"),
+    [
+      { event: "PermissionRequest", matcher: "ExitPlanMode", suffix: "" },
+      { event: "PreToolUse", matcher: "EnterPlanMode", suffix: "improve-context" },
+    ],
+    paths.binaryPaths,
+    environment.platform,
+    false,
+    "managed Claude Code hooks",
+    request,
+    state,
+  );
+
+  cleanupHooksJson(
+    join(paths.codexDir, "hooks.json"),
+    [{ event: "Stop", suffix: "" }],
+    paths.binaryPaths,
+    environment.platform,
+    true,
+    "managed Codex Stop hook",
+    request,
+    state,
+  );
+  cleanupCodexConfig(
+    join(paths.codexDir, "config.toml"),
+    request,
+    state,
+  );
+
+  cleanupGeminiSettings(
+    join(environment.homeDir, ".gemini", "settings.json"),
+    paths.binaryPaths,
+    environment.platform,
+    request,
+    state,
+  );
+
+  for (const configDir of paths.configDirs) {
+    for (const name of ["opencode.json", "opencode.jsonc"]) {
+      cleanupOpenCodeConfig(
+        join(configDir, "opencode", name),
+        request,
+        state,
+      );
+    }
+  }
+}
+
+function removeInstalledFiles(
+  request: UninstallRequest,
+  environment: UninstallEnvironment,
+  paths: ReturnType<typeof resolveOwnedPaths>,
+  state: MutableUninstallResult,
+): void {
+  for (const skill of CORE_SKILLS) {
+    removePath(
+      join(paths.claudeDir, "skills", skill),
+      request,
+      state,
+    );
+    removePath(
+      join(environment.homeDir, ".agents", "skills", skill),
+      request,
+      state,
+    );
+  }
+
+  for (const skill of STALE_SHARED_SKILLS) {
+    removePath(join(paths.claudeDir, "skills", skill), request, state);
+    removePath(
+      join(environment.homeDir, ".agents", "skills", skill),
+      request,
+      state,
+    );
+  }
+
+  for (const staleLayout of ["core", "extra"]) {
+    removePath(
+      join(paths.claudeDir, "skills", staleLayout),
+      request,
+      state,
+    );
+  }
+
+  for (const skill of STALE_CODEX_SKILLS) {
+    removePath(join(paths.codexDir, "skills", skill), request, state);
+  }
+
+  for (const skill of KIRO_SKILLS) {
+    removePath(
+      join(environment.homeDir, ".kiro", "skills", skill),
+      request,
+      state,
+    );
+  }
+
+  for (const command of LEGACY_COMMAND_NAMES) {
+    removePath(
+      join(paths.claudeDir, "commands", `${command}.md`),
+      request,
+      state,
+    );
+    for (const configDir of paths.configDirs) {
+      removePath(
+        join(configDir, "opencode", "commands", `${command}.md`),
+        request,
+        state,
+      );
+    }
+  }
+
+  for (const command of [
+    "plannotator-review",
+    "plannotator-annotate",
+    "plannotator-last",
+  ]) {
+    removePath(
+      join(environment.homeDir, ".gemini", "commands", `${command}.toml`),
+      request,
+      state,
+    );
+  }
+
+  removePath(
+    join(environment.homeDir, ".gemini", "policies", "plannotator.toml"),
+    request,
+    state,
+  );
+
+  cleanupRecognizableKiroAgent(
+    join(environment.homeDir, ".kiro", "agents", "plannotator.json"),
+    request,
+    state,
+  );
+  for (const configDir of paths.configDirs) {
+    cleanupRecognizableAmpPlugin(
+      join(configDir, "amp", "plugins", "plannotator.ts"),
+      request,
+      state,
+    );
+  }
+
+  for (const cachePath of [
+    join(paths.xdgCacheDir, "opencode", "node_modules", "@plannotator"),
+    join(paths.xdgCacheDir, "opencode", "packages", "@plannotator"),
+    join(environment.homeDir, ".cache", "opencode", "node_modules", "@plannotator"),
+    join(environment.homeDir, ".cache", "opencode", "packages", "@plannotator"),
+    join(environment.homeDir, ".bun", "install", "cache", "@plannotator"),
+  ]) {
+    removePath(cachePath, request, state);
+  }
+}
+
+function removeInstallerData(
+  request: UninstallRequest,
+  state: MutableUninstallResult,
+): void {
+  // The sidecars are installed components. install-prefs and migrations are
+  // retained as local state in the default mode: the migration ledger is what
+  // prevents a later reinstall from mistaking separately installed extras for
+  // obsolete installer copies. Purge removes those files through its inventory.
+  for (const path of [
+    join(state.dataDir, "vendor", "sem"),
+    join(state.dataDir, "vendor", "agent-terminal"),
+  ]) {
+    removePath(path, request, state);
+  }
+}
+
+function purgeLocalData(
+  request: UninstallRequest,
+  state: MutableUninstallResult,
+): void {
+  if (!pathExists(state.dataDir)) return;
+
+  for (const name of PURGE_OWNED_TOP_LEVEL) {
+    removePath(join(state.dataDir, name), request, state);
+  }
+
+  let remaining: string[];
+  try {
+    remaining = readdirSync(state.dataDir);
+  } catch (error) {
+    if (existsSync(state.dataDir)) {
+      state.errors.push(
+        `Could not inspect ${state.dataDir} after purge: ${formatError(error)}`,
+      );
+    }
+    return;
+  }
+
+  if (request.dryRun) {
+    const recognized = new Set<string>(PURGE_OWNED_TOP_LEVEL);
+    const customEntries = remaining.filter((name) => !recognized.has(name));
+    if (customEntries.length === 0) {
+      state.planned.push(state.dataDir);
+      return;
+    }
+    for (const name of customEntries) {
+      state.preserved.push(
+        `${join(state.dataDir, name)} (unrecognized custom entry)`,
+      );
+    }
+    return;
+  }
+
+  if (remaining.length === 0) {
+    removePath(state.dataDir, request, state);
+    return;
+  }
+
+  const recognized = new Set<string>(PURGE_OWNED_TOP_LEVEL);
+  for (const name of remaining) {
+    const remainingPath = join(state.dataDir, name);
+    if (recognized.has(name)) {
+      state.errors.push(
+        `Known Plannotator data entry remains after purge: ${remainingPath}.`,
+      );
+    } else {
+      state.preserved.push(
+        `${remainingPath} (unrecognized custom entry)`,
+      );
+    }
+  }
+}
+
+async function removeWindowsPathEntry(
+  request: UninstallRequest,
+  environment: UninstallEnvironment,
+  paths: ReturnType<typeof resolveOwnedPaths>,
+  state: MutableUninstallResult,
+): Promise<void> {
+  if (environment.platform !== "win32") return;
+
+  const label = `Windows user PATH entry ${paths.windowsInstallDir}`;
+  if (request.dryRun) {
+    state.planned.push(label);
+    return;
+  }
+
+  const powershell =
+    environment.which("powershell.exe") ||
+    environment.which("pwsh.exe");
+  if (!powershell) {
+    state.warnings.push(
+      `Could not inspect the Windows user PATH; remove ${paths.windowsInstallDir} from PATH manually if present.`,
+    );
+    return;
+  }
+
+  const result = await environment.runCommand(
+    powershell,
+    ["-NoProfile", "-NonInteractive", "-Command", WINDOWS_PATH_SCRIPT],
+    { PLANNOTATOR_UNINSTALL_PATH: paths.windowsInstallDir },
+  );
+  if (result.exitCode === 0) {
+    state.removed.push(label);
+  } else if (result.exitCode !== 3) {
+    state.warnings.push(
+      `Could not remove ${paths.windowsInstallDir} from the Windows user PATH.`,
+    );
+  }
+}
+
+async function removeBinaries(
+  request: UninstallRequest,
+  environment: UninstallEnvironment,
+  paths: ReturnType<typeof resolveOwnedPaths>,
+  state: MutableUninstallResult,
+): Promise<void> {
+  for (const binaryPath of paths.binaryPaths) {
+    if (!pathExists(binaryPath)) continue;
+
+    if (request.dryRun) {
+      state.planned.push(binaryPath);
+      continue;
+    }
+
+    const isCurrentWindowsBinary =
+      environment.platform === "win32" &&
+      samePath(binaryPath, environment.execPath, "win32");
+
+    if (isCurrentWindowsBinary) {
+      const scheduled = await environment.scheduleWindowsSelfDelete(
+        binaryPath,
+        dirname(binaryPath),
+      );
+      if (scheduled) {
+        state.removed.push(`${binaryPath} (scheduled after exit)`);
+      } else {
+        state.errors.push(
+          `Could not schedule removal of the running executable ${binaryPath}.`,
+        );
+      }
+      continue;
+    }
+
+    removePath(binaryPath, request, state);
+  }
+}
+
+function cleanupHooksJson(
+  filePath: string,
+  specs: readonly HookCleanupSpec[],
+  binaryPaths: readonly string[],
+  platform: NodeJS.Platform,
+  removeWhenEmpty: boolean,
+  label: string,
+  request: UninstallRequest,
+  state: MutableUninstallResult,
+): void {
+  const parsed = readJsonRecord(filePath, state);
+  if (!parsed) return;
+
+  const hooks = asRecord(parsed.hooks);
+  if (!hooks) return;
+
+  let changed = false;
+  for (const spec of specs) {
+    const entries = hooks[spec.event];
+    if (!Array.isArray(entries)) continue;
+
+    const nextEntries: unknown[] = [];
+    let eventChanged = false;
+    for (const value of entries) {
+      const entry = asRecord(value);
+      if (
+        !entry ||
+        (spec.matcher !== undefined && entry.matcher !== spec.matcher)
+      ) {
+        nextEntries.push(value);
+        continue;
+      }
+
+      const hookEntries = entry.hooks;
+      if (!Array.isArray(hookEntries)) {
+        nextEntries.push(value);
+        continue;
+      }
+
+      const nextHooks = hookEntries.filter(
+        (hook) => !isManagedHook(hook, binaryPaths, spec.suffix, platform),
+      );
+      if (nextHooks.length === hookEntries.length) {
+        nextEntries.push(value);
+        continue;
+      }
+
+      changed = true;
+      eventChanged = true;
+      if (nextHooks.length === 0 && hasOnlyKeys(entry, ["matcher", "hooks"])) {
+        continue;
+      }
+      nextEntries.push({ ...entry, hooks: nextHooks });
+    }
+
+    if (!eventChanged) continue;
+    if (nextEntries.length === 0) delete hooks[spec.event];
+    else hooks[spec.event] = nextEntries;
+  }
+
+  if (!changed) return;
+  if (Object.keys(hooks).length === 0) delete parsed.hooks;
+  else parsed.hooks = hooks;
+
+  if (request.dryRun) {
+    state.planned.push(`${label} in ${filePath}`);
+    return;
+  }
+
+  if (removeWhenEmpty && Object.keys(parsed).length === 0) {
+    removePath(filePath, request, state);
+    return;
+  }
+
+  writeJson(filePath, parsed, label, state);
+}
+
+function cleanupCodexConfig(
+  filePath: string,
+  request: UninstallRequest,
+  state: MutableUninstallResult,
+): void {
+  if (!existsSync(filePath)) return;
+  let content: string;
+  try {
+    content = readFileSync(filePath, "utf8");
+  } catch (error) {
+    state.warnings.push(`Could not inspect ${filePath}: ${formatError(error)}`);
+    return;
+  }
+
+  const meaningfulLines = content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const isInstallerTemplate =
+    meaningfulLines.length === 2 &&
+    meaningfulLines[0] === "[features]" &&
+    /^hooks\s*=\s*true$/.test(meaningfulLines[1]);
+
+  if (!isInstallerTemplate) return;
+  removePath(filePath, request, state);
+}
+
+function cleanupGeminiSettings(
+  filePath: string,
+  binaryPaths: readonly string[],
+  platform: NodeJS.Platform,
+  request: UninstallRequest,
+  state: MutableUninstallResult,
+): void {
+  const parsed = readJsonRecord(filePath, state);
+  if (!parsed) return;
+  const wasInstallerTemplate = isGeminiInstallerTemplate(
+    parsed,
+    binaryPaths,
+    platform,
+  );
+
+  const hooks = asRecord(parsed.hooks);
+  const beforeTool = hooks?.BeforeTool;
+  if (!hooks || !Array.isArray(beforeTool)) return;
+
+  let changed = false;
+  const nextEntries: unknown[] = [];
+  for (const value of beforeTool) {
+    const entry = asRecord(value);
+    if (
+      !entry ||
+      entry.matcher !== "exit_plan_mode" ||
+      !Array.isArray(entry.hooks)
+    ) {
+      nextEntries.push(value);
+      continue;
+    }
+
+    const nextHooks = entry.hooks.filter(
+      (hook) => !isManagedHook(hook, binaryPaths, "", platform),
+    );
+    if (nextHooks.length === entry.hooks.length) {
+      nextEntries.push(value);
+      continue;
+    }
+
+    changed = true;
+    if (nextHooks.length === 0 && hasOnlyKeys(entry, ["matcher", "hooks"])) {
+      continue;
+    }
+    nextEntries.push({ ...entry, hooks: nextHooks });
+  }
+
+  if (!changed) return;
+  if (request.dryRun) {
+    state.planned.push(`managed Gemini hook in ${filePath}`);
+    return;
+  }
+
+  if (wasInstallerTemplate) {
+    removePath(filePath, request, state);
+    return;
+  }
+
+  if (nextEntries.length === 0) delete hooks.BeforeTool;
+  else hooks.BeforeTool = nextEntries;
+  if (Object.keys(hooks).length === 0) delete parsed.hooks;
+  else parsed.hooks = hooks;
+  writeJson(filePath, parsed, "managed Gemini hook", state);
+}
+
+function cleanupOpenCodeConfig(
+  filePath: string,
+  request: UninstallRequest,
+  state: MutableUninstallResult,
+): void {
+  const parsed = readJsonRecord(filePath, state);
+  if (!parsed || !Array.isArray(parsed.plugin)) return;
+
+  const next = parsed.plugin.filter(
+    (entry) => !isPlannotatorOpenCodePlugin(entry),
+  );
+  if (next.length === parsed.plugin.length) return;
+
+  if (request.dryRun) {
+    state.planned.push(`@plannotator/opencode entry in ${filePath}`);
+    return;
+  }
+
+  parsed.plugin = next;
+  writeJson(filePath, parsed, "@plannotator/opencode entry", state);
+}
+
+function cleanupRecognizableKiroAgent(
+  filePath: string,
+  request: UninstallRequest,
+  state: MutableUninstallResult,
+): void {
+  const parsed = readJsonRecord(filePath, state);
+  if (!parsed) return;
+
+  const prompt = typeof parsed.prompt === "string" ? parsed.prompt : "";
+  const description =
+    typeof parsed.description === "string" ? parsed.description : "";
+  const recognizable =
+    parsed.name === "plannotator" &&
+    description.includes("Kiro custom agent wiring for Plannotator") &&
+    prompt.includes("Each skill runs a `plannotator` shell command");
+
+  if (recognizable) {
+    removePath(filePath, request, state);
+  } else {
+    state.preserved.push(`${filePath} (custom or unrecognized Kiro agent)`);
+  }
+}
+
+function cleanupRecognizableAmpPlugin(
+  filePath: string,
+  request: UninstallRequest,
+  state: MutableUninstallResult,
+): void {
+  if (!existsSync(filePath)) return;
+  let content: string;
+  try {
+    content = readFileSync(filePath, "utf8");
+  } catch (error) {
+    state.warnings.push(`Could not inspect ${filePath}: ${formatError(error)}`);
+    return;
+  }
+
+  const recognizable =
+    content.includes('const CATEGORY = "Plannotator"') &&
+    content.includes("export default function plannotatorAmpPlugin") &&
+    content.includes("PLANNOTATOR_ORIGIN");
+
+  if (recognizable) {
+    removePath(filePath, request, state);
+  } else {
+    state.preserved.push(`${filePath} (custom or unrecognized Amp plugin)`);
+  }
+}
+
+function readJsonRecord(
+  filePath: string,
+  state: MutableUninstallResult,
+): JsonRecord | null {
+  if (!existsSync(filePath)) return null;
+  let content: string;
+  try {
+    content = readFileSync(filePath, "utf8");
+  } catch (error) {
+    state.warnings.push(`Could not inspect ${filePath}: ${formatError(error)}`);
+    return null;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(content);
+    const record = asRecord(parsed);
+    if (!record) {
+      state.warnings.push(`Preserved ${filePath}: expected a JSON object.`);
+      return null;
+    }
+    return record;
+  } catch {
+    state.warnings.push(
+      `Preserved ${filePath}: it is not strict JSON, so managed entries could not be removed safely.`,
+    );
+    return null;
+  }
+}
+
+function writeJson(
+  filePath: string,
+  value: JsonRecord,
+  label: string,
+  state: MutableUninstallResult,
+): void {
+  try {
+    writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+    state.removed.push(`${label} in ${filePath}`);
+  } catch (error) {
+    state.errors.push(`Could not update ${filePath}: ${formatError(error)}`);
+  }
+}
+
+function removePath(
+  path: string,
+  request: UninstallRequest,
+  state: MutableUninstallResult,
+): void {
+  let stat: ReturnType<typeof lstatSync>;
+  try {
+    stat = lstatSync(path);
+  } catch (error) {
+    if (isMissingPathError(error)) return;
+    state.errors.push(`Could not inspect ${path}: ${formatError(error)}`);
+    return;
+  }
+
+  if (request.dryRun) {
+    state.planned.push(path);
+    return;
+  }
+
+  try {
+    rmSync(path, {
+      recursive: stat.isDirectory() && !stat.isSymbolicLink(),
+      force: true,
+    });
+    state.removed.push(path);
+  } catch (error) {
+    state.errors.push(`Could not remove ${path}: ${formatError(error)}`);
+  }
+}
+
+function isManagedHook(
+  value: unknown,
+  binaryPaths: readonly string[],
+  suffix: "" | "improve-context",
+  platform: NodeJS.Platform,
+): boolean {
+  const hook = asRecord(value);
+  if (!hook || hook.type !== "command" || typeof hook.command !== "string") {
+    return false;
+  }
+
+  const command = hook.command.trim();
+  const expectedBare = suffix ? `plannotator ${suffix}` : "plannotator";
+  if (command === expectedBare) return true;
+
+  for (const binaryPath of binaryPaths) {
+    const candidates = suffix
+      ? [`${binaryPath} ${suffix}`, `"${binaryPath}" ${suffix}`]
+      : [binaryPath, `"${binaryPath}"`];
+    if (candidates.some((candidate) => sameCommand(command, candidate, platform))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isGeminiInstallerTemplate(
+  value: JsonRecord,
+  binaryPaths: readonly string[],
+  platform: NodeJS.Platform,
+): boolean {
+  const hooks = asRecord(value.hooks);
+  const experimental = asRecord(value.experimental);
+  if (!hooks || !experimental || experimental.plan !== true) return false;
+  if (!hasOnlyKeys(value, ["hooks", "experimental"])) return false;
+  if (!hasOnlyKeys(experimental, ["plan"])) return false;
+
+  const beforeTool = hooks.BeforeTool;
+  if (
+    !hasOnlyKeys(hooks, ["BeforeTool"]) ||
+    !Array.isArray(beforeTool) ||
+    beforeTool.length !== 1
+  ) {
+    return false;
+  }
+
+  const entry = asRecord(beforeTool[0]);
+  if (
+    !entry ||
+    entry.matcher !== "exit_plan_mode" ||
+    !hasOnlyKeys(entry, ["matcher", "hooks"]) ||
+    !Array.isArray(entry.hooks) ||
+    entry.hooks.length !== 1
+  ) {
+    return false;
+  }
+
+  const hook = asRecord(entry.hooks[0]);
+  return (
+    hook !== null &&
+    hasOnlyKeys(hook, ["type", "command", "timeout"]) &&
+    isManagedHook(hook, binaryPaths, "", platform)
+  );
+}
+
+function isPlannotatorOpenCodePlugin(value: unknown): boolean {
+  const spec =
+    typeof value === "string"
+      ? value
+      : Array.isArray(value) && typeof value[0] === "string"
+        ? value[0]
+        : null;
+  return spec !== null && /^@plannotator\/opencode(?:@|$)/.test(spec);
+}
+
+function hasEnabledPlugin(filePath: string, pluginId: string): boolean {
+  const parsed = tryReadJsonRecord(filePath);
+  const enabled = parsed ? asRecord(parsed.enabledPlugins) : null;
+  return enabled?.[pluginId] === true;
+}
+
+function hasPiPackage(filePath: string): boolean {
+  const parsed = tryReadJsonRecord(filePath);
+  const packages = parsed?.packages;
+  if (!Array.isArray(packages)) return false;
+
+  return packages.some((entry) => {
+    const record = asRecord(entry);
+    const source =
+      typeof entry === "string"
+        ? entry
+        : typeof record?.source === "string"
+          ? record.source
+          : null;
+    return (
+      typeof source === "string" &&
+      /^npm:@plannotator\/pi-extension(?:@|$)/.test(source)
+    );
+  });
+}
+
+function tryReadJsonRecord(filePath: string): JsonRecord | null {
+  if (!existsSync(filePath)) return null;
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(filePath, "utf8"));
+    return asRecord(parsed);
+  } catch {
+    return null;
+  }
+}
+
+function hasDirectoryWithPrefix(directory: string, prefix: string): boolean {
+  try {
+    return readdirSync(directory).some((entry) => entry.startsWith(prefix));
+  } catch {
+    return false;
+  }
+}
+
+function asRecord(value: unknown): JsonRecord | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as JsonRecord
+    : null;
+}
+
+function hasOnlyKeys(
+  value: JsonRecord,
+  allowed: readonly string[],
+): boolean {
+  const allowedSet = new Set(allowed);
+  return Object.keys(value).every((key) => allowedSet.has(key));
+}
+
+function sameCommand(
+  left: string,
+  right: string,
+  platform: NodeJS.Platform,
+): boolean {
+  const normalizedLeft = left.replace(/\\/g, "/");
+  const normalizedRight = right.replace(/\\/g, "/");
+  return platform === "win32"
+    ? normalizedLeft.toLowerCase() === normalizedRight.toLowerCase()
+    : normalizedLeft === normalizedRight;
+}
+
+function samePath(
+  left: string,
+  right: string,
+  platform: NodeJS.Platform,
+): boolean {
+  const normalizedLeft = normalize(resolve(left));
+  const normalizedRight = normalize(resolve(right));
+  return platform === "win32"
+    ? normalizedLeft.toLowerCase() === normalizedRight.toLowerCase()
+    : normalizedLeft === normalizedRight;
+}
+
+function uniquePaths(paths: readonly string[]): string[] {
+  return [...new Set(paths.map((path) => normalize(resolve(path))))];
+}
+
+function getDataDirSafetyIssue(
+  dataDir: string,
+  homeDir: string,
+  tempDir: string,
+  platform: NodeJS.Platform,
+): string | null {
+  if (!isAbsolute(dataDir)) {
+    return "the data directory is not absolute";
+  }
+  const root = parse(dataDir).root;
+  if (samePath(dataDir, root, platform)) {
+    return "the data directory is a filesystem root";
+  }
+  if (samePath(dataDir, homeDir, platform)) {
+    return "the data directory is the home directory; choose a dedicated PLANNOTATOR_DATA_DIR";
+  }
+  if (isAncestorOrSame(dataDir, homeDir, platform)) {
+    return `the data directory contains the home directory ${homeDir}`;
+  }
+  if (samePath(dataDir, tempDir, platform)) {
+    return "the data directory is the shared temporary directory";
+  }
+  return null;
+}
+
+function inspectDataDir(dataDir: string): string | null {
+  try {
+    const stat = lstatSync(dataDir);
+    if (stat.isSymbolicLink()) {
+      return "the data directory is a symlink; set PLANNOTATOR_DATA_DIR to its resolved target and retry";
+    }
+    if (!stat.isDirectory()) {
+      return "the data path is not a directory";
+    }
+  } catch (error) {
+    if (isMissingPathError(error)) return null;
+    return `the data directory could not be inspected (${formatError(error)})`;
+  }
+  return null;
+}
+
+function isAncestorOrSame(
+  parent: string,
+  child: string,
+  platform: NodeJS.Platform,
+): boolean {
+  const resolvedParent = resolve(parent);
+  const resolvedChild = resolve(child);
+  const rel = platform === "win32"
+    ? relative(resolvedParent.toLowerCase(), resolvedChild.toLowerCase())
+    : relative(resolvedParent, resolvedChild);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+async function defaultRunCommand(
+  command: string,
+  args: readonly string[],
+  env?: Readonly<Record<string, string>>,
+): Promise<UninstallCommandResult> {
+  let proc: Bun.Subprocess<"ignore", "ignore", "ignore">;
+  try {
+    proc = Bun.spawn([command, ...args], {
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "ignore",
+      env: { ...process.env, ...env },
+    });
+  } catch {
+    return { exitCode: 1, timedOut: false };
+  }
+
+  let timedOut = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<number>((resolveTimeout) => {
+    timer = setTimeout(() => {
+      timedOut = true;
+      proc.kill();
+      resolveTimeout(124);
+    }, 15_000);
+  });
+  const exitCode = await Promise.race([proc.exited, timeout]);
+  if (timer) clearTimeout(timer);
+  return { exitCode, timedOut };
+}
+
+async function defaultScheduleWindowsSelfDelete(
+  target: string,
+  parent: string,
+): Promise<boolean> {
+  const powershell = Bun.which("powershell.exe") || Bun.which("pwsh.exe");
+  if (!powershell) return false;
+
+  try {
+    const proc = Bun.spawn(
+      [
+        powershell,
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        WINDOWS_SELF_DELETE_SCRIPT,
+      ],
+      {
+        stdin: "ignore",
+        stdout: "ignore",
+        stderr: "ignore",
+        detached: true,
+        env: {
+          ...process.env,
+          PLANNOTATOR_UNINSTALL_TARGET: target,
+          PLANNOTATOR_UNINSTALL_PARENT: parent,
+        },
+      },
+    );
+    proc.unref();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function pathExists(path: string): boolean {
+  try {
+    lstatSync(path);
+    return true;
+  } catch (error) {
+    return !isMissingPathError(error);
+  }
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error.code === "ENOENT" || error.code === "ENOTDIR")
+  );
+}

--- a/packages/server/uninstall.ts
+++ b/packages/server/uninstall.ts
@@ -121,6 +121,12 @@ const WINDOWS_SELF_DELETE_SCRIPT = [
   "Remove-Item -LiteralPath $parent -Force -ErrorAction SilentlyContinue",
 ].join(" ");
 
+const WINDOWS_SELF_DELETE_BOOTSTRAP_SCRIPT = [
+  "$ErrorActionPreference='Stop'",
+  "$self=(Get-Process -Id $PID).Path",
+  "Start-Process -FilePath $self -ArgumentList @('-NoProfile','-NonInteractive','-EncodedCommand',$env:PLANNOTATOR_UNINSTALL_DELETE_SCRIPT) -WindowStyle Hidden",
+].join("; ");
+
 type JsonRecord = Record<string, unknown>;
 
 /** Result returned by a host CLI command invoked during uninstall. */
@@ -1700,22 +1706,24 @@ async function defaultScheduleWindowsSelfDelete(
         "-NoProfile",
         "-NonInteractive",
         "-Command",
-        WINDOWS_SELF_DELETE_SCRIPT,
+        WINDOWS_SELF_DELETE_BOOTSTRAP_SCRIPT,
       ],
       {
         stdin: "ignore",
         stdout: "ignore",
         stderr: "ignore",
-        detached: true,
         env: {
           ...process.env,
           PLANNOTATOR_UNINSTALL_TARGET: target,
           PLANNOTATOR_UNINSTALL_PARENT: parent,
+          PLANNOTATOR_UNINSTALL_DELETE_SCRIPT: Buffer.from(
+            WINDOWS_SELF_DELETE_SCRIPT,
+            "utf16le",
+          ).toString("base64"),
         },
       },
     );
-    proc.unref();
-    return true;
+    return await proc.exited === 0;
   } catch {
     return false;
   }

--- a/scripts/install.cmd
+++ b/scripts/install.cmd
@@ -1101,6 +1101,8 @@ if !ERRORLEVEL! neq 0 (
     echo.
     echo   set PATH=%%PATH%%;!INSTALL_DIR!
 )
+echo.
+echo To uninstall later: plannotator uninstall
 goto :eof
 
 REM ======================================================================

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -420,6 +420,8 @@ function Show-PathAdvice {
         [Environment]::SetEnvironmentVariable("Path", "$userPath;$installDir", "User")
         Write-Host "Added to PATH. Restart your terminal for changes to take effect."
     }
+    Write-Host ""
+    Write-Host "To uninstall later: plannotator uninstall"
 }
 
 # Binary-only mode stops here (see the $minimal resolution near the top): the

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -495,6 +495,8 @@ print_path_advice() {
         echo "  echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ${shell_config}"
         echo "  source ${shell_config}"
     fi
+    echo ""
+    echo "To uninstall later: plannotator uninstall"
 }
 
 # Binary-only mode stops here: the binary is installed, so print PATH advice and

--- a/scripts/install.test.ts
+++ b/scripts/install.test.ts
@@ -766,6 +766,18 @@ describe("install shared behavior", () => {
   const sh = readScript("install.sh");
   const ps = readScript("install.ps1");
 
+  test("all installers advertise the conventional uninstall command", () => {
+    for (const [name, script] of [
+      ["install.sh", sh],
+      ["install.ps1", ps],
+      ["install.cmd", readScript("install.cmd")],
+    ] as const) {
+      expect(script, name).toContain(
+        "To uninstall later: plannotator uninstall",
+      );
+    }
+  });
+
   test("every extras install command uses global scope", () => {
     const files = [
       "scripts/install.sh",


### PR DESCRIPTION
## Summary

- add a conventional `plannotator uninstall` command
- preserve local plans, history, drafts, guides, and settings by default
- add explicit `--purge`, `--yes`, `--dry-run`, and recovery-oriented `--skip-hosts` modes
- remove recognized binaries, sidecars, skills, commands, hooks, caches, integrations, and detected host plugins
- preserve custom files and keep the CLI available when fail-safe cleanup needs a retry

## Safety hardening

- refuse broad, symlinked, and non-directory purge targets
- compare existing purge targets to roots, HOME, HOME ancestors, and shared temp by device/inode identity, including case aliases, symlinks, hardlinks, and bind mounts
- retain conservative lexical checks for nonexistent paths and fail closed when an existing safety relationship cannot be inspected
- treat every malformed host config as fail-safe because managed spellings cannot be classified reliably; `--skip-hosts` is the only explicit bypass
- provide `--skip-hosts` to leave plugin managers and shared/recognizable host config for manual cleanup when a host CLI or config is broken
- capture the initial data-directory device/inode, then re-run identity, root, HOME, ancestor, temp, and symlink guards immediately after awaited host commands and before the synchronous data-removal block
- refuse a swapped data directory without touching either the original directory or its replacement target, and retain the CLI for retry
- edit shared OpenCode JSON/JSONC without dropping unrelated entries or comments; preserve indentation, EOL, and trailing-newline style in strict JSON rewrites
- preserve unknown skill layouts, vendor content, scoped package caches, and external save paths
- detect disabled Claude and Droid plugin installations and installer-adopted relocated Codex hooks
- restore the exact original Windows user PATH if self-delete scheduling fails
- schedule Windows parent removal only for the dedicated `%LOCALAPPDATA%\plannotator` install directory, never a shared executable parent
- unlink installer-owned files, symlinks, and hardlink entries directly so recursive removal can only run on real directories and never traverse a link target
- report partial failures instead of claiming a complete uninstall

## Validation

- focused uninstall/CLI tests: 54 passed, 0 failed (including case-variant HOME and post-host-command path-swap regressions)
- full `bun test` suite: 2,664 passed, 198 skipped, 0 failed
- `bun run typecheck`
- marketing production build
- Windows x64 and ARM64 compiled CLI cross-builds
- workflow YAML parsing and `git diff --check`
- self-review completed after the adversarial review fixes

## Windows QA

- focused uninstall tests run on `windows-latest` for every PR
- the existing compiled-binary Windows smoke runs preserve-data and purge flows
- coverage verifies PATH cleanup/rollback, delayed running-EXE deletion, target-preserving symlink/hardlink cleanup, and that legacy `~/.local/bin` installs never schedule shared-parent removal
- all filesystem fixtures use isolated temporary homes; the compiled smoke restores the disposable runner user PATH in `finally`
