### PR TITLE
fix(uninstall): require host cleanup before binary removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,10 +236,10 @@ Purge requires typing `purge` at the prompt and explains that the data is
 local-only: it is not stored on a Plannotator server and cannot be recovered.
 For automation, pass `--yes` (or `-y`); non-interactive removal refuses to run
 without it. Use `--dry-run` to preview recognized work without making changes.
-If a broken or unavailable host blocks cleanup, `--skip-hosts` leaves host
-plugin managers and shared host configuration untouched so the remaining
-installer-owned components and binary can still be removed; clean up those
-host integrations manually afterward.
+Host integrations are always part of uninstall. If a broken or unavailable
+host prevents safe cleanup, the command names the blocking plugin manager or
+configuration, gives exact manual cleanup instructions, and stops before
+deleting the binary. Complete that cleanup and rerun uninstall.
 These mechanics keep the ordinary confirmation default-negative, make the
 irreversible outcome require a stronger explicit word, and still give package
 managers and scripts a conventional non-interactive flag.
@@ -253,8 +253,7 @@ updates preserve the file's indentation, line endings, and trailing-newline
 style. Custom
 or unrecognized files, separately installed optional skills, project-local
 integrations, external plan-save locations, and invalid configs are preserved
-(malformed host config is a fail-safe error unless `--skip-hosts` is explicit).
-If cleanup reports an error,
+(malformed host config is a fail-safe error). If cleanup reports an error,
 the CLI remains available for a safe retry, and its Windows PATH entry is
 retained or restored when possible. If PATH restoration itself fails, the
 output gives the full CLI path for retry and asks for manual PATH repair.

--- a/apps/hook/server/cli.test.ts
+++ b/apps/hook/server/cli.test.ts
@@ -35,7 +35,6 @@ describe("CLI top-level help", () => {
     expect(output).toContain("plannotator copilot-last [--gate] [--json] [--hook]");
     expect(output).toContain("plannotator setup-goal <interview|facts>");
     expect(output).toContain("plannotator uninstall [--purge] [--yes]");
-    expect(output).toContain("[--skip-hosts]");
     expect(output).toContain("Run 'plannotator <command> --help' for command-specific usage.");
     expect(output).toContain("running 'plannotator' without arguments is for hook integration");
   });
@@ -120,7 +119,6 @@ describe("CLI subcommand help", () => {
     expect(formatSubcommandHelp("uninstall")).toContain(
       "not stored on a Plannotator server",
     );
-    expect(formatSubcommandHelp("uninstall")).toContain("--skip-hosts");
     // unknown key falls back to top-level help
     expect(formatSubcommandHelp("nope")).toBe(formatTopLevelHelp());
   });
@@ -132,18 +130,16 @@ describe("uninstall CLI options", () => {
       purge: false,
       yes: false,
       dryRun: false,
-      skipHosts: false,
     });
   });
 
   test("parses purge, automation, and preview flags", () => {
     expect(
-      parseUninstallOptions(["--dry-run", "--purge", "-y", "--skip-hosts"]),
+      parseUninstallOptions(["--dry-run", "--purge", "-y"]),
     ).toEqual({
       purge: true,
       yes: true,
       dryRun: true,
-      skipHosts: true,
     });
   });
 
@@ -157,9 +153,9 @@ describe("uninstall CLI options", () => {
     expect(() => parseUninstallOptions(["--yes", "-y"])).toThrow(
       "--yes/-y may only be specified once",
     );
-    expect(() =>
-      parseUninstallOptions(["--skip-hosts", "--skip-hosts"]),
-    ).toThrow("--skip-hosts may only be specified once");
+    expect(() => parseUninstallOptions(["--dry-run", "--dry-run"])).toThrow(
+      "--dry-run may only be specified once",
+    );
   });
 
   test("uses a stronger confirmation for purge", () => {

--- a/apps/hook/server/cli.ts
+++ b/apps/hook/server/cli.ts
@@ -10,7 +10,6 @@ export interface ParsedUninstallOptions {
   purge: boolean;
   yes: boolean;
   dryRun: boolean;
-  skipHosts: boolean;
 }
 
 /**
@@ -22,7 +21,6 @@ export function parseUninstallOptions(
   let purge = false;
   let yes = false;
   let dryRun = false;
-  let skipHosts = false;
 
   for (const arg of args) {
     if (arg === "--purge") {
@@ -34,15 +32,12 @@ export function parseUninstallOptions(
     } else if (arg === "--dry-run") {
       if (dryRun) throw new Error("--dry-run may only be specified once");
       dryRun = true;
-    } else if (arg === "--skip-hosts") {
-      if (skipHosts) throw new Error("--skip-hosts may only be specified once");
-      skipHosts = true;
     } else {
       throw new Error(`Unknown uninstall option: ${arg}`);
     }
   }
 
-  return { purge, yes, dryRun, skipHosts };
+  return { purge, yes, dryRun };
 }
 
 /**
@@ -152,7 +147,7 @@ export function formatTopLevelHelp(): string {
     "  plannotator last",
     "  plannotator archive",
     "  plannotator sessions",
-    "  plannotator uninstall [--purge] [--yes] [--dry-run] [--skip-hosts]",
+    "  plannotator uninstall [--purge] [--yes] [--dry-run]",
     "  plannotator improve-context",
     "",
     "Run 'plannotator <command> --help' for command-specific usage.",
@@ -269,7 +264,7 @@ const SUBCOMMAND_HELP: Record<string, string> = {
   ].join("\n"),
   uninstall: [
     "Usage:",
-    "  plannotator uninstall [--purge] [--yes | -y] [--dry-run] [--skip-hosts]",
+    "  plannotator uninstall [--purge] [--yes | -y] [--dry-run]",
     "",
     "Remove Plannotator-installed components. Local plans, history, drafts,",
     "settings, and other Plannotator data are preserved by default.",
@@ -278,8 +273,6 @@ const SUBCOMMAND_HELP: Record<string, string> = {
     "  --purge       Also permanently delete known local Plannotator data",
     "  --yes, -y     Skip the interactive confirmation (required without a TTY)",
     "  --dry-run     Preview recognized removal work without changing anything",
-    "  --skip-hosts   Leave host plugin managers and shared host config untouched",
-    "                 (for recovery when a host install or config is broken)",
     "",
     "Purge data is local-only: it is not stored on a Plannotator server and",
     "cannot be recovered after purge. Unrecognized custom files are preserved.",

--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -340,7 +340,6 @@ if (args[0] === "uninstall") {
     {
       purge: options.purge,
       dryRun: options.dryRun,
-      skipHosts: options.skipHosts,
     },
     environment,
   );

--- a/apps/marketing/src/content/docs/getting-started/installation.md
+++ b/apps/marketing/src/content/docs/getting-started/installation.md
@@ -110,17 +110,17 @@ local-only: it is not stored on a Plannotator server and cannot be recovered
 after purge. `--yes` (or `-y`) skips confirmation for automation, and is
 required when no interactive terminal is available. `--dry-run` previews the
 recognized removal set without changing anything.
-If a broken or unavailable host blocks cleanup, `--skip-hosts` leaves host
-plugin managers and shared host configuration untouched while removing the
-remaining installer-owned components and binary. Remove the skipped host
-integrations manually afterward.
+Host integrations are always part of uninstall. If a broken or unavailable
+host prevents safe cleanup, the command names the blocking plugin manager or
+configuration, gives exact manual cleanup instructions, and stops before
+deleting the binary. Complete that cleanup and rerun uninstall.
 
 The purge removes only known Plannotator entries from the configured data
 directory. Unknown top-level files are preserved rather than guessed at, and
 custom external plan-save paths or project-local integrations are never
-deleted. Malformed host config is treated as a fail-safe error unless
-`--skip-hosts` is explicit. If a host plugin manager is unavailable or a shared
-config cannot be edited safely, the command reports the follow-up and preserves
+deleted. Malformed host config is treated as a fail-safe error. If a host
+plugin manager is unavailable or a shared config cannot be edited safely, the
+command reports the exact manual follow-up and preserves
 the CLI and its Windows PATH entry so you can fix the problem and retry. If
 Windows PATH restoration itself fails, the CLI remains on disk and the output
 gives its full path for retry and manual PATH repair.

--- a/packages/server/uninstall.test.ts
+++ b/packages/server/uninstall.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeAll, describe, expect, test } from "bun:test";
 import {
+  chmodSync,
   existsSync,
   linkSync,
   lstatSync,
@@ -368,7 +369,7 @@ describe("default uninstall", () => {
     });
 
     const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: false, skipHosts: false },
+      { purge: false, dryRun: false },
       fixture.environment,
     );
 
@@ -470,7 +471,7 @@ describe("default uninstall", () => {
     const before = snapshotTree(fixture.root);
 
     const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: true, skipHosts: false },
+      { purge: false, dryRun: true },
       {
         ...fixture.environment,
         which: () => "/fake/claude",
@@ -511,7 +512,7 @@ describe("default uninstall", () => {
     writeText(configPath, contents);
 
     const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: false, skipHosts: false },
+      { purge: false, dryRun: false },
       fixture.environment,
     );
 
@@ -526,7 +527,7 @@ describe("default uninstall", () => {
     expect(result.errors).toEqual([]);
   });
 
-  test("preserves invalid OpenCode config rather than guessing", async () => {
+  test("keeps the binary until malformed OpenCode config is cleaned manually", async () => {
     const fixture = createFixture();
     const binary = join(
       fixture.homeDir,
@@ -545,16 +546,31 @@ describe("default uninstall", () => {
     writeText(configPath, contents);
 
     const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: false, skipHosts: false },
+      { purge: false, dryRun: false },
       fixture.environment,
     );
 
     expect(readFileSync(configPath, "utf8")).toBe(contents);
     expect(existsSync(binary)).toBe(true);
     expect(result.ok).toBe(false);
-    expect(result.errors).toContain(
-      `Preserved ${configPath}: it is not valid JSON or JSONC, so managed host entries cannot be classified safely. Re-run with --skip-hosts to leave host integrations for manual cleanup.`,
+    expect(result.errors[0]).toContain(
+      `Preserved ${configPath}: it is not valid JSON or JSONC, so @plannotator/opencode plugin entries cannot be classified safely.`,
     );
+    expect(result.errors[0]).toContain(
+      "Remove every plugin array entry for @plannotator/opencode, including versioned entries and tuple entries",
+    );
+    expect(result.errors[0]).toContain(
+      "Then rerun `plannotator uninstall`.",
+    );
+
+    writeJson(configPath, { plugin: ["keep-plugin"] });
+    const retry = await runPlannotatorUninstall(
+      { purge: false, dryRun: false },
+      fixture.environment,
+    );
+    expect(retry.ok).toBe(true);
+    expect(existsSync(binary)).toBe(false);
+    expect(readJson(configPath)).toEqual({ plugin: ["keep-plugin"] });
   });
 
   test("preserves a custom Gemini hook sharing the managed matcher", async () => {
@@ -580,7 +596,7 @@ describe("default uninstall", () => {
     });
 
     await runPlannotatorUninstall(
-      { purge: false, dryRun: false, skipHosts: false },
+      { purge: false, dryRun: false },
       fixture.environment,
     );
 
@@ -623,7 +639,7 @@ describe("default uninstall", () => {
     writeText(settingsPath, contents);
 
     const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: false, skipHosts: false },
+      { purge: false, dryRun: false },
       fixture.environment,
     );
 
@@ -632,6 +648,60 @@ describe("default uninstall", () => {
       ['{', '    "theme": "custom"', '}', ''].join("\r\n"),
     );
   });
+
+  test.skipIf(process.platform === "win32")(
+    "keeps the binary and hook when Gemini settings cannot be edited",
+    async () => {
+      const fixture = createFixture();
+      const binary = join(fixture.homeDir, ".local", "bin", "plannotator");
+      const settingsPath = join(
+        fixture.homeDir,
+        ".gemini",
+        "settings.json",
+      );
+      writeText(binary);
+      writeJson(settingsPath, {
+        theme: "custom",
+        hooks: {
+          BeforeTool: [
+            {
+              matcher: "exit_plan_mode",
+              hooks: [{ type: "command", command: "plannotator" }],
+            },
+          ],
+        },
+      });
+      chmodSync(settingsPath, 0o400);
+
+      const blocked = await runPlannotatorUninstall(
+        { purge: false, dryRun: false },
+        fixture.environment,
+      );
+
+      expect(blocked.ok).toBe(false);
+      expect(existsSync(binary)).toBe(true);
+      expect(readFileSync(settingsPath, "utf8")).toContain("plannotator");
+      expect(blocked.errors[0]).toContain(
+        `Could not update ${settingsPath}`,
+      );
+      expect(blocked.errors[0]).toContain(
+        'Remove only Plannotator command hooks from hooks.BeforeTool entries whose matcher is "exit_plan_mode"',
+      );
+      expect(blocked.errors[0]).toContain(
+        "Then rerun `plannotator uninstall`.",
+      );
+
+      chmodSync(settingsPath, 0o600);
+      writeJson(settingsPath, { theme: "custom" });
+      const retry = await runPlannotatorUninstall(
+        { purge: false, dryRun: false },
+        fixture.environment,
+      );
+      expect(retry.ok).toBe(true);
+      expect(existsSync(binary)).toBe(false);
+      expect(readJson(settingsPath)).toEqual({ theme: "custom" });
+    },
+  );
 
   test("removes a relocated Codex hook adopted by the installer", async () => {
     const fixture = createFixture();
@@ -656,7 +726,7 @@ describe("default uninstall", () => {
     });
 
     const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: false, skipHosts: false },
+      { purge: false, dryRun: false },
       fixture.environment,
     );
 
@@ -677,7 +747,7 @@ describe("default uninstall", () => {
     });
   });
 
-  test("requires an explicit host skip for unrelated malformed Gemini settings", async () => {
+  test("requires manual repair for unrelated malformed Gemini settings", async () => {
     const fixture = createFixture();
     const binary = join(fixture.homeDir, ".local", "bin", "plannotator");
     const settingsPath = join(
@@ -690,24 +760,31 @@ describe("default uninstall", () => {
     writeText(settingsPath, contents);
 
     const blocked = await runPlannotatorUninstall(
-      { purge: false, dryRun: false, skipHosts: false },
+      { purge: false, dryRun: false },
       fixture.environment,
     );
 
     expect(blocked.ok).toBe(false);
     expect(existsSync(binary)).toBe(true);
     expect(readFileSync(settingsPath, "utf8")).toBe(contents);
-    expect(blocked.errors).toContain(
-      `Preserved ${settingsPath}: it is not strict JSON, so managed host entries cannot be classified safely. Re-run with --skip-hosts to leave host integrations for manual cleanup.`,
+    expect(blocked.errors[0]).toContain(
+      `Preserved ${settingsPath}: it is not strict JSON, so managed Gemini hooks cannot be classified safely.`,
+    );
+    expect(blocked.errors[0]).toContain(
+      'Remove only Plannotator command hooks from hooks.BeforeTool entries whose matcher is "exit_plan_mode"',
+    );
+    expect(blocked.errors[0]).toContain(
+      "Then rerun `plannotator uninstall`.",
     );
 
-    const escaped = await runPlannotatorUninstall(
-      { purge: false, dryRun: false, skipHosts: true },
+    writeJson(settingsPath, { theme: "custom" });
+    const retry = await runPlannotatorUninstall(
+      { purge: false, dryRun: false },
       fixture.environment,
     );
-    expect(escaped.ok).toBe(true);
+    expect(retry.ok).toBe(true);
     expect(existsSync(binary)).toBe(false);
-    expect(readFileSync(settingsPath, "utf8")).toBe(contents);
+    expect(readJson(settingsPath)).toEqual({ theme: "custom" });
   });
 
   test("fails safe for escaped managed spellings in malformed host config", async () => {
@@ -731,26 +808,27 @@ describe("default uninstall", () => {
     writeText(kiroAgentPath, kiroContents);
 
     const blocked = await runPlannotatorUninstall(
-      { purge: false, dryRun: false, skipHosts: false },
+      { purge: false, dryRun: false },
       fixture.environment,
     );
 
     expect(blocked.ok).toBe(false);
     expect(existsSync(binary)).toBe(true);
     expect(contents.toLowerCase()).not.toContain("plannotator");
-    expect(blocked.errors[0]).toContain("cannot be classified safely");
-    expect(blocked.errors[0]).toContain("--skip-hosts");
-
-    const escaped = await runPlannotatorUninstall(
-      { purge: false, dryRun: false, skipHosts: true },
-      fixture.environment,
+    expect(blocked.errors).toHaveLength(2);
+    expect(blocked.errors[0]).toContain(
+      "managed Gemini hooks cannot be classified safely",
     );
-
-    expect(escaped.ok).toBe(true);
-    expect(existsSync(binary)).toBe(false);
+    expect(blocked.errors[1]).toContain(
+      "the Plannotator Kiro agent cannot be classified safely",
+    );
+    expect(
+      blocked.errors.every((error) =>
+        error.includes("Then rerun `plannotator uninstall`.")
+      ),
+    ).toBe(true);
     expect(readFileSync(settingsPath, "utf8")).toBe(contents);
     expect(readFileSync(kiroAgentPath, "utf8")).toBe(kiroContents);
-    expect(escaped.warnings[0]).toContain("Skipped host plugin managers");
   });
 
   test("skips data-contained runtimes when the configured data root is broad", async () => {
@@ -771,7 +849,7 @@ describe("default uninstall", () => {
     writeText(unrelatedVendorFile, "unrelated");
 
     const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: false, skipHosts: false },
+      { purge: false, dryRun: false },
       {
         ...fixture.environment,
         dataDir: fixture.homeDir,
@@ -793,7 +871,7 @@ describe("purge uninstall", () => {
     writeText(join(fixture.dataDir, "vendor", "sem", "v0.8.0", "sem"));
 
     const result = await runPlannotatorUninstall(
-      { purge: true, dryRun: true, skipHosts: false },
+      { purge: true, dryRun: true },
       fixture.environment,
     );
 
@@ -809,7 +887,7 @@ describe("purge uninstall", () => {
     mkdirSync(vendorDirectory, { recursive: true });
 
     const preview = await runPlannotatorUninstall(
-      { purge: true, dryRun: true, skipHosts: false },
+      { purge: true, dryRun: true },
       fixture.environment,
     );
     expect(preview.preserved).toContain(
@@ -817,7 +895,7 @@ describe("purge uninstall", () => {
     );
 
     const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: false, skipHosts: false },
+      { purge: false, dryRun: false },
       fixture.environment,
     );
 
@@ -842,7 +920,7 @@ describe("purge uninstall", () => {
     writeText(customPath, "not installer-owned");
 
     const result = await runPlannotatorUninstall(
-      { purge: true, dryRun: false, skipHosts: false },
+      { purge: true, dryRun: false },
       fixture.environment,
     );
 
@@ -865,7 +943,7 @@ describe("purge uninstall", () => {
     writeText(join(fixture.dataDir, "vendor", "sem", "v0.8.0", "sem"));
 
     const result = await runPlannotatorUninstall(
-      { purge: true, dryRun: false, skipHosts: false },
+      { purge: true, dryRun: false },
       fixture.environment,
     );
 
@@ -892,7 +970,7 @@ describe("purge uninstall", () => {
     writeText(binary);
 
     const result = await runPlannotatorUninstall(
-      { purge: true, dryRun: false, skipHosts: false },
+      { purge: true, dryRun: false },
       {
         ...fixture.environment,
         dataDir: fixture.homeDir,
@@ -925,7 +1003,7 @@ describe("purge uninstall", () => {
     });
 
     const result = await runPlannotatorUninstall(
-      { purge: true, dryRun: false, skipHosts: false },
+      { purge: true, dryRun: false },
       {
         ...fixture.environment,
         which: (command) => command === "claude" ? "/fake/claude" : null,
@@ -966,7 +1044,7 @@ describe("purge uninstall", () => {
       writeText(binary);
 
       const result = await runPlannotatorUninstall(
-        { purge: true, dryRun: false, skipHosts: false },
+        { purge: true, dryRun: false },
         {
           ...fixture.environment,
           dataDir: caseVariantHome,
@@ -1016,7 +1094,7 @@ describe("purge uninstall", () => {
       writeText(binary);
 
       const result = await runPlannotatorUninstall(
-        { purge: true, dryRun: false, skipHosts: false },
+        { purge: true, dryRun: false },
         {
           ...fixture.environment,
           ...safetyCase.configure(fixture),
@@ -1040,7 +1118,7 @@ describe("purge uninstall", () => {
     linkSync(externalFile, join(fixture.dataDir, "config.json"));
 
     const result = await runPlannotatorUninstall(
-      { purge: true, dryRun: false, skipHosts: false },
+      { purge: true, dryRun: false },
       fixture.environment,
     );
 
@@ -1066,7 +1144,7 @@ describe("purge uninstall", () => {
     writeText(binary);
 
     const result = await runPlannotatorUninstall(
-      { purge: true, dryRun: false, skipHosts: false },
+      { purge: true, dryRun: false },
       {
         ...fixture.environment,
         dataDir: symlink,
@@ -1092,7 +1170,7 @@ describe("purge uninstall", () => {
     writeText(binary);
 
     const result = await runPlannotatorUninstall(
-      { purge: true, dryRun: false, skipHosts: false },
+      { purge: true, dryRun: false },
       {
         ...fixture.environment,
         dataDir: dataFile,
@@ -1106,7 +1184,7 @@ describe("purge uninstall", () => {
 });
 
 describe("host and platform integrations", () => {
-  test("returns a partial-failure status when a detected host is unavailable", async () => {
+  test("keeps the binary and reports the exact command when a host is unavailable", async () => {
     const fixture = createFixture();
     const binary = join(
       fixture.homeDir,
@@ -1120,7 +1198,7 @@ describe("host and platform integrations", () => {
     });
 
     const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: false, skipHosts: false },
+      { purge: false, dryRun: false },
       fixture.environment,
     );
 
@@ -1128,19 +1206,60 @@ describe("host and platform integrations", () => {
     expect(result.errors[0]).toContain(
       "Droid plugin plannotator@plannotator",
     );
-    expect(result.errors[0]).toContain("was not removed");
+    expect(result.errors[0]).toContain("droid is unavailable");
+    expect(result.errors[0]).toContain(
+      "restore droid on PATH and run `droid plugin uninstall plannotator@plannotator --scope user`",
+    );
+    expect(result.errors[0]).toContain(
+      "After it succeeds, rerun `plannotator uninstall`.",
+    );
     expect(existsSync(binary)).toBe(true);
     expect(result.warnings).toContain(
       "Preserved the Plannotator CLI and its Windows PATH entry so you can resolve the errors and retry uninstall.",
     );
 
-    const escaped = await runPlannotatorUninstall(
-      { purge: false, dryRun: false, skipHosts: true },
+    writeJson(join(fixture.homeDir, ".factory", "settings.json"), {
+      enabledPlugins: {},
+    });
+    const retry = await runPlannotatorUninstall(
+      { purge: false, dryRun: false },
       fixture.environment,
     );
-    expect(escaped.ok).toBe(true);
+    expect(retry.ok).toBe(true);
     expect(existsSync(binary)).toBe(false);
-    expect(escaped.warnings[0]).toContain("Skipped host plugin managers");
+  });
+
+  test("keeps the binary and reports the exact command when a host manager fails", async () => {
+    const fixture = createFixture();
+    const binary = join(fixture.homeDir, ".local", "bin", "plannotator");
+    writeText(binary);
+    writeJson(join(fixture.homeDir, ".pi", "agent", "settings.json"), {
+      packages: [{ source: "npm:@plannotator/pi-extension@0.25.1" }],
+    });
+
+    const result = await runPlannotatorUninstall(
+      { purge: true, dryRun: false },
+      {
+        ...fixture.environment,
+        which: (command) => command === "pi" ? "/fake/pi" : null,
+        runCommand: async (command, args, env) => {
+          fixture.commandCalls.push({ command, args, env });
+          return { exitCode: 23, timedOut: false };
+        },
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(existsSync(binary)).toBe(true);
+    expect(result.errors[0]).toContain(
+      "Pi extension npm:@plannotator/pi-extension was not removed automatically (exit 23)",
+    );
+    expect(result.errors[0]).toContain(
+      "run `pi remove npm:@plannotator/pi-extension` directly",
+    );
+    expect(result.errors[0]).toContain(
+      "Then rerun `plannotator uninstall --purge`.",
+    );
   });
 
   test("detects disabled Claude and Droid plugins from installation metadata", async () => {
@@ -1167,7 +1286,7 @@ describe("host and platform integrations", () => {
     );
 
     await runPlannotatorUninstall(
-      { purge: false, dryRun: false, skipHosts: false },
+      { purge: false, dryRun: false },
       {
         ...fixture.environment,
         which: (command) => `/fake/${command}`,
@@ -1219,7 +1338,7 @@ describe("host and platform integrations", () => {
     );
 
     await runPlannotatorUninstall(
-      { purge: false, dryRun: false, skipHosts: false },
+      { purge: false, dryRun: false },
       {
         ...fixture.environment,
         which: (command) => `/fake/${command}`,
@@ -1261,7 +1380,7 @@ describe("host and platform integrations", () => {
     });
 
     await runPlannotatorUninstall(
-      { purge: true, dryRun: false, skipHosts: false },
+      { purge: true, dryRun: false },
       {
         ...fixture.environment,
         which: (command) => `/fake/${command}`,
@@ -1286,7 +1405,7 @@ describe("host and platform integrations", () => {
     writeText(legacyExe);
 
     const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: false, skipHosts: false },
+      { purge: false, dryRun: false },
       {
         ...fixture.environment,
         platform: "win32",
@@ -1322,7 +1441,7 @@ describe("host and platform integrations", () => {
     writeText(unrelatedFile);
 
     const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: false, skipHosts: false },
+      { purge: false, dryRun: false },
       {
         ...fixture.environment,
         platform: "win32",
@@ -1347,7 +1466,7 @@ describe("host and platform integrations", () => {
     writeText(currentExe);
 
     const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: false, skipHosts: false },
+      { purge: false, dryRun: false },
       {
         ...fixture.environment,
         platform: "win32",
@@ -1373,7 +1492,7 @@ describe("host and platform integrations", () => {
     writeText(currentExe);
 
     const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: false, skipHosts: false },
+      { purge: false, dryRun: false },
       {
         ...fixture.environment,
         platform: "win32",
@@ -1404,7 +1523,7 @@ describe("host and platform integrations", () => {
     let commandCount = 0;
 
     const result = await runPlannotatorUninstall(
-      { purge: false, dryRun: false, skipHosts: false },
+      { purge: false, dryRun: false },
       {
         ...fixture.environment,
         platform: "win32",

--- a/packages/server/uninstall.ts
+++ b/packages/server/uninstall.ts
@@ -169,8 +169,6 @@ export interface UninstallEnvironment {
 export interface UninstallRequest {
   readonly purge: boolean;
   readonly dryRun: boolean;
-  /** Leave host plugin managers and shared host configuration untouched. */
-  readonly skipHosts: boolean;
 }
 
 /** Caller-visible record of completed, planned, preserved, and failed work. */
@@ -202,6 +200,10 @@ type HookCleanupSpec = {
 type HookCleanupPolicy = {
   readonly allowRelocatedBinary: boolean;
   readonly removeFileWhenEmpty: boolean;
+};
+
+type HostCleanupRecovery = {
+  readonly manualCleanup: string;
 };
 
 type PathIdentity = {
@@ -287,14 +289,8 @@ export async function runPlannotatorUninstall(
 
   const paths = resolveOwnedPaths(environment);
 
-  if (request.skipHosts) {
-    state.warnings.push(
-      "Skipped host plugin managers and shared host configuration (--skip-hosts); remove any remaining host integrations manually.",
-    );
-  } else {
-    await removeHostPlugins(request, environment, paths, state);
-    removeHostConfigEntries(request, environment, paths, state);
-  }
+  await removeHostPlugins(request, environment, paths, state);
+  removeHostConfigEntries(request, environment, paths, state);
   removeInstalledFiles(request, environment, paths, state);
   if (dataDirSafetyIssue) {
     state.warnings.push(
@@ -369,6 +365,24 @@ export function formatUninstallResult(result: UninstallResult): string {
   }
 
   return lines.join("\n");
+}
+
+function formatUninstallRetryCommand(request: UninstallRequest): string {
+  return request.purge
+    ? "plannotator uninstall --purge"
+    : "plannotator uninstall";
+}
+
+function reportHostCleanupFailure(
+  summary: string,
+  problem: string,
+  recovery: HostCleanupRecovery,
+  request: UninstallRequest,
+  state: MutableUninstallResult,
+): void {
+  state.errors.push(
+    `${summary}: ${problem}. Manual cleanup: ${recovery.manualCleanup} Then rerun \`${formatUninstallRetryCommand(request)}\`.`,
+  );
 }
 
 function resolveOwnedPaths(environment: UninstallEnvironment) {
@@ -499,9 +513,10 @@ async function removeHostPlugins(
     }
 
     const executable = environment.which(action.command);
+    const manualCommand = [action.command, ...action.args].join(" ");
     if (!executable) {
       state.errors.push(
-        `${action.label} was detected but ${action.command} is unavailable; it was not removed. Use the host's plugin manager manually, or re-run with --skip-hosts to leave host integrations for manual cleanup.`,
+        `${action.label} was detected but ${action.command} is unavailable; it was not removed. Manual cleanup: restore ${action.command} on PATH and run \`${manualCommand}\`. After it succeeds, rerun \`${formatUninstallRetryCommand(request)}\`.`,
       );
       continue;
     }
@@ -511,7 +526,7 @@ async function removeHostPlugins(
       state.removed.push(action.label);
     } else {
       state.errors.push(
-        `${action.label} was not removed automatically (${result.timedOut ? "command timed out" : `exit ${result.exitCode}`}); use the host's plugin manager manually, or re-run with --skip-hosts to leave host integrations for manual cleanup.`,
+        `${action.label} was not removed automatically (${result.timedOut ? "command timed out" : `exit ${result.exitCode}`}). Manual cleanup: run \`${manualCommand}\` directly and resolve the host error until it succeeds. Then rerun \`${formatUninstallRetryCommand(request)}\`.`,
       );
     }
   }
@@ -536,6 +551,7 @@ function removeHostConfigEntries(
       removeFileWhenEmpty: false,
     },
     "managed Claude Code hooks",
+    `Make ${join(paths.claudeDir, "settings.json")} a readable, writable strict JSON object. Remove only Plannotator command hooks from hooks.PermissionRequest entries whose matcher is "ExitPlanMode" and hooks.PreToolUse entries whose matcher is "EnterPlanMode", then save the file.`,
     request,
     state,
   );
@@ -550,6 +566,7 @@ function removeHostConfigEntries(
       removeFileWhenEmpty: true,
     },
     "managed Codex Stop hook",
+    `Make ${join(paths.codexDir, "hooks.json")} a readable, writable strict JSON object. Remove only Plannotator command hooks from hooks.Stop entries, then save the file; delete it only if no other settings remain.`,
     request,
     state,
   );
@@ -664,19 +681,17 @@ function removeInstalledFiles(
     state,
   );
 
-  if (!request.skipHosts) {
-    cleanupRecognizableKiroAgent(
-      join(environment.homeDir, ".kiro", "agents", "plannotator.json"),
+  cleanupRecognizableKiroAgent(
+    join(environment.homeDir, ".kiro", "agents", "plannotator.json"),
+    request,
+    state,
+  );
+  for (const configDir of paths.configDirs) {
+    cleanupRecognizableAmpPlugin(
+      join(configDir, "amp", "plugins", "plannotator.ts"),
       request,
       state,
     );
-    for (const configDir of paths.configDirs) {
-      cleanupRecognizableAmpPlugin(
-        join(configDir, "amp", "plugins", "plannotator.ts"),
-        request,
-        state,
-      );
-    }
   }
 
   for (const cachePath of [
@@ -977,10 +992,18 @@ function cleanupHooksJson(
   platform: NodeJS.Platform,
   policy: HookCleanupPolicy,
   label: string,
+  manualCleanup: string,
   request: UninstallRequest,
   state: MutableUninstallResult,
 ): void {
-  const parsed = readJsonRecord(filePath, state);
+  const recovery = { manualCleanup };
+  const parsed = readJsonRecord(
+    filePath,
+    label,
+    recovery,
+    request,
+    state,
+  );
   if (!parsed) return;
 
   const hooks = asRecord(parsed.hooks);
@@ -1047,11 +1070,11 @@ function cleanupHooksJson(
   }
 
   if (policy.removeFileWhenEmpty && Object.keys(parsed).length === 0) {
-    removePath(filePath, request, state);
+    removePath(filePath, request, state, recovery);
     return;
   }
 
-  writeJson(filePath, parsed, label, state);
+  writeJson(filePath, parsed, label, recovery, request, state);
 }
 
 function cleanupCodexConfig(
@@ -1060,11 +1083,20 @@ function cleanupCodexConfig(
   state: MutableUninstallResult,
 ): void {
   if (!existsSync(filePath)) return;
+  const recovery = {
+    manualCleanup: `Make ${filePath} readable and writable. If its only nonblank lines are [features] and hooks = true, delete the file; otherwise leave its custom content in place.`,
+  };
   let content: string;
   try {
     content = readFileSync(filePath, "utf8");
   } catch (error) {
-    state.errors.push(`Could not inspect ${filePath}: ${formatError(error)}`);
+    reportHostCleanupFailure(
+      `Could not inspect ${filePath}`,
+      formatError(error),
+      recovery,
+      request,
+      state,
+    );
     return;
   }
 
@@ -1078,7 +1110,7 @@ function cleanupCodexConfig(
     /^hooks\s*=\s*true$/.test(meaningfulLines[1]);
 
   if (!isInstallerTemplate) return;
-  removePath(filePath, request, state);
+  removePath(filePath, request, state, recovery);
 }
 
 function cleanupGeminiSettings(
@@ -1088,7 +1120,16 @@ function cleanupGeminiSettings(
   request: UninstallRequest,
   state: MutableUninstallResult,
 ): void {
-  const parsed = readJsonRecord(filePath, state);
+  const recovery = {
+    manualCleanup: `Make ${filePath} a readable, writable strict JSON object. Remove only Plannotator command hooks from hooks.BeforeTool entries whose matcher is "exit_plan_mode", then save the file.`,
+  };
+  const parsed = readJsonRecord(
+    filePath,
+    "managed Gemini hooks",
+    recovery,
+    request,
+    state,
+  );
   if (!parsed) return;
   const wasInstallerTemplate = isGeminiInstallerTemplate(
     parsed,
@@ -1135,7 +1176,7 @@ function cleanupGeminiSettings(
   }
 
   if (wasInstallerTemplate) {
-    removePath(filePath, request, state);
+    removePath(filePath, request, state, recovery);
     return;
   }
 
@@ -1143,7 +1184,14 @@ function cleanupGeminiSettings(
   else hooks.BeforeTool = nextEntries;
   if (Object.keys(hooks).length === 0) delete parsed.hooks;
   else parsed.hooks = hooks;
-  writeJson(filePath, parsed, "managed Gemini hook", state);
+  writeJson(
+    filePath,
+    parsed,
+    "managed Gemini hook",
+    recovery,
+    request,
+    state,
+  );
 }
 
 function cleanupOpenCodeConfig(
@@ -1152,12 +1200,21 @@ function cleanupOpenCodeConfig(
   state: MutableUninstallResult,
 ): void {
   if (!existsSync(filePath)) return;
+  const recovery = {
+    manualCleanup: `Make ${filePath} readable, writable, and valid JSON or JSONC. Remove every plugin array entry for @plannotator/opencode, including versioned entries and tuple entries, then save the file.`,
+  };
 
   let content: string;
   try {
     content = readFileSync(filePath, "utf8");
   } catch (error) {
-    state.errors.push(`Could not inspect ${filePath}: ${formatError(error)}`);
+    reportHostCleanupFailure(
+      `Could not inspect ${filePath}`,
+      formatError(error),
+      recovery,
+      request,
+      state,
+    );
     return;
   }
 
@@ -1171,6 +1228,9 @@ function cleanupOpenCodeConfig(
     reportMalformedSharedConfig(
       filePath,
       "it is not valid JSON or JSONC",
+      "@plannotator/opencode plugin entries",
+      recovery,
+      request,
       state,
     );
     return;
@@ -1198,6 +1258,8 @@ function cleanupOpenCodeConfig(
     filePath,
     updated,
     "@plannotator/opencode entry",
+    recovery,
+    request,
     state,
   );
 }
@@ -1267,7 +1329,16 @@ function cleanupRecognizableKiroAgent(
   request: UninstallRequest,
   state: MutableUninstallResult,
 ): void {
-  const parsed = readJsonRecord(filePath, state);
+  const recovery = {
+    manualCleanup: `Make ${filePath} a readable, writable strict JSON object without changing its intent. If it is the installer-provided Plannotator Kiro agent, delete it; otherwise keep the repaired custom agent at that path.`,
+  };
+  const parsed = readJsonRecord(
+    filePath,
+    "the Plannotator Kiro agent",
+    recovery,
+    request,
+    state,
+  );
   if (!parsed) return;
 
   const prompt = typeof parsed.prompt === "string" ? parsed.prompt : "";
@@ -1279,7 +1350,7 @@ function cleanupRecognizableKiroAgent(
     prompt.includes("Each skill runs a `plannotator` shell command");
 
   if (recognizable) {
-    removePath(filePath, request, state);
+    removePath(filePath, request, state, recovery);
   } else {
     state.preserved.push(`${filePath} (custom or unrecognized Kiro agent)`);
   }
@@ -1291,11 +1362,20 @@ function cleanupRecognizableAmpPlugin(
   state: MutableUninstallResult,
 ): void {
   if (!existsSync(filePath)) return;
+  const recovery = {
+    manualCleanup: `Make ${filePath} readable and writable. If it contains the installer-provided Plannotator Amp plugin, delete it; otherwise keep the custom plugin at that path.`,
+  };
   let content: string;
   try {
     content = readFileSync(filePath, "utf8");
   } catch (error) {
-    state.errors.push(`Could not inspect ${filePath}: ${formatError(error)}`);
+    reportHostCleanupFailure(
+      `Could not inspect ${filePath}`,
+      formatError(error),
+      recovery,
+      request,
+      state,
+    );
     return;
   }
 
@@ -1305,7 +1385,7 @@ function cleanupRecognizableAmpPlugin(
     content.includes("PLANNOTATOR_ORIGIN");
 
   if (recognizable) {
-    removePath(filePath, request, state);
+    removePath(filePath, request, state, recovery);
   } else {
     state.preserved.push(`${filePath} (custom or unrecognized Amp plugin)`);
   }
@@ -1313,6 +1393,9 @@ function cleanupRecognizableAmpPlugin(
 
 function readJsonRecord(
   filePath: string,
+  integration: string,
+  recovery: HostCleanupRecovery,
+  request: UninstallRequest,
   state: MutableUninstallResult,
 ): JsonRecord | null {
   if (!existsSync(filePath)) return null;
@@ -1320,7 +1403,13 @@ function readJsonRecord(
   try {
     content = readFileSync(filePath, "utf8");
   } catch (error) {
-    state.errors.push(`Could not inspect ${filePath}: ${formatError(error)}`);
+    reportHostCleanupFailure(
+      `Could not inspect ${filePath}`,
+      formatError(error),
+      recovery,
+      request,
+      state,
+    );
     return null;
   }
 
@@ -1331,6 +1420,9 @@ function readJsonRecord(
       reportMalformedSharedConfig(
         filePath,
         "it is not a JSON object",
+        integration,
+        recovery,
+        request,
         state,
       );
       return null;
@@ -1340,6 +1432,9 @@ function readJsonRecord(
     reportMalformedSharedConfig(
       filePath,
       "it is not strict JSON",
+      integration,
+      recovery,
+      request,
       state,
     );
     return null;
@@ -1349,10 +1444,17 @@ function readJsonRecord(
 function reportMalformedSharedConfig(
   filePath: string,
   reason: string,
+  integration: string,
+  recovery: HostCleanupRecovery,
+  request: UninstallRequest,
   state: MutableUninstallResult,
 ): void {
-  state.errors.push(
-    `Preserved ${filePath}: ${reason}, so managed host entries cannot be classified safely. Re-run with --skip-hosts to leave host integrations for manual cleanup.`,
+  reportHostCleanupFailure(
+    `Preserved ${filePath}`,
+    `${reason}, so ${integration} cannot be classified safely`,
+    recovery,
+    request,
+    state,
   );
 }
 
@@ -1360,6 +1462,8 @@ function writeJson(
   filePath: string,
   value: JsonRecord,
   label: string,
+  recovery: HostCleanupRecovery,
+  request: UninstallRequest,
   state: MutableUninstallResult,
 ): void {
   try {
@@ -1376,7 +1480,13 @@ function writeJson(
     );
     state.removed.push(`${label} in ${filePath}`);
   } catch (error) {
-    state.errors.push(`Could not update ${filePath}: ${formatError(error)}`);
+    reportHostCleanupFailure(
+      `Could not update ${filePath}`,
+      formatError(error),
+      recovery,
+      request,
+      state,
+    );
   }
 }
 
@@ -1384,13 +1494,21 @@ function writeTextUpdate(
   filePath: string,
   content: string,
   label: string,
+  recovery: HostCleanupRecovery,
+  request: UninstallRequest,
   state: MutableUninstallResult,
 ): void {
   try {
     writeFileSync(filePath, content, "utf8");
     state.removed.push(`${label} in ${filePath}`);
   } catch (error) {
-    state.errors.push(`Could not update ${filePath}: ${formatError(error)}`);
+    reportHostCleanupFailure(
+      `Could not update ${filePath}`,
+      formatError(error),
+      recovery,
+      request,
+      state,
+    );
   }
 }
 
@@ -1506,13 +1624,24 @@ function removePath(
   path: string,
   request: UninstallRequest,
   state: MutableUninstallResult,
+  recovery?: HostCleanupRecovery,
 ): void {
   let stat: ReturnType<typeof lstatSync>;
   try {
     stat = lstatSync(path);
   } catch (error) {
     if (isMissingPathError(error)) return;
-    state.errors.push(`Could not inspect ${path}: ${formatError(error)}`);
+    if (recovery) {
+      reportHostCleanupFailure(
+        `Could not inspect ${path}`,
+        formatError(error),
+        recovery,
+        request,
+        state,
+      );
+    } else {
+      state.errors.push(`Could not inspect ${path}: ${formatError(error)}`);
+    }
     return;
   }
 
@@ -1531,7 +1660,17 @@ function removePath(
     }
     state.removed.push(path);
   } catch (error) {
-    state.errors.push(`Could not remove ${path}: ${formatError(error)}`);
+    if (recovery) {
+      reportHostCleanupFailure(
+        `Could not remove ${path}`,
+        formatError(error),
+        recovery,
+        request,
+        state,
+      );
+    } else {
+      state.errors.push(`Could not remove ${path}: ${formatError(error)}`);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- retire the host-cleanup bypass from CLI parsing, types, runtime branches, help, docs, diagnostics, and tests
- always run recognized host plugin/config cleanup before binary removal
- give host-specific manual cleanup commands or config-field guidance, followed by the correct uninstall rerun command
- preserve the existing fail-safe gate that keeps the CLI and Windows PATH entry available after cleanup errors
- add regressions for malformed and uneditable host config, unavailable and failing plugin managers, manual-cleanup retry, data retention, purge, and platform safeguards

## Validation

- focused uninstall/CLI suite: 56 passed, 0 failed
- full suite: 2,670 passed, 204 skipped, 0 failed
- bun run typecheck
- bun run build:marketing
- git diff --check
- exhaustive repository and read-only Mintlify docs searches found no remaining retired-flag references

## Docs

The separate Mintlify docs checkout contains no references requiring a companion change.

Closes #1175
