### PR TITLE
chore(deps): bump @pierre/diffs to 1.3.2

### DIFF
--- a/apps/pi-extension/package.json
+++ b/apps/pi-extension/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@joplin/turndown-plugin-gfm": "^1.0.64",
-    "@pierre/diffs": "1.3.1",
+    "@pierre/diffs": "1.3.2",
     "@plannotator/webtui": "0.1.0",
     "chokidar": "^5.0.0",
     "diff": "^8.0.4",

--- a/apps/review/package.json
+++ b/apps/review/package.json
@@ -12,7 +12,7 @@
     "@plannotator/review-editor": "workspace:*",
     "@plannotator/server": "workspace:*",
     "@plannotator/ui": "workspace:*",
-    "@pierre/diffs": "1.3.1",
+    "@pierre/diffs": "1.3.2",
     "dompurify": "^3.3.3",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.92",
         "@opencode-ai/sdk": "^1.3.0",
-        "@pierre/diffs": "1.3.1",
+        "@pierre/diffs": "1.3.2",
         "diff": "^8.0.4",
         "dockview-react": "^5.2.0",
         "dompurify": "^3.3.3",
@@ -88,7 +88,7 @@
       "version": "0.25.1",
       "dependencies": {
         "@joplin/turndown-plugin-gfm": "^1.0.64",
-        "@pierre/diffs": "1.3.1",
+        "@pierre/diffs": "1.3.2",
         "@plannotator/webtui": "0.1.0",
         "chokidar": "^5.0.0",
         "diff": "^8.0.4",
@@ -128,7 +128,7 @@
       "name": "@plannotator/review",
       "version": "0.0.1",
       "dependencies": {
-        "@pierre/diffs": "1.3.1",
+        "@pierre/diffs": "1.3.2",
         "@plannotator/review-editor": "workspace:*",
         "@plannotator/server": "workspace:*",
         "@plannotator/ui": "workspace:*",
@@ -205,7 +205,7 @@
         "@base-ui/react": "^1.6.0",
         "@fontsource-variable/geist-mono": "5.2.7",
         "@fontsource-variable/inter": "^5.2.8",
-        "@pierre/diffs": "1.3.1",
+        "@pierre/diffs": "1.3.2",
         "@plannotator/shared": "workspace:*",
         "@plannotator/ui": "workspace:*",
         "highlight.js": "^11.11.1",
@@ -226,7 +226,7 @@
       "name": "@plannotator/server",
       "version": "0.25.1",
       "dependencies": {
-        "@pierre/diffs": "1.3.1",
+        "@pierre/diffs": "1.3.2",
         "@plannotator/ai": "workspace:*",
         "@plannotator/shared": "workspace:*",
         "@plannotator/webtui": "0.1.0",
@@ -272,7 +272,7 @@
         "@fontsource-variable/inter": "^5.2.8",
         "@lezer/common": "^1.5.2",
         "@lezer/highlight": "^1.2.3",
-        "@pierre/diffs": "1.3.1",
+        "@pierre/diffs": "1.3.2",
         "@plannotator/atomic-editor": "^0.8.0",
         "@plannotator/core": "workspace:*",
         "@plannotator/markdown-editor": "^0.4.0",
@@ -793,7 +793,7 @@
 
     "@oven/bun-windows-x64-baseline": ["@oven/bun-windows-x64-baseline@1.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-uIjLUC1S9DWgICzuoMba7vurBJnBruE4S5CxnvmZkdqWVXRzx1Rgu636HoH+k0qeaQCFh3jeG3JQ1y6fRHv0sw=="],
 
-    "@pierre/diffs": ["@pierre/diffs@1.3.1", "", { "dependencies": { "@pierre/theme": "2.0.0", "@pierre/theming": "1.0.0", "@shikijs/transformers": "^3.0.0 || ^4.0.0", "diff": "9.0.0", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0 || ^4.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-jSAm+Rybo7milxGg7ps7KjM3QZl2exhE9uYjQ4RSCdPNa9GS0mD4vBP99MoFhV95bLDKL1KSMdy0596BMLUacw=="],
+    "@pierre/diffs": ["@pierre/diffs@1.3.2", "", { "dependencies": { "@pierre/theme": "2.0.0", "@pierre/theming": "1.0.0", "@shikijs/transformers": "^3.0.0 || ^4.0.0", "diff": "9.0.0", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0 || ^4.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-+aSaxN/fGwmegUF/UVkXOOA8Run+sYOqhqTc1JvlieoYXsW/9KykOIR88FvgXjesI0MGZJLsX8dthn3+x2kymA=="],
 
     "@pierre/theme": ["@pierre/theme@2.0.0", "", {}, "sha512-yNDd9GYLQl1mEUJR8AneJ5e4ohLIHQd/wZLWr4fagt78vS2RwwZNW530vVgHqXFAyFVcFlRmGUD5ramXH46OXw=="],
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.92",
     "@opencode-ai/sdk": "^1.3.0",
-    "@pierre/diffs": "1.3.1",
+    "@pierre/diffs": "1.3.2",
     "diff": "^8.0.4",
     "dockview-react": "^5.2.0",
     "dompurify": "^3.3.3",

--- a/packages/review-editor/package.json
+++ b/packages/review-editor/package.json
@@ -12,7 +12,7 @@
     "@base-ui/react": "^1.6.0",
     "@fontsource-variable/geist-mono": "5.2.7",
     "@fontsource-variable/inter": "^5.2.8",
-    "@pierre/diffs": "1.3.1",
+    "@pierre/diffs": "1.3.2",
     "@plannotator/shared": "workspace:*",
     "@plannotator/ui": "workspace:*",
     "highlight.js": "^11.11.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -31,7 +31,7 @@
     "*.mjs"
   ],
   "dependencies": {
-    "@pierre/diffs": "1.3.1",
+    "@pierre/diffs": "1.3.2",
     "@plannotator/ai": "workspace:*",
     "@plannotator/shared": "workspace:*",
     "@plannotator/webtui": "0.1.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -66,7 +66,7 @@
     "@fontsource-variable/inter": "^5.2.8",
     "@lezer/common": "^1.5.2",
     "@lezer/highlight": "^1.2.3",
-    "@pierre/diffs": "1.3.1",
+    "@pierre/diffs": "1.3.2",
     "@plannotator/atomic-editor": "^0.8.0",
     "@plannotator/core": "workspace:*",
     "@plannotator/markdown-editor": "^0.4.0",


### PR DESCRIPTION
Pure pin bump of `@pierre/diffs` from exact `1.3.1` to exact `1.3.2` in the six package.json files (root, `packages/ui`, `packages/server`, `packages/review-editor`, `apps/review`, `apps/pi-extension`) plus `bun.lock`. No Plannotator code changes.

## Upstream delta (diffs-v1.3.1 to diffs-v1.3.2)

The Pierre repo history is linear between the two tags. The shipped `packages/diffs` source delta is four commits plus the version bump, two more than initially briefed:

- `94b65d72` fix(diffs): keep scroll anchor stable when CodeView removes items (#1047). This is the commit we want: it protects scroll position when virtualized CodeView items are removed, relevant to our virtualized all-files review view.
- `218def7f` diffs: add CodeView.removeItem API (#1050). New API only. **Adoption is deliberately deferred**; this PR changes no Plannotator code.
- `76207447` [diffs/edit] hide selection action when selection is offscreen (#1039). Editor surface polish; Plannotator does not use the diffs edit surface.
- `e72c4282` [diffs/edit] add `keymap` editor option (#1040). Same, editor surface only.
- `ecdfad73` updates Shiki to 4.4.1 in the Pierre repo's dev catalog only; the published `shiki` dependency range is unchanged (`^3.0.0 || ^4.0.0`) and our lockfile keeps shiki `3.23.0`.

## Young release disclosure and provenance verification

`1.3.2` was published `2026-08-04T02:19:04Z`, under one day before this bump, well inside our 7 day `minimumReleaseAge` posture (it installs via the `bunfig.toml` excludes for `@pierre/*`). The maintainer approved proceeding, compensated by the same deep provenance check used for the 1.3.1 bump:

- Tarball `diffs-1.3.2.tgz` downloaded from the registry: shasum `1dbe298a4f0b6f2935937a4c900a8df8f46eb0bf` and sha512 both match the registry `dist` metadata and the new `bun.lock` integrity line exactly.
- Registry signatures present (keyid `SHA256:DhQ8wR5APBvFHLF/+Tc+AYvPOdTpcIDqOhxsBHRwC7U`, the npm registry key).
- Zero lifecycle scripts in the shipped package (`scripts: {}`, no install/postinstall hooks). The repo-side `prepublishOnly` is publish-machine only and is not shipped.
- Maintainer set unchanged from 1.3.1: the same six accounts (fat, imownbey, mdo, nicolas.pierreco, slexaxton, amadeusdemarzi).
- Source byte comparison: every `sourcesContent` entry shipped in the tarball's 394 sourcemaps was compared against the `diffs-v1.3.2` tag (`39ef68a7`) of the Pierre repo. 191 unique repo files are byte identical, zero mismatches, zero files missing from the tag. Entries without content are 199 `.d.ts.map` declaration maps (never carry sources) and 2 generated asset shims with empty source lists.
- Shipped `package.json` matches the tag modulo the expected publish substitutions: `workspace:*` resolved to `@pierre/theme 2.0.0` and `@pierre/theming 1.0.0`, `catalog:` entries resolved to `diff 9.0.0`, `hast-util-to-html 9.0.5`, `lru_map 0.4.1`, all matching the tag's `pnpm-workspace.yaml` catalog. The 1.3.2 dependency set is byte identical to 1.3.1's.
- `@pierre/theme` resolution stays `2.0.0` and `@pierre/theming` stays `1.0.0` (unchanged, as required).

## Lockfile accounting

The `bun.lock` diff is exactly 7 changed lines, every one explained:

- 6 workspace dependency declarations: `"@pierre/diffs": "1.3.1"` to `"1.3.2"` (root, pi-extension, apps/review, review-editor, server, ui).
- 1 resolution entry: `@pierre/diffs@1.3.1` to `@1.3.2` with the new sha512 integrity (matches the tarball digest computed locally). The recorded dependency object is unchanged.

No other resolution moved: root `diff` stays `8.0.4`, `shiki` stays `3.23.0`, `@pierre/theme` stays `2.0.0`, `@pierre/theming` stays `1.0.0`.

## Verification

| Check | Result |
|---|---|
| Typecheck (`bun run typecheck`, all 7 tsconfigs) | pass |
| Full `bun test` | 2793 pass, 0 fail, 214 skip (no flake isolation needed) |
| `DOM_TESTS=1` isolated file-browser test (per test.yml) | 6 pass, 0 fail |
| `DOM_TESTS=1` seam-contract + DOM suite (per test.yml) | 155 pass, 0 fail |
| Build: `apps/review` | pass, 18,132.87 kB (gzip 5,418.50 kB) |
| Build: `build:hook` | pass, plan editor 23,026.88 kB (byte identical to 1.3.1) |
| Build: `build:opencode` | pass, copies verified |
| Build: `apps/pi-extension` | pass (vendor + HTML copies) |
| Bundle size delta vs 1.3.1 | review editor +786 bytes raw, +0.25 kB gzip; plan editor unchanged (does not bundle @pierre/diffs) |
| #880 fresh-install check | `bun pm pack apps/pi-extension`, clean-cache npm install of the tarball, `preloadFile` from `@pierre/diffs/ssr` renders 50 kB of prerendered HTML under plain Node v24.15.0 |
| CDP runtime, standalone demo HTML | 1.3.1 and 1.3.2 identical DOM counts (330 elements) and identical console output; 0 page exceptions |
| CDP runtime, live review server | initial load: 0 app console errors (one benign `/api/draft` 404 draft-restore probe), 0 exceptions; opening a changed file renders the pierre CodeView with identical DOM counts on 1.3.1 and 1.3.2 and 0 errors |

One pre-existing note surfaced during CDP testing: opening the `bun.lock` diff logs a `DiffHunksRenderer.processDiffResult: deletionLine and additionLine are null` console error. It reproduces identically on 1.3.1 with the same hunk, so it is not a 1.3.2 regression; the view still renders.

## Deferred

`CodeView.removeItem` (#1050) is not adopted here on purpose. If we want it for the all-files view later, that is its own change with its own review.
