### PR TITLE
fix(review): keep large-diff memory bound when the object-size probe fails

### DIFF
--- a/packages/shared/gitbutler-core.test.ts
+++ b/packages/shared/gitbutler-core.test.ts
@@ -581,8 +581,12 @@ describe("GitButler diffs and expansion", () => {
           `:100644 100644 ${oldObjectId} ${newObjectId} M\0large [*]?.txt\0`,
         );
       }
-      if (commandArgs[0] === "cat-file") {
-        return commandResult(`${MAX_REVIEW_FILE_CONTENT_BYTES + 1}\n`);
+      if (commandArgs[0] === "cat-file" && commandArgs.some((arg) => arg.startsWith("--batch-check"))) {
+        return commandResult(
+          (options?.stdin ?? "").trim().split("\n").filter(Boolean).map((objectId) =>
+            `${objectId} blob ${MAX_REVIEW_FILE_CONTENT_BYTES + 1}`,
+          ).join("\n"),
+        );
       }
       if (commandArgs[0] === "diff" && commandArgs.some((arg) => arg.startsWith(":(top,exclude,literal)"))) {
         return commandResult();

--- a/packages/shared/pr-stack.test.ts
+++ b/packages/shared/pr-stack.test.ts
@@ -126,10 +126,16 @@ describe("runPRFullStackDiff", () => {
     const newObjectId = "b".repeat(40);
     const runtime: ReviewGitRuntime = {
       ...unavailableFileMethods,
-      async runGit(args) {
+      async runGit(args, options) {
         calls.push(args);
         if (args[0] === "show-ref") return result();
-        if (args[0] === "cat-file") return result(`${MAX_REVIEW_FILE_CONTENT_BYTES + 1}\n`);
+        if (args[0] === "cat-file" && args.some((arg) => arg.startsWith("--batch-check"))) {
+          return result(
+            (options?.stdin ?? "").trim().split("\n").filter(Boolean).map((objectId) =>
+              `${objectId} blob ${MAX_REVIEW_FILE_CONTENT_BYTES + 1}`,
+            ).join("\n"),
+          );
+        }
         if (args[0] === "diff" && args.includes("--raw")) {
           return result(
             `:100644 100644 ${oldObjectId} ${newObjectId} M\0large [*]?.txt\0`,
@@ -304,11 +310,18 @@ describe("runPRLayerLocalDiff", () => {
     const calls: string[][] = [];
     const runtime: ReviewGitRuntime = {
       ...unavailableFileMethods,
-      async runGit(args) {
+      async runGit(args, options) {
         calls.push(args);
         if (args[0] === "cat-file" && args[1] === "-t") return result();
         if (args[0] === "cat-file" && args[1] === "-s") {
           return result(`${MAX_REVIEW_FILE_CONTENT_BYTES + 1}\n`);
+        }
+        if (args[0] === "cat-file" && args.some((arg) => arg.startsWith("--batch-check"))) {
+          return result(
+            (options?.stdin ?? "").trim().split("\n").filter(Boolean).map((objectId) =>
+              `${objectId} blob ${MAX_REVIEW_FILE_CONTENT_BYTES + 1}`,
+            ).join("\n"),
+          );
         }
         if (args[0] === "diff" && args.includes("--raw")) {
           return result(

--- a/packages/shared/review-core.test.ts
+++ b/packages/shared/review-core.test.ts
@@ -33,6 +33,8 @@ import {
   runGitDiff,
   splitPorcelainRename,
   type DiffType,
+  type GitCommandOptions,
+  type GitCommandResult,
   type ReviewGitRuntime,
 } from "./review-core";
 
@@ -133,6 +135,40 @@ function makeRuntime(baseCwd: string): ReviewGitRuntime {
   };
 }
 
+/**
+ * Like `makeRuntime`, but routes every command through `prepareGitCommand`
+ * and forwards the prepared environment to git — the way the production Bun
+ * and Pi runtimes do — so per-command `config` (GIT_CONFIG_*) actually
+ * reaches the spawned process. `intercept` lets a test sabotage individual
+ * commands (e.g. force the cat-file size probe to fail).
+ */
+function makeConfigForwardingRuntime(
+  baseCwd: string,
+  intercept?: (args: string[]) => GitCommandResult | null,
+): ReviewGitRuntime {
+  const base = makeRuntime(baseCwd);
+  return {
+    ...base,
+    async runGit(args: string[], options?: GitCommandOptions) {
+      const intercepted = intercept?.(args);
+      if (intercepted) return intercepted;
+      const command = prepareGitCommand(args, options, process.env);
+      const result = spawnSync("git", command.args, {
+        cwd: options?.cwd ?? baseCwd,
+        encoding: "utf-8",
+        maxBuffer: MAX_REVIEW_FILE_CONTENT_BYTES * 4,
+        input: options?.stdin,
+        env: command.env as NodeJS.ProcessEnv | undefined,
+      });
+      return {
+        stdout: result.stdout ?? "",
+        stderr: result.stderr ?? "",
+        exitCode: result.status ?? (result.error ? 1 : 0),
+      };
+    },
+  };
+}
+
 function initRepo(initialBranch = "main"): string {
   const repoDir = makeTempDir("plannotator-review-core-");
   git(repoDir, ["init"]);
@@ -220,6 +256,61 @@ describe("review-core", () => {
       args: ["-c", "core.quotePath=false", "fetch", "origin", "main"],
       isolateProcessGroup: false,
     });
+  });
+
+  test("per-command config rides GIT_CONFIG_* environment variables, never argv", () => {
+    const command = prepareGitCommand(
+      ["diff", "--no-ext-diff", "--cached"],
+      { config: { "core.bigFileThreshold": "5242880" } },
+      { PATH: "/usr/bin" },
+    );
+
+    // argv must stay byte-identical to the configless invocation: callers and
+    // test mocks match on the exact argument vector.
+    expect(command.args).toEqual(["-c", "core.quotePath=false", "diff", "--no-ext-diff", "--cached"]);
+    expect(command.env).toEqual({
+      PATH: "/usr/bin",
+      GIT_CONFIG_COUNT: "1",
+      GIT_CONFIG_KEY_0: "core.bigFileThreshold",
+      GIT_CONFIG_VALUE_0: "5242880",
+    });
+    expect(command.isolateProcessGroup).toBe(false);
+  });
+
+  test("per-command config appends after config inherited from the environment", () => {
+    const command = prepareGitCommand(
+      ["diff"],
+      { config: { "core.bigFileThreshold": "5242880" } },
+      {
+        GIT_CONFIG_COUNT: "1",
+        GIT_CONFIG_KEY_0: "user.name",
+        GIT_CONFIG_VALUE_0: "Env User",
+      },
+    );
+
+    expect(command.env).toMatchObject({
+      GIT_CONFIG_COUNT: "2",
+      GIT_CONFIG_KEY_0: "user.name",
+      GIT_CONFIG_VALUE_0: "Env User",
+      GIT_CONFIG_KEY_1: "core.bigFileThreshold",
+      GIT_CONFIG_VALUE_1: "5242880",
+    });
+  });
+
+  test("per-command config combines with the noninteractive policy environment", () => {
+    const command = prepareGitCommand(
+      ["cat-file", "--batch-check=%(objectname) %(objecttype) %(objectsize)"],
+      { timeoutMs: 5_000, interaction: "forbid", config: { "core.bigFileThreshold": "1" } },
+      { PATH: "/usr/bin" },
+    );
+
+    expect(command.env).toMatchObject({
+      GIT_CONFIG_COUNT: "1",
+      GIT_CONFIG_KEY_0: "core.bigFileThreshold",
+      GIT_CONFIG_VALUE_0: "1",
+      GIT_TERMINAL_PROMPT: "0",
+    });
+    expect(command.isolateProcessGroup).toBe(true);
   });
 
   test("remote-default discovery requests bounded noninteractive execution", async () => {
@@ -671,6 +762,182 @@ describe("review-core", () => {
     expect(batchCalls).toBe(1);
     expect(individualSizeCalls).toBe(0);
   });
+
+  test("a failed size probe renders the diff instead of blanking it with binary stubs", async () => {
+    const renderedPatch =
+      "diff --git a/x.ts b/x.ts\n--- a/x.ts\n+++ b/x.ts\n@@ -1 +1 @@\n-old\n+new\n";
+    const calls: Array<{ args: string[]; options?: GitCommandOptions }> = [];
+    const runtime: ReviewGitRuntime = {
+      ...unavailableFileMethods,
+      async runGit(args, options) {
+        calls.push({ args, options });
+        if (args[0] === "diff" && args.includes("--raw")) {
+          return {
+            stdout: `:100644 100644 ${"a".repeat(40)} ${"b".repeat(40)} M\0x.ts\0`,
+            stderr: "",
+            exitCode: 0,
+          };
+        }
+        if (args[0] === "cat-file" && args.some((arg) => arg.startsWith("--batch-check"))) {
+          return { stdout: "", stderr: "fatal: unable to read object database", exitCode: 128 };
+        }
+        if (args[0] === "rev-parse") return { stdout: "/repo\n", stderr: "", exitCode: 0 };
+        if (args[0] === "diff") return { stdout: renderedPatch, stderr: "", exitCode: 0 };
+        throw new Error(`Unexpected git command: ${args.join(" ")}`);
+      },
+      async readTextFile() {
+        return null;
+      },
+    };
+
+    const result = await runGitDiff(runtime, "staged", "main", "/repo");
+
+    // The review shows the real diff — not one binary stub per file.
+    expect(result.patch).toContain("+new");
+    expect(result.patch).not.toContain("Binary files");
+    expect(
+      calls.some(({ args }) => args.some((arg) => arg.startsWith(":(top,exclude,literal)"))),
+    ).toBe(false);
+
+    // The probe is timeout-guarded and noninteractive so a hung git cannot
+    // stall the review server.
+    const probe = calls.find(({ args }) => args[0] === "cat-file");
+    expect(probe?.options).toMatchObject({ timeoutMs: 5000, interaction: "forbid" });
+
+    // Memory stays bounded by git itself: the rendered diff carries the
+    // core.bigFileThreshold config while argv stays byte-identical.
+    const rendered = calls.filter(
+      ({ args }) => args[0] === "diff" && !args.includes("--raw"),
+    );
+    expect(rendered.length).toBeGreaterThan(0);
+    for (const { args, options } of rendered) {
+      expect(options?.config).toEqual({
+        "core.bigFileThreshold": String(MAX_REVIEW_FILE_CONTENT_BYTES),
+      });
+      expect(args.some((arg) => arg.includes("bigFileThreshold"))).toBe(false);
+    }
+  });
+
+  test("a single object the probe reports missing still excludes only that path", async () => {
+    const smallOld = "1".repeat(40);
+    const smallNew = "2".repeat(40);
+    const brokenOld = "3".repeat(40);
+    const brokenNew = "4".repeat(40);
+    const runtime: ReviewGitRuntime = {
+      ...unavailableFileMethods,
+      async runGit(args, options) {
+        if (args[0] === "diff" && args.includes("--raw")) {
+          return {
+            stdout: [
+              `:100644 100644 ${smallOld} ${smallNew} M\0small.ts\0`,
+              `:100644 100644 ${brokenOld} ${brokenNew} M\0broken.bin\0`,
+            ].join(""),
+            stderr: "",
+            exitCode: 0,
+          };
+        }
+        if (args[0] === "cat-file" && args.some((arg) => arg.startsWith("--batch-check"))) {
+          const input = (options as { stdin?: string } | undefined)?.stdin ?? "";
+          return {
+            stdout: input.trim().split("\n").filter(Boolean).map((objectId) =>
+              objectId === brokenNew ? `${objectId} missing` : `${objectId} blob 10`,
+            ).join("\n"),
+            stderr: "",
+            exitCode: 0,
+          };
+        }
+        if (args[0] === "rev-parse") return { stdout: "/repo\n", stderr: "", exitCode: 0 };
+        if (args[0] === "diff") {
+          return { stdout: "diff --git a/small.ts b/small.ts\n-old\n+new\n", stderr: "", exitCode: 0 };
+        }
+        throw new Error(`Unexpected git command: ${args.join(" ")}`);
+      },
+      async readTextFile() {
+        return null;
+      },
+    };
+
+    const result = await runGitDiff(runtime, "staged", "main", "/repo");
+
+    expect(result.patch).toContain("+new");
+    expect(result.patch).toContain("Binary files a/broken.bin and b/broken.bin differ");
+    expect(result.patch).not.toContain("Binary files a/small.ts");
+  });
+
+  test("a failed size probe keeps oversized committed blobs git-bounded", async () => {
+    const repoDir = initRepo();
+    const largeSize = MAX_REVIEW_FILE_CONTENT_BYTES + 1;
+    writeFileSync(join(repoDir, "big.txt"), "a".repeat(largeSize), "utf-8");
+    writeFileSync(join(repoDir, "tracked.txt"), "after\n", "utf-8");
+    git(repoDir, ["add", "big.txt", "tracked.txt"]);
+
+    const runtime = makeConfigForwardingRuntime(repoDir, (args) =>
+      args.some((arg) => arg.startsWith("--batch-check"))
+        ? { stdout: "", stderr: "fatal: probe unavailable", exitCode: 128 }
+        : null,
+    );
+
+    const result = await runGitDiff(runtime, "staged", "main");
+
+    // The small file's real diff survives — the review is not blanked.
+    expect(result.patch).toContain("+after");
+    // git's own core.bigFileThreshold stubs the oversized staged blob.
+    expect(result.patch).toContain("Binary files");
+    expect(result.patch).not.toContain("aaaaaaaaaa");
+    expect(result.patch.length).toBeLessThan(4_000);
+  }, 20_000);
+
+  test("a failed size probe still excludes oversized working-tree files by stat", async () => {
+    const repoDir = initRepo();
+    const largeSize = MAX_REVIEW_FILE_CONTENT_BYTES + 1;
+    writeFileSync(join(repoDir, "big.txt"), "a".repeat(largeSize), "utf-8");
+    git(repoDir, ["add", "big.txt"]);
+    git(repoDir, ["commit", "-m", "add big file"]);
+
+    // Dirty working tree: core.bigFileThreshold does NOT bound the worktree
+    // side of a diff (git hashes the file and content-based binary detection
+    // wins), so the stat-based exclusion door must work without the probe.
+    writeFileSync(join(repoDir, "big.txt"), "b".repeat(largeSize), "utf-8");
+    writeFileSync(join(repoDir, "tracked.txt"), "after\n", "utf-8");
+
+    const runtime = makeConfigForwardingRuntime(repoDir, (args) =>
+      args.some((arg) => arg.startsWith("--batch-check"))
+        ? { stdout: "", stderr: "fatal: probe unavailable", exitCode: 128 }
+        : null,
+    );
+
+    const result = await runGitDiff(runtime, "uncommitted", "main");
+
+    expect(result.patch).toContain("+after");
+    expect(result.patch).toContain("Binary files");
+    expect(result.patch).not.toContain("bbbbbbbbbb");
+    expect(result.patch.length).toBeLessThan(4_000);
+  }, 20_000);
+
+  test("staleness fingerprinting survives a failed size probe and still tracks content", async () => {
+    const repoDir = initRepo();
+    const largeSize = MAX_REVIEW_FILE_CONTENT_BYTES + 1;
+    writeFileSync(join(repoDir, "big.txt"), "a".repeat(largeSize), "utf-8");
+    git(repoDir, ["add", "big.txt"]);
+    git(repoDir, ["commit", "-m", "add big file"]);
+
+    const runtime = makeConfigForwardingRuntime(repoDir, (args) =>
+      args.some((arg) => arg.startsWith("--batch-check"))
+        ? { stdout: "", stderr: "fatal: probe unavailable", exitCode: 128 }
+        : null,
+    );
+
+    writeFileSync(join(repoDir, "big.txt"), "b".repeat(largeSize), "utf-8");
+    const first = await getGitDiffFingerprint(runtime, "uncommitted", "main");
+    writeFileSync(join(repoDir, "big.txt"), "b".repeat(largeSize + 1), "utf-8");
+    const second = await getGitDiffFingerprint(runtime, "uncommitted", "main");
+
+    // Best-effort semantics preserved: the probe failing must not turn the
+    // staleness poll into a permanent false all-clear.
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    expect(second).not.toBe(first);
+  }, 20_000);
 
   test("synthesizes quoted rename and copy metadata from raw status details", async () => {
     const renamedFrom = 'old "rename" path';

--- a/packages/shared/review-core.ts
+++ b/packages/shared/review-core.ts
@@ -148,6 +148,15 @@ export interface GitCommandOptions {
   stdin?: string;
   /** Whether the command may ask the user for credentials. Defaults to `"allow"`. */
   interaction?: "allow" | "forbid";
+  /**
+   * Extra Git configuration for this one command, injected through the
+   * `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_n` / `GIT_CONFIG_VALUE_n`
+   * environment variables at the process boundary (`prepareGitCommand`).
+   * Deliberately NOT passed as `-c` argv flags: callers and tests match on
+   * the exact argv a command was invoked with, so config must never change
+   * the argument vector.
+   */
+  config?: Record<string, string>;
 }
 
 /** Runtime-neutral Git arguments and subprocess policy produced at the process boundary. */
@@ -207,22 +216,50 @@ function usesPlink(
 }
 
 /**
+ * Translate `GitCommandOptions.config` into `GIT_CONFIG_*` environment
+ * variables. Entries append after any config already injected through the
+ * inherited environment (git reads keys `0..COUNT-1`), so a caller-provided
+ * `GIT_CONFIG_COUNT` keeps working. Returns null when there is nothing to add.
+ */
+function gitConfigEnvironment(
+  config: Record<string, string> | undefined,
+  environment: Readonly<Record<string, string | undefined>>,
+): Record<string, string> | null {
+  const entries = Object.entries(config ?? {});
+  if (entries.length === 0) return null;
+  const inheritedCount = Number(environment.GIT_CONFIG_COUNT ?? "0");
+  const offset =
+    Number.isSafeInteger(inheritedCount) && inheritedCount > 0 ? inheritedCount : 0;
+  const env: Record<string, string> = {
+    GIT_CONFIG_COUNT: String(offset + entries.length),
+  };
+  entries.forEach(([key, value], index) => {
+    env[`GIT_CONFIG_KEY_${offset + index}`] = key;
+    env[`GIT_CONFIG_VALUE_${offset + index}`] = value;
+  });
+  return env;
+}
+
+/**
  * Prepare one Git subprocess without mutating the parent environment.
  *
  * Commands that forbid interaction disable Git credential prompts, request SSH
  * batch mode (including PuTTY/plink), and request process-group isolation so
  * the runtime can terminate transport children on timeout. Interactive Git
- * commands retain the caller's exact authentication behavior.
+ * commands retain the caller's exact authentication behavior. Per-command
+ * config rides `GIT_CONFIG_*` environment variables, never argv.
  */
 export function prepareGitCommand(
   args: string[],
   options: GitCommandOptions | undefined,
   environment: Readonly<Record<string, string | undefined>>,
 ): PreparedGitCommand {
+  const configEnv = gitConfigEnvironment(options?.config, environment);
   const interaction = options?.interaction ?? "allow";
   if (interaction === "allow") {
     return {
       args: ["-c", "core.quotePath=false", ...args],
+      ...(configEnv ? { env: { ...environment, ...configEnv } } : {}),
       isolateProcessGroup: false,
     };
   }
@@ -243,6 +280,7 @@ export function prepareGitCommand(
     ],
     env: {
       ...environment,
+      ...configEnv,
       GIT_TERMINAL_PROMPT: "0",
       GIT_SSH_COMMAND: `${sshCommand} ${sshBatchOptions}`,
       SSH_ASKPASS_REQUIRE: "never",
@@ -782,23 +820,42 @@ function isGitlink(entry: RawDiffEntry): boolean {
   return entry.oldMode === "160000" || entry.newMode === "160000";
 }
 
+/**
+ * Batch-probe object sizes for the oversized-path preflight.
+ *
+ * Returns `null` when the batch command itself fails (locked or corrupt
+ * object database, resource exhaustion, a hung git killed by the timeout).
+ * Callers must then treat blob sizes as unknown-but-bounded and rely on the
+ * git-native `core.bigFileThreshold` bound applied to every rendered diff
+ * (`BOUNDED_DIFF_GIT_CONFIG`) — the old behavior of marking EVERY object
+ * oversized replaced the whole review with binary stubs on one failed probe.
+ * Working-tree sizes come from filesystem stat and never from this probe.
+ *
+ * The per-object doors stay conservative on a probe that ran: an object the
+ * batch reports as `missing`, omits from its output, or answers with an
+ * unparseable/negative size maps to infinity. That is evidence about one
+ * object only, and excluding just its path keeps the stub's rename/copy/mode
+ * metadata rendering while the rest of the diff stays intact.
+ */
 async function getGitObjectSizes(
   runtime: ReviewGitRuntime,
   objectIds: string[],
   cwd?: string,
-): Promise<Map<string, number>> {
+): Promise<Map<string, number> | null> {
   const uniqueObjectIds = [...new Set(objectIds.filter((objectId) => !isNullObjectId(objectId)))];
   const sizes = new Map<string, number>();
   if (uniqueObjectIds.length === 0) return sizes;
 
   const result = await runtime.runGit(
     ["cat-file", "--batch-check=%(objectname) %(objecttype) %(objectsize)"],
-    { cwd, stdin: `${uniqueObjectIds.join("\n")}\n` },
+    {
+      cwd,
+      stdin: `${uniqueObjectIds.join("\n")}\n`,
+      timeoutMs: 5000,
+      interaction: "forbid",
+    },
   );
-  if (result.exitCode !== 0) {
-    for (const objectId of uniqueObjectIds) sizes.set(objectId, Number.POSITIVE_INFINITY);
-    return sizes;
-  }
+  if (result.exitCode !== 0) return null;
 
   for (const line of result.stdout.split("\n")) {
     const [objectId, objectType, objectSize] = line.split(" ");
@@ -891,12 +948,30 @@ interface BoundedTrackedDiff {
 }
 
 /**
+ * Git-native memory bound for rendered review diffs. `core.bigFileThreshold`
+ * makes git itself treat blobs above the review content cap as binary and
+ * emit tiny `Binary files ... differ` stubs instead of formatting their
+ * bytes, so patch output stays bounded even when the JS-side size probe
+ * cannot run. Injected as `GIT_CONFIG_*` environment entries (never `-c`
+ * argv flags) so every diff invocation keeps a byte-identical argv.
+ */
+const BOUNDED_DIFF_GIT_CONFIG: Record<string, string> = {
+  "core.bigFileThreshold": String(MAX_REVIEW_FILE_CONTENT_BYTES),
+};
+
+/**
  * Render a tracked diff without ever asking Git to format an oversized file.
  *
  * A raw, no-textconv preflight identifies changed paths and object sizes first.
  * Every over-limit path is then excluded with a top-level literal pathspec and
  * represented by a small, parseable binary stub. The stub's object ids retain
  * a content-sensitive fingerprint without putting file bytes in patch output.
+ *
+ * The size probe is best-effort: every rendered diff also carries
+ * `BOUNDED_DIFF_GIT_CONFIG`, so git itself never formats an oversized blob
+ * even when the probe fails and blob-side exclusion is skipped. Oversized
+ * working-tree sides are excluded from filesystem stat, independent of the
+ * probe.
  */
 async function buildBoundedTrackedDiff(
   runtime: ReviewGitRuntime,
@@ -922,7 +997,10 @@ async function buildBoundedTrackedDiff(
   const entries = parseRawDiffEntries(rawResult.stdout);
   if (entries.length === 0) {
     return {
-      patch: assertGitSuccess(await runtime.runGit(args, { cwd }), args).stdout,
+      patch: assertGitSuccess(
+        await runtime.runGit(args, { cwd, config: BOUNDED_DIFF_GIT_CONFIG }),
+        args,
+      ).stdout,
       fingerprintMetadata: [],
     };
   }
@@ -936,14 +1014,29 @@ async function buildBoundedTrackedDiff(
     nonGitlinks.flatMap((entry) => [entry.oldObjectId, entry.newObjectId]),
     cwd,
   );
+  // A failed batch probe (null) used to mark every object oversized, which
+  // replaced the ENTIRE review with binary stubs and no visible error. The
+  // memory bound no longer depends on the probe:
+  //  - Blob sides live in the object database, where BOUNDED_DIFF_GIT_CONFIG
+  //    makes git itself stub oversized content, so an unknown blob size reads
+  //    as "not oversized" and the file renders (git-bounded) instead of being
+  //    excluded.
+  //  - Working-tree sides are NOT covered by core.bigFileThreshold (git hashes
+  //    the file for the index line and content-based binary detection wins),
+  //    but their sizes come from filesystem stat, not the probe, so that
+  //    exclusion door keeps working below regardless of the probe outcome.
   for (const entry of entries) {
     if (isGitlink(entry)) continue;
     const oldSize = isNullObjectId(entry.oldObjectId)
       ? null
-      : objectSizes.get(entry.oldObjectId) ?? Number.POSITIVE_INFINITY;
+      : objectSizes === null
+        ? null
+        : objectSizes.get(entry.oldObjectId) ?? Number.POSITIVE_INFINITY;
     const newObjectSize = isNullObjectId(entry.newObjectId)
       ? null
-      : objectSizes.get(entry.newObjectId) ?? Number.POSITIVE_INFINITY;
+      : objectSizes === null
+        ? null
+        : objectSizes.get(entry.newObjectId) ?? Number.POSITIVE_INFINITY;
     const workingTreeInfo = isNullObjectId(entry.newObjectId)
       ? await getWorkingTreeFileInfo(runtime, root, entry.newPath)
       : null;
@@ -975,7 +1068,10 @@ async function buildBoundedTrackedDiff(
 
   if (oversized.length === 0) {
     return {
-      patch: assertGitSuccess(await runtime.runGit(args, { cwd }), args).stdout,
+      patch: assertGitSuccess(
+        await runtime.runGit(args, { cwd, config: BOUNDED_DIFF_GIT_CONFIG }),
+        args,
+      ).stdout,
       fingerprintMetadata,
     };
   }
@@ -987,7 +1083,10 @@ async function buildBoundedTrackedDiff(
       : []),
   ]);
   const patchArgs = [...args, "--", ...exclusions];
-  const boundedPatch = assertGitSuccess(await runtime.runGit(patchArgs, { cwd }), patchArgs).stdout;
+  const boundedPatch = assertGitSuccess(
+    await runtime.runGit(patchArgs, { cwd, config: BOUNDED_DIFF_GIT_CONFIG }),
+    patchArgs,
+  ).stdout;
   return {
     patch: boundedPatch + oversized.map(buildOversizedTrackedStub).join(""),
     fingerprintMetadata,


### PR DESCRIPTION
**TLDR**: A single failed `git cat-file --batch-check` size probe used to mark every changed object as oversized, silently replacing the entire review diff with `Binary files ... differ` stubs and degrading the staleness fingerprint. The memory bound is now enforced by git itself via `core.bigFileThreshold` (injected as `GIT_CONFIG_*` environment variables on every rendered diff, never as `-c` argv flags), so a failed probe degrades gracefully: files render normally, oversized blobs are stubbed by git, and the stat-based door for oversized working-tree files keeps working independently of the probe.

*AI-assisted: this change was implemented and tested with an AI agent.*

## The failure mode

`getGitObjectSizes()` in `packages/shared/review-core.ts` runs one `cat-file --batch-check` for all changed objects. When that whole command failed (locked or corrupt object database, resource exhaustion, transient spawn failure), every object mapped to `Number.POSITIVE_INFINITY`, and downstream code in `buildBoundedTrackedDiff` treated infinity as "exclude from the diff and stub as binary". Result: one failed batch command blanked the ENTIRE review with binary stubs and no visible error, and `appendDiffFingerprint` quietly hashed the stubbed patch instead of the real one.

## The fix: a git-native bound

Every patch-rendering `git diff` inside `buildBoundedTrackedDiff` now carries `core.bigFileThreshold=<MAX_REVIEW_FILE_CONTENT_BYTES>` through a new `config` option on `GitCommandOptions`, translated to `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_n` / `GIT_CONFIG_VALUE_n` in `prepareGitCommand` (entries append after any config already inherited from the environment). Environment injection keeps every diff argv byte-identical, which existing test mocks and call sites depend on. Both runtimes (Bun `packages/server/git.ts` and Pi `apps/pi-extension/server/vcs.ts`) already forward the prepared environment to the spawned process, so zero runtime-side lines were needed; Pi picks the shared change up through `vendor.sh` as usual.

With git bounding blob content natively, a failed probe now means "blob sizes unknown but bounded": no JS-side blob exclusion, no blanked diff. Two important details discovered while validating on real git (2.50.1):

- Blob-to-blob diffs (staged, committed, since-base committed sides) are fully bounded by the threshold: a 5 MB+ blob renders as a ~105 byte binary stub.
- The dirty working-tree side of a diff is NOT covered by `core.bigFileThreshold` (git hashes the worktree file for the index line and content-based binary detection wins). That side was never protected by the object probe either; it is protected by the filesystem-stat door (`getFileInfo`), which is probe-independent and stays fully active on probe failure. Together the two bounds cover every side of every diff, so the issue #1120 scenario (huge tracked file) cannot re-inflate whether the file is committed, staged, or dirty in the worktree.

Per-object doors stay conservative when the probe ran: an object reported `missing`, omitted from the batch output, or answered with an unparseable or negative size still maps to infinity and excludes only its own path, preserving rename/copy/mode metadata in the stub while the rest of the diff stays intact.

The probe also gains `timeoutMs: 5000` and `interaction: "forbid"` (matching the existing convention for background git calls) so a hung git cannot stall the review server. The staleness fingerprint contract is unchanged: `null` still means "cannot fingerprint, treat as fresh", and a failed probe no longer changes what gets hashed for working-tree files (the `large:path:size:mtime` metadata path does not depend on the probe).

## Rejected designs

- Throwing on `exitCode !== 0`: closes only one of the doors and turns the background staleness poll into a permanent silent false all-clear, since the fingerprint path swallows the throw and reports "fresh" forever.
- "Unknown size means do not exclude" without a git-native bound: measured 316.7 MB peak RSS on the #1120 repro versus 5.5 MB today; the JS-side memory bound fires precisely on the unknown case, so it cannot simply be dropped.

## Test-mock fixes

Three existing tests mocked the batch-check call with data not in batch-check format and passed only because of the all-infinity behavior. They now return well-formed `<oid> <type> <size>` lines derived from the probe's stdin, so they pass for the right reason:

- `pr-stack.test.ts` "omits oversized tracked object content with literal pathspec exclusions" (returned a bare `cat-file -s` style size)
- `pr-stack.test.ts` "omits oversized layer objects before rendering their patch" (had no batch-check branch at all, so the probe hit the catch-all `exitCode: 1`, which is exactly door 1)
- `gitbutler-core.test.ts` GitButler oversized-branch-diff test (returned a bare size for every `cat-file`)

## New tests

`review-core.test.ts` adds: `prepareGitCommand` config-to-environment translation (argv unchanged, append-after-inherited-count, composition with the noninteractive policy); a mocked probe-failure test asserting the diff renders instead of blanking, the probe carries timeout/noninteractive options, and every rendered diff carries the threshold config off-argv; a mocked single-missing-object test asserting only that path is excluded; and three real-git integration tests through a config-forwarding runtime proving that with a sabotaged probe (a) oversized staged blobs are git-bounded, (b) oversized dirty worktree files are still stat-excluded, and (c) the staleness fingerprint stays non-null and content-sensitive.

`bun test` (full suite): 2892 pass, 0 fail. `apps/pi-extension` suite: 177 pass, 0 fail. `bun run typecheck`: clean.
