### PR TITLE
chore(deps): bump @pierre/diffs to 1.2.12 (stage 1 of 2)

### DIFF
--- a/apps/pi-extension/package.json
+++ b/apps/pi-extension/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@joplin/turndown-plugin-gfm": "^1.0.64",
-    "@pierre/diffs": "1.2.8",
+    "@pierre/diffs": "1.2.12",
     "@plannotator/webtui": "0.1.0",
     "chokidar": "^5.0.0",
     "diff": "^8.0.4",

--- a/apps/review/package.json
+++ b/apps/review/package.json
@@ -12,7 +12,7 @@
     "@plannotator/review-editor": "workspace:*",
     "@plannotator/server": "workspace:*",
     "@plannotator/ui": "workspace:*",
-    "@pierre/diffs": "1.2.8",
+    "@pierre/diffs": "1.2.12",
     "dompurify": "^3.3.3",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.92",
         "@opencode-ai/sdk": "^1.3.0",
-        "@pierre/diffs": "1.2.8",
+        "@pierre/diffs": "1.2.12",
         "diff": "^8.0.4",
         "dockview-react": "^5.2.0",
         "dompurify": "^3.3.3",
@@ -63,7 +63,7 @@
     },
     "apps/opencode-plugin": {
       "name": "@plannotator/opencode",
-      "version": "0.24.1",
+      "version": "0.25.1",
       "dependencies": {
         "@opencode-ai/plugin": "^1.1.10",
       },
@@ -85,10 +85,10 @@
     },
     "apps/pi-extension": {
       "name": "@plannotator/pi-extension",
-      "version": "0.24.1",
+      "version": "0.25.1",
       "dependencies": {
         "@joplin/turndown-plugin-gfm": "^1.0.64",
-        "@pierre/diffs": "1.2.8",
+        "@pierre/diffs": "1.2.12",
         "@plannotator/webtui": "0.1.0",
         "chokidar": "^5.0.0",
         "diff": "^8.0.4",
@@ -128,7 +128,7 @@
       "name": "@plannotator/review",
       "version": "0.0.1",
       "dependencies": {
-        "@pierre/diffs": "1.2.8",
+        "@pierre/diffs": "1.2.12",
         "@plannotator/review-editor": "workspace:*",
         "@plannotator/server": "workspace:*",
         "@plannotator/ui": "workspace:*",
@@ -148,7 +148,7 @@
     },
     "apps/vscode-extension": {
       "name": "plannotator-webview",
-      "version": "0.16.7",
+      "version": "0.16.8",
       "devDependencies": {
         "@types/bun": "latest",
         "@types/vscode": "^1.85.0",
@@ -205,7 +205,7 @@
         "@base-ui/react": "^1.6.0",
         "@fontsource-variable/geist-mono": "5.2.7",
         "@fontsource-variable/inter": "^5.2.8",
-        "@pierre/diffs": "1.2.8",
+        "@pierre/diffs": "1.2.12",
         "@plannotator/shared": "workspace:*",
         "@plannotator/ui": "workspace:*",
         "highlight.js": "^11.11.1",
@@ -224,9 +224,9 @@
     },
     "packages/server": {
       "name": "@plannotator/server",
-      "version": "0.24.1",
+      "version": "0.25.1",
       "dependencies": {
-        "@pierre/diffs": "1.2.8",
+        "@pierre/diffs": "1.2.12",
         "@plannotator/ai": "workspace:*",
         "@plannotator/shared": "workspace:*",
         "@plannotator/webtui": "0.1.0",
@@ -272,7 +272,7 @@
         "@fontsource-variable/inter": "^5.2.8",
         "@lezer/common": "^1.5.2",
         "@lezer/highlight": "^1.2.3",
-        "@pierre/diffs": "1.2.8",
+        "@pierre/diffs": "1.2.12",
         "@plannotator/atomic-editor": "^0.8.0",
         "@plannotator/core": "workspace:*",
         "@plannotator/markdown-editor": "^0.4.0",
@@ -793,9 +793,11 @@
 
     "@oven/bun-windows-x64-baseline": ["@oven/bun-windows-x64-baseline@1.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-uIjLUC1S9DWgICzuoMba7vurBJnBruE4S5CxnvmZkdqWVXRzx1Rgu636HoH+k0qeaQCFh3jeG3JQ1y6fRHv0sw=="],
 
-    "@pierre/diffs": ["@pierre/diffs@1.2.8", "", { "dependencies": { "@pierre/theme": "1.0.3", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-HVaWzZ1cW5GDKodivaPCN1hU05DGvoLiG/uvVBNZODD+qY2NTr36KYgATGhb79Vr8OCKNG3qATTWJEwbkMGfzA=="],
+    "@pierre/diffs": ["@pierre/diffs@1.2.12", "", { "dependencies": { "@pierre/theme": "1.1.0", "@pierre/theming": "0.0.2", "@shikijs/transformers": "^3.0.0 || ^4.0.0", "diff": "9.0.0", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0 || ^4.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-pY/gmgWL03WnagqCyCnBi3QtRXUv4hCIY6FYqd5b1ZGaoI6a4Bsji8j+yRl2RfzPh/8Hf19rCl1GE80G6a1cLQ=="],
 
-    "@pierre/theme": ["@pierre/theme@1.0.3", "", {}, "sha512-sWHv11TMoqKxKDgTIk5VbhQjdPhs8DCcBxbjh3mRlS3YOM/OcrWoGX6MM8eBGn9cUu3M46Py0JnxsG2nJaFTuA=="],
+    "@pierre/theme": ["@pierre/theme@1.1.0", "", {}, "sha512-GC2OWTAfTIIWWYhPCygwG8t2EtePQkRfON4MI2rwIkJylmiyqIttJID2dCL8sUD8cNdEvYkEyfEHHKMeCiDLoQ=="],
+
+    "@pierre/theming": ["@pierre/theming@0.0.2", "", { "peerDependencies": { "@pierre/theme": "^1.1.0", "@shikijs/themes": "^3.0.0 || ^4.0.0", "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0", "shiki": "^3.0.0 || ^4.0.0" }, "optionalPeers": ["@pierre/theme", "@shikijs/themes", "react", "react-dom", "shiki"] }, "sha512-QM1M4stXfnzfaE8I8YbjXSApV8c+2dBsXJj8eYg9WTpBR/cTmCZIcfGnN4p13iRrYu2Br/R/OJfEL7uR8Qjctw=="],
 
     "@plannotator/ai": ["@plannotator/ai@workspace:packages/ai"],
 
@@ -2627,7 +2629,7 @@
 
     "@opencode-ai/plugin/zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
 
-    "@pierre/diffs/diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
+    "@pierre/diffs/diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
 
     "@plannotator/hooks/@types/node": ["@types/node@22.19.20", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw=="],
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.92",
     "@opencode-ai/sdk": "^1.3.0",
-    "@pierre/diffs": "1.2.8",
+    "@pierre/diffs": "1.2.12",
     "diff": "^8.0.4",
     "dockview-react": "^5.2.0",
     "dompurify": "^3.3.3",

--- a/packages/review-editor/package.json
+++ b/packages/review-editor/package.json
@@ -12,7 +12,7 @@
     "@base-ui/react": "^1.6.0",
     "@fontsource-variable/geist-mono": "5.2.7",
     "@fontsource-variable/inter": "^5.2.8",
-    "@pierre/diffs": "1.2.8",
+    "@pierre/diffs": "1.2.12",
     "@plannotator/shared": "workspace:*",
     "@plannotator/ui": "workspace:*",
     "highlight.js": "^11.11.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -31,7 +31,7 @@
     "*.mjs"
   ],
   "dependencies": {
-    "@pierre/diffs": "1.2.8",
+    "@pierre/diffs": "1.2.12",
     "@plannotator/ai": "workspace:*",
     "@plannotator/shared": "workspace:*",
     "@plannotator/webtui": "0.1.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -66,7 +66,7 @@
     "@fontsource-variable/inter": "^5.2.8",
     "@lezer/common": "^1.5.2",
     "@lezer/highlight": "^1.2.3",
-    "@pierre/diffs": "1.2.8",
+    "@pierre/diffs": "1.2.12",
     "@plannotator/atomic-editor": "^0.8.0",
     "@plannotator/core": "workspace:*",
     "@plannotator/markdown-editor": "^0.4.0",


### PR DESCRIPTION
## Why staged

This is stage 1 of a two stage `@pierre/diffs` upgrade. 1.2.12 was published 2026-06-29 and is safely aged per our 7 day supply chain posture. Stage 2 (next week, once aged) takes 1.3.x, which carries the `@pierre/theme` major and the hover pipeline visual rework; that one needs dedicated visual QA, so it is deliberately not in this PR.

## What 1.2.9 to 1.2.12 delivers

- Focus no longer moves on line number click (1.2.12)
- Merge conflict actions remain available after resolving one conflict (1.2.12)
- `shiki` range widened to `^3 || ^4` (1.2.10); we still resolve shiki 3.23.0
- Misc fixes

Note: 1.2.9's npm tarball was historically broken (our #880 era). The fresh install check below specifically guards that failure mode for 1.2.12.

## One audit correction

The pre-upgrade audit stated 1.2.9 to 1.2.12 carries no theme dependency change. The registry disagrees: `@pierre/diffs@1.2.12` pins `@pierre/theme@1.1.0` (was `1.0.3`) and adds a new `@pierre/theming@0.0.2` package. Both are transitive only; no workspace package depends on `@pierre/theme` directly, and our source has zero direct theme imports. This is a theme minor, not the 2.x major that stage 2 carries, but it does mean the rendered CSS is not byte identical, which raises the value of the manual visual QA below.

## Lockfile diff, every changed line

- `"@pierre/diffs": "1.2.8"` to `"1.2.12"` in the six workspace dependency blocks (root, packages/ui, packages/server, packages/review-editor, apps/review, apps/pi-extension): the bump itself.
- `@pierre/diffs` resolution entry: new version, new integrity hash, and its dependency block now lists `@pierre/theme 1.1.0`, `@pierre/theming 0.0.2`, `diff 9.0.0`, and `shiki`/`@shikijs/transformers` at `^3 || ^4`.
- `@pierre/theme` entry: 1.0.3 to 1.1.0 (transitive, pulled by diffs).
- `@pierre/theming@0.0.2`: new transitive entry (its peer deps resolve to already present packages).
- `"@pierre/diffs/diff": diff@8.0.3` to `diff@9.0.0`: scoped override inside `@pierre/diffs` only. Our own top level `diff` stays `^8.0.4` and still resolves to 8.0.4.
- Workspace version resyncs: `apps/opencode-plugin`, `apps/pi-extension`, and `packages/server` 0.24.1 to 0.25.1, `apps/vscode-extension` 0.16.7 to 0.16.8. These are pre-existing drift on main: the release version bumps landed in the package.json files without a lockfile refresh, so any `bun install` on main today writes these same four lines. Verified by diffing `HEAD:bun.lock` against the package.json versions at `HEAD`.

## Verification performed

| Check | Result |
|---|---|
| `bun run typecheck` (all seven tsconfigs, after `vendor.sh`) | pass |
| Full `bun test` (3007 tests, 250 files) | pass (one run had a single failure in `packages/server/review-workspace.test.ts` semantic diff availability; it passes in isolation and the full suite reran fully green, consistent with the known server file timing flakes) |
| `DOM_TESTS=1` isolated `useFileBrowser.test.tsx` | pass (6/6) |
| `DOM_TESTS=1` CI DOM set (28 files from test.yml) | pass (163/163) |
| `bun run --cwd apps/review build` | pass, no warnings |
| `bun run build:hook` | pass |
| `bun run build:opencode` | pass |
| `bun run build:pi` | pass |
| Built HTML not committed | confirmed, all dist and copied plugin HTML paths are gitignored |
| Worker pool bundling (`@pierre/diffs/worker/worker.js?worker&inline`) | inline worker blob present in `apps/review/dist/index.html` (`createObjectURL` plus data URL script), build emitted no warnings |
| Installed tree | `node_modules/@pierre/diffs` is 1.2.12; exports map intact for our import surface (`.`, `./react`, `./ssr`, `./worker/worker.js`) |
| SSR parity (before vs after) | `preloadFile` output on three fixture files at 1.2.8 vs 1.2.12: prerendered HTML structure identical except `tabindex="0"` removed from the `<pre>` wrapper, which matches the 1.2.12 focus fix. The embedded `data-core-css` stylesheet changed: 1.2.12 ships it unminified (formatting and attribute quoting noise) plus real rule evolution consistent with the release notes (merge conflict actions, hover computed vars). No structural surprises. |
| Fresh install regression (#880 mode) | `bun pm pack` of apps/pi-extension, then `npm install` of the tarball in a scratch dir with a clean cache: resolves `@pierre/diffs@1.2.12` from the registry, dist/ssr and dist/worker intact, and a Node runtime smoke of `preloadFile` from that install renders successfully |
| `@pierre/theme` still 1.0.3 | no: 1.2.12 requires 1.1.0 transitively (see audit correction above); we have no direct dependency on it |

## Not verified here: manual visual QA checklist

Headless verification cannot observe rendering, and the theme 1.1.0 transitive bump means CSS did change. I am not claiming visual parity. Before merging, a human should check:

- [ ] 40+ file diff in all files view with fast scrolling
- [ ] Stage/unstage header chips
- [ ] File comment popover anchoring
- [ ] Hover a changed line at subtle/normal/strong intensity, in light and dark
- [ ] Guided Review on a large diff
- [ ] CodeFilePopout
- [ ] DiffHunkPreview
- [ ] Single file split and unified views with expand unchanged
- [ ] Search highlighting
- [ ] One session with `VITE_PIERRE_VALIDATE_HEIGHTS=1`

## Stage 2 pointer

Next week, once 1.3.x has aged past the 7 day window: bump to 1.3.x, take the `@pierre/theme` major and the hover pipeline visual work, with full visual QA. Do not fast forward this PR to 1.3.x.
