### PR TITLE
fix(opencode): drop runtime dependency on prerelease plugin nightly

### DIFF
--- a/apps/opencode-plugin/package.json
+++ b/apps/opencode-plugin/package.json
@@ -40,10 +40,8 @@
     "postinstall": "mkdir -p ${XDG_CONFIG_HOME:-$HOME/.config}/opencode/commands && cp ./commands/*.md ${XDG_CONFIG_HOME:-$HOME/.config}/opencode/commands/ 2>/dev/null || true",
     "prepublishOnly": "bun run build"
   },
-  "dependencies": {
-    "@opencode-ai/plugin": "0.0.0-next-16775"
-  },
   "devDependencies": {
+    "@opencode-ai/plugin": "0.0.0-next-16775",
     "@plannotator/server": "workspace:*",
     "@plannotator/shared": "workspace:*"
   },

--- a/apps/opencode-plugin/server.ts
+++ b/apps/opencode-plugin/server.ts
@@ -1,4 +1,4 @@
-import { Plugin } from "@opencode-ai/plugin";
+import type { Plugin } from "@opencode-ai/plugin";
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -52,7 +52,9 @@ type EmbeddedRuntimeModule = {
   }) => Promise<OpenCodePlanReviewResult>;
 };
 
-const serverPlugin = Plugin.define({
+// `Plugin.define` is an identity function in @opencode-ai/plugin; keeping the import
+// type-only avoids shipping a runtime dependency on an exact prerelease nightly.
+const serverPlugin = {
   id: "plannotator",
   setup: async (ctx) => {
     const workflowOptions = normalizeWorkflowOptions(ctx.options as PlannotatorOpenCodeOptions);
@@ -212,7 +214,7 @@ const serverPlugin = Plugin.define({
       });
     });
   },
-});
+} satisfies Plugin.Plugin;
 
 function getPlanEdits(input: unknown): PlanEdit[] | undefined {
   if (!input || typeof input !== "object") return undefined;

--- a/apps/opencode-plugin/server.ts
+++ b/apps/opencode-plugin/server.ts
@@ -319,7 +319,13 @@ async function runPlanReview(input: {
         htmlContent: getPlanHtml(),
         timeoutSeconds: input.timeoutSeconds,
         abortSignal: input.abortSignal,
-        // handleServerReady owns the stable, exactly-once session URL output.
+        // Intentionally empty. OpenCode 2's server-plugin context exposes no log or
+        // tui domain, and the V2 client's app.log falls through to console.error,
+        // which is the same stderr stream handleServerReady already prints to.
+        // Wiring this up would duplicate the session URL in remote mode and add a
+        // stray line locally. V1 does target client.app.log and client.tui.showToast,
+        // which are HTTP surfaces separate from stderr, so V1 never repeats itself.
+        // A real toast here needs an upstream OpenCode API that does not exist yet.
         logReady: () => {},
       });
     } catch (error) {

--- a/bun.lock
+++ b/bun.lock
@@ -64,10 +64,8 @@
     "apps/opencode-plugin": {
       "name": "@plannotator/opencode",
       "version": "0.25.1",
-      "dependencies": {
-        "@opencode-ai/plugin": "0.0.0-next-16775",
-      },
       "devDependencies": {
+        "@opencode-ai/plugin": "0.0.0-next-16775",
         "@plannotator/server": "workspace:*",
         "@plannotator/shared": "workspace:*",
       },


### PR DESCRIPTION
## Problem

`apps/opencode-plugin` listed `@opencode-ai/plugin` as a runtime dependency pinned to the exact nightly `0.0.0-next-16775`. Every `npm install @plannotator/opencode` therefore resolved a prerelease snapshot inside npm's 72h unpublish window and pulled 95MB across 101 packages (`effect@4.0.0-beta.101` alone is 47MB).

The only runtime use was `Plugin.define`, an identity function (`export function define(plugin) { return plugin; }`, identical across next-16775, next-16600, next-16797 and stable 1.18.13).

## Fix

The import in `server.ts` is now type-only, the plugin is a plain object literal checked with `satisfies Plugin.Plugin`, and the package moves to `devDependencies`. OpenCode 2's loader validation is structural (`Schema.Struct({ id: String, setup: function })`), so an object literal satisfies it.

A second commit replaces the misleading one-line comment on the V2 `logReady` callback. The empty function is correct: V2's plugin context has no log or tui domain, and `app.log` bottoms out in `console.error`, the same stream `handleServerReady` already writes to.

## Verification

- `dist/index.js` and `dist/embedded.js` byte-identical to a pre-change build. `dist/server.js` differs only by the dropped import and the two wrapper lines.
- `bun test apps/opencode-plugin`: 107 pass, 0 fail.
- Packed tarball: no `dependencies` key; `main`, `exports`, and `files` unchanged.
- Built `dist/server.js` loads under node and bun in a directory with no `node_modules`; default export has `id: "plannotator"` and a callable `setup`.
- `smoke:v2` still fails for environmental reasons (needs an OpenCode 2 binary); untouched here.
