### PR TITLE
fix(annotate): enforce archive read-only surfaces

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,8 @@ jobs:
           packages/ui/hooks/useLinkedDoc.test.tsx
           packages/ui/components/DocBadges.test.tsx
           packages/editor/planDiffAutoExit.test.tsx
+          packages/editor/App.archiveReadOnly.test.tsx
+          packages/editor/actionsLabelMode.test.ts
 
   pi-extension-ai-runtime-windows:
     # Exercises the Pi extension's Node/jiti server mirror on Windows with an

--- a/apps/pi-extension/server/serverPlan.ts
+++ b/apps/pi-extension/server/serverPlan.ts
@@ -53,6 +53,7 @@ import {
 } from "./reference.ts";
 import { handleFileBrowserStreamRequest } from "./file-browser-watch.ts";
 import { warmFileListCache } from "../generated/resolve-file.ts";
+import { isArchiveDocumentMutation } from "../generated/archive-mode.ts";
 
 export interface PlanReviewDecision {
 	approved: boolean;
@@ -169,6 +170,11 @@ export async function startPlanReviewServer(options: {
 		if (url.pathname === "/api/done" && req.method === "POST") {
 			resolveDone?.();
 			json(res, { ok: true });
+		} else if (
+			options.mode === "archive" &&
+			isArchiveDocumentMutation(req.method ?? "GET", url.pathname)
+		) {
+			json(res, { error: "Archive is read-only" }, 403);
 		} else if (url.pathname === "/api/archive/plans" && req.method === "GET") {
 			const customPath = url.searchParams.get("customPath") || undefined;
 			if (!cachedArchivePlans)

--- a/apps/pi-extension/vendor.sh
+++ b/apps/pi-extension/vendor.sh
@@ -29,7 +29,7 @@ for f in config-types storage-types workspace-status-types; do
 done
 
 # Everything else in the original flat list stays sourced from packages/shared.
-for f in prompts review-core diff-paths cli-pagination jj-core gitbutler-core vcs-core review-args draft annotate-history pr-types pr-context-live pr-artifact-document pr-provider pr-stack pr-github pr-gitlab checklist integrations-common repo reference-common resolve-file annotate-reference-roots-node worktree worktree-pool html-to-markdown html-diff html-assets html-assets-node url-to-markdown tour annotate-args at-reference review-workspace-node review-workspace pfm-reminder improvement-hooks code-nav data-dir semantic-diff-types semantic-diff single-flight source-save-node review-profiles guide guide-store commit-avatars commit-history port-range annotate-client-lease annotate-decision; do
+for f in prompts review-core diff-paths cli-pagination jj-core gitbutler-core vcs-core review-args draft annotate-history pr-types pr-context-live pr-artifact-document pr-provider pr-stack pr-github pr-gitlab checklist integrations-common repo reference-common resolve-file annotate-reference-roots-node worktree worktree-pool html-to-markdown html-diff html-assets html-assets-node url-to-markdown tour annotate-args at-reference review-workspace-node review-workspace pfm-reminder improvement-hooks code-nav data-dir semantic-diff-types semantic-diff single-flight source-save-node review-profiles guide guide-store commit-avatars commit-history port-range annotate-client-lease annotate-decision archive-mode; do
   src="../../packages/shared/$f.ts"
   printf '// @generated — DO NOT EDIT. Source: packages/shared/%s.ts\n' "$f" | cat - "$src" > "generated/$f.ts"
 done

--- a/packages/editor/App.archiveReadOnly.test.tsx
+++ b/packages/editor/App.archiveReadOnly.test.tsx
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+const hasDom = typeof document !== "undefined";
+
+if (hasDom) {
+  document.cookie = "plannotator-look-feel-announcement-seen=2; path=/";
+  document.cookie = "plannotator-vim-mode-announcement-seen=2; path=/";
+  document.cookie = "plannotator-plan-ai-announcement-seen=1; path=/";
+}
+
+const appModule = hasDom ? await import("./App") : null;
+const App = appModule?.default as typeof import("./App")["default"];
+const originalFetch = globalThis.fetch;
+const originalEventSource = globalThis.EventSource;
+
+interface PlanResponse {
+  readonly plan: string;
+  readonly origin: "codex";
+  readonly mode: "archive" | "annotate";
+  readonly filePath?: string;
+  readonly archivePlans?: readonly [{
+    readonly filename: string;
+    readonly status: "approved";
+    readonly timestamp: string;
+    readonly title: string;
+  }];
+  readonly sharingEnabled: false;
+  readonly serverConfig: Record<string, never>;
+}
+
+class SilentEventSource {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
+
+  readonly CONNECTING = 0;
+  readonly OPEN = 1;
+  readonly CLOSED = 2;
+  readonly readyState = SilentEventSource.OPEN;
+  readonly url: string;
+  readonly withCredentials = false;
+  onerror: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onopen: ((event: Event) => void) | null = null;
+
+  constructor(url: string | URL) {
+    this.url = String(url);
+  }
+
+  addEventListener(): void {}
+  close(): void {}
+  dispatchEvent(): boolean { return true; }
+  removeEventListener(): void {}
+}
+
+let root: Root | null = null;
+let host: HTMLElement | null = null;
+let requestedRoutes: string[] = [];
+
+function responseFor(planResponse: PlanResponse): typeof fetch {
+  return async (input, init) => {
+    const rawUrl = input instanceof Request ? input.url : String(input);
+    const method = input instanceof Request ? input.method : init?.method ?? "GET";
+    if (rawUrl.startsWith("https://api.github.com/")) {
+      return new Response(null, { status: 404 });
+    }
+
+    const url = new URL(rawUrl, "http://localhost");
+    requestedRoutes.push(`${method} ${url.pathname}`);
+    if (url.pathname === "/api/plan") return Response.json(planResponse);
+    if (url.pathname === "/api/archive/plans") {
+      return Response.json({ plans: planResponse.archivePlans ?? [] });
+    }
+    if (url.pathname === "/api/archive/plan") {
+      return Response.json({ markdown: planResponse.plan, filepath: "saved.md" });
+    }
+    if (url.pathname === "/api/ai/capabilities") {
+      return Response.json({ available: false, providers: [] });
+    }
+    if (url.pathname === "/api/open-in/apps") {
+      return Response.json({
+        available: true,
+        apps: [{ id: "reveal", label: "Finder", kind: "file-manager", icon: "finder" }],
+      });
+    }
+    if (url.pathname === "/api/draft") {
+      return Response.json({ error: "Not found" }, { status: 404 });
+    }
+    return Response.json({});
+  };
+}
+
+async function mountApp(planResponse: PlanResponse): Promise<void> {
+  requestedRoutes = [];
+  globalThis.fetch = responseFor(planResponse);
+  // SAFETY: the App only uses EventSource's constructor, handlers, and close;
+  // this test double implements those browser-facing members without I/O.
+  globalThis.EventSource = SilentEventSource as unknown as typeof EventSource;
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  root = createRoot(host);
+  await act(async () => {
+    root?.render(<App />);
+  });
+
+  for (let attempt = 0; attempt < 20 && !document.body.textContent?.includes(planResponse.plan.slice(2)); attempt += 1) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+}
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  root = null;
+  host?.remove();
+  host = null;
+  globalThis.fetch = originalFetch;
+  globalThis.EventSource = originalEventSource;
+  if (hasDom) document.body.replaceChildren();
+});
+
+describe.if(hasDom)("App document permissions", () => {
+  test("standalone archive renders Markdown without mutation entry points", async () => {
+    await mountApp({
+      plan: "# Archived document",
+      origin: "codex",
+      mode: "archive",
+      archivePlans: [{
+        filename: "saved.md",
+        status: "approved",
+        timestamp: "2026-07-31T00:00:00.000Z",
+        title: "Archived document",
+      }],
+      sharingEnabled: false,
+      serverConfig: {},
+    });
+
+    expect(document.body.textContent).toContain("Archived document");
+    expect(document.querySelector('button[title="Add global comment"]')).toBeNull();
+    expect(document.querySelector('button[title="Attachments"]')).toBeNull();
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent("keydown", {
+        key: "Enter",
+        metaKey: true,
+      }));
+    });
+    expect(requestedRoutes).not.toContain("POST /api/approve");
+    expect(requestedRoutes).not.toContain("POST /api/deny");
+  });
+
+  test("normal annotate remains writable", async () => {
+    await mountApp({
+      plan: "# Writable document",
+      origin: "codex",
+      mode: "annotate",
+      filePath: "/tmp/writable.md",
+      sharingEnabled: false,
+      serverConfig: {},
+    });
+
+    expect(document.body.textContent).toContain("Writable document");
+    expect(document.querySelector('button[title="Add global comment"]')).not.toBeNull();
+    expect(document.querySelector('button[title="Attachments"]')).not.toBeNull();
+  });
+});

--- a/packages/editor/App.archiveReadOnly.test.tsx
+++ b/packages/editor/App.archiveReadOnly.test.tsx
@@ -10,6 +10,7 @@ if (hasDom) {
   document.cookie = "plannotator-plan-ai-announcement-seen=1; path=/";
 }
 
+const storageModule = hasDom ? await import("@plannotator/ui/utils/storage") : null;
 const appModule = hasDom ? await import("./App") : null;
 const App = appModule?.default as typeof import("./App")["default"];
 const originalFetch = globalThis.fetch;
@@ -59,6 +60,27 @@ let root: Root | null = null;
 let host: HTMLElement | null = null;
 let requestedRoutes: string[] = [];
 
+const noteSettings = new Map<string, string>();
+
+function configureNotesApps(): void {
+  storageModule?.setStorageBackend({
+    getItem: (key) => noteSettings.get(key) ?? null,
+    setItem: (key, value) => noteSettings.set(key, value),
+    removeItem: (key) => { noteSettings.delete(key); },
+  });
+  noteSettings.set("plannotator-obsidian-enabled", "true");
+  noteSettings.set("plannotator-obsidian-vault", "TestVault");
+  noteSettings.set("plannotator-bear-enabled", "true");
+  noteSettings.set("plannotator-octarine-enabled", "true");
+  noteSettings.set("plannotator-octarine-workspace", "TestWorkspace");
+  noteSettings.set("plannotator-default-notes-app", "obsidian");
+}
+
+function findButton(label: string): HTMLButtonElement | undefined {
+  return Array.from(document.querySelectorAll("button"))
+    .find((button) => button.textContent?.trim() === label);
+}
+
 function responseFor(planResponse: PlanResponse): typeof fetch {
   return async (input, init) => {
     const rawUrl = input instanceof Request ? input.url : String(input);
@@ -88,6 +110,15 @@ function responseFor(planResponse: PlanResponse): typeof fetch {
     if (url.pathname === "/api/draft") {
       return Response.json({ error: "Not found" }, { status: 404 });
     }
+    if (url.pathname === "/api/save-notes") {
+      return Response.json({
+        results: {
+          obsidian: { success: true },
+          bear: { success: true },
+          octarine: { success: true },
+        },
+      });
+    }
     return Response.json({});
   };
 }
@@ -105,7 +136,8 @@ async function mountApp(planResponse: PlanResponse): Promise<void> {
     root?.render(<App />);
   });
 
-  for (let attempt = 0; attempt < 20 && !document.body.textContent?.includes(planResponse.plan.slice(2)); attempt += 1) {
+  const expectedTitle = planResponse.plan.match(/^#\s+(.+)$/m)?.[1] ?? planResponse.plan;
+  for (let attempt = 0; attempt < 20 && !document.body.textContent?.includes(expectedTitle); attempt += 1) {
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
@@ -119,13 +151,16 @@ afterEach(async () => {
   host = null;
   globalThis.fetch = originalFetch;
   globalThis.EventSource = originalEventSource;
+  noteSettings.clear();
+  storageModule?.resetStorageBackend();
   if (hasDom) document.body.replaceChildren();
 });
 
 describe.if(hasDom)("App document permissions", () => {
   test("standalone archive renders Markdown without mutation entry points", async () => {
+    configureNotesApps();
     await mountApp({
-      plan: "# Archived document",
+      plan: "# Archived document\n\n```typescript\nconst archived = true;\n```",
       origin: "codex",
       mode: "archive",
       archivePlans: [{
@@ -142,17 +177,60 @@ describe.if(hasDom)("App document permissions", () => {
     expect(document.querySelector('button[title="Add global comment"]')).toBeNull();
     expect(document.querySelector('button[title="Attachments"]')).toBeNull();
 
+    const codeBlock = document.querySelector<HTMLElement>('pre')?.closest<HTMLElement>('[data-block-id]');
+    const code = codeBlock?.querySelector('code');
+    if (!codeBlock || !code) throw new Error("Archived fenced code block did not render");
+    const renderedCode = code.innerHTML;
+    await act(async () => {
+      codeBlock.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+      codeBlock.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(document.querySelector('.annotation-toolbar')).toBeNull();
+    expect(document.querySelector('textarea')).toBeNull();
+    expect(document.querySelector('[data-quick-label-picker]')).toBeNull();
+    expect(code.querySelector('mark')).toBeNull();
+    expect(code.innerHTML).toBe(renderedCode);
+
+    const optionsButton = document.querySelector<HTMLButtonElement>('button[title="Options"]');
+    if (!optionsButton) throw new Error("Options menu trigger did not render");
+    await act(async () => optionsButton.click());
+    expect(findButton("Save to Obsidian")).toBeUndefined();
+    expect(findButton("Save to Bear")).toBeUndefined();
+    expect(findButton("Save to Octarine")).toBeUndefined();
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent("keydown", {
+        key: "s",
+        metaKey: true,
+      }));
+      window.dispatchEvent(new KeyboardEvent("keydown", {
+        key: "s",
+        ctrlKey: true,
+      }));
+    });
+    expect(requestedRoutes).not.toContain("POST /api/save-notes");
+
     await act(async () => {
       window.dispatchEvent(new KeyboardEvent("keydown", {
         key: "Enter",
         metaKey: true,
       }));
+      window.dispatchEvent(new KeyboardEvent("keydown", {
+        key: "Enter",
+        ctrlKey: true,
+      }));
     });
     expect(requestedRoutes).not.toContain("POST /api/approve");
     expect(requestedRoutes).not.toContain("POST /api/deny");
+
+    const exportButton = findButton("Export");
+    if (!exportButton) throw new Error("Export menu item did not render");
+    await act(async () => exportButton.click());
+    expect(findButton("Notes")).toBeUndefined();
   });
 
   test("normal annotate remains writable", async () => {
+    configureNotesApps();
     await mountApp({
       plan: "# Writable document",
       origin: "codex",
@@ -165,5 +243,22 @@ describe.if(hasDom)("App document permissions", () => {
     expect(document.body.textContent).toContain("Writable document");
     expect(document.querySelector('button[title="Add global comment"]')).not.toBeNull();
     expect(document.querySelector('button[title="Attachments"]')).not.toBeNull();
+
+    const optionsButton = document.querySelector<HTMLButtonElement>('button[title="Options"]');
+    if (!optionsButton) throw new Error("Options menu trigger did not render");
+    await act(async () => optionsButton.click());
+    expect(findButton("Save to Obsidian")).not.toBeUndefined();
+    expect(findButton("Save to Bear")).not.toBeUndefined();
+    expect(findButton("Save to Octarine")).not.toBeUndefined();
+
+    requestedRoutes = [];
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent("keydown", {
+        key: "s",
+        metaKey: true,
+      }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(requestedRoutes).toContain("POST /api/save-notes");
   });
 });

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -3588,6 +3588,8 @@ const App: React.FC = () => {
   };
 
   const handleQuickSaveToNotes = async (target: 'obsidian' | 'bear' | 'octarine') => {
+    if (documentReadOnly) return;
+
     const body: { obsidian?: object; bear?: object; octarine?: object } = {};
     // Mid-edit saves describe the live buffer, matching handleApprove.
     const quickSaveMarkdown = isEditingMarkdown
@@ -3856,6 +3858,7 @@ const App: React.FC = () => {
   useEffect(() => {
     const handleSaveShortcut = (e: KeyboardEvent) => {
       if (e.key !== 's' || !(e.metaKey || e.ctrlKey)) return;
+      if (documentReadOnly) return;
 
       const tag = (e.target as HTMLElement)?.tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA') return;
@@ -3898,7 +3901,7 @@ const App: React.FC = () => {
   }, [
     showExport, showFeedbackPrompt, showClaudeCodeWarning, showSourceFileEditWarning, showExitWarning, showApproveWithNotesConfirmation, showAgentWarning,
     showPermissionModeSetup, pendingPasteImage,
-    submitted, isApiMode, isEditingMarkdown, handleSaveEditedSourceFile, displayedMarkdown, annotationsOutput,
+    submitted, isApiMode, documentReadOnly, isEditingMarkdown, handleSaveEditedSourceFile, displayedMarkdown, annotationsOutput,
   ]);
 
   // Cmd/Ctrl+P keyboard shortcut — print plan
@@ -4824,7 +4827,7 @@ const App: React.FC = () => {
           taterSprite={taterMode ? <TaterSpritePullup /> : undefined}
           sharingEnabled={canShareCurrentSession}
           markdown={markdown}
-          isApiMode={isApiMode}
+          isApiMode={isApiMode && !documentReadOnly}
           initialTab={initialExportTab}
           wrapCopiedAnnotations={wrapCopiedFeedback}
         />

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -101,6 +101,7 @@ import {
   type SourceSaveResponse,
 } from '@plannotator/shared/source-save';
 import type { AgentTerminalCapability } from '@plannotator/shared/agent-terminal';
+import { observeActionsLabelMode } from './actionsLabelMode';
 // Demo content toggle. Default: the original Real-time Collaboration plan.
 // Opt-in diff-engine stress test: `VITE_DIFF_DEMO=1 bun run dev:hook` swaps
 // in the 20-case Auth Service Refactor test plan. dev-mock-api.ts reads the
@@ -915,6 +916,7 @@ const App: React.FC = () => {
     markdown, viewerRef, linkedDocHook,
     setMarkdown, setAnnotations, setSelectedAnnotationId, setSubmitted,
   });
+  const documentReadOnly = archive.archiveMode;
 
   const canUseWideMode = useMemo(() => canUseAnnotateWideMode({
     archiveMode: archive.archiveMode,
@@ -1340,7 +1342,9 @@ const App: React.FC = () => {
   const activeSection = useActiveSection(containerRef, headingCount, scrollViewport);
 
   const { editorAnnotations, deleteEditorAnnotation } = useEditorAnnotations();
-  const { externalAnnotations, updateExternalAnnotation, deleteExternalAnnotation } = useExternalAnnotations<Annotation>({ enabled: isApiMode && !goalSetupMode });
+  const { externalAnnotations, updateExternalAnnotation, deleteExternalAnnotation } = useExternalAnnotations<Annotation>({
+    enabled: isApiMode && !goalSetupMode && !documentReadOnly,
+  });
 
   // Drive DOM highlights for SSE-delivered external annotations. Disabled
   // while a linked doc overlay is open (Viewer DOM is hidden) and while the
@@ -1557,15 +1561,9 @@ const App: React.FC = () => {
 
     const el = planAreaRef.current;
     if (!el) return;
-    const bucket = (w: number): ActionsLabelMode =>
-      w >= 800 ? 'full' : w >= 680 ? 'short' : 'icon';
-    setActionsLabelMode(bucket(el.getBoundingClientRect().width));
-    const ro = new ResizeObserver(([entry]) => {
-      const next = bucket(entry.contentRect.width);
+    return observeActionsLabelMode(el, (next) => {
       setActionsLabelMode((prev) => (prev === next ? prev : next));
     });
-    ro.observe(el);
-    return () => ro.disconnect();
   }, [isLoading, isSharedSession]);
 
   // The user's current direct-edit text: the open editor buffer, else the
@@ -1599,7 +1597,7 @@ const App: React.FC = () => {
     getEditedMarkdown: getDraftEditedMarkdown,
     getEditedDocuments: editableDocuments.getDraftDocuments,
     getSavedFileChanges: editableDocuments.getDraftSavedFileChanges,
-    isApiMode: isApiMode && !goalSetupMode,
+    isApiMode: isApiMode && !goalSetupMode && !documentReadOnly,
     isSharedSession,
     // isSubmitting counts: a save firing while approve/deny is in flight can
     // land after the server's draft delete and ghost a "Draft Recovered"
@@ -2624,6 +2622,7 @@ const App: React.FC = () => {
 
   // Global paste listener for image attachments
   useEffect(() => {
+    if (documentReadOnly) return;
     const handlePaste = (e: ClipboardEvent) => {
       const items = e.clipboardData?.items;
       if (!items) return;
@@ -2645,11 +2644,11 @@ const App: React.FC = () => {
 
     document.addEventListener('paste', handlePaste);
     return () => document.removeEventListener('paste', handlePaste);
-  }, [globalAttachments]);
+  }, [documentReadOnly, globalAttachments]);
 
   // Handle paste annotator accept — name comes from ImageAnnotator
   const handlePasteAnnotatorAccept = async (blob: Blob, hasDrawings: boolean, name: string) => {
-    if (!pendingPasteImage) return;
+    if (documentReadOnly || !pendingPasteImage) return;
 
     try {
       const formData = new FormData();
@@ -3113,6 +3112,9 @@ const App: React.FC = () => {
       // Don't intercept in demo/share mode (no API)
       if (!isApiMode) return;
 
+      // Standalone archive is navigable but has no review decision to submit.
+      if (documentReadOnly) return;
+
       // While the markdown editor is open, submit shortcuts belong to editing,
       // not the review session.
       if (isEditingMarkdown) return;
@@ -3177,13 +3179,14 @@ const App: React.FC = () => {
   }, [
     showExport, showImport, showFeedbackPrompt, showClaudeCodeWarning, showSourceFileEditWarning, showExitWarning, showApproveWithNotesConfirmation, showAgentWarning,
     showPermissionModeSetup, pendingPasteImage,
-    submitted, isSubmitting, isExiting, goalSetupAction.isSubmitting, isApiMode, isEditingMarkdown, linkedDocHook.isActive, annotations.length, codeAnnotations.length, externalAnnotations.length, annotateMode,
+    submitted, isSubmitting, isExiting, goalSetupAction.isSubmitting, isApiMode, documentReadOnly, isEditingMarkdown, linkedDocHook.isActive, annotations.length, codeAnnotations.length, externalAnnotations.length, annotateMode,
     gate, approvalNotesSupported, hasFeedbackToSend, goalSetupMode, goalSetupAction.canSubmit, isAgentTerminalReady,
     annotateSource, origin, getAgentWarning,
     maybeConfirmUnsavedSourceFileEdits,
   ]);
 
   const handleAddAnnotation = (ann: Annotation) => {
+    if (documentReadOnly) return;
     setAnnotations(prev => [...prev, ann]);
     setSelectedAnnotationId(ann.id);
     setSelectedCodeAnnotationId(null);
@@ -3197,6 +3200,7 @@ const App: React.FC = () => {
   }, [isMobile, wideModeType]);
 
   const handleAddCodeAnnotation = React.useCallback((input: CodeFileAnnotationInput) => {
+    if (documentReadOnly) return;
     const annotation: CodeAnnotation = {
       id: generateId('code-ann'),
       type: 'comment',
@@ -3214,7 +3218,7 @@ const App: React.FC = () => {
     setCodeAnnotations(prev => [...prev, annotation]);
     setSelectedAnnotationId(null);
     setSelectedCodeAnnotationId(annotation.id);
-  }, []);
+  }, [documentReadOnly]);
 
   // The code popout is full-viewport modal — the annotation panel is behind it.
   // This handler only fires when the popout is closed (sidebar visible), so
@@ -3229,16 +3233,19 @@ const App: React.FC = () => {
   }, [codeAnnotations, codeFilePopout.open, isMobile, wideModeType]);
 
   const handleDeleteCodeAnnotation = React.useCallback((id: string) => {
+    if (documentReadOnly) return;
     setCodeAnnotations(prev => prev.filter(a => a.id !== id));
     if (selectedCodeAnnotationId === id) setSelectedCodeAnnotationId(null);
-  }, [selectedCodeAnnotationId]);
+  }, [documentReadOnly, selectedCodeAnnotationId]);
 
   const handleEditCodeAnnotation = React.useCallback((id: string, updates: Partial<CodeAnnotation>) => {
+    if (documentReadOnly) return;
     setCodeAnnotations(prev => prev.map(a => a.id === id ? { ...a, ...updates } : a));
-  }, []);
+  }, [documentReadOnly]);
 
   // Core annotation removal — highlight cleanup + state filter + selection clear
   const removeAnnotation = (id: string) => {
+    if (documentReadOnly) return;
     viewerRef.current?.removeHighlight(id);
     setAnnotations(prev => prev.filter(a => a.id !== id));
     if (selectedAnnotationId === id) setSelectedAnnotationId(null);
@@ -3253,6 +3260,7 @@ const App: React.FC = () => {
   });
 
   const handleDeleteAnnotation = (id: string) => {
+    if (documentReadOnly) return;
     const ann = allAnnotations.find(a => a.id === id);
     // External annotations (live in SSE hook) route to the SSE hook, not local state.
     // Check membership by ID — source alone is insufficient because share-imported
@@ -3272,6 +3280,7 @@ const App: React.FC = () => {
   };
 
   const handleEditAnnotation = (id: string, updates: Partial<Annotation>) => {
+    if (documentReadOnly) return;
     const ann = allAnnotations.find(a => a.id === id);
     if (ann?.source && externalAnnotations.some(e => e.id === id)) {
       updateExternalAnnotation(id, updates);
@@ -3283,19 +3292,22 @@ const App: React.FC = () => {
   };
 
   const handleIdentityChange = useCallback((oldIdentity: string, newIdentity: string) => {
+    if (documentReadOnly) return;
     setAnnotations(prev => prev.map(ann =>
       ann.author === oldIdentity ? { ...ann, author: newIdentity } : ann
     ));
     setCodeAnnotations(prev => prev.map(ann =>
       ann.author === oldIdentity ? { ...ann, author: newIdentity } : ann
     ));
-  }, []);
+  }, [documentReadOnly]);
 
   const handleAddGlobalAttachment = (image: ImageAttachment) => {
+    if (documentReadOnly) return;
     setGlobalAttachments(prev => [...prev, image]);
   };
 
   const handleRemoveGlobalAttachment = (path: string) => {
+    if (documentReadOnly) return;
     setGlobalAttachments(prev => prev.filter(p => p.path !== path));
   };
 
@@ -4595,6 +4607,7 @@ const App: React.FC = () => {
                     diffActive={isPlanDiffActive && !!htmlDiffHtml}
                     onToggleDiff={() => setIsPlanDiffActive((v) => !v)}
                     onAskAI={canUseDocumentAskAI ? handleAskAI : undefined}
+                    readOnly={documentReadOnly}
                   />
                 ) : isEditingMarkdown ? (
                   <MarkdownEditor
@@ -4675,6 +4688,7 @@ const App: React.FC = () => {
                     checkboxOverrides={checkbox.overrides}
                     actionsLabelMode={actionsLabelMode}
                     onAskAI={canUseDocumentAskAI ? handleAskAI : undefined}
+                    readOnly={documentReadOnly}
                   />
                 )}
               </div>
@@ -4718,6 +4732,7 @@ const App: React.FC = () => {
               onDiscard: item.id === 'plan' ? () => handleDiscardEdits() : undefined,
             })) ?? null}
             onOtherFileAnnotationsClick={handleFlashAnnotatedFiles}
+            readOnly={documentReadOnly}
           />
           {isPanelOpen && rightSidebarTab === 'ai' && wideModeType === null && !goalSetupMode && canUseAskAI && (
             <aside
@@ -4778,9 +4793,9 @@ const App: React.FC = () => {
             {...codeFilePopout.popoutProps}
             annotations={codeAnnotations.filter((ann) => ann.filePath === codeFilePopout.popoutProps?.filepath)}
             selectedAnnotationId={selectedCodeAnnotationId}
-            onAddAnnotation={handleAddCodeAnnotation}
-            onEditAnnotation={handleEditCodeAnnotation}
-            onDeleteAnnotation={handleDeleteCodeAnnotation}
+            onAddAnnotation={documentReadOnly ? undefined : handleAddCodeAnnotation}
+            onEditAnnotation={documentReadOnly ? undefined : handleEditCodeAnnotation}
+            onDeleteAnnotation={documentReadOnly ? undefined : handleDeleteCodeAnnotation}
             onSelectAnnotation={(id) => {
               setSelectedAnnotationId(null);
               setSelectedCodeAnnotationId(id);

--- a/packages/editor/actionsLabelMode.test.ts
+++ b/packages/editor/actionsLabelMode.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  actionsLabelModeForWidth,
+  observeActionsLabelMode,
+} from "./actionsLabelMode";
+
+const originalResizeObserver = globalThis.ResizeObserver;
+
+class ControllableResizeObserver implements ResizeObserver {
+  static latest: ControllableResizeObserver | null = null;
+
+  readonly callback: ResizeObserverCallback;
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    ControllableResizeObserver.latest = this;
+  }
+
+  disconnect(): void {}
+  observe(): void {}
+  unobserve(): void {}
+}
+
+afterEach(() => {
+  globalThis.ResizeObserver = originalResizeObserver;
+  ControllableResizeObserver.latest = null;
+});
+
+describe("action-label responsive measurement", () => {
+  test("maps exact thresholds without overlap", () => {
+    expect(actionsLabelModeForWidth(800)).toBe("full");
+    expect(actionsLabelModeForWidth(799.99)).toBe("short");
+    expect(actionsLabelModeForWidth(680)).toBe("short");
+    expect(actionsLabelModeForWidth(679.99)).toBe("icon");
+  });
+
+  test("uses the border box for both initial and observer-triggered measurements", () => {
+    globalThis.ResizeObserver = ControllableResizeObserver;
+    let borderBoxWidth = 800;
+    const element = {
+      getBoundingClientRect: () => ({ width: borderBoxWidth }),
+    };
+    const modes: string[] = [];
+
+    // SAFETY: observeActionsLabelMode only reads getBoundingClientRect and passes
+    // the same object to this test's no-op ResizeObserver implementation.
+    const disconnect = observeActionsLabelMode(
+      element as HTMLElement,
+      (mode) => modes.push(mode),
+    );
+    expect(modes).toEqual(["full"]);
+
+    borderBoxWidth = 679;
+    const observer = ControllableResizeObserver.latest;
+    if (!observer) throw new Error("ResizeObserver was not installed");
+    const contentBoxEntry: ResizeObserverEntry = {
+      target: element as HTMLElement,
+      contentRect: {
+        width: 900,
+        height: 0,
+        x: 0,
+        y: 0,
+        top: 0,
+        right: 900,
+        bottom: 0,
+        left: 0,
+        toJSON: () => ({}),
+      },
+      borderBoxSize: [],
+      contentBoxSize: [],
+      devicePixelContentBoxSize: [],
+    };
+    observer.callback([contentBoxEntry], observer);
+
+    expect(modes).toEqual(["full", "icon"]);
+    disconnect();
+  });
+});

--- a/packages/editor/actionsLabelMode.test.ts
+++ b/packages/editor/actionsLabelMode.test.ts
@@ -10,14 +10,22 @@ class ControllableResizeObserver implements ResizeObserver {
   static latest: ControllableResizeObserver | null = null;
 
   readonly callback: ResizeObserverCallback;
+  observedTarget: Element | null = null;
+  observedOptions: ResizeObserverOptions | undefined;
+  disconnected = false;
 
   constructor(callback: ResizeObserverCallback) {
     this.callback = callback;
     ControllableResizeObserver.latest = this;
   }
 
-  disconnect(): void {}
-  observe(): void {}
+  disconnect(): void {
+    this.disconnected = true;
+  }
+  observe(target: Element, options?: ResizeObserverOptions): void {
+    this.observedTarget = target;
+    this.observedOptions = options;
+  }
   unobserve(): void {}
 }
 
@@ -50,9 +58,11 @@ describe("action-label responsive measurement", () => {
     );
     expect(modes).toEqual(["full"]);
 
-    borderBoxWidth = 679;
     const observer = ControllableResizeObserver.latest;
     if (!observer) throw new Error("ResizeObserver was not installed");
+    expect(observer.observedTarget).toBe(element as HTMLElement);
+    expect(observer.observedOptions).toEqual({ box: "border-box" });
+
     const contentBoxEntry: ResizeObserverEntry = {
       target: element as HTMLElement,
       contentRect: {
@@ -66,13 +76,19 @@ describe("action-label responsive measurement", () => {
         left: 0,
         toJSON: () => ({}),
       },
-      borderBoxSize: [],
+      borderBoxSize: [{ inlineSize: 679, blockSize: 0 }],
       contentBoxSize: [],
       devicePixelContentBoxSize: [],
     };
     observer.callback([contentBoxEntry], observer);
 
     expect(modes).toEqual(["full", "icon"]);
+
+    borderBoxWidth = 700;
+    observer.callback([{ ...contentBoxEntry, borderBoxSize: [] }], observer);
+    expect(modes).toEqual(["full", "icon", "short"]);
+
     disconnect();
+    expect(observer.disconnected).toBe(true);
   });
 });

--- a/packages/editor/actionsLabelMode.ts
+++ b/packages/editor/actionsLabelMode.ts
@@ -13,12 +13,18 @@ export function observeActionsLabelMode(
   element: HTMLElement,
   onModeChange: (mode: ActionsLabelMode) => void,
 ): () => void {
-  const update = () => {
-    onModeChange(actionsLabelModeForWidth(element.getBoundingClientRect().width));
+  const update = (entries?: readonly ResizeObserverEntry[]) => {
+    const entry = entries?.find((candidate) => candidate.target === element);
+    const borderBoxSize = entry?.borderBoxSize;
+    const measuredBorderBox = Array.isArray(borderBoxSize)
+      ? borderBoxSize[0]
+      : borderBoxSize;
+    const width = measuredBorderBox?.inlineSize ?? element.getBoundingClientRect().width;
+    onModeChange(actionsLabelModeForWidth(width));
   };
 
   update();
-  const observer = new ResizeObserver(update);
-  observer.observe(element);
+  const observer = new ResizeObserver((entries) => update(entries));
+  observer.observe(element, { box: "border-box" });
   return () => observer.disconnect();
 }

--- a/packages/editor/actionsLabelMode.ts
+++ b/packages/editor/actionsLabelMode.ts
@@ -1,0 +1,24 @@
+import type { ActionsLabelMode } from "@plannotator/ui/types";
+
+/** Map the plan area's border-box width to the available action-label space. */
+export function actionsLabelModeForWidth(width: number): ActionsLabelMode {
+  return width >= 800 ? "full" : width >= 680 ? "short" : "icon";
+}
+
+/**
+ * Measure and observe action-label space using the element's border box for
+ * both the initial read and every ResizeObserver notification.
+ */
+export function observeActionsLabelMode(
+  element: HTMLElement,
+  onModeChange: (mode: ActionsLabelMode) => void,
+): () => void {
+  const update = () => {
+    onModeChange(actionsLabelModeForWidth(element.getBoundingClientRect().width));
+  };
+
+  update();
+  const observer = new ResizeObserver(update);
+  observer.observe(element);
+  return () => observer.disconnect();
+}

--- a/packages/editor/components/AppHeader.tsx
+++ b/packages/editor/components/AppHeader.tsx
@@ -376,9 +376,9 @@ export const AppHeader = React.memo<AppHeaderProps>(({
           sharingEnabled={canShareCurrentSession}
           isApiMode={isApiMode}
           agentInstructionsEnabled={agentInstructionsEnabled}
-          obsidianConfigured={!goalSetupMode && obsidianConfigured}
-          bearConfigured={!goalSetupMode && bearConfigured}
-          octarineConfigured={!goalSetupMode && octarineConfigured}
+          obsidianConfigured={!archiveMode && !goalSetupMode && obsidianConfigured}
+          bearConfigured={!archiveMode && !goalSetupMode && bearConfigured}
+          octarineConfigured={!archiveMode && !goalSetupMode && octarineConfigured}
         />
       </div>
     </header>

--- a/packages/server/api-404-guard.test.ts
+++ b/packages/server/api-404-guard.test.ts
@@ -114,6 +114,40 @@ const serverCases = [
   },
 ] satisfies readonly ServerCase[];
 
+const archiveServerCases = [
+  {
+    name: "Bun plan",
+    start: () =>
+      startBunPlanServer({
+        plan: "# Test Plan",
+        origin: "claude-code",
+        htmlContent: SPA_HTML,
+        mode: "archive",
+        customPlanPath: archivePath,
+      }),
+  },
+  {
+    name: "Pi plan",
+    start: () =>
+      startPiPlanServer({
+        plan: "# Test Plan",
+        origin: "pi",
+        htmlContent: SPA_HTML,
+        mode: "archive",
+        customPlanPath: archivePath,
+      }),
+  },
+] as const;
+
+const archiveMutationRequests = [
+  { path: "/api/approve", method: "POST" },
+  { path: "/api/deny", method: "POST" },
+  { path: "/api/draft", method: "POST" },
+  { path: "/api/draft", method: "DELETE" },
+  { path: "/api/save-notes", method: "POST" },
+  { path: "/api/upload", method: "POST" },
+] as const;
+
 async function expectJsonNotFound(
   server: RunningServer,
   requestPath: string,
@@ -221,6 +255,24 @@ describe("API route 404 guards", () => {
         expect(spaResponse.status).toBe(200);
         expect(spaResponse.headers.get("content-type")).toContain("text/html");
         expect(await spaResponse.text()).toBe(SPA_HTML);
+      } finally {
+        server.stop();
+      }
+    });
+  }
+
+  for (const serverCase of archiveServerCases) {
+    test(`${serverCase.name} rejects document mutations in archive mode`, async () => {
+      const server = await startOnRandomLocalPort(serverCase.start);
+
+      try {
+        for (const request of archiveMutationRequests) {
+          const response = await fetch(`${server.url}${request.path}`, {
+            method: request.method,
+          });
+          expect(response.status).toBe(403);
+          expect(await response.json()).toEqual({ error: "Archive is read-only" });
+        }
       } finally {
         server.stop();
       }

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -54,6 +54,7 @@ import { createExternalAnnotationHandler } from "./external-annotations";
 import { isWSL } from "./browser";
 import { AI_QUERY_ENDPOINT, createAIRuntime } from "./ai-runtime";
 import { isAIEndpointPath, type AIEndpoints } from "@plannotator/ai";
+import { isArchiveDocumentMutation } from "@plannotator/shared/archive-mode";
 
 // Re-export utilities
 export { isRemoteSession, getServerPort } from "./remote";
@@ -263,6 +264,10 @@ export async function startPlannotatorServer(
           if (url.pathname === "/api/done" && req.method === "POST") {
             resolveDone?.();
             return Response.json({ ok: true });
+          }
+
+          if (mode === "archive" && isArchiveDocumentMutation(req.method, url.pathname)) {
+            return Response.json({ error: "Archive is read-only" }, { status: 403 });
           }
 
           // API: Get plan content

--- a/packages/shared/archive-mode.ts
+++ b/packages/shared/archive-mode.ts
@@ -1,0 +1,16 @@
+const ARCHIVE_POST_MUTATIONS = new Set([
+  "/api/approve",
+  "/api/deny",
+  "/api/draft",
+  "/api/save-notes",
+  "/api/upload",
+]);
+
+/**
+ * Return whether an HTTP request would mutate document-review state and must
+ * therefore be rejected by the standalone archive server.
+ */
+export function isArchiveDocumentMutation(method: string, pathname: string): boolean {
+  return (method === "POST" && ARCHIVE_POST_MUTATIONS.has(pathname))
+    || (method === "DELETE" && pathname === "/api/draft");
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -71,7 +71,8 @@
     "./review-profiles": "./review-profiles.ts",
     "./commit-avatars": "./commit-avatars.ts",
     "./annotate-client-lease": "./annotate-client-lease.ts",
-    "./annotate-decision": "./annotate-decision.ts"
+    "./annotate-decision": "./annotate-decision.ts",
+    "./archive-mode": "./archive-mode.ts"
   },
   "dependencies": {
     "@plannotator/core": "workspace:*",

--- a/packages/ui/components/AnnotationPanel.props.test.tsx
+++ b/packages/ui/components/AnnotationPanel.props.test.tsx
@@ -77,6 +77,25 @@ describe('AnnotationPanel consumer props', () => {
     expect(document.querySelector('button[title="Edit annotation"]')).toBeNull();
   });
 
+  test.skipIf(!hasDom)('readOnly hides direct-edit discard and host mutation slots', async () => {
+    await mount(
+      <AnnotationPanel
+        {...baseProps}
+        readOnly
+        directEdits={[{
+          id: 'plan',
+          added: 1,
+          removed: 0,
+          diffText: '@@ -1 +1 @@\n-old\n+new',
+          onDiscard: () => {},
+        }]}
+        renderCardFooter={() => <button type="button">Reply</button>}
+      />,
+    );
+    expect(document.body.textContent).not.toContain('Discard');
+    expect(document.body.textContent).not.toContain('Reply');
+  });
+
   test.skipIf(!hasDom)('renderCardFooter renders per-card and does not select the card', async () => {
     const selected: string[] = [];
     let footerClicks = 0;

--- a/packages/ui/components/AnnotationPanel.tsx
+++ b/packages/ui/components/AnnotationPanel.tsx
@@ -77,7 +77,7 @@ interface PanelProps {
     *  resolve UI). The panel stays presentation-only; clicks inside the slot
     *  do not select the card. Default: nothing rendered. */
   renderCardFooter?: (annotation: Annotation) => React.ReactNode;
-  /** Hide every mutation affordance (delete/edit buttons on all card kinds).
+  /** Hide every mutation affordance (delete/edit, direct-edit discard, and host card footers).
     *  Selection and scrolling still work. Default false — today's behavior. */
   readOnly?: boolean;
 }
@@ -178,7 +178,7 @@ export const AnnotationPanel: React.FC<PanelProps> = ({
       <OverlayScrollArea className="flex-1 min-h-0">
         <div ref={listRef} className="p-2 flex flex-col gap-1.5">
         {directEdits?.map((item) => (
-          <DirectEditsCard key={item.id} {...item} />
+          <DirectEditsCard key={item.id} {...item} onDiscard={readOnly ? undefined : item.onDiscard} />
         ))}
         {totalCount === 0 ? (
           (!directEdits || directEdits.length === 0) && (
@@ -204,7 +204,7 @@ export const AnnotationPanel: React.FC<PanelProps> = ({
                   onDelete={() => onDelete(entry.annotation.id)}
                   onEdit={onEdit ? (updates: Partial<Annotation>) => onEdit(entry.annotation.id, updates) : undefined}
                   readOnly={readOnly}
-                  footer={renderCardFooter?.(entry.annotation)}
+                  footer={readOnly ? undefined : renderCardFooter?.(entry.annotation)}
                 />
               ) : (
                 <CodeAnnotationCard

--- a/packages/ui/components/BlockRenderer.tsx
+++ b/packages/ui/components/BlockRenderer.tsx
@@ -106,7 +106,7 @@ export const BlockRenderer: React.FC<{
     }
 
     case 'code':
-      return <CodeBlock block={block} onHover={() => {}} onLeave={() => {}} isHovered={false} />;
+      return <CodeBlock block={block} isHovered={false} />;
 
     case 'table':
       return (

--- a/packages/ui/components/Viewer.consumer.test.tsx
+++ b/packages/ui/components/Viewer.consumer.test.tsx
@@ -38,6 +38,17 @@ const blocks: Block[] = [
   { id: 'b1', type: 'paragraph', content: 'hello world', order: 0, startLine: 1 },
 ];
 
+const fencedCodeBlocks: Block[] = [
+  {
+    id: 'code-1',
+    type: 'code',
+    content: 'const archived = true;',
+    language: 'typescript',
+    order: 0,
+    startLine: 1,
+  },
+];
+
 let root: Root | null = null;
 let host: HTMLElement | null = null;
 
@@ -105,6 +116,61 @@ describe('Viewer consumer props', () => {
     expect(globalCommentButton()).toBeNull();
     expect(document.querySelector('button[title="Attachments"]')).toBeNull();
     expect(document.body.textContent).toContain('hello world');
+  });
+
+  test.skipIf(!hasDom)('readOnly fenced code never opens composers or mutates the rendered code', async () => {
+    const additions: unknown[] = [];
+    await mount(
+      <Viewer
+        {...viewerProps}
+        blocks={fencedCodeBlocks}
+        markdown={'```typescript\nconst archived = true;\n```'}
+        readOnly
+        onAddAnnotation={(annotation) => additions.push(annotation)}
+      />,
+    );
+
+    const codeBlock = document.querySelector<HTMLElement>('[data-block-id="code-1"]');
+    const code = codeBlock?.querySelector('code');
+    if (!codeBlock || !code) throw new Error('Fenced code block did not render');
+    const renderedCode = code.innerHTML;
+
+    await act(async () => {
+      codeBlock.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+      codeBlock.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(document.querySelector('.annotation-toolbar')).toBeNull();
+    expect(document.querySelector('textarea')).toBeNull();
+    expect(document.querySelector('[data-quick-label-picker]')).toBeNull();
+    expect(code.querySelector('mark')).toBeNull();
+    expect(code.innerHTML).toBe(renderedCode);
+    expect(additions).toEqual([]);
+
+    for (const mode of ['comment', 'redline', 'quickLabel'] as const) {
+      await act(async () => {
+        root?.render(
+          <Viewer
+            {...viewerProps}
+            blocks={fencedCodeBlocks}
+            markdown={'```typescript\nconst archived = true;\n```'}
+            inputMethod="pinpoint"
+            mode={mode}
+            readOnly
+            onAddAnnotation={(annotation) => additions.push(annotation)}
+          />,
+        );
+      });
+      await act(async () => {
+        codeBlock.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+
+      expect(document.querySelector('textarea')).toBeNull();
+      expect(document.querySelector('[data-quick-label-picker]')).toBeNull();
+      expect(code.querySelector('mark')).toBeNull();
+      expect(code.innerHTML).toBe(renderedCode);
+      expect(additions).toEqual([]);
+    }
   });
 });
 

--- a/packages/ui/components/Viewer.consumer.test.tsx
+++ b/packages/ui/components/Viewer.consumer.test.tsx
@@ -30,6 +30,9 @@ const Viewer = viewerMod?.Viewer as typeof import('./Viewer')['Viewer'];
 const popoverMod = hasDom ? await import('./CommentPopover') : null;
 const CommentPopover =
   popoverMod?.CommentPopover as typeof import('./CommentPopover')['CommentPopover'];
+const htmlViewerMod = hasDom ? await import('./html-viewer/HtmlViewer') : null;
+const HtmlViewer =
+  htmlViewerMod?.HtmlViewer as typeof import('./html-viewer/HtmlViewer')['HtmlViewer'];
 
 const blocks: Block[] = [
   { id: 'b1', type: 'paragraph', content: 'hello world', order: 0, startLine: 1 },
@@ -102,6 +105,61 @@ describe('Viewer consumer props', () => {
     expect(globalCommentButton()).toBeNull();
     expect(document.querySelector('button[title="Attachments"]')).toBeNull();
     expect(document.body.textContent).toContain('hello world');
+  });
+});
+
+describe('HtmlViewer consumer props', () => {
+  const htmlViewerProps = {
+    rawHtml: '<html><body><p>raw document</p></body></html>',
+    annotations: [],
+    onAddAnnotation: () => {},
+    onSelectAnnotation: () => {},
+    selectedAnnotationId: null,
+    mode: 'comment' as const,
+    inputMethod: 'drag' as const,
+    onAddGlobalAttachment: () => {},
+    onRemoveGlobalAttachment: () => {},
+  };
+
+  function dispatchSelection(modeOverride?: 'redline'): void {
+    const iframe = document.querySelector<HTMLIFrameElement>('iframe');
+    if (!iframe?.contentWindow) throw new Error('HTML iframe missing');
+    window.dispatchEvent(new MessageEvent('message', {
+      source: iframe.contentWindow,
+      data: {
+        type: 'plannotator-bridge-selection',
+        text: 'raw document',
+        rect: { top: 10, left: 10, width: 100, height: 20 },
+        modeOverride,
+      },
+    }));
+  }
+
+  test.skipIf(!hasDom)('default remains writable for raw-HTML annotate surfaces', async () => {
+    await mount(<HtmlViewer {...htmlViewerProps} />);
+    expect(globalCommentButton()).not.toBeNull();
+    expect(document.querySelector('button[title="Attachments"]')).not.toBeNull();
+
+    await act(async () => dispatchSelection());
+    expect(document.querySelector('textarea')).not.toBeNull();
+  });
+
+  test.skipIf(!hasDom)('readOnly hides raw-HTML mutation controls and ignores selection composers', async () => {
+    const additions: unknown[] = [];
+    await mount(
+      <HtmlViewer
+        {...htmlViewerProps}
+        readOnly
+        onAddAnnotation={(annotation) => additions.push(annotation)}
+      />,
+    );
+    expect(globalCommentButton()).toBeNull();
+    expect(document.querySelector('button[title="Attachments"]')).toBeNull();
+
+    await act(async () => dispatchSelection());
+    expect(document.querySelector('textarea')).toBeNull();
+    await act(async () => dispatchSelection('redline'));
+    expect(additions).toEqual([]);
   });
 });
 

--- a/packages/ui/components/Viewer.tsx
+++ b/packages/ui/components/Viewer.tsx
@@ -297,6 +297,8 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
     codeBlock: { block: Block; element: HTMLElement };
   } | null>(null);
   const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const readOnlyRef = useRef(readOnly);
+  readOnlyRef.current = readOnly;
   const stickySentinelRef = useRef<HTMLDivElement>(null);
   const lastAutoScrolledHashRef = useRef<string | null>(null);
   const [isStuck, setIsStuck] = useState(false);
@@ -344,6 +346,8 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
     isQuickLabel?: boolean,
     quickLabelTip?: string,
   ) => {
+    if (readOnlyRef.current) return;
+
     const id = `codeblock-${Date.now()}`;
     const codeText = codeEl.textContent || '';
 
@@ -375,6 +379,8 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
 
   // Pinpoint mode: hover + click to select elements
   const handlePinpointCodeBlockClick = useCallback((blockId: string, element: HTMLElement) => {
+    if (readOnlyRef.current) return;
+
     const block = blocks.find((candidate) => candidate.id === blockId);
     const codeEl = element.querySelector('code');
     if (!block || !codeEl) return;
@@ -403,6 +409,8 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
     element: HTMLElement,
     modeOverride?: EditorMode,
   ) => {
+    if (readOnlyRef.current) return;
+
     const block = blocks.find((candidate) => candidate.id === blockId);
     const codeEl = element.querySelector('code');
     if (!block || !codeEl) return;
@@ -486,6 +494,18 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
   const pinpointOverlayTarget = vimOwnsHudTarget
     ? null
     : (inputMethod === 'pinpoint' ? hoverTarget : null) ?? legacyVimTarget;
+
+  useEffect(() => {
+    if (!readOnly) return;
+    if (hoverTimeoutRef.current) {
+      clearTimeout(hoverTimeoutRef.current);
+      hoverTimeoutRef.current = null;
+    }
+    setCodeBlockToolbar(null);
+    setIsCodeBlockToolbarExiting(false);
+    setViewerCommentPopover(null);
+    setCodeBlockQuickLabelPicker(null);
+  }, [readOnly]);
 
   useEffect(() => {
     if (!vimOwnsDocumentNavigation) return;
@@ -623,7 +643,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
   // --- Viewer-specific: code block annotation ---
 
   const handleCodeBlockAnnotate = (type: AnnotationType) => {
-    if (!codeBlockToolbar) return;
+    if (readOnlyRef.current || !codeBlockToolbar) return;
     const codeEl = codeBlockToolbar.element.querySelector('code');
     if (!codeEl) return;
     applyCodeBlockAnnotation(codeBlockToolbar.block.id, codeEl, type);
@@ -631,7 +651,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
   };
 
   const handleCodeBlockQuickLabel = (label: QuickLabel) => {
-    if (!codeBlockToolbar) return;
+    if (readOnlyRef.current || !codeBlockToolbar) return;
     const codeEl = codeBlockToolbar.element.querySelector('code');
     if (!codeEl) return;
     applyCodeBlockAnnotation(
@@ -648,7 +668,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
   // Viewer-specific comment popover handlers (code blocks + global comments)
 
   const handleCodeBlockRequestComment = (initialChar?: string) => {
-    if (!codeBlockToolbar) return;
+    if (readOnlyRef.current || !codeBlockToolbar) return;
     const codeText = codeBlockToolbar.element.querySelector('code')?.textContent || '';
     setViewerCommentPopover({
       anchorEl: codeBlockToolbar.element,
@@ -662,7 +682,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
   };
 
   const handleViewerCommentSubmit = (text: string, images?: ImageAttachment[]) => {
-    if (!viewerCommentPopover) return;
+    if (readOnlyRef.current || !viewerCommentPopover) return;
 
     if (viewerCommentPopover.isGlobal) {
       const newAnnotation: Annotation = {
@@ -884,7 +904,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
             <CodeBlock
               key={group.block.id}
               block={group.block}
-              onHover={inputMethod === 'pinpoint' ? () => {} : (element) => {
+              onHover={readOnly || inputMethod === 'pinpoint' ? undefined : (element) => {
                 // Clear any pending leave timeout
                 if (hoverTimeoutRef.current) {
                   clearTimeout(hoverTimeoutRef.current);
@@ -905,7 +925,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
                   });
                 }
               }}
-              onLeave={inputMethod === 'pinpoint' ? () => {} : () => {
+              onLeave={readOnly || inputMethod === 'pinpoint' ? undefined : () => {
                 if (keyboardCodeBlockToolbarOpen) return;
                 // Delay then start exit animation
                 hoverTimeoutRef.current = setTimeout(() => {
@@ -918,7 +938,8 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
                 }, 100);
               }}
               isHovered={
-                inputMethod !== 'pinpoint'
+                !readOnly
+                && inputMethod !== 'pinpoint'
                 && !vimOwnsDocumentNavigation
                 && codeBlockToolbar?.block.id === group.block.id
               }
@@ -929,7 +950,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
         )}
 
         {/* Text selection toolbar */}
-        {toolbarState && (
+        {!readOnly && toolbarState && (
           <ToolbarErrorBoundary>
             <AnnotationToolbar
               element={toolbarState.element}
@@ -980,7 +1001,8 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
         )}
 
         {/* Code block hover toolbar */}
-        {codeBlockToolbar
+        {!readOnly
+          && codeBlockToolbar
           && !toolbarState
           && !(vimOwnsDocumentNavigation && codeBlockToolbar.activation === 'pointer')
           && (
@@ -1060,7 +1082,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
         )}
 
         {/* Comment popover — hook handles text selection, Viewer handles global + code block */}
-        {hookCommentPopover && (
+        {!readOnly && hookCommentPopover && (
             <CommentPopover
               anchorEl={hookCommentPopover.anchorEl}
               contextText={hookCommentPopover.contextText}
@@ -1078,7 +1100,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
               }}
             />
           )}
-        {viewerCommentPopover && (
+        {!readOnly && viewerCommentPopover && (
           <CommentPopover
             anchorEl={viewerCommentPopover.anchorEl}
             contextText={viewerCommentPopover.contextText}
@@ -1098,7 +1120,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
         )}
 
         {/* Quick Label floating picker — hook handles text selection, Viewer handles code blocks */}
-        {hookQuickLabelPicker && (
+        {!readOnly && hookQuickLabelPicker && (
           <FloatingQuickLabelPicker
             anchorEl={hookQuickLabelPicker.anchorEl}
             cursorHint={hookQuickLabelPicker.cursorHint}
@@ -1106,7 +1128,7 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
             onDismiss={hookQuickLabelPickerDismiss}
           />
         )}
-        {codeBlockQuickLabelPicker && (
+        {!readOnly && codeBlockQuickLabelPicker && (
           <FloatingQuickLabelPicker
             anchorEl={codeBlockQuickLabelPicker.anchorEl}
             onSelect={(label: QuickLabel) => {

--- a/packages/ui/components/blocks/CodeBlock.tsx
+++ b/packages/ui/components/blocks/CodeBlock.tsx
@@ -5,8 +5,8 @@ import type { Block } from '../../types';
 
 interface CodeBlockProps {
   block: Block;
-  onHover: (element: HTMLElement) => void;
-  onLeave: () => void;
+  onHover?: (element: HTMLElement) => void;
+  onLeave?: () => void;
   isHovered: boolean;
 }
 
@@ -36,7 +36,7 @@ export const CodeBlock: React.FC<CodeBlockProps> = ({ block, onHover, onLeave })
   }, [block.content]);
 
   const handleMouseEnter = () => {
-    if (containerRef.current) {
+    if (containerRef.current && onHover) {
       onHover(containerRef.current);
     }
   };
@@ -49,7 +49,7 @@ export const CodeBlock: React.FC<CodeBlockProps> = ({ block, onHover, onLeave })
       ref={containerRef}
       className="relative group my-5"
       data-block-id={block.id}
-      onMouseEnter={handleMouseEnter}
+      onMouseEnter={onHover ? handleMouseEnter : undefined}
       onMouseLeave={onLeave}
     >
       <button

--- a/packages/ui/components/html-viewer/HtmlViewer.tsx
+++ b/packages/ui/components/html-viewer/HtmlViewer.tsx
@@ -160,6 +160,8 @@ export interface HtmlViewerProps {
   /** Toggle the diff-highlighted view on/off. */
   onToggleDiff?: () => void;
   onAskAI?: CommentAskAIHandler;
+  /** Disable every annotation mutation entry point while preserving reading and navigation. */
+  readOnly?: boolean;
   /** Accessible iframe title. */
   title?: string;
 }
@@ -192,6 +194,7 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
       diffActive,
       onToggleDiff,
       onAskAI,
+      readOnly = false,
       title = "HTML Plan Viewer",
     },
     ref,
@@ -208,7 +211,7 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
     const [vimHudCommand, setVimHudCommand] = useState<VimHudCommand | null>(null);
     const [vimHelpOpen, setVimHelpOpen] = useState(false);
     const vimHudSequenceRef = useRef(0);
-    const vimHudActive = vimModeEnabled && vimHudEnabled;
+    const vimHudActive = !readOnly && vimModeEnabled && vimHudEnabled;
     const [globalCommentPopover, setGlobalCommentPopover] = useState<{
       anchorEl: HTMLElement;
       contextText: string;
@@ -234,6 +237,7 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
 
     const hook = useHtmlAnnotation({
       iframeRef,
+      enabled: !readOnly,
       annotations,
       onAddAnnotation,
       onSelectAnnotation,
@@ -256,7 +260,8 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
         if (vimCopy !== null) {
           const iframe = iframeRef.current;
           if (
-            vimModeEnabled
+            !readOnly
+            && vimModeEnabled
             && iframe
             && document.activeElement === iframe
           ) {
@@ -288,7 +293,7 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
       }
       window.addEventListener("message", handler);
       return () => window.removeEventListener("message", handler);
-    }, [vimHudActive, vimModeEnabled]);
+    }, [readOnly, vimHudActive, vimModeEnabled]);
 
     useEffect(() => {
       if (vimHudActive) return;
@@ -312,7 +317,7 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
 
     const focusVimDocument = useCallback((): boolean => {
       const iframe = iframeRef.current;
-      if (!vimModeEnabled || !iframe) return false;
+      if (readOnly || !vimModeEnabled || !iframe) return false;
       if (document.activeElement === iframe) return false;
       iframe.focus({ preventScroll: true });
       if (document.activeElement !== iframe) return false;
@@ -321,10 +326,10 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
         "*",
       );
       return true;
-    }, [vimModeEnabled]);
+    }, [readOnly, vimModeEnabled]);
 
     useVimDocumentFocus({
-      enabled: vimModeEnabled,
+      enabled: !readOnly && vimModeEnabled,
       blocked: !!hook.toolbarState || !!hook.commentPopover || !!hook.quickLabelPicker,
       focusDocument: focusVimDocument,
     });
@@ -352,13 +357,13 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
       iframe?.contentWindow?.postMessage(
         {
           type: `${PREFIX}set-vim-mode`,
-          enabled: vimModeEnabled,
+          enabled: !readOnly && vimModeEnabled,
           hudEnabled: vimHudEnabled,
           mode,
         },
         "*",
       );
-      if (vimModeEnabled && iframe === document.activeElement) {
+      if (!readOnly && vimModeEnabled && iframe === document.activeElement) {
         // The initial parent focus can land before the sandbox bridge is ready.
         // Reassert it after configuration so raw HTML enters BLOCK immediately,
         // matching the Markdown surface instead of waiting for the first key.
@@ -367,7 +372,7 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
           "*",
         );
       }
-    }, [iframeReadyVersion, mode, vimHudEnabled, vimModeEnabled]);
+    }, [iframeReadyVersion, mode, readOnly, vimHudEnabled, vimModeEnabled]);
 
     const vimOverlayWasOpenRef = useRef(false);
     useEffect(() => {
@@ -375,7 +380,8 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
       const wasOpen = vimOverlayWasOpenRef.current;
       vimOverlayWasOpenRef.current = overlayOpen;
       if (
-        vimModeEnabled
+        !readOnly
+        && vimModeEnabled
         && wasOpen
         && !overlayOpen
         && (document.activeElement === document.body || document.activeElement === null)
@@ -386,7 +392,7 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
           "*",
         );
       }
-    }, [hook.commentPopover, hook.quickLabelPicker, hook.toolbarState, vimModeEnabled]);
+    }, [hook.commentPopover, hook.quickLabelPicker, hook.toolbarState, readOnly, vimModeEnabled]);
 
     useEffect(() => {
       if (iframeReadyVersion === 0) return;
@@ -418,6 +424,7 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
 
     const handleGlobalCommentSubmit = useCallback(
       (text: string, images?: ImageAttachment[]) => {
+        if (readOnly) return;
         onAddAnnotation({
           id: `global-${Date.now()}`,
           blockId: "",
@@ -432,8 +439,14 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
         });
         setGlobalCommentPopover(null);
       },
-      [onAddAnnotation],
+      [onAddAnnotation, readOnly],
     );
+
+    useEffect(() => {
+      if (readOnly) setGlobalCommentPopover(null);
+    }, [readOnly]);
+
+    const hasActionButtons = !readOnly || Boolean(diffAvailable && onToggleDiff);
 
     // Document-level controls (attachments + global comment). Shared between the
     // normal layout (bar above the card) and full-viewport (floating overlay), so
@@ -452,7 +465,7 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
             <span>{diffActive ? "Hide changes" : "Show changes"}</span>
           </button>
         )}
-        {onAddGlobalAttachment && onRemoveGlobalAttachment && (
+        {!readOnly && onAddGlobalAttachment && onRemoveGlobalAttachment && (
           <AttachmentsButton
             images={globalAttachments}
             onAdd={onAddGlobalAttachment}
@@ -460,22 +473,23 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
             variant="toolbar"
           />
         )}
-        <button
-          ref={globalCommentButtonRef}
-          onClick={() => {
-            setGlobalCommentPopover({
-              anchorEl: globalCommentButtonRef.current!,
-              contextText: "",
-            });
-          }}
-          className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground bg-muted/50 hover:bg-muted rounded-md transition-colors cursor-pointer"
-          title="Add global comment"
-        >
-          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.087.16 2.185.283 3.293.369V21l4.076-4.076a1.526 1.526 0 011.037-.443 48.282 48.282 0 005.68-.494c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z" />
-          </svg>
-          <span>Comment</span>
-        </button>
+        {!readOnly && (
+          <button
+            ref={globalCommentButtonRef}
+            onClick={() => {
+              const anchorEl = globalCommentButtonRef.current;
+              if (!anchorEl) return;
+              setGlobalCommentPopover({ anchorEl, contextText: "" });
+            }}
+            className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground bg-muted/50 hover:bg-muted rounded-md transition-colors cursor-pointer"
+            title="Add global comment"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.087.16 2.185.283 3.293.369V21l4.076-4.076a1.526 1.526 0 011.037-.443 48.282 48.282 0 005.68-.494c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z" />
+            </svg>
+            <span>Comment</span>
+          </button>
+        )}
       </>
     );
 
@@ -486,7 +500,7 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
           style={fullViewport ? undefined : { maxWidth: maxWidth ?? undefined }}
         >
           {/* Action bar — above the iframe in normal mode (outside overflow:hidden). */}
-          {!fullViewport && (
+          {!fullViewport && hasActionButtons && (
             <div data-print-hide className="flex justify-end gap-1 md:gap-2 mb-2">
               {actionButtons}
             </div>
@@ -499,7 +513,7 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
             {/* Full-viewport mode has no card chrome, so float the same controls
                 over the top-right of the iframe (with a backdrop so they read over
                 any HTML). The selection toolbar is portaled separately. */}
-            {fullViewport && !hideControls && (
+            {fullViewport && !hideControls && hasActionButtons && (
               <div
                 data-print-hide
                 className="absolute top-3 right-3 z-10 flex items-center gap-1 md:gap-2 rounded-lg border border-border/50 bg-background/80 px-1.5 py-1 shadow-md backdrop-blur-sm"
@@ -517,7 +531,7 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
                 border: "none",
                 display: "block",
                 colorScheme: "auto",
-                outline: vimModeEnabled ? "none" : undefined,
+                outline: !readOnly && vimModeEnabled ? "none" : undefined,
               }}
               title={title}
               onFocus={() => setIframeFocused(true)}
@@ -561,7 +575,7 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
           )}
 
         {/* Toolbar portal */}
-        {hook.toolbarState &&
+        {!readOnly && hook.toolbarState &&
           createPortal(
             <AnnotationToolbar
               positionMode="center-above"
@@ -576,7 +590,7 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
           )}
 
         {/* Comment popover portal */}
-        {hook.commentPopover &&
+        {!readOnly && hook.commentPopover &&
           createPortal(
             <CommentPopover
               anchorEl={hook.commentPopover.anchorEl}
@@ -596,7 +610,7 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
           )}
 
         {/* Quick label picker portal */}
-        {hook.quickLabelPicker &&
+        {!readOnly && hook.quickLabelPicker &&
           createPortal(
             <FloatingQuickLabelPicker
               anchorEl={hook.quickLabelPicker.anchorEl}
@@ -608,7 +622,7 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
           )}
 
         {/* Global comment popover portal */}
-        {globalCommentPopover &&
+        {!readOnly && globalCommentPopover &&
           createPortal(
             <CommentPopover
               anchorEl={globalCommentPopover.anchorEl}

--- a/packages/ui/components/html-viewer/useHtmlAnnotation.ts
+++ b/packages/ui/components/html-viewer/useHtmlAnnotation.ts
@@ -43,6 +43,8 @@ type BridgeMessage =
 /** Dependencies and callbacks for the sandboxed HTML annotation bridge. */
 export interface UseHtmlAnnotationOptions {
   iframeRef: RefObject<HTMLIFrameElement | null>;
+  /** Whether selection bridge messages may open composers or create annotations. */
+  enabled?: boolean;
   annotations: Annotation[];
   onAddAnnotation?: (ann: Annotation) => void;
   onSelectAnnotation?: (id: string | null) => void;
@@ -124,6 +126,7 @@ function parseBridgeMessage(value: unknown): BridgeMessage | null {
  */
 export function useHtmlAnnotation({
   iframeRef,
+  enabled = true,
   onAddAnnotation,
   onSelectAnnotation,
   selectedAnnotationId,
@@ -138,6 +141,8 @@ export function useHtmlAnnotation({
   const [quickLabelPicker, setQuickLabelPicker] = useState<QuickLabelPickerState | null>(null);
 
   const pendingTextRef = useRef<string>("");
+  const enabledRef = useRef(enabled);
+  enabledRef.current = enabled;
   const modeRef = useRef(mode);
   modeRef.current = mode;
   // Mirror toolbar visibility into a ref so the (stable) message handler can gate
@@ -196,6 +201,10 @@ export function useHtmlAnnotation({
       if (!message) return;
 
       const type = message.type;
+
+      if (!enabledRef.current && type !== `${PREFIX}mark-click` && type !== `${PREFIX}resize`) {
+        return;
+      }
 
       if (type === `${PREFIX}selection`) {
         pendingTextRef.current = message.text;
@@ -301,6 +310,17 @@ export function useHtmlAnnotation({
   }, [iframeRef, positionAnchor, onResize, getOrCreateAnchor]);
 
   useEffect(() => {
+    if (enabled) return;
+    setToolbarState(null);
+    setCommentPopover(null);
+    setQuickLabelPicker(null);
+    pendingTextRef.current = "";
+    anchorRef.current?.remove();
+    anchorRef.current = null;
+    postToIframe(iframeRef.current, { type: `${PREFIX}cancel-selection` });
+  }, [enabled, iframeRef]);
+
+  useEffect(() => {
     if (selectedAnnotationId) {
       postToIframe(iframeRef.current, {
         type: `${PREFIX}scroll-to`,
@@ -316,6 +336,7 @@ export function useHtmlAnnotation({
 
   const handleAnnotate = useCallback(
     (type: AnnotationType) => {
+      if (!enabledRef.current) return;
       const text = pendingTextRef.current;
       if (!text || type !== AnnotationType.DELETION) return;
 
@@ -340,6 +361,7 @@ export function useHtmlAnnotation({
 
   const handleRequestComment = useCallback(
     (initialChar?: string) => {
+      if (!enabledRef.current) return;
       const text = pendingTextRef.current;
       if (!text) return;
       const anchor = anchorRef.current ?? getOrCreateAnchor();
@@ -351,6 +373,7 @@ export function useHtmlAnnotation({
 
   const handleCommentSubmit = useCallback(
     (comment: string, images?: ImageAttachment[]) => {
+      if (!enabledRef.current) return;
       // Prefer the text captured when the popover opened — it can't be clobbered by
       // a later selection change or clear while the user is composing the comment.
       const text = commentPopoverRef.current?.selectedText || pendingTextRef.current;
@@ -391,6 +414,7 @@ export function useHtmlAnnotation({
 
   const applyQuickLabel = useCallback(
     (label: QuickLabel, clearState: () => void) => {
+      if (!enabledRef.current) return;
       const text = pendingTextRef.current;
       if (!text) return;
       const id = nextHtmlAnnId();


### PR DESCRIPTION
## Summary
- make standalone archive document surfaces read-only across Markdown, raw HTML, annotation panels, paste uploads, drafts, code annotations, and submit shortcuts
- reject archive document mutations in both Bun and Pi plan servers
- use the plan area border-box metric for both initial and ResizeObserver action-label bucketing
- cover archive, writable annotate, raw-HTML selection, server parity, and responsive thresholds with regressions

## Verification
- bun test (2631 passed, 203 skipped, 0 failed)
- DOM_TESTS=1 bun test packages/editor/App.archiveReadOnly.test.tsx packages/editor/actionsLabelMode.test.ts packages/ui/components/Viewer.consumer.test.tsx packages/ui/components/AnnotationPanel.props.test.tsx (31 passed)
- bun test packages/server/api-404-guard.test.ts (9 passed)
- bun run typecheck
- bun run --cwd apps/review build
- bun run build:hook