### PR TITLE
fix(opencode): drop the bun peerDependency that made npm download a 50MB runtime

### DIFF
--- a/apps/opencode-plugin/fixtures/v2-installed-smoke.ts
+++ b/apps/opencode-plugin/fixtures/v2-installed-smoke.ts
@@ -8,8 +8,8 @@ if (!opencodeBin || !pluginTarball) {
   throw new Error("Usage: bun fixtures/v2-installed-smoke.ts <opencode2-bin> <packed-plugin.tgz>");
 }
 
-// OpenCode 2 installs the configured plugin (and its whole dependency closure, which the
-// `bun` peer dependency makes large) through the throwaway registry below before the plugin
+// OpenCode 2 installs the configured plugin through the throwaway registry below before the
+// plugin
 // can appear in /api/plugin, and it answers /api/health only once the server has finished
 // booting. On a warm macOS dev box that is ~0.8s to healthy and ~6s to activated; on a cold
 // Linux CI runner the measured numbers are ~9s and ~47s. These budgets are sized for the slow

--- a/apps/opencode-plugin/package.json
+++ b/apps/opencode-plugin/package.json
@@ -45,7 +45,7 @@
     "@plannotator/server": "workspace:*",
     "@plannotator/shared": "workspace:*"
   },
-  "peerDependencies": {
+  "engines": {
     "bun": ">=1.0.0"
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -69,9 +69,6 @@
         "@plannotator/server": "workspace:*",
         "@plannotator/shared": "workspace:*",
       },
-      "peerDependencies": {
-        "bun": ">=1.0.0",
-      },
     },
     "apps/paste-service": {
       "name": "@plannotator/paste-service",


### PR DESCRIPTION
TLDR: `apps/opencode-plugin/package.json` declared `"peerDependencies": { "bun": ">=1.0.0" }` to say "this plugin needs the Bun runtime", but npm >= 7 auto-installs peer dependencies, and the npm registry package named `bun` contains the full ~50MB Bun binary. Every OpenCode user installing `@plannotator/opencode` therefore downloaded a useless second copy of Bun. This PR removes the peer dependency and expresses the requirement as an informational `"engines": { "bun": ">=1.0.0" }` field instead, which npm records but never installs.

This change was AI-assisted.

## Why the peer dependency was wrong

Since npm 7, peer dependencies are installed automatically by default rather than merely checked. A peer dep on `bun` is resolved against the registry, where `bun` is a real published package: a wrapper whose optional dependencies carry the platform binaries for Bun itself. So the declaration did not act as a runtime hint; it acted as an instruction to download the Bun runtime into every consumer's `node_modules`.

The `engines` field is the right place for a runtime requirement: it is purely informational (npm only enforces engines it knows how to check, and only under `engine-strict`), it never triggers a download, and it still documents the ">=1.0.0" expectation for humans and tooling.

## Changes

- `apps/opencode-plugin/package.json`: replace the `peerDependencies` block with `"engines": { "bun": ">=1.0.0" }`. `main` (`dist/index.js`, OpenCode 1) and `exports["."]` (`./dist/server.js`, OpenCode 2) are untouched, and `@opencode-ai/plugin` stays pinned in devDependencies exactly as #1199 left it.
- `bun.lock`: regenerated via `bun install`; only the workspace entry's `peerDependencies` block disappears. The top-level `bun@1.3.14` resolution remains because `packages/server` (workspace-internal, not published as part of this plugin's tarball) still declares the same peer dep; that is out of scope here.
- `apps/opencode-plugin/fixtures/v2-installed-smoke.ts`: drop the now-stale comment claiming the `bun` peer dependency makes the install closure large.

House style note: no workspace package used a `bun` engines field before; the only prior `engines` usage is the VS Code extension's mandatory `"vscode"` engine. `engines` fits here because the published tarball must keep carrying no runtime dependencies.

## Verification

- `bun install` at repo root, then `bun run build:review && bun run build:hook && bun run build:opencode` in that order: all pass.
- `bun test apps/opencode-plugin`: 107 pass, 0 fail (14 files).
- `bun run typecheck`: clean.
- `npm pack --dry-run --ignore-scripts --json` in `apps/opencode-plugin`: manifest has no `dependencies` and no `peerDependencies`; the tarball file list (10 entries: `dist/{index,server,embedded}.js`, `commands/*.md`, `plannotator.html`, `review-editor.html`, `README.md`, `package.json`) is unchanged versus main except the manifest itself.
- Ran the installed-package smoke locally, mirroring the `opencode-v2` CI job: installed `@opencode-ai/cli@0.0.0-next-16775` into a throwaway prefix, packed the real tarball, and ran `bun run --cwd apps/opencode-plugin smoke:v2` against it. Healthy after 0.8s, plugin activated after 1.6s, and `/api/plugin` reports `{"id":"plannotator"}`. The CI job will repeat this on a cold Linux runner.
