### PR TITLE
feat(review): author suggestions by editing code in place (experimental, flag-gated)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,7 @@ jobs:
           packages/review-editor/components/ReviewSubmissionDialog.ui.test.tsx
           packages/review-editor/components/FileHeader.edit.test.tsx
           packages/review-editor/edit/useEditSession.recovery.test.tsx
+          packages/review-editor/edit/selectionActionPopover.test.ts
           packages/review-editor/hooks/useReviewSearch.test.tsx
           packages/ui/components/AnnotationPanel.props.test.tsx
           packages/ui/components/Viewer.consumer.test.tsx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,7 @@ jobs:
           packages/ui/components/sidebar/FileBrowser.test.ts
           packages/editor/editableDocumentsHook.test.tsx
           packages/review-editor/components/ReviewSubmissionDialog.ui.test.tsx
+          packages/review-editor/components/FileHeader.edit.test.tsx
           packages/review-editor/hooks/useReviewSearch.test.tsx
           packages/ui/components/AnnotationPanel.props.test.tsx
           packages/ui/components/Viewer.consumer.test.tsx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,7 @@ jobs:
           packages/editor/editableDocumentsHook.test.tsx
           packages/review-editor/components/ReviewSubmissionDialog.ui.test.tsx
           packages/review-editor/components/FileHeader.edit.test.tsx
+          packages/review-editor/edit/useEditSession.recovery.test.tsx
           packages/review-editor/hooks/useReviewSearch.test.tsx
           packages/ui/components/AnnotationPanel.props.test.tsx
           packages/ui/components/Viewer.consumer.test.tsx

--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -32,6 +32,7 @@ import { useCodeAnnotationDraft } from '@plannotator/ui/hooks/useCodeAnnotationD
 import { useGitAdd } from './hooks/useGitAdd';
 import { generateId } from './utils/generateId';
 import type { SuggestionHunk } from './edit/deriveSuggestions';
+import type { EditSelectionComment } from './edit/useEditSession';
 import { useAIChat } from './hooks/useAIChat';
 import { toast, Toaster } from 'sonner';
 import { useCodeNav, type CodeNavRequest } from './hooks/useCodeNav';
@@ -1522,6 +1523,33 @@ const ReviewApp: React.FC = () => {
     ]);
   }, [identity, withPRContext]);
 
+  // Sink for the edit session's "Make annotation" selection action: a plain
+  // line-scoped comment whose anchor was mapped from the edited buffer to
+  // PRISTINE new-side coordinates at selection time (edit/selectionAnchor.ts),
+  // so it renders and exports correctly whether the session later completes
+  // or is discarded. `selectedText` preserves what was actually highlighted;
+  // `selectedTextFromEdits` flags an approximate anchor (selection overlapped
+  // in-session edits) so the export can label it honestly.
+  const handleAddEditorCommentForFile = useCallback((filePath: string, comment: EditSelectionComment) => {
+    const trimmed = comment.text.trim();
+    if (!trimmed) return;
+    const newAnnotation: CodeAnnotation = {
+      id: generateId(),
+      type: 'comment',
+      scope: 'line',
+      filePath,
+      lineStart: comment.lineStart,
+      lineEnd: comment.lineEnd,
+      side: 'new',
+      text: trimmed,
+      selectedText: comment.selectedText || undefined,
+      ...(comment.exact ? {} : { selectedTextFromEdits: true }),
+      createdAt: Date.now(),
+      author: identity,
+    };
+    setAnnotations(prev => [...prev, withPRContext(newAnnotation)]);
+  }, [identity, withPRContext]);
+
   const handleAddAnnotation = useCallback((
     type: CodeAnnotationType,
     text?: string,
@@ -2411,6 +2439,7 @@ const ReviewApp: React.FC = () => {
     onAddAnnotationForFile: handleAddAnnotationForFile,
     editSuggestionsEnabled,
     onAddSuggestionsForFile: handleAddSuggestionsForFile,
+    onAddEditorCommentForFile: handleAddEditorCommentForFile,
     onAddFileComment: handleAddFileComment,
     onAddFileCommentForFile: handleAddFileCommentForFile,
     onEditAnnotation: handleEditAnnotation,
@@ -2509,7 +2538,7 @@ const ReviewApp: React.FC = () => {
     isPRContextLoading, prContextError, fetchPRContext, platformUser, openDiffFile,
     handleOpenTour, handleOpenGuide, isAllFilesActive, allFilesOrder, allFilesAllCollapsed, onToggleAllFilesCollapsed, registerAllFilesCollapseToggle, commitInfo, isSemanticDiffActive, semanticDiffAvailable,
     handleSemanticDiffUnavailable, handleSemanticDiffLoadError, handleSemanticDiffLoadSuccess, handleAddAnnotationForFile,
-    editSuggestionsEnabled, handleAddSuggestionsForFile,
+    editSuggestionsEnabled, handleAddSuggestionsForFile, handleAddEditorCommentForFile,
     handleCodeNavRequest, codeNav.result, codeNav.isLoading, codeNav.activeSymbol,
   ]);
 

--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -31,6 +31,7 @@ import { useResizablePanel } from '@plannotator/ui/hooks/useResizablePanel';
 import { useCodeAnnotationDraft } from '@plannotator/ui/hooks/useCodeAnnotationDraft';
 import { useGitAdd } from './hooks/useGitAdd';
 import { generateId } from './utils/generateId';
+import type { SuggestionHunk } from './edit/deriveSuggestions';
 import { useAIChat } from './hooks/useAIChat';
 import { toast, Toaster } from 'sonner';
 import { useCodeNav, type CodeNavRequest } from './hooks/useCodeNav';
@@ -246,6 +247,8 @@ const ReviewApp: React.FC = () => {
   const diffFontFamily = useConfigValue('diffFontFamily');
   const diffFontSize = useConfigValue('diffFontSize');
   const diffTabSize = useConfigValue('diffTabSize');
+  // EXPERIMENTAL: edit code in place to author suggestions (default OFF).
+  const editSuggestionsEnabled = useConfigValue('editSuggestions');
   // Global plan-look preference; surfaced here only by the shared 0.20.0
   // look-and-feel announcement (the grid/clean chooser applies to plan review).
   const gridEnabled = useConfigValue('gridEnabled');
@@ -1489,6 +1492,36 @@ const ReviewApp: React.FC = () => {
     setPendingSelection(null);
   }, [pendingSelection, identity, withPRContext]);
 
+  // Sink for the experimental edit-to-suggestion flow: a completed edit
+  // session delivers one hunk per contiguous changed region, each becoming a
+  // normal suggestion annotation (same shape SuggestionModal produces —
+  // type 'comment' carrying suggestedCode/originalCode) so it flows through
+  // rendering, sidebar, and feedback export unchanged. The browser never
+  // writes files; the agent applies these suggestions.
+  const handleAddSuggestionsForFile = useCallback((filePath: string, hunks: SuggestionHunk[]) => {
+    if (hunks.length === 0) return;
+    const now = Date.now();
+    setAnnotations(prev => [
+      ...prev,
+      ...hunks.map((hunk) => withPRContext({
+        id: generateId(),
+        type: 'comment' as CodeAnnotationType,
+        scope: 'line' as const,
+        filePath,
+        lineStart: hunk.lineStart,
+        lineEnd: hunk.lineEnd,
+        side: 'new' as const,
+        // A fully-emptied file derives an empty suggestion; the export
+        // template skips falsy suggestedCode, so describe it in text instead.
+        text: hunk.suggestedCode === '' ? 'Suggested change: remove these lines.' : undefined,
+        suggestedCode: hunk.suggestedCode === '' ? undefined : hunk.suggestedCode,
+        originalCode: hunk.originalCode === '' ? undefined : hunk.originalCode,
+        createdAt: now,
+        author: identity,
+      })),
+    ]);
+  }, [identity, withPRContext]);
+
   const handleAddAnnotation = useCallback((
     type: CodeAnnotationType,
     text?: string,
@@ -2376,6 +2409,8 @@ const ReviewApp: React.FC = () => {
     onLineSelection: handleLineSelection,
     onAddAnnotation: handleAddAnnotation,
     onAddAnnotationForFile: handleAddAnnotationForFile,
+    editSuggestionsEnabled,
+    onAddSuggestionsForFile: handleAddSuggestionsForFile,
     onAddFileComment: handleAddFileComment,
     onAddFileCommentForFile: handleAddFileCommentForFile,
     onEditAnnotation: handleEditAnnotation,
@@ -2474,6 +2509,7 @@ const ReviewApp: React.FC = () => {
     isPRContextLoading, prContextError, fetchPRContext, platformUser, openDiffFile,
     handleOpenTour, handleOpenGuide, isAllFilesActive, allFilesOrder, allFilesAllCollapsed, onToggleAllFilesCollapsed, registerAllFilesCollapseToggle, commitInfo, isSemanticDiffActive, semanticDiffAvailable,
     handleSemanticDiffUnavailable, handleSemanticDiffLoadError, handleSemanticDiffLoadSuccess, handleAddAnnotationForFile,
+    editSuggestionsEnabled, handleAddSuggestionsForFile,
     handleCodeNavRequest, codeNav.result, codeNav.isLoading, codeNav.activeSymbol,
   ]);
 

--- a/packages/review-editor/components/AllFilesCodeView.tsx
+++ b/packages/review-editor/components/AllFilesCodeView.tsx
@@ -11,7 +11,7 @@ import type {
   PostRenderPhase,
   SelectedLineRange,
 } from '@pierre/diffs';
-import { CodeView, type CodeViewHandle, useStableCallback } from '@pierre/diffs/react';
+import { CodeView, EditProvider, type CodeViewHandle, useStableCallback } from '@pierre/diffs/react';
 import type { DiffTokenEventBaseProps } from '@pierre/diffs';
 import type {
   CodeAnnotation,
@@ -33,6 +33,8 @@ import { ToolbarHost, type ToolbarHostHandle } from './ToolbarHost';
 import { FileHeader } from './FileHeader';
 import { FileCommentBanner } from './FileCommentBanner';
 import { annotationMatchesPrScope, isFileScopedAnnotation, lineRangeForAnnotation } from '../utils/annotationScope';
+import { useEditSession } from '../edit/useEditSession';
+import type { SuggestionHunk } from '../edit/deriveSuggestions';
 import { lineAnnotationMetadata } from '../utils/annotationDisplay';
 import { InlineAnnotation } from './InlineAnnotation';
 import { InlineAIMarker } from './InlineAIMarker';
@@ -142,6 +144,15 @@ import {
  *    needs real WebKit validation.)
  *
  * The worker pool remains a later phase.
+ *
+ * EXPERIMENTAL edit-to-suggestion (flag-gated, default OFF): the plain
+ * all-files panel can opt into Pierre's experimental edit mode. One file at a
+ * time enters an in-place editor (lazy-loaded chunk); on completion the net
+ * change is diffed against the pre-session content and becomes ordinary
+ * suggestion annotations. The item's pristine FileDiffMetadata is deep-cloned
+ * before the session and restored (version bump + updateItem) when it ends,
+ * because Pierre's editor mutates the metadata in place. See
+ * ../edit/useEditSession.ts and ../edit/pierreEditAdapter.ts.
  */
 interface AllFilesCodeViewProps {
   files: DiffFile[];
@@ -257,6 +268,16 @@ interface AllFilesCodeViewProps {
   /** Let wheel/touch gestures continue into a containing page when this nested
    * viewer reaches either vertical boundary. Guided Review file cards opt in. */
   allowScrollChaining?: boolean;
+  /** EXPERIMENTAL flag-gated edit-to-suggestion mode. Only the plain all-files
+   * dock panel passes this — Guided Review surfaces deliberately do NOT (the
+   * GuideViewportManager evicts CodeViews beyond ~8 mounted, which would
+   * destroy an active editor's state; scoping edit mode to this surface is the
+   * simple safe v1 choice). When absent/false, no edit UI renders and the
+   * editor module is never loaded. */
+  enableEditSuggestions?: boolean;
+  /** Sink for suggestions derived from a completed edit session. Required for
+   * edit mode to activate. */
+  onAddSuggestionsForFile?: (filePath: string, hunks: SuggestionHunk[]) => void;
 }
 
 // Diffshub-style stable path-based id allocation. Plannotator's file list is
@@ -506,6 +527,8 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
   onClickAIMarker,
   getAIHistoryForFile,
   allowScrollChaining = false,
+  enableEditSuggestions = false,
+  onAddSuggestionsForFile,
 }) => {
   const mountCollapsedRef = useRef(mountCollapsed);
   const seedCollapsed = mountCollapsedRef.current ?? defaultCollapsed;
@@ -879,6 +902,11 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
     setSelectedLines(null);
     pendingToolbarRange.current = null;
     visibleFileRef.current = null;
+    // An edit session cannot survive the CodeView remount (Pierre tears the
+    // editor down without a completion callback). Drop the session state; the
+    // remounted items are already pristine. In-progress edits are discarded —
+    // acceptable because every diff refresh/switch is user-initiated.
+    editSession.handleFileSetChange();
     setFileCommentAnchor(null);
     fileCommentButtonRefs.current.clear();
     // Resync the header-refresh snapshots to the current props so the post-
@@ -941,6 +969,11 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
     const item = handle?.getItem(itemId);
     if (handle == null || viewer == null || item == null) return;
 
+    // Collapsing a file that is mid-edit ends its session first (Pierre would
+    // otherwise end it implicitly; routing through finishIfEditing keeps the
+    // suggestion capture + pristine restore on our one code path).
+    if (item.collapsed !== true) editSession.finishIfEditing(itemId);
+
     // If the item top is above scrollTop, re-anchor after the update so the
     // collapsing file stays in view (it would otherwise shift the content
     // below it upward, jumping the scroll). Diffshub anchor fix.
@@ -962,6 +995,7 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
     const handle = viewerRef.current;
     const item = handle?.getItem(itemId);
     if (handle == null || item == null || item.collapsed === true) return;
+    editSession.finishIfEditing(itemId);
     item.collapsed = true;
     item.version = (item.version ?? 0) + 1;
     handle.updateItem(item);
@@ -982,6 +1016,7 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
     for (const { id } of identity.items) {
       const item = handle.getItem(id);
       if (item == null || (item.collapsed === true) === collapsed) continue;
+      if (collapsed) editSession.finishIfEditing(id);
       item.collapsed = collapsed;
       item.version = (item.version ?? 0) + 1;
       handle.updateItem(item);
@@ -1062,6 +1097,23 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
   itemIdToFileRef.current = itemIdToFile;
   const fileSetKeyRef = useRef(fileSetKey);
   fileSetKeyRef.current = fileSetKey;
+
+  // --- Edit-to-suggestion sessions (EXPERIMENTAL, flag-gated) -----------------
+  // One file at a time; the editor chunk lazy-loads on first entry; the item's
+  // pristine FileDiffMetadata is deep-cloned before the session and restored
+  // (via version bump + updateItem) when it ends. See useEditSession.
+  const editEnabled = enableEditSuggestions && onAddSuggestionsForFile != null;
+  const editSession = useEditSession({
+    enabled: editEnabled,
+    viewerRef,
+    itemIdToFileRef,
+    fileSetKeyRef,
+    reviewBaseRef,
+    reviewSnapshotIdRef,
+    annotationsRef,
+    onAddSuggestions: onAddSuggestionsForFile,
+    refreshItem,
+  });
 
   // Augmentation APPLIES are deferred to scroll-idle. updateItem() mutates
   // item layout — the full-content parse counts collapsed-context regions the
@@ -1221,6 +1273,14 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
             augmentState.set(itemId, { status: 'done', controller, generation });
             return;
           }
+          // Never clobber an active edit session's document: the editor is
+          // mutating item.fileDiff in place, and the session already ensured
+          // full content before starting. Mark done — the pristine restore at
+          // session end republishes whatever the session started from.
+          if (itemId === editSession.editingItemIdRef.current) {
+            augmentState.set(itemId, { status: 'done', controller, generation });
+            return;
+          }
 
           // cacheKey MUST change when fileDiff contents change (types.ts warning):
           // otherwise the worker / highlight caches would serve the stale partial
@@ -1324,6 +1384,8 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
       const host = rootNode instanceof ShadowRoot ? rootNode.host : null;
       const itemId = host instanceof HTMLElement ? nodeToItemIdRef.current.get(host) : undefined;
       if (itemId == null) return;
+      // Text drags inside an active editor are the editor's own selection.
+      if (itemId === editSession.editingItemIdRef.current) return;
       const filePath = itemIdToFilePath.get(itemId);
       if (filePath == null) return;
       routeSelectionToToolbar(
@@ -1690,6 +1752,9 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
   const handleLineSelectionEnd = useStableCallback(
     (range: SelectedLineRange | null, item: CodeViewItem<DiffAnnotationMetadata>) => {
       if (range == null || item.type !== 'diff') return;
+      // The file being edited owns its pointer interactions — opening the
+      // annotation toolbar over an active editor would fight its focus.
+      if (item.id === editSession.editingItemIdRef.current) return;
       const filePath = itemIdToFilePath.get(item.id);
       if (filePath == null) return;
       routeSelectionToToolbar(range, filePath);
@@ -1699,6 +1764,7 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
   const handleGutterUtilityClick = useStableCallback(
     (range: SelectedLineRange, item: CodeViewItem<DiffAnnotationMetadata>) => {
       if (item.type !== 'diff') return;
+      if (item.id === editSession.editingItemIdRef.current) return;
       const filePath = itemIdToFilePath.get(item.id);
       if (filePath == null) return;
       routeSelectionToToolbar(range, filePath);
@@ -2030,6 +2096,12 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
 
     const collapsed = item.collapsed === true;
     const fileComments = fileCommentsByPath.get(filePath) ?? [];
+    // Edit-to-suggestion affordance (flag-gated). Slot portals republish on
+    // updateItem BEFORE React commits state, so read the session's refs.
+    const isEditingThis = editEnabled && editSession.editingItemIdRef.current === item.id;
+    const editDisabledReason = editEnabled
+      ? editSession.editUnavailableRef.current.get(filePath) ?? null
+      : null;
 
     return (
       <div className="flex flex-col">
@@ -2038,6 +2110,11 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
         patch={file.patch}
         status={file.status}
         oldPath={file.oldPath}
+        onEditFile={editEnabled ? () => editSession.startEdit(item.id) : undefined}
+        isEditing={isEditingThis}
+        editDisabledReason={editDisabledReason}
+        onCompleteEdit={editEnabled ? editSession.completeEdit : undefined}
+        onCancelEdit={editEnabled ? editSession.cancelEdit : undefined}
         isViewed={viewedFiles?.has(filePath)}
         onToggleViewed={onToggleViewed ? () => handleToggleViewedAndCollapse(filePath, item.id) : undefined}
         isStaged={stagedFiles?.has(filePath)}
@@ -2216,31 +2293,49 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
     return <div className="relative h-full" />;
   }
 
+  const codeView = (
+    <CodeView<DiffAnnotationMetadata>
+      // Remount on diff switch so uncontrolled `initialItems` re-seeds from
+      // the freshly computed identity. Without this, switching diff
+      // type/base/whitespace/PR with the all-files panel open would keep the
+      // OLD diff on screen (the panel instance is reused, not recreated).
+      key={fileSetKey}
+      ref={viewerRef}
+      containerRef={attachScrollContainer}
+      // Containment mirrors Pierre's own production wrapper (diffshub
+      // CodeViewWrapper): without it, every forced layout during scrolling
+      // recomputes the whole document instead of the clipped subtree.
+      // overflow-anchor:none disables the BROWSER's scroll anchoring, which
+      // otherwise fights CodeView's own anchor resolution whenever item
+      // heights change (our augmentation applies).
+      className={`relative h-full overflow-y-auto overflow-x-clip ${allowScrollChaining ? 'overscroll-auto' : 'overscroll-contain'} [contain:strict] [overflow-anchor:none] [will-change:scroll-position] [&_diffs-container]:overflow-clip [&_diffs-container]:[contain:layout_paint_style]`}
+      initialItems={identity.items}
+      options={options}
+      selectedLines={selectedLines}
+      onSelectedLinesChange={handleSelectedLinesChange}
+      onScroll={handleScroll}
+      renderCustomHeader={renderCustomHeader}
+      renderAnnotation={renderAnnotation}
+      // Edit-to-suggestion (flag-gated): only wired when enabled so the
+      // flag-off surface is byte-identical to the pre-feature one.
+      {...(editEnabled && {
+        editorOptions: editSession.editorOptions,
+        onItemEditChange: editSession.onItemEditChange,
+        onItemEditComplete: editSession.onItemEditComplete,
+      })}
+    />
+  );
+
   return (
     <div className="relative h-full">
-      <CodeView<DiffAnnotationMetadata>
-        // Remount on diff switch so uncontrolled `initialItems` re-seeds from
-        // the freshly computed identity. Without this, switching diff
-        // type/base/whitespace/PR with the all-files panel open would keep the
-        // OLD diff on screen (the panel instance is reused, not recreated).
-        key={fileSetKey}
-        ref={viewerRef}
-        containerRef={attachScrollContainer}
-        // Containment mirrors Pierre's own production wrapper (diffshub
-        // CodeViewWrapper): without it, every forced layout during scrolling
-        // recomputes the whole document instead of the clipped subtree.
-        // overflow-anchor:none disables the BROWSER's scroll anchoring, which
-        // otherwise fights CodeView's own anchor resolution whenever item
-        // heights change (our augmentation applies).
-        className={`relative h-full overflow-y-auto overflow-x-clip ${allowScrollChaining ? 'overscroll-auto' : 'overscroll-contain'} [contain:strict] [overflow-anchor:none] [will-change:scroll-position] [&_diffs-container]:overflow-clip [&_diffs-container]:[contain:layout_paint_style]`}
-        initialItems={identity.items}
-        options={options}
-        selectedLines={selectedLines}
-        onSelectedLinesChange={handleSelectedLinesChange}
-        onScroll={handleScroll}
-        renderCustomHeader={renderCustomHeader}
-        renderAnnotation={renderAnnotation}
-      />
+      {/* EditProvider only mounts when the experimental flag is on; its
+          factory declines attaches until the lazy editor chunk has loaded
+          (the chunk loads on first Edit click, never before). */}
+      {editEnabled ? (
+        <EditProvider createEditor={editSession.createEditor}>{codeView}</EditProvider>
+      ) : (
+        codeView
+      )}
 
       {/* Leading content (commit description card) lives INSIDE the scroll
           container at content-top: absolutely positioned children of a scroller

--- a/packages/review-editor/components/AllFilesCodeView.tsx
+++ b/packages/review-editor/components/AllFilesCodeView.tsx
@@ -272,8 +272,9 @@ interface AllFilesCodeViewProps {
    * dock panel passes this — Guided Review surfaces deliberately do NOT (the
    * GuideViewportManager evicts CodeViews beyond ~8 mounted, which would
    * destroy an active editor's state; scoping edit mode to this surface is the
-   * simple safe v1 choice). When absent/false, no edit UI renders and the
-   * editor module is never loaded. */
+   * simple safe v1 choice). When absent/false, no edit UI renders and no
+   * editor is ever constructed (code-split hosts also never fetch the editor
+   * chunk; the single-file build inlines it, functionally inert). */
   enableEditSuggestions?: boolean;
   /** Sink for suggestions derived from a completed edit session. Required for
    * edit mode to activate. */
@@ -903,9 +904,11 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
     pendingToolbarRange.current = null;
     visibleFileRef.current = null;
     // An edit session cannot survive the CodeView remount (Pierre tears the
-    // editor down without a completion callback). Drop the session state; the
-    // remounted items are already pristine. In-progress edits are discarded —
-    // acceptable because every diff refresh/switch is user-initiated.
+    // editor down without a completion callback), and fileSetKey also changes
+    // on sort-order / collapse-default flips, not just diff switches. The
+    // session controller drops a clean session silently; a dirty one prompts
+    // to keep its recovered edits as suggestions (this effect runs
+    // post-commit, so the synchronous confirm inside is safe).
     editSession.handleFileSetChange();
     setFileCommentAnchor(null);
     fileCommentButtonRefs.current.clear();

--- a/packages/review-editor/components/AllFilesCodeView.tsx
+++ b/packages/review-editor/components/AllFilesCodeView.tsx
@@ -31,6 +31,7 @@ import { getDiffSelection, getLineNumberFromNode, getSideFromNode } from '../uti
 import { isContentConsistentWithPatch } from '../utils/patchConsistency';
 import { ToolbarHost, type ToolbarHostHandle } from './ToolbarHost';
 import { FileHeader } from './FileHeader';
+import { EditSessionHud } from './EditSessionHud';
 import { FileCommentBanner } from './FileCommentBanner';
 import { annotationMatchesPrScope, isFileScopedAnnotation, lineRangeForAnnotation } from '../utils/annotationScope';
 import { useEditSession } from '../edit/useEditSession';
@@ -2116,8 +2117,6 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
         onEditFile={editEnabled ? () => editSession.startEdit(item.id) : undefined}
         isEditing={isEditingThis}
         editDisabledReason={editDisabledReason}
-        onCompleteEdit={editEnabled ? editSession.completeEdit : undefined}
-        onCancelEdit={editEnabled ? editSession.cancelEdit : undefined}
         isViewed={viewedFiles?.has(filePath)}
         onToggleViewed={onToggleViewed ? () => handleToggleViewedAndCollapse(filePath, item.id) : undefined}
         isStaged={stagedFiles?.has(filePath)}
@@ -2160,6 +2159,17 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
         }
         onCollapseToggle={() => toggleItemCollapsed(item.id)}
         />
+        {/* EXPERIMENTAL edit-session HUD: session controls + state in a slim
+            strip below the header, above the file content. Appears/disappears
+            with session start/end, which both go through a version-bumped
+            updateItem, so the slot height is re-measured on each transition. */}
+        {isEditingThis && (
+          <EditSessionHud
+            onComplete={editSession.completeEdit}
+            onCancel={editSession.cancelEdit}
+            dirtyStore={editSession.dirtyStore}
+          />
+        )}
         {/* File-scoped comments live in the header (below the path), shown only
             when the file is expanded. They ride the sticky header — fine for a
             short guide note; long ones scroll within the banner. */}

--- a/packages/review-editor/components/AllFilesCodeView.tsx
+++ b/packages/review-editor/components/AllFilesCodeView.tsx
@@ -35,6 +35,7 @@ import { EditSessionHud } from './EditSessionHud';
 import { FileCommentBanner } from './FileCommentBanner';
 import { annotationMatchesPrScope, isFileScopedAnnotation, lineRangeForAnnotation } from '../utils/annotationScope';
 import { useEditSession } from '../edit/useEditSession';
+import type { EditSelectionAnnotationRequest, EditSelectionComment } from '../edit/useEditSession';
 import type { SuggestionHunk } from '../edit/deriveSuggestions';
 import { lineAnnotationMetadata } from '../utils/annotationDisplay';
 import { InlineAnnotation } from './InlineAnnotation';
@@ -280,6 +281,10 @@ interface AllFilesCodeViewProps {
   /** Sink for suggestions derived from a completed edit session. Required for
    * edit mode to activate. */
   onAddSuggestionsForFile?: (filePath: string, hunks: SuggestionHunk[]) => void;
+  /** Sink for a comment authored through the edit session's Selection Action
+   * ("Make annotation"): a line-scoped comment anchored to PRISTINE new-side
+   * lines snapshotted at selection time (see edit/selectionAnchor.ts). */
+  onAddEditorCommentForFile?: (filePath: string, comment: EditSelectionComment) => void;
 }
 
 // Diffshub-style stable path-based id allocation. Plannotator's file list is
@@ -531,6 +536,7 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
   allowScrollChaining = false,
   enableEditSuggestions = false,
   onAddSuggestionsForFile,
+  onAddEditorCommentForFile,
 }) => {
   const mountCollapsedRef = useRef(mountCollapsed);
   const seedCollapsed = mountCollapsedRef.current ?? defaultCollapsed;
@@ -911,6 +917,9 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
     // to keep its recovered edits as suggestions (this effect runs
     // post-commit, so the synchronous confirm inside is safe).
     editSession.handleFileSetChange();
+    // A pending editor-selection comment entry is anchored to the OLD diff's
+    // pristine coordinates — stale once the file set changes.
+    setSelectionAnnotationRequest(null);
     setFileCommentAnchor(null);
     fileCommentButtonRefs.current.clear();
     // Resync the header-refresh snapshots to the current props so the post-
@@ -1107,6 +1116,14 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
   // pristine FileDiffMetadata is deep-cloned before the session and restored
   // (via version bump + updateItem) when it ends. See useEditSession.
   const editEnabled = enableEditSuggestions && onAddSuggestionsForFile != null;
+  // A pending "Make annotation" request from the edit session's Selection
+  // Action popover. The Pierre popover (shadow DOM) only snapshots the
+  // selection; the actual comment entry is the app's own CommentPopover,
+  // anchored at the snapshotted rect — focusing an input inside the editor's
+  // popover would blur the editor, collapse the selection, and tear the
+  // popover down mid-typing, so entry deliberately lives OUTSIDE the editor.
+  const [selectionAnnotationRequest, setSelectionAnnotationRequest] =
+    useState<EditSelectionAnnotationRequest | null>(null);
   const editSession = useEditSession({
     enabled: editEnabled,
     viewerRef,
@@ -1116,8 +1133,16 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
     reviewSnapshotIdRef,
     annotationsRef,
     onAddSuggestions: onAddSuggestionsForFile,
+    onSelectionAnnotation: onAddEditorCommentForFile ? setSelectionAnnotationRequest : undefined,
     refreshItem,
   });
+
+  // Surface a mid-session comment inside the editor as a marker as soon as it
+  // lands in the annotations prop. Stable callback; no-op outside a session.
+  const refreshEditSessionMarkers = editSession.refreshMarkers;
+  useEffect(() => {
+    refreshEditSessionMarkers();
+  }, [annotations, refreshEditSessionMarkers]);
 
   // Augmentation APPLIES are deferred to scroll-idle. updateItem() mutates
   // item layout — the full-content parse counts collapsed-context regions the
@@ -2389,6 +2414,36 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
             setFileCommentAnchor(null);
           }}
           onClose={() => setFileCommentAnchor(null)}
+        />
+      )}
+
+      {/* Comment entry for the edit session's "Make annotation" action. The
+          anchor rect and the pristine line range were snapshotted at click
+          time, so this stays valid even if the editor selection has since
+          collapsed or the session has ended (pristine coordinates are
+          session-invariant). */}
+      {selectionAnnotationRequest && onAddEditorCommentForFile && (
+        <CommentPopover
+          key={`edit-selection:${selectionAnnotationRequest.filePath}:${selectionAnnotationRequest.lineStart}-${selectionAnnotationRequest.lineEnd}`}
+          anchorRect={selectionAnnotationRequest.anchorRect}
+          contextText={selectionAnnotationRequest.selectedText.replace(/\s+/g, ' ').trim()}
+          isGlobal={false}
+          allowImages={false}
+          onSubmit={(text) => {
+            onAddEditorCommentForFile(selectionAnnotationRequest.filePath, {
+              lineStart: selectionAnnotationRequest.lineStart,
+              lineEnd: selectionAnnotationRequest.lineEnd,
+              exact: selectionAnnotationRequest.exact,
+              selectedText: selectionAnnotationRequest.selectedText,
+              text,
+            });
+            // The editor kept its ranged selection while the entry was open;
+            // collapse it so the Selection Action popover does not re-open
+            // over the just-annotated lines.
+            editSession.collapseSelection();
+            setSelectionAnnotationRequest(null);
+          }}
+          onClose={() => setSelectionAnnotationRequest(null)}
         />
       )}
     </div>

--- a/packages/review-editor/components/EditSessionHud.tsx
+++ b/packages/review-editor/components/EditSessionHud.tsx
@@ -1,0 +1,85 @@
+import React, { useSyncExternalStore } from 'react';
+import type { EditSessionDirtyStore } from '../edit/useEditSession';
+
+interface EditSessionHudProps {
+  /** Finish the session; net changes become suggestion annotations. */
+  onComplete: () => void;
+  /** Discard the session; no annotations, pristine diff restored. */
+  onCancel: () => void;
+  /** Live net change count of the session (see useEditSession.dirtyStore). */
+  dirtyStore: EditSessionDirtyStore;
+}
+
+function changeLabel(count: number): string {
+  if (count === 0) return 'No changes yet';
+  return count === 1 ? '1 change' : `${count} changes`;
+}
+
+/**
+ * EXPERIMENTAL edit-to-suggestion session HUD: a slim strip rendered directly
+ * below the file header (inside the file card, above the content) while an
+ * edit session is active. Carries the session controls and state, so the
+ * header itself keeps only the Edit entry button when no session is active.
+ *
+ * Lives inside Pierre's memoized custom-header slot portal, so it rides the
+ * sticky header; the dirty count arrives via an external store subscription
+ * because the portal only republishes on updateItem, never on keystrokes.
+ */
+export const EditSessionHud: React.FC<EditSessionHudProps> = ({
+  onComplete,
+  onCancel,
+  dirtyStore,
+}) => {
+  const changeCount = useSyncExternalStore(dirtyStore.subscribe, dirtyStore.getSnapshot);
+
+  return (
+    <div
+      className="flex flex-shrink-0 items-center gap-2 border-b border-warning/20 bg-warning/5 px-3 py-1 text-xs"
+      data-testid="edit-session-hud"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <span className="flex items-center gap-1 font-medium text-warning" data-testid="edit-session-badge">
+        <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+        </svg>
+        Editing
+      </span>
+      <span
+        className="rounded border border-border/60 px-1 py-px text-[9px] font-medium uppercase tracking-wide text-muted-foreground/70"
+        title="Edit Code to Suggest is experimental"
+      >
+        Experimental
+      </span>
+      <span
+        className={changeCount > 0 ? 'text-foreground/80' : 'text-muted-foreground/70'}
+        data-testid="edit-session-dirty"
+      >
+        {changeLabel(changeCount)}
+      </span>
+      <div className="ml-auto flex items-center gap-1.5">
+        <button
+          onClick={onComplete}
+          className="flex items-center gap-1 rounded bg-primary/15 px-2 py-0.5 text-xs text-primary transition-colors hover:bg-primary/25"
+          title="Finish editing — net changes become a suggestion"
+          data-testid="edit-session-complete"
+        >
+          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+          <span>Suggest</span>
+        </button>
+        <button
+          onClick={onCancel}
+          className="flex items-center gap-1 rounded px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          title="Discard edits and restore the diff"
+          data-testid="edit-session-cancel"
+        >
+          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+          <span>Discard</span>
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/packages/review-editor/components/FileHeader.edit.test.tsx
+++ b/packages/review-editor/components/FileHeader.edit.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * DOM-gated tests (DOM_TESTS=1) for the experimental edit-to-suggestion
+ * affordance in FileHeader. Registered in .github/workflows/test.yml's
+ * "Run UI seam-contract + DOM tests" step.
+ *
+ * Flag-off invariant: when the feature is off, AllFilesCodeView passes no
+ * onEditFile, so FileHeader must render ZERO edit UI (byte-identical header).
+ */
+import { afterEach, describe, expect, test } from 'bun:test';
+import React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { FileHeader } from './FileHeader';
+// Relative import: the ui package exposes './config' (no ./config/settings
+// subpath), and the registry itself is not re-exported from the barrel.
+import { SETTINGS } from '../../ui/config/settings';
+
+const hasDom = typeof document !== 'undefined';
+
+let host: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+async function mount(node: React.ReactElement): Promise<HTMLDivElement> {
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  root = createRoot(host);
+  await act(async () => {
+    root!.render(node);
+  });
+  return host;
+}
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => root!.unmount());
+    root = null;
+  }
+  host?.remove();
+  host = null;
+});
+
+describe('edit-to-suggestion flag', () => {
+  test('the editSuggestions setting defaults OFF', () => {
+    expect(SETTINGS.editSuggestions.defaultValue).toBe(false);
+    // Cookie-only while experimental: never synced to server config.
+    expect(SETTINGS.editSuggestions.serverKey).toBeUndefined();
+  });
+});
+
+describe.if(hasDom)('FileHeader edit affordance (DOM)', () => {
+  const baseProps = { filePath: 'src/calc.ts', patch: '@@ -1 +1 @@\n-a\n+b\n' };
+
+  test('renders no edit UI when the feature is off (no onEditFile)', async () => {
+    const el = await mount(<FileHeader {...baseProps} />);
+    expect(el.querySelector('[data-testid="edit-session-start"]')).toBeNull();
+    expect(el.querySelector('[data-testid="edit-session-badge"]')).toBeNull();
+    expect(el.querySelector('[data-testid="edit-session-complete"]')).toBeNull();
+    expect(el.querySelector('[data-testid="edit-session-cancel"]')).toBeNull();
+  });
+
+  test('renders the Edit entry button when enabled and idle', async () => {
+    let started = 0;
+    const el = await mount(<FileHeader {...baseProps} onEditFile={() => started++} />);
+    const btn = el.querySelector<HTMLButtonElement>('[data-testid="edit-session-start"]');
+    expect(btn).not.toBeNull();
+    await act(async () => btn!.click());
+    expect(started).toBe(1);
+    expect(el.querySelector('[data-testid="edit-session-badge"]')).toBeNull();
+  });
+
+  test('disabled reason blocks entry and surfaces as tooltip', async () => {
+    let started = 0;
+    const el = await mount(
+      <FileHeader
+        {...baseProps}
+        onEditFile={() => started++}
+        editDisabledReason="Full file content unavailable"
+      />,
+    );
+    const btn = el.querySelector<HTMLButtonElement>('[data-testid="edit-session-start"]');
+    expect(btn).not.toBeNull();
+    expect(btn!.disabled).toBe(true);
+    expect(btn!.title).toBe('Full file content unavailable');
+    await act(async () => btn!.click());
+    expect(started).toBe(0);
+  });
+
+  test('editing state swaps to Suggest/Discard session controls', async () => {
+    let completed = 0;
+    let cancelled = 0;
+    const el = await mount(
+      <FileHeader
+        {...baseProps}
+        onEditFile={() => {}}
+        isEditing
+        onCompleteEdit={() => completed++}
+        onCancelEdit={() => cancelled++}
+      />,
+    );
+    expect(el.querySelector('[data-testid="edit-session-start"]')).toBeNull();
+    expect(el.querySelector('[data-testid="edit-session-badge"]')).not.toBeNull();
+    const complete = el.querySelector<HTMLButtonElement>('[data-testid="edit-session-complete"]');
+    const cancel = el.querySelector<HTMLButtonElement>('[data-testid="edit-session-cancel"]');
+    expect(complete).not.toBeNull();
+    expect(cancel).not.toBeNull();
+    await act(async () => complete!.click());
+    await act(async () => cancel!.click());
+    expect(completed).toBe(1);
+    expect(cancelled).toBe(1);
+  });
+});

--- a/packages/review-editor/components/FileHeader.edit.test.tsx
+++ b/packages/review-editor/components/FileHeader.edit.test.tsx
@@ -68,6 +68,36 @@ describe.if(hasDom)('FileHeader edit affordance (DOM)', () => {
     expect(el.querySelector('[data-testid="edit-session-badge"]')).toBeNull();
   });
 
+  test('Edit entry renders at the far right of the action row, after other buttons', async () => {
+    const el = await mount(
+      <FileHeader
+        {...baseProps}
+        onEditFile={() => {}}
+        onToggleViewed={() => {}}
+        onFileComment={() => {}}
+      />,
+    );
+    const editBtn = el.querySelector<HTMLButtonElement>('[data-testid="edit-session-start"]');
+    expect(editBtn).not.toBeNull();
+    const buttons = Array.from(el.querySelectorAll('button'));
+    // Viewed and Comment precede Edit; only the OpenInApp file-actions
+    // dropdown may follow it (Edit sits adjacent to the dropdown/chevron).
+    const viewedBtn = buttons.find((b) => b.title.includes('viewed'));
+    const commentBtn = buttons.find((b) => b.title === 'Add file-scoped comment');
+    expect(viewedBtn).not.toBeUndefined();
+    expect(commentBtn).not.toBeUndefined();
+    for (const btn of [viewedBtn!, commentBtn!]) {
+      expect(
+        btn.compareDocumentPosition(editBtn!) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+    }
+    const after = buttons.slice(buttons.indexOf(editBtn!) + 1);
+    for (const btn of after) {
+      const label = btn.getAttribute('aria-label') ?? btn.title;
+      expect(/open in|file actions|choose app/i.test(label)).toBe(true);
+    }
+  });
+
   test('disabled reason blocks entry and surfaces as tooltip', async () => {
     let started = 0;
     const el = await mount(

--- a/packages/review-editor/components/FileHeader.edit.test.tsx
+++ b/packages/review-editor/components/FileHeader.edit.test.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { FileHeader } from './FileHeader';
+import { EditSessionHud } from './EditSessionHud';
 // Relative import: the ui package exposes './config' (no ./config/settings
 // subpath), and the registry itself is not re-exported from the barrel.
 import { SETTINGS } from '../../ui/config/settings';
@@ -115,20 +116,51 @@ describe.if(hasDom)('FileHeader edit affordance (DOM)', () => {
     expect(started).toBe(0);
   });
 
-  test('editing state swaps to Suggest/Discard session controls', async () => {
+  test('editing state hides the entry button and renders NO session controls (the HUD owns them)', async () => {
+    const el = await mount(<FileHeader {...baseProps} onEditFile={() => {}} isEditing />);
+    expect(el.querySelector('[data-testid="edit-session-start"]')).toBeNull();
+    expect(el.querySelector('[data-testid="edit-session-badge"]')).toBeNull();
+    expect(el.querySelector('[data-testid="edit-session-complete"]')).toBeNull();
+    expect(el.querySelector('[data-testid="edit-session-cancel"]')).toBeNull();
+  });
+});
+
+describe.if(hasDom)('EditSessionHud (DOM)', () => {
+  function makeStore(initial: number) {
+    let count = initial;
+    const listeners = new Set<() => void>();
+    return {
+      store: {
+        subscribe: (cb: () => void) => {
+          listeners.add(cb);
+          return () => listeners.delete(cb);
+        },
+        getSnapshot: () => count,
+      },
+      set(next: number) {
+        count = next;
+        listeners.forEach((cb) => cb());
+      },
+    };
+  }
+
+  test('renders session controls, dirty indicator, and the experimental label', async () => {
     let completed = 0;
     let cancelled = 0;
+    const { store, set } = makeStore(0);
     const el = await mount(
-      <FileHeader
-        {...baseProps}
-        onEditFile={() => {}}
-        isEditing
-        onCompleteEdit={() => completed++}
-        onCancelEdit={() => cancelled++}
-      />,
+      <EditSessionHud onComplete={() => completed++} onCancel={() => cancelled++} dirtyStore={store} />,
     );
-    expect(el.querySelector('[data-testid="edit-session-start"]')).toBeNull();
+    expect(el.querySelector('[data-testid="edit-session-hud"]')).not.toBeNull();
     expect(el.querySelector('[data-testid="edit-session-badge"]')).not.toBeNull();
+    expect(el.textContent).toContain('Experimental');
+    expect(el.querySelector('[data-testid="edit-session-dirty"]')!.textContent).toBe('No changes yet');
+
+    await act(async () => set(1));
+    expect(el.querySelector('[data-testid="edit-session-dirty"]')!.textContent).toBe('1 change');
+    await act(async () => set(3));
+    expect(el.querySelector('[data-testid="edit-session-dirty"]')!.textContent).toBe('3 changes');
+
     const complete = el.querySelector<HTMLButtonElement>('[data-testid="edit-session-complete"]');
     const cancel = el.querySelector<HTMLButtonElement>('[data-testid="edit-session-cancel"]');
     expect(complete).not.toBeNull();

--- a/packages/review-editor/components/FileHeader.tsx
+++ b/packages/review-editor/components/FileHeader.tsx
@@ -28,6 +28,17 @@ interface FileHeaderProps {
   fileCommentButtonRef?: (el: HTMLButtonElement | null) => void;
   collapseToggle?: React.ReactNode;
   onCollapseToggle?: () => void;
+  /** EXPERIMENTAL edit-to-suggestion mode: enter edit mode on this file.
+   * Absent = the feature is off and no edit UI renders. */
+  onEditFile?: () => void;
+  /** This file currently hosts the active edit session. */
+  isEditing?: boolean;
+  /** When set, the Edit button is disabled with this tooltip. */
+  editDisabledReason?: string | null;
+  /** Finish the session — net changes become suggestion annotations. */
+  onCompleteEdit?: () => void;
+  /** Discard the session — no annotations, pristine diff restored. */
+  onCancelEdit?: () => void;
 }
 
 function splitFilePath(filePath: string): { directory: string; name: string } {
@@ -104,6 +115,11 @@ export const FileHeader: React.FC<FileHeaderProps> = ({
   fileCommentButtonRef,
   collapseToggle,
   onCollapseToggle,
+  onEditFile,
+  isEditing = false,
+  editDisabledReason,
+  onCompleteEdit,
+  onCancelEdit,
 }) => {
   const [headerWidth, setHeaderWidth] = useState<number>(0);
   const state = useReviewStateOptional();
@@ -187,6 +203,68 @@ export const FileHeader: React.FC<FileHeaderProps> = ({
         )}
       </div>
       <div className={`flex flex-shrink-0 items-center pl-2 ${isCompact ? 'gap-1' : 'gap-2'}`}>
+        {/* EXPERIMENTAL edit-to-suggestion controls. While editing, the pair
+            of session controls replaces the entry button. */}
+        {onEditFile && isEditing && (
+          <>
+            <span className="text-xs px-1.5 py-0.5 rounded bg-warning/15 text-warning font-medium whitespace-nowrap" data-testid="edit-session-badge">
+              Editing
+            </span>
+            {onCompleteEdit && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCompleteEdit();
+                }}
+                className="text-xs rounded transition-colors flex items-center gap-1 px-2 py-1 bg-primary/15 text-primary hover:bg-primary/25"
+                title="Finish editing — net changes become a suggestion"
+                data-testid="edit-session-complete"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
+                {!isVeryTight && <span>Suggest</span>}
+              </button>
+            )}
+            {onCancelEdit && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCancelEdit();
+                }}
+                className="text-xs rounded transition-colors flex items-center gap-1 px-2 py-1 text-muted-foreground hover:text-foreground hover:bg-muted"
+                title="Discard edits and restore the diff"
+                data-testid="edit-session-cancel"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+                {!isVeryTight && <span>Discard</span>}
+              </button>
+            )}
+          </>
+        )}
+        {onEditFile && !isEditing && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              if (!editDisabledReason) onEditFile();
+            }}
+            disabled={!!editDisabledReason}
+            className={`text-xs rounded transition-colors flex items-center ${isVeryTight ? 'px-1.5 py-1' : 'gap-1 px-2 py-1'} ${
+              editDisabledReason
+                ? 'opacity-50 cursor-not-allowed text-muted-foreground'
+                : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+            }`}
+            title={editDisabledReason ?? 'Edit this file to author a suggestion (experimental)'}
+            data-testid="edit-session-start"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+            </svg>
+            {!isVeryTight && <span>Edit</span>}
+          </button>
+        )}
         {onToggleViewed && (
           <button
             onClick={onToggleViewed}

--- a/packages/review-editor/components/FileHeader.tsx
+++ b/packages/review-editor/components/FileHeader.tsx
@@ -31,14 +31,12 @@ interface FileHeaderProps {
   /** EXPERIMENTAL edit-to-suggestion mode: enter edit mode on this file.
    * Absent = the feature is off and no edit UI renders. */
   onEditFile?: () => void;
-  /** This file currently hosts the active edit session. */
+  /** This file currently hosts the active edit session. Suppresses the Edit
+   * entry button; the session controls live in the EditSessionHud strip the
+   * owner renders below this header, never here. */
   isEditing?: boolean;
   /** When set, the Edit button is disabled with this tooltip. */
   editDisabledReason?: string | null;
-  /** Finish the session — net changes become suggestion annotations. */
-  onCompleteEdit?: () => void;
-  /** Discard the session — no annotations, pristine diff restored. */
-  onCancelEdit?: () => void;
 }
 
 function splitFilePath(filePath: string): { directory: string; name: string } {
@@ -118,8 +116,6 @@ export const FileHeader: React.FC<FileHeaderProps> = ({
   onEditFile,
   isEditing = false,
   editDisabledReason,
-  onCompleteEdit,
-  onCancelEdit,
 }) => {
   const [headerWidth, setHeaderWidth] = useState<number>(0);
   const state = useReviewStateOptional();
@@ -203,47 +199,6 @@ export const FileHeader: React.FC<FileHeaderProps> = ({
         )}
       </div>
       <div className={`flex flex-shrink-0 items-center pl-2 ${isCompact ? 'gap-1' : 'gap-2'}`}>
-        {/* EXPERIMENTAL edit-to-suggestion controls. While editing, the pair
-            of session controls replaces the entry button. */}
-        {onEditFile && isEditing && (
-          <>
-            <span className="text-xs px-1.5 py-0.5 rounded bg-warning/15 text-warning font-medium whitespace-nowrap" data-testid="edit-session-badge">
-              Editing
-            </span>
-            {onCompleteEdit && (
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onCompleteEdit();
-                }}
-                className="text-xs rounded transition-colors flex items-center gap-1 px-2 py-1 bg-primary/15 text-primary hover:bg-primary/25"
-                title="Finish editing — net changes become a suggestion"
-                data-testid="edit-session-complete"
-              >
-                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                </svg>
-                {!isVeryTight && <span>Suggest</span>}
-              </button>
-            )}
-            {onCancelEdit && (
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onCancelEdit();
-                }}
-                className="text-xs rounded transition-colors flex items-center gap-1 px-2 py-1 text-muted-foreground hover:text-foreground hover:bg-muted"
-                title="Discard edits and restore the diff"
-                data-testid="edit-session-cancel"
-              >
-                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-                </svg>
-                {!isVeryTight && <span>Discard</span>}
-              </button>
-            )}
-          </>
-        )}
         {onToggleViewed && (
           <button
             onClick={onToggleViewed}

--- a/packages/review-editor/components/FileHeader.tsx
+++ b/packages/review-editor/components/FileHeader.tsx
@@ -244,27 +244,6 @@ export const FileHeader: React.FC<FileHeaderProps> = ({
             )}
           </>
         )}
-        {onEditFile && !isEditing && (
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              if (!editDisabledReason) onEditFile();
-            }}
-            disabled={!!editDisabledReason}
-            className={`text-xs rounded transition-colors flex items-center ${isVeryTight ? 'px-1.5 py-1' : 'gap-1 px-2 py-1'} ${
-              editDisabledReason
-                ? 'opacity-50 cursor-not-allowed text-muted-foreground'
-                : 'text-muted-foreground hover:text-foreground hover:bg-muted'
-            }`}
-            title={editDisabledReason ?? 'Edit this file to author a suggestion (experimental)'}
-            data-testid="edit-session-start"
-          >
-            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-            </svg>
-            {!isVeryTight && <span>Edit</span>}
-          </button>
-        )}
         {onToggleViewed && (
           <button
             onClick={onToggleViewed}
@@ -339,6 +318,30 @@ export const FileHeader: React.FC<FileHeaderProps> = ({
           </button>
         )}
         <SemanticFileBadge filePath={filePath} />
+        {/* Edit entry lives at the far right of the row, next to the file
+            actions dropdown, so the experimental affordance stays out of the
+            everyday Viewed/Add/Comment cluster. */}
+        {onEditFile && !isEditing && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              if (!editDisabledReason) onEditFile();
+            }}
+            disabled={!!editDisabledReason}
+            className={`text-xs rounded transition-colors flex items-center ${isVeryTight ? 'px-1.5 py-1' : 'gap-1 px-2 py-1'} ${
+              editDisabledReason
+                ? 'opacity-50 cursor-not-allowed text-muted-foreground'
+                : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+            }`}
+            title={editDisabledReason ?? 'Edit this file to author a suggestion (experimental)'}
+            data-testid="edit-session-start"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+            </svg>
+            {!isVeryTight && <span>Edit</span>}
+          </button>
+        )}
         {/* File actions: open in app (when the live checkout matches this
             snapshot), copy path, copy file diff. Copy actions remain when a
             PR has no checkout or a committed GitButler layer is selected. */}

--- a/packages/review-editor/components/FileTree.tsx
+++ b/packages/review-editor/components/FileTree.tsx
@@ -178,8 +178,16 @@ export const FileTree: React.FC<FileTreeProps> = ({
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if (!enableKeyboardNav || e.defaultPrevented) return;
 
-    // Don't interfere with input fields
-    if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+    // Don't interfere with input fields. composedPath()[0] pierces shadow DOM
+    // (same guard as AllFilesCodeView): window-level e.target retargets to the
+    // shadow HOST, so keystrokes in the Pierre editor's contenteditable (edit
+    // sessions) would otherwise read as non-editable and Home/End/arrows would
+    // switch files mid-edit.
+    const origin = (e.composedPath?.()[0] ?? e.target) as HTMLElement | null;
+    if (
+      origin &&
+      (origin.tagName === 'INPUT' || origin.tagName === 'TEXTAREA' || origin.isContentEditable)
+    ) {
       return;
     }
 

--- a/packages/review-editor/components/SectionsPanel.tsx
+++ b/packages/review-editor/components/SectionsPanel.tsx
@@ -331,7 +331,15 @@ export const SectionsPanel: React.FC<SectionsPanelProps> = ({
     if (enableKeyboardNav === false) return;
     const handler = (e: KeyboardEvent) => {
       if (searchQuery.trim()) return; // search results own the panel
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      // composedPath()[0] pierces shadow DOM (same guard as AllFilesCodeView):
+      // window-level e.target retargets to the shadow HOST, so keystrokes in
+      // the Pierre editor's contenteditable (edit sessions) would otherwise
+      // read as non-editable and Home/End/arrows would switch files mid-edit.
+      const origin = (e.composedPath?.()[0] ?? e.target) as HTMLElement | null;
+      if (
+        origin &&
+        (origin.tagName === 'INPUT' || origin.tagName === 'TEXTAREA' || origin.isContentEditable)
+      ) return;
       const active = document.activeElement;
       if (
         active instanceof HTMLElement &&

--- a/packages/review-editor/dock/ReviewStateContext.tsx
+++ b/packages/review-editor/dock/ReviewStateContext.tsx
@@ -9,6 +9,7 @@ import type { PRMetadata, PRContext } from '@plannotator/shared/pr-types';
 import type { PRArtifact } from '../utils/prArtifacts';
 import type { PRDiffScope } from '@plannotator/shared/pr-stack';
 import type { FeedbackDiffContext } from '../utils/exportFeedback';
+import type { SuggestionHunk } from '../edit/deriveSuggestions';
 
 /**
  * Shared review state consumed by dockview panel wrappers.
@@ -61,6 +62,12 @@ export interface ReviewState {
   onLineSelection: (range: SelectedLineRange | null) => void;
   onAddAnnotation: (type: CodeAnnotationType, text?: string, suggestedCode?: string, originalCode?: string, conventionalLabel?: ConventionalLabel, decorations?: ConventionalDecoration[], tokenMeta?: TokenAnnotationMeta) => void;
   onAddAnnotationForFile: (filePath: string, type: CodeAnnotationType, text?: string, suggestedCode?: string, originalCode?: string, conventionalLabel?: ConventionalLabel, decorations?: ConventionalDecoration[], tokenMeta?: TokenAnnotationMeta) => void;
+  /** EXPERIMENTAL edit-to-suggestion flag (cookie setting, default OFF). Only
+   * the plain all-files panel consumes it — Guided Review surfaces stay off. */
+  editSuggestionsEnabled: boolean;
+  /** Sink for suggestions derived from a completed edit session (one hunk per
+   * contiguous changed region; becomes normal suggestion annotations). */
+  onAddSuggestionsForFile: (filePath: string, hunks: SuggestionHunk[]) => void;
   onAddFileComment: (text: string) => void;
   onAddFileCommentForFile: (filePath: string, text: string) => void;
   onEditAnnotation: (id: string, text?: string, suggestedCode?: string, originalCode?: string, conventionalLabel?: ConventionalLabel | null, decorations?: ConventionalDecoration[]) => void;

--- a/packages/review-editor/dock/ReviewStateContext.tsx
+++ b/packages/review-editor/dock/ReviewStateContext.tsx
@@ -10,6 +10,7 @@ import type { PRArtifact } from '../utils/prArtifacts';
 import type { PRDiffScope } from '@plannotator/shared/pr-stack';
 import type { FeedbackDiffContext } from '../utils/exportFeedback';
 import type { SuggestionHunk } from '../edit/deriveSuggestions';
+import type { EditSelectionComment } from '../edit/useEditSession';
 
 /**
  * Shared review state consumed by dockview panel wrappers.
@@ -68,6 +69,9 @@ export interface ReviewState {
   /** Sink for suggestions derived from a completed edit session (one hunk per
    * contiguous changed region; becomes normal suggestion annotations). */
   onAddSuggestionsForFile: (filePath: string, hunks: SuggestionHunk[]) => void;
+  /** Sink for a comment authored through the edit session's Selection Action
+   * ("Make annotation"): line-scoped comment on pristine new-side lines. */
+  onAddEditorCommentForFile: (filePath: string, comment: EditSelectionComment) => void;
   onAddFileComment: (text: string) => void;
   onAddFileCommentForFile: (filePath: string, text: string) => void;
   onEditAnnotation: (id: string, text?: string, suggestedCode?: string, originalCode?: string, conventionalLabel?: ConventionalLabel | null, decorations?: ConventionalDecoration[]) => void;

--- a/packages/review-editor/dock/panels/ReviewAllFilesDiffPanel.tsx
+++ b/packages/review-editor/dock/panels/ReviewAllFilesDiffPanel.tsx
@@ -74,6 +74,11 @@ export const ReviewAllFilesDiffPanel: React.FC<IDockviewPanelProps> = () => {
       getAIHistoryForFile={state.getAIHistoryForFile}
       defaultCollapsed={!!commitInfo}
       leadingContent={leadingContent}
+      // EXPERIMENTAL edit-to-suggestion mode. This plain all-files panel is
+      // the ONLY surface that opts in (Guided Review's viewport manager
+      // evicts CodeViews, which would destroy an active editor session).
+      enableEditSuggestions={state.editSuggestionsEnabled}
+      onAddSuggestionsForFile={state.onAddSuggestionsForFile}
     />
   );
 };

--- a/packages/review-editor/dock/panels/ReviewAllFilesDiffPanel.tsx
+++ b/packages/review-editor/dock/panels/ReviewAllFilesDiffPanel.tsx
@@ -79,6 +79,7 @@ export const ReviewAllFilesDiffPanel: React.FC<IDockviewPanelProps> = () => {
       // evicts CodeViews, which would destroy an active editor session).
       enableEditSuggestions={state.editSuggestionsEnabled}
       onAddSuggestionsForFile={state.onAddSuggestionsForFile}
+      onAddEditorCommentForFile={state.onAddEditorCommentForFile}
     />
   );
 };

--- a/packages/review-editor/edit/adapterWall.test.ts
+++ b/packages/review-editor/edit/adapterWall.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+/**
+ * Adapter-wall invariant: every reference to Pierre's experimental
+ * `@pierre/diffs/edit` entry must live in exactly one module,
+ * packages/review-editor/edit/pierreEditAdapter.ts, so an upstream rename is
+ * a one-file fix. App code imports the adapter, never the entry.
+ */
+const REPO_ROOT = join(import.meta.dir, '..', '..', '..');
+const SCAN_ROOTS = ['packages', 'apps'];
+const ALLOWED = 'packages/review-editor/edit/pierreEditAdapter.ts';
+const SKIP_DIRS = new Set(['node_modules', 'dist', '.git', 'vendor', 'legacy']);
+
+function* walk(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    const stat = statSync(full, { throwIfNoEntry: false });
+    if (!stat) continue;
+    if (stat.isDirectory()) yield* walk(full);
+    else if (/\.(ts|tsx|js|jsx|mjs)$/.test(entry)) yield full;
+  }
+}
+
+describe('pierre edit adapter wall', () => {
+  test('only pierreEditAdapter.ts references @pierre/diffs/edit', () => {
+    const offenders: string[] = [];
+    for (const root of SCAN_ROOTS) {
+      for (const file of walk(join(REPO_ROOT, root))) {
+        const rel = relative(REPO_ROOT, file);
+        if (rel === ALLOWED || rel.endsWith('adapterWall.test.ts')) continue;
+        const content = readFileSync(file, 'utf8');
+        if (content.includes('@pierre/diffs/edit')) offenders.push(rel);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  test('the adapter itself only imports the edit entry lazily or as types', () => {
+    const content = readFileSync(join(REPO_ROOT, ALLOWED), 'utf8');
+    // Static VALUE imports of the edit entry would defeat the lazy chunk.
+    // `import type` and `typeof import(...)` are type-only; the single
+    // runtime reference must be a dynamic import().
+    const staticValueImport = /^import\s+(?!type\b)[^;]*from\s+['"]@pierre\/diffs\/edit['"]/m;
+    expect(staticValueImport.test(content)).toBe(false);
+    expect(content.includes("import('@pierre/diffs/edit')")).toBe(true);
+  });
+});

--- a/packages/review-editor/edit/cloneDiff.test.ts
+++ b/packages/review-editor/edit/cloneDiff.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test';
+import { getSingularPatch } from '@pierre/diffs';
+import { cloneFileDiff } from './cloneDiff';
+
+const PATCH = `diff --git a/calc.ts b/calc.ts
+index 111..222 100644
+--- a/calc.ts
++++ b/calc.ts
+@@ -1,3 +1,4 @@
+ export function add(a: number, b: number): number {
+-  return a + b;
++  const sum = a + b;
++  return sum;
+ }
+`;
+
+describe('cloneFileDiff', () => {
+  test('clone is byte-identical to the source and fully detached', () => {
+    const original = getSingularPatch(PATCH);
+    const reference = JSON.stringify(original);
+    const clone = cloneFileDiff(original);
+
+    // Byte-identical snapshot.
+    expect(JSON.stringify(clone)).toBe(reference);
+
+    // Simulate what Pierre's edit session does to the live object: replace
+    // additionLines, clobber hunks, stamp the session flag.
+    const live = original as unknown as Record<string, unknown>;
+    (live.additionLines as string[]).push('// injected by editor\n');
+    live.hunks = [];
+    live.editSessionDirty = true;
+    live.cacheKey = 'mutated';
+
+    // The pristine clone must be unaffected (the restore invariant).
+    expect(JSON.stringify(clone)).toBe(reference);
+    expect((clone as unknown as Record<string, unknown>).editSessionDirty).toBeUndefined();
+  });
+
+  test('nested arrays are deep-cloned, not shared', () => {
+    const original = getSingularPatch(PATCH);
+    const clone = cloneFileDiff(original);
+    expect(clone.additionLines).not.toBe(original.additionLines);
+    expect(clone.hunks).not.toBe(original.hunks);
+    expect(clone.additionLines).toEqual(original.additionLines);
+  });
+});

--- a/packages/review-editor/edit/cloneDiff.ts
+++ b/packages/review-editor/edit/cloneDiff.ts
@@ -1,0 +1,18 @@
+import type { FileDiffMetadata } from '@pierre/diffs';
+
+/**
+ * Deep-clone a FileDiffMetadata BEFORE handing it to Pierre's editor.
+ *
+ * Pierre's edit session mutates the metadata object in place (replaces
+ * `additionLines`, `Object.assign`s recomputed `hunks`, stamps
+ * `editSessionDirty`). The pristine clone is what gets republished onto the
+ * CodeView item when the session ends (complete OR cancel), so the diff view
+ * always returns to exactly what the reviewer saw before editing.
+ *
+ * FileDiffMetadata is plain structured data (strings/numbers/arrays/objects),
+ * so structuredClone covers it; if upstream ever adds an uncloneable field,
+ * this throws loudly at session start instead of silently sharing state.
+ */
+export function cloneFileDiff(diff: FileDiffMetadata): FileDiffMetadata {
+  return structuredClone(diff);
+}

--- a/packages/review-editor/edit/deriveSuggestions.test.ts
+++ b/packages/review-editor/edit/deriveSuggestions.test.ts
@@ -1,5 +1,41 @@
 import { describe, expect, test } from 'bun:test';
-import { deriveSuggestionHunks } from './deriveSuggestions';
+import { deriveSuggestionHunks, type SuggestionHunk } from './deriveSuggestions';
+
+/** Assert the non-overlap invariant: hunks ascend and never share a line. */
+function expectDisjoint(hunks: SuggestionHunk[]): void {
+  for (let i = 1; i < hunks.length; i++) {
+    expect(hunks[i].lineStart).toBeGreaterThan(hunks[i - 1].lineEnd);
+  }
+  for (const hunk of hunks) {
+    expect(hunk.lineEnd).toBeGreaterThanOrEqual(hunk.lineStart);
+  }
+}
+
+function splitContentLines(content: string): string[] {
+  if (content === '') return [];
+  const lines = content.split('\n');
+  if (lines[lines.length - 1] === '') lines.pop();
+  return lines;
+}
+
+/** Apply hunks the way an agent would: sequentially against original line
+ * numbers, tracking the running insert/delete offset. */
+function applyHunks(before: string, hunks: SuggestionHunk[]): string {
+  const lines = splitContentLines(before);
+  let offset = 0;
+  for (const hunk of hunks) {
+    const replacement = splitContentLines(hunk.suggestedCode);
+    const at = hunk.lineStart - 1 + offset;
+    const removeCount = Math.min(hunk.lineEnd - hunk.lineStart + 1, Math.max(0, lines.length - at));
+    lines.splice(at, removeCount, ...replacement);
+    offset += replacement.length - removeCount;
+  }
+  return lines.join('\n');
+}
+
+function normalizeForCompare(content: string): string {
+  return splitContentLines(content.replace(/\r\n/g, '\n').replace(/\r/g, '\n')).join('\n');
+}
 
 const FILE = [
   'export function add(a: number, b: number): number {',
@@ -145,5 +181,139 @@ describe('deriveSuggestionHunks', () => {
     expect(hunks).toEqual([
       { lineStart: 1, lineEnd: 1, originalCode: '', suggestedCode: 'hello' },
     ]);
+  });
+
+  describe('anchor collisions between adjacent regions', () => {
+    test('file-start insert plus adjacent insert do not claim the same line', () => {
+      // Region 1 (insert S before line 1) must anchor forward to line 1;
+      // region 2 (insert N0 before line 2) then finds its backward anchor
+      // (line 1) taken and anchors forward to line 2 instead.
+      const before = 'A\nB\nC\n';
+      const after = 'S\nA\nN0\nB\nC\n';
+      const hunks = deriveSuggestionHunks(before, after);
+      expect(hunks).toEqual([
+        { lineStart: 1, lineEnd: 1, originalCode: 'A', suggestedCode: 'S\nA' },
+        { lineStart: 2, lineEnd: 2, originalCode: 'B', suggestedCode: 'N0\nB' },
+      ]);
+      expect(applyHunks(before, hunks)).toBe(normalizeForCompare(after));
+    });
+
+    test('two deletes sharing one kept line between them do not overlap', () => {
+      // Region 1 (delete line 1) anchors forward to line 2; region 2 (delete
+      // line 3) finds line 2 taken and anchors forward to line 4.
+      const before = 'A\nB\nC\nD\n';
+      const after = 'B\nD\n';
+      const hunks = deriveSuggestionHunks(before, after);
+      expect(hunks).toEqual([
+        { lineStart: 1, lineEnd: 2, originalCode: 'A\nB', suggestedCode: 'B' },
+        { lineStart: 3, lineEnd: 4, originalCode: 'C\nD', suggestedCode: 'D' },
+      ]);
+      expect(applyHunks(before, hunks)).toBe(normalizeForCompare(after));
+    });
+
+    test('adjacent regions at file start: delete then insert after the kept line', () => {
+      const before = 'A\nB\nC\n';
+      const after = 'B\nZ\nC\n';
+      const hunks = deriveSuggestionHunks(before, after);
+      expectDisjoint(hunks);
+      expect(applyHunks(before, hunks)).toBe(normalizeForCompare(after));
+    });
+
+    test('adjacent regions at file end merge into one spanning hunk', () => {
+      // Region 1 (delete line 1) anchors forward, claiming line 2 (the last
+      // line); region 2 (append X at end of file) then has no anchor in
+      // either direction and merges into region 1's hunk.
+      const before = 'A\nB\n';
+      const after = 'B\nX\n';
+      const hunks = deriveSuggestionHunks(before, after);
+      expect(hunks).toEqual([
+        { lineStart: 1, lineEnd: 2, originalCode: 'A\nB', suggestedCode: 'B\nX' },
+      ]);
+      expect(applyHunks(before, hunks)).toBe(normalizeForCompare(after));
+    });
+
+    test('delete at file end after a claimed neighbor merges into the previous hunk', () => {
+      // Region 1 (insert before line 1 at file start) anchors forward to line
+      // 1; region 2 (delete line 2, the last line) finds backward taken and
+      // has no forward line, so it merges.
+      const before = 'A\nB\n';
+      const after = 'X\nA\n';
+      const hunks = deriveSuggestionHunks(before, after);
+      expect(hunks).toEqual([
+        { lineStart: 1, lineEnd: 2, originalCode: 'A\nB', suggestedCode: 'X\nA' },
+      ]);
+      expect(applyHunks(before, hunks)).toBe(normalizeForCompare(after));
+    });
+  });
+
+  describe('fuzz: derived hunks never overlap and reconstruct the edit', () => {
+    // Deterministic seeded PRNG (mulberry32) so failures are reproducible.
+    function mulberry32(seed: number): () => number {
+      let a = seed >>> 0;
+      return () => {
+        a |= 0;
+        a = (a + 0x6d2b79f5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+      };
+    }
+
+    const POOL = ['alpha', 'bravo', 'charlie', 'delta', 'echo'];
+
+    function generateCase(rand: () => number): { before: string; after: string } {
+      const lineCountBefore = Math.floor(rand() * 9); // 0..8 lines
+      const beforeLines: string[] = [];
+      for (let i = 0; i < lineCountBefore; i++) {
+        beforeLines.push(POOL[Math.floor(rand() * POOL.length)]);
+      }
+      const afterLines: string[] = [];
+      const maybeInsert = () => {
+        // Insertions between every position (including file start and end)
+        // are what produce adjacent expanding regions.
+        while (rand() < 0.25) {
+          afterLines.push(POOL[Math.floor(rand() * POOL.length)]);
+        }
+      };
+      maybeInsert();
+      for (const line of beforeLines) {
+        const roll = rand();
+        if (roll < 0.25) {
+          // delete the line
+        } else if (roll < 0.45) {
+          afterLines.push(POOL[Math.floor(rand() * POOL.length)]); // replace
+        } else {
+          afterLines.push(line); // keep
+        }
+        maybeInsert();
+      }
+      const terminate = (lines: string[]) => (lines.length > 0 ? `${lines.join('\n')}\n` : '');
+      return { before: terminate(beforeLines), after: terminate(afterLines) };
+    }
+
+    test('5000 seeded multi-region edits: zero overlaps, all round-trip', () => {
+      const rand = mulberry32(0x5eed);
+      let overlaps = 0;
+      let roundTripFailures = 0;
+      let anchorMismatches = 0;
+      for (let i = 0; i < 5000; i++) {
+        const { before, after } = generateCase(rand);
+        const hunks = deriveSuggestionHunks(before, after);
+        const beforeLines = splitContentLines(before);
+        for (let j = 1; j < hunks.length; j++) {
+          if (hunks[j].lineStart <= hunks[j - 1].lineEnd) overlaps++;
+        }
+        for (const hunk of hunks) {
+          const expectedOriginal = beforeLines
+            .slice(hunk.lineStart - 1, hunk.lineEnd)
+            .join('\n');
+          if (hunk.originalCode !== expectedOriginal) anchorMismatches++;
+        }
+        if (applyHunks(before, hunks) !== normalizeForCompare(after)) roundTripFailures++;
+      }
+      expect(overlaps).toBe(0);
+      expect(anchorMismatches).toBe(0);
+      expect(roundTripFailures).toBe(0);
+    });
   });
 });

--- a/packages/review-editor/edit/deriveSuggestions.test.ts
+++ b/packages/review-editor/edit/deriveSuggestions.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from 'bun:test';
+import { deriveSuggestionHunks } from './deriveSuggestions';
+
+const FILE = [
+  'export function add(a: number, b: number): number {',
+  '  return a + b;',
+  '}',
+  '',
+  'export function subtract(a: number, b: number): number {',
+  '  return a - b;',
+  '}',
+].join('\n');
+
+describe('deriveSuggestionHunks', () => {
+  test('no-op edit produces no hunks', () => {
+    expect(deriveSuggestionHunks(FILE, FILE)).toEqual([]);
+  });
+
+  test('single modified line produces one hunk anchored to that line', () => {
+    const edited = FILE.replace('return a + b;', 'return b + a;');
+    const hunks = deriveSuggestionHunks(FILE, edited);
+    expect(hunks).toEqual([
+      {
+        lineStart: 2,
+        lineEnd: 2,
+        originalCode: '  return a + b;',
+        suggestedCode: '  return b + a;',
+      },
+    ]);
+  });
+
+  test('two separate edits produce two hunks', () => {
+    const edited = FILE.replace('return a + b;', 'return b + a;').replace(
+      'return a - b;',
+      'return -(b - a);',
+    );
+    const hunks = deriveSuggestionHunks(FILE, edited);
+    expect(hunks).toHaveLength(2);
+    expect(hunks[0]).toMatchObject({ lineStart: 2, lineEnd: 2, suggestedCode: '  return b + a;' });
+    expect(hunks[1]).toMatchObject({ lineStart: 6, lineEnd: 6, suggestedCode: '  return -(b - a);' });
+  });
+
+  test('multi-line replacement groups into one modified hunk', () => {
+    const edited = FILE.replace(
+      '  return a + b;\n}',
+      '  const sum = a + b;\n  return sum;\n}',
+    );
+    const hunks = deriveSuggestionHunks(FILE, edited);
+    expect(hunks).toEqual([
+      {
+        lineStart: 2,
+        lineEnd: 2,
+        originalCode: '  return a + b;',
+        suggestedCode: '  const sum = a + b;\n  return sum;',
+      },
+    ]);
+  });
+
+  test('pure insertion anchors to the preceding line', () => {
+    const edited = FILE.replace('  return a + b;', '  return a + b;\n  // done');
+    const hunks = deriveSuggestionHunks(FILE, edited);
+    expect(hunks).toEqual([
+      {
+        lineStart: 2,
+        lineEnd: 2,
+        originalCode: '  return a + b;',
+        suggestedCode: '  return a + b;\n  // done',
+      },
+    ]);
+  });
+
+  test('insertion at file start anchors to the first line', () => {
+    const edited = `// header\n${FILE}`;
+    const hunks = deriveSuggestionHunks(FILE, edited);
+    expect(hunks).toEqual([
+      {
+        lineStart: 1,
+        lineEnd: 1,
+        originalCode: 'export function add(a: number, b: number): number {',
+        suggestedCode: '// header\nexport function add(a: number, b: number): number {',
+      },
+    ]);
+  });
+
+  test('pure deletion keeps the preceding line so suggestedCode is non-empty', () => {
+    const edited = FILE.replace('  return a - b;\n', '');
+    const hunks = deriveSuggestionHunks(FILE, edited);
+    expect(hunks).toEqual([
+      {
+        lineStart: 5,
+        lineEnd: 6,
+        originalCode: 'export function subtract(a: number, b: number): number {\n  return a - b;',
+        suggestedCode: 'export function subtract(a: number, b: number): number {',
+      },
+    ]);
+  });
+
+  test('deletion of the first line anchors to the following line', () => {
+    const lines = FILE.split('\n');
+    const edited = lines.slice(1).join('\n');
+    const hunks = deriveSuggestionHunks(FILE, edited);
+    expect(hunks).toEqual([
+      {
+        lineStart: 1,
+        lineEnd: 2,
+        originalCode: 'export function add(a: number, b: number): number {\n  return a + b;',
+        suggestedCode: '  return a + b;',
+      },
+    ]);
+  });
+
+  test('emptying the whole file yields empty suggestedCode', () => {
+    const hunks = deriveSuggestionHunks('one\ntwo\n', '');
+    expect(hunks).toEqual([
+      { lineStart: 1, lineEnd: 2, originalCode: 'one\ntwo', suggestedCode: '' },
+    ]);
+  });
+
+  test('CRLF content diffs against LF edits without phantom changes', () => {
+    const crlf = FILE.replace(/\n/g, '\r\n');
+    expect(deriveSuggestionHunks(crlf, FILE)).toEqual([]);
+    const edited = FILE.replace('return a + b;', 'return b + a;');
+    const hunks = deriveSuggestionHunks(crlf, edited);
+    expect(hunks).toEqual([
+      {
+        lineStart: 2,
+        lineEnd: 2,
+        originalCode: '  return a + b;',
+        suggestedCode: '  return b + a;',
+      },
+    ]);
+  });
+
+  test('trailing-newline-only difference is not a phantom hunk on untouched lines', () => {
+    const hunks = deriveSuggestionHunks(`${FILE}\n`, FILE);
+    // The last line loses its newline; diffLines reports the final line changed.
+    // Whatever the diff engine reports must stay anchored to the final line only.
+    for (const hunk of hunks) {
+      expect(hunk.lineStart).toBeGreaterThanOrEqual(7);
+    }
+  });
+
+  test('edit into an empty file produces an unanchored insertion hunk', () => {
+    const hunks = deriveSuggestionHunks('', 'hello\n');
+    expect(hunks).toEqual([
+      { lineStart: 1, lineEnd: 1, originalCode: '', suggestedCode: 'hello' },
+    ]);
+  });
+});

--- a/packages/review-editor/edit/deriveSuggestions.ts
+++ b/packages/review-editor/edit/deriveSuggestions.ts
@@ -44,6 +44,15 @@ interface RawRegion {
   suggestedLines: string[];
 }
 
+/** A hunk under construction: line arrays instead of joined strings so the
+ * collision pass can merge and fold before the final join. */
+interface PendingHunk {
+  lineStart: number;
+  lineEnd: number;
+  origLines: string[];
+  suggLines: string[];
+}
+
 /**
  * Diff the pre-edit content against the edited content and return one
  * SuggestionHunk per contiguous changed region.
@@ -56,8 +65,28 @@ interface RawRegion {
  *   reviewer's diff shows what the lines currently are) and — except when the
  *   whole file was emptied — non-empty `suggestedCode` (the export template
  *   skips falsy suggestedCode, so a bare deletion must carry its kept
- *   neighbor). Anchoring prefers the preceding line; at file start it uses the
- *   following line instead.
+ *   neighbor).
+ *
+ * Anchor collision resolution (hunks MUST never overlap — an agent applying
+ * them against original line numbers would otherwise drop or duplicate code):
+ * regions are emitted left to right, and each expansion checks its neighbors
+ * BEFORE claiming an anchor line.
+ * - Backward (the preceding line) is preferred, but only when that line is not
+ *   already claimed by the previously emitted hunk.
+ * - Otherwise the following line is used. A forward anchor is always an
+ *   unchanged line (diffLines separates regions by at least one unchanged
+ *   line), and later regions see it as claimed, so they can never take it.
+ * - When both directions are unavailable (previous hunk claims the preceding
+ *   line AND the region runs to end of file), the region merges into the
+ *   previous hunk as one spanning suggestion.
+ * - A region spanning the whole file (emptied file, insert into empty file)
+ *   stays unanchored: suggestedCode may be '' and the caller is responsible
+ *   for describing the deletion in text.
+ *
+ * The emission order makes overlap structurally impossible; a defensive fold
+ * at the end enforces the invariant (`lineStart > previous lineEnd`) anyway,
+ * merging any violating hunk into its predecessor rather than ever returning
+ * overlapping ranges.
  */
 export function deriveSuggestionHunks(preEditContent: string, editedContent: string): SuggestionHunk[] {
   const original = normalize(preEditContent);
@@ -91,53 +120,111 @@ export function deriveSuggestionHunks(preEditContent: string, editedContent: str
   }
   if (current) regions.push(current);
 
-  return regions.map((region) => {
-    let { start } = region;
-    const orig = [...region.originalLines];
-    const sugg = [...region.suggestedLines];
-    let end = start + orig.length - 1;
+  const lineCount = originalLines.length;
+  const hunks: PendingHunk[] = [];
+  const prevEnd = () => (hunks.length > 0 ? hunks[hunks.length - 1].lineEnd : 0);
 
-    if (orig.length === 0) {
-      // Pure insertion before line `start`. Anchor to the preceding line when
-      // one exists; at file start anchor to the (current) first line instead.
-      if (start > 1) {
-        const anchor = originalLines[start - 2];
-        orig.unshift(anchor);
-        sugg.unshift(anchor);
-        start -= 1;
-        end = start;
-      } else if (originalLines.length > 0) {
-        const anchor = originalLines[0];
-        orig.push(anchor);
-        sugg.push(anchor);
-        end = start;
-      } else {
-        // Inserting into an empty file: nothing to anchor to.
-        end = start;
-      }
-    } else if (sugg.length === 0) {
-      // Pure deletion. Keep one unchanged neighbor so suggestedCode stays
-      // non-empty (the feedback export skips falsy suggestedCode).
-      if (start > 1) {
-        const anchor = originalLines[start - 2];
-        orig.unshift(anchor);
-        sugg.push(anchor);
-        start -= 1;
-      } else if (end < originalLines.length) {
-        const anchor = originalLines[end];
-        orig.push(anchor);
-        sugg.push(anchor);
-        end += 1;
-      }
-      // else: the whole file was emptied — suggestedCode stays '' and the
-      // caller is responsible for describing the deletion in text.
+  for (const region of regions) {
+    const rawStart = region.start;
+    // Last original line the region occupies; rawStart - 1 for pure inserts
+    // (they occupy no original lines).
+    const rawEnd = rawStart + region.originalLines.length - 1;
+    const isInsert = region.originalLines.length === 0;
+    const isDelete = !isInsert && region.suggestedLines.length === 0;
+
+    if (!isInsert && !isDelete) {
+      // Modification: never expands, and raw regions never overlap.
+      hunks.push({
+        lineStart: rawStart,
+        lineEnd: rawEnd,
+        origLines: [...region.originalLines],
+        suggLines: [...region.suggestedLines],
+      });
+      continue;
     }
 
-    return {
-      lineStart: start,
-      lineEnd: end,
-      originalCode: orig.join('\n'),
-      suggestedCode: sugg.join('\n'),
-    };
-  });
+    const backwardLine = rawStart - 1;
+    const canBackward = backwardLine >= 1 && backwardLine > prevEnd();
+    // For an insert this is the line the new lines go before; for a delete the
+    // first kept line after the removed run. Both are unchanged lines.
+    const forwardLine = rawEnd + 1;
+    const canForward = forwardLine <= lineCount;
+
+    if (canBackward) {
+      const anchor = originalLines[backwardLine - 1];
+      hunks.push(
+        isInsert
+          ? {
+              lineStart: backwardLine,
+              lineEnd: backwardLine,
+              origLines: [anchor],
+              suggLines: [anchor, ...region.suggestedLines],
+            }
+          : {
+              lineStart: backwardLine,
+              lineEnd: rawEnd,
+              origLines: [anchor, ...region.originalLines],
+              suggLines: [anchor],
+            },
+      );
+    } else if (canForward) {
+      const anchor = originalLines[forwardLine - 1];
+      hunks.push(
+        isInsert
+          ? {
+              lineStart: forwardLine,
+              lineEnd: forwardLine,
+              origLines: [anchor],
+              suggLines: [...region.suggestedLines, anchor],
+            }
+          : {
+              lineStart: rawStart,
+              lineEnd: forwardLine,
+              origLines: [...region.originalLines, anchor],
+              suggLines: [anchor],
+            },
+      );
+    } else if (hunks.length > 0 && prevEnd() === rawStart - 1) {
+      // Both anchor directions are taken (previous hunk claims the preceding
+      // line; the region runs to end of file): merge into the previous hunk
+      // as one spanning suggestion. Contiguity is guaranteed — backward is
+      // only blocked when the previous hunk ends exactly one line before.
+      const prev = hunks[hunks.length - 1];
+      prev.lineEnd = Math.max(prev.lineEnd, rawEnd);
+      prev.origLines.push(...region.originalLines);
+      prev.suggLines.push(...region.suggestedLines);
+    } else {
+      // Region spans the whole file (emptied file / insert into empty file):
+      // nothing to anchor to.
+      hunks.push({
+        lineStart: rawStart,
+        lineEnd: Math.max(rawEnd, rawStart),
+        origLines: [...region.originalLines],
+        suggLines: [...region.suggestedLines],
+      });
+    }
+  }
+
+  // Hard invariant: hunks are disjoint and ascending. The emission above makes
+  // a violation impossible; if one ever appears, fold the offender into its
+  // predecessor (originalCode recomputed from the source lines so the anchor
+  // stays truthful) rather than emitting overlapping ranges.
+  const folded: PendingHunk[] = [];
+  for (const hunk of hunks) {
+    const prev = folded[folded.length - 1];
+    if (prev && hunk.lineStart <= prev.lineEnd) {
+      prev.lineEnd = Math.max(prev.lineEnd, hunk.lineEnd);
+      prev.origLines = originalLines.slice(prev.lineStart - 1, prev.lineEnd);
+      prev.suggLines = [...prev.suggLines, ...hunk.suggLines];
+      continue;
+    }
+    folded.push(hunk);
+  }
+
+  return folded.map((hunk) => ({
+    lineStart: hunk.lineStart,
+    lineEnd: hunk.lineEnd,
+    originalCode: hunk.origLines.join('\n'),
+    suggestedCode: hunk.suggLines.join('\n'),
+  }));
 }

--- a/packages/review-editor/edit/deriveSuggestions.ts
+++ b/packages/review-editor/edit/deriveSuggestions.ts
@@ -1,0 +1,143 @@
+import { diffLines } from 'diff';
+
+/**
+ * One contiguous changed region of an edit session, expressed as a suggestion
+ * anchored to the PRE-EDIT content's line numbers.
+ *
+ * The edit session operates on the diff's NEW-side (post-image) file content,
+ * so `lineStart`/`lineEnd` are new-side file line numbers — exactly the
+ * numbering `CodeAnnotation` uses with `side: 'new'`. The browser never writes
+ * files; these hunks become suggestion annotations the agent applies.
+ */
+export interface SuggestionHunk {
+  /** 1-based first line (inclusive) of the replaced range in the pre-edit content. */
+  lineStart: number;
+  /** 1-based last line (inclusive) of the replaced range in the pre-edit content. */
+  lineEnd: number;
+  /** The pre-edit lines being replaced (no trailing newline). */
+  originalCode: string;
+  /** The replacement lines (no trailing newline). */
+  suggestedCode: string;
+}
+
+/** Normalize line endings so a CRLF file edited by an LF editor (or vice
+ * versa) doesn't report every untouched line as changed. Suggestions are
+ * emitted LF-only; the applying agent re-normalizes to the file's own style. */
+function normalize(content: string): string {
+  return content.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+function splitLines(content: string): string[] {
+  if (content === '') return [];
+  const lines = content.split('\n');
+  // A trailing newline yields a final empty element that is not a real line.
+  if (lines[lines.length - 1] === '') lines.pop();
+  return lines;
+}
+
+interface RawRegion {
+  /** 1-based line in the pre-edit content where the region starts. For pure
+   * insertions this is the line BEFORE which the new lines go (may be one past
+   * the last line for end-of-file appends). */
+  start: number;
+  originalLines: string[];
+  suggestedLines: string[];
+}
+
+/**
+ * Diff the pre-edit content against the edited content and return one
+ * SuggestionHunk per contiguous changed region.
+ *
+ * Rules:
+ * - A no-op edit (identical after CRLF normalization) returns [].
+ * - Consecutive removed+added runs merge into a single "modified" hunk.
+ * - Pure insertions and pure deletions are expanded to include one adjacent
+ *   unchanged anchor line, so every hunk has non-empty `originalCode` (the
+ *   reviewer's diff shows what the lines currently are) and — except when the
+ *   whole file was emptied — non-empty `suggestedCode` (the export template
+ *   skips falsy suggestedCode, so a bare deletion must carry its kept
+ *   neighbor). Anchoring prefers the preceding line; at file start it uses the
+ *   following line instead.
+ */
+export function deriveSuggestionHunks(preEditContent: string, editedContent: string): SuggestionHunk[] {
+  const original = normalize(preEditContent);
+  const edited = normalize(editedContent);
+  if (original === edited) return [];
+
+  const originalLines = splitLines(original);
+  const parts = diffLines(original, edited);
+
+  const regions: RawRegion[] = [];
+  let current: RawRegion | null = null;
+  // 1-based number of the NEXT line to consume from the original content.
+  let origLine = 1;
+
+  for (const part of parts) {
+    const lines = splitLines(part.value);
+    if (part.added) {
+      if (!current) current = { start: origLine, originalLines: [], suggestedLines: [] };
+      current.suggestedLines.push(...lines);
+    } else if (part.removed) {
+      if (!current) current = { start: origLine, originalLines: [], suggestedLines: [] };
+      current.originalLines.push(...lines);
+      origLine += lines.length;
+    } else {
+      if (current) {
+        regions.push(current);
+        current = null;
+      }
+      origLine += lines.length;
+    }
+  }
+  if (current) regions.push(current);
+
+  return regions.map((region) => {
+    let { start } = region;
+    const orig = [...region.originalLines];
+    const sugg = [...region.suggestedLines];
+    let end = start + orig.length - 1;
+
+    if (orig.length === 0) {
+      // Pure insertion before line `start`. Anchor to the preceding line when
+      // one exists; at file start anchor to the (current) first line instead.
+      if (start > 1) {
+        const anchor = originalLines[start - 2];
+        orig.unshift(anchor);
+        sugg.unshift(anchor);
+        start -= 1;
+        end = start;
+      } else if (originalLines.length > 0) {
+        const anchor = originalLines[0];
+        orig.push(anchor);
+        sugg.push(anchor);
+        end = start;
+      } else {
+        // Inserting into an empty file: nothing to anchor to.
+        end = start;
+      }
+    } else if (sugg.length === 0) {
+      // Pure deletion. Keep one unchanged neighbor so suggestedCode stays
+      // non-empty (the feedback export skips falsy suggestedCode).
+      if (start > 1) {
+        const anchor = originalLines[start - 2];
+        orig.unshift(anchor);
+        sugg.push(anchor);
+        start -= 1;
+      } else if (end < originalLines.length) {
+        const anchor = originalLines[end];
+        orig.push(anchor);
+        sugg.push(anchor);
+        end += 1;
+      }
+      // else: the whole file was emptied — suggestedCode stays '' and the
+      // caller is responsible for describing the deletion in text.
+    }
+
+    return {
+      lineStart: start,
+      lineEnd: end,
+      originalCode: orig.join('\n'),
+      suggestedCode: sugg.join('\n'),
+    };
+  });
+}

--- a/packages/review-editor/edit/pierreEditAdapter.ts
+++ b/packages/review-editor/edit/pierreEditAdapter.ts
@@ -1,0 +1,93 @@
+/**
+ * Adapter wall for Pierre's EXPERIMENTAL edit mode.
+ *
+ * Every reference to `@pierre/diffs/edit` in this repo lives in THIS module —
+ * runtime imports are dynamic (the editor code never loads until a user
+ * actually enters edit mode) and type references are `import type` only, so
+ * an upstream rename/reshape of the edit entry is a one-file fix here.
+ *
+ * App code must import editor types and functions from this module, never
+ * from `@pierre/diffs/edit` directly. (`packages/review-editor/edit/
+ * adapterWall.test.ts` enforces this.)
+ *
+ * Notes pinned to @pierre/diffs 1.3.1:
+ * - The edit entry exports only `Editor` and `TextDocument`; sessions are
+ *   driven by CodeView via `item.edit = true` + an `EditProvider` factory.
+ * - `persistState` is deliberately NOT used (upstream bug, open PR #1048;
+ *   it is also file-item-only — diff items never persist state anyway).
+ * - `Marker` / `SelectionActionContext` have no public export path, so they
+ *   are re-derived structurally from the `Editor` class type.
+ */
+import type { CodeAnnotation } from '@plannotator/ui/types';
+
+type EditModule = typeof import('@pierre/diffs/edit');
+
+/** The concrete editor class instance (structural — never import the class type directly elsewhere). */
+export type PierreEditorInstance = InstanceType<EditModule['Editor']>;
+/** Constructor options for the editor (Pierre's `EditorOptions`). */
+export type PierreEditorOptions = NonNullable<ConstructorParameters<EditModule['Editor']>[0]>;
+/** Pierre's `Marker` type, re-derived structurally (it has no export path). */
+export type PierreEditorMarker = Parameters<PierreEditorInstance['setMarkers']>[0][number];
+
+let modulePromise: Promise<EditModule> | null = null;
+let loadedModule: EditModule | null = null;
+
+/** Whether the editor module has finished loading (factory calls before this resolves decline the attach). */
+export function isPierreEditLoaded(): boolean {
+  return loadedModule != null;
+}
+
+/**
+ * Load the editor chunk. Idempotent; called when the user first enters edit
+ * mode. CodeView's `createEditor` factory contract allows returning undefined
+ * to decline an attach (it retries on later render passes), so a factory
+ * backed by this loader is safe to install before the module has loaded.
+ */
+export async function loadPierreEdit(): Promise<void> {
+  if (!modulePromise) {
+    modulePromise = import('@pierre/diffs/edit').then((mod) => {
+      loadedModule = mod;
+      return mod;
+    });
+  }
+  await modulePromise;
+}
+
+/**
+ * Synchronous editor factory for Pierre's `EditProvider`. Returns undefined
+ * until `loadPierreEdit()` has resolved — CodeView treats that as "decline
+ * and retry", which is exactly the lazy-load behavior we want.
+ */
+export function createPierreEditor(options: PierreEditorOptions): PierreEditorInstance | undefined {
+  if (!loadedModule) return undefined;
+  return new loadedModule.Editor(options);
+}
+
+/** Test-only: reset module state so load-order tests are deterministic. */
+export function __resetPierreEditForTests(): void {
+  modulePromise = null;
+  loadedModule = null;
+}
+
+/**
+ * Project a file's existing line annotations (agent findings, review
+ * comments) into editor severity markers so they stay visible during an edit
+ * session. Marker ranges are zero-based LSP-shaped positions; annotations are
+ * 1-based file line numbers. Only new-side line annotations map (the editor
+ * document IS the new side).
+ */
+export function buildEditorMarkers(annotations: CodeAnnotation[], filePath: string): PierreEditorMarker[] {
+  const markers: PierreEditorMarker[] = [];
+  for (const ann of annotations) {
+    if (ann.filePath !== filePath || (ann.scope ?? 'line') !== 'line' || ann.side !== 'new') continue;
+    const message = ann.text || (ann.suggestedCode ? 'Suggested change' : 'Comment');
+    markers.push({
+      start: { line: Math.max(0, ann.lineStart - 1), character: 0 },
+      end: { line: Math.max(0, ann.lineEnd - 1), character: 0 },
+      severity: ann.severity === 'important' || ann.type === 'concern' ? 'warning' : 'info',
+      message,
+      source: ann.source || ann.author || 'plannotator',
+    });
+  }
+  return markers;
+}

--- a/packages/review-editor/edit/pierreEditAdapter.ts
+++ b/packages/review-editor/edit/pierreEditAdapter.ts
@@ -28,6 +28,11 @@ export type PierreEditorInstance = InstanceType<EditModule['Editor']>;
 export type PierreEditorOptions = NonNullable<ConstructorParameters<EditModule['Editor']>[0]>;
 /** Pierre's `Marker` type, re-derived structurally (it has no export path). */
 export type PierreEditorMarker = Parameters<PierreEditorInstance['setMarkers']>[0][number];
+/** Pierre's `SelectionActionContext`, re-derived structurally from the
+ * `renderSelectionAction` editor option (it has no public export path). */
+export type PierreSelectionActionContext = Parameters<
+  NonNullable<PierreEditorOptions['renderSelectionAction']>
+>[0];
 
 let modulePromise: Promise<EditModule> | null = null;
 let loadedModule: EditModule | null = null;

--- a/packages/review-editor/edit/pierreEditAdapter.ts
+++ b/packages/review-editor/edit/pierreEditAdapter.ts
@@ -38,10 +38,12 @@ export function isPierreEditLoaded(): boolean {
 }
 
 /**
- * Load the editor chunk. Idempotent; called when the user first enters edit
- * mode. CodeView's `createEditor` factory contract allows returning undefined
- * to decline an attach (it retries on later render passes), so a factory
- * backed by this loader is safe to install before the module has loaded.
+ * Load the editor chunk. Idempotent; the session controller awaits this
+ * BEFORE flipping any item into edit mode, so the factory below never runs
+ * unloaded in practice. That ordering matters: the core CodeView treats a
+ * null factory return as "decline the attach", but the React wrapper's shim
+ * THROWS on an undefined return ("EditProvider.createEditor must return an
+ * editor instance"), so an unloaded factory is not a graceful retry path.
  */
 export async function loadPierreEdit(): Promise<void> {
   if (!modulePromise) {
@@ -55,8 +57,11 @@ export async function loadPierreEdit(): Promise<void> {
 
 /**
  * Synchronous editor factory for Pierre's `EditProvider`. Returns undefined
- * until `loadPierreEdit()` has resolved — CodeView treats that as "decline
- * and retry", which is exactly the lazy-load behavior we want.
+ * until `loadPierreEdit()` has resolved. This is a defensive guard, not a
+ * documented retry contract: the React CodeView wrapper throws on an
+ * undefined return, which would fail that attach. The session controller
+ * awaits `loadPierreEdit()` before any item enters edit mode, so the guard
+ * is unreachable in the wired flow.
  */
 export function createPierreEditor(options: PierreEditorOptions): PierreEditorInstance | undefined {
   if (!loadedModule) return undefined;
@@ -75,15 +80,23 @@ export function __resetPierreEditForTests(): void {
  * session. Marker ranges are zero-based LSP-shaped positions; annotations are
  * 1-based file line numbers. Only new-side line annotations map (the editor
  * document IS the new side).
+ *
+ * The range must have real width: upstream's overlay renderer skips
+ * zero-width blocks (`#renderSelectionBlock` returns on width 0), so a
+ * collapsed `start === end` range never paints. Ending at character 0 of the
+ * line AFTER the last annotated line covers every annotated line in full
+ * (the exclusive-end LSP convention); the editor's TextDocument clamps an
+ * end past the last line back to end-of-document.
  */
 export function buildEditorMarkers(annotations: CodeAnnotation[], filePath: string): PierreEditorMarker[] {
   const markers: PierreEditorMarker[] = [];
   for (const ann of annotations) {
     if (ann.filePath !== filePath || (ann.scope ?? 'line') !== 'line' || ann.side !== 'new') continue;
     const message = ann.text || (ann.suggestedCode ? 'Suggested change' : 'Comment');
+    const startLine = Math.max(0, ann.lineStart - 1);
     markers.push({
-      start: { line: Math.max(0, ann.lineStart - 1), character: 0 },
-      end: { line: Math.max(0, ann.lineEnd - 1), character: 0 },
+      start: { line: startLine, character: 0 },
+      end: { line: Math.max(ann.lineEnd, startLine + 1), character: 0 },
       severity: ann.severity === 'important' || ann.type === 'concern' ? 'warning' : 'info',
       message,
       source: ann.source || ann.author || 'plannotator',

--- a/packages/review-editor/edit/selectionActionPopover.test.ts
+++ b/packages/review-editor/edit/selectionActionPopover.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Selection Action popover DOM builder. Pierre renders this node inside the
+ * editor's shadow DOM where the app's stylesheets do not apply, so the
+ * contract under test is: inline styles only, colors via inherited theme
+ * custom properties, mousedown suppressed (an unprevented mousedown blurs the
+ * editor and collapses the selection before the click can read it), and the
+ * click reporting the button's own rect for anchoring the app-side entry.
+ *
+ * DOM-gated (DOM_TESTS=1); registered in .github/workflows/test.yml's
+ * "Run UI seam-contract + DOM tests" step.
+ */
+import { describe, expect, test } from 'bun:test';
+import { buildSelectionActionElement } from './selectionActionPopover';
+
+const hasDom = typeof document !== 'undefined';
+
+describe.if(hasDom)('buildSelectionActionElement (DOM)', () => {
+  test('renders a single Make annotation action', () => {
+    const el = buildSelectionActionElement(() => {});
+    expect(el.dataset.testid).toBe('edit-selection-action');
+    const buttons = el.querySelectorAll('button');
+    expect(buttons.length).toBe(1);
+    const button = buttons[0];
+    expect(button.dataset.testid).toBe('edit-selection-make-annotation');
+    expect(button.textContent).toContain('Make annotation');
+  });
+
+  test('styles inline through theme tokens (shadow DOM: no app CSS applies)', () => {
+    const el = buildSelectionActionElement(() => {});
+    const button = el.querySelector('button')!;
+    const style = button.getAttribute('style') ?? '';
+    expect(style).toContain('var(--card)');
+    expect(style).toContain('var(--border)');
+    // No class names: Tailwind cannot reach into the editor's shadow root.
+    expect(button.className).toBe('');
+  });
+
+  test('prevents the default mousedown so the editor selection survives', () => {
+    const el = buildSelectionActionElement(() => {});
+    const button = el.querySelector('button')!;
+    const event = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+    button.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  test('click reports the button rect to the callback', () => {
+    let received: DOMRect | null = null;
+    const el = buildSelectionActionElement((rect) => {
+      received = rect;
+    });
+    document.body.append(el);
+    try {
+      const button = el.querySelector('button')!;
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      expect(received).not.toBeNull();
+      expect(typeof received!.top).toBe('number');
+      expect(typeof received!.left).toBe('number');
+    } finally {
+      el.remove();
+    }
+  });
+});

--- a/packages/review-editor/edit/selectionActionPopover.ts
+++ b/packages/review-editor/edit/selectionActionPopover.ts
@@ -1,0 +1,77 @@
+/**
+ * DOM builder for the edit-session Selection Action popover content.
+ *
+ * Pierre's `renderSelectionAction` returns a PLAIN DOM node (not React) that
+ * renders inside the editor's shadow DOM, where the app's Tailwind/global CSS
+ * does not apply — so everything here is styled inline. CSS custom properties
+ * DO inherit through the shadow boundary, so colors come from the app's theme
+ * tokens (var(--card), var(--border), ...) and track light/dark and theme
+ * switches for free.
+ *
+ * No Pierre types cross this module: the caller (useEditSession) adapts the
+ * SelectionActionContext into the single `onMakeAnnotation` callback.
+ */
+
+const ICON_COMMENT_SVG =
+  '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M21 12c0 4.418-4.03 8-9 8a9.86 9.86 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/></svg>';
+
+const BUTTON_STYLE = [
+  'display: inline-flex',
+  'align-items: center',
+  'gap: 5px',
+  'font-family: var(--font-sans), system-ui, sans-serif',
+  'font-size: 12px',
+  'font-weight: 500',
+  'line-height: 1',
+  'padding: 5px 10px',
+  'border-radius: 6px',
+  'border: 1px solid var(--border)',
+  'background-color: var(--card)',
+  'color: var(--card-foreground)',
+  'cursor: pointer',
+  'box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18)',
+  'white-space: nowrap',
+].join('; ');
+
+const BUTTON_HOVER_BACKGROUND = 'var(--muted)';
+
+/**
+ * Build the popover element: a single "Make annotation" action.
+ *
+ * `onMakeAnnotation` receives the button's viewport rect so the caller can
+ * anchor the app-side comment entry where the popover was. The handler must
+ * snapshot everything it needs from the editor synchronously — the caller
+ * closes the Pierre popover right after, and the editor selection may
+ * collapse as soon as focus moves to the app-side entry.
+ */
+export function buildSelectionActionElement(
+  onMakeAnnotation: (anchorRect: DOMRect) => void,
+): HTMLElement {
+  const container = document.createElement('div');
+  container.style.cssText = 'display: flex; gap: 4px;';
+  container.dataset.testid = 'edit-selection-action';
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.style.cssText = BUTTON_STYLE;
+  button.innerHTML = `${ICON_COMMENT_SVG}<span>Make annotation</span>`;
+  button.title = 'Create a Plannotator comment on the selected lines';
+  button.dataset.testid = 'edit-selection-make-annotation';
+
+  button.addEventListener('mouseenter', () => {
+    button.style.backgroundColor = BUTTON_HOVER_BACKGROUND;
+  });
+  button.addEventListener('mouseleave', () => {
+    button.style.backgroundColor = 'var(--card)';
+  });
+  // Suppress the default mousedown so clicking the action doesn't blur the
+  // editor and collapse the selection we're about to read (same trick as
+  // Pierre's own selection-action demo).
+  button.addEventListener('mousedown', (event) => event.preventDefault());
+  button.addEventListener('click', () => {
+    onMakeAnnotation(button.getBoundingClientRect());
+  });
+
+  container.append(button);
+  return container;
+}

--- a/packages/review-editor/edit/selectionAnchor.test.ts
+++ b/packages/review-editor/edit/selectionAnchor.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, test } from 'bun:test';
+import { mapEditedRangeToPristine, selectionToLineRange } from './selectionAnchor';
+
+/**
+ * Anchor mapping for "Make annotation" selections made inside an edit session:
+ * edited-buffer line ranges map to PRISTINE (pre-edit, new-side) coordinates,
+ * which are what the rendered diff and the feedback export anchor to. See
+ * selectionAnchor.ts for the rules under test.
+ */
+describe('mapEditedRangeToPristine', () => {
+  test('identity when nothing was edited', () => {
+    const content = 'a\nb\nc\nd\n';
+    expect(mapEditedRangeToPristine(content, content, 2, 3)).toEqual({
+      lineStart: 2,
+      lineEnd: 3,
+      exact: true,
+    });
+  });
+
+  test('unedited-region selection maps exactly through line shifts from edits above', () => {
+    const pristine = 'a\nb\nc\nd\ne\n';
+    // Line 1 replaced by two lines: everything below shifts down by one.
+    const edited = 'x\ny\nb\nc\nd\ne\n';
+    expect(mapEditedRangeToPristine(pristine, edited, 3, 4)).toEqual({
+      lineStart: 2,
+      lineEnd: 3,
+      exact: true,
+    });
+  });
+
+  test('unedited-region selection maps exactly through line shifts from a deletion above', () => {
+    const pristine = 'a\nb\nc\nd\ne\n';
+    const edited = 'a\nd\ne\n'; // b, c deleted
+    expect(mapEditedRangeToPristine(pristine, edited, 2, 3)).toEqual({
+      lineStart: 4,
+      lineEnd: 5,
+      exact: true,
+    });
+  });
+
+  test('selection inside a modified region anchors to the pristine lines it replaces', () => {
+    const pristine = 'a\nb\nc\nd\n';
+    const edited = 'a\nB1\nB2\nc\nd\n'; // line 2 replaced by two lines
+    expect(mapEditedRangeToPristine(pristine, edited, 2, 3)).toEqual({
+      lineStart: 2,
+      lineEnd: 2,
+      exact: false,
+    });
+  });
+
+  test('selection on a pure insertion anchors to the preceding pristine line', () => {
+    const pristine = 'a\nb\nc\n';
+    const edited = 'a\nb\nX\nc\n';
+    expect(mapEditedRangeToPristine(pristine, edited, 3, 3)).toEqual({
+      lineStart: 2,
+      lineEnd: 2,
+      exact: false,
+    });
+  });
+
+  test('selection on an insertion at the top of the file anchors to line 1', () => {
+    const pristine = 'a\nb\n';
+    const edited = 'X\na\nb\n';
+    expect(mapEditedRangeToPristine(pristine, edited, 1, 1)).toEqual({
+      lineStart: 1,
+      lineEnd: 1,
+      exact: false,
+    });
+  });
+
+  test('selection on an end-of-file append anchors to the last pristine line', () => {
+    const pristine = 'a\nb\n';
+    const edited = 'a\nb\nc\nd\n';
+    expect(mapEditedRangeToPristine(pristine, edited, 3, 4)).toEqual({
+      lineStart: 2,
+      lineEnd: 2,
+      exact: false,
+    });
+  });
+
+  test('selection spanning unchanged and edited regions covers the union (hunk boundary)', () => {
+    const pristine = 'a\nb\nc\nd\ne\n';
+    const edited = 'a\nb\nC\nd\ne\n'; // line 3 modified
+    expect(mapEditedRangeToPristine(pristine, edited, 2, 4)).toEqual({
+      lineStart: 2,
+      lineEnd: 4,
+      exact: false,
+    });
+  });
+
+  test('selection spanning two separate edit regions covers both plus the gap', () => {
+    const pristine = 'a\nb\nc\nd\ne\n';
+    const edited = 'a\nB\nc\nD\ne\n'; // lines 2 and 4 modified, line 3 untouched
+    expect(mapEditedRangeToPristine(pristine, edited, 2, 4)).toEqual({
+      lineStart: 2,
+      lineEnd: 4,
+      exact: false,
+    });
+  });
+
+  test('a deletion strictly inside the selection widens the range and is not exact', () => {
+    const pristine = 'a\nb\nc\nd\ne\n';
+    const edited = 'a\nb\nd\ne\n'; // c deleted
+    // Highlighting edited b and d straddles the deleted pristine c.
+    expect(mapEditedRangeToPristine(pristine, edited, 2, 3)).toEqual({
+      lineStart: 2,
+      lineEnd: 4,
+      exact: false,
+    });
+  });
+
+  test('a deletion adjacent to (but outside) the selection stays exact', () => {
+    const pristine = 'a\nb\nc\nd\ne\n';
+    const edited = 'a\nb\nd\ne\n'; // c deleted
+    // Selection starts AT the line after the deletion: nothing removed inside.
+    expect(mapEditedRangeToPristine(pristine, edited, 3, 4)).toEqual({
+      lineStart: 4,
+      lineEnd: 5,
+      exact: true,
+    });
+  });
+
+  test('whole-file replacement anchors to the whole pristine file', () => {
+    const pristine = 'a\nb\n';
+    const edited = 'x\ny\nz\n';
+    expect(mapEditedRangeToPristine(pristine, edited, 1, 3)).toEqual({
+      lineStart: 1,
+      lineEnd: 2,
+      exact: false,
+    });
+  });
+
+  test('empty pristine content falls back to line 1, not exact', () => {
+    expect(mapEditedRangeToPristine('', 'x\ny\n', 1, 2)).toEqual({
+      lineStart: 1,
+      lineEnd: 1,
+      exact: false,
+    });
+  });
+
+  test('CRLF pristine against LF edited content still maps exactly', () => {
+    const pristine = 'a\r\nb\r\nc\r\n';
+    const edited = 'a\nb\nc\n';
+    expect(mapEditedRangeToPristine(pristine, edited, 2, 2)).toEqual({
+      lineStart: 2,
+      lineEnd: 2,
+      exact: true,
+    });
+  });
+
+  test('out-of-range selection lines clamp into the file', () => {
+    const content = 'a\nb\nc\n';
+    expect(mapEditedRangeToPristine(content, content, 2, 99)).toEqual({
+      lineStart: 2,
+      lineEnd: 3,
+      exact: true,
+    });
+    expect(mapEditedRangeToPristine(content, content, -5, 0)).toEqual({
+      lineStart: 1,
+      lineEnd: 1,
+      exact: true,
+    });
+  });
+
+  test('reversed input range is normalized', () => {
+    const content = 'a\nb\nc\nd\n';
+    expect(mapEditedRangeToPristine(content, content, 3, 2)).toEqual({
+      lineStart: 2,
+      lineEnd: 3,
+      exact: true,
+    });
+  });
+});
+
+describe('selectionToLineRange', () => {
+  test('converts zero-based positions to a 1-based inclusive range', () => {
+    expect(
+      selectionToLineRange({ start: { line: 2, character: 4 }, end: { line: 4, character: 7 } }),
+    ).toEqual({ lineStart: 3, lineEnd: 5 });
+  });
+
+  test('a selection ending at character 0 does not include that line', () => {
+    expect(
+      selectionToLineRange({ start: { line: 2, character: 0 }, end: { line: 4, character: 0 } }),
+    ).toEqual({ lineStart: 3, lineEnd: 4 });
+  });
+
+  test('a single-line selection ending at character 0 keeps its line', () => {
+    expect(
+      selectionToLineRange({ start: { line: 3, character: 0 }, end: { line: 3, character: 0 } }),
+    ).toEqual({ lineStart: 4, lineEnd: 4 });
+  });
+
+  test('reversed positions are normalized', () => {
+    expect(
+      selectionToLineRange({ start: { line: 5, character: 2 }, end: { line: 1, character: 3 } }),
+    ).toEqual({ lineStart: 2, lineEnd: 6 });
+  });
+});

--- a/packages/review-editor/edit/selectionAnchor.ts
+++ b/packages/review-editor/edit/selectionAnchor.ts
@@ -1,0 +1,217 @@
+import { diffLines } from 'diff';
+
+/**
+ * Anchor mapping for "Make annotation" selections made INSIDE an edit session.
+ *
+ * The selection lives in the EDITED buffer, but annotations anchor to the
+ * rendered diff's new-side line numbers — which are the session's PRE-EDIT
+ * content (the pristine FileDiffMetadata restored when the session ends).
+ * Pre-edit coordinates are session-invariant: the pristine content never
+ * changes while the session runs, so an anchor mapped at click time stays
+ * correct after the session completes OR is discarded, no matter what the
+ * user edits afterwards.
+ *
+ * Mapping rules (computed from diffLines(preEdit, edited) at click time):
+ * - Lines in UNEDITED regions map 1:1 (edits above only shift the offset,
+ *   which the diff walk accounts for). This is the common case — a reviewer
+ *   highlighting existing code — and it maps exactly (`exact: true`).
+ * - Lines in EDITED regions map to the pristine lines that region replaces
+ *   (the removed side of the modification). The annotation is still created,
+ *   but flagged `exact: false` so the caller can record the highlighted text
+ *   and label the anchor as approximate.
+ * - Lines in PURE-INSERT regions (no pristine lines replaced) anchor to the
+ *   adjacent pristine line, preferring the preceding one — the same anchor
+ *   preference deriveSuggestionHunks uses. Also `exact: false`.
+ * - A selection whose covering range straddles a pure DELETION (kept lines
+ *   highlighted on both sides of removed pristine lines) includes the removed
+ *   lines in its covering range and is flagged `exact: false` — the range is
+ *   honest but wider than what was highlighted.
+ * - Results are clamped to [1, pristine line count]; an empty pristine file
+ *   anchors to line 1 with `exact: false`.
+ */
+export interface PristineAnchor {
+  /** 1-based first pristine (pre-edit, new-side) line of the anchor. */
+  lineStart: number;
+  /** 1-based last pristine line of the anchor (inclusive). */
+  lineEnd: number;
+  /** True when every highlighted line lies in an unedited region and the
+   * covering range contains no in-session changes. */
+  exact: boolean;
+}
+
+function normalize(content: string): string {
+  return content.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+function countLines(content: string): number {
+  if (content === '') return 0;
+  const lines = content.split('\n');
+  if (lines[lines.length - 1] === '') lines.pop();
+  return lines.length;
+}
+
+interface SameSegment {
+  kind: 'same';
+  editStart: number;
+  editEnd: number;
+  /** Pristine line corresponding to editStart. */
+  origStart: number;
+}
+
+interface ChangedSegment {
+  kind: 'changed';
+  /** Edited lines this region occupies (empty for pure deletions: editEnd < editStart). */
+  editStart: number;
+  editEnd: number;
+  /** Pristine lines this region replaces (empty for pure inserts: origEnd < origStart). */
+  origStart: number;
+  origEnd: number;
+}
+
+type Segment = SameSegment | ChangedSegment;
+
+/** Group the diffLines parts into alternating same/changed segments with both
+ * coordinate spaces attached. Consecutive removed+added parts fold into one
+ * changed segment regardless of emission order. */
+function buildSegments(original: string, edited: string): Segment[] {
+  const parts = diffLines(original, edited);
+  const segments: Segment[] = [];
+  let origLine = 1;
+  let editLine = 1;
+  let pending: ChangedSegment | null = null;
+
+  const flush = () => {
+    if (pending) {
+      segments.push(pending);
+      pending = null;
+    }
+  };
+
+  for (const part of parts) {
+    const n = countLines(part.value);
+    if (n === 0) continue;
+    if (part.added) {
+      pending ??= {
+        kind: 'changed',
+        editStart: editLine,
+        editEnd: editLine - 1,
+        origStart: origLine,
+        origEnd: origLine - 1,
+      };
+      pending.editEnd = editLine + n - 1;
+      editLine += n;
+    } else if (part.removed) {
+      pending ??= {
+        kind: 'changed',
+        editStart: editLine,
+        editEnd: editLine - 1,
+        origStart: origLine,
+        origEnd: origLine - 1,
+      };
+      pending.origEnd = origLine + n - 1;
+      origLine += n;
+    } else {
+      flush();
+      segments.push({ kind: 'same', editStart: editLine, editEnd: editLine + n - 1, origStart: origLine });
+      origLine += n;
+      editLine += n;
+    }
+  }
+  flush();
+  return segments;
+}
+
+/**
+ * Map a 1-based inclusive line range of the EDITED buffer to the pristine
+ * (pre-edit) new-side coordinates the annotation system anchors to.
+ */
+export function mapEditedRangeToPristine(
+  preEditContent: string,
+  editedContent: string,
+  editedLineStart: number,
+  editedLineEnd: number,
+): PristineAnchor {
+  const original = normalize(preEditContent);
+  const edited = normalize(editedContent);
+  const origCount = countLines(original);
+  const editCount = countLines(edited);
+
+  if (origCount === 0) return { lineStart: 1, lineEnd: 1, exact: false };
+
+  const clamp = (line: number) => Math.min(Math.max(line, 1), origCount);
+  let s = Math.max(1, Math.min(editedLineStart, editedLineEnd));
+  let e = Math.min(Math.max(editedLineStart, editedLineEnd), Math.max(editCount, 1));
+  if (s > e) s = e;
+
+  if (original === edited) {
+    return { lineStart: clamp(s), lineEnd: clamp(e), exact: true };
+  }
+
+  const segments = buildSegments(original, edited);
+  let minLine = Number.POSITIVE_INFINITY;
+  let maxLine = Number.NEGATIVE_INFINITY;
+  let exact = true;
+  const extend = (a: number, b: number) => {
+    minLine = Math.min(minLine, a);
+    maxLine = Math.max(maxLine, b);
+  };
+
+  for (const seg of segments) {
+    if (seg.kind === 'same') {
+      const from = Math.max(s, seg.editStart);
+      const to = Math.min(e, seg.editEnd);
+      if (from > to) continue;
+      extend(seg.origStart + (from - seg.editStart), seg.origStart + (to - seg.editStart));
+      continue;
+    }
+    const hasEditedLines = seg.editEnd >= seg.editStart;
+    const hasOrigLines = seg.origEnd >= seg.origStart;
+    if (hasEditedLines) {
+      if (seg.editStart > e || seg.editEnd < s) continue;
+      exact = false;
+      if (hasOrigLines) {
+        // Modification: anchor to the pristine lines the edit replaces.
+        extend(seg.origStart, seg.origEnd);
+      } else {
+        // Pure insert: anchor to the adjacent pristine line, preferring the
+        // preceding one (mirrors deriveSuggestionHunks' anchor preference).
+        const anchor = seg.origStart > 1 ? seg.origStart - 1 : clamp(seg.origStart);
+        extend(anchor, anchor);
+      }
+    } else if (hasOrigLines) {
+      // Pure deletion: occupies no edited lines. It sits strictly inside the
+      // selection only when highlighted lines exist on BOTH sides — i.e. the
+      // selection starts before the deletion point and ends at or after it.
+      if (s < seg.editStart && e >= seg.editStart) {
+        exact = false;
+        extend(seg.origStart, seg.origEnd);
+      }
+    }
+  }
+
+  if (!Number.isFinite(minLine)) {
+    // Selection matched no segment (degenerate input): clamp into the file.
+    return { lineStart: clamp(s), lineEnd: clamp(e), exact: false };
+  }
+  return { lineStart: clamp(minLine), lineEnd: clamp(maxLine), exact };
+}
+
+/**
+ * Convert an editor selection (zero-based Positions, exclusive-feeling end:
+ * a selection ending at character 0 of a line does not include that line)
+ * into a 1-based inclusive line range. Mirrors the line-range treatment in
+ * Pierre's own selection-action demo.
+ */
+export function selectionToLineRange(selection: {
+  start: { line: number; character: number };
+  end: { line: number; character: number };
+}): { lineStart: number; lineEnd: number } {
+  const endLine =
+    selection.end.character === 0 && selection.end.line > selection.start.line
+      ? selection.end.line - 1
+      : selection.end.line;
+  return {
+    lineStart: Math.min(selection.start.line, endLine) + 1,
+    lineEnd: Math.max(selection.start.line, endLine) + 1,
+  };
+}

--- a/packages/review-editor/edit/useEditSession.recovery.test.tsx
+++ b/packages/review-editor/edit/useEditSession.recovery.test.tsx
@@ -1,0 +1,266 @@
+/**
+ * Dirty-session recovery on file-set change.
+ *
+ * `fileSetKey` changes on more than diff switches — sort-order and
+ * collapse-default flips remount the CodeView too — and Pierre tears the
+ * editor down without a completion callback on remount. A dirty session must
+ * never be silently discarded there: the controller recovers the last-known
+ * document contents and prompts to keep them as suggestions (the same
+ * pattern as the dirty file-switch prompt in startEdit).
+ *
+ * The pure recovery helper is tested without DOM; the full hook flow
+ * (startEdit -> change -> fileSetKey change -> prompt -> suggestion sink) is
+ * DOM-gated (DOM_TESTS=1) and registered in .github/workflows/test.yml's
+ * "Run UI seam-contract + DOM tests" step.
+ */
+import { afterEach, describe, expect, test } from 'bun:test';
+import React, { useRef } from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { CodeViewHandle } from '@pierre/diffs/react';
+import type { CodeViewItem, FileDiffMetadata } from '@pierre/diffs';
+import type { DiffAnnotationMetadata } from '@plannotator/ui/types';
+import type { DiffFile } from '../types';
+import { recoverDirtySessionHunks, useEditSession, type EditSessionApi } from './useEditSession';
+import type { SuggestionHunk } from './deriveSuggestions';
+
+const hasDom = typeof document !== 'undefined';
+
+describe('recoverDirtySessionHunks', () => {
+  test('derives hunks from the last observed contents', () => {
+    const hunks = recoverDirtySessionHunks({
+      preEditContent: 'one\ntwo\nthree\n',
+      latestContents: { contents: 'one\nTWO\nthree\n' },
+    });
+    expect(hunks).toEqual([
+      { lineStart: 2, lineEnd: 2, originalCode: 'two', suggestedCode: 'TWO' },
+    ]);
+  });
+
+  test('reads contents lazily at recovery time (live getter)', () => {
+    let text = 'one\n';
+    const live = {
+      get contents() {
+        return text;
+      },
+    };
+    const session = { preEditContent: 'one\n', latestContents: live };
+    text = 'one\nnew line\n';
+    const hunks = recoverDirtySessionHunks(session);
+    expect(hunks).toHaveLength(1);
+    expect(hunks[0].suggestedCode).toBe('one\nnew line');
+  });
+
+  test('returns [] when nothing was captured', () => {
+    expect(recoverDirtySessionHunks({ preEditContent: 'one\n', latestContents: null })).toEqual([]);
+  });
+
+  test('returns [] when the document can no longer be read', () => {
+    const broken = {
+      get contents(): string {
+        throw new Error('document disposed');
+      },
+    };
+    expect(
+      recoverDirtySessionHunks({ preEditContent: 'one\n', latestContents: broken }),
+    ).toEqual([]);
+  });
+
+  test('returns [] when the edits net out to no change', () => {
+    expect(
+      recoverDirtySessionHunks({
+        preEditContent: 'one\ntwo\n',
+        latestContents: { contents: 'one\ntwo\n' },
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe.if(hasDom)('useEditSession file-set change with a dirty session (DOM)', () => {
+  const PRE_EDIT = 'line one\nline two\nline three\n';
+
+  let host: HTMLDivElement | null = null;
+  let root: Root | null = null;
+  // The describe body runs (for registration) even when the suite is skipped,
+  // so window may only be touched behind the hasDom guard.
+  const realConfirm = hasDom ? window.confirm : undefined;
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => root!.unmount());
+      root = null;
+    }
+    host?.remove();
+    host = null;
+    if (hasDom && realConfirm) window.confirm = realConfirm;
+  });
+
+  interface Harness {
+    api: EditSessionApi;
+    item: CodeViewItem<DiffAnnotationMetadata>;
+    fileSetKeyRef: { current: string };
+    added: Array<{ filePath: string; hunks: SuggestionHunk[] }>;
+  }
+
+  async function mountHarness(): Promise<Harness> {
+    const fileDiff = {
+      name: 'src/calc.ts',
+      isPartial: false,
+      additionLines: PRE_EDIT.split(/(?<=\n)/),
+      hunks: [],
+    } as unknown as FileDiffMetadata;
+    const item = {
+      id: 'item-1',
+      type: 'diff',
+      fileDiff,
+      version: 0,
+    } as unknown as CodeViewItem<DiffAnnotationMetadata>;
+    const handle = {
+      getItem: (id: string) => (id === item.id ? item : undefined),
+      updateItem: () => {},
+    } as unknown as CodeViewHandle<DiffAnnotationMetadata>;
+    const file: DiffFile = {
+      path: 'src/calc.ts',
+      status: 'modified',
+      additions: 1,
+      deletions: 1,
+      patch: '@@ -1 +1 @@\n-a\n+b\n',
+    } as DiffFile;
+
+    const added: Array<{ filePath: string; hunks: SuggestionHunk[] }> = [];
+    const fileSetKeyRef = { current: 'gen-1' };
+    let api: EditSessionApi | null = null;
+
+    function HookHost() {
+      const viewerRef = useRef<CodeViewHandle<DiffAnnotationMetadata> | null>(handle);
+      const itemIdToFileRef = useRef(new Map([[item.id, file]]));
+      const reviewBaseRef = useRef<string | undefined>(undefined);
+      const reviewSnapshotIdRef = useRef<string | undefined>(undefined);
+      const annotationsRef = useRef([]);
+      api = useEditSession({
+        enabled: true,
+        viewerRef,
+        itemIdToFileRef,
+        fileSetKeyRef,
+        reviewBaseRef,
+        reviewSnapshotIdRef,
+        annotationsRef,
+        onAddSuggestions: (filePath, hunks) => added.push({ filePath, hunks }),
+        refreshItem: () => {},
+      });
+      return null;
+    }
+
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    await act(async () => {
+      root!.render(<HookHost />);
+    });
+
+    // startEdit loads the (real) editor chunk before flipping edit on.
+    await act(async () => {
+      api!.startEdit(item.id);
+    });
+    for (let i = 0; i < 20 && api!.editingItemIdRef.current !== item.id; i++) {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      });
+    }
+    expect(api!.editingItemIdRef.current).toBe(item.id);
+    return { api: api!, item, fileSetKeyRef, added };
+  }
+
+  test('dirty session prompts and keeps recovered edits as suggestions on confirm', async () => {
+    const { api, item, fileSetKeyRef, added } = await mountHarness();
+    const prompts: string[] = [];
+    window.confirm = (message?: string) => {
+      prompts.push(message ?? '');
+      return true;
+    };
+
+    await act(async () => {
+      api.onItemEditChange(item, { contents: 'line one\nline 2 edited\nline three\n' });
+    });
+    fileSetKeyRef.current = 'gen-2'; // sort-order flip, diff switch, etc.
+    await act(async () => {
+      api.handleFileSetChange();
+    });
+
+    expect(prompts).toHaveLength(1);
+    expect(prompts[0]).toContain('src/calc.ts');
+    expect(added).toEqual([
+      {
+        filePath: 'src/calc.ts',
+        hunks: [
+          {
+            lineStart: 2,
+            lineEnd: 2,
+            originalCode: 'line two',
+            suggestedCode: 'line 2 edited',
+          },
+        ],
+      },
+    ]);
+    expect(api.editingItemIdRef.current).toBeNull();
+  });
+
+  test('dirty session discards on decline, but only after asking', async () => {
+    const { api, item, fileSetKeyRef, added } = await mountHarness();
+    let prompted = 0;
+    window.confirm = () => {
+      prompted++;
+      return false;
+    };
+
+    await act(async () => {
+      api.onItemEditChange(item, { contents: 'changed\n' });
+    });
+    fileSetKeyRef.current = 'gen-2';
+    await act(async () => {
+      api.handleFileSetChange();
+    });
+
+    expect(prompted).toBe(1);
+    expect(added).toEqual([]);
+    expect(api.editingItemIdRef.current).toBeNull();
+  });
+
+  test('clean session drops silently without prompting', async () => {
+    const { api, fileSetKeyRef, added } = await mountHarness();
+    let prompted = 0;
+    window.confirm = () => {
+      prompted++;
+      return true;
+    };
+
+    fileSetKeyRef.current = 'gen-2';
+    await act(async () => {
+      api.handleFileSetChange();
+    });
+
+    expect(prompted).toBe(0);
+    expect(added).toEqual([]);
+    expect(api.editingItemIdRef.current).toBeNull();
+  });
+
+  test('dirty session whose edits net out to no change does not prompt', async () => {
+    const { api, item, fileSetKeyRef, added } = await mountHarness();
+    let prompted = 0;
+    window.confirm = () => {
+      prompted++;
+      return true;
+    };
+
+    await act(async () => {
+      api.onItemEditChange(item, { contents: PRE_EDIT });
+    });
+    fileSetKeyRef.current = 'gen-2';
+    await act(async () => {
+      api.handleFileSetChange();
+    });
+
+    expect(prompted).toBe(0);
+    expect(added).toEqual([]);
+  });
+});

--- a/packages/review-editor/edit/useEditSession.ts
+++ b/packages/review-editor/edit/useEditSession.ts
@@ -12,7 +12,6 @@ import { cloneFileDiff } from './cloneDiff';
 import { mapEditedRangeToPristine, selectionToLineRange } from './selectionAnchor';
 import { buildSelectionActionElement } from './selectionActionPopover';
 import {
-  buildEditorMarkers,
   createPierreEditor,
   loadPierreEdit,
   type PierreEditorInstance,
@@ -558,19 +557,11 @@ export function useEditSession(params: UseEditSessionParams): EditSessionApi {
     createPierreEditor(options),
   ) as unknown as CreateEditor<DiffAnnotationMetadata>;
 
-  /** Re-project the session file's annotations into editor markers. Called
-   * after an annotation is added mid-session so the new comment shows up
-   * inside the editor immediately. Best-effort chrome — never throws. */
-  const refreshMarkers = useStableCallback(() => {
-    const session = sessionRef.current;
-    const editor = session?.editor;
-    if (!session || !editor) return;
-    try {
-      editor.setMarkers(buildEditorMarkers(annotationsRef.current ?? [], session.filePath));
-    } catch {
-      // The document may not be initialized (or already torn down) — skip.
-    }
-  });
+  /** Marker projection is intentionally disabled: wavy underlines read as
+   * errors in every editor's visual language, which misrepresents comments.
+   * Annotations render in their normal slots below the code instead. Kept as
+   * a no-op so callers need no knowledge of the decision. */
+  const refreshMarkers = useStableCallback(() => {});
 
   /** Collapse the current editor selection to its end (post-submit cleanup;
    * see EditSessionApi.collapseSelection). Best-effort, never throws. */
@@ -647,25 +638,9 @@ export function useEditSession(params: UseEditSessionParams): EditSessionApi {
       onAttach: (editor: unknown) => {
         const session = sessionRef.current;
         if (!session) return;
-        // Stash the instance for mid-session marker refreshes (new comments).
+        // Stash the instance for selection collapse after annotation submit.
         session.editor = editor as PierreEditorInstance;
-        const markers = buildEditorMarkers(annotationsRef.current ?? [], session.filePath);
-        if (markers.length === 0) return;
-        // Markers are best-effort chrome; never let them break the session.
-        // setMarkers throws until the editor's text document is initialized,
-        // which can be after onAttach — retry across a few frames.
-        const itemId = session.itemId;
-        let attempts = 0;
-        const apply = () => {
-          if (sessionRef.current?.itemId !== itemId) return;
-          try {
-            (editor as PierreEditorInstance).setMarkers(markers);
-          } catch {
-            attempts += 1;
-            if (attempts < 10) requestAnimationFrame(apply);
-          }
-        };
-        requestAnimationFrame(apply);
+        // Annotation markers are intentionally not projected; see refreshMarkers.
       },
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/review-editor/edit/useEditSession.ts
+++ b/packages/review-editor/edit/useEditSession.ts
@@ -1,0 +1,431 @@
+import { useMemo, useRef, useState } from 'react';
+import type React from 'react';
+import { processFile } from '@pierre/diffs';
+import type { CodeViewItem, FileDiffMetadata } from '@pierre/diffs';
+import { useStableCallback } from '@pierre/diffs/react';
+import type { CodeViewHandle, CreateEditor } from '@pierre/diffs/react';
+import type { CodeAnnotation, DiffAnnotationMetadata } from '@plannotator/ui/types';
+import type { DiffFile } from '../types';
+import { isContentConsistentWithPatch } from '../utils/patchConsistency';
+import { deriveSuggestionHunks, type SuggestionHunk } from './deriveSuggestions';
+import { cloneFileDiff } from './cloneDiff';
+import {
+  buildEditorMarkers,
+  createPierreEditor,
+  loadPierreEdit,
+  type PierreEditorInstance,
+  type PierreEditorOptions,
+} from './pierreEditAdapter';
+
+/**
+ * Controller for the flag-gated "edit code to author a suggestion" session
+ * (one file at a time, plain all-files view only).
+ *
+ * Lifecycle contract with Pierre's CodeView (v1.3.1):
+ * - `item.edit = true` + version bump + updateItem starts a session (needs an
+ *   EditProvider factory above the CodeView; ours declines until the lazy
+ *   editor chunk has loaded).
+ * - The editor MUTATES `item.fileDiff` in place per keystroke. We deep-clone
+ *   the pristine metadata before starting and republish it when the session
+ *   ends, so the diff view always returns to the exact pre-edit state.
+ * - `onItemEditComplete` fires once per session WITH changes (never for a
+ *   zero-change session, never on unmount teardown). Suggestion derivation
+ *   happens there; the pristine restore is scheduled by whichever path ended
+ *   the session so it also covers the zero-change case.
+ * - `persistState` is deliberately unused (upstream bug, open PR #1048).
+ *   Session state lives only while the editor is mounted.
+ */
+interface ActiveEditSession {
+  itemId: string;
+  filePath: string;
+  /** Deep clone of the pre-session FileDiffMetadata (the restore target). */
+  pristine: FileDiffMetadata;
+  /** Full new-side content the editor started from (suggestion diff base). */
+  preEditContent: string;
+  /** The fileSetKey generation the session belongs to. */
+  generation: string;
+  dirty: boolean;
+  /** Set by Cancel: the completion callback must not create suggestions. */
+  suppressSuggestions: boolean;
+  /** Set by our explicit complete/cancel paths (restore already scheduled). */
+  ending: boolean;
+  /** Monotonic per-session counter for fresh restore cacheKeys. */
+  seq: number;
+}
+
+interface UseEditSessionParams {
+  enabled: boolean;
+  viewerRef: React.RefObject<CodeViewHandle<DiffAnnotationMetadata> | null>;
+  itemIdToFileRef: React.RefObject<Map<string, DiffFile>>;
+  fileSetKeyRef: React.RefObject<string>;
+  reviewBaseRef: React.RefObject<string | undefined>;
+  reviewSnapshotIdRef: React.RefObject<string | undefined>;
+  annotationsRef: React.RefObject<CodeAnnotation[]>;
+  onAddSuggestions?: (filePath: string, hunks: SuggestionHunk[]) => void;
+  /** Republish one item's slots (version bump + updateItem). */
+  refreshItem: (itemId: string) => void;
+}
+
+export interface EditSessionApi {
+  /** Item id currently in an edit session, or null. */
+  editingItemId: string | null;
+  /**
+   * Mirror ref for stable callbacks and slot-portal renders. Pierre's header
+   * slots republish synchronously inside updateItem — BEFORE React commits
+   * the state update — so anything rendered into a slot must read this ref,
+   * never the state value.
+   */
+  editingItemIdRef: React.RefObject<string | null>;
+  /** filePath -> human-readable reason the edit button is disabled. Ref for
+   * the same slot-portal ordering reason as editingItemIdRef. */
+  editUnavailableRef: React.RefObject<Map<string, string>>;
+  /** Enter edit mode on an item (ends any current session first, prompting if dirty). */
+  startEdit: (itemId: string) => void;
+  /** Finish the session; changes become suggestion annotations. */
+  completeEdit: () => void;
+  /** Discard the session; no annotations, pristine diff restored. */
+  cancelEdit: () => void;
+  /** If this item is being edited, finish the session first (collapse paths). */
+  finishIfEditing: (itemId: string) => void;
+  /** Called by the fileSetKey reset effect: the old items are gone. */
+  handleFileSetChange: () => void;
+  /** CodeView prop: fires per document change while a session is active. */
+  onItemEditChange: (item: CodeViewItem<DiffAnnotationMetadata>) => void;
+  /** CodeView prop: fires once when a session with changes ends. */
+  onItemEditComplete: (
+    item: CodeViewItem<DiffAnnotationMetadata>,
+    file: { contents: string },
+  ) => void;
+  /** EditProvider factory. Returns undefined until the lazy editor chunk has
+   * loaded — CodeView's documented decline-and-retry contract, which
+   * upstream's React `CreateEditor` type does not yet model (hence the cast
+   * where this is produced). */
+  createEditor: CreateEditor<DiffAnnotationMetadata>;
+  /** Editor construction options (markers wired via onAttach). Structural
+   * subset of Pierre's EditorOptions so the generic variance stays out of
+   * app code. */
+  editorOptions: EditSessionEditorOptions;
+}
+
+export interface EditSessionEditorOptions {
+  enabledSelectionAction: boolean;
+  onAttach: (editor: unknown) => void;
+}
+
+export function useEditSession(params: UseEditSessionParams): EditSessionApi {
+  const {
+    enabled,
+    viewerRef,
+    itemIdToFileRef,
+    fileSetKeyRef,
+    reviewBaseRef,
+    reviewSnapshotIdRef,
+    annotationsRef,
+    onAddSuggestions,
+    refreshItem,
+  } = params;
+
+  const [editingItemId, setEditingItemId] = useState<string | null>(null);
+  const editingItemIdRef = useRef<string | null>(null);
+  const editUnavailableRef = useRef<Map<string, string>>(new Map());
+  const sessionRef = useRef<ActiveEditSession | null>(null);
+  const onAddSuggestionsRef = useRef(onAddSuggestions);
+  onAddSuggestionsRef.current = onAddSuggestions;
+
+  const setEditing = (itemId: string | null) => {
+    // Ref first: header slots republish synchronously on the very next
+    // updateItem, before React commits the state update.
+    editingItemIdRef.current = itemId;
+    setEditingItemId(itemId);
+  };
+
+  const markUnavailable = (filePath: string, reason: string) => {
+    editUnavailableRef.current.set(filePath, reason);
+  };
+
+  /** The pristine write applied to an item when its session ends: restored
+   * fileDiff with a FRESH cacheKey (contents changed back; a reused key would
+   * serve the edited session's highlight cache for the pristine lines). */
+  const writeRestore = useStableCallback((session: ActiveEditSession) => {
+    // Only touch the item if the diff generation it belongs to is still on
+    // screen — after a diff switch the remounted items are already pristine.
+    if (fileSetKeyRef.current !== session.generation) return;
+    const handle = viewerRef.current;
+    const item = handle?.getItem(session.itemId);
+    if (handle == null || item == null || item.type !== 'diff') return;
+    const restored = session.pristine;
+    session.seq += 1;
+    restored.cacheKey = `${session.generation}::${session.itemId}#edit-restore${session.seq}`;
+    item.fileDiff = restored;
+    item.edit = false;
+    item.version = (item.version ?? 0) + 1;
+    handle.updateItem(item);
+  });
+
+  /** End the current session. `suppress` skips suggestion creation (Cancel).
+   *
+   * Upstream's documented commit pattern is ONE combined item write: edit off
+   * AND the final fileDiff (fresh cacheKey) in the same updateItem. A
+   * two-step write (edit off first, restore later) races CodeView's own
+   * session-teardown re-render — on large files the teardown render lands
+   * after the deferred restore and leaves the edited content on screen. The
+   * completion callback still fires from this write with the session's final
+   * contents, which is all the suggestion derivation needs. */
+  const endSession = useStableCallback((suppress: boolean) => {
+    const session = sessionRef.current;
+    if (!session) return;
+    session.suppressSuggestions = suppress;
+    session.ending = true;
+    // The write republishes the header slot synchronously, so the editing ref
+    // must already read idle; sessionRef must still point at this session
+    // because onItemEditComplete fires from inside the write.
+    editingItemIdRef.current = null;
+    writeRestore(session);
+    sessionRef.current = null;
+    setEditingItemId(null);
+  });
+
+  const completeEdit = useStableCallback(() => endSession(false));
+  const cancelEdit = useStableCallback(() => endSession(true));
+
+  const finishIfEditing = useStableCallback((itemId: string) => {
+    if (sessionRef.current?.itemId === itemId) endSession(false);
+  });
+
+  const handleFileSetChange = useStableCallback(() => {
+    // The CodeView holding the session remounted (diff switch / refresh). The
+    // old items are unreachable; Pierre tore the editor down without a
+    // completion callback. Drop the session — in-progress edits are discarded
+    // (documented v1 behavior; refresh is always user-initiated).
+    if (sessionRef.current) {
+      sessionRef.current = null;
+      setEditing(null);
+    }
+    // A fresh diff may make previously-unavailable files editable again.
+    editUnavailableRef.current.clear();
+  });
+
+  /** Ensure the item carries a full-content (non-partial) FileDiffMetadata.
+   * Pierre's applyDocumentChange THROWS on partial diffs, so this is a hard
+   * precondition for starting a session. */
+  const ensureFullContent = useStableCallback(
+    async (itemId: string, file: DiffFile): Promise<{ ok: true } | { ok: false; reason: string }> => {
+      const handle = viewerRef.current;
+      const item = handle?.getItem(itemId);
+      if (handle == null || item == null || item.type !== 'diff') {
+        return { ok: false, reason: 'File is not available' };
+      }
+      if (item.fileDiff.isPartial !== true) return { ok: true };
+
+      const generation = fileSetKeyRef.current;
+      const params = new URLSearchParams({ path: file.path });
+      if (file.oldPath) params.set('oldPath', file.oldPath);
+      const base = reviewBaseRef.current;
+      if (base) params.set('base', base);
+      const snapshot = reviewSnapshotIdRef.current;
+      if (snapshot) params.set('snapshot', snapshot);
+
+      let data: { oldContent: string | null; newContent: string | null } | null = null;
+      try {
+        const res = await fetch(`/api/file-content?${params}`);
+        data = res.ok ? await res.json() : null;
+      } catch {
+        data = null;
+      }
+      if (fileSetKeyRef.current !== generation) return { ok: false, reason: 'Diff changed' };
+      if (!data || data.newContent == null) {
+        return { ok: false, reason: 'Full file content unavailable' };
+      }
+      if (!isContentConsistentWithPatch(file.patch, data.oldContent, data.newContent)) {
+        return { ok: false, reason: 'File changed since the diff was captured' };
+      }
+
+      let augmented: FileDiffMetadata | null = null;
+      try {
+        const result = processFile(file.patch, {
+          oldFile:
+            data.oldContent != null
+              ? { name: file.oldPath || file.path, contents: data.oldContent }
+              : undefined,
+          newFile: { name: file.path, contents: data.newContent },
+        });
+        if (result && !result.isPartial) augmented = result;
+      } catch {
+        augmented = null;
+      }
+      if (!augmented) return { ok: false, reason: 'Full file content unavailable' };
+
+      const liveHandle = viewerRef.current;
+      const liveItem = liveHandle?.getItem(itemId);
+      if (liveHandle == null || liveItem == null || liveItem.type !== 'diff') {
+        return { ok: false, reason: 'File is not available' };
+      }
+      augmented.cacheKey = `${generation}::${itemId}#edit-full`;
+      liveItem.fileDiff = augmented;
+      liveItem.version = (liveItem.version ?? 0) + 1;
+      liveHandle.updateItem(liveItem);
+      return { ok: true };
+    },
+  );
+
+  const startEdit = useStableCallback((itemId: string) => {
+    if (!enabled) return;
+    const current = sessionRef.current;
+    if (current?.itemId === itemId) return;
+    if (current) {
+      if (current.dirty) {
+        const proceed = window.confirm(
+          `Finish editing ${current.filePath} first? Your changes there will become suggestions.`,
+        );
+        if (!proceed) return;
+        endSession(false);
+      } else {
+        endSession(true);
+      }
+    }
+
+    const file = itemIdToFileRef.current.get(itemId);
+    if (!file) return;
+    if (file.status === 'deleted') {
+      markUnavailable(file.path, 'Deleted files have no content to edit');
+      refreshItem(itemId);
+      return;
+    }
+
+    const generation = fileSetKeyRef.current;
+    void (async () => {
+      try {
+        await loadPierreEdit();
+      } catch {
+        markUnavailable(file.path, 'Editor failed to load');
+        refreshItem(itemId);
+        return;
+      }
+      const hydrated = await ensureFullContent(itemId, file);
+      if (fileSetKeyRef.current !== generation) return;
+      if (!hydrated.ok) {
+        markUnavailable(file.path, hydrated.reason);
+        refreshItem(itemId);
+        return;
+      }
+      // A session may have been started elsewhere while we were loading.
+      if (sessionRef.current) return;
+      const handle = viewerRef.current;
+      const item = handle?.getItem(itemId);
+      if (handle == null || item == null || item.type !== 'diff') return;
+
+      let pristine: FileDiffMetadata;
+      try {
+        pristine = cloneFileDiff(item.fileDiff);
+      } catch {
+        markUnavailable(file.path, 'This diff cannot be edited');
+        refreshItem(itemId);
+        return;
+      }
+
+      sessionRef.current = {
+        itemId,
+        filePath: file.path,
+        pristine,
+        // The editor document is additionLines joined verbatim (they carry
+        // their own line breaks) — this is the derivation baseline.
+        preEditContent: (item.fileDiff.additionLines ?? []).join(''),
+        generation,
+        dirty: false,
+        suppressSuggestions: false,
+        ending: false,
+        seq: 0,
+      };
+      setEditing(itemId);
+      item.collapsed = false;
+      item.edit = true;
+      item.version = (item.version ?? 0) + 1;
+      handle.updateItem(item);
+    })();
+  });
+
+  const onItemEditChange = useStableCallback((item: CodeViewItem<DiffAnnotationMetadata>) => {
+    const session = sessionRef.current;
+    if (session && session.itemId === item.id) session.dirty = true;
+  });
+
+  const onItemEditComplete = useStableCallback(
+    (item: CodeViewItem<DiffAnnotationMetadata>, file: { contents: string }) => {
+      const session = sessionRef.current;
+      if (!session || session.itemId !== item.id) return;
+      if (!session.suppressSuggestions) {
+        // Copy immediately: `contents` is a live getter over the (already
+        // cleaned-up) session document.
+        const edited = String(file.contents);
+        const hunks = deriveSuggestionHunks(session.preEditContent, edited);
+        if (hunks.length > 0) onAddSuggestionsRef.current?.(session.filePath, hunks);
+      }
+      // External session end (a Pierre-initiated teardown we didn't route
+      // through endSession, e.g. an unrouted collapse): restore on a fresh
+      // task so we never re-enter the teardown's own updateItem, then clear
+      // the session.
+      if (!session.ending) {
+        session.ending = true;
+        sessionRef.current = null;
+        editingItemIdRef.current = null;
+        setEditingItemId(null);
+        setTimeout(() => writeRestore(session), 0);
+      }
+    },
+  );
+
+  // Cast rationale: our factory returns undefined before the lazy chunk has
+  // loaded. That is CodeView's documented "decline the attach; retry on later
+  // render passes" contract, but upstream's React `CreateEditor` type does
+  // not model the undefined return yet.
+  const createEditor = useStableCallback((options: PierreEditorOptions) =>
+    createPierreEditor(options),
+  ) as unknown as CreateEditor<DiffAnnotationMetadata>;
+
+  // Editor construction options. Markers surface the file's existing line
+  // annotations during the session; onAttach re-fires across virtualization
+  // re-attaches, which is exactly when markers need re-applying.
+  const editorOptions = useMemo<EditSessionEditorOptions>(
+    () => ({
+      enabledSelectionAction: false,
+      onAttach: (editor: unknown) => {
+        const session = sessionRef.current;
+        if (!session) return;
+        const markers = buildEditorMarkers(annotationsRef.current ?? [], session.filePath);
+        if (markers.length === 0) return;
+        // Markers are best-effort chrome; never let them break the session.
+        // setMarkers throws until the editor's text document is initialized,
+        // which can be after onAttach — retry across a few frames.
+        const itemId = session.itemId;
+        let attempts = 0;
+        const apply = () => {
+          if (sessionRef.current?.itemId !== itemId) return;
+          try {
+            (editor as PierreEditorInstance).setMarkers(markers);
+          } catch {
+            attempts += 1;
+            if (attempts < 10) requestAnimationFrame(apply);
+          }
+        };
+        requestAnimationFrame(apply);
+      },
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  return {
+    editingItemId,
+    editingItemIdRef,
+    editUnavailableRef,
+    startEdit,
+    completeEdit,
+    cancelEdit,
+    finishIfEditing,
+    handleFileSetChange,
+    onItemEditChange,
+    onItemEditComplete,
+    createEditor,
+    editorOptions,
+  };
+}

--- a/packages/review-editor/edit/useEditSession.ts
+++ b/packages/review-editor/edit/useEditSession.ts
@@ -23,8 +23,9 @@ import {
  *
  * Lifecycle contract with Pierre's CodeView (v1.3.1):
  * - `item.edit = true` + version bump + updateItem starts a session (needs an
- *   EditProvider factory above the CodeView; ours declines until the lazy
- *   editor chunk has loaded).
+ *   EditProvider factory above the CodeView; startEdit awaits the lazy editor
+ *   chunk BEFORE flipping edit on, because the React wrapper throws if the
+ *   factory returns undefined).
  * - The editor MUTATES `item.fileDiff` in place per keystroke. We deep-clone
  *   the pristine metadata before starting and republish it when the session
  *   ends, so the diff view always returns to the exact pre-edit state.
@@ -45,6 +46,11 @@ interface ActiveEditSession {
   /** The fileSetKey generation the session belongs to. */
   generation: string;
   dirty: boolean;
+  /** The FileContents delivered with the most recent change event. Its
+   * `contents` getter closes over the session's TextDocument (which stays
+   * readable after Pierre's editor cleanup), so a dirty session torn down by
+   * a CodeView remount can still recover its final text from here. */
+  latestContents: { contents: string } | null;
   /** Set by Cancel: the completion callback must not create suggestions. */
   suppressSuggestions: boolean;
   /** Set by our explicit complete/cancel paths (restore already scheduled). */
@@ -87,19 +93,25 @@ export interface EditSessionApi {
   cancelEdit: () => void;
   /** If this item is being edited, finish the session first (collapse paths). */
   finishIfEditing: (itemId: string) => void;
-  /** Called by the fileSetKey reset effect: the old items are gone. */
+  /** Called by the fileSetKey reset effect (post-commit, so prompting is
+   * safe): the old items are gone. A dirty session prompts to keep its edits
+   * as suggestions; a clean one is dropped silently. */
   handleFileSetChange: () => void;
   /** CodeView prop: fires per document change while a session is active. */
-  onItemEditChange: (item: CodeViewItem<DiffAnnotationMetadata>) => void;
+  onItemEditChange: (
+    item: CodeViewItem<DiffAnnotationMetadata>,
+    file?: { contents: string },
+  ) => void;
   /** CodeView prop: fires once when a session with changes ends. */
   onItemEditComplete: (
     item: CodeViewItem<DiffAnnotationMetadata>,
     file: { contents: string },
   ) => void;
   /** EditProvider factory. Returns undefined until the lazy editor chunk has
-   * loaded — CodeView's documented decline-and-retry contract, which
-   * upstream's React `CreateEditor` type does not yet model (hence the cast
-   * where this is produced). */
+   * loaded — a defensive guard the wired flow never hits (startEdit awaits
+   * the chunk before any item enters edit mode; the React wrapper would
+   * throw on an undefined return). Upstream's React `CreateEditor` type does
+   * not model the undefined return, hence the cast where this is produced. */
   createEditor: CreateEditor<DiffAnnotationMetadata>;
   /** Editor construction options (markers wired via onAttach). Structural
    * subset of Pierre's EditorOptions so the generic variance stays out of
@@ -110,6 +122,30 @@ export interface EditSessionApi {
 export interface EditSessionEditorOptions {
   enabledSelectionAction: boolean;
   onAttach: (editor: unknown) => void;
+}
+
+/**
+ * Derive the suggestions a torn-down dirty session would have produced from
+ * its last observed document contents. Pierre delivers a FileContents whose
+ * `contents` getter closes over the session's TextDocument on every change
+ * event; the document stays readable after editor cleanup, so the read is
+ * deliberately lazy — one string build at recovery time instead of one per
+ * keystroke. Returns [] when nothing was captured, the document can no
+ * longer be read, or the edits net out to no change.
+ */
+export function recoverDirtySessionHunks(session: {
+  preEditContent: string;
+  latestContents: { contents: string } | null;
+}): SuggestionHunk[] {
+  const latest = session.latestContents;
+  if (!latest) return [];
+  let edited: string;
+  try {
+    edited = String(latest.contents);
+  } catch {
+    return [];
+  }
+  return deriveSuggestionHunks(session.preEditContent, edited);
 }
 
 export function useEditSession(params: UseEditSessionParams): EditSessionApi {
@@ -193,13 +229,27 @@ export function useEditSession(params: UseEditSessionParams): EditSessionApi {
   });
 
   const handleFileSetChange = useStableCallback(() => {
-    // The CodeView holding the session remounted (diff switch / refresh). The
-    // old items are unreachable; Pierre tore the editor down without a
-    // completion callback. Drop the session — in-progress edits are discarded
-    // (documented v1 behavior; refresh is always user-initiated).
-    if (sessionRef.current) {
+    // The CodeView holding the session remounted (diff switch / refresh, or a
+    // sort-order / collapse-default change — fileSetKey covers all of them).
+    // The old items are unreachable and Pierre tore the editor down without a
+    // completion callback, so the session cannot continue. A clean session is
+    // dropped silently; a DIRTY session must never be silently discarded —
+    // recover its last-known contents and prompt (the same pattern as the
+    // dirty file-switch path in startEdit; this runs from a post-commit
+    // effect, so a synchronous confirm is safe here).
+    const session = sessionRef.current;
+    if (session) {
       sessionRef.current = null;
       setEditing(null);
+      if (session.dirty && !session.ending && !session.suppressSuggestions) {
+        const hunks = recoverDirtySessionHunks(session);
+        if (hunks.length > 0) {
+          const keep = window.confirm(
+            `The file view changed and ended your edit session on ${session.filePath}. Keep your changes there as suggestions?`,
+          );
+          if (keep) onAddSuggestionsRef.current?.(session.filePath, hunks);
+        }
+      }
     }
     // A fresh diff may make previously-unavailable files editable again.
     editUnavailableRef.current.clear();
@@ -332,6 +382,7 @@ export function useEditSession(params: UseEditSessionParams): EditSessionApi {
         preEditContent: (item.fileDiff.additionLines ?? []).join(''),
         generation,
         dirty: false,
+        latestContents: null,
         suppressSuggestions: false,
         ending: false,
         seq: 0,
@@ -344,10 +395,19 @@ export function useEditSession(params: UseEditSessionParams): EditSessionApi {
     })();
   });
 
-  const onItemEditChange = useStableCallback((item: CodeViewItem<DiffAnnotationMetadata>) => {
-    const session = sessionRef.current;
-    if (session && session.itemId === item.id) session.dirty = true;
-  });
+  const onItemEditChange = useStableCallback(
+    (item: CodeViewItem<DiffAnnotationMetadata>, file?: { contents: string }) => {
+      const session = sessionRef.current;
+      if (session && session.itemId === item.id) {
+        session.dirty = true;
+        // Keep the FileContents object, not a copy: its `contents` getter is
+        // lazy, so holding it costs nothing per keystroke and the document
+        // stays readable even after an unrouted teardown (see
+        // recoverDirtySessionHunks).
+        if (file) session.latestContents = file;
+      }
+    },
+  );
 
   const onItemEditComplete = useStableCallback(
     (item: CodeViewItem<DiffAnnotationMetadata>, file: { contents: string }) => {
@@ -375,16 +435,20 @@ export function useEditSession(params: UseEditSessionParams): EditSessionApi {
   );
 
   // Cast rationale: our factory returns undefined before the lazy chunk has
-  // loaded. That is CodeView's documented "decline the attach; retry on later
-  // render passes" contract, but upstream's React `CreateEditor` type does
-  // not model the undefined return yet.
+  // loaded — a guard the wired flow never hits (startEdit awaits the chunk
+  // before flipping edit on; the React wrapper throws on an undefined
+  // return). Upstream's React `CreateEditor` type does not model the
+  // undefined return, hence the cast.
   const createEditor = useStableCallback((options: PierreEditorOptions) =>
     createPierreEditor(options),
   ) as unknown as CreateEditor<DiffAnnotationMetadata>;
 
   // Editor construction options. Markers surface the file's existing line
-  // annotations during the session; onAttach re-fires across virtualization
-  // re-attaches, which is exactly when markers need re-applying.
+  // annotations during the session. Upstream delivers onAttach ONCE per
+  // editor (an attachState.delivered guard) — it does not re-fire across
+  // virtualization re-attaches — so this is a one-shot projection; the
+  // retry loop below only covers the text document initializing after the
+  // callback fires.
   const editorOptions = useMemo<EditSessionEditorOptions>(
     () => ({
       enabledSelectionAction: false,

--- a/packages/review-editor/edit/useEditSession.ts
+++ b/packages/review-editor/edit/useEditSession.ts
@@ -72,6 +72,19 @@ interface UseEditSessionParams {
   refreshItem: (itemId: string) => void;
 }
 
+/**
+ * External store for the active session's net change count (suggestion hunks
+ * the session would produce right now). The HUD lives inside Pierre's
+ * memoized header slot portal, which only republishes on updateItem — never
+ * on parent state changes — so the count is delivered as a subscribable the
+ * HUD reads via useSyncExternalStore, letting it re-render itself while the
+ * user types without touching the item.
+ */
+export interface EditSessionDirtyStore {
+  subscribe: (listener: () => void) => () => void;
+  getSnapshot: () => number;
+}
+
 export interface EditSessionApi {
   /** Item id currently in an edit session, or null. */
   editingItemId: string | null;
@@ -93,6 +106,8 @@ export interface EditSessionApi {
   cancelEdit: () => void;
   /** If this item is being edited, finish the session first (collapse paths). */
   finishIfEditing: (itemId: string) => void;
+  /** Net change count of the active session for the HUD (debounced). */
+  dirtyStore: EditSessionDirtyStore;
   /** Called by the fileSetKey reset effect (post-commit, so prompting is
    * safe): the old items are gone. A dirty session prompts to keep its edits
    * as suggestions; a clean one is dropped silently. */
@@ -168,6 +183,36 @@ export function useEditSession(params: UseEditSessionParams): EditSessionApi {
   const onAddSuggestionsRef = useRef(onAddSuggestions);
   onAddSuggestionsRef.current = onAddSuggestions;
 
+  // --- Dirty-count store (see EditSessionDirtyStore) ------------------------
+  const changeCountRef = useRef(0);
+  const changeListenersRef = useRef(new Set<() => void>());
+  const changeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const publishChangeCount = (count: number) => {
+    if (changeCountRef.current === count) return;
+    changeCountRef.current = count;
+    for (const listener of changeListenersRef.current) listener();
+  };
+
+  const resetChangeCount = () => {
+    if (changeTimerRef.current != null) {
+      clearTimeout(changeTimerRef.current);
+      changeTimerRef.current = null;
+    }
+    publishChangeCount(0);
+  };
+
+  const dirtyStore = useMemo<EditSessionDirtyStore>(
+    () => ({
+      subscribe: (listener) => {
+        changeListenersRef.current.add(listener);
+        return () => changeListenersRef.current.delete(listener);
+      },
+      getSnapshot: () => changeCountRef.current,
+    }),
+    [],
+  );
+
   const setEditing = (itemId: string | null) => {
     // Ref first: header slots republish synchronously on the very next
     // updateItem, before React commits the state update.
@@ -219,6 +264,7 @@ export function useEditSession(params: UseEditSessionParams): EditSessionApi {
     writeRestore(session);
     sessionRef.current = null;
     setEditingItemId(null);
+    resetChangeCount();
   });
 
   const completeEdit = useStableCallback(() => endSession(false));
@@ -241,6 +287,7 @@ export function useEditSession(params: UseEditSessionParams): EditSessionApi {
     if (session) {
       sessionRef.current = null;
       setEditing(null);
+      resetChangeCount();
       if (session.dirty && !session.ending && !session.suppressSuggestions) {
         const hunks = recoverDirtySessionHunks(session);
         if (hunks.length > 0) {
@@ -387,6 +434,7 @@ export function useEditSession(params: UseEditSessionParams): EditSessionApi {
         ending: false,
         seq: 0,
       };
+      resetChangeCount();
       setEditing(itemId);
       item.collapsed = false;
       item.edit = true;
@@ -405,6 +453,16 @@ export function useEditSession(params: UseEditSessionParams): EditSessionApi {
         // stays readable even after an unrouted teardown (see
         // recoverDirtySessionHunks).
         if (file) session.latestContents = file;
+        // Refresh the HUD's net change count on a short debounce: the count is
+        // a full-content line diff, so once per pause rather than per
+        // keystroke. Guarded against the session ending before the timer fires.
+        if (changeTimerRef.current != null) clearTimeout(changeTimerRef.current);
+        changeTimerRef.current = setTimeout(() => {
+          changeTimerRef.current = null;
+          const live = sessionRef.current;
+          if (!live || live.itemId !== item.id) return;
+          publishChangeCount(recoverDirtySessionHunks(live).length);
+        }, 250);
       }
     },
   );
@@ -429,6 +487,7 @@ export function useEditSession(params: UseEditSessionParams): EditSessionApi {
         sessionRef.current = null;
         editingItemIdRef.current = null;
         setEditingItemId(null);
+        resetChangeCount();
         setTimeout(() => writeRestore(session), 0);
       }
     },
@@ -482,6 +541,7 @@ export function useEditSession(params: UseEditSessionParams): EditSessionApi {
     editingItemId,
     editingItemIdRef,
     editUnavailableRef,
+    dirtyStore,
     startEdit,
     completeEdit,
     cancelEdit,

--- a/packages/review-editor/edit/useEditSession.ts
+++ b/packages/review-editor/edit/useEditSession.ts
@@ -9,12 +9,15 @@ import type { DiffFile } from '../types';
 import { isContentConsistentWithPatch } from '../utils/patchConsistency';
 import { deriveSuggestionHunks, type SuggestionHunk } from './deriveSuggestions';
 import { cloneFileDiff } from './cloneDiff';
+import { mapEditedRangeToPristine, selectionToLineRange } from './selectionAnchor';
+import { buildSelectionActionElement } from './selectionActionPopover';
 import {
   buildEditorMarkers,
   createPierreEditor,
   loadPierreEdit,
   type PierreEditorInstance,
   type PierreEditorOptions,
+  type PierreSelectionActionContext,
 } from './pierreEditAdapter';
 
 /**
@@ -57,6 +60,41 @@ interface ActiveEditSession {
   ending: boolean;
   /** Monotonic per-session counter for fresh restore cacheKeys. */
   seq: number;
+  /** The attached editor instance (marker refresh target), set by onAttach. */
+  editor: PierreEditorInstance | null;
+}
+
+/**
+ * A "Make annotation" request emitted from the edit-session Selection Action
+ * popover. Everything is snapshotted at click time: `lineStart`/`lineEnd` are
+ * PRISTINE (pre-edit, new-side) line numbers — the coordinates the rendered
+ * diff and the feedback export anchor to — mapped from the edited-buffer
+ * selection via `mapEditedRangeToPristine` (see selectionAnchor.ts for the
+ * anchoring rules). Pristine coordinates are session-invariant, so the anchor
+ * stays correct whether the session later completes or is discarded.
+ */
+export interface EditSelectionAnnotationRequest {
+  filePath: string;
+  /** 1-based pristine new-side line range the annotation anchors to. */
+  lineStart: number;
+  lineEnd: number;
+  /** False when the selection overlapped in-session edits (anchor maps to the
+   * pristine lines those edits replace — approximate, and labeled as such). */
+  exact: boolean;
+  /** The exact text highlighted in the editor when the request was made. */
+  selectedText: string;
+  /** Viewport rect of the popover action, for anchoring the comment entry. */
+  anchorRect: DOMRect;
+}
+
+/** The submitted comment for an EditSelectionAnnotationRequest: the request's
+ * snapshotted anchor plus the reviewer's comment text. */
+export interface EditSelectionComment {
+  lineStart: number;
+  lineEnd: number;
+  exact: boolean;
+  selectedText: string;
+  text: string;
 }
 
 interface UseEditSessionParams {
@@ -68,6 +106,10 @@ interface UseEditSessionParams {
   reviewSnapshotIdRef: React.RefObject<string | undefined>;
   annotationsRef: React.RefObject<CodeAnnotation[]>;
   onAddSuggestions?: (filePath: string, hunks: SuggestionHunk[]) => void;
+  /** Sink for "Make annotation" requests from the editor's Selection Action
+   * popover. When absent the popover renders no action (defensive; the wired
+   * flow always provides it). */
+  onSelectionAnnotation?: (request: EditSelectionAnnotationRequest) => void;
   /** Republish one item's slots (version bump + updateItem). */
   refreshItem: (itemId: string) => void;
 }
@@ -112,6 +154,15 @@ export interface EditSessionApi {
    * safe): the old items are gone. A dirty session prompts to keep its edits
    * as suggestions; a clean one is dropped silently. */
   handleFileSetChange: () => void;
+  /** Re-project the file's current annotations into editor markers so a
+   * comment created mid-session becomes visible inside the editor. No-op
+   * outside a session; markers are best-effort chrome (never throws). */
+  refreshMarkers: () => void;
+  /** Collapse the editor selection to its end. Called after the app-side
+   * comment entry submits: the editor keeps its selection while the entry is
+   * open (useful context), but once the annotation exists the still-ranged
+   * selection would re-open the Selection Action popover over it. */
+  collapseSelection: () => void;
   /** CodeView prop: fires per document change while a session is active. */
   onItemEditChange: (
     item: CodeViewItem<DiffAnnotationMetadata>,
@@ -136,6 +187,7 @@ export interface EditSessionApi {
 
 export interface EditSessionEditorOptions {
   enabledSelectionAction: boolean;
+  renderSelectionAction: (context: PierreSelectionActionContext) => HTMLElement;
   onAttach: (editor: unknown) => void;
 }
 
@@ -173,6 +225,7 @@ export function useEditSession(params: UseEditSessionParams): EditSessionApi {
     reviewSnapshotIdRef,
     annotationsRef,
     onAddSuggestions,
+    onSelectionAnnotation,
     refreshItem,
   } = params;
 
@@ -182,6 +235,8 @@ export function useEditSession(params: UseEditSessionParams): EditSessionApi {
   const sessionRef = useRef<ActiveEditSession | null>(null);
   const onAddSuggestionsRef = useRef(onAddSuggestions);
   onAddSuggestionsRef.current = onAddSuggestions;
+  const onSelectionAnnotationRef = useRef(onSelectionAnnotation);
+  onSelectionAnnotationRef.current = onSelectionAnnotation;
 
   // --- Dirty-count store (see EditSessionDirtyStore) ------------------------
   const changeCountRef = useRef(0);
@@ -433,6 +488,7 @@ export function useEditSession(params: UseEditSessionParams): EditSessionApi {
         suppressSuggestions: false,
         ending: false,
         seq: 0,
+        editor: null,
       };
       resetChangeCount();
       setEditing(itemId);
@@ -502,18 +558,97 @@ export function useEditSession(params: UseEditSessionParams): EditSessionApi {
     createPierreEditor(options),
   ) as unknown as CreateEditor<DiffAnnotationMetadata>;
 
+  /** Re-project the session file's annotations into editor markers. Called
+   * after an annotation is added mid-session so the new comment shows up
+   * inside the editor immediately. Best-effort chrome — never throws. */
+  const refreshMarkers = useStableCallback(() => {
+    const session = sessionRef.current;
+    const editor = session?.editor;
+    if (!session || !editor) return;
+    try {
+      editor.setMarkers(buildEditorMarkers(annotationsRef.current ?? [], session.filePath));
+    } catch {
+      // The document may not be initialized (or already torn down) — skip.
+    }
+  });
+
+  /** Collapse the current editor selection to its end (post-submit cleanup;
+   * see EditSessionApi.collapseSelection). Best-effort, never throws. */
+  const collapseSelection = useStableCallback(() => {
+    const editor = sessionRef.current?.editor;
+    if (!editor) return;
+    try {
+      const sel = editor.getState().selections?.at(-1);
+      if (!sel) return;
+      editor.setSelections([{ start: sel.end, end: sel.end, direction: 'none' }]);
+    } catch {
+      // Cosmetic cleanup only; the session must never break over it.
+    }
+  });
+
+  /** The Selection Action popover's "Make annotation" click. Everything is
+   * snapshotted synchronously — the popover is torn down as soon as the
+   * editor selection collapses (which focusing the app-side comment entry
+   * causes), so nothing here may defer reading the selection. */
+  const handleMakeAnnotation = useStableCallback(
+    (context: PierreSelectionActionContext, anchorRect: DOMRect) => {
+      const session = sessionRef.current;
+      const sink = onSelectionAnnotationRef.current;
+      if (!session || !sink) return;
+      let selectedText = '';
+      try {
+        selectedText = context.getSelectionText();
+      } catch {
+        // Fall through with empty text; the anchor range still stands.
+      }
+      // The text document is the authoritative edited content at click time
+      // (latestContents lags by one change-event dispatch at most, but the
+      // document read is direct and always current).
+      let edited: string;
+      try {
+        edited = context.textDocument.getText();
+      } catch {
+        try {
+          edited = session.latestContents ? String(session.latestContents.contents) : session.preEditContent;
+        } catch {
+          edited = session.preEditContent;
+        }
+      }
+      const { lineStart, lineEnd } = selectionToLineRange(context.selection);
+      const anchor = mapEditedRangeToPristine(session.preEditContent, edited, lineStart, lineEnd);
+      sink({
+        filePath: session.filePath,
+        lineStart: anchor.lineStart,
+        lineEnd: anchor.lineEnd,
+        exact: anchor.exact,
+        selectedText,
+        anchorRect,
+      });
+      try {
+        context.close();
+      } catch {
+        // Popover teardown is Pierre's job; a failure here is cosmetic.
+      }
+    },
+  );
+
   // Editor construction options. Markers surface the file's existing line
   // annotations during the session. Upstream delivers onAttach ONCE per
   // editor (an attachState.delivered guard) — it does not re-fire across
   // virtualization re-attaches — so this is a one-shot projection; the
   // retry loop below only covers the text document initializing after the
-  // callback fires.
+  // callback fires. The Selection Action popover (a plain DOM node rendered
+  // into the editor's shadow DOM) carries the "Make annotation" action.
   const editorOptions = useMemo<EditSessionEditorOptions>(
     () => ({
-      enabledSelectionAction: false,
+      enabledSelectionAction: true,
+      renderSelectionAction: (context: PierreSelectionActionContext) =>
+        buildSelectionActionElement((anchorRect) => handleMakeAnnotation(context, anchorRect)),
       onAttach: (editor: unknown) => {
         const session = sessionRef.current;
         if (!session) return;
+        // Stash the instance for mid-session marker refreshes (new comments).
+        session.editor = editor as PierreEditorInstance;
         const markers = buildEditorMarkers(annotationsRef.current ?? [], session.filePath);
         if (markers.length === 0) return;
         // Markers are best-effort chrome; never let them break the session.
@@ -547,6 +682,8 @@ export function useEditSession(params: UseEditSessionParams): EditSessionApi {
     cancelEdit,
     finishIfEditing,
     handleFileSetChange,
+    refreshMarkers,
+    collapseSelection,
     onItemEditChange,
     onItemEditComplete,
     createEditor,

--- a/packages/review-editor/index.css
+++ b/packages/review-editor/index.css
@@ -850,10 +850,10 @@ diffs-container {
   background: var(--code-bg);
 }
 
-/* GitHub-style suggestion block */
+/* GitHub-style suggestion block. The colored header is the sole identity
+   marker; no left accent bar on the card body. */
 .suggestion-block {
   border: 1px solid oklch(from var(--success) l c h / 0.3);
-  border-left: 3px solid var(--success);
   border-radius: var(--radius-sm);
   overflow: hidden;
 }
@@ -898,7 +898,6 @@ diffs-container {
 
 .light .suggestion-block {
   border-color: oklch(from var(--success) l c h / 0.3);
-  border-left-color: var(--success);
 }
 
 .light .suggestion-block-header {

--- a/packages/review-editor/utils/exportFeedback.test.ts
+++ b/packages/review-editor/utils/exportFeedback.test.ts
@@ -184,6 +184,56 @@ describe("exportReviewFeedback", () => {
     expect(result).toContain("const x = 1;");
   });
 
+  it("emits a Replaces block before Suggested code when originalCode is present", () => {
+    const result = exportReviewFeedback([
+      ann({ suggestedCode: "const x = 1;", originalCode: "let x = 1;" }),
+    ]);
+    const replaces = result.indexOf("**Replaces:**\n```\nlet x = 1;\n```");
+    const suggested = result.indexOf("**Suggested code:**\n```\nconst x = 1;\n```");
+    expect(replaces).toBeGreaterThan(-1);
+    expect(suggested).toBeGreaterThan(replaces);
+  });
+
+  it("pairs Replaces with the matching Suggested code per annotation", () => {
+    const result = exportReviewFeedback([
+      ann({ lineStart: 2, lineEnd: 2, suggestedCode: "two'", originalCode: "two" }),
+      ann({ lineStart: 8, lineEnd: 9, suggestedCode: "eight'\nnine'", originalCode: "eight\nnine" }),
+    ]);
+    expect(result).toContain(
+      "**Replaces:**\n```\ntwo\n```\n\n**Suggested code:**\n```\ntwo'\n```",
+    );
+    expect(result).toContain(
+      "**Replaces:**\n```\neight\nnine\n```\n\n**Suggested code:**\n```\neight'\nnine'\n```",
+    );
+  });
+
+  it("emits Replaces without Suggested code for a deletion-only suggestion", () => {
+    // The edit-session derivation for a fully-emptied file produces text +
+    // originalCode with no suggestedCode; the anchor must still export.
+    const result = exportReviewFeedback([
+      ann({ text: "Suggested change: remove these lines.", originalCode: "one\ntwo" }),
+    ]);
+    expect(result).toContain("**Replaces:**\n```\none\ntwo\n```");
+    expect(result).not.toContain("**Suggested code:**");
+  });
+
+  it("omits Replaces when the annotation has no originalCode", () => {
+    const result = exportReviewFeedback([
+      ann({ suggestedCode: "const x = 1;" }),
+    ]);
+    expect(result).not.toContain("**Replaces:**");
+  });
+
+  it("emits Replaces for file-scoped suggestions too", () => {
+    const result = exportReviewFeedback([
+      ann({ scope: "file", suggestedCode: "const x = 1;", originalCode: "let x = 1;" }),
+    ]);
+    const replaces = result.indexOf("**Replaces:**\n```\nlet x = 1;\n```");
+    const suggested = result.indexOf("**Suggested code:**");
+    expect(replaces).toBeGreaterThan(-1);
+    expect(suggested).toBeGreaterThan(replaces);
+  });
+
   it("includes side indicator", () => {
     const result = exportReviewFeedback([
       ann({ side: "old", lineStart: 3, lineEnd: 3 }),

--- a/packages/review-editor/utils/exportFeedback.test.ts
+++ b/packages/review-editor/utils/exportFeedback.test.ts
@@ -224,6 +224,36 @@ describe("exportReviewFeedback", () => {
     expect(result).not.toContain("**Replaces:**");
   });
 
+  it("emits a Highlighted text block for an edit-session selection comment", () => {
+    const result = exportReviewFeedback([
+      ann({ text: "Rename this", selectedText: "const widget = make();" }),
+    ]);
+    expect(result).toContain("Rename this\n");
+    expect(result).toContain("**Highlighted text:**\n```\nconst widget = make();\n```");
+    // A plain comment must never masquerade as a replacement.
+    expect(result).not.toContain("**Replaces:**");
+    expect(result).not.toContain("approximate");
+  });
+
+  it("labels an approximate anchor when the selection overlapped in-session edits", () => {
+    const result = exportReviewFeedback([
+      ann({
+        text: "Not sure about this",
+        selectedText: "const edited = true;",
+        selectedTextFromEdits: true,
+      }),
+    ]);
+    const note = result.indexOf("in-progress edits");
+    const highlighted = result.indexOf("**Highlighted text:**\n```\nconst edited = true;\n```");
+    expect(note).toBeGreaterThan(-1);
+    expect(highlighted).toBeGreaterThan(note);
+  });
+
+  it("omits the Highlighted text block when there is no selectedText", () => {
+    const result = exportReviewFeedback([ann()]);
+    expect(result).not.toContain("**Highlighted text:**");
+  });
+
   it("emits Replaces for file-scoped suggestions too", () => {
     const result = exportReviewFeedback([
       ann({ scope: "file", suggestedCode: "const x = 1;", originalCode: "let x = 1;" }),

--- a/packages/review-editor/utils/exportFeedback.ts
+++ b/packages/review-editor/utils/exportFeedback.ts
@@ -171,10 +171,28 @@ function formatFileAnnotations(fileAnnotations: CodeAnnotation[], headingLevel =
     if (ann.reasoning) {
       output += `\n**Reasoning:** ${ann.reasoning}\n`;
     }
+    output += formatSelectedTextBlock(ann);
     output += formatSuggestionBlocks(ann);
     output += '\n';
   }
 
+  return output;
+}
+
+/**
+ * The highlighted-text payload for a comment created inside an edit session:
+ * the exact text the reviewer had selected in the editor. When the selection
+ * overlapped the reviewer's own in-progress edits, the line anchor points at
+ * the pristine lines that region replaces (approximate), and the note says so
+ * — otherwise the anchored lines and the highlighted text are the same code.
+ */
+function formatSelectedTextBlock(ann: CodeAnnotation): string {
+  if (!ann.selectedText) return '';
+  let output = '';
+  if (ann.selectedTextFromEdits) {
+    output += `_The highlighted text below includes the reviewer's in-progress edits; the line range above anchors to the current file lines that region replaces (approximate)._\n`;
+  }
+  output += `\n**Highlighted text:**\n\`\`\`\n${ann.selectedText}\n\`\`\`\n`;
   return output;
 }
 

--- a/packages/review-editor/utils/exportFeedback.ts
+++ b/packages/review-editor/utils/exportFeedback.ts
@@ -148,9 +148,7 @@ function formatFileAnnotations(fileAnnotations: CodeAnnotation[], headingLevel =
       } else if (prefix) {
         output += `${prefix.trimEnd()}\n`;
       }
-      if (ann.suggestedCode) {
-        output += `\n**Suggested code:**\n\`\`\`\n${ann.suggestedCode}\n\`\`\`\n`;
-      }
+      output += formatSuggestionBlocks(ann);
       output += '\n';
       continue;
     }
@@ -173,12 +171,32 @@ function formatFileAnnotations(fileAnnotations: CodeAnnotation[], headingLevel =
     if (ann.reasoning) {
       output += `\n**Reasoning:** ${ann.reasoning}\n`;
     }
-    if (ann.suggestedCode) {
-      output += `\n**Suggested code:**\n\`\`\`\n${ann.suggestedCode}\n\`\`\`\n`;
-    }
+    output += formatSuggestionBlocks(ann);
     output += '\n';
   }
 
+  return output;
+}
+
+/**
+ * The suggestion payload for one annotation: an optional "Replaces:" block
+ * (the exact current lines the suggestion swaps out — the applying agent
+ * must verify these against the file before applying, and skip with a note
+ * if they no longer match) followed by the "Suggested code:" block. Both
+ * SuggestionModal-authored and edit-session-derived suggestions carry
+ * `originalCode`, so both sources export through this one format. A
+ * deletion-only suggestion (no suggestedCode; the annotation text describes
+ * the removal) still emits its "Replaces:" block so the anchor stays
+ * verifiable.
+ */
+function formatSuggestionBlocks(ann: CodeAnnotation): string {
+  let output = '';
+  if ((ann.suggestedCode || ann.text) && ann.originalCode) {
+    output += `\n**Replaces:**\n\`\`\`\n${ann.originalCode}\n\`\`\`\n`;
+  }
+  if (ann.suggestedCode) {
+    output += `\n**Suggested code:**\n\`\`\`\n${ann.suggestedCode}\n\`\`\`\n`;
+  }
   return output;
 }
 

--- a/packages/ui/components/Settings.tsx
+++ b/packages/ui/components/Settings.tsx
@@ -379,6 +379,21 @@ const ReviewDisplayTab: React.FC = () => {
 
   return (
     <>
+      {/* Experimental: edit code to author suggestions */}
+      <div className="space-y-3">
+        <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          Experimental
+        </div>
+        <ToggleSwitch
+          checked={editSuggestions}
+          onChange={(v) => configStore.set('editSuggestions', v)}
+          label="Edit Code to Suggest"
+          description="Edit a file in place in the all-files view; your net change becomes a suggestion comment. Files are never written from the browser. Uses an experimental upstream editor."
+        />
+      </div>
+
+      <div className="border-t border-border" />
+
       {/* Font Family */}
       <div className="space-y-2">
         <div>
@@ -535,18 +550,6 @@ const ReviewDisplayTab: React.FC = () => {
 
       <div className="border-t border-border" />
 
-      {/* Experimental: edit code to author suggestions */}
-      <div className="space-y-3">
-        <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-          Experimental
-        </div>
-        <ToggleSwitch
-          checked={editSuggestions}
-          onChange={(v) => configStore.set('editSuggestions', v)}
-          label="Edit Code to Suggest"
-          description="Edit a file in place in the all-files view; your net change becomes a suggestion comment. Files are never written from the browser. Uses an experimental upstream editor."
-        />
-      </div>
 
     </>
   );
@@ -831,7 +834,7 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
     }
     if (mode === 'review') {
       t.push({ id: 'git', label: 'Git' });
-      t.push({ id: 'display', label: 'Display' });
+      t.push({ id: 'display', label: 'Editor' });
       t.push({ id: 'comments', label: 'Comments' });
       if (aiProviders.length > 0) {
         t.push({ id: 'ai', label: 'AI' });

--- a/packages/ui/components/Settings.tsx
+++ b/packages/ui/components/Settings.tsx
@@ -367,6 +367,7 @@ const ReviewDisplayTab: React.FC = () => {
   const diffShowBackground = useConfigValue('diffShowBackground');
   const diffLineBgIntensity = useConfigValue('diffLineBgIntensity');
   const diffHideWhitespace = useConfigValue('diffHideWhitespace');
+  const editSuggestions = useConfigValue('editSuggestions');
   const diffExpandUnchanged = useConfigValue('diffExpandUnchanged');
   const diffFontFamily = useConfigValue('diffFontFamily');
   const diffFontSize = useConfigValue('diffFontSize');
@@ -531,6 +532,21 @@ const ReviewDisplayTab: React.FC = () => {
         label="Hide Whitespace"
         description="Ignore whitespace-only changes in diffs"
       />
+
+      <div className="border-t border-border" />
+
+      {/* Experimental: edit code to author suggestions */}
+      <div className="space-y-3">
+        <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          Experimental
+        </div>
+        <ToggleSwitch
+          checked={editSuggestions}
+          onChange={(v) => configStore.set('editSuggestions', v)}
+          label="Edit Code to Suggest"
+          description="Edit a file in place in the all-files view; your net change becomes a suggestion comment. Files are never written from the browser. Uses an experimental upstream editor."
+        />
+      </div>
 
     </>
   );

--- a/packages/ui/config/settings.ts
+++ b/packages/ui/config/settings.ts
@@ -305,8 +305,11 @@ export const SETTINGS = {
   },
   /** Experimental: author suggestions by editing code in place in the review
    *  all-files view. Cookie-only (no server sync) while the feature is
-   *  experimental — default OFF, and when off no edit UI renders and the
-   *  editor module is never imported. */
+   *  experimental — default OFF, and when off no edit UI renders and no
+   *  editor is ever constructed. (In code-split hosts the editor chunk is
+   *  never fetched; Plannotator's single-file production build inlines all
+   *  dynamic imports, so there the module namespace exists at page load —
+   *  audited free of top-level side effects — but stays inert.) */
   editSuggestions: {
     defaultValue: false as boolean,
     fromCookie: () => {

--- a/packages/ui/config/settings.ts
+++ b/packages/ui/config/settings.ts
@@ -303,6 +303,22 @@ export const SETTINGS = {
     },
     toServer: (v: DiffLineBgIntensity) => ({ diffOptions: { lineBgIntensity: v } }),
   },
+  /** Experimental: author suggestions by editing code in place in the review
+   *  all-files view. Cookie-only (no server sync) while the feature is
+   *  experimental — default OFF, and when off no edit UI renders and the
+   *  editor module is never imported. */
+  editSuggestions: {
+    defaultValue: false as boolean,
+    fromCookie: () => {
+      const v = storage.getItem('plannotator-experimental-edit-suggestions');
+      return v === 'true' ? true : v === 'false' ? false : undefined;
+    },
+    toCookie: (v: boolean) =>
+      storage.setItem('plannotator-experimental-edit-suggestions', String(v)),
+    serverKey: undefined,
+    fromServer: undefined,
+    toServer: undefined,
+  },
   conventionalComments: {
     defaultValue: false as boolean,
     fromCookie: () => {

--- a/packages/ui/types.ts
+++ b/packages/ui/types.ts
@@ -165,6 +165,15 @@ export interface CodeAnnotation {
   charStart?: number; // Character offset within lineStart (token-level selection)
   charEnd?: number; // Character offset within lineEnd (token-level selection)
   tokenText?: string; // Selected token/span text (token-level selection)
+  /** Exact text highlighted when the comment was created inside an edit
+   *  session (captured from the editor selection). Exported alongside the
+   *  comment so the agent sees what was highlighted even when it differs
+   *  from the anchored diff lines. */
+  selectedText?: string;
+  /** True when the edit-session selection overlapped in-session edits: the
+   *  line anchor maps to the pristine lines those edits replace, so it is
+   *  approximate and the export labels it as such. */
+  selectedTextFromEdits?: boolean;
   createdAt: number;
   author?: string;
   source?: string; // External tool identifier (e.g., "eslint") — set when annotation comes from external API


### PR DESCRIPTION
## What this is

A reviewer in the all-files code review view can now enter edit mode on ONE file at a time, fix the code in place using Pierre's experimental editor, and on finishing, the net change becomes ordinary suggestion annotations (`suggestedCode`/`originalCode` on a `CodeAnnotation`, the exact shape SuggestionModal produces today). The suggestions render inline, appear in the sidebar, and flow through the existing feedback export, which now also emits each suggestion's `originalCode` as a fenced "Replaces:" block ahead of the "Suggested code:" block so the applying agent can validate the anchor before applying (SuggestionModal-authored and edit-derived suggestions use the same format). The browser never writes files; the agent applies suggestions.

**The edit-mode UI is OFF by default.** It is gated behind a new cookie-only setting, `editSuggestions` (Settings > Display > Experimental > "Edit Code to Suggest"). With the flag off, zero new UI renders and no editor is ever constructed (in code-split hosts the editor chunk is never fetched; see Bundle numbers for the single-file build's inlining). One clarification: the flag gates only the edit-mode UI. The "Replaces:" block in the feedback export is not flag-gated; it is emitted for every suggestion that carries `originalCode`, including SuggestionModal suggestions authored with the flag off.

## v1 boundaries and why

- **One file at a time.** A single session keeps the clone/restore lifecycle simple. Entering edit on a second file ends the current session (with a confirm prompt if it has unsaved changes; confirming turns them into suggestions).
- **Plain all-files view only.** Guided Review deliberately does not opt in: its `GuideViewportManager` (#1158) evicts CodeView instances beyond ~8 mounted, and an evicted card destroys editor state. Scoping the entry point to the plain all-files panel (the only surface that passes the new props) was the simple safe option; pinning edited cards in the guide is possible later.
- **No `persistState`.** Deliberately unused (upstream bug, open PR pierre#1048; it is also file-item-only upstream, so diff items never persist state anyway). Session state lives only while the editor is mounted.
- **Diff refresh while editing.** Investigated: this app never auto-applies a refreshed diff. `useDiffFreshness` only shows a non-blocking "Diff out of date" chip and refresh is always user-initiated, so there is nothing to block. If the user refreshes, switches diff type, or changes the sort order or collapse default mid-session (all of these remount the CodeView; `fileSetKey` covers them), Pierre tears the editor down without a completion callback and the session cannot continue. A dirty session is never silently discarded there: the controller keeps the live document handle from the last change event, recovers the final text, and prompts to keep the edits as suggestions (the same pattern as the dirty file-switch prompt). Declining discards; a clean session drops silently.
- **Selection action:** skipped. v1 is whole-session capture on exit; a "make suggestion from selection" popover action would complicate the session lifecycle for little gain.

## Design: the adapter wall

Every reference to `@pierre/diffs/edit` lives in ONE module, `packages/review-editor/edit/pierreEditAdapter.ts`:

- The editor chunk loads via `import('@pierre/diffs/edit')` on the first Edit click, never before. The session controller awaits the load BEFORE flipping any item into edit mode: the React wrapper throws if the `EditProvider` factory returns undefined, so the factory's undefined return is a defensive guard rather than a retry contract.
- Types (`Marker`, editor options, the editor instance) are derived structurally from the `Editor` class type because upstream exports no public paths for them.
- `packages/review-editor/edit/adapterWall.test.ts` enforces the wall: any new import of the edit entry outside the adapter fails CI.

Around it:

- `edit/cloneDiff.ts`: deep-clones `FileDiffMetadata` before a session (Pierre's editor mutates `additionLines`, `hunks`, `editSessionDirty` in place). The clone is the restore target.
- `edit/deriveSuggestions.ts`: our own diff (the `diff` package) of final contents vs pre-session content; one minimal hunk per contiguous changed region; pure inserts and deletes are expanded by one unchanged anchor line so `originalCode` and `suggestedCode` stay non-empty; CRLF normalized. Anchor expansion is collision-aware: regions are emitted left to right, backward expansion is only taken when the preceding line is not already claimed, forward expansion is used otherwise, and a region with no available anchor merges into the previous hunk as one spanning suggestion. A hard non-overlap invariant (`lineStart` strictly after the previous `lineEnd`) is enforced by a defensive fold. Fuzzed at 20,000 seeded multi-region edits (12,629 multi-hunk): zero overlapping ranges, zero `originalCode` anchor mismatches, zero round-trip failures under a sequential offset-tracking applier. A 5,000-case seeded fuzz with the same assertions is part of the unit suite.
- `edit/useEditSession.ts`: the lifecycle controller (hydration gate, clone, session end as one combined item write, suggestion creation, dirty-switch prompt, dirty remount recovery, collapse routing, remount cleanup).

## The five research questions, answered by the build

1. **Is the partial-diff hydration throw real?** Yes, by design. `DiffHunksRenderer.applyDocumentChange` in 1.3.1 throws `"Could not apply document change for partial diff"` when `isPartial` is true. The session therefore hard-gates on full content: it fetches `/api/file-content`, verifies `isContentConsistentWithPatch`, reparses with `processFile`, and only then sets `item.edit = true`. If content cannot be fetched (binary, demo, changed on disk, stale snapshot) the Edit button becomes disabled with a tooltip naming the reason. The throw was never observed in any CDP run because of the gate.
2. **Token-transformer re-render cost on a big file, with numbers.** Measured via CDP on a live server, token transformer active (code-nav on), typing 30 keystrokes with no delay into an active session: 13 line file: about 0.4 to 1.0 ms per keystroke, 0 long tasks. 7,499 line file (fully hydrated, three collapsed-context regions): about 1.4 to 1.7 ms per keystroke, 0 long tasks (PerformanceObserver `longtask`, 50 ms threshold). Keystroke cost grows with file size but stays comfortably interactive.
3. **Do renderAnnotation slots survive?** Yes. Annotation cards created from a completed session render through the normal item-state path and survive the session-end `updateItem`. They even render inside a subsequent active edit session on the same file (screenshot evidence). The editor-marker projection of existing annotations (`setMarkers` via `onAttach`) now renders: single-line annotations previously produced a collapsed zero-width range that upstream's overlay renderer skips, so markers never painted. Marker ranges now end at character 0 of the line after the last annotated line, and a CDP run against a live review server confirms the severity squiggle renders across the annotated line during an active edit session, with the hover popover showing the annotation source and message.
4. **Deferred UX vs immediate.** Immediate: suggestions are created as ordinary annotations at session completion, not deferred to submission. This reuses the entire existing annotation machinery (rendering, sidebar, selection, drafts, export, external-annotation dedupe) and gives the reviewer an immediately visible, editable artifact. No new persistence or submission surface was needed.
5. **Own diff vs Pierre's session hunks.** Own diff. Pierre's session hunks are mutated in place, deliberately region-frozen during a session (`editSessionDirty` semantics), and the completion payload is only a `FileContents`; there is no stable emitted hunk artifact to trust. Diffing the final contents against the cloned pre-session content with the `diff` package gives deterministic minimal hunks, CRLF handling, collision-resolved anchors with a machine-checked non-overlap invariant, and is unit-tested and fuzzed in isolation.

One additional finding worth recording: ending a session as two writes (edit off first, restore later) races CodeView's own teardown re-render, and on large files the teardown render lands last, leaving edited content on screen. Upstream's documented commit pattern (ONE combined `updateItem` carrying `edit: false` plus the final `fileDiff` with a fresh `cacheKey`) is what the controller does, and the completion callback still fires from inside that write.

## CDP evidence (live review server with a real git repo, plus vite dev server)

Five scripted scenarios, all green (screenshots and logs captured during the runs):

- **Main flow** (13/13 checks): flag-off shows zero edit affordances; flag-on shows the Edit button; enter edit on `calc.ts`, type a change, Suggest; the annotation appears with the correct `suggestedCode`, the edited text exists ONLY inside the suggestion UI (diff restored pristine), and Send Feedback produces an export containing the `**Suggested code:**` block with the edited line anchored at `### Line 8 (new)`.
- **Escape hatches**: typing then clicking Edit on another file prompts ("Finish editing calc.ts first? Your changes there will become suggestions."); dismissing keeps the session and edits; Discard ends the session, removes all typed text, creates no annotation, and restores the pristine rows.
- **Perf and big file**: a 7,499 line file hydrates, edits, completes, and restores pristine (edited text appears only inside the suggestion UI).
- **Markers**: with an existing new-side line annotation on the file, entering an edit session renders the severity marker squiggle across the annotated line with real width, and hovering shows the marker popover (source and message). Screenshot evidence captured.
- **Network evidence** (vite dev server, per-module requests): flag-off never requests the editor module; flag-on does not request it at load; `@pierre_diffs_edit.js` is fetched only after clicking Edit.

## Bundle numbers

- Code-split builds (dev server or any multi-chunk host): the editor is a genuinely lazy chunk, **151.3 KB raw / 49.0 KB gzip**, fetched on first Edit click only.
- Plannotator's production artifact is a single-file HTML with `inlineDynamicImports: true` (`viteSingleFile`), so the lazy chunk is inlined: `review.html` grows **+167 KB raw / +54 KB gzip** (18,132 KB to 18,299 KB raw; 5,429 KB to 5,483 KB gzip, about 1 percent), paid even with the flag off. This means the edit module namespace is constructed at page load in the single-file build (audited: no top-level side effects across all 21 modules); it stays functionally inert with the flag off. This is a property of the single-file build, not the adapter; serving the editor as a sidecar asset from both servers would restore true zero cost and is a reasonable follow-up if the feature graduates.
- Flag-off UI cost beyond that is just the header-button and controller code; no `EditProvider`, no edit props, and no editor construction path is reachable with the flag off.

## Verification

| Check | Result |
|---|---|
| `bun run typecheck` (CI set) | pass |
| `bun test` (full, 3,048 tests) | 2,826 pass, 222 skip, 0 fail |
| `DOM_TESTS=1` CI DOM step including `FileHeader.edit.test.tsx` and the new `useEditSession.recovery.test.tsx` | 175 pass, 0 fail |
| New unit tests (derivation incl. collision cases + 5,000-case fuzz, clone invariant, adapter wall, dirty-session recovery) | 31 pass |
| 20,000-case derivation fuzz (overlaps / anchor mismatches / round-trip failures) | 0 / 0 / 0 |
| Builds in order: `apps/review` build, `build:hook`, `build:opencode` | pass, no dist committed |
| CDP main flow / escape hatches / perf / markers / network | all green |

The DOM-gated tests are registered in `test.yml`'s DOM step.

## Honest remaining risks

- The entire feature sits on an **experimental upstream API** (`@pierre/diffs/edit`, the CodeView `edit` item flag). The adapter wall confines upstream renames to one file and the adapter-wall test keeps it that way, but upstream behavior changes (teardown ordering, completion semantics) could still surface as session bugs. The flag stays OFF by default for exactly this reason.
- Dirty-session recovery on a CodeView remount reads the torn-down editor's document through the FileContents delivered with the last change event. That read is guarded (a failure falls back to dropping the session, never a crash), but it relies on the document staying readable after upstream cleanup, which is observed behavior rather than documented contract.
- Suggestions anchored to context lines outside the visible patch render in the sidebar and export correctly, but their inline card is only visible when the surrounding context is expanded.


## UI polish round (maintainer design feedback)

Two design changes after trying the feature live:

- **Suggestion cards lost the green left accent bar.** The colored SUGGESTION header is now the sole identity marker on the card body. Since the styling predates this PR (modal-authored suggestions share the same `.suggestion-block` CSS), the change intentionally applies to ALL suggestion cards for consistency: the inline (below-line) card and the compact sidebar card both lose the left edge line. Comment cards and every other annotation surface are untouched.
- **The Edit entry button moved to the far right of the file header action row**, after the Sem badge and adjacent to the file actions dropdown, keeping the experimental affordance out of the everyday Viewed / Git Add / Comment cluster. The `isVeryTight` responsive behavior is unchanged (icon-only at narrow widths, verified in a live CDP run at a 464 px header), and the FileHeader DOM test now asserts the ordering.


## Make annotation from an editor selection

Selecting text during an edit session now shows Pierre's Selection Action popover with one action, "Make annotation". Clicking it opens the app's existing CommentPopover (anchored at the popover's screen position) and the submitted comment becomes a normal line-scoped comment annotation.

- **Anchoring.** The selection lives in the edited buffer; annotations anchor to the rendered diff's new side, which is the session's pre-edit content. `edit/selectionAnchor.ts` maps the selected line range through `diffLines(preEdit, edited)` at click time: unedited regions map exactly (the common case, including line shifts from edits above), ranges overlapping session edits anchor to the pristine lines those edits replace and are flagged approximate, and pure insertions anchor to the adjacent pristine line. Pre-edit coordinates never change during a session, so the anchor is correct after both Suggest and Discard.
- **Entry UX.** The comment entry deliberately lives outside the editor popover: focusing an input inside the shadow-DOM popover would blur the editor, collapse the selection, and tear the popover down mid-typing. The popover only snapshots (text, mapped range, rect) and hands off to the CommentPopover. The popover button itself is inline-styled with theme tokens (custom properties inherit through the shadow boundary), so it tracks light/dark and theme switches.
- **Export.** The captured selection text rides on the annotation (`selectedText`) and exports as a "Highlighted text" block; approximate anchors add an explicit note. A new comment also re-projects into editor markers immediately, and the editor selection collapses after submit so the popover does not reopen over the annotated lines.
- **Related fix.** SectionsPanel and FileTree window-level keyboard nav guards did not pierce shadow DOM, so Home/End/arrows typed inside the editor switched files mid-session; both now use the same `composedPath()[0]` guard AllFilesCodeView already had.
- **Tests.** Anchor-mapping unit tests (exact shifts, edited regions, insertions, deletions inside a selection, CRLF, clamping), export coverage for the Highlighted text block, and a DOM-gated popover-builder test registered in the CI DOM step. Verified end to end over CDP against a live review server: popover, entry, mid-session card, post-Suggest anchoring, and the exported feedback ("Lines 22-23 (new)" for a selection made below an in-session insert).

## Edit session HUD

While a session is active, a slim strip renders below the file header with the session state (Editing, experimental chip, debounced change count) and the Suggest and Discard actions. The header carries only the Edit entry button when idle, so session controls have one home. Later commits also rename the review Settings Display tab to Editor with the edit toggle first, and remove the projection of annotations as editor markers (wavy underlines read as errors, which misrepresents comments; annotations render in their normal slots instead).

