### PR TITLE
chore(deps): bump @pierre/diffs to 1.3.x with theme major (stage 2 of 2)

### DIFF
--- a/apps/pi-extension/package.json
+++ b/apps/pi-extension/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@joplin/turndown-plugin-gfm": "^1.0.64",
-    "@pierre/diffs": "1.2.12",
+    "@pierre/diffs": "1.3.1",
     "@plannotator/webtui": "0.1.0",
     "chokidar": "^5.0.0",
     "diff": "^8.0.4",

--- a/apps/review/package.json
+++ b/apps/review/package.json
@@ -12,7 +12,7 @@
     "@plannotator/review-editor": "workspace:*",
     "@plannotator/server": "workspace:*",
     "@plannotator/ui": "workspace:*",
-    "@pierre/diffs": "1.2.12",
+    "@pierre/diffs": "1.3.1",
     "dompurify": "^3.3.3",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.92",
         "@opencode-ai/sdk": "^1.3.0",
-        "@pierre/diffs": "1.2.12",
+        "@pierre/diffs": "1.3.1",
         "diff": "^8.0.4",
         "dockview-react": "^5.2.0",
         "dompurify": "^3.3.3",
@@ -88,7 +88,7 @@
       "version": "0.25.1",
       "dependencies": {
         "@joplin/turndown-plugin-gfm": "^1.0.64",
-        "@pierre/diffs": "1.2.12",
+        "@pierre/diffs": "1.3.1",
         "@plannotator/webtui": "0.1.0",
         "chokidar": "^5.0.0",
         "diff": "^8.0.4",
@@ -128,7 +128,7 @@
       "name": "@plannotator/review",
       "version": "0.0.1",
       "dependencies": {
-        "@pierre/diffs": "1.2.12",
+        "@pierre/diffs": "1.3.1",
         "@plannotator/review-editor": "workspace:*",
         "@plannotator/server": "workspace:*",
         "@plannotator/ui": "workspace:*",
@@ -205,7 +205,7 @@
         "@base-ui/react": "^1.6.0",
         "@fontsource-variable/geist-mono": "5.2.7",
         "@fontsource-variable/inter": "^5.2.8",
-        "@pierre/diffs": "1.2.12",
+        "@pierre/diffs": "1.3.1",
         "@plannotator/shared": "workspace:*",
         "@plannotator/ui": "workspace:*",
         "highlight.js": "^11.11.1",
@@ -226,7 +226,7 @@
       "name": "@plannotator/server",
       "version": "0.25.1",
       "dependencies": {
-        "@pierre/diffs": "1.2.12",
+        "@pierre/diffs": "1.3.1",
         "@plannotator/ai": "workspace:*",
         "@plannotator/shared": "workspace:*",
         "@plannotator/webtui": "0.1.0",
@@ -272,7 +272,7 @@
         "@fontsource-variable/inter": "^5.2.8",
         "@lezer/common": "^1.5.2",
         "@lezer/highlight": "^1.2.3",
-        "@pierre/diffs": "1.2.12",
+        "@pierre/diffs": "1.3.1",
         "@plannotator/atomic-editor": "^0.8.0",
         "@plannotator/core": "workspace:*",
         "@plannotator/markdown-editor": "^0.4.0",
@@ -793,11 +793,11 @@
 
     "@oven/bun-windows-x64-baseline": ["@oven/bun-windows-x64-baseline@1.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-uIjLUC1S9DWgICzuoMba7vurBJnBruE4S5CxnvmZkdqWVXRzx1Rgu636HoH+k0qeaQCFh3jeG3JQ1y6fRHv0sw=="],
 
-    "@pierre/diffs": ["@pierre/diffs@1.2.12", "", { "dependencies": { "@pierre/theme": "1.1.0", "@pierre/theming": "0.0.2", "@shikijs/transformers": "^3.0.0 || ^4.0.0", "diff": "9.0.0", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0 || ^4.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-pY/gmgWL03WnagqCyCnBi3QtRXUv4hCIY6FYqd5b1ZGaoI6a4Bsji8j+yRl2RfzPh/8Hf19rCl1GE80G6a1cLQ=="],
+    "@pierre/diffs": ["@pierre/diffs@1.3.1", "", { "dependencies": { "@pierre/theme": "2.0.0", "@pierre/theming": "1.0.0", "@shikijs/transformers": "^3.0.0 || ^4.0.0", "diff": "9.0.0", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0 || ^4.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-jSAm+Rybo7milxGg7ps7KjM3QZl2exhE9uYjQ4RSCdPNa9GS0mD4vBP99MoFhV95bLDKL1KSMdy0596BMLUacw=="],
 
-    "@pierre/theme": ["@pierre/theme@1.1.0", "", {}, "sha512-GC2OWTAfTIIWWYhPCygwG8t2EtePQkRfON4MI2rwIkJylmiyqIttJID2dCL8sUD8cNdEvYkEyfEHHKMeCiDLoQ=="],
+    "@pierre/theme": ["@pierre/theme@2.0.0", "", {}, "sha512-yNDd9GYLQl1mEUJR8AneJ5e4ohLIHQd/wZLWr4fagt78vS2RwwZNW530vVgHqXFAyFVcFlRmGUD5ramXH46OXw=="],
 
-    "@pierre/theming": ["@pierre/theming@0.0.2", "", { "peerDependencies": { "@pierre/theme": "^1.1.0", "@shikijs/themes": "^3.0.0 || ^4.0.0", "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0", "shiki": "^3.0.0 || ^4.0.0" }, "optionalPeers": ["@pierre/theme", "@shikijs/themes", "react", "react-dom", "shiki"] }, "sha512-QM1M4stXfnzfaE8I8YbjXSApV8c+2dBsXJj8eYg9WTpBR/cTmCZIcfGnN4p13iRrYu2Br/R/OJfEL7uR8Qjctw=="],
+    "@pierre/theming": ["@pierre/theming@1.0.0", "", { "peerDependencies": { "@pierre/theme": "^1.1.0", "@shikijs/themes": "^3.0.0 || ^4.0.0", "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0", "shiki": "^3.0.0 || ^4.0.0" }, "optionalPeers": ["@pierre/theme", "@shikijs/themes", "react", "react-dom", "shiki"] }, "sha512-WsdrnhKfjeyXGDikZmN9pkpeZ5S/cl6EE72feiSc0tlynT1tMYqXqouhuv/foK+PY9OEnebOAVRQn3+rAstR8g=="],
 
     "@plannotator/ai": ["@plannotator/ai@workspace:packages/ai"],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,7 +1,7 @@
 [install]
 linker = "isolated"
 minimumReleaseAge = 604800  # 7 days in seconds
-minimumReleaseAgeExcludes = ["@pierre/diffs", "@plannotator/atomic-editor", "@plannotator/markdown-editor", "@plannotator/webtui"]
+minimumReleaseAgeExcludes = ["@pierre/diffs", "@pierre/theme", "@pierre/theming", "@plannotator/atomic-editor", "@plannotator/markdown-editor", "@plannotator/webtui"]
 
 [test]
 preload = ["./packages/ui/test-setup/happy-dom.ts"]

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.92",
     "@opencode-ai/sdk": "^1.3.0",
-    "@pierre/diffs": "1.2.12",
+    "@pierre/diffs": "1.3.1",
     "diff": "^8.0.4",
     "dockview-react": "^5.2.0",
     "dompurify": "^3.3.3",

--- a/packages/review-editor/hooks/usePierreTheme.ts
+++ b/packages/review-editor/hooks/usePierreTheme.ts
@@ -62,6 +62,17 @@ export interface PierreTheme {
  * 88 / 80) since darker themes need a larger colour share to read at the
  * same perceptual intensity.
  *
+ * `hoverMix*` values are the FINAL rendered bg shares, matching what our
+ * pre-1.3 overrides produced. Since @pierre/diffs 1.3.0 the per-selector
+ * hover rules (`[data-hovered] { --mix-light: … }`) are gone; hover is one
+ * central rule that re-mixes `--diffs-computed-editor-active-line-bg`
+ * 97% (light) / 91% (dark) toward `--diffs-hover-mix-target` (the
+ * addition/deletion base colour on changed lines). Our hovered `--mix-*`
+ * values therefore feed the rest formula first and get multiplied by
+ * 0.97 / 0.91 on the way to the screen — `hoverEmittedMix()` divides the
+ * targets back out so the composed result equals these numbers exactly
+ * (color-mix in lab is linear, so the compensation is exact).
+ *
  * Driving the line bg through these vars (instead of overriding the final
  * `background-color`) keeps Pierre's `--diffs-line-bg` pipeline intact, so
  * selected / hovered / decorated states keep their state-specific visuals.
@@ -76,6 +87,29 @@ interface IntensityConfig {
 const INTENSITY_CONFIG: Record<Exclude<DiffLineBgIntensity, 'subtle'>, IntensityConfig> = {
   normal: { restMixLight: 55, restMixDark: 45, hoverMixLight: 45, hoverMixDark: 35 },
   strong: { restMixLight: 35, restMixDark: 25, hoverMixLight: 25, hoverMixDark: 15 },
+};
+
+/** Pierre's central hover rule mixes the rest bg by these shares toward the
+ * hover mix target (light-dark(97%, 91%) since 1.3.0). */
+const PIERRE_HOVER_KEEP_LIGHT = 0.97;
+const PIERRE_HOVER_KEEP_DARK = 0.91;
+
+/** Convert a desired FINAL hovered bg share into the `--mix-*` value to emit,
+ * compensating for Pierre's central hover re-mix. */
+function hoverEmittedMix(finalShare: number, keep: number): string {
+  return (finalShare / keep).toFixed(2);
+}
+
+/**
+ * At 1.2.12 Pierre's own per-selector hover rules gave changed lines these
+ * final bg shares (deletion 80/75, addition 80/70). `subtle` rode them
+ * untouched; 1.3.x's central hover rule instead lands at ~85.4 light /
+ * ~72.8 dark, a visibly weaker light-theme hover. We pin the old finals so
+ * `subtle` hover looks the same before and after the upgrade.
+ */
+const SUBTLE_HOVER_FINALS = {
+  deletion: { light: 80, dark: 75 },
+  addition: { light: 80, dark: 70 },
 };
 
 /**
@@ -114,11 +148,6 @@ export function buildLineBgOverrides(intensity: DiffLineBgIntensity, mode: 'ligh
       background-color: transparent !important;
     }
   `;
-  if (intensity === 'subtle') return hideEmphasisWithoutBg;
-  const cfg = INTENSITY_CONFIG[intensity];
-  const lShift = mode === 'dark'
-    ? `+ ${EMPHASIS_LIGHTNESS_SHIFT}`
-    : `- ${EMPHASIS_LIGHTNESS_SHIFT}`;
   // Targeting `[data-line]` and `[data-no-newline]` only — the actual code
   // lines. Skipping `[data-gutter-buffer]` / `[data-column-number]` keeps the
   // line-number gutter at the page bg (matching the existing
@@ -126,20 +155,46 @@ export function buildLineBgOverrides(intensity: DiffLineBgIntensity, mode: 'ligh
   // `[data-background]` mirrors the library's own `:where([data-background])`
   // scoping, so the "Diff background" toggle still turns line bgs off.
   //
-  // Specificity is (0,0,4); wins against the library's (0,0,1) baseline and
-  // (0,0,3) hover rule. The `:not([data-hovered])` variant yields to the
-  // explicit `[data-hovered]` variant on hover.
+  // Specificity is (0,4,0); wins against the library's rest rules (max
+  // (0,2,0) inside `:where([data-background])`). Since 1.3.0 the library's
+  // hover rule sets `--diffs-computed-hovered-line-bg` (a different property)
+  // on `[data-line][data-hovered]`, so there is no specificity race on
+  // `--mix-*` anymore — our hovered `--mix-*` values flow through the rest
+  // formula and Pierre's central hover re-mix composes on top (compensated
+  // via hoverEmittedMix, see INTENSITY_CONFIG docs).
   const changedLine =
     "[data-background] :is([data-line-type='change-addition'], [data-line-type='change-deletion'])" +
     ":is([data-line], [data-no-newline])";
+  if (intensity === 'subtle') {
+    // Keep Pierre's rest bg untouched, but pin the hovered finals to the
+    // 1.2.x values (see SUBTLE_HOVER_FINALS). Per-type split preserved:
+    // 1.2.x deletion hover was 80/75, addition 80/70.
+    const del = SUBTLE_HOVER_FINALS.deletion;
+    const add = SUBTLE_HOVER_FINALS.addition;
+    return `
+      [data-background] [data-line-type='change-deletion']:is([data-line], [data-no-newline])[data-hovered] {
+        --mix-light: ${hoverEmittedMix(del.light, PIERRE_HOVER_KEEP_LIGHT)}%;
+        --mix-dark: ${hoverEmittedMix(del.dark, PIERRE_HOVER_KEEP_DARK)}%;
+      }
+      [data-background] [data-line-type='change-addition']:is([data-line], [data-no-newline])[data-hovered] {
+        --mix-light: ${hoverEmittedMix(add.light, PIERRE_HOVER_KEEP_LIGHT)}%;
+        --mix-dark: ${hoverEmittedMix(add.dark, PIERRE_HOVER_KEEP_DARK)}%;
+      }
+      ${hideEmphasisWithoutBg}
+    `;
+  }
+  const cfg = INTENSITY_CONFIG[intensity];
+  const lShift = mode === 'dark'
+    ? `+ ${EMPHASIS_LIGHTNESS_SHIFT}`
+    : `- ${EMPHASIS_LIGHTNESS_SHIFT}`;
   return `
     ${changedLine}:not([data-hovered]) {
       --mix-light: ${cfg.restMixLight}%;
       --mix-dark: ${cfg.restMixDark}%;
     }
     ${changedLine}[data-hovered] {
-      --mix-light: ${cfg.hoverMixLight}%;
-      --mix-dark: ${cfg.hoverMixDark}%;
+      --mix-light: ${hoverEmittedMix(cfg.hoverMixLight, PIERRE_HOVER_KEEP_LIGHT)}%;
+      --mix-dark: ${hoverEmittedMix(cfg.hoverMixDark, PIERRE_HOVER_KEEP_DARK)}%;
     }
     ${changedLine} {
       --diffs-bg-addition-emphasis: oklch(from var(--diffs-computed-diff-line-bg) calc(l ${lShift}) c h);

--- a/packages/review-editor/package.json
+++ b/packages/review-editor/package.json
@@ -12,7 +12,7 @@
     "@base-ui/react": "^1.6.0",
     "@fontsource-variable/geist-mono": "5.2.7",
     "@fontsource-variable/inter": "^5.2.8",
-    "@pierre/diffs": "1.2.12",
+    "@pierre/diffs": "1.3.1",
     "@plannotator/shared": "workspace:*",
     "@plannotator/ui": "workspace:*",
     "highlight.js": "^11.11.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -31,7 +31,7 @@
     "*.mjs"
   ],
   "dependencies": {
-    "@pierre/diffs": "1.2.12",
+    "@pierre/diffs": "1.3.1",
     "@plannotator/ai": "workspace:*",
     "@plannotator/shared": "workspace:*",
     "@plannotator/webtui": "0.1.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -66,7 +66,7 @@
     "@fontsource-variable/inter": "^5.2.8",
     "@lezer/common": "^1.5.2",
     "@lezer/highlight": "^1.2.3",
-    "@pierre/diffs": "1.2.12",
+    "@pierre/diffs": "1.3.1",
     "@plannotator/atomic-editor": "^0.8.0",
     "@plannotator/core": "workspace:*",
     "@plannotator/markdown-editor": "^0.4.0",


### PR DESCRIPTION
Stage 2 of the @pierre/diffs upgrade. Bumps `@pierre/diffs` 1.2.12 -> **1.3.1** (newest stable; 1.3.2 does not exist, and all 1.3.0 betas/rcs were skipped) together with its pinned transitive majors `@pierre/theme@2.0.0` and `@pierre/theming@1.0.0`.

> **Base branch note:** opened against `chore/pierre-diffs-1.2.12` (stage 1, #1188, reviewed but unmerged). GitHub will retarget this PR to `main` automatically when #1188 merges.

**Edit mode is NOT enabled.** No `EditProvider`, no `edit` props, no `@pierre/diffs/edit` imports anywhere in this PR (verified by grep; the `dist/edit` entry ships in the package but nothing references it).

## What 1.3.x delivers for our usage

Per the stage audit: SlotPortals memoization (fewer portal re-renders in the all-files view), annotation wrap fixes, and the split-view offset fix. Plus the hover pipeline rework described below. SSR also picked up a dehydrated split-scroll shared-grid layout to prevent pre-hydration row shift (not exercised by our current preloadFile usage, which is unified single-file).

## Hover-styling re-tune (the real work of this stage)

At 1.2.12, hovered changed lines were styled by per-selector rules (`[data-hovered] { --mix-light: 80% ... }`) that our `buildLineBgOverrides` in `packages/review-editor/hooks/usePierreTheme.ts` simply out-specified. In 1.3.x those rules are gone: hover is one central `@media (pointer: fine)` rule that re-mixes `--diffs-computed-editor-active-line-bg` **97% (light) / 91% (dark)** toward `--diffs-hover-mix-target` (the addition/deletion base color on changed lines). Our hovered `--mix-*` values now feed the rest formula first and get multiplied by 0.97 / 0.91 on the way to the screen, so unchanged overrides would render hover slightly too strong (and asymmetrically: -1.35pp bg share in light, -3.15pp in dark at "normal").

Because `color-mix(in lab, ...)` is linear, the compensation is exact: the re-tune divides the target final bg shares by 0.97 / 0.91 (`hoverEmittedMix()`). Additionally, `subtle` (which used to ride Pierre's own per-selector hover values and would otherwise silently shift to 1.3's weaker defaults, 85.4%/72.8% effective vs the old 80%/75% deletion and 80%/70% addition) now pins the 1.2.x hover finals explicitly, preserving the old per-type split. Rest-state values are untouched at all intensities.

### Measured before/after (CDP, headless Chrome 150, computed `background-color` of changed `[data-line]`s, default color theme)

Rest colors: **byte-identical** in all 12 configurations (dE(lab) = 0.000).

Hovered colors (before = 1.2.12 build, after = 1.3.1 build + re-tune):

| Config | Line | 1.2.12 hovered | 1.3.1 hovered | dE(lab) |
|---|---|---|---|---|
| dark/subtle | addition | lab(23.13 -16.53 3.37) | lab(23.13 -16.53 3.37) | 0.003 |
| dark/subtle | deletion | lab(16.39 18.90 7.86) | lab(16.39 18.90 7.86) | 0.002 |
| dark/normal | addition | lab(46.63 -35.66 12.79) | lab(46.63 -35.66 12.79) | 0.001 |
| dark/normal | deletion | lab(37.83 49.35 27.96) | lab(37.83 49.35 27.96) | 0.002 |
| dark/strong | addition | lab(60.06 -46.59 18.16) | lab(60.06 -46.59 18.16) | 0.003 |
| dark/strong | deletion | lab(48.55 64.58 38.00) | lab(48.56 64.58 38.00) | 0.003 |
| light/subtle | addition | lab(89.13 -9.52 2.26) | lab(89.13 -9.52 2.26) | 0.003 |
| light/subtle | deletion | lab(86.81 12.72 6.24) | lab(86.81 12.72 6.24) | 0.004 |
| light/normal | addition | lab(76.23 -25.71 9.52) | lab(76.23 -25.71 9.52) | 0.001 |
| light/normal | deletion | lab(69.85 35.44 20.44) | lab(69.85 35.44 20.45) | 0.002 |
| light/strong | addition | lab(68.86 -34.97 13.66) | lab(68.85 -34.97 13.66) | 0.002 |
| light/strong | deletion | lab(60.16 48.43 28.56) | lab(60.16 48.43 28.56) | 0.003 |

Max dE(lab) 0.004 across all 24 measurements (rest + hovered), pure rounding residue from the two-decimal emitted percentages; the perceptibility threshold is ~1.0. Hover screenshots (rest + hovered, all 12 configs, both versions) captured as evidence during verification.

## Theme major (1.1.0 -> 2.0.0) verification

- `@pierre/theming@1.0.0` still registers Pierre themes under **kebab ids** (`pierre-dark`, `pierre-light`, ...); only `displayName` uses the "Pierre Dark" format. Our fallback lookup keys are unchanged and correct.
- `@pierre/theme@2.0.0` exports `./pierre-dark` and `./pierre-light` subpaths that theming imports; both resolve.
- All 44 distinct shiki theme ids referenced by `SHIKI_THEME_MAP` exist in the installed `@shikijs/themes@3.23.0` bundle: zero missing.
- The new colorblind variants (protanopia-deuteranopia, tritanopia, soft, vibrant) are shipped but deliberately NOT added to the picker (separate follow-up as agreed).

## bunfig.toml change

`@pierre/theme` and `@pierre/theming` added to `minimumReleaseAgeExcludes` alongside `@pierre/diffs` (review follow-up from #1188). Publish-date disclosure:

| Package | Published | Age today |
|---|---|---|
| @pierre/diffs@1.3.1 | 2026-08-01 | **~2 days (younger than the 7-day gate; installed via the pre-existing @pierre/diffs exclude)** |
| @pierre/theme@2.0.0 | 2026-07-24 | ~10 days |
| @pierre/theming@1.0.0 | 2026-07-24 | ~10 days |

## Lockfile forensics (every changed line)

`bun.lock` changes are exactly nine lines, nothing else:

1-6. The six workspace `"@pierre/diffs": "1.2.12"` pins -> `"1.3.1"` (root, packages/ui, packages/server, packages/review-editor, apps/review, apps/pi-extension).
7. `@pierre/diffs` package entry: version 1.2.12 -> 1.3.1, its pinned deps `@pierre/theme` 1.1.0 -> 2.0.0 and `@pierre/theming` 0.0.2 -> 1.0.0, new integrity hash. All other deps of the entry unchanged (`diff@9.0.0` scoped override intact).
8. `@pierre/theme` entry: 1.1.0 -> 2.0.0, new hash.
9. `@pierre/theming` entry: 0.0.2 -> 1.0.0, new hash (peer range on `@pierre/theme` still `^1.1.0`, see supply-chain note).

Invariants held: root `diff` stays **8.0.4**; `shiki` stays **3.23.0** (3.x; nothing dragged shiki or `@shikijs/*` to 4.x); no other package added, removed, or re-resolved.

## Verification battery

| Check | Result |
|---|---|
| `bun run typecheck` (official script) | PASS |
| Options-bag narrowing (`controlledSelection` / `createEditor` / `onSelectedLinesChange` absent from `AllFilesCodeView` options) | PASS (bag contains none; typecheck clean; ad-hoc `tsc -p packages/review-editor` errors are byte-identical to the 1.2.12 baseline, all pre-existing) |
| `bun test` (full) | 2793 pass / 0 fail (214 skip) |
| CI DOM sets (`DOM_TESTS=1`, exact CI file lists) | 6 + 115 pass / 0 fail |
| Builds in order (apps/review -> build:hook -> build:opencode -> pi build) | All PASS, no dist files tracked by git |
| Bundle size vs 1.2.12 branch | review.html 18,066,117 -> 18,132,083 (+65,966 B, +0.37%); plan index.html 23,014,044 -> 23,026,880 (+12,836 B, +0.06%) |
| Row-height validation (`VITE_PIERRE_VALIDATE_HEIGHTS=1`, live dev server, scrolled full list) | No NEW drift: 1.3.1 emits the exact same 16 pre-existing validation messages (byte-identical payloads, e.g. sticky deltas -66/-8, first-item -33) as 1.2.12 under the same headless harness; `itemMetrics` constants left unchanged |
| DOM data-attribute touchpoints (`[data-separator]`, `[data-expand-button]`, `[data-diff-span]`, `[data-line]`, `diffs-container`, `[data-hovered]`) | All present in 1.3.1 dist and confirmed live against a real diff (28 separators / 28 expand buttons rendered) |
| onToken*-dropped-before-transformer quirk | Still present in 1.3.1 (`DiffHunksRenderer`/`FileRenderer` pool options only honor explicit `useTokenTransformer`); the forced `useTokenTransformer: true` workaround is kept |
| CDP runtime, built 1.2.12 vs 1.3.1, standalone demo + real review server on this branch's diff | Identical DOM counts in both scenarios; zero new console errors (the demo's `parseLineType` noise and two 404s occur identically on both versions) |
| Fresh-install #880 check | PASS: `bun pm pack` of apps/pi-extension, clean-cache npm install of the tarball, `preloadFile` executed under plain Node 24 (`prerenderedHTML` length 53063, no module-resolution errors) |
| SSR parity (preloadFile 1.2.12 vs 1.3.1, same options as our call sites: `{ disableFileHeader: true }`) | Structural changes explained below |
| Supply chain | `npm audit signatures`: 0 invalid/missing; publisher `amadeusdemarzi` for all three versions; maintainer set identical to @pierre/diffs' known six accounts (fat, imownbey, mdo, nicolas.pierreco, slexaxton, amadeusdemarzi); zero lifecycle scripts in all three manifests; no new dependencies vs 1.2.12 |

### SSR parity: structural changes in preloadFile output

1. **Trailing-newline handling changed (behavioral):** content ending in `\n` now renders one extra empty trailing context line (grid-row span +1). Every SSR-preloaded file preview of a newline-terminated file shows one extra blank row under 1.3.1. Cosmetic, but real.
2. New CSS custom properties in the embedded style (hover pipeline + edit-mode vars): `--diffs-hover-mix-target`, `--diffs-computed-editor-active-line-bg`, `--diffs-editor-active-line-source-mix`, `--diffs-selection-emphasis-mix-target`, `--diffs-warning-light`, `--diffs-warning-dark`.
3. Hover CSS consolidated into the central rule described above (matches the re-tune).
4. New selectors shipped but inert for us: `[data-editor-overlay]`, `[data-editor-active-line]`, dehydrated split-scroll grid, an `input, button` font reset.
5. Unchanged: wrapper markup, icon sprite set, token variable naming, all other nesting.

### Supply-chain note (upstream packaging defect, not a compromise)

`@pierre/theming@1.0.0` still declares its optional peer `@pierre/theme: ^1.1.0`, not bumped for the theme 2.0.0 major. Bun accepts this; a strict `npm install` of the three exact pins standalone hits ERESOLVE (needs `--legacy-peer-deps`), and the pi-extension tarball install resolves it by hoisting a separate `@pierre/theme@1.1.0` for theming while `@pierre/diffs` gets its nested 2.0.0. The fresh-install smoke test passes regardless. Worth reporting upstream.

## What remains for human visual QA

The CDP measurements cover computed colors of changed code lines at all three intensities in both modes, DOM parity, and console cleanliness. They do NOT cover: perceived hover feel while actually mousing across a large diff (gutter/line-number hover, selected-plus-hovered combinations, decoration-stacked lines), non-default color themes interacting with the new hover target chain, the extra SSR trailing blank line in reference previews, split-view hover, and general 1.3.x rendering polish across real-world diffs. A human pass over a real review session in light and dark at each intensity is still warranted before release.
