### PR TITLE
fix(ui): render language-less code blocks as plain text

### DIFF
--- a/packages/ui/components/Viewer.tsx
+++ b/packages/ui/components/Viewer.tsx
@@ -630,7 +630,11 @@ export const Viewer = forwardRef<ViewerHandle, ViewerProps>(({
           const block = blocks.find(b => b.id === codeEl.closest('[data-block-id]')?.getAttribute('data-block-id'));
           codeEl.removeAttribute('data-highlighted');
           codeEl.className = `hljs font-mono${block?.language ? ` language-${block.language}` : ''}`;
-          hljs.highlightElement(codeEl);
+          // Skip highlighting language-less fences so highlight.js doesn't
+          // auto-detect a language and color plain text.
+          if (block?.language) {
+            hljs.highlightElement(codeEl);
+          }
         }
       });
 

--- a/packages/ui/components/blocks/CodeBlock.tsx
+++ b/packages/ui/components/blocks/CodeBlock.tsx
@@ -16,13 +16,17 @@ export const CodeBlock: React.FC<CodeBlockProps> = ({ block, onHover, onLeave })
   const containerRef = useRef<HTMLDivElement>(null);
   const codeRef = useRef<HTMLElement>(null);
 
-  // Highlight code block on mount and when content/language changes
+  // Highlight code block on mount and when content/language changes.
+  // Skip highlighting for language-less fences so highlight.js doesn't
+  // auto-detect a language and color plain text.
   useEffect(() => {
     if (codeRef.current) {
       // Reset any previous highlighting
       codeRef.current.removeAttribute('data-highlighted');
       codeRef.current.className = `hljs font-mono${block.language ? ` language-${block.language}` : ''}`;
-      hljs.highlightElement(codeRef.current);
+      if (block.language) {
+        hljs.highlightElement(codeRef.current);
+      }
     }
   }, [block.content, block.language]);
 

--- a/packages/ui/components/plan-diff/PlanCleanDiffView.tsx
+++ b/packages/ui/components/plan-diff/PlanCleanDiffView.tsx
@@ -700,7 +700,11 @@ const SimpleCodeBlock: React.FC<{ block: Block }> = ({ block }) => {
     if (codeRef.current) {
       codeRef.current.removeAttribute("data-highlighted");
       codeRef.current.className = `hljs font-mono${block.language ? ` language-${block.language}` : ""}`;
-      hljs.highlightElement(codeRef.current);
+      // Skip highlighting language-less fences so highlight.js doesn't
+      // auto-detect a language and color plain text.
+      if (block.language) {
+        hljs.highlightElement(codeRef.current);
+      }
     }
   }, [block.content, block.language]);
 


### PR DESCRIPTION
This PR makes bare fenced code blocks (triple backticks with no language tag) render as plain monospaced text instead of getting auto-detected syntax highlighting.

`hljs.highlightElement()` was called unconditionally in three components. When a block has no language, highlight.js falls back to auto-detection and colors ordinary words like `in`, `and`, `open`, `is`, `to`. This is most visible in annotate mode when a document uses fenced blocks as plain-text quote/preview containers.

The parser already sets `language` to `undefined` for a bare fence, so the fix just guards the highlight call in:

- `packages/ui/components/blocks/CodeBlock.tsx`
- `packages/ui/components/plan-diff/PlanCleanDiffView.tsx`
- `packages/ui/components/Viewer.tsx`

Blocks with a language are unchanged.

Fixes https://github.com/backnotprop/plannotator/issues/1210
