### PR TITLE
fix(annotate): recognize wrapped URLs in token probe and port #1185 coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,6 +280,8 @@ Slash-command hosts forward raw user words to `plannotator annotate` verbatim (o
 
 Strict invocations (`--require-approval` / `--result-file`) bypass all three tiers: `args[1]` is the target and a typo'd path stays a startup failure with exit `2`.
 
+The bang prefix in the Claude Code skill is deliberate: #872 (commit `aac5aacb`, "restore `/plannotator-*` bash execution on Claude Code") put it back so the slash command never depends on the model choosing to run the binary. Argument-shape problems belong here in the CLI's resolution, not in the skill templates.
+
 ### Strict direct annotate results
 
 Direct `plannotator annotate` invocations may add `--require-approval` and/or `--result-file <path>` only with `--gate --json`; both reject `--hook` and are not shared with OpenCode/Pi slash-command parsing. When neither strict option is present, single-target invocations keep the legacy plaintext, JSON, hook, and exit behavior unchanged; multi-token invocations go through the tolerant tiers described under "Tolerant argument resolution" above.

--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -162,6 +162,7 @@ import {
 import { completeAnnotateCommand } from "./annotate-command";
 import {
   annotateStartupFailureExitCode,
+  isStrictAnnotateInvocation,
   assertResultPathAvailable,
   resolveResultFilePath,
   STRICT_GATE_ERROR_EXIT_CODE,
@@ -1022,8 +1023,12 @@ if (args[0] === "sessions") {
 
   // Strict invocations keep the exact legacy contract: args[1] is the target,
   // a typo'd path stays a startup failure (exit 2), and stdout carries only
-  // the decision record. The tolerant token fallback below never runs.
-  const strictAnnotate = requireApprovalFlag || !!resultFile;
+  // the decision record. The tolerant token fallback below never runs. Same
+  // predicate as the exit-code path, so the two cannot drift.
+  const strictAnnotate = isStrictAnnotateInvocation({
+    requireApproval: requireApprovalFlag,
+    resultFile,
+  });
 
   // Tolerant argument handling (#1182): slash-command hosts forward raw user
   // words verbatim, so a non-strict invocation with several tokens probes

--- a/apps/hook/server/strict-annotate-result.test.ts
+++ b/apps/hook/server/strict-annotate-result.test.ts
@@ -159,6 +159,11 @@ describe("annotate startup failure exit codes", () => {
     // tolerant handoff's `process.exit(0)` is fine: exit 0 is never a strict
     // outcome and the handoff is gated off strict invocations.)
     expect(annotateStartupBlock).not.toContain("process.exit(1)");
+    // The tolerance gate must be the NEGATED strict predicate: an inverted
+    // gate (tolerance in strict mode) cannot be spawn-tested without starting
+    // a server, so pin the source shape here.
+    expect(annotateStartupBlock).toContain("!strictAnnotate");
+    expect(annotateStartupBlock).toContain("isStrictAnnotateInvocation(");
     // The usage failure and every resolution failure route through the helper
     // that reads the strict flags.
     for (const failure of [

--- a/apps/hook/server/strict-annotate-result.ts
+++ b/apps/hook/server/strict-annotate-result.ts
@@ -24,6 +24,28 @@ export interface AnnotateOutcome {
  */
 export const STRICT_GATE_ERROR_EXIT_CODE = 2;
 
+export interface StrictAnnotateFlags {
+  requireApproval: boolean;
+  resultFile?: string;
+}
+
+/**
+ * True when the invocation carries a strict flag (`--require-approval` /
+ * `--result-file`, neither of which the CLI accepts without `--gate --json`).
+ *
+ * Strict invocations own the exit-code contract below, which is why tolerant
+ * annotate argument resolution is bypassed for them: quietly annotating a
+ * later argument because the first one was a typo would let a gate publish
+ * "approved" for a document the caller never named. A typo must keep exiting
+ * 2 here. This predicate is the single definition both the exit-code path
+ * and the tolerance bypass read, so the two can never drift.
+ */
+export function isStrictAnnotateInvocation(
+  flags: StrictAnnotateFlags,
+): boolean {
+  return flags.requireApproval || !!flags.resultFile;
+}
+
 /**
  * Exit code for an annotate startup failure (missing path, unreachable URL,
  * empty folder, ambiguous name, missing file, oversized file).
@@ -32,13 +54,10 @@ export const STRICT_GATE_ERROR_EXIT_CODE = 2;
  * "the reviewer did not approve", so a startup failure must exit with the gate
  * error code instead — otherwise automation reads a typo'd path as a rejection.
  */
-export function annotateStartupFailureExitCode(strict: {
-  requireApproval: boolean;
-  resultFile?: string;
-}): number {
-  return strict.requireApproval || strict.resultFile
-    ? STRICT_GATE_ERROR_EXIT_CODE
-    : 1;
+export function annotateStartupFailureExitCode(
+  strict: StrictAnnotateFlags,
+): number {
+  return isStrictAnnotateInvocation(strict) ? STRICT_GATE_ERROR_EXIT_CODE : 1;
 }
 
 export function serializeStrictAnnotateResult(

--- a/packages/shared/annotate-target.test.ts
+++ b/packages/shared/annotate-target.test.ts
@@ -28,6 +28,16 @@ beforeAll(() => {
   // Exists so that a wrongly split quoted token ("my notes.md" -> "notes.md")
   // would resolve if token boundaries were not preserved.
   writeFileSync(join(root, "notes.md"), "# Notes");
+  // Wider plain-text set (guards ANNOTATABLE_DOC_REGEX breadth, which the
+  // probe's no-walk cheapness for word tokens relies on).
+  writeFileSync(join(root, "notes.txt"), "notes");
+  writeFileSync(join(root, "config.yaml"), "a: 1");
+  // Real scoped-package-style directory for the literal-@ fallback.
+  mkdirSync(join(root, "@scope"), { recursive: true });
+  writeFileSync(join(root, "@scope/README.md"), "# scoped");
+  // Whole-string preference: the un-split input names this file even though
+  // its second token also names an annotatable file on its own.
+  writeFileSync(join(root, "Meeting Notes.md"), "# Meeting Notes");
 });
 
 afterAll(() => {
@@ -40,6 +50,15 @@ describe("probeAnnotateToken", () => {
   test("accepts URLs by shape without fetching", () => {
     expect(probe("https://example.com/page")).toBe("https://example.com/page");
     expect(probe("HTTP://example.com")).toBe("HTTP://example.com");
+  });
+
+  test("recognizes wrapped URLs: `@`-prefixed and quoted", () => {
+    // The pipeline strips the `@` reference marker and wrapping quotes
+    // before its own URL check, so the probe must unwrap the same way or
+    // `annotate @https://example.com/page and summarize it` hands off
+    // instead of opening the URL.
+    expect(probe("@https://example.com/page")).toBe("https://example.com/page");
+    expect(probe('"https://example.com/page"')).toBe("https://example.com/page");
   });
 
   test("resolves folders to absolute paths", () => {
@@ -55,6 +74,22 @@ describe("probeAnnotateToken", () => {
     expect(probe("plan.md")).toBe(join(root, "plan.md"));
     expect(probe("nested.md")).toBe(join(root, "notes/deep/nested.md"));
     expect(probe("@plan.md")).toBe(join(root, "plan.md"));
+  });
+
+  test("resolves an absolute path", () => {
+    expect(probe(join(root, "plan.md"))).toBe(join(root, "plan.md"));
+  });
+
+  test("resolves the wider plain-text set (.txt, .yaml)", () => {
+    expect(probe("notes.txt")).toBe(join(root, "notes.txt"));
+    expect(probe("config.yaml")).toBe(join(root, "config.yaml"));
+  });
+
+  test("resolves a scoped-package-style literal `@` path", () => {
+    // The strip half of the `@` handling is covered above (@plan.md); this
+    // covers the literal fallback: no `scope/README.md` exists, so only the
+    // literal `@scope/README.md` path can match.
+    expect(probe("@scope/README.md")).toBe(join(root, "@scope/README.md"));
   });
 
   test("returns the token itself for ambiguous document names", () => {
@@ -96,6 +131,15 @@ describe("annotateInputNamesExistingTarget", () => {
     expect(annotateInputNamesExistingTarget("", root)).toBe(false);
     expect(annotateInputNamesExistingTarget("   ", root)).toBe(false);
   });
+
+  test("the whole un-split string wins over its own tokens", () => {
+    // "Meeting Notes.md" names a real file whose second token ("Notes.md")
+    // also resolves on its own; the pre-pass must prefer the whole string so
+    // OpenCode/Pi keep supporting unquoted paths with spaces.
+    expect(probeAnnotateToken("Notes.md", root)).not.toBeNull();
+    expect(annotateInputNamesExistingTarget("Meeting Notes.md", root)).toBe(true);
+    expect(probeAnnotateToken("Meeting Notes.md", root)).toBe(join(root, "Meeting Notes.md"));
+  });
 });
 
 describe("selectAnnotateTokenTarget", () => {
@@ -105,6 +149,17 @@ describe("selectAnnotateTokenTarget", () => {
     if (selection.kind === "single") {
       expect(selection.candidate.token).toBe("docs/spec.md");
       expect(selection.candidate.value).toBe(join(root, "docs/spec.md"));
+    }
+  });
+
+  test("fast path: a wrapped URL among natural language is the candidate", () => {
+    const selection = selectAnnotateTokenTarget(
+      "@https://example.com/page and summarize it",
+      probe,
+    );
+    expect(selection.kind).toBe("single");
+    if (selection.kind === "single") {
+      expect(selection.candidate.value).toBe("https://example.com/page");
     }
   });
 

--- a/packages/shared/annotate-target.ts
+++ b/packages/shared/annotate-target.ts
@@ -91,7 +91,12 @@ export function probeAnnotateToken(
 ): string | null {
   if (!token) return null;
 
-  if (/^https?:\/\//i.test(token)) return token;
+  // Unwrap the `@` reference marker and wrapping quotes before the URL
+  // check: the pipeline strips them first (and re-strips harmlessly), so
+  // `@https://example.com/page` in a multi-token invocation must count as a
+  // URL candidate, not fall through to the handoff.
+  const unwrapped = stripAtPrefix(token);
+  if (/^https?:\/\//i.test(unwrapped)) return unwrapped;
 
   const allowBareDirectory = options?.bareDirectories !== false;
   if (allowBareDirectory || /[\\/]/.test(token)) {
@@ -111,13 +116,12 @@ export function probeAnnotateToken(
   });
   if (html !== null) return resolveUserPath(html, projectRoot);
 
-  const stripped = stripAtPrefix(token);
-  let doc = resolveMarkdownFile(stripped, projectRoot);
-  if (doc.kind === "not_found" && stripped !== token) {
+  let doc = resolveMarkdownFile(unwrapped, projectRoot);
+  if (doc.kind === "not_found" && unwrapped !== token) {
     doc = resolveMarkdownFile(token, projectRoot);
   }
   if (doc.kind === "found") return doc.path;
-  if (doc.kind === "ambiguous") return stripped;
+  if (doc.kind === "ambiguous") return unwrapped;
 
   // Bare existence is file-only: directories are candidates exclusively via
   // the folder branch above, so disabling bare directories cannot be undone


### PR DESCRIPTION
Ports five small items from @technicalpickles' closed parallel implementation (#1185) into the tolerant annotate argument resolution that landed via #1183 (#1182). Full credit to @technicalpickles for catching the URL-probe bug and the coverage gaps; a comparison pass of the two implementations surfaced these.

## 1. Bug fix: wrapped URLs were not URL candidates

`probeAnnotateToken` tested the raw token against `/^https?:\/\//i`, but the resolution pipeline strips the `@` reference marker and wrapping quotes before its own URL check (`stripAtPrefix` unwraps both). So the multi-token invocation

```
plannotator annotate @https://example.com/page and summarize it
```

probed to zero candidates and emitted the tier-3 handoff instead of opening the URL. The probe now unwraps with `stripAtPrefix` before the regex and returns the unwrapped form; the pipeline re-strips harmlessly. Verified by unit tests (`@`-prefixed and quote-wrapped URLs, single and multi-token) and a manual smoke: the invocation above now reaches `Fetching: https://example.com` (tier 1), while `annotate the aim doc` still hands off and a strict typo still exits 2.

## 2. Test ports

Added to `packages/shared/annotate-target.test.ts` from their suite's coverage: absolute paths resolve as candidates; the wider plain-text set (`.txt`, `.yaml`) resolves, guarding `ANNOTATABLE_DOC_REGEX` breadth (which the probe's no-walk cheapness argument relies on); the scoped-package literal-`@` fallback resolves against a real `@scope/` directory (the strip half was covered, the fallback half was not); and the whole un-split string is preferred over its own tokens (`Meeting Notes.md` wins over a resolving `Notes.md` token), covering `annotateInputNamesExistingTarget` in the OpenCode/Pi pre-pass direction.

## 3. Defensive source scan

The strict bypass cannot be spawn-tested in its inverted form (tolerance applying in strict mode would require a live server to observe). The existing source-scan test in `apps/hook/server/strict-annotate-result.test.ts` now also asserts the annotate startup block gates tolerance on `!strictAnnotate` computed via `isStrictAnnotateInvocation`, so an inverted or bypassed gate fails the scan.

## 4. DRY: single strict predicate

The strict predicate (`requireApproval || !!resultFile`) was defined twice: in `annotateStartupFailureExitCode` and inline in `index.ts` for the tolerance bypass. Adopted their factoring: a `StrictAnnotateFlags` type plus `isStrictAnnotateInvocation` in `strict-annotate-result.ts`, used by both the exit-code helper and the bypass, so the two paths can never drift. Behavior is byte-identical; the existing subprocess tests in `annotate-cli.test.ts` pass unchanged.

## 5. Docs

The AGENTS.md tolerant-resolution section now cites #872 (commit `aac5aacb`, "restore `/plannotator-*` bash execution on Claude Code") for why the bang prefix is deliberate, and states that argument-shape issues belong in the CLI's resolution rather than the skill templates.

## Verified

- `bun run typecheck` green; full `bun test` green (2709 pass, 0 fail); `bash apps/pi-extension/vendor.sh` regenerates cleanly.
- Manual smoke: `annotate @https://example.com and summarize --no-jina` resolves the URL (tier 1, fetch reached); `annotate the aim doc` still hands off with exit 0; `annotate nope-not-here.md --gate --json --require-approval` still exits 2 with `File not found` on stderr.

Refs #1185, #1182. Co-authored with Josh Nichols (@technicalpickles).
