### PR TITLE
chore(deps): bump @pierre/diffs to 1.3.x with theme major (stage 2 of 2)

### DIFF
--- a/apps/pi-extension/package.json
+++ b/apps/pi-extension/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@joplin/turndown-plugin-gfm": "^1.0.64",
-    "@pierre/diffs": "1.2.12",
+    "@pierre/diffs": "1.3.1",
     "@plannotator/webtui": "0.1.0",
     "chokidar": "^5.0.0",
     "diff": "^8.0.4",

--- a/apps/review/package.json
+++ b/apps/review/package.json
@@ -12,7 +12,7 @@
     "@plannotator/review-editor": "workspace:*",
     "@plannotator/server": "workspace:*",
     "@plannotator/ui": "workspace:*",
-    "@pierre/diffs": "1.2.12",
+    "@pierre/diffs": "1.3.1",
     "dompurify": "^3.3.3",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.92",
         "@opencode-ai/sdk": "^1.3.0",
-        "@pierre/diffs": "1.2.12",
+        "@pierre/diffs": "1.3.1",
         "diff": "^8.0.4",
         "dockview-react": "^5.2.0",
         "dompurify": "^3.3.3",
@@ -88,7 +88,7 @@
       "version": "0.25.1",
       "dependencies": {
         "@joplin/turndown-plugin-gfm": "^1.0.64",
-        "@pierre/diffs": "1.2.12",
+        "@pierre/diffs": "1.3.1",
         "@plannotator/webtui": "0.1.0",
         "chokidar": "^5.0.0",
         "diff": "^8.0.4",
@@ -128,7 +128,7 @@
       "name": "@plannotator/review",
       "version": "0.0.1",
       "dependencies": {
-        "@pierre/diffs": "1.2.12",
+        "@pierre/diffs": "1.3.1",
         "@plannotator/review-editor": "workspace:*",
         "@plannotator/server": "workspace:*",
         "@plannotator/ui": "workspace:*",
@@ -205,7 +205,7 @@
         "@base-ui/react": "^1.6.0",
         "@fontsource-variable/geist-mono": "5.2.7",
         "@fontsource-variable/inter": "^5.2.8",
-        "@pierre/diffs": "1.2.12",
+        "@pierre/diffs": "1.3.1",
         "@plannotator/shared": "workspace:*",
         "@plannotator/ui": "workspace:*",
         "highlight.js": "^11.11.1",
@@ -226,7 +226,7 @@
       "name": "@plannotator/server",
       "version": "0.25.1",
       "dependencies": {
-        "@pierre/diffs": "1.2.12",
+        "@pierre/diffs": "1.3.1",
         "@plannotator/ai": "workspace:*",
         "@plannotator/shared": "workspace:*",
         "@plannotator/webtui": "0.1.0",
@@ -272,7 +272,7 @@
         "@fontsource-variable/inter": "^5.2.8",
         "@lezer/common": "^1.5.2",
         "@lezer/highlight": "^1.2.3",
-        "@pierre/diffs": "1.2.12",
+        "@pierre/diffs": "1.3.1",
         "@plannotator/atomic-editor": "^0.8.0",
         "@plannotator/core": "workspace:*",
         "@plannotator/markdown-editor": "^0.4.0",
@@ -793,11 +793,11 @@
 
     "@oven/bun-windows-x64-baseline": ["@oven/bun-windows-x64-baseline@1.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-uIjLUC1S9DWgICzuoMba7vurBJnBruE4S5CxnvmZkdqWVXRzx1Rgu636HoH+k0qeaQCFh3jeG3JQ1y6fRHv0sw=="],
 
-    "@pierre/diffs": ["@pierre/diffs@1.2.12", "", { "dependencies": { "@pierre/theme": "1.1.0", "@pierre/theming": "0.0.2", "@shikijs/transformers": "^3.0.0 || ^4.0.0", "diff": "9.0.0", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0 || ^4.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-pY/gmgWL03WnagqCyCnBi3QtRXUv4hCIY6FYqd5b1ZGaoI6a4Bsji8j+yRl2RfzPh/8Hf19rCl1GE80G6a1cLQ=="],
+    "@pierre/diffs": ["@pierre/diffs@1.3.1", "", { "dependencies": { "@pierre/theme": "2.0.0", "@pierre/theming": "1.0.0", "@shikijs/transformers": "^3.0.0 || ^4.0.0", "diff": "9.0.0", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0 || ^4.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-jSAm+Rybo7milxGg7ps7KjM3QZl2exhE9uYjQ4RSCdPNa9GS0mD4vBP99MoFhV95bLDKL1KSMdy0596BMLUacw=="],
 
-    "@pierre/theme": ["@pierre/theme@1.1.0", "", {}, "sha512-GC2OWTAfTIIWWYhPCygwG8t2EtePQkRfON4MI2rwIkJylmiyqIttJID2dCL8sUD8cNdEvYkEyfEHHKMeCiDLoQ=="],
+    "@pierre/theme": ["@pierre/theme@2.0.0", "", {}, "sha512-yNDd9GYLQl1mEUJR8AneJ5e4ohLIHQd/wZLWr4fagt78vS2RwwZNW530vVgHqXFAyFVcFlRmGUD5ramXH46OXw=="],
 
-    "@pierre/theming": ["@pierre/theming@0.0.2", "", { "peerDependencies": { "@pierre/theme": "^1.1.0", "@shikijs/themes": "^3.0.0 || ^4.0.0", "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0", "shiki": "^3.0.0 || ^4.0.0" }, "optionalPeers": ["@pierre/theme", "@shikijs/themes", "react", "react-dom", "shiki"] }, "sha512-QM1M4stXfnzfaE8I8YbjXSApV8c+2dBsXJj8eYg9WTpBR/cTmCZIcfGnN4p13iRrYu2Br/R/OJfEL7uR8Qjctw=="],
+    "@pierre/theming": ["@pierre/theming@1.0.0", "", { "peerDependencies": { "@pierre/theme": "^1.1.0", "@shikijs/themes": "^3.0.0 || ^4.0.0", "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0", "shiki": "^3.0.0 || ^4.0.0" }, "optionalPeers": ["@pierre/theme", "@shikijs/themes", "react", "react-dom", "shiki"] }, "sha512-WsdrnhKfjeyXGDikZmN9pkpeZ5S/cl6EE72feiSc0tlynT1tMYqXqouhuv/foK+PY9OEnebOAVRQn3+rAstR8g=="],
 
     "@plannotator/ai": ["@plannotator/ai@workspace:packages/ai"],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,7 +1,7 @@
 [install]
 linker = "isolated"
 minimumReleaseAge = 604800  # 7 days in seconds
-minimumReleaseAgeExcludes = ["@pierre/diffs", "@plannotator/atomic-editor", "@plannotator/markdown-editor", "@plannotator/webtui"]
+minimumReleaseAgeExcludes = ["@pierre/diffs", "@pierre/theme", "@pierre/theming", "@plannotator/atomic-editor", "@plannotator/markdown-editor", "@plannotator/webtui"]
 
 [test]
 preload = ["./packages/ui/test-setup/happy-dom.ts"]

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.92",
     "@opencode-ai/sdk": "^1.3.0",
-    "@pierre/diffs": "1.2.12",
+    "@pierre/diffs": "1.3.1",
     "diff": "^8.0.4",
     "dockview-react": "^5.2.0",
     "dompurify": "^3.3.3",

--- a/packages/review-editor/hooks/usePierreTheme.ts
+++ b/packages/review-editor/hooks/usePierreTheme.ts
@@ -62,6 +62,17 @@ export interface PierreTheme {
  * 88 / 80) since darker themes need a larger colour share to read at the
  * same perceptual intensity.
  *
+ * `hoverMix*` values are the FINAL rendered bg shares, matching what our
+ * pre-1.3 overrides produced. Since @pierre/diffs 1.3.0 the per-selector
+ * hover rules (`[data-hovered] { --mix-light: … }`) are gone; hover is one
+ * central rule that re-mixes `--diffs-computed-editor-active-line-bg`
+ * 97% (light) / 91% (dark) toward `--diffs-hover-mix-target` (the
+ * addition/deletion base colour on changed lines). Our hovered `--mix-*`
+ * values therefore feed the rest formula first and get multiplied by
+ * 0.97 / 0.91 on the way to the screen — `hoverEmittedMix()` divides the
+ * targets back out so the composed result equals these numbers exactly
+ * (color-mix in lab is linear, so the compensation is exact).
+ *
  * Driving the line bg through these vars (instead of overriding the final
  * `background-color`) keeps Pierre's `--diffs-line-bg` pipeline intact, so
  * selected / hovered / decorated states keep their state-specific visuals.
@@ -76,6 +87,29 @@ interface IntensityConfig {
 const INTENSITY_CONFIG: Record<Exclude<DiffLineBgIntensity, 'subtle'>, IntensityConfig> = {
   normal: { restMixLight: 55, restMixDark: 45, hoverMixLight: 45, hoverMixDark: 35 },
   strong: { restMixLight: 35, restMixDark: 25, hoverMixLight: 25, hoverMixDark: 15 },
+};
+
+/** Pierre's central hover rule mixes the rest bg by these shares toward the
+ * hover mix target (light-dark(97%, 91%) since 1.3.0). */
+const PIERRE_HOVER_KEEP_LIGHT = 0.97;
+const PIERRE_HOVER_KEEP_DARK = 0.91;
+
+/** Convert a desired FINAL hovered bg share into the `--mix-*` value to emit,
+ * compensating for Pierre's central hover re-mix. */
+function hoverEmittedMix(finalShare: number, keep: number): string {
+  return (finalShare / keep).toFixed(2);
+}
+
+/**
+ * At 1.2.12 Pierre's own per-selector hover rules gave changed lines these
+ * final bg shares (deletion 80/75, addition 80/70). `subtle` rode them
+ * untouched; 1.3.x's central hover rule instead lands at ~85.4 light /
+ * ~72.8 dark, a visibly weaker light-theme hover. We pin the old finals so
+ * `subtle` hover looks the same before and after the upgrade.
+ */
+const SUBTLE_HOVER_FINALS = {
+  deletion: { light: 80, dark: 75 },
+  addition: { light: 80, dark: 70 },
 };
 
 /**
@@ -114,11 +148,6 @@ export function buildLineBgOverrides(intensity: DiffLineBgIntensity, mode: 'ligh
       background-color: transparent !important;
     }
   `;
-  if (intensity === 'subtle') return hideEmphasisWithoutBg;
-  const cfg = INTENSITY_CONFIG[intensity];
-  const lShift = mode === 'dark'
-    ? `+ ${EMPHASIS_LIGHTNESS_SHIFT}`
-    : `- ${EMPHASIS_LIGHTNESS_SHIFT}`;
   // Targeting `[data-line]` and `[data-no-newline]` only — the actual code
   // lines. Skipping `[data-gutter-buffer]` / `[data-column-number]` keeps the
   // line-number gutter at the page bg (matching the existing
@@ -126,20 +155,46 @@ export function buildLineBgOverrides(intensity: DiffLineBgIntensity, mode: 'ligh
   // `[data-background]` mirrors the library's own `:where([data-background])`
   // scoping, so the "Diff background" toggle still turns line bgs off.
   //
-  // Specificity is (0,0,4); wins against the library's (0,0,1) baseline and
-  // (0,0,3) hover rule. The `:not([data-hovered])` variant yields to the
-  // explicit `[data-hovered]` variant on hover.
+  // Specificity is (0,4,0); wins against the library's rest rules (max
+  // (0,2,0) inside `:where([data-background])`). Since 1.3.0 the library's
+  // hover rule sets `--diffs-computed-hovered-line-bg` (a different property)
+  // on `[data-line][data-hovered]`, so there is no specificity race on
+  // `--mix-*` anymore — our hovered `--mix-*` values flow through the rest
+  // formula and Pierre's central hover re-mix composes on top (compensated
+  // via hoverEmittedMix, see INTENSITY_CONFIG docs).
   const changedLine =
     "[data-background] :is([data-line-type='change-addition'], [data-line-type='change-deletion'])" +
     ":is([data-line], [data-no-newline])";
+  if (intensity === 'subtle') {
+    // Keep Pierre's rest bg untouched, but pin the hovered finals to the
+    // 1.2.x values (see SUBTLE_HOVER_FINALS). Per-type split preserved:
+    // 1.2.x deletion hover was 80/75, addition 80/70.
+    const del = SUBTLE_HOVER_FINALS.deletion;
+    const add = SUBTLE_HOVER_FINALS.addition;
+    return `
+      [data-background] [data-line-type='change-deletion']:is([data-line], [data-no-newline])[data-hovered] {
+        --mix-light: ${hoverEmittedMix(del.light, PIERRE_HOVER_KEEP_LIGHT)}%;
+        --mix-dark: ${hoverEmittedMix(del.dark, PIERRE_HOVER_KEEP_DARK)}%;
+      }
+      [data-background] [data-line-type='change-addition']:is([data-line], [data-no-newline])[data-hovered] {
+        --mix-light: ${hoverEmittedMix(add.light, PIERRE_HOVER_KEEP_LIGHT)}%;
+        --mix-dark: ${hoverEmittedMix(add.dark, PIERRE_HOVER_KEEP_DARK)}%;
+      }
+      ${hideEmphasisWithoutBg}
+    `;
+  }
+  const cfg = INTENSITY_CONFIG[intensity];
+  const lShift = mode === 'dark'
+    ? `+ ${EMPHASIS_LIGHTNESS_SHIFT}`
+    : `- ${EMPHASIS_LIGHTNESS_SHIFT}`;
   return `
     ${changedLine}:not([data-hovered]) {
       --mix-light: ${cfg.restMixLight}%;
       --mix-dark: ${cfg.restMixDark}%;
     }
     ${changedLine}[data-hovered] {
-      --mix-light: ${cfg.hoverMixLight}%;
-      --mix-dark: ${cfg.hoverMixDark}%;
+      --mix-light: ${hoverEmittedMix(cfg.hoverMixLight, PIERRE_HOVER_KEEP_LIGHT)}%;
+      --mix-dark: ${hoverEmittedMix(cfg.hoverMixDark, PIERRE_HOVER_KEEP_DARK)}%;
     }
     ${changedLine} {
       --diffs-bg-addition-emphasis: oklch(from var(--diffs-computed-diff-line-bg) calc(l ${lShift}) c h);

--- a/packages/review-editor/package.json
+++ b/packages/review-editor/package.json
@@ -12,7 +12,7 @@
     "@base-ui/react": "^1.6.0",
     "@fontsource-variable/geist-mono": "5.2.7",
     "@fontsource-variable/inter": "^5.2.8",
-    "@pierre/diffs": "1.2.12",
+    "@pierre/diffs": "1.3.1",
     "@plannotator/shared": "workspace:*",
     "@plannotator/ui": "workspace:*",
     "highlight.js": "^11.11.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -31,7 +31,7 @@
     "*.mjs"
   ],
   "dependencies": {
-    "@pierre/diffs": "1.2.12",
+    "@pierre/diffs": "1.3.1",
     "@plannotator/ai": "workspace:*",
     "@plannotator/shared": "workspace:*",
     "@plannotator/webtui": "0.1.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -66,7 +66,7 @@
     "@fontsource-variable/inter": "^5.2.8",
     "@lezer/common": "^1.5.2",
     "@lezer/highlight": "^1.2.3",
-    "@pierre/diffs": "1.2.12",
+    "@pierre/diffs": "1.3.1",
     "@plannotator/atomic-editor": "^0.8.0",
     "@plannotator/core": "workspace:*",
     "@plannotator/markdown-editor": "^0.4.0",


### PR DESCRIPTION
Continuation of #1189, which GitHub auto-closed when its base branch (`chore/pierre-diffs-1.2.12`) was deleted by the #1188 squash merge and could not be reopened. Same single commit, now rebased onto main past the #1188 squash (`git rebase --onto main d2b5a526`), exactly as the adversarial review required: without the rebase this diff would have re-shown all of stage 1.

Everything else is unchanged from #1189: `@pierre/diffs@1.3.1`, `@pierre/theme@2.0.0`, `@pierre/theming@1.0.0`, the hover re-tune with measured parity, the bunfig age-gate excludes, edit mode NOT enabled. Full PR description and verification tables: #1189. Adversarial review verdict (merge as-is): https://github.com/backnotprop/plannotator/pull/1189#issuecomment-5173579566

Maintainer has approved merging after adequate review, with the visual QA folded into the release QA gate.
