### PR TITLE
fix(annotate): tolerate non-path tokens in annotate arguments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,6 +270,16 @@ User annotates content, provides feedback
 Send Annotations → feedback sent to agent session
 ```
 
+### Tolerant annotate target resolution
+
+The host slash commands invoke the CLI through a bash-substitution prefix (`` !`plannotator annotate $ARGUMENTS` ``), so `$ARGUMENTS` reaches argv unquoted and unparsed and trailing natural language used to be fatal (`/plannotator-annotate the aim doc` → `File not found: the`). Argument resolution is therefore tolerant, in `packages/shared/annotate-target.ts` (`resolveAnnotateTargetArg`) and shared by all three hosts — the Claude Code binary, OpenCode, and Pi — so the behavior and both error messages are identical everywhere. The bang prefix is deliberate (#872) and the skill templates are **not** the place to fix this.
+
+The rule is conservative: every candidate token is resolved and the command proceeds only when **exactly one** resolves to a path, URL, or folder. Two resolving tokens are ambiguous and error naming both — never guess, never pick the first. Nothing resolving errors naming what was tried plus the accepted shapes, which is the message that tells a user their slash-command argument shape was the real problem. Flag-shaped tokens are never candidates. Hosts that receive the remainder pre-joined (OpenCode, Pi) try the un-split string first, so an unquoted path containing spaces still wins over its own tokens.
+
+Two cases deliberately stay with the caller's existing, more specific error: a single unresolvable token (`File not found: typo.md`) and an argument that does exist but isn't annotatable (`File type not supported: .pdf`).
+
+**Tolerance is bypassed for strict invocations** (`--require-approval` / `--result-file` — see `isStrictAnnotateInvocation` in `apps/hook/server/strict-annotate-result.ts`, the same predicate that picks the startup-failure exit code). Those own an exit-code contract: a typo must keep exiting 2, and quietly annotating a later argument because the first one was a typo would let a gate publish `approved` for a document the caller never named.
+
 ### Strict direct annotate results
 
 Direct `plannotator annotate` invocations may add `--require-approval` and/or `--result-file <path>` only with `--gate --json`; both reject `--hook` and are not shared with OpenCode/Pi slash-command parsing. Legacy plaintext, JSON, hook, and exit behavior remains unchanged when neither strict option is present.

--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -96,6 +96,11 @@ import {
   type GoalSetupStage,
 } from "@plannotator/shared/goal-setup";
 import { stripAtPrefix, resolveAtReference } from "@plannotator/shared/at-reference";
+import {
+  annotateInputExists,
+  annotateTokenResolves,
+  resolveAnnotateTargetArg,
+} from "@plannotator/shared/annotate-target";
 import { htmlToMarkdown } from "@plannotator/shared/html-to-markdown";
 import { urlToMarkdown, isConvertedSource } from "@plannotator/shared/url-to-markdown";
 import { createWorktreePool, type WorktreePool, type PoolEntry } from "@plannotator/shared/worktree-pool";
@@ -161,6 +166,7 @@ import { completeAnnotateCommand } from "./annotate-command";
 import {
   annotateStartupFailureExitCode,
   assertResultPathAvailable,
+  isStrictAnnotateInvocation,
   resolveResultFilePath,
   STRICT_GATE_ERROR_EXIT_CODE,
 } from "./strict-annotate-result";
@@ -1000,7 +1006,7 @@ if (args[0] === "sessions") {
     );
   }
 
-  const rawFilePath = args[1];
+  let rawFilePath = args[1];
   if (!rawFilePath) {
     exitAnnotateStartupFailure("Usage: plannotator annotate <file.md | file.txt | file.html | https://... | folder/>  [--markdown] [--no-jina] [--gate] [--json] [--hook] [--require-approval] [--result-file <path>]");
   }
@@ -1012,6 +1018,23 @@ if (args[0] === "sessions") {
 
   // Use PLANNOTATOR_CWD if set (original working directory before script cd'd)
   const projectRoot = process.env.PLANNOTATOR_CWD || process.cwd();
+
+  // Tolerant target selection: the host slash commands substitute
+  // `$ARGUMENTS` unquoted, so trailing prose lands in argv as extra tokens.
+  // Strict invocations bypass this and keep their exit-code contract — see
+  // resolveAnnotateTargetArg.
+  const annotateTarget = resolveAnnotateTargetArg({
+    raw: rawFilePath,
+    tokens: args.slice(1),
+    strict: isStrictAnnotateInvocation({ requireApproval: requireApprovalFlag, resultFile }),
+    resolves: (token) => annotateTokenResolves(token, projectRoot),
+    inputExists: (input) => annotateInputExists(input, projectRoot),
+  });
+  if (annotateTarget.kind === "error") {
+    exitAnnotateStartupFailure(annotateTarget.message);
+  }
+  rawFilePath = annotateTarget.token;
+  filePath = stripAtPrefix(rawFilePath);
 
   if (resultFile) {
     try {

--- a/apps/hook/server/strict-annotate-result.test.ts
+++ b/apps/hook/server/strict-annotate-result.test.ts
@@ -15,9 +15,16 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
+  annotateInputExists,
+  annotateTokenResolves,
+  resolveAnnotateTargetArg,
+} from "@plannotator/shared/annotate-target";
+import { parseStrictAnnotateOptions } from "./cli";
+import {
   annotateOutcomeExitCode,
   annotateStartupFailureExitCode,
   assertResultPathAvailable,
+  isStrictAnnotateInvocation,
   resolveResultFilePath,
   serializeStrictAnnotateResult,
   STRICT_GATE_ERROR_EXIT_CODE,
@@ -175,6 +182,151 @@ describe("annotate startup failure exit codes", () => {
         annotateStartupBlock.slice(0, site).lastIndexOf("console.error("),
       );
     }
+  });
+});
+
+describe("tolerant annotate target resolution vs the strict exit-code contract", () => {
+  /**
+   * Replay exactly the wiring `index.ts` uses for the annotate branch:
+   * parse the strict options off argv, ask whether the invocation is strict,
+   * resolve the target, and — when nothing usable came back — pick the
+   * startup-failure exit code from those same strict flags.
+   *
+   * Nothing here spawns the binary: `index.ts` imports the bundled
+   * `../dist/*.html`, which CI's `bun test` never builds. So the contract is
+   * asserted over the real production units in the real order instead.
+   */
+  function annotateInvocation(argv: string[], projectRoot: string) {
+    const parsed = parseStrictAnnotateOptions(argv);
+    const args = parsed.remainingArgs.filter(
+      (arg) => arg !== "--gate" && arg !== "--json",
+    );
+    const rawFilePath = args[1];
+    const decision = resolveAnnotateTargetArg({
+      raw: rawFilePath,
+      tokens: args.slice(1),
+      strict: isStrictAnnotateInvocation(parsed),
+      resolves: (token) => annotateTokenResolves(token, projectRoot),
+      inputExists: (input) => annotateInputExists(input, projectRoot),
+    });
+    return {
+      strict: isStrictAnnotateInvocation(parsed),
+      decision,
+      startupFailureExitCode: annotateStartupFailureExitCode(parsed),
+    };
+  }
+
+  async function projectWithOneDocument(): Promise<string> {
+    const directory = await makeTemporaryDirectory();
+    await writeFile(join(directory, "spec.md"), "# Spec\n", "utf8");
+    return directory;
+  }
+
+  test("a typo under --gate --json --require-approval still exits 2", async () => {
+    const projectRoot = await projectWithOneDocument();
+    const { strict, decision, startupFailureExitCode } = annotateInvocation(
+      ["annotate", "typo.md", "--gate", "--json", "--require-approval"],
+      projectRoot,
+    );
+
+    expect(strict).toBe(true);
+    // Tolerance is bypassed: the target is what was typed, verbatim.
+    expect(decision).toEqual({ kind: "target", token: "typo.md" });
+    // …and it does not resolve, so the startup-failure path is the one taken.
+    expect(annotateTokenResolves("typo.md", projectRoot)).toBe(false);
+    expect(startupFailureExitCode).toBe(STRICT_GATE_ERROR_EXIT_CODE);
+  });
+
+  test("a typo under --gate --json --result-file still exits 2", async () => {
+    const projectRoot = await projectWithOneDocument();
+    const { strict, decision, startupFailureExitCode } = annotateInvocation(
+      [
+        "annotate",
+        "typo.md",
+        "--gate",
+        "--json",
+        "--result-file",
+        join(projectRoot, "result.json"),
+      ],
+      projectRoot,
+    );
+
+    expect(strict).toBe(true);
+    expect(decision).toEqual({ kind: "target", token: "typo.md" });
+    expect(startupFailureExitCode).toBe(STRICT_GATE_ERROR_EXIT_CODE);
+  });
+
+  test("strict never annotates a different argument than the one it was given", async () => {
+    const projectRoot = await projectWithOneDocument();
+    // `spec.md` is real and would win under tolerant resolution. A gate that
+    // silently reviewed it would publish "approved" for a document the caller
+    // never named, so strict must keep failing on `typo.md`.
+    const { decision, startupFailureExitCode } = annotateInvocation(
+      ["annotate", "typo.md", "spec.md", "--gate", "--json", "--require-approval"],
+      projectRoot,
+    );
+
+    expect(decision).toEqual({ kind: "target", token: "typo.md" });
+    expect(startupFailureExitCode).toBe(STRICT_GATE_ERROR_EXIT_CODE);
+  });
+
+  test("strict does not error on ambiguity either — it just uses argv[1]", async () => {
+    const projectRoot = await projectWithOneDocument();
+    await writeFile(join(projectRoot, "notes.md"), "# Notes\n", "utf8");
+    const { decision } = annotateInvocation(
+      ["annotate", "spec.md", "notes.md", "--gate", "--json", "--require-approval"],
+      projectRoot,
+    );
+
+    expect(decision).toEqual({ kind: "target", token: "spec.md" });
+  });
+
+  test("the same argv without a strict flag gets the tolerant behavior", async () => {
+    const projectRoot = await projectWithOneDocument();
+
+    // Prose around a real file resolves to the file.
+    expect(
+      annotateInvocation(
+        ["annotate", "the", "aim", "spec.md", "--gate", "--json"],
+        projectRoot,
+      ),
+    ).toMatchObject({
+      strict: false,
+      decision: { kind: "target", token: "spec.md" },
+      startupFailureExitCode: 1,
+    });
+
+    // Nothing usable errors with the shape hint instead of "File not found: the".
+    const noTarget = annotateInvocation(
+      ["annotate", "the", "aim", "doc"],
+      projectRoot,
+    );
+    expect(noTarget.decision.kind).toBe("error");
+    if (noTarget.decision.kind !== "error") throw new Error("unreachable");
+    expect(noTarget.decision.message).toContain("Tried: the, aim, doc");
+    expect(noTarget.decision.message).toContain("path, URL, or folder");
+  });
+
+  test("index.ts gates tolerant resolution on the strict predicate", () => {
+    // The bypass has to be wired in the annotate startup block itself; a
+    // tolerant path that forgot `strict` would pass every unit test above
+    // and still break the gate contract in production.
+    const source = readFileSync(join(import.meta.dir, "index.ts"), "utf8");
+    const start = source.indexOf('} else if (args[0] === "annotate") {');
+    const end = source.indexOf(
+      '} else if (args[0] === "annotate-last" || args[0] === "last") {',
+      start,
+    );
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+
+    const annotateStartupBlock = source.slice(start, end);
+    const call = annotateStartupBlock.indexOf("resolveAnnotateTargetArg({");
+    expect(call).toBeGreaterThan(-1);
+    const callArgs = annotateStartupBlock.slice(call, call + 600);
+    expect(callArgs).toContain("strict: isStrictAnnotateInvocation({");
+    expect(callArgs).toContain("requireApproval: requireApprovalFlag");
+    expect(callArgs).toContain("resultFile");
   });
 });
 

--- a/apps/hook/server/strict-annotate-result.ts
+++ b/apps/hook/server/strict-annotate-result.ts
@@ -24,6 +24,27 @@ export interface AnnotateOutcome {
  */
 export const STRICT_GATE_ERROR_EXIT_CODE = 2;
 
+export interface StrictAnnotateFlags {
+  requireApproval: boolean;
+  resultFile?: string;
+}
+
+/**
+ * True when the invocation carries a strict flag (`--require-approval` /
+ * `--result-file`, neither of which the CLI accepts without `--gate --json`).
+ *
+ * Strict invocations own the exit-code contract below, which is why tolerant
+ * annotate argument resolution is bypassed for them: quietly annotating a
+ * later argument because the first one was a typo would let a gate publish
+ * "approved" for a document the caller never named. A typo must keep exiting
+ * 2 here.
+ */
+export function isStrictAnnotateInvocation(
+  flags: StrictAnnotateFlags,
+): boolean {
+  return flags.requireApproval || !!flags.resultFile;
+}
+
 /**
  * Exit code for an annotate startup failure (missing path, unreachable URL,
  * empty folder, ambiguous name, missing file, oversized file).
@@ -32,13 +53,10 @@ export const STRICT_GATE_ERROR_EXIT_CODE = 2;
  * "the reviewer did not approve", so a startup failure must exit with the gate
  * error code instead — otherwise automation reads a typo'd path as a rejection.
  */
-export function annotateStartupFailureExitCode(strict: {
-  requireApproval: boolean;
-  resultFile?: string;
-}): number {
-  return strict.requireApproval || strict.resultFile
-    ? STRICT_GATE_ERROR_EXIT_CODE
-    : 1;
+export function annotateStartupFailureExitCode(
+  strict: StrictAnnotateFlags,
+): number {
+  return isStrictAnnotateInvocation(strict) ? STRICT_GATE_ERROR_EXIT_CODE : 1;
 }
 
 export function serializeStrictAnnotateResult(

--- a/apps/opencode-plugin/commands.ts
+++ b/apps/opencode-plugin/commands.ts
@@ -27,6 +27,12 @@ import { resolveMarkdownFile, resolveUserPath, hasMarkdownFiles, ANNOTATABLE_DOC
 import { FILE_BROWSER_EXCLUDED } from "@plannotator/shared/reference-common";
 import { htmlToMarkdown } from "@plannotator/shared/html-to-markdown";
 import { parseAnnotateArgs } from "@plannotator/shared/annotate-args";
+import {
+  annotateInputExists,
+  annotateTokenResolves,
+  resolveAnnotateTargetArg,
+} from "@plannotator/shared/annotate-target";
+import { stripAtPrefix } from "@plannotator/shared/at-reference";
 import { parseReviewArgs } from "@plannotator/shared/review-args";
 import { urlToMarkdown, isConvertedSource } from "@plannotator/shared/url-to-markdown";
 import { buildLocalWorkspaceReview, type WorkspaceDiffType } from "@plannotator/server/review-workspace";
@@ -218,7 +224,9 @@ export async function handleAnnotateCommand(
   // --json is accepted silently (OpenCode writes to session, not stdout).
   // parseAnnotateArgs strips leading @ on filePath (reference-mode convention).
   // `rawFilePath` preserves it for the scoped-package markdown fallback.
-  const { filePath, rawFilePath, gate, renderMarkdown: renderMarkdownFlag, noJina } = parseAnnotateArgs(rawArgs);
+  const parsedAnnotateArgs = parseAnnotateArgs(rawArgs);
+  const { gate, renderMarkdown: renderMarkdownFlag, noJina } = parsedAnnotateArgs;
+  let { filePath, rawFilePath } = parsedAnnotateArgs;
   // @ts-ignore - Event properties contain sessionID
   const sessionId = event.properties?.sessionID;
 
@@ -226,6 +234,25 @@ export async function handleAnnotateCommand(
     client.app.log({ level: "error", message: "Usage: /plannotator-annotate <file.md | file.txt | file.html | https://... | folder/> [--markdown] [--no-jina] [--gate] [--json]" });
     return;
   }
+
+  // Tolerant target selection: the slash command hands us whatever the user
+  // typed, so trailing prose ("the aim doc") used to be fatal. The un-split
+  // string is tried first, so an unquoted path containing spaces still wins
+  // over its own tokens; only then do we sift per token.
+  const agentCwd = directory || process.cwd();
+  // No `strict` here — OpenCode writes decisions back into the session and
+  // owns no exit-code contract.
+  const annotateTarget = resolveAnnotateTargetArg({
+    raw: rawFilePath,
+    resolves: (token) => annotateTokenResolves(token, agentCwd),
+    inputExists: (input) => annotateInputExists(input, agentCwd),
+  });
+  if (annotateTarget.kind === "error") {
+    client.app.log({ level: "error", message: annotateTarget.message });
+    return;
+  }
+  rawFilePath = annotateTarget.token;
+  filePath = stripAtPrefix(rawFilePath);
 
   let markdown: string;
   let rawHtml: string | undefined;
@@ -235,7 +262,6 @@ export async function handleAnnotateCommand(
   let isFolder = false;
   let sourceInfo: string | undefined;
   let sourceConverted = false;
-  const agentCwd = directory || process.cwd();
 
   // --- URL annotation ---
   const isUrl = /^https?:\/\//i.test(filePath);

--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -92,15 +92,20 @@ function loadPlannotatorPrompts(): Promise<PlannotatorPromptsModule> {
 }
 
 async function loadAnnotateCommandModules() {
-	const [annotateArgs, atReference, resolveFile, referenceCommon] = await Promise.all([
+	const [annotateArgs, annotateTarget, atReference, resolveFile, referenceCommon] = await Promise.all([
 		import("./generated/annotate-args.ts"),
+		import("./generated/annotate-target.ts"),
 		import("./generated/at-reference.ts"),
 		import("./generated/resolve-file.ts"),
 		import("./generated/reference-common.ts"),
 	]);
 	return {
 		parseAnnotateArgs: annotateArgs.parseAnnotateArgs,
+		annotateInputExists: annotateTarget.annotateInputExists,
+		annotateTokenResolves: annotateTarget.annotateTokenResolves,
+		resolveAnnotateTargetArg: annotateTarget.resolveAnnotateTargetArg,
 		resolveAtReference: atReference.resolveAtReference,
+		stripAtPrefix: atReference.stripAtPrefix,
 		hasMarkdownFiles: resolveFile.hasMarkdownFiles,
 		resolveUserPath: resolveFile.resolveUserPath,
 		isAnnotatableTextPath: resolveFile.isAnnotatableTextPath,
@@ -636,7 +641,11 @@ export default function plannotator(pi: ExtensionAPI): void {
 				FILE_BROWSER_EXCLUDED,
 				hasMarkdownFiles,
 				parseAnnotateArgs,
+				annotateInputExists,
+				annotateTokenResolves,
+				resolveAnnotateTargetArg,
 				resolveAtReference,
+				stripAtPrefix,
 				resolveUserPath,
 				isAnnotatableTextPath,
 				ANNOTATABLE_DOC_REGEX,
@@ -647,11 +656,14 @@ export default function plannotator(pi: ExtensionAPI): void {
 			// accepted (Pi writes back via sendUserMessage, not stdout).
 			// `rawFilePath` keeps any leading `@` for the literal-@ fallback
 			// (scoped-package-style names).
-			const { filePath, rawFilePath, gate, renderMarkdown: renderMarkdownFlag, noJina } = parseAnnotateArgs(args ?? "");
+			const parsedAnnotateArgs = parseAnnotateArgs(args ?? "");
+			const { gate, renderMarkdown: renderMarkdownFlag, noJina } = parsedAnnotateArgs;
+			let { filePath, rawFilePath } = parsedAnnotateArgs;
 			if (!filePath) {
 				ctx.ui.notify("Usage: /plannotator-annotate <file.md | file.txt | file.html | https://... | folder/> [--markdown] [--no-jina] [--gate] [--json]", "error");
 				return;
 			}
+
 			if (!hasPlanBrowserHtml()) {
 				ctx.ui.notify(
 					"Annotation UI not available. Run 'bun run build' in the pi-extension directory.",
@@ -659,6 +671,22 @@ export default function plannotator(pi: ExtensionAPI): void {
 				);
 				return;
 			}
+
+			// Tolerant target selection: the slash command hands us whatever the
+			// user typed, so trailing prose ("the aim doc") used to be fatal. No
+			// `strict` here — Pi writes decisions back through sendUserMessage
+			// and owns no exit-code contract.
+			const annotateTarget = resolveAnnotateTargetArg({
+				raw: rawFilePath,
+				resolves: (token: string) => annotateTokenResolves(token, ctx.cwd),
+				inputExists: (input: string) => annotateInputExists(input, ctx.cwd),
+			});
+			if (annotateTarget.kind === "error") {
+				ctx.ui.notify(annotateTarget.message, "error");
+				return;
+			}
+			rawFilePath = annotateTarget.token;
+			filePath = stripAtPrefix(rawFilePath);
 
 			let markdown: string;
 			let rawHtml: string | undefined;

--- a/apps/pi-extension/vendor.sh
+++ b/apps/pi-extension/vendor.sh
@@ -29,7 +29,7 @@ for f in config-types storage-types workspace-status-types; do
 done
 
 # Everything else in the original flat list stays sourced from packages/shared.
-for f in prompts review-core diff-paths cli-pagination jj-core gitbutler-core vcs-core review-args draft annotate-history pr-types pr-context-live pr-artifact-document pr-provider pr-stack pr-github pr-gitlab checklist integrations-common repo reference-common resolve-file annotate-reference-roots-node worktree worktree-pool html-to-markdown html-diff html-assets html-assets-node url-to-markdown tour annotate-args at-reference review-workspace-node review-workspace pfm-reminder improvement-hooks code-nav data-dir semantic-diff-types semantic-diff single-flight source-save-node review-profiles guide guide-store commit-avatars commit-history port-range annotate-client-lease annotate-decision archive-mode; do
+for f in prompts review-core diff-paths cli-pagination jj-core gitbutler-core vcs-core review-args draft annotate-history pr-types pr-context-live pr-artifact-document pr-provider pr-stack pr-github pr-gitlab checklist integrations-common repo reference-common resolve-file annotate-reference-roots-node worktree worktree-pool html-to-markdown html-diff html-assets html-assets-node url-to-markdown tour annotate-args annotate-target at-reference review-workspace-node review-workspace pfm-reminder improvement-hooks code-nav data-dir semantic-diff-types semantic-diff single-flight source-save-node review-profiles guide guide-store commit-avatars commit-history port-range annotate-client-lease annotate-decision archive-mode; do
   src="../../packages/shared/$f.ts"
   printf '// @generated — DO NOT EDIT. Source: packages/shared/%s.ts\n' "$f" | cat - "$src" > "generated/$f.ts"
 done

--- a/packages/shared/annotate-target.test.ts
+++ b/packages/shared/annotate-target.test.ts
@@ -1,0 +1,387 @@
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+	annotateInputExists,
+	annotateTokenResolves,
+	formatAmbiguousAnnotateTargetError,
+	formatNoAnnotateTargetError,
+	isAnnotateTargetCandidate,
+	isAnnotateUrlToken,
+	resolveAnnotateTargetArg,
+	selectAnnotateTarget,
+	selectAnnotateTargetFromRaw,
+} from "./annotate-target";
+
+// --- Pure selection, with an injected predicate -----------------------------
+
+/** Stand-in for the filesystem: these tokens "resolve", nothing else does. */
+function resolvesOneOf(...resolvable: string[]) {
+	return (token: string) => resolvable.includes(token);
+}
+
+describe("selectAnnotateTarget", () => {
+	const cases: Array<{
+		name: string;
+		tokens: string[];
+		resolvable: string[];
+		expected: ReturnType<typeof selectAnnotateTarget>;
+	}> = [
+		{
+			name: "one valid path plus trailing prose",
+			tokens: ["the", "aim", "doc.md"],
+			resolvable: ["doc.md"],
+			expected: { kind: "resolved", token: "doc.md" },
+		},
+		{
+			name: "path first, prose after",
+			tokens: ["docs/spec.md", "and", "give", "me", "the", "URL", "for", "it"],
+			resolvable: ["docs/spec.md"],
+			expected: { kind: "resolved", token: "docs/spec.md" },
+		},
+		{
+			name: "URL plus prose",
+			tokens: ["https://example.com/page", "and", "summarize", "it"],
+			resolvable: ["https://example.com/page"],
+			expected: { kind: "resolved", token: "https://example.com/page" },
+		},
+		{
+			name: "folder plus prose",
+			tokens: ["review", "docs/"],
+			resolvable: ["docs/"],
+			expected: { kind: "resolved", token: "docs/" },
+		},
+		{
+			name: "two valid paths is ambiguous — both named, neither guessed",
+			tokens: ["spec.md", "and", "notes.md"],
+			resolvable: ["spec.md", "notes.md"],
+			expected: { kind: "ambiguous", candidates: ["spec.md", "notes.md"] },
+		},
+		{
+			name: "three valid paths are all named",
+			tokens: ["a.md", "b.md", "c.md"],
+			resolvable: ["a.md", "b.md", "c.md"],
+			expected: { kind: "ambiguous", candidates: ["a.md", "b.md", "c.md"] },
+		},
+		{
+			name: "the same path twice is one target, not an ambiguity",
+			tokens: ["spec.md", "spec.md"],
+			resolvable: ["spec.md"],
+			expected: { kind: "resolved", token: "spec.md" },
+		},
+		{
+			name: "zero valid tokens reports everything it tried",
+			tokens: ["the", "aim", "doc"],
+			resolvable: [],
+			expected: { kind: "none", tried: ["the", "aim", "doc"] },
+		},
+		{
+			name: "flag-shaped tokens are never candidates",
+			tokens: ["--unknown", "-x", "spec.md"],
+			resolvable: ["spec.md"],
+			expected: { kind: "resolved", token: "spec.md" },
+		},
+		{
+			name: "flag-shaped tokens stay out of the tried list",
+			tokens: ["--unknown", "prose"],
+			resolvable: [],
+			expected: { kind: "none", tried: ["prose"] },
+		},
+		{
+			name: "empty tokens are dropped",
+			tokens: ["", "  ", "spec.md"],
+			resolvable: ["spec.md"],
+			expected: { kind: "resolved", token: "spec.md" },
+		},
+	];
+
+	for (const { name, tokens, resolvable, expected } of cases) {
+		test(name, () => {
+			expect(selectAnnotateTarget(tokens, resolvesOneOf(...resolvable))).toEqual(
+				expected,
+			);
+		});
+	}
+
+	test("no tokens at all resolves to nothing tried", () => {
+		expect(selectAnnotateTarget([], resolvesOneOf())).toEqual({
+			kind: "none",
+			tried: [],
+		});
+	});
+});
+
+describe("selectAnnotateTargetFromRaw", () => {
+	test("prefers the whole un-split string so paths with spaces still win", () => {
+		expect(
+			selectAnnotateTargetFromRaw(
+				"My Notes.md",
+				resolvesOneOf("My Notes.md", "Notes.md"),
+			),
+		).toEqual({ kind: "resolved", token: "My Notes.md" });
+	});
+
+	test("falls back to per-token selection when the whole string misses", () => {
+		expect(
+			selectAnnotateTargetFromRaw("the aim doc.md", resolvesOneOf("doc.md")),
+		).toEqual({ kind: "resolved", token: "doc.md" });
+	});
+
+	test("ambiguity is still refused after splitting", () => {
+		expect(
+			selectAnnotateTargetFromRaw(
+				"spec.md and notes.md",
+				resolvesOneOf("spec.md", "notes.md"),
+			),
+		).toEqual({ kind: "ambiguous", candidates: ["spec.md", "notes.md"] });
+	});
+
+	test("reports what it tried when nothing resolves", () => {
+		expect(
+			selectAnnotateTargetFromRaw("the aim doc", resolvesOneOf()),
+		).toEqual({ kind: "none", tried: ["the", "aim", "doc"] });
+	});
+});
+
+describe("token shape helpers", () => {
+	test("recognizes URL tokens, `@`-prefixed included", () => {
+		expect(isAnnotateUrlToken("https://example.com")).toBe(true);
+		expect(isAnnotateUrlToken("HTTP://example.com")).toBe(true);
+		expect(isAnnotateUrlToken("@https://example.com")).toBe(true);
+		expect(isAnnotateUrlToken("example.com")).toBe(false);
+		expect(isAnnotateUrlToken("the")).toBe(false);
+	});
+
+	test("excludes flag-shaped and blank tokens from candidacy", () => {
+		expect(isAnnotateTargetCandidate("spec.md")).toBe(true);
+		expect(isAnnotateTargetCandidate("--gate")).toBe(false);
+		expect(isAnnotateTargetCandidate("-x")).toBe(false);
+		expect(isAnnotateTargetCandidate("")).toBe(false);
+		expect(isAnnotateTargetCandidate("   ")).toBe(false);
+	});
+});
+
+// --- Error message wording --------------------------------------------------
+
+describe("error messages", () => {
+	test("ambiguity names every candidate and refuses to pick", () => {
+		expect(
+			formatAmbiguousAnnotateTargetError(["spec.md", "notes.md"]),
+		).toBe(
+			[
+				"Ambiguous annotate target — 2 arguments name something annotatable:",
+				"  spec.md",
+				"  notes.md",
+				"Pass exactly one path, URL, or folder.",
+			].join("\n"),
+		);
+	});
+
+	test("no-target names what was tried and states the accepted shapes", () => {
+		const message = formatNoAnnotateTargetError(["the", "aim", "doc"]);
+		expect(message).toBe(
+			[
+				"No annotate target found. Tried: the, aim, doc",
+				"plannotator annotate accepts a path, URL, or folder — e.g. docs/spec.md, ./docs/, or https://example.com/page.",
+			].join("\n"),
+		);
+		// The shape hint is most of this change's value: today's bare
+		// "File not found: and" gave no clue the real problem was the
+		// slash command's argument shape.
+		expect(message).toContain("path, URL, or folder");
+	});
+});
+
+// --- Real filesystem resolution --------------------------------------------
+
+describe("annotateTokenResolves", () => {
+	let root: string;
+
+	beforeAll(() => {
+		root = mkdtempSync(join(tmpdir(), "plannotator-annotate-target-"));
+		mkdirSync(join(root, "docs"));
+		writeFileSync(join(root, "docs", "spec.md"), "# Spec\n");
+		writeFileSync(join(root, "notes.txt"), "notes\n");
+		writeFileSync(join(root, "config.yaml"), "a: 1\n");
+		writeFileSync(join(root, "page.html"), "<p>hi</p>\n");
+		writeFileSync(join(root, "report.pdf"), "not really a pdf\n");
+		mkdirSync(join(root, "@scope"));
+		writeFileSync(join(root, "@scope", "README.md"), "# scoped\n");
+	});
+
+	afterAll(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	test("resolves a relative markdown path", () => {
+		expect(annotateTokenResolves("docs/spec.md", root)).toBe(true);
+	});
+
+	test("resolves a bare filename found inside the project", () => {
+		expect(annotateTokenResolves("spec.md", root)).toBe(true);
+	});
+
+	test("resolves an absolute path", () => {
+		expect(annotateTokenResolves(join(root, "notes.txt"), root)).toBe(true);
+	});
+
+	test("resolves the wider plain-text set (.txt, .yaml)", () => {
+		expect(annotateTokenResolves("notes.txt", root)).toBe(true);
+		expect(annotateTokenResolves("config.yaml", root)).toBe(true);
+	});
+
+	test("resolves an HTML file", () => {
+		expect(annotateTokenResolves("page.html", root)).toBe(true);
+	});
+
+	test("resolves a folder, with or without a trailing slash", () => {
+		expect(annotateTokenResolves("docs", root)).toBe(true);
+		expect(annotateTokenResolves("docs/", root)).toBe(true);
+	});
+
+	test("resolves a URL without touching the filesystem", () => {
+		expect(annotateTokenResolves("https://example.com/page", root)).toBe(true);
+	});
+
+	test("resolves an `@`-reference and its scoped-package literal form", () => {
+		expect(annotateTokenResolves("@docs/spec.md", root)).toBe(true);
+		expect(annotateTokenResolves("@scope/README.md", root)).toBe(true);
+	});
+
+	test("rejects bare prose", () => {
+		for (const word of ["the", "aim", "doc", "and", "give", "me", "URL", "it"]) {
+			expect(annotateTokenResolves(word, root)).toBe(false);
+		}
+	});
+
+	test("rejects a file that exists but isn't annotatable", () => {
+		expect(annotateTokenResolves("report.pdf", root)).toBe(false);
+	});
+
+	test("rejects a plausible-looking path that doesn't exist", () => {
+		expect(annotateTokenResolves("docs/missing.md", root)).toBe(false);
+	});
+
+	test("annotateInputExists sees on-disk entries regardless of type", () => {
+		expect(annotateInputExists("report.pdf", root)).toBe(true);
+		expect(annotateInputExists("docs", root)).toBe(true);
+		expect(annotateInputExists("@scope/README.md", root)).toBe(true);
+		expect(annotateInputExists("nope", root)).toBe(false);
+	});
+
+	test("end-to-end: prose around a real file picks the file", () => {
+		const decision = resolveAnnotateTargetArg({
+			raw: "the",
+			tokens: ["the", "aim", "docs/spec.md"],
+			resolves: (token) => annotateTokenResolves(token, root),
+			inputExists: (input) => annotateInputExists(input, root),
+		});
+		expect(decision).toEqual({ kind: "target", token: "docs/spec.md" });
+	});
+});
+
+// --- The decision, including the strict bypass ------------------------------
+
+describe("resolveAnnotateTargetArg", () => {
+	const resolves = resolvesOneOf("spec.md", "notes.md");
+	const existsOnDisk = (input: string) =>
+		["spec.md", "notes.md", "report.pdf"].includes(input);
+
+	test("passes the single resolving token through", () => {
+		expect(
+			resolveAnnotateTargetArg({
+				raw: "the",
+				tokens: ["the", "aim", "spec.md"],
+				resolves,
+				inputExists: existsOnDisk,
+			}),
+		).toEqual({ kind: "target", token: "spec.md" });
+	});
+
+	test("errors on ambiguity", () => {
+		const decision = resolveAnnotateTargetArg({
+			raw: "spec.md",
+			tokens: ["spec.md", "notes.md"],
+			resolves,
+			inputExists: existsOnDisk,
+		});
+		expect(decision.kind).toBe("error");
+		if (decision.kind !== "error") throw new Error("unreachable");
+		expect(decision.message).toContain("spec.md");
+		expect(decision.message).toContain("notes.md");
+		expect(decision.message).toContain("Ambiguous annotate target");
+	});
+
+	test("errors when nothing resolves and there was prose to sift", () => {
+		const decision = resolveAnnotateTargetArg({
+			raw: "the",
+			tokens: ["the", "aim", "doc"],
+			resolves,
+			inputExists: existsOnDisk,
+		});
+		expect(decision.kind).toBe("error");
+		if (decision.kind !== "error") throw new Error("unreachable");
+		expect(decision.message).toContain("Tried: the, aim, doc");
+		expect(decision.message).toContain("path, URL, or folder");
+	});
+
+	test("a lone unresolvable token keeps the caller's specific error", () => {
+		// One candidate means there was no prose to sift — the caller's
+		// "File not found: typo.md" says more than a shape hint would.
+		expect(
+			resolveAnnotateTargetArg({
+				raw: "typo.md",
+				tokens: ["typo.md"],
+				resolves,
+				inputExists: existsOnDisk,
+			}),
+		).toEqual({ kind: "target", token: "typo.md" });
+	});
+
+	test("an argument that exists but isn't annotatable keeps the caller's error", () => {
+		// Would otherwise trade "File type not supported: .pdf" for a
+		// vaguer hint.
+		expect(
+			resolveAnnotateTargetArg({
+				raw: "report.pdf",
+				tokens: ["report.pdf", "please"],
+				resolves,
+				inputExists: existsOnDisk,
+			}),
+		).toEqual({ kind: "target", token: "report.pdf" });
+	});
+
+	test("strict invocations bypass tolerance entirely", () => {
+		// Requirement 4. Even though `spec.md` resolves, a strict invocation
+		// must keep annotating exactly what it was handed — otherwise a
+		// typo'd first argument could publish "approved" for some other file.
+		expect(
+			resolveAnnotateTargetArg({
+				raw: "typo.md",
+				tokens: ["typo.md", "spec.md"],
+				strict: true,
+				resolves,
+				inputExists: existsOnDisk,
+			}),
+		).toEqual({ kind: "target", token: "typo.md" });
+	});
+
+	test("strict invocations never emit a tolerant error", () => {
+		for (const tokens of [
+			["the", "aim", "doc"], // would be "none"
+			["spec.md", "notes.md"], // would be "ambiguous"
+		]) {
+			expect(
+				resolveAnnotateTargetArg({
+					raw: tokens[0],
+					tokens,
+					strict: true,
+					resolves,
+					inputExists: existsOnDisk,
+				}),
+			).toEqual({ kind: "target", token: tokens[0] });
+		}
+	});
+});

--- a/packages/shared/annotate-target.ts
+++ b/packages/shared/annotate-target.ts
@@ -1,0 +1,235 @@
+/**
+ * Tolerant annotate target selection.
+ *
+ * The host slash commands invoke the CLI through a bash-substitution prefix
+ * (`` !`plannotator annotate $ARGUMENTS` ``), so `$ARGUMENTS` reaches argv
+ * unquoted and unparsed. Any trailing natural language used to be fatal:
+ *
+ *   /plannotator-annotate and give me the URL for it  ->  File not found: and
+ *   /plannotator-annotate the aim doc                 ->  File not found: the
+ *
+ * Fixing that in argument resolution (rather than in the skill templates)
+ * means every host gets the forgiving behavior at once. The rule is
+ * deliberately conservative: resolve every candidate token and proceed only
+ * when EXACTLY ONE resolves. Two resolving tokens are ambiguous and error
+ * naming both — we never guess, and never pick the first.
+ *
+ * Callers keep their own resolution logic for the token that wins; this
+ * module only decides WHICH token is the target, and formats the two new
+ * errors so every runtime words them identically.
+ */
+
+import { existsSync, statSync } from "node:fs";
+
+import { resolveAtReference, stripAtPrefix } from "./at-reference";
+import { resolveMarkdownFile, resolveUserPath } from "./resolve-file";
+
+export type AnnotateTargetSelection =
+	/** Exactly one candidate resolved — annotate it. */
+	| { kind: "resolved"; token: string }
+	/** Two or more candidates resolved — refuse to guess. */
+	| { kind: "ambiguous"; candidates: string[] }
+	/** Nothing resolved. `tried` is every token we tested, in order. */
+	| { kind: "none"; tried: string[] };
+
+/** A `https://` / `http://` target, `@`-prefix tolerant. */
+export function isAnnotateUrlToken(token: string): boolean {
+	return /^https?:\/\//i.test(stripAtPrefix(token));
+}
+
+/**
+ * Tokens worth testing as a target. Flag-shaped tokens are excluded so an
+ * unrecognized `--foo` never becomes a candidate (and so the "tried" list in
+ * the error message stays prose, not flags).
+ */
+export function isAnnotateTargetCandidate(token: string): boolean {
+	return token.trim().length > 0 && !token.startsWith("-");
+}
+
+/**
+ * Does this token name something `annotate` can actually open — a URL, a
+ * directory, an HTML file, or an annotatable plain-text file?
+ *
+ * Mirrors the three resolution branches at the call sites (URL / folder /
+ * HTML / markdown-and-friends), including their `@`-reference semantics:
+ * stripped form first, literal form as the scoped-package fallback.
+ *
+ * Cheap for prose. `resolveMarkdownFile` rejects anything without an
+ * annotatable extension before it walks the project, so a bare word like
+ * `the` costs two failed `stat` calls, not a tree walk.
+ *
+ * An in-project name matching several files counts as resolved: the user
+ * clearly meant it as the target, and the existing "Ambiguous filename"
+ * error is a better message than "no target found".
+ */
+export function annotateTokenResolves(
+	token: string,
+	projectRoot: string,
+): boolean {
+	if (isAnnotateUrlToken(token)) return true;
+
+	return (
+		resolveAtReference(token, (candidate) => {
+			const absolute = resolveUserPath(candidate, projectRoot);
+			if (!absolute) return false;
+			try {
+				if (statSync(absolute).isDirectory()) return true;
+			} catch {
+				/* not a directory (or unreadable) — keep checking */
+			}
+			if (/\.html?$/i.test(absolute) && existsSync(absolute)) return true;
+			const resolved = resolveMarkdownFile(candidate, projectRoot);
+			return resolved.kind === "found" || resolved.kind === "ambiguous";
+		}) !== null
+	);
+}
+
+/**
+ * Does the literal argument point at something that already exists on disk?
+ *
+ * When it does, the caller's own type-specific errors ("File type not
+ * supported: .pdf", "No annotatable files … found in …") say more than the
+ * tolerant "no target found" hint, so callers use this to stay out of the
+ * way. `@`-reference semantics apply, same as resolution.
+ */
+export function annotateInputExists(
+	input: string,
+	projectRoot: string,
+): boolean {
+	return (
+		resolveAtReference(input, (candidate) => {
+			const absolute = resolveUserPath(candidate, projectRoot);
+			return !!absolute && existsSync(absolute);
+		}) !== null
+	);
+}
+
+/**
+ * Pick the single annotate target out of already-tokenized args.
+ *
+ * `resolves` is injected so this stays pure and table-testable; production
+ * callers pass a closure over `annotateTokenResolves`. Duplicate tokens
+ * collapse — `annotate spec.md spec.md` is one target, not an ambiguity.
+ */
+export function selectAnnotateTarget(
+	tokens: readonly string[],
+	resolves: (token: string) => boolean,
+): AnnotateTargetSelection {
+	const candidates = tokens.filter(isAnnotateTargetCandidate);
+	const hits: string[] = [];
+	for (const candidate of candidates) {
+		if (hits.includes(candidate)) continue;
+		if (resolves(candidate)) hits.push(candidate);
+	}
+
+	if (hits.length === 1) return { kind: "resolved", token: hits[0] };
+	if (hits.length > 1) return { kind: "ambiguous", candidates: hits };
+	return { kind: "none", tried: candidates };
+}
+
+/**
+ * Pick the target out of a raw args string (OpenCode and Pi receive the
+ * whole slash-command remainder pre-joined).
+ *
+ * The un-split string is tried first, so an unquoted path containing spaces
+ * still wins over its own tokens — that's existing supported behavior on
+ * those hosts. Only when the whole string doesn't resolve do we fall back to
+ * per-token selection.
+ */
+export function selectAnnotateTargetFromRaw(
+	rawFilePath: string,
+	resolves: (token: string) => boolean,
+): AnnotateTargetSelection {
+	const raw = rawFilePath.trim();
+	if (isAnnotateTargetCandidate(raw) && resolves(raw)) {
+		return { kind: "resolved", token: raw };
+	}
+	return selectAnnotateTarget(raw.split(/\s+/), resolves);
+}
+
+const ANNOTATE_TARGET_SHAPE_HINT =
+	"plannotator annotate accepts a path, URL, or folder — e.g. docs/spec.md, ./docs/, or https://example.com/page.";
+
+/** Name both candidates rather than guessing between them. */
+export function formatAmbiguousAnnotateTargetError(
+	candidates: readonly string[],
+): string {
+	return [
+		`Ambiguous annotate target — ${candidates.length} arguments name something annotatable:`,
+		...candidates.map((candidate) => `  ${candidate}`),
+		"Pass exactly one path, URL, or folder.",
+	].join("\n");
+}
+
+/** Name what was tried, and state the shape the command wants. */
+export function formatNoAnnotateTargetError(tried: readonly string[]): string {
+	return [
+		`No annotate target found. Tried: ${tried.join(", ")}`,
+		ANNOTATE_TARGET_SHAPE_HINT,
+	].join("\n");
+}
+
+export type AnnotateTargetDecision =
+	/** Annotate this argument. Callers keep their own per-type resolution. */
+	| { kind: "target"; token: string }
+	/** Refuse with this message — already formatted for the host. */
+	| { kind: "error"; message: string };
+
+export interface AnnotateTargetRequest {
+	/**
+	 * The literal argument as the user gave it — `argv[1]` for the Claude Code
+	 * binary, or the whole joined slash-command remainder for OpenCode/Pi.
+	 * Also the fallback target, so a caller's own downstream errors stay
+	 * reachable.
+	 */
+	raw: string;
+	/**
+	 * Pre-tokenized argument tail, for hosts that get real argv. Omit on hosts
+	 * that receive the remainder pre-joined: `raw` is then tried whole first
+	 * (so an unquoted path with spaces still wins) before being split.
+	 */
+	tokens?: readonly string[];
+	/**
+	 * Strict invocations (`--require-approval` / `--result-file`, which the CLI
+	 * already requires `--gate --json` alongside) own an exit-code contract, so
+	 * tolerance is bypassed for them: a typo must keep exiting 2 rather than
+	 * quietly annotating a later argument and reporting "approved" for a
+	 * document the caller never named.
+	 */
+	strict?: boolean;
+	resolves: (token: string) => boolean;
+	inputExists: (input: string) => boolean;
+}
+
+/**
+ * The one tolerant-resolution decision, shared by every host so the behavior
+ * and both error messages are identical everywhere.
+ */
+export function resolveAnnotateTargetArg(
+	request: AnnotateTargetRequest,
+): AnnotateTargetDecision {
+	const { raw, tokens, strict, resolves, inputExists } = request;
+	if (strict) return { kind: "target", token: raw };
+
+	const selection = tokens
+		? selectAnnotateTarget(tokens, resolves)
+		: selectAnnotateTargetFromRaw(raw, resolves);
+
+	if (selection.kind === "resolved") {
+		return { kind: "target", token: selection.token };
+	}
+	if (selection.kind === "ambiguous") {
+		return {
+			kind: "error",
+			message: formatAmbiguousAnnotateTargetError(selection.candidates),
+		};
+	}
+	// Nothing resolved. Only speak up when there was genuinely prose to sift:
+	// a single unresolvable token, or a literal argument that does exist but
+	// isn't annotatable, keeps the caller's more specific downstream error
+	// ("File not found: …", "File type not supported: .pdf").
+	if (selection.tried.length > 1 && !inputExists(raw)) {
+		return { kind: "error", message: formatNoAnnotateTargetError(selection.tried) };
+	}
+	return { kind: "target", token: raw };
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -55,6 +55,7 @@
     "./guide": "./guide.ts",
     "./guide-store": "./guide-store.ts",
     "./annotate-args": "./annotate-args.ts",
+    "./annotate-target": "./annotate-target.ts",
     "./at-reference": "./at-reference.ts",
     "./code-nav": "./code-nav.ts",
     "./goal-setup": "./goal-setup.ts",


### PR DESCRIPTION
Closes #1182.

Takes the direction from your reply: tolerant resolution in the CLI's argument handling rather than the skill template, so every host gets it at once and the bang prefix stays exactly as #872 left it.

## Summary

- `annotate` resolves each whitespace-delimited token and proceeds only when exactly one names something annotatable, so trailing prose from a slash command stops being fatal.
- Two or more resolving is an error listing both candidates, rather than guessing which was meant.
- Nothing resolving reports what it tried and what the command accepts. That is the part that would have saved most of the retries behind #1182.
- Strict surfaces keep their exit-code contract. `--gate --json` with `--require-approval` or `--result-file` still exits 2 on a typo and still takes its target from argv, so tolerant resolution never reaches them.

Resolution lives in `packages/shared/annotate-target.ts` so the Bun and Pi runtimes share one implementation, vendored through `vendor.sh`. All three hosts call it.

## Behavior

```
$ plannotator annotate the aim doc
No annotate target found. Tried: the, aim, doc
plannotator annotate accepts a path, URL, or folder, e.g. docs/spec.md, ./docs/, or https://example.com/page.
(exit 1)

$ plannotator annotate README.md and give me the URL for it
(annotates README.md)

$ plannotator annotate README.md CONTRIBUTING.md
(reports an ambiguous target, lists both candidates, exits 1)
  README.md
  CONTRIBUTING.md
Pass exactly one path, URL, or folder.
```

The exact ambiguity header wording is pinned as a literal in `packages/shared/annotate-target.test.ts`.

## How a token resolves

`annotateTokenResolves()` mirrors the branches already at the call sites, in order: `https?://` prefix, then directory, then an existing `.html`/`.htm`, then `resolveMarkdownFile()` returning found or ambiguous. Ambiguous counts as resolved deliberately, so the existing "Ambiguous filename" error still fires with its in-project matches instead of being replaced by a vaguer hint. Everything routes through `resolveAtReference`, so `@`-references and the scoped-package literal fallback behave as before.

Cheap for prose tokens: `resolveMarkdownFile` rejects anything without an annotatable extension before walking the tree, so a word like `the` costs two failed stat calls. Flag-shaped tokens are never candidates, and identical tokens collapse so `annotate spec.md spec.md` is not an ambiguity.

## Test plan

`bun run typecheck` is clean. The three behaviors above were exercised against the real entry point, not just unit tests.

`packages/shared/annotate-target.test.ts` covers resolution, and `apps/hook/server/strict-annotate-result.test.ts` pins the strict contract, including that a typo under `--gate --json --require-approval` and under `--gate --json --result-file` still exits 2, and that the same argv without a strict flag gets tolerant behavior. Error text is asserted as literal strings rather than against a shared constant, so rewording the message fails the test.

`bun test` has three failures in `apps/pi-extension/server.test.ts` that predate this branch and reproduce on a sibling branch off the same base: a global `gpg.format=ssh` config leaks into the test's temp HOME and git cannot write a commit object. That file imports only `./server.ts` plus generated modules.

## Note

This branch and #1184 both touch `apps/hook/server/index.ts`, in different regions. `git merge-tree` reports a clean merge, so they can land in either order.
