### PR TITLE
docs: correct archive sharing posture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,7 +287,7 @@ User runs plannotator archive (CLI)
         ↓
 Server starts in mode:"archive", reads ~/.plannotator/plans/
         ↓
-Browser opens read-only archive viewer (sharing disabled)
+Browser opens read-only archive viewer
         ↓
 User browses saved plan decisions with approved/denied badges
         ↓


### PR DESCRIPTION
## Summary
- remove the false claim that standalone archive mode disables sharing
- retain archive read-only behavior while leaving sharing code unchanged

Closes #1172

## Validation
- `CLAUDE.md` remains the `AGENTS.md` symlink, so both entry points show the corrected flow
- `git diff --check`
- no product code changed