### PR TITLE
ci: glob the OpenCode smoke tarball instead of pinning the version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,10 +106,12 @@ jobs:
         run: npm pack --ignore-scripts --pack-destination "$RUNNER_TEMP"
 
       - name: Run installed-package smoke
+        # Glob the tarball so this job survives version bumps; npm pack wrote
+        # exactly one plannotator-opencode-*.tgz into RUNNER_TEMP above.
         run: >-
           bun run --cwd apps/opencode-plugin smoke:v2 --
           "$(command -v opencode2)"
-          "$RUNNER_TEMP/plannotator-opencode-0.25.1.tgz"
+          "$RUNNER_TEMP"/plannotator-opencode-*.tgz
 
   uninstall-windows:
     # Run the filesystem and path logic under real Windows path semantics.


### PR DESCRIPTION
**TLDR:** One line in CI. The OpenCode 2 installed-package smoke passed a hardcoded `plannotator-opencode-0.25.1.tgz` path, so the next version bump would have broken the `Test` workflow on the bump commit. It now globs `plannotator-opencode-*.tgz`, which resolves to the single tarball `npm pack` writes into `RUNNER_TEMP` in the prior step. CI-only; no user-facing behavior.

The hardcoded name came in with #1194 when the job was created. #1202 repaired the job's timeouts but left the pin in place; this removes it before the v0.26.0 bump trips it.

*AI-assisted.*