### PR TITLE
feat(opencode): add OpenCode 2 plan review adapter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,35 @@ jobs:
           packages/editor/App.archiveReadOnly.test.tsx
           packages/editor/actionsLabelMode.test.ts
 
+  opencode-v2:
+    name: OpenCode 2 installed package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Install OpenCode 2
+        run: npm install --global @opencode-ai/cli@0.0.0-next-16770
+
+      - name: Build OpenCode plugin assets
+        run: bun run build:review && bun run build:hook && bun run build:opencode
+
+      - name: Pack OpenCode plugin
+        working-directory: apps/opencode-plugin
+        run: npm pack --ignore-scripts --pack-destination "$RUNNER_TEMP"
+
+      - name: Run installed-package smoke
+        run: >-
+          bun run --cwd apps/opencode-plugin smoke:v2 --
+          "$(command -v opencode2)"
+          "$RUNNER_TEMP/plannotator-opencode-0.25.1.tgz"
+
   uninstall-windows:
     # Run the filesystem and path logic under real Windows path semantics.
     # The tests inject temporary homes and process boundaries, so this job

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
         run: bun install
 
       - name: Install OpenCode 2
-        run: npm install --global @opencode-ai/cli@0.0.0-next-16770
+        run: npm install --global @opencode-ai/cli@0.0.0-next-16775
 
       - name: Build OpenCode plugin assets
         run: bun run build:review && bun run build:hook && bun run build:opencode

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,8 @@ plannotator/
 │   │   └── dist/                 # Built single-file apps (index.html, review.html)
 │   ├── opencode-plugin/          # OpenCode plugin
 │   │   ├── commands/             # Slash command stubs (review, annotate, last — plugin intercepts execution)
-│   │   ├── index.ts              # Plugin entry with submit_plan tool + review/annotate event handlers
+│   │   ├── index.ts              # OpenCode 1 entry with submit_plan tool + review/annotate event handlers
+│   │   ├── server.ts             # OpenCode 2 adapter (experimental V2 plugin API)
 │   │   ├── plannotator.html      # Built plan review app
 │   │   └── review-editor.html    # Built code review app
 │   ├── amp-plugin/               # Amp plugin

--- a/apps/opencode-plugin/README.md
+++ b/apps/opencode-plugin/README.md
@@ -19,6 +19,36 @@ Obsidian users can auto-save approved plans to Obsidian as well. [See details](#
 
 ## Install
 
+### OpenCode 2 beta
+
+Install OpenCode 2 from npm's `next` tag, then add Plannotator to the V2 `plugins` field:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugins": [
+    {
+      "package": "@plannotator/opencode@latest",
+      "options": {
+        "workflow": "plan-agent",
+        "planningAgents": ["plan"]
+      }
+    }
+  ]
+}
+```
+
+Restart OpenCode 2 and verify that `plannotator` appears in `opencode2 plugin list`.
+
+OpenCode 2 support is experimental while its plugin API is in beta. The core `submit_plan` review flow works, but the current API has these limitations:
+
+- OpenCode 2 does not expose deterministic command interception, so `/plannotator-review`, `/plannotator-annotate`, and `/plannotator-last` remain OpenCode 1-only instead of silently becoming model-mediated commands.
+- V2 tool execution does not expose an abort signal. Cancelling a turn cannot yet stop a running review server or CLI child immediately.
+- The V2 plugin context cannot switch the active session agent. Agent switching selected in the review UI is ignored with a server-log warning; switch to `build` manually after approval before implementation.
+- The V2 plugin context has no TUI toast/log API, so remote session URLs are written to the server output rather than shown as a toast.
+
+### OpenCode 1
+
 Add to your `opencode.json`:
 
 ```json
@@ -30,7 +60,7 @@ Add to your `opencode.json`:
 
 Restart OpenCode. By default, the `submit_plan` tool is available to OpenCode's `plan` agent, not to `build` or other primary agents.
 
-> **Slash commands:** Run the install script to get `/plannotator-review`, `/plannotator-annotate`, and `/plannotator-last`:
+> **OpenCode 1 slash commands:** Run the install script to get `/plannotator-review`, `/plannotator-annotate`, and `/plannotator-last`:
 > ```bash
 > curl -fsSL https://plannotator.ai/install.sh | bash
 > ```
@@ -38,7 +68,7 @@ Restart OpenCode. By default, the `submit_plan` tool is available to OpenCode's 
 
 ## Workflow Modes
 
-Plannotator supports four OpenCode workflows:
+The examples below use the OpenCode 1 config shape. OpenCode 2 places the same option keys under the plugin entry's `options` object shown above. In V2, `manual` intentionally registers no tool and the deterministic slash commands are unavailable, so it currently leaves the integration inactive.
 
 - **`plan-agent`** (default): `submit_plan` is available to OpenCode's built-in `plan` agent plus any extra agents listed in `planningAgents`. This keeps Plannotator integrated with OpenCode plan mode without nudging `build` to call it.
 - **`manual`**: `submit_plan` is not registered. Use `/plannotator-last`, `/plannotator-annotate`, and `/plannotator-review` when you want Plannotator.

--- a/apps/opencode-plugin/README.md
+++ b/apps/opencode-plugin/README.md
@@ -42,7 +42,7 @@ Restart OpenCode 2 and verify that `plannotator` appears in `opencode2 plugin li
 
 OpenCode 2 support is experimental while its plugin API is in beta. The core `submit_plan` review flow works, but the current API has these limitations:
 
-- OpenCode 2 does not expose deterministic command interception, so `/plannotator-review`, `/plannotator-annotate`, and `/plannotator-last` remain OpenCode 1-only instead of silently becoming model-mediated commands.
+- OpenCode 2 does not expose a native slash-command execution hook. Its command definitions expand to model prompts, so `/plannotator-review`, `/plannotator-annotate`, and `/plannotator-last` remain OpenCode 1-only instead of silently becoming model-mediated commands.
 - V2 tool execution does not expose an abort signal. Cancelling a turn cannot yet stop a running review server or CLI child immediately.
 - The V2 plugin context cannot switch the active session agent. Agent switching selected in the review UI is ignored with a server-log warning; switch to `build` manually after approval before implementation.
 - The V2 plugin context has no TUI toast/log API, so remote session URLs are written to the server output rather than shown as a toast.
@@ -68,7 +68,7 @@ Restart OpenCode. By default, the `submit_plan` tool is available to OpenCode's 
 
 ## Workflow Modes
 
-The examples below use the OpenCode 1 config shape. OpenCode 2 places the same option keys under the plugin entry's `options` object shown above. In V2, `manual` intentionally registers no tool and the deterministic slash commands are unavailable, so it currently leaves the integration inactive.
+The examples below use the OpenCode 1 config shape. OpenCode 2 places the same option keys under the plugin entry's `options` object shown above. In V2, `manual` intentionally registers no tool and native slash-command handlers are unavailable, so it currently leaves the integration inactive.
 
 - **`plan-agent`** (default): `submit_plan` is available to OpenCode's built-in `plan` agent plus any extra agents listed in `planningAgents`. This keeps Plannotator integrated with OpenCode plan mode without nudging `build` to call it.
 - **`manual`**: `submit_plan` is not registered. Use `/plannotator-last`, `/plannotator-annotate`, and `/plannotator-review` when you want Plannotator.

--- a/apps/opencode-plugin/cli-bridge.ts
+++ b/apps/opencode-plugin/cli-bridge.ts
@@ -473,7 +473,7 @@ export async function runCliPlanReview(input: {
   planContent: string;
   cwd?: string;
   timeoutSeconds: number | null;
-  abortSignal: AbortSignal;
+  abortSignal?: AbortSignal;
   bridge?: OpenCodeBridgeContext;
 }): Promise<OpenCodePlanReviewResult> {
   const result = await runPlannotatorCli({

--- a/apps/opencode-plugin/embedded.ts
+++ b/apps/opencode-plugin/embedded.ts
@@ -17,7 +17,7 @@ export interface EmbeddedPlanReviewInput {
   pasteApiUrl?: string;
   htmlContent: string;
   timeoutSeconds: number | null;
-  abortSignal: AbortSignal;
+  abortSignal?: AbortSignal;
   logReady: (url: string, isRemote: boolean, port: number) => void;
 }
 
@@ -69,7 +69,7 @@ export async function deliverEmbeddedAnnotateMessagePrompt(input: {
 export async function runEmbeddedPlanReview(
   input: EmbeddedPlanReviewInput,
 ): Promise<EmbeddedPlanReviewResult> {
-  input.abortSignal.throwIfAborted();
+  input.abortSignal?.throwIfAborted();
   const { startPlannotatorServer, handleServerReady } = await loadPlanServer();
   const server = await startPlannotatorServer({
     plan: input.planContent,

--- a/apps/opencode-plugin/fixtures/v2-installed-smoke.ts
+++ b/apps/opencode-plugin/fixtures/v2-installed-smoke.ts
@@ -1,0 +1,174 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { createServer } from "node:net";
+
+const [opencodeBin, pluginTarball] = Bun.argv.slice(2);
+if (!opencodeBin || !pluginTarball) {
+  throw new Error("Usage: bun fixtures/v2-installed-smoke.ts <opencode2-bin> <packed-plugin.tgz>");
+}
+
+const packageJson = JSON.parse(readFileSync(path.join(import.meta.dir, "..", "package.json"), "utf-8")) as {
+  name: string;
+  version: string;
+  [key: string]: unknown;
+};
+const root = mkdtempSync(path.join(tmpdir(), "plannotator-opencode-v2-smoke-"));
+const port = await getFreePort();
+const registryPort = await getFreePort();
+const url = `http://127.0.0.1:${port}`;
+const registryUrl = `http://127.0.0.1:${registryPort}`;
+mkdirSync(path.join(root, "config"), { recursive: true });
+mkdirSync(path.join(root, "data"), { recursive: true });
+mkdirSync(path.join(root, "cache"), { recursive: true });
+
+const env = {
+  ...process.env,
+  XDG_CONFIG_HOME: path.join(root, "config"),
+  XDG_DATA_HOME: path.join(root, "data"),
+  XDG_CACHE_HOME: path.join(root, "cache"),
+  OPENCODE_DB: path.join(root, "opencode.db"),
+  OPENCODE_CONFIG_CONTENT: JSON.stringify({
+    plugins: [{ package: `${packageJson.name}@${packageJson.version}`, options: { workflow: "plan-agent" } }],
+  }),
+  OPENCODE_LOG_LEVEL: "DEBUG",
+  OPENCODE_PASSWORD: "plannotator-smoke",
+  OPENCODE_SERVER_PASSWORD: "plannotator-smoke",
+  NPM_CONFIG_REGISTRY: registryUrl,
+  npm_config_registry: registryUrl,
+};
+
+const registry = Bun.serve({
+  hostname: "127.0.0.1",
+  port: registryPort,
+  async fetch(request) {
+    const requestUrl = new URL(request.url);
+    const packageName = decodeURIComponent(requestUrl.pathname.slice(1));
+    if (packageName === packageJson.name) {
+      return Response.json({
+        name: packageJson.name,
+        "dist-tags": { latest: packageJson.version },
+        versions: {
+          [packageJson.version]: {
+            ...packageJson,
+            dist: { tarball: `${registryUrl}/plannotator-opencode.tgz` },
+          },
+        },
+      });
+    }
+    if (requestUrl.pathname === "/plannotator-opencode.tgz") {
+      return new Response(Bun.file(path.resolve(pluginTarball)));
+    }
+
+    const upstream = await fetch(`https://registry.npmjs.org${requestUrl.pathname}${requestUrl.search}`);
+    const headers = new Headers(upstream.headers);
+    headers.delete("content-encoding");
+    headers.delete("content-length");
+    return new Response(upstream.body, {
+      status: upstream.status,
+      headers,
+    });
+  },
+});
+
+const server = Bun.spawn([
+  opencodeBin,
+  "serve",
+  "--hostname",
+  "127.0.0.1",
+  "--port",
+  String(port),
+], {
+  cwd: process.cwd(),
+  env,
+  stdout: "pipe",
+  stderr: "pipe",
+});
+const serverStdout = new Response(server.stdout).text();
+const serverStderr = new Response(server.stderr).text();
+let failed = false;
+
+try {
+  await waitForHealthyServer(url);
+  const plugins = await waitForPlugin(url);
+  console.log(JSON.stringify(plugins));
+} catch (error) {
+  failed = true;
+  throw error;
+} finally {
+  server.kill();
+  await server.exited;
+  await registry.stop();
+  const stdout = await serverStdout;
+  const stderr = await serverStderr;
+  if (failed) {
+    console.error(stdout);
+    console.error(stderr);
+  }
+  if (process.env.PLANNOTATOR_KEEP_SMOKE === "1") {
+    console.error(`Smoke artifacts: ${root}`);
+  } else {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+async function getFreePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("Could not allocate a smoke-test port."));
+        return;
+      }
+      server.close((error) => error ? reject(error) : resolve(address.port));
+    });
+  });
+}
+
+async function waitForHealthyServer(url: string): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${url}/api/health`, {
+        headers: authHeaders(),
+      });
+      if (response.ok) return;
+    } catch {
+      // The server has not bound yet.
+    }
+    await Bun.sleep(50);
+  }
+  throw new Error("OpenCode 2 smoke server did not become healthy.");
+}
+
+async function waitForPlugin(url: string): Promise<unknown> {
+  const deadline = Date.now() + 20_000;
+  let lastOutput = "";
+  while (Date.now() < deadline) {
+    const httpResponse = await fetch(`${url}/api/plugin`, {
+      headers: {
+        ...authHeaders(),
+        "x-opencode-directory": encodeURIComponent(process.cwd()),
+      },
+    });
+    lastOutput = await httpResponse.text();
+    if (!httpResponse.ok) {
+      throw new Error(`OpenCode plugin API returned ${httpResponse.status}: ${lastOutput}`);
+    }
+    const response = JSON.parse(lastOutput) as { data?: Array<{ id?: string } | string> };
+    if (response.data?.some((plugin) =>
+      typeof plugin === "string" ? plugin === "plannotator" : plugin.id === "plannotator"
+    )) return response;
+    await Bun.sleep(50);
+  }
+  throw new Error(`Plannotator did not activate in OpenCode 2. Last response: ${lastOutput}`);
+}
+
+function authHeaders(): Record<string, string> {
+  return {
+    Authorization: `Basic ${Buffer.from("opencode:plannotator-smoke").toString("base64")}`,
+  };
+}

--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -542,7 +542,7 @@ Do NOT proceed with implementation until your plan is approved.`);
             directory: ctx.directory,
             workflowOptions,
           }, {
-            reviewPlan: async ({ planContent, abortSignal }) => await runPlanReview({
+            reviewPlan: async ({ planContent }) => await runPlanReview({
               client: ctx.client,
               runtime: workflowOptions.runtime,
               planContent,
@@ -551,7 +551,7 @@ Do NOT proceed with implementation until your plan is approved.`);
               pasteApiUrl: getPasteApiUrl(),
               htmlContent: getPlanHtml(),
               timeoutSeconds: getPlanTimeoutSeconds(),
-              abortSignal,
+              abortSignal: context.abort,
               cwd: ctx.directory,
               bridge: await getBridgeContext(),
             }),

--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -15,24 +15,17 @@
  * @packageDocumentation
  */
 
-import { type Plugin, tool } from "@opencode-ai/plugin";
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { type Plugin, tool } from "@opencode-ai/plugin/v1";
+import { existsSync, readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import {
-  getPlanDeniedPrompt,
-  getPlanApprovedPrompt,
-  getPlanApprovedWithNotesPrompt,
-  getPlanToolName,
-} from "@plannotator/shared/prompts";
 import { loadConfig, resolveSharingEnabled } from "@plannotator/shared/config";
 import { readImprovementHook } from "@plannotator/shared/improvement-hooks";
 import { composeImproveContext } from "@plannotator/shared/pfm-reminder";
 import {
   stripConflictingPlanModeRules,
 } from "./plan-mode";
-import { sanitizeTag } from "@plannotator/shared/project";
 import {
   applyWorkflowConfig,
   isPlanningAgent,
@@ -42,17 +35,9 @@ import {
   shouldInjectGenericPlanReminder,
   shouldModifyPrompts,
   shouldRegisterSubmitPlan,
-  shouldRejectSubmitPlanForAgent,
-  shouldStartImplementationForAgent,
   type RuntimeMode,
   type PlannotatorOpenCodeOptions,
 } from "./workflow";
-import {
-  applyEdits,
-  formatWithLineNumbers,
-  getPlanBackingPath,
-  validateEdits,
-} from "./plan-edits";
 import {
   handleCliCommand,
   runCliPlanReview,
@@ -61,6 +46,8 @@ import {
 } from "./cli-bridge";
 import { resolveValidatedTargetAgent } from "./agent-switch";
 import { shouldFallbackAfterEmbeddedError } from "./prompt-delivery-error";
+import { executeSubmitPlan } from "./submit-plan-executor";
+import { getPlanningPrompt } from "./planning-prompt";
 
 // Lazy-load HTML at first use instead of embedding in the bundle.
 // The two SPA files are ~20 MB combined — inlining them as string literals
@@ -99,62 +86,6 @@ function getReviewHtml(): string {
 }
 
 const DEFAULT_PLAN_TIMEOUT_SECONDS = 345_600; // 96 hours
-const MAX_PLAN_SIZE = 5 * 1024 * 1024; // 5MB
-
-// ── Planning prompt ───────────────────────────────────────────────────────
-
-/**
- * Unified planning prompt injected for all primary agents.
- *
- * Design principles:
- * - Explain the WHY — the model is smart, give it context
- * - Keep it lean — every line should pull its weight
- * - Don't overfit — let the agent and user dictate the workflow
- * - Edit-based: all submissions use line-range edits against a backing file
- */
-function getPlanningPrompt(): string {
-  return `## Plannotator — Plan Review
-
-You have a plan submission tool called \`submit_plan\`. It opens an interactive review UI where the user can annotate, approve, or request changes.
-
-**How to use it:**
-
-\`submit_plan\` accepts an array of line-range edits. On first submission, pass the full plan as a single edit starting at line 1:
-
-\`\`\`json
-{ "edits": [{ "start": 1, "content": "# My Plan\\n\\n## Goals\\n..." }] }
-\`\`\`
-
-If the user denies and requests changes, apply surgical edits using line ranges. The tool response includes your plan with line numbers so you can target specific ranges:
-
-\`\`\`json
-{ "edits": [
-  { "start": 12, "end": 14, "content": "revised section content" },
-  { "start": 30, "end": 30, "content": "" }
-] }
-\`\`\`
-
-Edit semantics:
-- \`start\` and \`end\` are 1-indexed, inclusive line numbers
-- Omit \`end\` to replace from \`start\` through end of file (use this for the initial full write)
-- Empty \`content\` with \`start\`/\`end\` deletes those lines
-- Multiple edits in one call are applied in order; line numbers refer to the state before edits
-
-### Before you write a plan
-
-Do not jump straight to writing a plan. First:
-
-1. **Explore** — Read the relevant code, trace dependencies, and look at existing patterns. The depth should match the task.
-2. **Ask questions** — If you need information only the user can provide (requirements, preferences, tradeoffs), ask using the \`question\` tool. Don't guess at ambiguous requirements.
-
-Only write and submit a plan once you have sufficient context.
-
-### What NOT to do
-
-- Don't proceed with implementation until the plan is approved.
-- Don't use \`plan_exit\` — use \`submit_plan\` instead.
-- Don't end your turn without either submitting a plan or asking the user a question.`;
-}
 
 // ── Plugin ────────────────────────────────────────────────────────────────
 
@@ -603,60 +534,15 @@ Do NOT proceed with implementation until your plan is approved.`);
         },
 
         async execute(args, context) {
-          const invokingAgent = context.agent;
-          if (shouldRejectSubmitPlanForAgent(invokingAgent, workflowOptions)) {
-            return `Plannotator is configured for plan-agent mode. submit_plan can only be called by: ${workflowOptions.planningAgents.join(", ")}.
-
-Use /plannotator-last or /plannotator-annotate for manual review, or set workflow to all-agents to allow broader submit_plan access.`;
-          }
-
-          context.abort.throwIfAborted();
-
-          if (!args.edits || args.edits.length === 0) {
-            return "Error: No edits provided. Pass at least one edit with start and content.";
-          }
-
-          // Read existing backing file (empty on first call)
-          const project = sanitizeTag(path.basename(ctx.directory)) || "_unknown";
-          const backingPath = getPlanBackingPath(project);
-          const backingDir = path.dirname(backingPath);
-          mkdirSync(backingDir, { recursive: true });
-
-          let existingContent = "";
-          if (existsSync(backingPath)) {
-            existingContent = readFileSync(backingPath, "utf-8");
-          }
-
-          // Validate and apply edits
-          const existingLines = existingContent ? existingContent.split("\n") : [];
-
-          const validationError = validateEdits(existingLines, args.edits);
-          if (validationError) {
-            return `Error: ${validationError}`;
-          }
-
-          let resultLines: string[];
-          try {
-            resultLines = applyEdits(existingLines, args.edits);
-          } catch (err) {
-            return `Error applying edits: ${err instanceof Error ? err.message : String(err)}`;
-          }
-
-          const planContent = resultLines.join("\n");
-          if (planContent.length > MAX_PLAN_SIZE) {
-            return `Error: Plan content exceeds the maximum size of ${MAX_PLAN_SIZE / (1024 * 1024)}MB.`;
-          }
-          if (!planContent.trim()) {
-            return "Error: Plan content is empty after applying edits.";
-          }
-
-          // Write backing file
-          writeFileSync(backingPath, planContent, "utf-8");
-
-          const timeoutSeconds = getPlanTimeoutSeconds();
-          let result: OpenCodePlanReviewResult;
-          try {
-            result = await runPlanReview({
+          return await executeSubmitPlan({
+            edits: args.edits,
+            invokingAgent: context.agent,
+            sessionId: context.sessionID,
+            abortSignal: context.abort,
+            directory: ctx.directory,
+            workflowOptions,
+          }, {
+            reviewPlan: async ({ planContent, abortSignal }) => await runPlanReview({
               client: ctx.client,
               runtime: workflowOptions.runtime,
               planContent,
@@ -664,75 +550,29 @@ Use /plannotator-last or /plannotator-annotate for manual review, or set workflo
               shareBaseUrl: getShareBaseUrl(),
               pasteApiUrl: getPasteApiUrl(),
               htmlContent: getPlanHtml(),
-              timeoutSeconds,
-              abortSignal: context.abort,
+              timeoutSeconds: getPlanTimeoutSeconds(),
+              abortSignal,
               cwd: ctx.directory,
               bridge: await getBridgeContext(),
-            });
-          } catch (error) {
-            context.abort.throwIfAborted();
-            return `[Plannotator] Failed to open plan review: ${error instanceof Error ? error.message : String(error)}`;
-          }
-
-          if (result.approved) {
-            // Clean up backing file after approval
-            try { unlinkSync(backingPath); } catch { /* already gone */ }
-
-            const targetAgent = await resolveValidatedTargetAgent({
-              client: ctx.client,
-              targetAgent: result.agentSwitch,
-              directory: ctx.directory,
-              delivery: "plan-approval",
-            });
-            const shouldStartImplementation = targetAgent
-              ? shouldStartImplementationForAgent(targetAgent, workflowOptions)
-              : false;
-
-            if (targetAgent) {
-              try {
-                await ctx.client.session.prompt({
-                  path: { id: context.sessionID },
-                  body: {
-                    agent: targetAgent,
-                    noReply: true,
-                    parts: [{
-                      type: "text",
-                      text: shouldStartImplementation
-                        ? "Proceed with implementation"
-                        : "Plan approved. Plan mode remains active; no implementation has been requested.",
-                    }],
-                  },
-                });
-              } catch {
-                // Silently fail if session is busy
-              }
-            }
-
-            if (result.feedback) {
-              return getPlanApprovedWithNotesPrompt("opencode", undefined, {
-                planFilePath: backingPath,
-                doneMsg: result.savedPath ? `Saved to: ${result.savedPath}` : "",
-                feedback: result.feedback,
-                proceedSuffix: shouldStartImplementation
-                  ? "\n\nProceed with implementation, incorporating these notes where applicable."
-                  : "",
+            }),
+            resolveTargetAgent: async ({ requestedAgent, directory, delivery }) =>
+              await resolveValidatedTargetAgent({
+                client: ctx.client,
+                targetAgent: requestedAgent,
+                directory,
+                delivery,
+              }),
+            sendApprovalHandoff: async ({ sessionId, targetAgent, text }) => {
+              await ctx.client.session.prompt({
+                path: { id: sessionId },
+                body: {
+                  agent: targetAgent,
+                  noReply: true,
+                  parts: [{ type: "text", text }],
+                },
               });
-            }
-
-            return getPlanApprovedPrompt("opencode", undefined, {
-              planFilePath: backingPath,
-              doneMsg: result.savedPath ? ` Saved to: ${result.savedPath}` : "",
-            });
-          } else {
-            const lineNumberedPlan = formatWithLineNumbers(planContent);
-            const totalLines = planContent.split("\n").length;
-
-            return getPlanDeniedPrompt("opencode", undefined, {
-              toolName: getPlanToolName("opencode"),
-              planFileRule: "",
-              feedback: result.feedback || "Plan changes requested",
-            }) + `\n\n## Current Plan (${totalLines} lines)\n\nThe plan below shows the current state with line numbers. Use these exact line numbers in your next \`submit_plan\` call:\n\n\`\`\`\n${lineNumberedPlan}\n\`\`\`\n\nCall \`submit_plan\` with targeted edits to address the feedback above.`;
-          }
+            },
+          });
         },
       }),
     };

--- a/apps/opencode-plugin/package-boundary.test.ts
+++ b/apps/opencode-plugin/package-boundary.test.ts
@@ -4,6 +4,7 @@ import packageJson from "./package.json";
 describe("OpenCode package entrypoints", () => {
   test("keeps V1 on main and exposes V2 from the package root", () => {
     expect(packageJson.main).toBe("dist/index.js");
+    // OpenCode 1 checks ./server before main, so that subpath must remain absent.
     expect(packageJson.exports).toEqual({
       ".": "./dist/server.js",
     });

--- a/apps/opencode-plugin/package-boundary.test.ts
+++ b/apps/opencode-plugin/package-boundary.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "bun:test";
+import packageJson from "./package.json";
+
+describe("OpenCode package entrypoints", () => {
+  test("keeps V1 on main and exposes V2 from the package root", () => {
+    expect(packageJson.main).toBe("dist/index.js");
+    expect(packageJson.exports).toEqual({
+      ".": "./dist/server.js",
+    });
+  });
+});

--- a/apps/opencode-plugin/package.json
+++ b/apps/opencode-plugin/package.json
@@ -23,6 +23,9 @@
     "coding-agent"
   ],
   "main": "dist/index.js",
+  "exports": {
+    ".": "./dist/server.js"
+  },
   "files": [
     "dist",
     "commands",
@@ -31,12 +34,12 @@
     "review-editor.html"
   ],
   "scripts": {
-    "build": "mkdir -p dist && cp ../hook/dist/index.html ./plannotator.html && cp ../review/dist/index.html ./review-editor.html && bun build embedded.ts --outfile dist/embedded.js --target bun --external @opencode-ai/plugin && bun build index.ts --outfile dist/index.js --target node",
+    "build": "mkdir -p dist && cp ../hook/dist/index.html ./plannotator.html && cp ../review/dist/index.html ./review-editor.html && bun build embedded.ts --outfile dist/embedded.js --target bun --external @opencode-ai/plugin && bun build index.ts --outfile dist/index.js --target node && bun build server.ts --outfile dist/server.js --target node --external @opencode-ai/plugin",
     "postinstall": "mkdir -p ${XDG_CONFIG_HOME:-$HOME/.config}/opencode/commands && cp ./commands/*.md ${XDG_CONFIG_HOME:-$HOME/.config}/opencode/commands/ 2>/dev/null || true",
     "prepublishOnly": "bun run build"
   },
   "dependencies": {
-    "@opencode-ai/plugin": "^1.1.10"
+    "@opencode-ai/plugin": "0.0.0-next-16770"
   },
   "devDependencies": {
     "@plannotator/server": "workspace:*",

--- a/apps/opencode-plugin/package.json
+++ b/apps/opencode-plugin/package.json
@@ -35,6 +35,7 @@
   ],
   "scripts": {
     "build": "mkdir -p dist && cp ../hook/dist/index.html ./plannotator.html && cp ../review/dist/index.html ./review-editor.html && bun build embedded.ts --outfile dist/embedded.js --target bun --external @opencode-ai/plugin && bun build index.ts --outfile dist/index.js --target node && bun build server.ts --outfile dist/server.js --target node --external @opencode-ai/plugin",
+    "smoke:v2": "bun fixtures/v2-installed-smoke.ts",
     "postinstall": "mkdir -p ${XDG_CONFIG_HOME:-$HOME/.config}/opencode/commands && cp ./commands/*.md ${XDG_CONFIG_HOME:-$HOME/.config}/opencode/commands/ 2>/dev/null || true",
     "prepublishOnly": "bun run build"
   },

--- a/apps/opencode-plugin/package.json
+++ b/apps/opencode-plugin/package.json
@@ -41,7 +41,7 @@
     "prepublishOnly": "bun run build"
   },
   "dependencies": {
-    "@opencode-ai/plugin": "0.0.0-next-16770"
+    "@opencode-ai/plugin": "0.0.0-next-16775"
   },
   "devDependencies": {
     "@plannotator/server": "workspace:*",

--- a/apps/opencode-plugin/package.json
+++ b/apps/opencode-plugin/package.json
@@ -22,6 +22,7 @@
     "ai-agent",
     "coding-agent"
   ],
+  "//": "OpenCode 1 loads main, while OpenCode 2 loads exports[.]. Do not add ./server: OpenCode 1 checks it before main and would load the V2 adapter.",
   "main": "dist/index.js",
   "exports": {
     ".": "./dist/server.js"

--- a/apps/opencode-plugin/planning-prompt.ts
+++ b/apps/opencode-plugin/planning-prompt.ts
@@ -1,0 +1,44 @@
+/** Planning instructions shared by the OpenCode 1 and OpenCode 2 adapters. */
+export function getPlanningPrompt(): string {
+  return `## Plannotator — Plan Review
+
+You have a plan submission tool called \`submit_plan\`. It opens an interactive review UI where the user can annotate, approve, or request changes.
+
+**How to use it:**
+
+\`submit_plan\` accepts an array of line-range edits. On first submission, pass the full plan as a single edit starting at line 1:
+
+\`\`\`json
+{ "edits": [{ "start": 1, "content": "# My Plan\\n\\n## Goals\\n..." }] }
+\`\`\`
+
+If the user denies and requests changes, apply surgical edits using line ranges. The tool response includes your plan with line numbers so you can target specific ranges:
+
+\`\`\`json
+{ "edits": [
+  { "start": 12, "end": 14, "content": "revised section content" },
+  { "start": 30, "end": 30, "content": "" }
+] }
+\`\`\`
+
+Edit semantics:
+- \`start\` and \`end\` are 1-indexed, inclusive line numbers
+- Omit \`end\` to replace from \`start\` through end of file (use this for the initial full write)
+- Empty \`content\` with \`start\`/\`end\` deletes those lines
+- Multiple edits in one call are applied in order; line numbers refer to the state before edits
+
+### Before you write a plan
+
+Do not jump straight to writing a plan. First:
+
+1. **Explore** — Read the relevant code, trace dependencies, and look at existing patterns. The depth should match the task.
+2. **Ask questions** — If you need information only the user can provide (requirements, preferences, tradeoffs), ask using the \`question\` tool. Don't guess at ambiguous requirements.
+
+Only write and submit a plan once you have sufficient context.
+
+### What NOT to do
+
+- Don't proceed with implementation until the plan is approved.
+- Don't use \`plan_exit\` — use \`submit_plan\` instead.
+- Don't end your turn without either submitting a plan or asking the user a question.`;
+}

--- a/apps/opencode-plugin/server.test.ts
+++ b/apps/opencode-plugin/server.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import serverPlugin from "./server";
+
+const originalAllowSubagents = process.env.PLANNOTATOR_ALLOW_SUBAGENTS;
+
+afterEach(() => {
+  if (originalAllowSubagents === undefined) delete process.env.PLANNOTATOR_ALLOW_SUBAGENTS;
+  else process.env.PLANNOTATOR_ALLOW_SUBAGENTS = originalAllowSubagents;
+});
+
+type SessionContextHook = (event: {
+  agent: string;
+  system: Array<{ type: "text"; text: string }>;
+  messages: unknown[];
+  tools: Record<string, { description: string; input: Record<string, unknown> }>;
+}) => Promise<void> | void;
+
+function createContext(
+  options: Record<string, unknown> = {},
+  agents: Array<{ id: string; description?: string; mode: string; hidden: boolean }> = [],
+) {
+  let toolDefinition: Record<string, any> | undefined;
+  let sessionContextHook: SessionContextHook | undefined;
+  const sessionGet = mock(async () => ({ location: { directory: "/project" } }));
+
+  return {
+    context: {
+      options,
+      agent: {
+        list: async () => ({ location: { directory: "/project" }, data: agents }),
+        transform: async () => ({ dispose: async () => {} }),
+      },
+      session: {
+        get: sessionGet,
+        hook: async (name: string, callback: SessionContextHook) => {
+          if (name === "context") sessionContextHook = callback;
+          return { dispose: async () => {} };
+        },
+      },
+      tool: {
+        transform: async (callback: (draft: { add: (tool: Record<string, any>) => void }) => void) => {
+          callback({
+            add(tool) {
+              toolDefinition = tool;
+            },
+          });
+          return { dispose: async () => {} };
+        },
+      },
+    },
+    getToolDefinition: () => toolDefinition,
+    getSessionContextHook: () => sessionContextHook,
+    sessionGet,
+  };
+}
+
+describe("OpenCode V2 server plugin", () => {
+  test("exports a stable V2 plugin object", () => {
+    expect(serverPlugin.id).toBe("plannotator");
+    expect(serverPlugin.setup).toBeInstanceOf(Function);
+  });
+
+  test("registers submit_plan with the V2 JSON Schema tool contract", async () => {
+    const testContext = createContext();
+    await serverPlugin.setup(testContext.context as never);
+
+    const tool = testContext.getToolDefinition();
+    expect(tool?.name).toBe("submit_plan");
+    expect(tool?.input).toEqual({
+      type: "object",
+      properties: {
+        edits: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              start: { type: "number", description: "1-indexed start line (inclusive)" },
+              end: {
+                type: "number",
+                description: "1-indexed end line (inclusive). Omit to replace from start through end of file.",
+              },
+              content: { type: "string", description: "Replacement content. Empty string deletes the line range." },
+            },
+            required: ["start", "content"],
+            additionalProperties: false,
+          },
+          description: "Array of line-range edits to apply to the plan.",
+        },
+      },
+      required: ["edits"],
+      additionalProperties: false,
+    });
+    expect(tool?.options).toEqual({ codemode: false });
+    expect(tool?.execute).toBeInstanceOf(Function);
+  });
+
+  test("resolves cwd from the V2 session and returns V2 tool content", async () => {
+    const testContext = createContext();
+    await serverPlugin.setup(testContext.context as never);
+
+    const result = await testContext.getToolDefinition()?.execute(
+      { edits: [] },
+      {
+        sessionID: "session-1",
+        agent: "plan",
+        messageID: "message-1",
+        callID: "call-1",
+        progress: async () => {},
+      },
+    );
+
+    expect(testContext.sessionGet).toHaveBeenCalledWith({ sessionID: "session-1" });
+    expect(result).toEqual({
+      content: "Error: No edits provided. Pass at least one edit with start and content.",
+    });
+  });
+
+  test("uses the context hook for planning prompts and tool visibility", async () => {
+    const testContext = createContext();
+    await serverPlugin.setup(testContext.context as never);
+    const hook = testContext.getSessionContextHook();
+    expect(hook).toBeInstanceOf(Function);
+
+    const planningEvent = {
+      agent: "plan",
+      system: [
+        { type: "text" as const, text: "Base system prompt" },
+        { type: "text" as const, text: "Earlier plugin prompt" },
+      ],
+      messages: [],
+      tools: {
+        submit_plan: { description: "Submit", input: {} },
+        plan_exit: { description: "Exit", input: {} },
+        todowrite: { description: "Write todos", input: {} },
+      },
+    };
+    await hook?.(planningEvent);
+
+    expect(planningEvent.system).toHaveLength(1);
+    expect(planningEvent.system[0]?.text).toStartWith(
+      "Base system prompt\n\nEarlier plugin prompt\n\n## Plannotator",
+    );
+    expect(planningEvent.tools.plan_exit.description).toContain("Use submit_plan instead");
+    expect(planningEvent.tools.todowrite.description).toContain("use submit_plan instead");
+
+    const buildEvent = {
+      agent: "build",
+      system: [{ type: "text" as const, text: "Base system prompt" }],
+      messages: [],
+      tools: {
+        submit_plan: { description: "Submit", input: {} },
+      },
+    };
+    await hook?.(buildEvent);
+    expect(buildEvent.tools.submit_plan).toBeUndefined();
+    expect(buildEvent.system).toEqual([{ type: "text", text: "Base system prompt" }]);
+
+    const strippedEvent = {
+      agent: "plan",
+      system: [{ type: "text" as const, text: "Call plan_exit when ready." }],
+      messages: [],
+      tools: {
+        submit_plan: { description: "Submit", input: {} },
+      },
+    };
+    await hook?.(strippedEvent);
+    expect(strippedEvent.system).toHaveLength(1);
+    expect(strippedEvent.system[0]?.text).toStartWith("## Plannotator");
+    expect(strippedEvent.system[0]?.text).not.toContain("undefined");
+  });
+
+  test("keeps all-agents mode scoped to primary agents by default", async () => {
+    delete process.env.PLANNOTATOR_ALLOW_SUBAGENTS;
+    const testContext = createContext(
+      { workflow: "all-agents" },
+      [{ id: "researcher", mode: "subagent", hidden: false }],
+    );
+    await serverPlugin.setup(testContext.context as never);
+    const event = {
+      agent: "researcher",
+      system: [{ type: "text" as const, text: "Base system prompt" }],
+      messages: [],
+      tools: {
+        submit_plan: { description: "Submit", input: {} },
+      },
+    };
+
+    await testContext.getSessionContextHook()?.(event);
+    expect(event.tools.submit_plan).toBeUndefined();
+  });
+});

--- a/apps/opencode-plugin/server.test.ts
+++ b/apps/opencode-plugin/server.test.ts
@@ -124,8 +124,8 @@ describe("OpenCode V2 server plugin", () => {
     const planningEvent = {
       agent: "plan",
       system: [
-        { type: "text" as const, text: "Base system prompt" },
-        { type: "text" as const, text: "Earlier plugin prompt" },
+        { type: "text" as const, text: "Base system prompt", metadata: { source: "base" } },
+        { type: "text" as const, text: "Earlier plugin prompt", cache: { type: "ephemeral" } },
       ],
       messages: [],
       tools: {
@@ -136,10 +136,14 @@ describe("OpenCode V2 server plugin", () => {
     };
     await hook?.(planningEvent);
 
-    expect(planningEvent.system).toHaveLength(1);
-    expect(planningEvent.system[0]?.text).toStartWith(
-      "Base system prompt\n\nEarlier plugin prompt\n\n## Plannotator",
-    );
+    expect(planningEvent.system).toHaveLength(3);
+    expect(planningEvent.system.slice(0, 2).map((part) => part.text)).toEqual([
+      "Base system prompt",
+      "Earlier plugin prompt",
+    ]);
+    expect(planningEvent.system[2]?.text).toStartWith("## Plannotator");
+    expect(planningEvent.system[0]?.metadata).toEqual({ source: "base" });
+    expect(planningEvent.system[1]?.cache).toEqual({ type: "ephemeral" });
     expect(planningEvent.tools.plan_exit.description).toContain("Use submit_plan instead");
     expect(planningEvent.tools.todowrite.description).toContain("use submit_plan instead");
 

--- a/apps/opencode-plugin/server.test.ts
+++ b/apps/opencode-plugin/server.test.ts
@@ -1,7 +1,20 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
-import serverPlugin from "./server";
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
 const originalAllowSubagents = process.env.PLANNOTATOR_ALLOW_SUBAGENTS;
+const originalDataDir = process.env.PLANNOTATOR_DATA_DIR;
+const testDataDir = mkdtempSync(path.join(tmpdir(), "plannotator-v2-server-test-"));
+process.env.PLANNOTATOR_DATA_DIR = testDataDir;
+
+const { default: serverPlugin } = await import("./server");
+
+afterAll(() => {
+  if (originalDataDir === undefined) delete process.env.PLANNOTATOR_DATA_DIR;
+  else process.env.PLANNOTATOR_DATA_DIR = originalDataDir;
+  rmSync(testDataDir, { recursive: true, force: true });
+});
 
 afterEach(() => {
   if (originalAllowSubagents === undefined) delete process.env.PLANNOTATOR_ALLOW_SUBAGENTS;

--- a/apps/opencode-plugin/server.test.ts
+++ b/apps/opencode-plugin/server.test.ts
@@ -1,20 +1,7 @@
-import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import path from "node:path";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import serverPlugin from "./server";
 
 const originalAllowSubagents = process.env.PLANNOTATOR_ALLOW_SUBAGENTS;
-const originalDataDir = process.env.PLANNOTATOR_DATA_DIR;
-const testDataDir = mkdtempSync(path.join(tmpdir(), "plannotator-v2-server-test-"));
-process.env.PLANNOTATOR_DATA_DIR = testDataDir;
-
-const { default: serverPlugin } = await import("./server");
-
-afterAll(() => {
-  if (originalDataDir === undefined) delete process.env.PLANNOTATOR_DATA_DIR;
-  else process.env.PLANNOTATOR_DATA_DIR = originalDataDir;
-  rmSync(testDataDir, { recursive: true, force: true });
-});
 
 afterEach(() => {
   if (originalAllowSubagents === undefined) delete process.env.PLANNOTATOR_ALLOW_SUBAGENTS;
@@ -149,12 +136,11 @@ describe("OpenCode V2 server plugin", () => {
     };
     await hook?.(planningEvent);
 
-    expect(planningEvent.system).toHaveLength(3);
     expect(planningEvent.system.slice(0, 2).map((part) => part.text)).toEqual([
       "Base system prompt",
       "Earlier plugin prompt",
     ]);
-    expect(planningEvent.system[2]?.text).toStartWith("## Plannotator");
+    expect(planningEvent.system.some((part) => part.text.startsWith("## Plannotator"))).toBe(true);
     expect(planningEvent.system[0]?.metadata).toEqual({ source: "base" });
     expect(planningEvent.system[1]?.cache).toEqual({ type: "ephemeral" });
     expect(planningEvent.tools.plan_exit.description).toContain("Use submit_plan instead");
@@ -181,9 +167,9 @@ describe("OpenCode V2 server plugin", () => {
       },
     };
     await hook?.(strippedEvent);
-    expect(strippedEvent.system).toHaveLength(1);
-    expect(strippedEvent.system[0]?.text).toStartWith("## Plannotator");
-    expect(strippedEvent.system[0]?.text).not.toContain("undefined");
+    const strippedSystemText = strippedEvent.system.map((part) => part.text);
+    expect(strippedSystemText.some((text) => text.startsWith("## Plannotator"))).toBe(true);
+    expect(strippedSystemText.join("\n")).not.toContain("undefined");
   });
 
   test("keeps all-agents mode scoped to primary agents by default", async () => {

--- a/apps/opencode-plugin/server.ts
+++ b/apps/opencode-plugin/server.ts
@@ -1,0 +1,383 @@
+import { Plugin } from "@opencode-ai/plugin";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { loadConfig, resolveSharingEnabled } from "@plannotator/shared/config";
+import { readImprovementHook } from "@plannotator/shared/improvement-hooks";
+import { composeImproveContext } from "@plannotator/shared/pfm-reminder";
+import { stripConflictingPlanModeRules } from "./plan-mode";
+import {
+  isPlanningAgent,
+  normalizeWorkflowOptions,
+  shouldInjectFullPlanningPrompt,
+  shouldInjectGenericPlanReminder,
+  shouldModifyPrompts,
+  shouldRegisterSubmitPlan,
+  type PlannotatorOpenCodeOptions,
+  type RuntimeMode,
+} from "./workflow";
+import {
+  runCliPlanReview,
+  type OpenCodeBridgeAgent,
+  type OpenCodeBridgeContext,
+  type OpenCodePlanReviewResult,
+} from "./cli-bridge";
+import { resolveTargetAgent } from "./agent-switch";
+import { executeSubmitPlan } from "./submit-plan-executor";
+import type { PlanEdit } from "./plan-edits";
+import { getPlanningPrompt } from "./planning-prompt";
+
+const DEFAULT_PLAN_TIMEOUT_SECONDS = 345_600;
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+let planHtml: string | undefined;
+
+type V2Client = {
+  app: {
+    agents: () => Promise<{ data: OpenCodeBridgeAgent[] }>;
+    log: (entry: { level: "info" | "error"; message: string }) => void;
+  };
+};
+
+type EmbeddedRuntimeModule = {
+  runEmbeddedPlanReview: (input: {
+    client: V2Client;
+    planContent: string;
+    sharingEnabled: boolean;
+    shareBaseUrl?: string;
+    pasteApiUrl?: string;
+    htmlContent: string;
+    timeoutSeconds: number | null;
+    abortSignal: AbortSignal;
+    logReady: (url: string, isRemote: boolean, port: number) => void;
+  }) => Promise<OpenCodePlanReviewResult>;
+};
+
+const serverPlugin = Plugin.define({
+  id: "plannotator",
+  setup: async (ctx) => {
+    const workflowOptions = normalizeWorkflowOptions(ctx.options as PlannotatorOpenCodeOptions);
+    let cachedAgents: OpenCodeBridgeAgent[] | undefined;
+    const loggedUrls = new Set<string>();
+
+    const getAgents = async (): Promise<OpenCodeBridgeAgent[]> => {
+      if (cachedAgents) return cachedAgents;
+      try {
+        const response = await ctx.agent.list();
+        cachedAgents = response.data.map((agent) => ({
+          name: agent.id,
+          description: agent.description,
+          mode: agent.mode,
+          hidden: agent.hidden,
+        }));
+      } catch {
+        cachedAgents = [];
+      }
+      return cachedAgents;
+    };
+
+    const client: V2Client = {
+      app: {
+        agents: async () => ({ data: await getAgents() }),
+        log: ({ message }) => {
+          const url = /https?:\/\/\S+/.exec(message)?.[0];
+          if (url && loggedUrls.has(url)) return;
+          if (url) loggedUrls.add(url);
+          console.error(message);
+        },
+      },
+    };
+
+    if (shouldModifyPrompts(workflowOptions)) {
+      await ctx.session.hook("context", async (event) => {
+        if (
+          workflowOptions.workflow === "plan-agent"
+          && !isPlanningAgent(event.agent, workflowOptions)
+        ) {
+          delete event.tools.submit_plan;
+          return;
+        }
+
+        const currentAgent = workflowOptions.workflow === "all-agents"
+          ? (await getAgents()).find((candidate) => candidate.name === event.agent)
+          : undefined;
+        if (!allowSubagents() && currentAgent?.mode === "subagent") {
+          delete event.tools.submit_plan;
+          return;
+        }
+
+        if (event.tools.plan_exit) {
+          event.tools.plan_exit.description =
+            "Do not call this tool. Use submit_plan instead - it opens a visual review UI for plan approval.";
+        }
+        if (event.tools.todowrite) {
+          event.tools.todowrite.description =
+            "While actively planning with the user, use submit_plan instead. Only use todos once implementation begins or unless the user explicitly asks.";
+        }
+
+        replaceStrictPlanReminder(event.messages);
+
+        const systemText = event.system.map((part) => part.text).join("\n").toLowerCase();
+        if (systemText.includes("title generator") || systemText.includes("generate a title")) return;
+
+        if (shouldInjectFullPlanningPrompt(event.agent, workflowOptions)) {
+          const additions = [getPlanningPrompt()];
+          const hook = readImprovementHook("enterplanmode-improve");
+          const improveContext = composeImproveContext({
+            pfmEnabled: loadConfig().pfmReminder === true,
+            improvementHookContent: hook?.content ?? null,
+          });
+          if (improveContext) additions.push(improveContext);
+          replaceSystemParts(
+            event.system,
+            stripConflictingPlanModeRules(event.system.map((part) => part.text)),
+            additions,
+          );
+          return;
+        }
+
+        if (!shouldInjectGenericPlanReminder(
+          event.agent,
+          currentAgent?.mode === "subagent",
+          workflowOptions,
+        )) return;
+
+        replaceSystemParts(event.system, event.system.map((part) => part.text), [getGenericPlanReminder()]);
+      });
+    }
+
+    if (!shouldRegisterSubmitPlan(workflowOptions)) return;
+
+    await ctx.tool.transform((tools) => {
+      tools.add({
+        name: "submit_plan",
+        description:
+          "Submit a plan for user review via line-range edits. First call: pass a single edit with start=1 and your full plan as content (omit end). Subsequent calls after denial: pass targeted edits using the line numbers from the previous response. The tool manages a backing file; you never touch the file directly.",
+        input: {
+          type: "object",
+          properties: {
+            edits: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  start: {
+                    type: "number",
+                    description: "1-indexed start line (inclusive)",
+                  },
+                  end: {
+                    type: "number",
+                    description: "1-indexed end line (inclusive). Omit to replace from start through end of file.",
+                  },
+                  content: {
+                    type: "string",
+                    description: "Replacement content. Empty string deletes the line range.",
+                  },
+                },
+                required: ["start", "content"],
+                additionalProperties: false,
+              },
+              description: "Array of line-range edits to apply to the plan.",
+            },
+          },
+          required: ["edits"],
+          additionalProperties: false,
+        },
+        options: { codemode: false },
+        execute: async (input, toolContext) => {
+          const session = await ctx.session.get({ sessionID: toolContext.sessionID });
+          const directory = session.location.directory;
+          const bridge = await getBridgeContext(getAgents);
+          const abortSignal = new AbortController().signal;
+          const result = await executeSubmitPlan({
+            edits: getPlanEdits(input),
+            invokingAgent: toolContext.agent,
+            sessionId: toolContext.sessionID,
+            abortSignal,
+            directory,
+            workflowOptions,
+          }, {
+            reviewPlan: async ({ planContent }) => await runPlanReview({
+              client,
+              runtime: workflowOptions.runtime,
+              planContent,
+              sharingEnabled: bridge.sharingEnabled ?? true,
+              shareBaseUrl: bridge.shareBaseUrl,
+              pasteApiUrl: bridge.pasteApiUrl,
+              timeoutSeconds: getPlanTimeoutSeconds(),
+              abortSignal,
+              directory,
+              bridge,
+            }),
+            resolveTargetAgent: async ({ requestedAgent }) => {
+              const targetAgent = resolveTargetAgent(requestedAgent);
+              if (!targetAgent) return undefined;
+              const available = (await getAgents()).some((agent) => agent.name === targetAgent);
+              if (!available) {
+                console.error(`[Plannotator] Configured OpenCode agent "${targetAgent}" is not available; approving the plan without switching agents.`);
+                return undefined;
+              }
+              // next-16770 exposes no session-agent switch operation to plugins.
+              console.error("[Plannotator] OpenCode 2 does not currently expose agent switching to plugins; approving the plan without switching agents.");
+              return undefined;
+            },
+            sendApprovalHandoff: async () => {},
+          });
+
+          return { content: result };
+        },
+      });
+    });
+  },
+});
+
+function getPlanEdits(input: unknown): PlanEdit[] | undefined {
+  if (!input || typeof input !== "object") return undefined;
+  const edits = Reflect.get(input, "edits");
+  return Array.isArray(edits) ? edits as PlanEdit[] : undefined;
+}
+
+function getPlanTimeoutSeconds(): number | null {
+  const raw = process.env.PLANNOTATOR_PLAN_TIMEOUT_SECONDS?.trim();
+  if (!raw) return DEFAULT_PLAN_TIMEOUT_SECONDS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    console.error(`[Plannotator] Invalid PLANNOTATOR_PLAN_TIMEOUT_SECONDS="${raw}". Using default ${DEFAULT_PLAN_TIMEOUT_SECONDS}s.`);
+    return DEFAULT_PLAN_TIMEOUT_SECONDS;
+  }
+  return parsed === 0 ? null : parsed;
+}
+
+function allowSubagents(): boolean {
+  const value = process.env.PLANNOTATOR_ALLOW_SUBAGENTS?.trim();
+  return value === "1" || value === "true";
+}
+
+async function getBridgeContext(
+  getAgents: () => Promise<OpenCodeBridgeAgent[]>,
+): Promise<OpenCodeBridgeContext> {
+  return {
+    sharingEnabled: resolveSharingEnabled(loadConfig()),
+    shareBaseUrl: process.env.PLANNOTATOR_SHARE_URL || undefined,
+    pasteApiUrl: process.env.PLANNOTATOR_PASTE_URL || undefined,
+    agents: await getAgents(),
+  };
+}
+
+function hasEmbeddedRuntime(): boolean {
+  return typeof (globalThis as typeof globalThis & { Bun?: { serve?: unknown } }).Bun?.serve === "function";
+}
+
+async function importEmbeddedRuntime(): Promise<EmbeddedRuntimeModule> {
+  const builtPath = path.join(moduleDir, "embedded.js");
+  if (existsSync(builtPath)) {
+    return await import(pathToFileURL(builtPath).href) as EmbeddedRuntimeModule;
+  }
+  const sourceSpecifier = "./embedded";
+  return await import(sourceSpecifier) as EmbeddedRuntimeModule;
+}
+
+function getPlanHtml(): string {
+  if (planHtml) return planHtml;
+  const candidates = [
+    path.join(moduleDir, "plannotator.html"),
+    path.join(moduleDir, "..", "plannotator.html"),
+  ];
+  const htmlPath = candidates.find((candidate) => existsSync(candidate));
+  if (!htmlPath) throw new Error("Could not find bundled HTML asset: plannotator.html");
+  planHtml = readFileSync(htmlPath, "utf-8");
+  return planHtml;
+}
+
+async function runPlanReview(input: {
+  client: V2Client;
+  runtime: RuntimeMode;
+  planContent: string;
+  sharingEnabled: boolean;
+  shareBaseUrl?: string;
+  pasteApiUrl?: string;
+  timeoutSeconds: number | null;
+  abortSignal: AbortSignal;
+  directory: string;
+  bridge: OpenCodeBridgeContext;
+}): Promise<OpenCodePlanReviewResult> {
+  if (input.runtime === "embedded" && !hasEmbeddedRuntime()) {
+    throw new Error('runtime "embedded" requires a Bun-hosted OpenCode plugin runtime. Use runtime "auto" or "cli" with this OpenCode host.');
+  }
+
+  if (input.runtime !== "cli" && hasEmbeddedRuntime()) {
+    try {
+      const embedded = await importEmbeddedRuntime();
+      return await embedded.runEmbeddedPlanReview({
+        client: input.client,
+        planContent: input.planContent,
+        sharingEnabled: input.sharingEnabled,
+        shareBaseUrl: input.shareBaseUrl,
+        pasteApiUrl: input.pasteApiUrl,
+        htmlContent: getPlanHtml(),
+        timeoutSeconds: input.timeoutSeconds,
+        abortSignal: input.abortSignal,
+        // handleServerReady owns the stable, exactly-once session URL output.
+        logReady: () => {},
+      });
+    } catch (error) {
+      if (input.runtime === "embedded") throw error;
+      console.error(`[Plannotator] Embedded runtime unavailable; falling back to CLI: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  return await runCliPlanReview({
+    client: input.client,
+    planContent: input.planContent,
+    cwd: input.directory,
+    timeoutSeconds: input.timeoutSeconds,
+    abortSignal: input.abortSignal,
+    bridge: input.bridge,
+  });
+}
+
+function replaceSystemParts(
+  system: Array<{ type: "text"; text: string; [key: string]: unknown }>,
+  existing: string[],
+  additions: string[],
+): void {
+  const text = [...existing, ...additions].filter(Boolean).join("\n\n");
+  const first = system[0] ?? { type: "text" as const, text: "" };
+  system.length = 0;
+  system.push({ ...first, type: "text", text });
+}
+
+function replaceStrictPlanReminder(messages: unknown[]): void {
+  for (const message of messages) {
+    if (!message || typeof message !== "object" || Reflect.get(message, "role") !== "user") continue;
+    const content = Reflect.get(message, "content");
+    if (!Array.isArray(content)) continue;
+    for (const part of content) {
+      if (!part || typeof part !== "object" || Reflect.get(part, "type") !== "text") continue;
+      const text = Reflect.get(part, "text");
+      if (typeof text !== "string" || !text.includes("STRICTLY FORBIDDEN")) continue;
+      Reflect.set(part, "text", `<system-reminder>
+# Plan Mode - System Reminder
+
+CRITICAL: Plan mode ACTIVE. You are in a PLANNING phase. The ONLY file modifications
+allowed are writing or editing markdown files (.md) - plans, specs, documentation, etc.
+All other file edits, code modifications, and system changes are STRICTLY FORBIDDEN.
+Do NOT use shell commands to manipulate non-markdown files. Commands may ONLY read/inspect.
+
+Use submit_plan to submit the completed plan for user review. Do not proceed with
+implementation until the plan is approved.
+</system-reminder>`);
+    }
+  }
+}
+
+function getGenericPlanReminder(): string {
+  return `## Plan Submission
+
+When you have completed your plan, call the \`submit_plan\` tool to submit it for user review. Pass your full plan as a single edit: \`{ "edits": [{ "start": 1, "content": "..." }] }\`.
+
+The user will review your plan in a visual UI where they can annotate, approve, or request changes. If rejected, the response includes your plan with line numbers; use targeted edits to revise specific sections.
+
+Do NOT proceed with implementation until your plan is approved.`;
+}
+
+export default serverPlugin;

--- a/apps/opencode-plugin/server.ts
+++ b/apps/opencode-plugin/server.ts
@@ -57,7 +57,6 @@ const serverPlugin = Plugin.define({
   setup: async (ctx) => {
     const workflowOptions = normalizeWorkflowOptions(ctx.options as PlannotatorOpenCodeOptions);
     let cachedAgents: OpenCodeBridgeAgent[] | undefined;
-    const loggedUrls = new Set<string>();
 
     const getAgents = async (): Promise<OpenCodeBridgeAgent[]> => {
       if (cachedAgents) return cachedAgents;
@@ -73,18 +72,6 @@ const serverPlugin = Plugin.define({
         cachedAgents = [];
       }
       return cachedAgents;
-    };
-
-    const client: V2Client = {
-      app: {
-        agents: async () => ({ data: await getAgents() }),
-        log: ({ message }) => {
-          const url = /https?:\/\/\S+/.exec(message)?.[0];
-          if (url && loggedUrls.has(url)) return;
-          if (url) loggedUrls.add(url);
-          console.error(message);
-        },
-      },
     };
 
     if (shouldModifyPrompts(workflowOptions)) {
@@ -127,9 +114,8 @@ const serverPlugin = Plugin.define({
             improvementHookContent: hook?.content ?? null,
           });
           if (improveContext) additions.push(improveContext);
-          replaceSystemParts(
+          replacePlanningSystemParts(
             event.system,
-            stripConflictingPlanModeRules(event.system.map((part) => part.text)),
             additions,
           );
           return;
@@ -141,7 +127,7 @@ const serverPlugin = Plugin.define({
           workflowOptions,
         )) return;
 
-        replaceSystemParts(event.system, event.system.map((part) => part.text), [getGenericPlanReminder()]);
+        event.system.push({ type: "text", text: getGenericPlanReminder() });
       });
     }
 
@@ -187,6 +173,7 @@ const serverPlugin = Plugin.define({
           const session = await ctx.session.get({ sessionID: toolContext.sessionID });
           const directory = session.location.directory;
           const bridge = await getBridgeContext(getAgents);
+          const client = createV2Client(getAgents);
           const abortSignal = new AbortController().signal;
           const result = await executeSubmitPlan({
             edits: getPlanEdits(input),
@@ -245,6 +232,23 @@ function getPlanTimeoutSeconds(): number | null {
     return DEFAULT_PLAN_TIMEOUT_SECONDS;
   }
   return parsed === 0 ? null : parsed;
+}
+
+function createV2Client(
+  getAgents: () => Promise<OpenCodeBridgeAgent[]>,
+): V2Client {
+  const loggedUrls = new Set<string>();
+  return {
+    app: {
+      agents: async () => ({ data: await getAgents() }),
+      log: ({ message }) => {
+        const url = /https?:\/\/\S+/.exec(message)?.[0];
+        if (url && loggedUrls.has(url)) return;
+        if (url) loggedUrls.add(url);
+        console.error(message);
+      },
+    },
+  };
 }
 
 function allowSubagents(): boolean {
@@ -335,15 +339,19 @@ async function runPlanReview(input: {
   });
 }
 
-function replaceSystemParts(
+function replacePlanningSystemParts(
   system: Array<{ type: "text"; text: string; [key: string]: unknown }>,
-  existing: string[],
   additions: string[],
 ): void {
-  const text = [...existing, ...additions].filter(Boolean).join("\n\n");
-  const first = system[0] ?? { type: "text" as const, text: "" };
+  const existing = system.flatMap((part) => {
+    const text = stripConflictingPlanModeRules([part.text])[0];
+    return text ? [{ ...part, text }] : [];
+  });
   system.length = 0;
-  system.push({ ...first, type: "text", text });
+  system.push(
+    ...existing,
+    ...additions.filter(Boolean).map((text) => ({ type: "text" as const, text })),
+  );
 }
 
 function replaceStrictPlanReminder(messages: unknown[]): void {

--- a/apps/opencode-plugin/server.ts
+++ b/apps/opencode-plugin/server.ts
@@ -200,7 +200,7 @@ const serverPlugin = Plugin.define({
                 console.error(`[Plannotator] Configured OpenCode agent "${targetAgent}" is not available; approving the plan without switching agents.`);
                 return undefined;
               }
-              // next-16770 exposes no session-agent switch operation to plugins.
+              // The current OpenCode 2 API exposes no session-agent switch operation to plugins.
               console.error("[Plannotator] OpenCode 2 does not currently expose agent switching to plugins; approving the plan without switching agents.");
               return undefined;
             },

--- a/apps/opencode-plugin/server.ts
+++ b/apps/opencode-plugin/server.ts
@@ -47,7 +47,7 @@ type EmbeddedRuntimeModule = {
     pasteApiUrl?: string;
     htmlContent: string;
     timeoutSeconds: number | null;
-    abortSignal: AbortSignal;
+    abortSignal?: AbortSignal;
     logReady: (url: string, isRemote: boolean, port: number) => void;
   }) => Promise<OpenCodePlanReviewResult>;
 };
@@ -174,12 +174,10 @@ const serverPlugin = Plugin.define({
           const directory = session.location.directory;
           const bridge = await getBridgeContext(getAgents);
           const client = createV2Client(getAgents);
-          const abortSignal = new AbortController().signal;
           const result = await executeSubmitPlan({
             edits: getPlanEdits(input),
             invokingAgent: toolContext.agent,
             sessionId: toolContext.sessionID,
-            abortSignal,
             directory,
             workflowOptions,
           }, {
@@ -191,7 +189,6 @@ const serverPlugin = Plugin.define({
               shareBaseUrl: bridge.shareBaseUrl,
               pasteApiUrl: bridge.pasteApiUrl,
               timeoutSeconds: getPlanTimeoutSeconds(),
-              abortSignal,
               directory,
               bridge,
             }),
@@ -300,7 +297,7 @@ async function runPlanReview(input: {
   shareBaseUrl?: string;
   pasteApiUrl?: string;
   timeoutSeconds: number | null;
-  abortSignal: AbortSignal;
+  abortSignal?: AbortSignal;
   directory: string;
   bridge: OpenCodeBridgeContext;
 }): Promise<OpenCodePlanReviewResult> {

--- a/apps/opencode-plugin/submit-plan-executor.test.ts
+++ b/apps/opencode-plugin/submit-plan-executor.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { executeSubmitPlan } from "./submit-plan-executor";
+import { getPlanBackingPath } from "./plan-edits";
+import { normalizeWorkflowOptions } from "./workflow";
+
+const originalDataDir = process.env.PLANNOTATOR_DATA_DIR;
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  if (originalDataDir === undefined) delete process.env.PLANNOTATOR_DATA_DIR;
+  else process.env.PLANNOTATOR_DATA_DIR = originalDataDir;
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function prepareDataDir(): void {
+  const dir = mkdtempSync(path.join(tmpdir(), "plannotator-submit-plan-"));
+  tempDirs.push(dir);
+  process.env.PLANNOTATOR_DATA_DIR = dir;
+}
+
+describe("executeSubmitPlan", () => {
+  test("persists denied plans and returns numbered revision context", async () => {
+    prepareDataDir();
+    const reviewPlan = mock(async () => ({ approved: false, feedback: "Add tests" }));
+
+    const result = await executeSubmitPlan({
+      edits: [{ start: 1, content: "# Plan\n\nShip it" }],
+      invokingAgent: "plan",
+      sessionId: "session-1",
+      abortSignal: new AbortController().signal,
+      directory: "/workspace/example",
+      workflowOptions: normalizeWorkflowOptions(undefined),
+    }, {
+      reviewPlan,
+      resolveTargetAgent: async () => undefined,
+      sendApprovalHandoff: async () => {},
+    });
+
+    const backingPath = getPlanBackingPath("example");
+    expect(readFileSync(backingPath, "utf-8")).toBe("# Plan\n\nShip it");
+    expect(result).toContain("Add tests");
+    expect(result).toContain("1| # Plan\n2| \n3| Ship it");
+    expect(reviewPlan).toHaveBeenCalledTimes(1);
+  });
+
+  test("cleans up approved plans and sends implementation handoff", async () => {
+    prepareDataDir();
+    const sendApprovalHandoff = mock(async () => {});
+
+    const result = await executeSubmitPlan({
+      edits: [{ start: 1, content: "# Approved" }],
+      invokingAgent: "plan",
+      sessionId: "session-2",
+      abortSignal: new AbortController().signal,
+      directory: "/workspace/example",
+      workflowOptions: normalizeWorkflowOptions(undefined),
+    }, {
+      reviewPlan: async () => ({ approved: true, agentSwitch: "build" }),
+      resolveTargetAgent: async () => "build",
+      sendApprovalHandoff,
+    });
+
+    expect(existsSync(getPlanBackingPath("example"))).toBe(false);
+    expect(sendApprovalHandoff).toHaveBeenCalledWith({
+      sessionId: "session-2",
+      targetAgent: "build",
+      text: "Proceed with implementation",
+    });
+    expect(result).toBe("Plan approved!");
+  });
+
+  test("preserves backing state when review startup fails", async () => {
+    prepareDataDir();
+
+    const result = await executeSubmitPlan({
+      edits: [{ start: 1, content: "# Retry later" }],
+      invokingAgent: "plan",
+      sessionId: "session-3",
+      abortSignal: new AbortController().signal,
+      directory: "/workspace/example",
+      workflowOptions: normalizeWorkflowOptions(undefined),
+    }, {
+      reviewPlan: async () => { throw new Error("browser unavailable"); },
+      resolveTargetAgent: async () => undefined,
+      sendApprovalHandoff: async () => {},
+    });
+
+    expect(result).toBe("[Plannotator] Failed to open plan review: browser unavailable");
+    expect(readFileSync(getPlanBackingPath("example"), "utf-8")).toBe("# Retry later");
+  });
+
+  test("rethrows the host abort reason instead of formatting it as startup failure", async () => {
+    prepareDataDir();
+    const controller = new AbortController();
+    const reason = new DOMException("Cancelled by OpenCode", "AbortError");
+
+    const execution = executeSubmitPlan({
+      edits: [{ start: 1, content: "# Cancelled" }],
+      invokingAgent: "plan",
+      sessionId: "session-4",
+      abortSignal: controller.signal,
+      directory: "/workspace/example",
+      workflowOptions: normalizeWorkflowOptions(undefined),
+    }, {
+      reviewPlan: async () => {
+        controller.abort(reason);
+        throw reason;
+      },
+      resolveTargetAgent: async () => undefined,
+      sendApprovalHandoff: async () => {},
+    });
+
+    await expect(execution).rejects.toBe(reason);
+  });
+});

--- a/apps/opencode-plugin/submit-plan-executor.test.ts
+++ b/apps/opencode-plugin/submit-plan-executor.test.ts
@@ -23,7 +23,7 @@ function prepareDataDir(): void {
 }
 
 describe("executeSubmitPlan", () => {
-  test("persists denied plans and returns numbered revision context", async () => {
+  test("supports hosts without cancellation signals", async () => {
     prepareDataDir();
     const reviewPlan = mock(async () => ({ approved: false, feedback: "Add tests" }));
 
@@ -31,7 +31,6 @@ describe("executeSubmitPlan", () => {
       edits: [{ start: 1, content: "# Plan\n\nShip it" }],
       invokingAgent: "plan",
       sessionId: "session-1",
-      abortSignal: new AbortController().signal,
       directory: "/workspace/example",
       workflowOptions: normalizeWorkflowOptions(undefined),
     }, {
@@ -45,6 +44,10 @@ describe("executeSubmitPlan", () => {
     expect(result).toContain("Add tests");
     expect(result).toContain("1| # Plan\n2| \n3| Ship it");
     expect(reviewPlan).toHaveBeenCalledTimes(1);
+    expect(reviewPlan).toHaveBeenCalledWith({
+      planContent: "# Plan\n\nShip it",
+      abortSignal: undefined,
+    });
   });
 
   test("cleans up approved plans and sends implementation handoff", async () => {

--- a/apps/opencode-plugin/submit-plan-executor.ts
+++ b/apps/opencode-plugin/submit-plan-executor.ts
@@ -33,7 +33,7 @@ export interface SubmitPlanInvocation {
   edits: PlanEdit[] | undefined;
   invokingAgent?: string;
   sessionId: string;
-  abortSignal: AbortSignal;
+  abortSignal?: AbortSignal;
   directory: string;
   workflowOptions: NormalizedWorkflowOptions;
 }
@@ -41,7 +41,7 @@ export interface SubmitPlanInvocation {
 export interface SubmitPlanHost {
   reviewPlan(input: {
     planContent: string;
-    abortSignal: AbortSignal;
+    abortSignal?: AbortSignal;
   }): Promise<SubmitPlanReviewResult>;
   resolveTargetAgent(input: {
     requestedAgent?: string;
@@ -65,7 +65,7 @@ export async function executeSubmitPlan(
 Use /plannotator-last or /plannotator-annotate for manual review, or set workflow to all-agents to allow broader submit_plan access.`;
   }
 
-  invocation.abortSignal.throwIfAborted();
+  invocation.abortSignal?.throwIfAborted();
 
   if (!invocation.edits || invocation.edits.length === 0) {
     return "Error: No edits provided. Pass at least one edit with start and content.";
@@ -104,7 +104,7 @@ Use /plannotator-last or /plannotator-annotate for manual review, or set workflo
       abortSignal: invocation.abortSignal,
     });
   } catch (error) {
-    invocation.abortSignal.throwIfAborted();
+    invocation.abortSignal?.throwIfAborted();
     return `[Plannotator] Failed to open plan review: ${error instanceof Error ? error.message : String(error)}`;
   }
 

--- a/apps/opencode-plugin/submit-plan-executor.ts
+++ b/apps/opencode-plugin/submit-plan-executor.ts
@@ -1,0 +1,165 @@
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import {
+  getPlanApprovedPrompt,
+  getPlanApprovedWithNotesPrompt,
+  getPlanDeniedPrompt,
+  getPlanToolName,
+} from "@plannotator/shared/prompts";
+import { sanitizeTag } from "@plannotator/shared/project";
+import {
+  applyEdits,
+  formatWithLineNumbers,
+  getPlanBackingPath,
+  type PlanEdit,
+  validateEdits,
+} from "./plan-edits";
+import {
+  shouldRejectSubmitPlanForAgent,
+  shouldStartImplementationForAgent,
+  type NormalizedWorkflowOptions,
+} from "./workflow";
+
+const MAX_PLAN_SIZE = 5 * 1024 * 1024;
+
+export interface SubmitPlanReviewResult {
+  approved: boolean;
+  feedback?: string;
+  savedPath?: string;
+  agentSwitch?: string;
+}
+
+export interface SubmitPlanInvocation {
+  edits: PlanEdit[] | undefined;
+  invokingAgent?: string;
+  sessionId: string;
+  abortSignal: AbortSignal;
+  directory: string;
+  workflowOptions: NormalizedWorkflowOptions;
+}
+
+export interface SubmitPlanHost {
+  reviewPlan(input: {
+    planContent: string;
+    abortSignal: AbortSignal;
+  }): Promise<SubmitPlanReviewResult>;
+  resolveTargetAgent(input: {
+    requestedAgent?: string;
+    directory: string;
+    delivery: "plan-approval";
+  }): Promise<string | undefined>;
+  sendApprovalHandoff(input: {
+    sessionId: string;
+    targetAgent: string;
+    text: string;
+  }): Promise<void>;
+}
+
+export async function executeSubmitPlan(
+  invocation: SubmitPlanInvocation,
+  host: SubmitPlanHost,
+): Promise<string> {
+  if (shouldRejectSubmitPlanForAgent(invocation.invokingAgent, invocation.workflowOptions)) {
+    return `Plannotator is configured for plan-agent mode. submit_plan can only be called by: ${invocation.workflowOptions.planningAgents.join(", ")}.
+
+Use /plannotator-last or /plannotator-annotate for manual review, or set workflow to all-agents to allow broader submit_plan access.`;
+  }
+
+  invocation.abortSignal.throwIfAborted();
+
+  if (!invocation.edits || invocation.edits.length === 0) {
+    return "Error: No edits provided. Pass at least one edit with start and content.";
+  }
+
+  const project = sanitizeTag(path.basename(invocation.directory)) || "_unknown";
+  const backingPath = getPlanBackingPath(project);
+  mkdirSync(path.dirname(backingPath), { recursive: true });
+
+  const existingContent = existsSync(backingPath)
+    ? readFileSync(backingPath, "utf-8")
+    : "";
+  const existingLines = existingContent ? existingContent.split("\n") : [];
+  const validationError = validateEdits(existingLines, invocation.edits);
+  if (validationError) return `Error: ${validationError}`;
+
+  let resultLines: string[];
+  try {
+    resultLines = applyEdits(existingLines, invocation.edits);
+  } catch (error) {
+    return `Error applying edits: ${error instanceof Error ? error.message : String(error)}`;
+  }
+
+  const planContent = resultLines.join("\n");
+  if (planContent.length > MAX_PLAN_SIZE) {
+    return `Error: Plan content exceeds the maximum size of ${MAX_PLAN_SIZE / (1024 * 1024)}MB.`;
+  }
+  if (!planContent.trim()) return "Error: Plan content is empty after applying edits.";
+
+  writeFileSync(backingPath, planContent, "utf-8");
+
+  let reviewResult: SubmitPlanReviewResult;
+  try {
+    reviewResult = await host.reviewPlan({
+      planContent,
+      abortSignal: invocation.abortSignal,
+    });
+  } catch (error) {
+    invocation.abortSignal.throwIfAborted();
+    return `[Plannotator] Failed to open plan review: ${error instanceof Error ? error.message : String(error)}`;
+  }
+
+  if (!reviewResult.approved) {
+    const lineNumberedPlan = formatWithLineNumbers(planContent);
+    const totalLines = planContent.split("\n").length;
+    return getPlanDeniedPrompt("opencode", undefined, {
+      toolName: getPlanToolName("opencode"),
+      planFileRule: "",
+      feedback: reviewResult.feedback || "Plan changes requested",
+    }) + `\n\n## Current Plan (${totalLines} lines)\n\nThe plan below shows the current state with line numbers. Use these exact line numbers in your next \`submit_plan\` call:\n\n\`\`\`\n${lineNumberedPlan}\n\`\`\`\n\nCall \`submit_plan\` with targeted edits to address the feedback above.`;
+  }
+
+  try {
+    unlinkSync(backingPath);
+  } catch {
+    // The approved plan may already have been removed.
+  }
+
+  const targetAgent = await host.resolveTargetAgent({
+    requestedAgent: reviewResult.agentSwitch,
+    directory: invocation.directory,
+    delivery: "plan-approval",
+  });
+  const shouldStartImplementation = targetAgent
+    ? shouldStartImplementationForAgent(targetAgent, invocation.workflowOptions)
+    : false;
+
+  if (targetAgent) {
+    try {
+      await host.sendApprovalHandoff({
+        sessionId: invocation.sessionId,
+        targetAgent,
+        text: shouldStartImplementation
+          ? "Proceed with implementation"
+          : "Plan approved. Plan mode remains active; no implementation has been requested.",
+      });
+    } catch {
+      // The session can still be busy while the tool result is being delivered.
+    }
+  }
+
+  if (reviewResult.feedback) {
+    return getPlanApprovedWithNotesPrompt("opencode", undefined, {
+      planFilePath: backingPath,
+      doneMsg: reviewResult.savedPath ? `Saved to: ${reviewResult.savedPath}` : "",
+      feedback: reviewResult.feedback,
+      proceedSuffix: shouldStartImplementation
+        ? "\n\nProceed with implementation, incorporating these notes where applicable."
+        : "",
+    });
+  }
+
+  return getPlanApprovedPrompt("opencode", undefined, {
+    planFilePath: backingPath,
+    doneMsg: reviewResult.savedPath ? ` Saved to: ${reviewResult.savedPath}` : "",
+  });
+}

--- a/bun.lock
+++ b/bun.lock
@@ -65,7 +65,7 @@
       "name": "@plannotator/opencode",
       "version": "0.25.1",
       "dependencies": {
-        "@opencode-ai/plugin": "^1.1.10",
+        "@opencode-ai/plugin": "0.0.0-next-16770",
       },
       "devDependencies": {
         "@plannotator/server": "workspace:*",
@@ -313,6 +313,8 @@
     },
   },
   "packages": {
+    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
+
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
 
     "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.141", "", { "dependencies": { "@anthropic-ai/sdk": "^0.93.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.141", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.141", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.141", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.141" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-AIBacMWGcZIUcXlUoObqjwJ6pmJI3BayAqPAFXuvSq3DHJXdiuZVs7l/zTB5l3nRhRv5cqSrI2XbiDeHgZWizw=="],
@@ -755,7 +757,15 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.16.2", "", { "dependencies": { "@opencode-ai/sdk": "1.16.2", "effect": "4.0.0-beta.74", "zod": "4.1.8" }, "peerDependencies": { "@opentui/core": ">=0.3.2", "@opentui/keymap": ">=0.3.2", "@opentui/solid": ">=0.3.2" }, "optionalPeers": ["@opentui/core", "@opentui/keymap", "@opentui/solid"] }, "sha512-FaZhVXrbz93xsdGLCtarRDTeqFt8AkLfh8B34tFBj6G4HXVmKSgBwVXmtELKKC+08xMtawBC9hshiMbXryv6cg=="],
+    "@opencode-ai/ai": ["@opencode-ai/ai@0.0.0-next-16770", "", { "dependencies": { "@opencode-ai/schema": "0.0.0-next-16770", "@smithy/eventstream-codec": "4.2.14", "@smithy/util-utf8": "4.2.2", "aws4fetch": "1.0.20", "effect": "4.0.0-beta.101", "google-auth-library": "10.5.0" } }, "sha512-J67T55JenepuvU8bCyWQebjKakVGg6hbZrFOugsO5fqk1Em5YDpUAZCZEjMek+WTjhVEotturowkaQqHVl0izQ=="],
+
+    "@opencode-ai/client": ["@opencode-ai/client@0.0.0-next-16770", "", { "dependencies": { "@opencode-ai/protocol": "0.0.0-next-16770", "@opencode-ai/schema": "0.0.0-next-16770" }, "peerDependencies": { "effect": "4.0.0-beta.101" }, "optionalPeers": ["effect"] }, "sha512-t6xBnp4xnATQditslc6RtzcLqI2yCzREhiWlK4f03SzcUiRZDXRoyLNKpRO/bV6/egEum6i9fZtVWIKSMGQU2g=="],
+
+    "@opencode-ai/plugin": ["@opencode-ai/plugin@0.0.0-next-16770", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@opencode-ai/ai": "0.0.0-next-16770", "@opencode-ai/client": "0.0.0-next-16770", "@opencode-ai/schema": "0.0.0-next-16770", "@opencode-ai/sdk": "1.18.5", "@standard-schema/spec": "1.1.0", "effect": "4.0.0-beta.101", "zod": "4.1.8" }, "peerDependencies": { "@opencode-ai/theme": "0.0.0-next-16770", "@opentui/core": ">=0.4.5", "@opentui/keymap": ">=0.4.5", "@opentui/solid": ">=0.4.5", "solid-js": ">=1.9.0" }, "optionalPeers": ["@opencode-ai/theme", "@opentui/core", "@opentui/keymap", "@opentui/solid", "solid-js"] }, "sha512-gmhi1/dsYLVHVO1waAqe4r/L+NWCPNuUKOVcT1O8tS/LjShb765VLFqLtmBd5UVLaG5be+T0bWCXbKtvEG4rVA=="],
+
+    "@opencode-ai/protocol": ["@opencode-ai/protocol@0.0.0-next-16770", "", { "dependencies": { "@opencode-ai/schema": "0.0.0-next-16770", "effect": "4.0.0-beta.101" } }, "sha512-Cwb3UoZODBpPRrK++f2cTLLc3P55RRbl3+RtEbiuJKD9NeACDUWBYvAF0QrZEaDMtkfIa5e3lNp/mqbd3BRoQQ=="],
+
+    "@opencode-ai/schema": ["@opencode-ai/schema@0.0.0-next-16770", "", { "dependencies": { "@standard-schema/spec": "1.1.0", "effect": "4.0.0-beta.101" } }, "sha512-JUMv2Qac1Mq76dP0Tc4JzUKixPxZh1ElEaZD/TH3NTFEtxBElUx934KV9nQZtSW1cgT46Hir1oCOHkBdfG0lTg=="],
 
     "@opencode-ai/sdk": ["@opencode-ai/sdk@1.16.2", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-Z/xZ7q79dYeE0afqIk/yFEcRNGEQFcE+H8ssYivUiy+xGZ1mGwT72jpaQZKBwPn3JH4sRCu4KA2lcktBQfcOjg=="],
 
@@ -959,6 +969,8 @@
 
     "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.3.8", "", { "dependencies": { "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg=="],
 
+    "@smithy/eventstream-codec": ["@smithy/eventstream-codec@4.2.14", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.1", "@smithy/util-hex-encoding": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw=="],
+
     "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.4.6", "", { "dependencies": { "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g=="],
 
     "@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
@@ -969,9 +981,11 @@
 
     "@smithy/types": ["@smithy/types@4.14.3", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ=="],
 
-    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@4.4.15", "", { "dependencies": { "@smithy/core": "^3.31.0", "tslib": "^2.6.2" } }, "sha512-l9nGf427a/YPs5CzxTxniSEJFtFHleNVU0DILtACxynzfeyXPpTgfa4tU2s2YE+cgajgSj7dTUdHcYn90SNCOg=="],
 
-    "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+    "@smithy/util-hex-encoding": ["@smithy/util-hex-encoding@4.4.15", "", { "dependencies": { "@smithy/core": "^3.31.0", "tslib": "^2.6.2" } }, "sha512-SBb6oMnuys6inwF82r5w3nfDaLwk/DTlEg2Pgk7GOUym6ZoTchEy7hBs5v3EHefqBrbBR+DPmSsSYNTJTv8QFw=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@4.2.2", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -1221,6 +1235,8 @@
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
+    "aws4fetch": ["aws4fetch@1.0.20", "", {}, "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g=="],
+
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
     "azure-devops-node-api": ["azure-devops-node-api@12.5.0", "", { "dependencies": { "tunnel": "0.0.6", "typed-rest-client": "^1.8.4" } }, "sha512-R5eFskGvOm3U/GzeAuxRkUsAl0hrAwGgWn6zAd2KrZmrEhWZVqLew4OOupbQlXUuojUzpGtq62SmdhJ06N88og=="],
@@ -1437,7 +1453,7 @@
 
     "dagre-d3-es": ["dagre-d3-es@7.0.14", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg=="],
 
-    "data-uri-to-buffer": ["data-uri-to-buffer@2.0.2", "", {}, "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA=="],
+    "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
     "dayjs": ["dayjs@1.11.21", "", {}, "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA=="],
 
@@ -1505,7 +1521,7 @@
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
-    "effect": ["effect@4.0.0-beta.74", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.8.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.1", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^14.0.0", "yaml": "^2.9.0" } }, "sha512-Yx+Kh12U+i2FmjwEfKs+ePFmpMd43RPD1oGqc/VraSS9bYzvF0Ff3PojwEFEVEewp8xc92Uxu28gTspU4qyvHA=="],
+    "effect": ["effect@4.0.0-beta.101", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-HjowumlIo+orthn4jMlEJPuzIYPBV+uq/XiciHWhiedLsXQpWHdNJHO5d59BVDP5s1LPuvERcktwFqRXnJqnhA=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.371", "", {}, "sha512-e9htk9mAYL6AzmkEhSvVVw7IWGSBJ/Bqdn2eRyRLrj1g6sncN4WbFt5qnILYoCktktr45pyjIrOiRvBThQ808w=="],
 
@@ -1581,7 +1597,7 @@
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
-    "fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
+    "fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -1657,13 +1673,15 @@
 
     "globby": ["globby@14.1.0", "", { "dependencies": { "@sindresorhus/merge-streams": "^2.1.0", "fast-glob": "^3.3.3", "ignore": "^7.0.3", "path-type": "^6.0.0", "slash": "^5.1.0", "unicorn-magic": "^0.3.0" } }, "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA=="],
 
-    "google-auth-library": ["google-auth-library@10.7.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ=="],
+    "google-auth-library": ["google-auth-library@10.5.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.0.0", "gcp-metadata": "^8.0.0", "google-logging-utils": "^1.0.0", "gtoken": "^8.0.0", "jws": "^4.0.0" } }, "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w=="],
 
     "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "gtoken": ["gtoken@8.0.0", "", { "dependencies": { "gaxios": "^7.0.0", "jws": "^4.0.0" } }, "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw=="],
 
     "h3": ["h3@1.15.11", "", { "dependencies": { "cookie-es": "^1.2.3", "crossws": "^0.3.5", "defu": "^6.1.6", "destr": "^2.0.5", "iron-webcrypto": "^1.2.1", "node-mock-http": "^1.0.4", "radix3": "^1.1.2", "ufo": "^1.6.3", "uncrypto": "^0.1.3" } }, "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg=="],
 
@@ -1790,6 +1808,8 @@
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
+    "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
     "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
@@ -2043,7 +2063,7 @@
 
     "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
 
-    "multipasta": ["multipasta@0.2.7", "", {}, "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA=="],
+    "multipasta": ["multipasta@0.2.8", "", {}, "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q=="],
 
     "mustache": ["mustache@4.2.0", "", { "bin": { "mustache": "bin/mustache" } }, "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="],
 
@@ -2431,7 +2451,7 @@
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
-    "toml": ["toml@4.1.1", "", {}, "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw=="],
+    "toml": ["toml@4.3.0", "", {}, "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A=="],
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
@@ -2603,6 +2623,10 @@
 
     "@astrojs/react/@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
+    "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
     "@aws-sdk/credential-provider-http/@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.7", "", { "dependencies": { "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A=="],
 
     "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1065.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.20", "@aws-sdk/nested-clients": "^3.997.19", "@aws-sdk/types": "^3.973.12", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-qdHQntq82gMqG6Tf8xrgmhJxacaYkxW4PEeDg/ISMVJ84EWe7iD6JyCTgbyox3uNDH6vqEJ8GUiTaXCq307zVw=="],
@@ -2627,6 +2651,10 @@
 
     "@earendil-works/pi-tui/marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
 
+    "@google/genai/google-auth-library": ["google-auth-library@10.7.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ=="],
+
+    "@opencode-ai/plugin/@opencode-ai/sdk": ["@opencode-ai/sdk@1.18.5", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-7KgMvP5/1oxbhHj6kYBtPSTEdFKYpUeEYOzBTKdzSaRpapUpFFdn6Hkus3rr0rljO0kukWZIgRd3DrVBwTULGA=="],
+
     "@opencode-ai/plugin/zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
 
     "@pierre/diffs/diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
@@ -2640,6 +2668,10 @@
     "@plannotator/webtui/lucide-react": ["lucide-react@0.577.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A=="],
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "@smithy/util-buffer-from/@smithy/core": ["@smithy/core@3.31.0", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-sylYk2l9d7CmRv8ts8p0SDQUr3VO+HMeS1nrjL6+UtbO8ktJHTOeQ1McX+aAyvGGccp5aZX9eNtdcXrSwzoZaw=="],
+
+    "@smithy/util-hex-encoding/@smithy/core": ["@smithy/core@3.31.0", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-sylYk2l9d7CmRv8ts8p0SDQUr3VO+HMeS1nrjL6+UtbO8ktJHTOeQ1McX+aAyvGGccp5aZX9eNtdcXrSwzoZaw=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q=="],
 
@@ -2695,11 +2727,15 @@
 
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
+    "effect/uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
+
     "encoding-sniffer/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "get-source/data-uri-to-buffer": ["data-uri-to-buffer@2.0.2", "", {}, "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA=="],
 
     "get-source/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
@@ -2724,8 +2760,6 @@
     "miniflare/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
     "miniflare/zod": ["zod@3.22.3", "", {}, "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug=="],
-
-    "node-fetch/data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
     "normalize-package-data/hosted-git-info": ["hosted-git-info@7.0.2", "", { "dependencies": { "lru-cache": "^10.0.1" } }, "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w=="],
 
@@ -2779,6 +2813,10 @@
 
     "@astrojs/react/@vitejs/plugin-react/react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
 
+    "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "@plannotator/hooks/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
@@ -2786,6 +2824,10 @@
     "@plannotator/portal/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "@plannotator/review/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "@smithy/util-buffer-from/@smithy/core/@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
+    "@smithy/util-hex-encoding/@smithy/core/@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
 
     "@textlint/linter-formatter/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -65,7 +65,7 @@
       "name": "@plannotator/opencode",
       "version": "0.25.1",
       "dependencies": {
-        "@opencode-ai/plugin": "0.0.0-next-16770",
+        "@opencode-ai/plugin": "0.0.0-next-16775",
       },
       "devDependencies": {
         "@plannotator/server": "workspace:*",
@@ -757,15 +757,15 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@opencode-ai/ai": ["@opencode-ai/ai@0.0.0-next-16770", "", { "dependencies": { "@opencode-ai/schema": "0.0.0-next-16770", "@smithy/eventstream-codec": "4.2.14", "@smithy/util-utf8": "4.2.2", "aws4fetch": "1.0.20", "effect": "4.0.0-beta.101", "google-auth-library": "10.5.0" } }, "sha512-J67T55JenepuvU8bCyWQebjKakVGg6hbZrFOugsO5fqk1Em5YDpUAZCZEjMek+WTjhVEotturowkaQqHVl0izQ=="],
+    "@opencode-ai/ai": ["@opencode-ai/ai@0.0.0-next-16775", "", { "dependencies": { "@opencode-ai/schema": "0.0.0-next-16775", "@smithy/eventstream-codec": "4.2.14", "@smithy/util-utf8": "4.2.2", "aws4fetch": "1.0.20", "effect": "4.0.0-beta.101", "google-auth-library": "10.5.0" } }, "sha512-rRjz1xBj17b4G4qTB8N3OaetRELepCYluWr4Torm8sR7pexLrA72+L5AI1y5pitlPQQdlbd2ilCNVlvJJkr8sQ=="],
 
-    "@opencode-ai/client": ["@opencode-ai/client@0.0.0-next-16770", "", { "dependencies": { "@opencode-ai/protocol": "0.0.0-next-16770", "@opencode-ai/schema": "0.0.0-next-16770" }, "peerDependencies": { "effect": "4.0.0-beta.101" }, "optionalPeers": ["effect"] }, "sha512-t6xBnp4xnATQditslc6RtzcLqI2yCzREhiWlK4f03SzcUiRZDXRoyLNKpRO/bV6/egEum6i9fZtVWIKSMGQU2g=="],
+    "@opencode-ai/client": ["@opencode-ai/client@0.0.0-next-16775", "", { "dependencies": { "@opencode-ai/protocol": "0.0.0-next-16775", "@opencode-ai/schema": "0.0.0-next-16775" }, "peerDependencies": { "effect": "4.0.0-beta.101" }, "optionalPeers": ["effect"] }, "sha512-XCRzZOtiDSDsQf5j3tc/7erxL1KcNIFikII96tR9NptX+f2l155jW3n7F63h1Bvmn5sI2pSC5CbJc4BVj/jcog=="],
 
-    "@opencode-ai/plugin": ["@opencode-ai/plugin@0.0.0-next-16770", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@opencode-ai/ai": "0.0.0-next-16770", "@opencode-ai/client": "0.0.0-next-16770", "@opencode-ai/schema": "0.0.0-next-16770", "@opencode-ai/sdk": "1.18.5", "@standard-schema/spec": "1.1.0", "effect": "4.0.0-beta.101", "zod": "4.1.8" }, "peerDependencies": { "@opencode-ai/theme": "0.0.0-next-16770", "@opentui/core": ">=0.4.5", "@opentui/keymap": ">=0.4.5", "@opentui/solid": ">=0.4.5", "solid-js": ">=1.9.0" }, "optionalPeers": ["@opencode-ai/theme", "@opentui/core", "@opentui/keymap", "@opentui/solid", "solid-js"] }, "sha512-gmhi1/dsYLVHVO1waAqe4r/L+NWCPNuUKOVcT1O8tS/LjShb765VLFqLtmBd5UVLaG5be+T0bWCXbKtvEG4rVA=="],
+    "@opencode-ai/plugin": ["@opencode-ai/plugin@0.0.0-next-16775", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@opencode-ai/ai": "0.0.0-next-16775", "@opencode-ai/client": "0.0.0-next-16775", "@opencode-ai/schema": "0.0.0-next-16775", "@opencode-ai/sdk": "1.18.5", "@standard-schema/spec": "1.1.0", "effect": "4.0.0-beta.101", "zod": "4.1.8" }, "peerDependencies": { "@opencode-ai/theme": "0.0.0-next-16775", "@opentui/core": ">=0.4.5", "@opentui/keymap": ">=0.4.5", "@opentui/solid": ">=0.4.5", "solid-js": ">=1.9.0" }, "optionalPeers": ["@opencode-ai/theme", "@opentui/core", "@opentui/keymap", "@opentui/solid", "solid-js"] }, "sha512-HjCKylamF+2o4Qqy8C7UzGwbn+Ar8rh0OGdOak1B/84EY92WqQeqmSQlwZo6RHNZQi+jVxOrWq01bxczhnl/Nw=="],
 
-    "@opencode-ai/protocol": ["@opencode-ai/protocol@0.0.0-next-16770", "", { "dependencies": { "@opencode-ai/schema": "0.0.0-next-16770", "effect": "4.0.0-beta.101" } }, "sha512-Cwb3UoZODBpPRrK++f2cTLLc3P55RRbl3+RtEbiuJKD9NeACDUWBYvAF0QrZEaDMtkfIa5e3lNp/mqbd3BRoQQ=="],
+    "@opencode-ai/protocol": ["@opencode-ai/protocol@0.0.0-next-16775", "", { "dependencies": { "@opencode-ai/schema": "0.0.0-next-16775", "effect": "4.0.0-beta.101" } }, "sha512-i9yCmqa30HEAnkiYOyn6xXfrP0b2kBhydiC3SL5xe+ZgwU3f+A3M4OyD1SezDt8IT//5H2E4yOpe6lbMa2vsMw=="],
 
-    "@opencode-ai/schema": ["@opencode-ai/schema@0.0.0-next-16770", "", { "dependencies": { "@standard-schema/spec": "1.1.0", "effect": "4.0.0-beta.101" } }, "sha512-JUMv2Qac1Mq76dP0Tc4JzUKixPxZh1ElEaZD/TH3NTFEtxBElUx934KV9nQZtSW1cgT46Hir1oCOHkBdfG0lTg=="],
+    "@opencode-ai/schema": ["@opencode-ai/schema@0.0.0-next-16775", "", { "dependencies": { "@standard-schema/spec": "1.1.0", "effect": "4.0.0-beta.101" } }, "sha512-GEBN2sO33hHgfojtQkThscHtNW6CCdHZC2hWTCoMWHyxPnaIO0Qe2mdScEMElnektkpQNAZGIz9pcx8BRvTxZg=="],
 
     "@opencode-ai/sdk": ["@opencode-ai/sdk@1.16.2", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-Z/xZ7q79dYeE0afqIk/yFEcRNGEQFcE+H8ssYivUiy+xGZ1mGwT72jpaQZKBwPn3JH4sRCu4KA2lcktBQfcOjg=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,6 +1,7 @@
 [install]
 linker = "isolated"
 minimumReleaseAge = 604800  # 7 days in seconds
+# OpenCode 2's required session/tool plugin APIs are only in matching next packages; remove these when they reach stable.
 minimumReleaseAgeExcludes = ["@opencode-ai/ai", "@opencode-ai/client", "@opencode-ai/plugin", "@opencode-ai/protocol", "@opencode-ai/schema", "@pierre/diffs", "@pierre/theme", "@pierre/theming", "@plannotator/atomic-editor", "@plannotator/markdown-editor", "@plannotator/webtui"]
 
 [test]

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,7 +1,7 @@
 [install]
 linker = "isolated"
 minimumReleaseAge = 604800  # 7 days in seconds
-minimumReleaseAgeExcludes = ["@pierre/diffs", "@pierre/theme", "@pierre/theming", "@plannotator/atomic-editor", "@plannotator/markdown-editor", "@plannotator/webtui"]
+minimumReleaseAgeExcludes = ["@opencode-ai/ai", "@opencode-ai/client", "@opencode-ai/plugin", "@opencode-ai/protocol", "@opencode-ai/schema", "@pierre/diffs", "@pierre/theme", "@pierre/theming", "@plannotator/atomic-editor", "@plannotator/markdown-editor", "@plannotator/webtui"]
 
 [test]
 preload = ["./packages/ui/test-setup/happy-dom.ts"]


### PR DESCRIPTION
Adds experimental OpenCode 2 plan review support while preserving the OpenCode 1 entrypoint and behavior. The package deliberately keeps V1 on `main` and exposes the V2 `{ id, setup }` adapter from `exports["."]`: OpenCode 1 checks `./server` before `main`, so adding that subpath would make V1 load the incompatible V2 adapter. Every V2 API touch stays in `server.ts` so future beta churn remains isolated.

Both adapters now share the host-independent `submit_plan` execution path for backing-file edits, browser review, approval/denial formatting, persistence, and cancellation semantics. The V2 adapter registers the JSON Schema tool, resolves cwd from the active session, applies planning/tool visibility through the session context hook, preserves ordered system parts and their metadata within V2's single system message, and leaves stable session URL output to the shared server path. URL deduplication is scoped to one review invocation so repeated remote reviews on the fixed port remain discoverable. V2 has command templates but no native slash-command execution hook, so `/plannotator-*` commands are intentionally not replaced with model-mediated behavior.

Current V2 limitations are documented in the package README: `next-16775` exposes neither a tool abort signal nor a plugin session-agent switch operation, so cancellation cannot immediately stop an active review and users must switch to `build` manually after approval. The adapter passes no synthetic cancellation signal, keeping its CLI child attached to the host instead of creating a detached process that cannot be cancelled. These gaps are called out rather than presented as full V1 parity.

The implementation pins `@opencode-ai/plugin@0.0.0-next-16775` and adds its five-package dependency family to Bun's minimum-release-age exclusions. Stable `@opencode-ai/plugin@1.18.13` cannot be used because its V2 context lacks the required `session` and `tool` domains; #1196 tracks moving to stable and removing those exclusions once the APIs ship.

Validation includes the full repository suite (`2802` passed, `0` failed), repository typecheck, both plugin bundles, and a packed-tarball smoke against the real `opencode2 v0.0.0-next-16775`; the smoke serves a temporary npm registry so OpenCode performs the package installation and root-entrypoint resolution itself, and runs as a dedicated CI job.

Refs #904
