### PR TITLE
test(review): repair guide virtualization mock and run its tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,9 @@ jobs:
           packages/review-editor/components/FileHeader.edit.test.tsx
           packages/review-editor/edit/useEditSession.recovery.test.tsx
           packages/review-editor/edit/selectionActionPopover.test.ts
+          packages/review-editor/components/AllFilesCodeView.lifecycle.test.tsx
+          packages/review-editor/components/guide/GuideSectionCard.test.tsx
+          packages/review-editor/components/guide/GuideView.test.tsx
           packages/review-editor/hooks/useReviewSearch.test.tsx
           packages/ui/components/AnnotationPanel.props.test.tsx
           packages/ui/components/Viewer.consumer.test.tsx

--- a/packages/review-editor/components/AllFilesCodeView.lifecycle.test.tsx
+++ b/packages/review-editor/components/AllFilesCodeView.lifecycle.test.tsx
@@ -69,6 +69,10 @@ mock.module('@pierre/diffs/react', () => ({
     }));
     return <div ref={props.containerRef} className={props.className} />;
   }),
+  // AllFilesCodeView imports EditProvider alongside CodeView/useStableCallback.
+  // mock.module replaces the whole specifier, so every value export the
+  // component reads must be present here or the import throws at load time.
+  EditProvider: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
   useStableCallback: <T extends (...args: never[]) => unknown>(callback: T): T => {
     const callbackRef = useRef(callback);
     callbackRef.current = callback;


### PR DESCRIPTION
## What broke

`AllFilesCodeView.lifecycle.test.tsx` stubs `@pierre/diffs/react` with `mock.module`, which replaces the entire specifier. #1193 added an `EditProvider` import to `AllFilesCodeView.tsx`, but the stub was not extended, so the file threw `SyntaxError: Export named 'EditProvider' not found` at import. The stub now provides every value export the component reads.

## Why nobody noticed

Two reasons stacked. The file was masked in any run that also loaded `useEditSession.recovery.test.tsx` first, which pulls in the real module. And the three DOM tests #1158 added for Guided Review virtualization were never registered in the `DOM_TESTS=1` CI step, so plain `bun test` skipped them and they never ran at all.

## What the tests guard

`GuideViewportManager` caps live Pierre CodeView instances at 8 while Guided Review renders one card per file. Before #1158 all of them mounted: roughly 1.07M shadow DOM elements, 770MB heap, 3.9 FPS. `GuideView.test.tsx` and `GuideSectionCard.test.tsx` assert the cap holds.

## CI cost

The DOM step goes from about 14.8s to about 16.9s locally, a delta of roughly +2.1s.

Verified non-vacuous: lifting the enforced cap while pinning the assertion bound at 8 fails two `GuideView.test.tsx` cases (20 and 9 mounted views). Probe reverted. Full suite: 2875 pass, 0 fail.
