### PR TITLE
Fix legacy sharing article redirect chain

### DIFF
--- a/apps/marketing/cloudfront/url-rewrite.js
+++ b/apps/marketing/cloudfront/url-rewrite.js
@@ -39,7 +39,7 @@ function handler(event) {
     '/blog/local-diff-review-for-coding-agents': 'https://docs.plannotator.ai/learn/local-diff-review-for-coding-agents',
     '/blog/plan-diff-see-what-changed': 'https://docs.plannotator.ai/learn/plan-diff-see-what-changed',
     '/blog/plannotator-meets-pi': 'https://docs.plannotator.ai/open-source/agents/pi',
-    '/blog/sharing-plans-with-your-team': 'https://docs.plannotator.ai/workspaces/review-plans-and-technical-decisions',
+    '/blog/sharing-plans-with-your-team': 'https://docs.plannotator.ai/open-source/workflows/sharing',
     '/blog/welcome': 'https://docs.plannotator.ai/open-source/'
   };
 

--- a/apps/marketing/cloudfront/url-rewrite.test.ts
+++ b/apps/marketing/cloudfront/url-rewrite.test.ts
@@ -37,15 +37,18 @@ describe('marketing CloudFront URL handling', () => {
     );
   });
 
-  test('redirects old blog URLs to their matching Learn pages', () => {
-    const result = run('/blog/plan-diff-see-what-changed/') as {
+  test('redirects the old sharing article directly to the current sharing guide', () => {
+    const result = run('/blog/sharing-plans-with-your-team') as {
       statusCode: number;
       headers: Record<string, { value: string }>;
     };
 
     expect(result.statusCode).toBe(301);
     expect(result.headers.location.value).toBe(
-      'https://docs.plannotator.ai/learn/plan-diff-see-what-changed',
+      'https://docs.plannotator.ai/open-source/workflows/sharing',
+    );
+    expect(run('/blog/sharing-plans-with-your-team/')).toEqual(
+      result,
     );
   });
 

--- a/apps/marketing/src/pages/rss.xml.ts
+++ b/apps/marketing/src/pages/rss.xml.ts
@@ -8,7 +8,7 @@ const migratedLinks: Record<string, string> = {
   'local-diff-review-for-coding-agents': 'https://docs.plannotator.ai/learn/local-diff-review-for-coding-agents',
   'plan-diff-see-what-changed': 'https://docs.plannotator.ai/learn/plan-diff-see-what-changed',
   'plannotator-meets-pi': 'https://docs.plannotator.ai/open-source/agents/pi',
-  'sharing-plans-with-your-team': 'https://docs.plannotator.ai/workspaces/review-plans-and-technical-decisions',
+  'sharing-plans-with-your-team': 'https://docs.plannotator.ai/open-source/workflows/sharing',
   welcome: 'https://docs.plannotator.ai/open-source/',
 };
 


### PR DESCRIPTION
## Summary
- redirect the legacy sharing article directly to the current public OSS sharing guide
- keep the migrated RSS item aligned
- cover slash and slashless redirect variants

## Validation
- `bun test apps/marketing/cloudfront/url-rewrite.test.ts`
- `bun run build:marketing`
- verified the destination returns 200 without another redirect, self-canonicalizes, appears in the Docs sitemap, and is crawlable