### PR TITLE
feat(ui): pair a light theme and a dark theme, switched by mode

### DIFF
--- a/apps/marketing/src/content/docs/getting-started/ui-settings.md
+++ b/apps/marketing/src/content/docs/getting-started/ui-settings.md
@@ -14,6 +14,10 @@ Open settings with the **gear icon** in the header. The dialog has three tabs: *
 
 The sun/moon toggle in the header switches between **Dark**, **Light**, and **System** themes. System follows your OS preference and updates automatically. Dark is the default.
 
+The **Theme** tab in Settings assigns a palette to each half of a pair: one theme for light mode, one for dark mode. A Light/Dark switch above the grid decides which half you are assigning, and the grid then lists only the palettes that can render it (Kanagawa Wave appears under Dark, Kanagawa Lotus under Light, and a palette that ships both variants appears under each with that mode's colors). The summary line above the grid always names both halves, and clicking either side jumps the grid to it.
+
+With **System** selected, your two choices swap as your OS switches between light and dark. All three mode buttons stay available whatever you pick, because a dark-only palette simply never occupies the light half. The pair is saved to `~/.plannotator/config.json` under `theme`, so it carries across sessions and hosts.
+
 ## General
 
 ### Identity

--- a/apps/pi-extension/server/serverAnnotate.ts
+++ b/apps/pi-extension/server/serverAnnotate.ts
@@ -618,10 +618,11 @@ export async function startAnnotateServer(options: {
 			handleShareHtml(res, url);
 		} else if (url.pathname === "/api/config" && req.method === "POST") {
 			try {
-				const body = (await parseBody(req)) as { displayName?: string; diffOptions?: Record<string, unknown>; conventionalComments?: boolean };
+				const body = (await parseBody(req)) as { displayName?: string; diffOptions?: Record<string, unknown>; theme?: Record<string, unknown>; conventionalComments?: boolean };
 				const toSave: Record<string, unknown> = {};
 				if (body.displayName !== undefined) toSave.displayName = body.displayName;
 				if (body.diffOptions !== undefined) toSave.diffOptions = body.diffOptions;
+				if (body.theme !== undefined) toSave.theme = body.theme;
 				if (body.conventionalComments !== undefined) toSave.conventionalComments = body.conventionalComments;
 				if (Object.keys(toSave).length > 0) saveConfig(toSave as Parameters<typeof saveConfig>[0]);
 				json(res, { ok: true });

--- a/apps/pi-extension/server/serverPlan.ts
+++ b/apps/pi-extension/server/serverPlan.ts
@@ -255,10 +255,11 @@ export async function startPlanReviewServer(options: {
 			});
 		} else if (url.pathname === "/api/config" && req.method === "POST") {
 			try {
-				const body = (await parseBody(req)) as { displayName?: string; diffOptions?: Record<string, unknown>; conventionalComments?: boolean; conventionalLabels?: unknown[] | null; pfmReminder?: boolean };
+				const body = (await parseBody(req)) as { displayName?: string; diffOptions?: Record<string, unknown>; theme?: Record<string, unknown>; conventionalComments?: boolean; conventionalLabels?: unknown[] | null; pfmReminder?: boolean };
 				const toSave: Record<string, unknown> = {};
 				if (body.displayName !== undefined) toSave.displayName = body.displayName;
 				if (body.diffOptions !== undefined) toSave.diffOptions = body.diffOptions;
+				if (body.theme !== undefined) toSave.theme = body.theme;
 				if (body.conventionalComments !== undefined) toSave.conventionalComments = body.conventionalComments;
 				if (body.conventionalLabels !== undefined) toSave.conventionalLabels = body.conventionalLabels;
 				if (body.pfmReminder !== undefined) toSave.pfmReminder = body.pfmReminder;

--- a/apps/pi-extension/server/serverReview.ts
+++ b/apps/pi-extension/server/serverReview.ts
@@ -2476,10 +2476,11 @@ export async function startReviewServer(options: {
 			}
 		} else if (url.pathname === "/api/config" && req.method === "POST") {
 			try {
-				const body = (await parseBody(req)) as { displayName?: string; diffOptions?: Record<string, unknown>; conventionalComments?: boolean };
+				const body = (await parseBody(req)) as { displayName?: string; diffOptions?: Record<string, unknown>; theme?: Record<string, unknown>; conventionalComments?: boolean };
 				const toSave: Record<string, unknown> = {};
 				if (body.displayName !== undefined) toSave.displayName = body.displayName;
 				if (body.diffOptions !== undefined) toSave.diffOptions = body.diffOptions;
+				if (body.theme !== undefined) toSave.theme = body.theme;
 				if (body.conventionalComments !== undefined) toSave.conventionalComments = body.conventionalComments;
 				if (Object.keys(toSave).length > 0) saveConfig(toSave as Parameters<typeof saveConfig>[0]);
 				json(res, { ok: true });

--- a/packages/core/config-types.ts
+++ b/packages/core/config-types.ts
@@ -1,6 +1,17 @@
 export type DefaultDiffType = 'since-base' | 'uncommitted' | 'unstaged' | 'staged' | 'merge-base' | 'all';
 export type DiffLineBgIntensity = 'subtle' | 'normal' | 'strong';
 
+/**
+ * The user's appearance choice: a palette for the light half, a palette for
+ * the dark half, and which of them the mode selects. `system` follows the OS,
+ * so the two halves swap with `prefers-color-scheme`.
+ */
+export interface ThemeConfig {
+  mode?: 'light' | 'dark' | 'system';
+  light?: string;
+  dark?: string;
+}
+
 export interface DiffOptions {
   diffStyle?: 'split' | 'unified';
   overflow?: 'scroll' | 'wrap';

--- a/packages/review-editor/components/ReviewHeaderMenu.tsx
+++ b/packages/review-editor/components/ReviewHeaderMenu.tsx
@@ -7,7 +7,6 @@ import {
 } from '@plannotator/ui/components/ActionMenu';
 import { useTheme } from '@plannotator/ui/components/ThemeProvider';
 import { THEME_MODES } from '@plannotator/ui/components/themeModes';
-import { isThemeModeAvailable } from '@plannotator/ui/utils/themeRegistry';
 import { MenuVersionSection } from '@plannotator/ui/components/MenuVersionSection';
 import { ReviewAgentsIcon } from '@plannotator/ui/components/ReviewAgentsIcon';
 import { TextShimmer } from '@plannotator/ui/components/TextShimmer';
@@ -46,7 +45,7 @@ export const ReviewHeaderMenu: React.FC<ReviewHeaderMenuProps> = ({
   origin,
   isWSL = false,
 }) => {
-  const { theme, setTheme, colorTheme } = useTheme();
+  const { theme, setTheme } = useTheme();
 
   const showUpdateDot = !!updateInfo?.updateAvailable && !updateInfo.dismissed;
 
@@ -87,30 +86,23 @@ export const ReviewHeaderMenu: React.FC<ReviewHeaderMenuProps> = ({
           <div className="px-3 py-2 space-y-1.5">
             <ActionMenuSectionLabel>Theme</ActionMenuSectionLabel>
             <div className="flex items-center gap-1 rounded-lg bg-muted/50 p-0.5">
-              {THEME_MODES.map(({ id, label, Icon }) => {
-                const available = isThemeModeAvailable(colorTheme, id);
-                return (
-                  <button
-                    key={id}
-                    disabled={!available}
-                    title={available ? undefined : 'Not supported by the current color theme'}
-                    onClick={() => {
-                      closeMenu();
-                      setTheme(id);
-                    }}
-                    className={`flex flex-1 items-center justify-center gap-1.5 rounded-md px-2 py-1 text-[11px] font-medium transition-colors ${
-                      !available
-                        ? 'cursor-not-allowed text-muted-foreground opacity-40'
-                        : theme === id
-                          ? 'bg-background text-foreground shadow-sm'
-                          : 'text-muted-foreground hover:text-foreground'
-                    }`}
-                  >
-                    <Icon />
-                    <span>{label}</span>
-                  </button>
-                );
-              })}
+              {THEME_MODES.map(({ id, label, Icon }) => (
+                <button
+                  key={id}
+                  onClick={() => {
+                    closeMenu();
+                    setTheme(id);
+                  }}
+                  className={`flex flex-1 items-center justify-center gap-1.5 rounded-md px-2 py-1 text-[11px] font-medium transition-colors ${
+                    theme === id
+                      ? 'bg-background text-foreground shadow-sm'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  <Icon />
+                  <span>{label}</span>
+                </button>
+              ))}
             </div>
           </div>
 

--- a/packages/server/annotate.ts
+++ b/packages/server/annotate.ts
@@ -562,10 +562,11 @@ export async function startAnnotateServer(
           // API: Update user config (write-back to ~/.plannotator/config.json)
           if (url.pathname === "/api/config" && req.method === "POST") {
             try {
-              const body = (await req.json()) as { displayName?: string; diffOptions?: Record<string, unknown>; conventionalComments?: boolean; conventionalLabels?: unknown[] | null };
+              const body = (await req.json()) as { displayName?: string; diffOptions?: Record<string, unknown>; theme?: Record<string, unknown>; conventionalComments?: boolean; conventionalLabels?: unknown[] | null };
               const toSave: Record<string, unknown> = {};
               if (body.displayName !== undefined) toSave.displayName = body.displayName;
               if (body.diffOptions !== undefined) toSave.diffOptions = body.diffOptions;
+              if (body.theme !== undefined) toSave.theme = body.theme;
               if (body.conventionalComments !== undefined) toSave.conventionalComments = body.conventionalComments;
               if (body.conventionalLabels !== undefined) toSave.conventionalLabels = body.conventionalLabels;
               if (Object.keys(toSave).length > 0) saveConfig(toSave as Parameters<typeof saveConfig>[0]);

--- a/packages/server/goal-setup.ts
+++ b/packages/server/goal-setup.ts
@@ -132,6 +132,7 @@ export async function startGoalSetupServer(
               const body = (await req.json()) as {
                 displayName?: string;
                 diffOptions?: Record<string, unknown>;
+                theme?: Record<string, unknown>;
                 conventionalComments?: boolean;
                 conventionalLabels?: unknown[] | null;
               };
@@ -141,6 +142,9 @@ export async function startGoalSetupServer(
               }
               if (body.diffOptions !== undefined) {
                 toSave.diffOptions = body.diffOptions;
+              }
+              if (body.theme !== undefined) {
+                toSave.theme = body.theme;
               }
               if (body.conventionalComments !== undefined) {
                 toSave.conventionalComments = body.conventionalComments;

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -321,10 +321,11 @@ export async function startPlannotatorServer(
           // API: Update user config (write-back to ~/.plannotator/config.json)
           if (url.pathname === "/api/config" && req.method === "POST") {
             try {
-              const body = (await req.json()) as { displayName?: string; diffOptions?: Record<string, unknown>; conventionalComments?: boolean; conventionalLabels?: unknown[] | null; pfmReminder?: boolean };
+              const body = (await req.json()) as { displayName?: string; diffOptions?: Record<string, unknown>; theme?: Record<string, unknown>; conventionalComments?: boolean; conventionalLabels?: unknown[] | null; pfmReminder?: boolean };
               const toSave: Record<string, unknown> = {};
               if (body.displayName !== undefined) toSave.displayName = body.displayName;
               if (body.diffOptions !== undefined) toSave.diffOptions = body.diffOptions;
+              if (body.theme !== undefined) toSave.theme = body.theme;
               if (body.conventionalComments !== undefined) toSave.conventionalComments = body.conventionalComments;
               if (body.conventionalLabels !== undefined) toSave.conventionalLabels = body.conventionalLabels;
               if (body.pfmReminder !== undefined) toSave.pfmReminder = body.pfmReminder;

--- a/packages/server/review.ts
+++ b/packages/server/review.ts
@@ -2543,10 +2543,11 @@ export async function startReviewServer(
           // API: Update user config (write-back to ~/.plannotator/config.json)
           if (url.pathname === "/api/config" && req.method === "POST") {
             try {
-              const body = (await req.json()) as { displayName?: string; diffOptions?: Record<string, unknown>; conventionalComments?: boolean; conventionalLabels?: unknown[] | null };
+              const body = (await req.json()) as { displayName?: string; diffOptions?: Record<string, unknown>; theme?: Record<string, unknown>; conventionalComments?: boolean; conventionalLabels?: unknown[] | null };
               const toSave: Record<string, unknown> = {};
               if (body.displayName !== undefined) toSave.displayName = body.displayName;
               if (body.diffOptions !== undefined) toSave.diffOptions = body.diffOptions;
+              if (body.theme !== undefined) toSave.theme = body.theme;
               if (body.conventionalComments !== undefined) toSave.conventionalComments = body.conventionalComments;
               if (body.conventionalLabels !== undefined) toSave.conventionalLabels = body.conventionalLabels;
               if (Object.keys(toSave).length > 0) saveConfig(toSave as Parameters<typeof saveConfig>[0]);

--- a/packages/shared/config.ts
+++ b/packages/shared/config.ts
@@ -10,8 +10,8 @@ import { getPlannotatorDataDir } from "./data-dir";
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
 import { execSync } from "child_process";
 
-import type { DefaultDiffType, DiffLineBgIntensity, DiffOptions } from '@plannotator/core/config-types';
-export type { DefaultDiffType, DiffLineBgIntensity, DiffOptions };
+import type { DefaultDiffType, DiffLineBgIntensity, DiffOptions, ThemeConfig } from '@plannotator/core/config-types';
+export type { DefaultDiffType, DiffLineBgIntensity, DiffOptions, ThemeConfig };
 
 /** Single conventional comment label entry stored in config.json */
 export interface CCLabelConfig {
@@ -87,6 +87,13 @@ export function mergePromptConfig(
 export interface PlannotatorConfig {
   displayName?: string;
   diffOptions?: DiffOptions;
+  /**
+   * Appearance: which mode, plus the palette assigned to each half of the
+   * light/dark pair. Written by the UI through POST /api/config, so a choice
+   * made in one session is picked up by the next one (each hook invocation
+   * runs on its own random port).
+   */
+  theme?: ThemeConfig;
   prompts?: PromptConfig;
   conventionalComments?: boolean;
   /** null = explicitly cleared (use defaults), undefined = not set */
@@ -215,11 +222,15 @@ export function saveConfig(partial: Partial<PlannotatorConfig>): void {
     const mergedDiffOptions = (current.diffOptions || partial.diffOptions)
       ? { ...current.diffOptions, ...partial.diffOptions }
       : undefined;
+    const mergedTheme = (current.theme || partial.theme)
+      ? { ...current.theme, ...partial.theme }
+      : undefined;
     const mergedPrompts = mergePromptConfig(current.prompts, partial.prompts);
     const merged = {
       ...current,
       ...partial,
       diffOptions: mergedDiffOptions,
+      theme: mergedTheme,
       prompts: mergedPrompts,
     };
     mkdirSync(CONFIG_DIR, { recursive: true });
@@ -249,6 +260,7 @@ export function detectGitUser(): string | null {
 export function getServerConfig(gitUser: string | null): {
   displayName?: string;
   diffOptions?: DiffOptions;
+  theme?: ThemeConfig;
   gitUser?: string;
   conventionalComments?: boolean;
   conventionalLabels?: CCLabelConfig[] | null;
@@ -257,6 +269,7 @@ export function getServerConfig(gitUser: string | null): {
   return {
     displayName: cfg.displayName,
     diffOptions: cfg.diffOptions,
+    ...(cfg.theme !== undefined && { theme: cfg.theme }),
     gitUser: gitUser ?? undefined,
     ...(cfg.conventionalComments !== undefined && { conventionalComments: cfg.conventionalComments }),
     ...(cfg.conventionalLabels !== undefined && { conventionalLabels: cfg.conventionalLabels }),

--- a/packages/ui/components/ModeToggle.tsx
+++ b/packages/ui/components/ModeToggle.tsx
@@ -1,10 +1,9 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useTheme } from './ThemeProvider';
 import { THEME_MODES } from './themeModes';
-import { isThemeModeAvailable } from '../utils/themeRegistry';
 
 export function ModeToggle() {
-  const { theme, setTheme, colorTheme } = useTheme();
+  const { theme, setTheme } = useTheme();
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -50,26 +49,19 @@ export function ModeToggle() {
 
       {isOpen && (
         <div className="absolute right-0 mt-1 w-32 rounded-lg border border-border bg-popover shadow-xl z-50 overflow-hidden py-1">
-          {THEME_MODES.map(({ id, label }) => {
-            const available = isThemeModeAvailable(colorTheme, id);
-            return (
-              <button
-                key={id}
-                disabled={!available}
-                title={available ? undefined : 'Not supported by the current color theme'}
-                onClick={() => { setTheme(id); setIsOpen(false); }}
-                className={`w-full px-3 py-1.5 text-left text-xs transition-colors ${
-                  !available
-                    ? 'cursor-not-allowed text-muted-foreground opacity-40'
-                    : theme === id
-                      ? 'text-primary bg-primary/10 font-medium'
-                      : 'text-popover-foreground hover:bg-muted'
-                }`}
-              >
-                {label}
-              </button>
-            );
-          })}
+          {THEME_MODES.map(({ id, label }) => (
+            <button
+              key={id}
+              onClick={() => { setTheme(id); setIsOpen(false); }}
+              className={`w-full px-3 py-1.5 text-left text-xs transition-colors ${
+                theme === id
+                  ? 'text-primary bg-primary/10 font-medium'
+                  : 'text-popover-foreground hover:bg-muted'
+              }`}
+            >
+              {label}
+            </button>
+          ))}
         </div>
       )}
     </div>

--- a/packages/ui/components/PlanHeaderMenu.tsx
+++ b/packages/ui/components/PlanHeaderMenu.tsx
@@ -7,7 +7,6 @@ import {
 } from './ActionMenu';
 import { useTheme } from './ThemeProvider';
 import { THEME_MODES } from './themeModes';
-import { isThemeModeAvailable } from '../utils/themeRegistry';
 import { ReviewAgentsIcon } from './ReviewAgentsIcon';
 import { MenuVersionSection } from './MenuVersionSection';
 import { TextShimmer } from './TextShimmer';
@@ -59,7 +58,7 @@ export const PlanHeaderMenu: React.FC<PlanHeaderMenuProps> = ({
   bearConfigured,
   octarineConfigured,
 }) => {
-  const { theme, setTheme, colorTheme } = useTheme();
+  const { theme, setTheme } = useTheme();
 
   const showUpdateDot = !!updateInfo?.updateAvailable && !updateInfo.dismissed;
 
@@ -103,30 +102,23 @@ export const PlanHeaderMenu: React.FC<PlanHeaderMenuProps> = ({
           <div className="px-3 py-2 space-y-1.5">
             <ActionMenuSectionLabel>Theme</ActionMenuSectionLabel>
             <div className="flex items-center gap-1 rounded-lg bg-muted/50 p-0.5">
-              {THEME_MODES.map(({ id, label, Icon }) => {
-                const available = isThemeModeAvailable(colorTheme, id);
-                return (
-                  <button
-                    key={id}
-                    disabled={!available}
-                    title={available ? undefined : 'Not supported by the current color theme'}
-                    onClick={() => {
-                      closeMenu();
-                      setTheme(id);
-                    }}
-                    className={`flex flex-1 items-center justify-center gap-1.5 rounded-md px-2 py-1 text-[11px] font-medium transition-colors ${
-                      !available
-                        ? 'cursor-not-allowed text-muted-foreground opacity-40'
-                        : theme === id
-                          ? 'bg-background text-foreground shadow-sm'
-                          : 'text-muted-foreground hover:text-foreground'
-                    }`}
-                  >
-                    <Icon />
-                    <span>{label}</span>
-                  </button>
-                );
-              })}
+              {THEME_MODES.map(({ id, label, Icon }) => (
+                <button
+                  key={id}
+                  onClick={() => {
+                    closeMenu();
+                    setTheme(id);
+                  }}
+                  className={`flex flex-1 items-center justify-center gap-1.5 rounded-md px-2 py-1 text-[11px] font-medium transition-colors ${
+                    theme === id
+                      ? 'bg-background text-foreground shadow-sm'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  <Icon />
+                  <span>{label}</span>
+                </button>
+              ))}
             </div>
           </div>
 

--- a/packages/ui/components/ThemeProvider.test.tsx
+++ b/packages/ui/components/ThemeProvider.test.tsx
@@ -23,6 +23,32 @@ let host: HTMLElement | null = null;
 let currentTheme: ReturnType<typeof useTheme> | null = null;
 let stored = new Map<string, string>();
 let originalMatchMediaDescriptor: PropertyDescriptor | undefined;
+let originalFetch: typeof globalThis.fetch | null = null;
+
+/** Capture every request the default server-sync transport would make. */
+function captureConfigPosts(): string[] {
+  const posts: string[] = [];
+  originalFetch = globalThis.fetch;
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : String(input);
+    if (url.includes('/api/config')) posts.push(String(init?.body ?? ''));
+    return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+  }) as typeof globalThis.fetch;
+  return posts;
+}
+
+/** Let the store's 300ms server-sync debounce fire (or prove it never does). */
+async function afterServerSyncDebounce(): Promise<void> {
+  await act(async () => {
+    await new Promise<void>(resolve => setTimeout(resolve, 400));
+  });
+}
+
+/** Flush writes an earlier test queued, so only this test's posts are counted. */
+async function drainPendingServerSync(posts: string[]): Promise<void> {
+  await afterServerSyncDebounce();
+  posts.length = 0;
+}
 
 function Probe() {
   currentTheme = useTheme();
@@ -117,6 +143,11 @@ async function mountTheme(children?: React.ReactNode): Promise<void> {
   // backend this test installed so seeded cookies (not a previous test's
   // values) decide the pair.
   configStore.loadFromBackend();
+  await mountThemeFresh(children);
+}
+
+/** Mount WITHOUT pre-seeding the store, i.e. what a cookie-less visit hits. */
+async function mountThemeFresh(children?: React.ReactNode): Promise<void> {
   host = document.createElement('div');
   document.body.appendChild(host);
   root = createRoot(host);
@@ -264,6 +295,11 @@ describe('ThemeProvider', () => {
         Reflect.deleteProperty(window, 'matchMedia');
       }
       originalMatchMediaDescriptor = undefined;
+    }
+    configStore.resetServerSync();
+    if (originalFetch) {
+      globalThis.fetch = originalFetch;
+      originalFetch = null;
     }
     resetStorageBackend();
   });
@@ -413,5 +449,199 @@ describe('ThemeProvider', () => {
     expect(host!.textContent).toContain('Dracula');
     await act(async () => clickButton(summaryButton('Light:')));
     expect(paletteNames()).toContain('Kanagawa Lotus');
+  });
+
+  test.skipIf(!hasDom)('honors a host\'s own storage keys when migrating to a pair', async () => {
+    stored.set('host-mode', 'system');
+    stored.set('host-palette', 'kanagawa-wave');
+    installMatchMedia(false);
+
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    await act(async () => {
+      root!.render(
+        <ThemeProvider storageKey="host-mode" colorThemeStorageKey="host-palette">
+          <Probe />
+        </ThemeProvider>,
+      );
+    });
+
+    // The host's stored preference is migrated, not discarded.
+    expect(themeState().mode).toBe('system');
+    expect(themeState().darkTheme).toBe('kanagawa-wave');
+    expect(themeState().colorTheme).toBe('kanagawa-wave');
+    // And the mirror keeps writing the host's keys, not Plannotator's.
+    expect(stored.get('host-mode')).toBe('system');
+    expect(stored.get('host-palette')).toBe('kanagawa-wave');
+  });
+});
+
+describe('ThemeProvider server write-back', () => {
+  let posts: string[] = [];
+
+  beforeEach(() => {
+    if (hasDom) {
+      originalMatchMediaDescriptor = Object.getOwnPropertyDescriptor(window, 'matchMedia');
+    }
+    stored = new Map<string, string>();
+    setStorageBackend({
+      getItem: key => stored.get(key) ?? null,
+      setItem: (key, value) => {
+        stored.set(key, value);
+      },
+      removeItem: key => {
+        stored.delete(key);
+      },
+    });
+    posts = captureConfigPosts();
+  });
+
+  afterEach(async () => {
+    if (hasDom) {
+      await unmountTheme();
+      document.documentElement.className = '';
+      if (originalMatchMediaDescriptor) {
+        Object.defineProperty(window, 'matchMedia', originalMatchMediaDescriptor);
+      } else {
+        Reflect.deleteProperty(window, 'matchMedia');
+      }
+      originalMatchMediaDescriptor = undefined;
+    }
+    configStore.resetServerSync();
+    if (originalFetch) {
+      globalThis.fetch = originalFetch;
+      originalFetch = null;
+    }
+    resetStorageBackend();
+  });
+
+  // A cookie-less visit (fresh profile, incognito, cleared cookies) must not
+  // write anything to ~/.plannotator/config.json: that POST would land after
+  // the server config arrives and reset the user's real theme to defaults.
+  test.skipIf(!hasDom)('posts nothing when mounting with no stored preference', async () => {
+    // Drain anything an earlier test's debounce still had in flight.
+    await drainPendingServerSync(posts);
+    installMatchMedia(false);
+
+    await mountThemeFresh();
+    await afterServerSyncDebounce();
+
+    expect(posts).toEqual([]);
+    // The pair still resolved and was persisted locally.
+    expect(themeState().colorTheme).toBe(DEFAULT_COLOR_THEME);
+    expect(stored.get('plannotator-light-theme')).toBe(DEFAULT_COLOR_THEME);
+  });
+
+  test.skipIf(!hasDom)('posts a real choice, so the pair still reaches config.json', async () => {
+    await drainPendingServerSync(posts);
+    installMatchMedia(false);
+
+    await mountThemeFresh();
+    await act(async () => themeState().setHalfTheme('dark', 'vesper'));
+    await afterServerSyncDebounce();
+
+    expect(posts.length).toBe(1);
+    expect(JSON.parse(posts[0]!)).toEqual({
+      theme: { mode: 'dark', light: DEFAULT_COLOR_THEME, dark: 'vesper' },
+    });
+  });
+
+  // The legacy single-palette API was cookie-only before pairs existed, and a
+  // host that never installed a serverSync transport has no endpoint to post to.
+  test.skipIf(!hasDom)('keeps the legacy setColorTheme cookie-only', async () => {
+    await drainPendingServerSync(posts);
+    installMatchMedia(false);
+
+    await mountThemeFresh();
+    await act(async () => themeState().setColorTheme('vesper'));
+    await afterServerSyncDebounce();
+
+    expect(posts).toEqual([]);
+    expect(themeState().darkTheme).toBe('vesper');
+    expect(stored.get('plannotator-dark-theme')).toBe('vesper');
+  });
+});
+
+describe('ThemeProvider legacy setColorTheme', () => {
+  beforeEach(() => {
+    if (hasDom) {
+      originalMatchMediaDescriptor = Object.getOwnPropertyDescriptor(window, 'matchMedia');
+    }
+    stored = new Map<string, string>();
+    setStorageBackend({
+      getItem: key => stored.get(key) ?? null,
+      setItem: (key, value) => {
+        stored.set(key, value);
+      },
+      removeItem: key => {
+        stored.delete(key);
+      },
+    });
+  });
+
+  afterEach(async () => {
+    if (hasDom) {
+      await unmountTheme();
+      document.documentElement.className = '';
+      if (originalMatchMediaDescriptor) {
+        Object.defineProperty(window, 'matchMedia', originalMatchMediaDescriptor);
+      } else {
+        Reflect.deleteProperty(window, 'matchMedia');
+      }
+      originalMatchMediaDescriptor = undefined;
+    }
+    configStore.resetServerSync();
+    resetStorageBackend();
+  });
+
+  test.skipIf(!hasDom)('assigns a both-mode palette to the half on screen only', async () => {
+    stored.set('plannotator-theme', 'dark');
+    stored.set('plannotator-light-theme', 'one-light');
+    stored.set('plannotator-dark-theme', 'vesper');
+    installMatchMedia(false);
+
+    await mountTheme();
+    await act(async () => themeState().setColorTheme('gruvbox'));
+
+    expect(themeState().darkTheme).toBe('gruvbox');
+    // The other half keeps the user's assignment.
+    expect(themeState().lightTheme).toBe('one-light');
+    expect(themeState().mode).toBe('dark');
+  });
+
+  test.skipIf(!hasDom)('assigns a mode-restricted palette without moving the mode', async () => {
+    stored.set('plannotator-theme', 'system');
+    stored.set('plannotator-light-theme', 'one-light');
+    stored.set('plannotator-dark-theme', 'nord');
+    const media = installMatchMedia(true);
+
+    await mountTheme();
+    expect(themeState().colorTheme).toBe('one-light');
+
+    await act(async () => themeState().setColorTheme('vesper'));
+    expect(themeState().darkTheme).toBe('vesper');
+    expect(themeState().lightTheme).toBe('one-light');
+    // Still System: a dark-only palette does not yank the user out of it.
+    expect(themeState().mode).toBe('system');
+    expect(themeState().colorTheme).toBe('one-light');
+
+    // And it is what renders as soon as the OS goes dark.
+    await act(async () => media.setMatches(false));
+    expect(themeState().colorTheme).toBe('vesper');
+  });
+
+  test.skipIf(!hasDom)('assigns a light-only palette to the light half from dark mode', async () => {
+    stored.set('plannotator-theme', 'dark');
+    stored.set('plannotator-light-theme', 'one-light');
+    stored.set('plannotator-dark-theme', 'nord');
+    installMatchMedia(false);
+
+    await mountTheme();
+    await act(async () => themeState().setColorTheme('kanagawa-lotus'));
+
+    expect(themeState().lightTheme).toBe('kanagawa-lotus');
+    expect(themeState().darkTheme).toBe('nord');
+    expect(themeState().mode).toBe('dark');
   });
 });

--- a/packages/ui/components/ThemeProvider.test.tsx
+++ b/packages/ui/components/ThemeProvider.test.tsx
@@ -1,8 +1,17 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
+import { configStore } from '../config/configStore';
 import { resetStorageBackend, setStorageBackend } from '../utils/storage';
-import { BUILT_IN_THEMES } from '../utils/themeRegistry';
+import {
+  BUILT_IN_THEMES,
+  DEFAULT_COLOR_THEME,
+  normalizeThemePair,
+  resetDefaultThemePair,
+  seedThemePair,
+  themesForHalf,
+  themeSupportsHalf,
+} from '../utils/themeRegistry';
 import { THEME_MODES, isThemeMode, parseThemeMode } from './themeModes';
 import { ThemeProvider, useTheme } from './ThemeProvider';
 import { ThemeTab } from './ThemeTab';
@@ -23,6 +32,43 @@ function Probe() {
 function themeState(): ReturnType<typeof useTheme> {
   if (!currentTheme) throw new Error('ThemeProvider is not mounted');
   return currentTheme;
+}
+
+/** Every palette card in the grid — the only buttons carrying color swatches. */
+function paletteButtons(): HTMLButtonElement[] {
+  return Array.from(host!.querySelectorAll('button')).filter(button =>
+    button.querySelector('.rounded-full')
+  );
+}
+
+function paletteNames(): string[] {
+  return paletteButtons().map(button => button.textContent?.trim() ?? '');
+}
+
+function palette(name: string): HTMLButtonElement {
+  const found = paletteButtons().find(button => button.textContent?.trim() === name);
+  if (!found) throw new Error(`palette "${name}" is not in the grid`);
+  return found;
+}
+
+function button(label: string): HTMLButtonElement {
+  const found = Array.from(host!.querySelectorAll('button')).find(
+    candidate => candidate.textContent?.trim() === label
+  );
+  if (!found) throw new Error(`button "${label}" did not render`);
+  return found;
+}
+
+function summaryButton(prefix: string): HTMLButtonElement {
+  const found = Array.from(host!.querySelectorAll('button')).find(candidate =>
+    candidate.textContent?.trim().startsWith(prefix)
+  );
+  if (!found) throw new Error(`summary button "${prefix}" did not render`);
+  return found;
+}
+
+function clickButton(target: HTMLButtonElement): void {
+  target.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
 }
 
 function installMatchMedia(initialMatches: boolean) {
@@ -67,6 +113,10 @@ function installMatchMedia(initialMatches: boolean) {
 }
 
 async function mountTheme(children?: React.ReactNode): Promise<void> {
+  // The config store is a process-wide singleton: re-read it from the storage
+  // backend this test installed so seeded cookies (not a previous test's
+  // values) decide the pair.
+  configStore.loadFromBackend();
   host = document.createElement('div');
   document.body.appendChild(host);
   root = createRoot(host);
@@ -110,6 +160,80 @@ describe('theme registry', () => {
     expect(theme.modeSupport).toBe('both');
     expect(theme.syntaxHighlighting).toBe(true);
     expect(theme.colors.dark.background).not.toBe(theme.colors.light.background);
+  });
+
+  test('offers each palette only for the half it can render', () => {
+    const light = themesForHalf(BUILT_IN_THEMES, 'light').map(({ id }) => id);
+    const dark = themesForHalf(BUILT_IN_THEMES, 'dark').map(({ id }) => id);
+
+    expect(light).toContain('kanagawa-lotus');
+    expect(light).not.toContain('kanagawa-wave');
+    expect(dark).toContain('kanagawa-wave');
+    expect(dark).not.toContain('kanagawa-lotus');
+
+    // A `both` palette — the colorblind theme included — belongs to each half.
+    for (const id of ['rose-pine', 'colorblind']) {
+      expect(light).toContain(id);
+      expect(dark).toContain(id);
+      expect(themeSupportsHalf(id, 'light')).toBe(true);
+      expect(themeSupportsHalf(id, 'dark')).toBe(true);
+    }
+  });
+
+  test('seeds both halves from the single palette older releases stored', () => {
+    // A palette that renders both modes takes over the whole pair.
+    expect(seedThemePair('rose-pine', 'system')).toEqual({
+      mode: 'system',
+      light: 'rose-pine',
+      dark: 'rose-pine',
+    });
+
+    // A mode-restricted one keeps its half; the other half falls back.
+    expect(seedThemePair('kanagawa-wave', 'dark')).toEqual({
+      mode: 'dark',
+      light: DEFAULT_COLOR_THEME,
+      dark: 'kanagawa-wave',
+    });
+    expect(seedThemePair('kanagawa-lotus', 'light')).toEqual({
+      mode: 'light',
+      light: 'kanagawa-lotus',
+      dark: DEFAULT_COLOR_THEME,
+    });
+
+    // Nothing stored, or a palette this build does not ship.
+    expect(seedThemePair(null, 'system')).toEqual({
+      mode: 'system',
+      light: DEFAULT_COLOR_THEME,
+      dark: DEFAULT_COLOR_THEME,
+    });
+    expect(seedThemePair('gone-in-this-build', 'dark')).toEqual({
+      mode: 'dark',
+      light: DEFAULT_COLOR_THEME,
+      dark: DEFAULT_COLOR_THEME,
+    });
+  });
+
+  test('repairs a pair whose halves hold unusable palettes', () => {
+    const fallback = { mode: 'system', light: 'rose-pine', dark: 'kanagawa-wave' } as const;
+
+    expect(normalizeThemePair({ mode: 'light', light: 'tinacious', dark: 'vesper' }, fallback)).toEqual({
+      mode: 'light',
+      light: 'tinacious',
+      dark: 'vesper',
+    });
+
+    // A dark-only palette can never occupy the light half, and vice versa.
+    expect(normalizeThemePair({ mode: 'sepia', light: 'vesper', dark: 'tinacious' }, fallback)).toEqual({
+      mode: 'system',
+      light: 'rose-pine',
+      dark: 'kanagawa-wave',
+    });
+
+    expect(normalizeThemePair(undefined)).toEqual({
+      mode: 'dark',
+      light: DEFAULT_COLOR_THEME,
+      dark: DEFAULT_COLOR_THEME,
+    });
   });
 });
 
@@ -168,78 +292,126 @@ describe('ThemeProvider', () => {
     expect(themeState().resolvedMode).toBe('dark');
   });
 
-  test.skipIf(!hasDom)('keeps System coherent and normalizes explicit modes for constrained palettes', async () => {
+  test.skipIf(!hasDom)('flips between the two halves of the pair when the OS scheme changes', async () => {
     stored.set('plannotator-theme', 'system');
-    stored.set('plannotator-color-theme', 'andromeeda');
+    stored.set('plannotator-light-theme', 'kanagawa-lotus');
+    stored.set('plannotator-dark-theme', 'kanagawa-wave');
     const media = installMatchMedia(true);
 
     await mountTheme();
-    expect(themeState().mode).toBe('system');
-    expect(themeState().preferredMode).toBe('light');
-    expect(themeState().resolvedMode).toBe('dark');
-    expect(document.documentElement.classList.contains('theme-andromeeda')).toBe(true);
-    expect(document.documentElement.classList.contains('light')).toBe(false);
+    expect(themeState().lightTheme).toBe('kanagawa-lotus');
+    expect(themeState().darkTheme).toBe('kanagawa-wave');
+    expect(themeState().colorTheme).toBe('kanagawa-lotus');
+    expect(themeState().resolvedMode).toBe('light');
+    expect(document.documentElement.classList.contains('theme-kanagawa-lotus')).toBe(true);
+    expect(document.documentElement.classList.contains('light')).toBe(true);
 
     await act(async () => media.setMatches(false));
-    expect(themeState().mode).toBe('system');
-    expect(themeState().preferredMode).toBe('dark');
+    expect(themeState().colorTheme).toBe('kanagawa-wave');
     expect(themeState().resolvedMode).toBe('dark');
+    expect(document.documentElement.classList.contains('theme-kanagawa-wave')).toBe(true);
+    expect(document.documentElement.classList.contains('light')).toBe(false);
 
-    await act(async () => themeState().setColorTheme('kanagawa-lotus'));
-    expect(themeState().mode).toBe('system');
-    expect(themeState().resolvedMode).toBe('light');
-    expect(stored.get('plannotator-theme')).toBe('system');
-
-    await act(async () => themeState().setMode('dark'));
-    expect(themeState().mode).toBe('light');
-    expect(themeState().resolvedMode).toBe('light');
-    expect(stored.get('plannotator-theme')).toBe('light');
-
-    await act(async () => themeState().setColorTheme('andromeeda'));
-    expect(themeState().mode).toBe('dark');
-    expect(themeState().resolvedMode).toBe('dark');
-    expect(stored.get('plannotator-theme')).toBe('dark');
-
-    await act(async () => {
-      themeState().setColorTheme('plannotator');
-      themeState().setMode('light');
-      themeState().setColorTheme('andromeeda');
-      themeState().setMode('light');
-    });
-    expect(themeState().mode).toBe('dark');
-    expect(themeState().resolvedMode).toBe('dark');
-    expect(stored.get('plannotator-theme')).toBe('dark');
+    // Older releases read the single-palette key, so it keeps tracking the
+    // palette actually on screen — a downgrade never lands unstyled.
+    expect(stored.get('plannotator-color-theme')).toBe('kanagawa-wave');
   });
 
-  test.skipIf(!hasDom)('repairs invalid persisted modes before exposing state', async () => {
+  test.skipIf(!hasDom)('migrates a stored dark-only palette into the dark half only', async () => {
+    stored.set('plannotator-theme', 'system');
+    stored.set('plannotator-color-theme', 'kanagawa-wave');
+    installMatchMedia(true);
+
+    await mountTheme();
+    expect(themeState().darkTheme).toBe('kanagawa-wave');
+    expect(themeState().lightTheme).toBe(DEFAULT_COLOR_THEME);
+    // The OS is light, so the migrated pair renders its light half — the mode
+    // is no longer coerced to keep a dark-only palette on screen.
+    expect(themeState().mode).toBe('system');
+    expect(themeState().preferredMode).toBe('light');
+    expect(themeState().resolvedMode).toBe('light');
+    expect(themeState().colorTheme).toBe(DEFAULT_COLOR_THEME);
+
+    // The migrated pair is persisted on arrival — the legacy key it was
+    // derived from is immediately overwritten with the active palette.
+    expect(stored.get('plannotator-light-theme')).toBe(DEFAULT_COLOR_THEME);
+    expect(stored.get('plannotator-dark-theme')).toBe('kanagawa-wave');
+    expect(stored.get('plannotator-color-theme')).toBe(DEFAULT_COLOR_THEME);
+  });
+
+  test.skipIf(!hasDom)('keeps every mode selectable while a dark-only palette owns the dark half', async () => {
+    stored.set('plannotator-theme', 'dark');
+    stored.set('plannotator-light-theme', 'rose-pine');
+    stored.set('plannotator-dark-theme', 'dracula');
+    installMatchMedia(false);
+
+    await mountTheme(<ThemeTab />);
+    expect(themeState().colorTheme).toBe('dracula');
+
+    const modeButtons = Array.from(host!.querySelectorAll('button')).filter(button =>
+      ['Light', 'Dark', 'System'].includes(button.textContent?.trim() ?? '')
+    );
+    expect(modeButtons.length).toBe(3);
+    expect(modeButtons.some(button => button.disabled)).toBe(false);
+
+    await act(async () => themeState().setMode('light'));
+    expect(themeState().mode).toBe('light');
+    expect(themeState().colorTheme).toBe('rose-pine');
+    expect(themeState().resolvedMode).toBe('light');
+    expect(stored.get('plannotator-theme')).toBe('light');
+    expect(stored.get('plannotator-dark-theme')).toBe('dracula');
+  });
+
+  test.skipIf(!hasDom)('repairs invalid persisted values before exposing state', async () => {
     stored.set('plannotator-theme', 'sepia');
+    stored.set('plannotator-light-theme', 'dracula');
+    stored.set('plannotator-dark-theme', 'gone-in-this-build');
     stored.set('plannotator-color-theme', 'andromeeda');
     installMatchMedia(true);
 
     await mountTheme();
     expect(themeState().mode).toBe('dark');
+    expect(themeState().lightTheme).toBe(DEFAULT_COLOR_THEME);
+    expect(themeState().darkTheme).toBe('andromeeda');
     expect(themeState().resolvedMode).toBe('dark');
     expect(stored.get('plannotator-theme')).toBe('dark');
   });
 
-  test.skipIf(!hasDom)('previews a constrained palette using the mode it actually renders', async () => {
-    stored.set('plannotator-theme', 'system');
-    stored.set('plannotator-color-theme', 'tinacious');
-    installMatchMedia(false);
+  test.skipIf(!hasDom)('assigns one half at a time from its own grid', async () => {
+    stored.set('plannotator-theme', 'light');
+    stored.set('plannotator-light-theme', DEFAULT_COLOR_THEME);
+    stored.set('plannotator-dark-theme', DEFAULT_COLOR_THEME);
+    installMatchMedia(true);
 
     await mountTheme(<ThemeTab />);
-    expect(themeState().preferredMode).toBe('dark');
-    expect(themeState().resolvedMode).toBe('light');
 
-    const paletteButton = Array.from(host!.querySelectorAll('button')).find(button =>
-      button.textContent?.includes('Tinacious')
-    );
-    if (!paletteButton) throw new Error('Tinacious palette preview did not render');
-    const swatches = paletteButton.querySelectorAll<HTMLElement>('.rounded-full');
-    const palette = BUILT_IN_THEMES.find(theme => theme.id === 'tinacious');
-    if (!palette) throw new Error('Tinacious palette is not registered');
+    // The grid opens on the half the user is actually looking at.
+    expect(paletteNames()).toContain('Kanagawa Lotus');
+    expect(paletteNames()).not.toContain('Kanagawa Wave');
 
-    expect(swatches[3]?.style.backgroundColor).toBe(palette.colors.light.background);
-    expect(swatches[3]?.style.backgroundColor).not.toBe(palette.colors.dark.background);
+    await act(async () => clickButton(palette('Tinacious')));
+    expect(themeState().lightTheme).toBe('tinacious');
+    expect(themeState().colorTheme).toBe('tinacious');
+
+    const swatches = palette('Tinacious').querySelectorAll<HTMLElement>('.rounded-full');
+    const tinacious = BUILT_IN_THEMES.find(theme => theme.id === 'tinacious');
+    if (!tinacious) throw new Error('Tinacious palette is not registered');
+    expect(swatches[3]?.style.backgroundColor).toBe(tinacious.colors.light.background);
+
+    // Assigning the other half leaves the visible palette alone.
+    await act(async () => clickButton(button('Dark theme')));
+    expect(paletteNames()).toContain('Kanagawa Wave');
+    expect(paletteNames()).not.toContain('Kanagawa Lotus');
+
+    await act(async () => clickButton(palette('Dracula')));
+    expect(themeState().darkTheme).toBe('dracula');
+    expect(themeState().mode).toBe('light');
+    expect(themeState().colorTheme).toBe('tinacious');
+
+    // The summary names both halves and jumps the grid back to the light one.
+    expect(host!.textContent).toContain('Tinacious');
+    expect(host!.textContent).toContain('Dracula');
+    await act(async () => clickButton(summaryButton('Light:')));
+    expect(paletteNames()).toContain('Kanagawa Lotus');
   });
 });

--- a/packages/ui/components/ThemeProvider.tsx
+++ b/packages/ui/components/ThemeProvider.tsx
@@ -1,12 +1,21 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { configStore } from '../config/configStore';
+import { readThemePairCookies, writeThemePairCookies } from '../config/settings';
+import { useConfigValue } from '../config/useConfig';
 import { storage } from '../utils/storage';
 import {
   BUILT_IN_THEMES,
-  normalizeThemeMode,
+  getUnsupportedMode,
+  resolvePairTheme,
   resolveThemeMode,
+  seedThemePair,
+  setDefaultThemePair,
+  themeSupportsHalf,
+  type ThemeHalf,
   type ThemeInfo,
+  type ThemePair,
 } from '../utils/themeRegistry';
-import { parseThemeMode, type Mode } from './themeModes';
+import type { Mode } from './themeModes';
 
 // Kept here because published consumers already import Mode from ThemeProvider.
 export type { Mode } from './themeModes';
@@ -19,9 +28,13 @@ type ThemeProviderState = {
   setMode: (mode: Mode) => void;
   preferredMode: 'dark' | 'light';
   resolvedMode: 'dark' | 'light';
-  // Color theme (palette)
+  // Color theme (the palette the current mode renders — pair[preferredMode])
   colorTheme: string;
   setColorTheme: (theme: string) => void;
+  // The pair itself: one palette per half, assignable independently
+  lightTheme: string;
+  darkTheme: string;
+  setHalfTheme: (half: ThemeHalf, theme: string) => void;
   availableThemes: ThemeInfo[];
 };
 
@@ -34,6 +47,9 @@ const ThemeProviderContext = createContext<ThemeProviderState>({
   resolvedMode: 'dark',
   colorTheme: 'plannotator',
   setColorTheme: () => null,
+  lightTheme: 'plannotator',
+  darkTheme: 'plannotator',
+  setHalfTheme: () => null,
   availableThemes: BUILT_IN_THEMES,
 });
 
@@ -74,22 +90,33 @@ export function ThemeProvider({
   storageKey = 'plannotator-theme',
   colorThemeStorageKey = 'plannotator-color-theme',
 }: ThemeProviderProps) {
-  const [colorTheme, setColorThemeState] = useState<string>(
-    () => storage.getItem(colorThemeStorageKey) || defaultColorTheme
-  );
-
-  const [mode, setModeState] = useState<Mode>(() => {
-    const storedMode = parseThemeMode(storage.getItem(storageKey), defaultTheme);
-    return normalizeThemeMode(colorTheme, storedMode);
+  // The props are the fallback for someone with no persisted preference. The
+  // config store is a singleton that may already have resolved its own default,
+  // so ask storage directly instead of trusting the resolved value; the seed is
+  // handed to the store below, once mounting is done.
+  const [propsSeed] = useState<ThemePair | null>(() => {
+    const fallback = seedThemePair(defaultColorTheme, defaultTheme);
+    setDefaultThemePair(fallback);
+    return readThemePairCookies() === undefined ? fallback : null;
   });
-  const colorThemeRef = useRef(colorTheme);
-  const modeRef = useRef(mode);
+  const pendingSeed = useRef(propsSeed);
+
+  const storePair = useConfigValue('themePair');
+  const pair = pendingSeed.current ?? storePair;
+  const mode = pair.mode;
+
+  useEffect(() => {
+    if (!pendingSeed.current) return;
+    configStore.set('themePair', pendingSeed.current);
+    pendingSeed.current = null;
+  }, []);
 
   const [systemIsLight, setSystemIsLight] = useState(getSystemIsLight);
 
-  // Keep the OS-resolved preference separate from the mode the palette can render.
+  // Keep the OS-resolved preference separate from the half it selects.
   const preferredMode: 'dark' | 'light' =
     mode === 'system' ? (systemIsLight ? 'light' : 'dark') : mode;
+  const colorTheme = resolvePairTheme(pair, preferredMode);
   const resolvedMode = resolveThemeMode(colorTheme, preferredMode);
 
   // [P3 fix] Apply theme class synchronously during initialization to prevent
@@ -128,28 +155,43 @@ export function ThemeProvider({
   }, [mode]);
 
   const setMode = useCallback((newMode: Mode) => {
-    const normalizedMode = normalizeThemeMode(colorThemeRef.current, newMode);
-    modeRef.current = normalizedMode;
-    storage.setItem(storageKey, normalizedMode);
-    setModeState(normalizedMode);
-  }, [storageKey]);
+    configStore.set('themePair', { ...configStore.get('themePair'), mode: newMode });
+  }, []);
 
+  /** Assign one palette to one half of the pair. */
+  const setHalfTheme = useCallback((half: ThemeHalf, newTheme: string) => {
+    if (!themeSupportsHalf(newTheme, half)) return;
+    configStore.set('themePair', { ...configStore.get('themePair'), [half]: newTheme });
+  }, []);
+
+  /**
+   * Legacy single-palette API. A palette that renders both modes takes over the
+   * whole pair; a mode-restricted one takes the half it supports and pins the
+   * mode there, so a caller that picks Dracula still sees Dracula.
+   */
   const setColorTheme = useCallback((newTheme: string) => {
-    const normalizedMode = normalizeThemeMode(newTheme, modeRef.current);
-    colorThemeRef.current = newTheme;
-    storage.setItem(colorThemeStorageKey, newTheme);
-    if (normalizedMode !== modeRef.current) {
-      modeRef.current = normalizedMode;
-      storage.setItem(storageKey, normalizedMode);
-      setModeState(normalizedMode);
+    const current = configStore.get('themePair');
+    const unsupported = getUnsupportedMode(newTheme);
+    if (!unsupported) {
+      configStore.set('themePair', { ...current, light: newTheme, dark: newTheme });
+      return;
     }
-    setColorThemeState(newTheme);
-  }, [colorThemeStorageKey, storageKey]);
+    const half: ThemeHalf = unsupported === 'light' ? 'dark' : 'light';
+    configStore.set('themePair', { ...current, [half]: newTheme, mode: half });
+  }, []);
 
-  // Repair invalid or incompatible values left by older versions at the boundary.
+  // Mirror the resolved choice onto the keys older releases read, so a
+  // downgrade lands on the user's palette instead of an unstyled first frame.
+  // The pair itself is written first: a pair migrated from the legacy
+  // single-palette key is derived, and the mirror below overwrites the key it
+  // was derived from.
   useEffect(() => {
+    writeThemePairCookies(pair);
+    if (storage.getItem(colorThemeStorageKey) !== colorTheme) {
+      storage.setItem(colorThemeStorageKey, colorTheme);
+    }
     if (storage.getItem(storageKey) !== mode) storage.setItem(storageKey, mode);
-  }, [mode, storageKey]);
+  }, [pair, colorTheme, colorThemeStorageKey, mode, storageKey]);
 
   const value = useMemo<ThemeProviderState>(() => ({
     theme: mode,
@@ -160,8 +202,11 @@ export function ThemeProvider({
     resolvedMode,
     colorTheme,
     setColorTheme,
+    lightTheme: pair.light,
+    darkTheme: pair.dark,
+    setHalfTheme,
     availableThemes: BUILT_IN_THEMES,
-  }), [mode, preferredMode, resolvedMode, colorTheme, setMode, setColorTheme]);
+  }), [mode, preferredMode, resolvedMode, colorTheme, pair.light, pair.dark, setMode, setColorTheme, setHalfTheme]);
 
   return (
     <ThemeProviderContext.Provider value={value}>

--- a/packages/ui/components/ThemeProvider.tsx
+++ b/packages/ui/components/ThemeProvider.tsx
@@ -79,7 +79,20 @@ interface ThemeProviderProps {
   children: React.ReactNode;
   defaultTheme?: Mode;
   defaultColorTheme?: string;
+  /**
+   * Where the mode is stored. Read when resolving the initial pair and written
+   * by the legacy mirror, so a host's already-stored preference survives the
+   * upgrade to pairs.
+   */
   storageKey?: string;
+  /**
+   * Where the single pre-pair palette is stored. Read as the migration source
+   * for both halves and kept in sync with the palette on screen.
+   *
+   * Note: the two halves themselves are a new concept with no pre-existing
+   * host data, so they always live under `plannotator-light-theme` /
+   * `plannotator-dark-theme`; these props rename only the two legacy values.
+   */
   colorThemeStorageKey?: string;
 }
 
@@ -90,25 +103,39 @@ export function ThemeProvider({
   storageKey = 'plannotator-theme',
   colorThemeStorageKey = 'plannotator-color-theme',
 }: ThemeProviderProps) {
-  // The props are the fallback for someone with no persisted preference. The
-  // config store is a singleton that may already have resolved its own default,
-  // so ask storage directly instead of trusting the resolved value; the seed is
-  // handed to the store below, once mounting is done.
-  const [propsSeed] = useState<ThemePair | null>(() => {
-    const fallback = seedThemePair(defaultColorTheme, defaultTheme);
-    setDefaultThemePair(fallback);
-    return readThemePairCookies() === undefined ? fallback : null;
+  const legacyKeys = useMemo(
+    () => ({ mode: storageKey, colorTheme: colorThemeStorageKey }),
+    [storageKey, colorThemeStorageKey],
+  );
+
+  // Resolve the pair this provider starts on from ITS OWN storage keys: what
+  // the user persisted (migrating a host's pre-pair values), else these props.
+  // The config store is a singleton that may already have resolved a default of
+  // its own, so storage is asked directly rather than trusting that value.
+  const [initialPair] = useState<ThemePair>(() => {
+    const resolved = readThemePairCookies(legacyKeys)
+      ?? seedThemePair(defaultColorTheme, defaultTheme);
+    setDefaultThemePair(resolved);
+    return resolved;
   });
-  const pendingSeed = useRef(propsSeed);
+  const pendingSeed = useRef<ThemePair | null>(initialPair);
+  const [, setSeedApplied] = useState(false);
 
   const storePair = useConfigValue('themePair');
   const pair = pendingSeed.current ?? storePair;
   const mode = pair.mode;
 
+  // Hand the resolved pair to the store as a SEED, not a user choice: seeding
+  // writes memory + cookies only. Routing it through set() would queue a
+  // server write of a value nobody picked, which (flushing after the server
+  // config arrives) would overwrite the user's real ~/.plannotator/config.json
+  // theme from any cookie-less visit.
   useEffect(() => {
-    if (!pendingSeed.current) return;
-    configStore.set('themePair', pendingSeed.current);
+    const seed = pendingSeed.current;
+    if (!seed) return;
     pendingSeed.current = null;
+    configStore.seed('themePair', seed);
+    setSeedApplied(true);
   }, []);
 
   const [systemIsLight, setSystemIsLight] = useState(getSystemIsLight);
@@ -118,6 +145,11 @@ export function ThemeProvider({
     mode === 'system' ? (systemIsLight ? 'light' : 'dark') : mode;
   const colorTheme = resolvePairTheme(pair, preferredMode);
   const resolvedMode = resolveThemeMode(colorTheme, preferredMode);
+
+  // Read by the legacy setColorTheme, which must target the half on screen
+  // without re-creating its callback on every mode change.
+  const preferredModeRef = useRef(preferredMode);
+  preferredModeRef.current = preferredMode;
 
   // [P3 fix] Apply theme class synchronously during initialization to prevent
   // flash of unstyled content. CSS tokens live under .theme-* selectors, so
@@ -165,19 +197,25 @@ export function ThemeProvider({
   }, []);
 
   /**
-   * Legacy single-palette API. A palette that renders both modes takes over the
-   * whole pair; a mode-restricted one takes the half it supports and pins the
-   * mode there, so a caller that picks Dracula still sees Dracula.
+   * Legacy single-palette API, kept for published consumers. It assigns exactly
+   * ONE half and changes nothing else:
+   *
+   *  - a palette that renders both modes goes to the half currently on screen,
+   *    leaving the other half's assignment alone;
+   *  - a mode-restricted palette goes to the half it supports without touching
+   *    the mode, because render-time resolution (`resolveThemeMode`) already
+   *    keeps a System user on a palette that can be drawn.
+   *
+   * Persistence stays cookie-only unless a host installed a serverSync
+   * transport, matching the side effects this API had before the pair existed.
    */
   const setColorTheme = useCallback((newTheme: string) => {
     const current = configStore.get('themePair');
     const unsupported = getUnsupportedMode(newTheme);
-    if (!unsupported) {
-      configStore.set('themePair', { ...current, light: newTheme, dark: newTheme });
-      return;
-    }
-    const half: ThemeHalf = unsupported === 'light' ? 'dark' : 'light';
-    configStore.set('themePair', { ...current, [half]: newTheme, mode: half });
+    const half: ThemeHalf = unsupported
+      ? (unsupported === 'light' ? 'dark' : 'light')
+      : preferredModeRef.current;
+    configStore.setLocal('themePair', { ...current, [half]: newTheme });
   }, []);
 
   // Mirror the resolved choice onto the keys older releases read, so a
@@ -186,12 +224,11 @@ export function ThemeProvider({
   // single-palette key is derived, and the mirror below overwrites the key it
   // was derived from.
   useEffect(() => {
-    writeThemePairCookies(pair);
+    writeThemePairCookies(pair, legacyKeys);
     if (storage.getItem(colorThemeStorageKey) !== colorTheme) {
       storage.setItem(colorThemeStorageKey, colorTheme);
     }
-    if (storage.getItem(storageKey) !== mode) storage.setItem(storageKey, mode);
-  }, [pair, colorTheme, colorThemeStorageKey, mode, storageKey]);
+  }, [pair, colorTheme, colorThemeStorageKey, legacyKeys]);
 
   const value = useMemo<ThemeProviderState>(() => ({
     theme: mode,

--- a/packages/ui/components/ThemeTab.tsx
+++ b/packages/ui/components/ThemeTab.tsx
@@ -1,22 +1,63 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTheme } from './ThemeProvider';
 import { THEME_MODES } from './themeModes';
-import { isThemeModeAvailable, resolveThemeMode } from '../utils/themeRegistry';
+import { themesForHalf, type ThemeHalf } from '../utils/themeRegistry';
 
 interface ThemeTabProps {
   onPreview?: () => void;
   compact?: boolean;
 }
 
+const HALVES: { id: ThemeHalf; label: string }[] = [
+  { id: 'light', label: 'Light' },
+  { id: 'dark', label: 'Dark' },
+];
+
+const SyntaxLinesIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h7" />
+  </svg>
+);
+
 export const ThemeTab: React.FC<ThemeTabProps> = ({ onPreview, compact }) => {
   const {
     mode,
     setMode,
-    colorTheme,
-    setColorTheme,
+    lightTheme,
+    darkTheme,
+    setHalfTheme,
     availableThemes,
     preferredMode,
   } = useTheme();
+
+  // Which half the grid assigns to. Follows the mode you are actually seeing,
+  // so opening Settings in dark mode edits the dark half first.
+  const [half, setHalf] = useState<ThemeHalf>(preferredMode);
+  useEffect(() => setHalf(preferredMode), [preferredMode]);
+
+  const pair: Record<ThemeHalf, string> = { light: lightTheme, dark: darkTheme };
+  const themes = themesForHalf(availableThemes, half);
+  const nameOf = (id: string) => availableThemes.find(theme => theme.id === id)?.name ?? id;
+
+  const summary = (
+    <div className={`flex items-center gap-1.5 text-[11px] text-muted-foreground ${compact ? '' : 'flex-wrap'}`}>
+      {HALVES.map(({ id, label }, index) => (
+        <React.Fragment key={id}>
+          {index > 0 && <span className="text-muted-foreground/40">·</span>}
+          <button
+            onClick={() => setHalf(id)}
+            title={`Assign the ${label.toLowerCase()} theme`}
+            className={`rounded px-1 py-0.5 transition-colors hover:bg-muted ${
+              half === id ? 'text-foreground' : ''
+            }`}
+          >
+            <span className="text-muted-foreground/70">{label}: </span>
+            <span className="font-medium">{nameOf(pair[id])}</span>
+          </button>
+        </React.Fragment>
+      ))}
+    </div>
+  );
 
   return (
     <div className={compact ? '' : 'space-y-5'}>
@@ -24,87 +65,95 @@ export const ThemeTab: React.FC<ThemeTabProps> = ({ onPreview, compact }) => {
       <div className={compact ? 'flex items-center gap-3 mb-2' : 'space-y-2'}>
         {!compact && <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Mode</label>}
         <div className="flex gap-1">
-          {THEME_MODES.map(({ id, label, Icon }) => {
-            const available = isThemeModeAvailable(colorTheme, id);
-            return (
-              <button
-                key={id}
-                disabled={!available}
-                title={available ? undefined : 'Not supported by the current color theme'}
-                onClick={() => setMode(id)}
-                className={`px-2.5 py-1.5 rounded-md text-xs font-medium transition-colors ${
-                  !available
-                    ? 'cursor-not-allowed bg-muted text-muted-foreground opacity-40'
-                    : mode === id
-                      ? 'bg-primary text-primary-foreground'
-                      : 'bg-muted text-muted-foreground hover:text-foreground'
-                }`}
-              >
-                <span className="flex items-center gap-1.5">
-                  <Icon className="w-3 h-3" />
-                  {label}
-                </span>
-              </button>
-            );
-          })}
+          {THEME_MODES.map(({ id, label, Icon }) => (
+            <button
+              key={id}
+              onClick={() => setMode(id)}
+              className={`px-2.5 py-1.5 rounded-md text-xs font-medium transition-colors ${
+                mode === id
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-muted text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              <span className="flex items-center gap-1.5">
+                <Icon className="w-3 h-3" />
+                {label}
+              </span>
+            </button>
+          ))}
         </div>
-        {compact && (
-          <span className="text-[10px] text-muted-foreground/60 ml-auto flex items-center gap-1">
-            <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h7" />
-            </svg>
-            syntax match
-          </span>
+        {!compact && (
+          <p className="text-[11px] text-muted-foreground/70">
+            System follows your OS and switches between the two themes below.
+          </p>
         )}
+        {compact && <div className="ml-auto">{summary}</div>}
       </div>
 
-      {/* Theme */}
-      <div className={compact ? '' : 'space-y-3'}>
+      {/* Theme pair */}
+      <div className={compact ? 'space-y-2' : 'space-y-3'}>
         {!compact && (
-          <div className="flex items-center justify-between border-t border-border pt-5">
-            <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Theme</label>
-            <div className="flex items-center gap-3">
-              <span className="text-[10px] text-muted-foreground/70 flex items-center gap-1">
-                <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h7" />
-                </svg>
-                = matched syntax colors
-              </span>
-              {onPreview && (
-                <button
-                  onClick={onPreview}
-                  className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-primary/10 text-primary border border-primary/20 hover:bg-primary/20 hover:border-primary/40 transition-colors"
-                >
-                  Preview Mode
-                </button>
-              )}
+          <>
+            <div className="flex items-center justify-between border-t border-border pt-5">
+              <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Theme</label>
+              <div className="flex items-center gap-3">
+                <span className="text-[10px] text-muted-foreground/70 flex items-center gap-1">
+                  <SyntaxLinesIcon className="w-2.5 h-2.5" />
+                  = matched syntax colors
+                </span>
+                {onPreview && (
+                  <button
+                    onClick={onPreview}
+                    className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-primary/10 text-primary border border-primary/20 hover:bg-primary/20 hover:border-primary/40 transition-colors"
+                  >
+                    Preview Mode
+                  </button>
+                )}
+              </div>
             </div>
-          </div>
+            {summary}
+          </>
         )}
+
+        {/* Which half the grid assigns to */}
+        <div className="flex items-center gap-2">
+          <span className="text-[11px] text-muted-foreground/70">Assigning</span>
+          <div className="flex items-center gap-0.5 rounded-lg bg-muted/50 p-0.5">
+            {HALVES.map(({ id, label }) => (
+              <button
+                key={id}
+                onClick={() => setHalf(id)}
+                aria-pressed={half === id}
+                className={`rounded-md px-2.5 py-1 text-[11px] font-medium transition-colors ${
+                  half === id
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                {label} theme
+              </button>
+            ))}
+          </div>
+        </div>
+
         <div className={`grid gap-2 overflow-y-auto pr-1 ${compact ? 'grid-cols-4' : 'grid-cols-3'}`}>
-          {availableThemes.map(theme => {
-            const isSelected = colorTheme === theme.id;
-            const previewMode = resolveThemeMode(theme.id, preferredMode);
-            const colors = theme.colors[previewMode];
-            const modeUnavailable = !isThemeModeAvailable(theme.id, preferredMode);
+          {themes.map(theme => {
+            const isSelected = pair[half] === theme.id;
+            const colors = theme.colors[half];
             return (
               <button
                 key={theme.id}
-                onClick={() => setColorTheme(theme.id)}
+                onClick={() => setHalfTheme(half, theme.id)}
                 className={`relative p-2 rounded-md border text-left transition-colors ${
                   isSelected
                     ? 'border-primary bg-primary/5'
-                    : modeUnavailable
-                      ? 'border-border/50 opacity-45'
-                      : 'border-border hover:border-muted-foreground/30 hover:bg-muted/30'
+                    : 'border-border hover:border-muted-foreground/30 hover:bg-muted/30'
                 }`}
               >
                 {/* Syntax highlighting badge */}
                 {theme.syntaxHighlighting && (
                   <div className="absolute top-1 right-1" title="Matched syntax highlighting in diffs">
-                    <svg className="w-2.5 h-2.5 text-muted-foreground/50" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h7" />
-                    </svg>
+                    <SyntaxLinesIcon className="w-2.5 h-2.5 text-muted-foreground/50" />
                   </div>
                 )}
                 {/* Color swatches */}

--- a/packages/ui/config/configStore.ts
+++ b/packages/ui/config/configStore.ts
@@ -29,6 +29,28 @@ function deepMerge(target: Record<string, unknown>, source: Record<string, unkno
   }
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Remove every leaf `shape` describes from `target`, pruning containers that
+ * empty out. Used to retract a queued server write once the server has spoken
+ * for the same leaves.
+ */
+function deletePaths(target: Record<string, unknown>, shape: Record<string, unknown>): void {
+  for (const key of Object.keys(shape)) {
+    if (!(key in target)) continue;
+    if (isPlainObject(target[key]) && isPlainObject(shape[key])) {
+      const child = target[key] as Record<string, unknown>;
+      deletePaths(child, shape[key] as Record<string, unknown>);
+      if (Object.keys(child).length === 0) delete target[key];
+    } else {
+      delete target[key];
+    }
+  }
+}
+
 /** Server write-back transport: posts a batch of changed server-synced settings. */
 export type ServerSyncFn = (payload: Record<string, unknown>) => void;
 
@@ -56,6 +78,10 @@ class ConfigStore {
   private serverSyncTimer: ReturnType<typeof setTimeout> | null = null;
   private pagehideFlushRegistered = false;
   private serverSync: ServerSyncFn = defaultServerSync;
+  /** True once a host installed its own transport via setServerSync(). */
+  private serverSyncInstalled = false;
+  /** Settings whose value came from the server config; seeds must not undo them. */
+  private serverOverridden = new Set<string>();
   private loaded = false;
 
   /**
@@ -132,10 +158,55 @@ class ConfigStore {
           if (fromServer !== undefined) {
             this.values.set(name, fromServer);
             def.toCookie(fromServer as never);
+            this.serverOverridden.add(name);
+            // Retract any write still queued for the leaves the server just
+            // spoke for. Without this, a write queued before init() flushes
+            // AFTER it and pushes the pre-init value back to the config file,
+            // which the next session would then restore over the cookie.
+            if (def.toServer) {
+              deletePaths(
+                this.pendingServerWrites,
+                def.toServer(fromServer as never) as Record<string, unknown>,
+              );
+            }
           }
         }
       }
     }
+    this.notify();
+  }
+
+  /**
+   * Install a resolved default for a setting: memory + cookie, never the
+   * server. For values a component computes at mount (e.g. ThemeProvider's
+   * default theme pair) rather than values a user chose — seeding must not
+   * write to ~/.plannotator/config.json, and must never overwrite a value the
+   * server already supplied through init().
+   */
+  seed<K extends SettingName>(key: K, value: SettingValue<K>): void {
+    this.ensureLoaded();
+    if (this.serverOverridden.has(key)) return;
+    const def = SETTINGS[key];
+    this.values.set(key, value);
+    def.toCookie(value as never);
+    this.notify();
+  }
+
+  /**
+   * Persist a user choice to memory + cookie, queuing the server write-back
+   * only when this store is actually talking to a server. Hosts that never
+   * installed a serverSync seam have no /api/config endpoint, so the legacy
+   * cookie-only APIs (ThemeProvider.setColorTheme) use this instead of set().
+   */
+  setLocal<K extends SettingName>(key: K, value: SettingValue<K>): void {
+    if (this.serverSyncInstalled) {
+      this.set(key, value);
+      return;
+    }
+    this.ensureLoaded();
+    const def = SETTINGS[key];
+    this.values.set(key, value);
+    def.toCookie(value as never);
     this.notify();
   }
 
@@ -169,9 +240,13 @@ class ConfigStore {
   /** Override the server write-back transport (default = inline POST /api/config). */
   setServerSync(fn: ServerSyncFn): void {
     this.serverSync = fn;
+    this.serverSyncInstalled = true;
   }
 
-  resetServerSync(): void { this.serverSync = defaultServerSync; }
+  resetServerSync(): void {
+    this.serverSync = defaultServerSync;
+    this.serverSyncInstalled = false;
+  }
 
   private notify(): void {
     this.version++;

--- a/packages/ui/config/settings.ts
+++ b/packages/ui/config/settings.ts
@@ -27,6 +27,24 @@ const LIGHT_THEME_COOKIE = 'plannotator-light-theme';
 const DARK_THEME_COOKIE = 'plannotator-dark-theme';
 
 /**
+ * Where a host keeps the two PRE-PAIR values, if not under Plannotator's own
+ * keys. These mirror ThemeProvider's `storageKey` / `colorThemeStorageKey`
+ * props, which existed before the pair and are what a host's already-stored
+ * user preference lives under.
+ *
+ * Only these two legacy keys are overridable. The pair halves are a new
+ * concept with no pre-existing host data, so they always use the fixed
+ * `plannotator-light-theme` / `plannotator-dark-theme` keys; two hosts sharing
+ * one origin with different key prefixes would share those halves.
+ */
+export interface ThemePairLegacyKeys {
+  /** Where the mode is stored (ThemeProvider's `storageKey`). */
+  mode?: string;
+  /** Where the single pre-pair palette is stored (`colorThemeStorageKey`). */
+  colorTheme?: string;
+}
+
+/**
  * Persist a pair to its cookies without touching the server.
  *
  * ThemeProvider calls this once it has resolved a pair, because a pair
@@ -34,8 +52,8 @@ const DARK_THEME_COOKIE = 'plannotator-dark-theme';
  * the provider then mirrors the active palette back onto that legacy key, so
  * leaving the halves underived would lose the migration on the next load.
  */
-export function writeThemePairCookies(pair: ThemePair): void {
-  storage.setItem(MODE_COOKIE, pair.mode);
+export function writeThemePairCookies(pair: ThemePair, keys?: ThemePairLegacyKeys): void {
+  storage.setItem(keys?.mode ?? MODE_COOKIE, pair.mode);
   storage.setItem(LIGHT_THEME_COOKIE, pair.light);
   storage.setItem(DARK_THEME_COOKIE, pair.dark);
 }
@@ -44,12 +62,15 @@ export function writeThemePairCookies(pair: ThemePair): void {
  * Read the persisted pair, seeding either half from the single palette older
  * releases stored. Returns undefined only when the user has never expressed a
  * theme preference at all — ThemeProvider reads that as "my props decide".
+ *
+ * `keys` points the two legacy reads at a host's own storage keys so an
+ * upgrade migrates that host's stored preference instead of discarding it.
  */
-export function readThemePairCookies(): ThemePair | undefined {
-  const mode = storage.getItem(MODE_COOKIE);
+export function readThemePairCookies(keys?: ThemePairLegacyKeys): ThemePair | undefined {
+  const mode = storage.getItem(keys?.mode ?? MODE_COOKIE);
   const light = storage.getItem(LIGHT_THEME_COOKIE);
   const dark = storage.getItem(DARK_THEME_COOKIE);
-  const legacy = storage.getItem(COLOR_THEME_COOKIE);
+  const legacy = storage.getItem(keys?.colorTheme ?? COLOR_THEME_COOKIE);
   if (!mode && !light && !dark && !legacy) return undefined;
   const seeded = seedThemePair(legacy, parseThemeMode(mode, getDefaultThemePair().mode));
   return normalizeThemePair({ mode, light: light ?? seeded.light, dark: dark ?? seeded.dark }, seeded);

--- a/packages/ui/config/settings.ts
+++ b/packages/ui/config/settings.ts
@@ -12,6 +12,48 @@
 import type { DiffLineBgIntensity } from '@plannotator/core/config-types';
 import { storage } from '../utils/storage';
 import { generateIdentity } from '../utils/generateIdentity';
+import {
+  getDefaultThemePair,
+  normalizeThemePair,
+  seedThemePair,
+  type ThemePair,
+} from '../utils/themeRegistry';
+import { parseThemeMode } from '../components/themeModes';
+
+/** Legacy single-palette key, still written so a downgrade renders styled. */
+const COLOR_THEME_COOKIE = 'plannotator-color-theme';
+const MODE_COOKIE = 'plannotator-theme';
+const LIGHT_THEME_COOKIE = 'plannotator-light-theme';
+const DARK_THEME_COOKIE = 'plannotator-dark-theme';
+
+/**
+ * Persist a pair to its cookies without touching the server.
+ *
+ * ThemeProvider calls this once it has resolved a pair, because a pair
+ * migrated from the legacy single-palette key is DERIVED until it is written:
+ * the provider then mirrors the active palette back onto that legacy key, so
+ * leaving the halves underived would lose the migration on the next load.
+ */
+export function writeThemePairCookies(pair: ThemePair): void {
+  storage.setItem(MODE_COOKIE, pair.mode);
+  storage.setItem(LIGHT_THEME_COOKIE, pair.light);
+  storage.setItem(DARK_THEME_COOKIE, pair.dark);
+}
+
+/**
+ * Read the persisted pair, seeding either half from the single palette older
+ * releases stored. Returns undefined only when the user has never expressed a
+ * theme preference at all — ThemeProvider reads that as "my props decide".
+ */
+export function readThemePairCookies(): ThemePair | undefined {
+  const mode = storage.getItem(MODE_COOKIE);
+  const light = storage.getItem(LIGHT_THEME_COOKIE);
+  const dark = storage.getItem(DARK_THEME_COOKIE);
+  const legacy = storage.getItem(COLOR_THEME_COOKIE);
+  if (!mode && !light && !dark && !legacy) return undefined;
+  const seeded = seedThemePair(legacy, parseThemeMode(mode, getDefaultThemePair().mode));
+  return normalizeThemePair({ mode, light: light ?? seeded.light, dark: dark ?? seeded.dark }, seeded);
+}
 
 const DIFF_LINE_BG_INTENSITY_VALUES = ['subtle', 'normal', 'strong'] as const;
 function isDiffLineBgIntensity(v: unknown): v is DiffLineBgIntensity {
@@ -38,6 +80,35 @@ export const SETTINGS = {
     fromServer: (sc: Record<string, unknown>) =>
       typeof sc.displayName === 'string' && sc.displayName ? sc.displayName : undefined,
     toServer: (v: string) => ({ displayName: v }),
+  },
+
+  /**
+   * Appearance: the mode plus the palette assigned to each half of the pair.
+   * Stored as one value because the three fields are only meaningful together —
+   * `mode: system` picks between `light` and `dark` at render time.
+   *
+   * Cookies: `plannotator-theme` (mode) keeps its meaning, joined by
+   * `plannotator-light-theme` / `plannotator-dark-theme`. A user arriving from
+   * an older release has neither half, so the pair is seeded from the single
+   * `plannotator-color-theme` palette they were on (ThemeProvider keeps writing
+   * that key, so a downgrade still finds a palette and never renders unstyled).
+   *
+   * Server: round-trips through `theme` in ~/.plannotator/config.json exactly
+   * like `diffOptions` does, so the choice survives the random port each hook
+   * invocation runs on.
+   */
+  themePair: {
+    defaultValue: () => getDefaultThemePair(),
+    fromCookie: () => readThemePairCookies(),
+    toCookie: (v: ThemePair) => writeThemePairCookies(v),
+    serverKey: 'theme',
+    fromServer: (sc: Record<string, unknown>) => {
+      const theme = sc.theme as Record<string, unknown> | undefined;
+      if (!theme || typeof theme !== 'object') return undefined;
+      if (theme.mode === undefined && theme.light === undefined && theme.dark === undefined) return undefined;
+      return normalizeThemePair(theme, getDefaultThemePair());
+    },
+    toServer: (v: ThemePair) => ({ theme: { mode: v.mode, light: v.light, dark: v.dark } }),
   },
 
   gridEnabled: {

--- a/packages/ui/config/themePairSetting.test.ts
+++ b/packages/ui/config/themePairSetting.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import { resetStorageBackend, setStorageBackend } from '../utils/storage';
 import { DEFAULT_COLOR_THEME, resetDefaultThemePair } from '../utils/themeRegistry';
+import { ConfigStoreForTest } from './configStore';
 import { SETTINGS } from './settings';
 
 function installStorage(seed: Record<string, string> = {}) {
@@ -113,5 +114,50 @@ describe('theme pair setting', () => {
     expect(SETTINGS.themePair.fromServer({})).toBeUndefined();
     expect(SETTINGS.themePair.fromServer({ theme: {} })).toBeUndefined();
     expect(SETTINGS.themePair.fromServer({ diffOptions: { diffStyle: 'unified' } })).toBeUndefined();
+  });
+});
+
+describe('config store seeding', () => {
+  test('a seed writes the cookie but never the server', async () => {
+    const values = installStorage();
+    const store = new ConfigStoreForTest();
+    const synced: Record<string, unknown>[] = [];
+    store.setServerSync(payload => { synced.push(payload); });
+
+    store.seed('themePair', { mode: 'system', light: 'rose-pine', dark: 'vesper' });
+    await new Promise<void>(resolve => setTimeout(resolve, 350));
+
+    expect(store.get('themePair')).toEqual({ mode: 'system', light: 'rose-pine', dark: 'vesper' });
+    expect(values.get('plannotator-dark-theme')).toBe('vesper');
+    expect(synced).toEqual([]);
+  });
+
+  test('a seed never undoes a value the server supplied', () => {
+    installStorage();
+    const store = new ConfigStoreForTest();
+
+    store.init({ theme: { mode: 'light', light: 'kanagawa-lotus', dark: 'nord' } });
+    store.seed('themePair', { mode: 'dark', light: DEFAULT_COLOR_THEME, dark: DEFAULT_COLOR_THEME });
+
+    expect(store.get('themePair')).toEqual({ mode: 'light', light: 'kanagawa-lotus', dark: 'nord' });
+  });
+
+  // A write queued before the server config arrives would otherwise flush
+  // AFTER it and push the superseded value back into config.json.
+  test('init() retracts queued writes for the keys it just overrode', async () => {
+    installStorage();
+    const store = new ConfigStoreForTest();
+    const synced: Record<string, unknown>[] = [];
+    store.setServerSync(payload => { synced.push(payload); });
+
+    store.set('themePair', { mode: 'dark', light: DEFAULT_COLOR_THEME, dark: DEFAULT_COLOR_THEME });
+    store.set('diffStyle', 'unified');
+    store.init({ theme: { mode: 'system', light: 'rose-pine', dark: 'vesper' } });
+    await new Promise<void>(resolve => setTimeout(resolve, 350));
+
+    // The theme write is gone; the untouched setting still syncs.
+    const merged = Object.assign({}, ...synced) as Record<string, unknown>;
+    expect(merged.theme).toBeUndefined();
+    expect(merged.diffOptions).toEqual({ diffStyle: 'unified' });
   });
 });

--- a/packages/ui/config/themePairSetting.test.ts
+++ b/packages/ui/config/themePairSetting.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { resetStorageBackend, setStorageBackend } from '../utils/storage';
+import { DEFAULT_COLOR_THEME, resetDefaultThemePair } from '../utils/themeRegistry';
+import { SETTINGS } from './settings';
+
+function installStorage(seed: Record<string, string> = {}) {
+  const values = new Map<string, string>(Object.entries(seed));
+  setStorageBackend({
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => { values.set(key, value); },
+    removeItem: (key) => { values.delete(key); },
+  });
+  return values;
+}
+
+afterEach(() => {
+  resetStorageBackend();
+  resetDefaultThemePair();
+});
+
+describe('theme pair setting', () => {
+  test('has no persisted value on a fresh install and defaults to one palette in both halves', () => {
+    installStorage();
+
+    expect(SETTINGS.themePair.fromCookie()).toBeUndefined();
+    expect(SETTINGS.themePair.defaultValue()).toEqual({
+      mode: 'dark',
+      light: DEFAULT_COLOR_THEME,
+      dark: DEFAULT_COLOR_THEME,
+    });
+  });
+
+  test('round-trips both halves through cookies', () => {
+    const values = installStorage();
+
+    SETTINGS.themePair.toCookie({ mode: 'system', light: 'kanagawa-lotus', dark: 'kanagawa-wave' });
+    expect(values.get('plannotator-theme')).toBe('system');
+    expect(values.get('plannotator-light-theme')).toBe('kanagawa-lotus');
+    expect(values.get('plannotator-dark-theme')).toBe('kanagawa-wave');
+
+    expect(SETTINGS.themePair.fromCookie()).toEqual({
+      mode: 'system',
+      light: 'kanagawa-lotus',
+      dark: 'kanagawa-wave',
+    });
+  });
+
+  test('seeds both halves from the single palette an older release stored', () => {
+    installStorage({ 'plannotator-theme': 'system', 'plannotator-color-theme': 'kanagawa-wave' });
+
+    expect(SETTINGS.themePair.fromCookie()).toEqual({
+      mode: 'system',
+      light: DEFAULT_COLOR_THEME,
+      dark: 'kanagawa-wave',
+    });
+
+    // A palette that renders both modes migrates into the whole pair.
+    installStorage({ 'plannotator-theme': 'light', 'plannotator-color-theme': 'rose-pine' });
+    expect(SETTINGS.themePair.fromCookie()).toEqual({
+      mode: 'light',
+      light: 'rose-pine',
+      dark: 'rose-pine',
+    });
+
+    // One half already assigned: the other still comes from the legacy key.
+    installStorage({
+      'plannotator-theme': 'system',
+      'plannotator-color-theme': 'rose-pine',
+      'plannotator-dark-theme': 'vesper',
+    });
+    expect(SETTINGS.themePair.fromCookie()).toEqual({
+      mode: 'system',
+      light: 'rose-pine',
+      dark: 'vesper',
+    });
+  });
+
+  test('drops a half whose palette cannot render it', () => {
+    installStorage({
+      'plannotator-theme': 'system',
+      'plannotator-light-theme': 'vesper',
+      'plannotator-dark-theme': 'kanagawa-lotus',
+    });
+
+    expect(SETTINGS.themePair.fromCookie()).toEqual({
+      mode: 'system',
+      light: DEFAULT_COLOR_THEME,
+      dark: DEFAULT_COLOR_THEME,
+    });
+  });
+
+  test('round-trips through the ~/.plannotator/config.json theme key', () => {
+    installStorage();
+
+    expect(SETTINGS.themePair.toServer({ mode: 'system', light: 'rose-pine', dark: 'vesper' })).toEqual({
+      theme: { mode: 'system', light: 'rose-pine', dark: 'vesper' },
+    });
+
+    expect(SETTINGS.themePair.fromServer({ theme: { mode: 'system', light: 'rose-pine', dark: 'vesper' } })).toEqual({
+      mode: 'system',
+      light: 'rose-pine',
+      dark: 'vesper',
+    });
+
+    // A hand-edited config.json is repaired, not trusted.
+    expect(SETTINGS.themePair.fromServer({ theme: { mode: 'sepia', light: 'vesper' } })).toEqual({
+      mode: 'dark',
+      light: DEFAULT_COLOR_THEME,
+      dark: DEFAULT_COLOR_THEME,
+    });
+
+    // Nothing to say about the theme leaves the cookie/default alone.
+    expect(SETTINGS.themePair.fromServer({})).toBeUndefined();
+    expect(SETTINGS.themePair.fromServer({ theme: {} })).toBeUndefined();
+    expect(SETTINGS.themePair.fromServer({ diffOptions: { diffStyle: 'unified' } })).toBeUndefined();
+  });
+});

--- a/packages/ui/utils/themeRegistry.ts
+++ b/packages/ui/utils/themeRegistry.ts
@@ -1,4 +1,4 @@
-import type { Mode } from '../components/themeModes';
+import { parseThemeMode, type Mode } from '../components/themeModes';
 
 export interface ThemeColors {
   primary: string;
@@ -587,18 +587,6 @@ export function getUnsupportedMode(themeId: string): 'light' | 'dark' | null {
   return null;
 }
 
-/** Return whether a palette can honor a mode choice without coercion. */
-export function isThemeModeAvailable(themeId: string, mode: Mode): boolean {
-  return mode === 'system' || getUnsupportedMode(themeId) !== mode;
-}
-
-/** Keep System intact while coercing an unsupported explicit mode. */
-export function normalizeThemeMode(themeId: string, mode: Mode): Mode {
-  const unsupportedMode = getUnsupportedMode(themeId);
-  if (mode === 'system' || mode !== unsupportedMode) return mode;
-  return unsupportedMode === 'light' ? 'dark' : 'light';
-}
-
 /** Resolve the mode a palette actually renders. */
 export function resolveThemeMode(
   themeId: string,
@@ -607,4 +595,102 @@ export function resolveThemeMode(
   const unsupportedMode = getUnsupportedMode(themeId);
   if (preferredMode !== unsupportedMode) return preferredMode;
   return unsupportedMode === 'light' ? 'dark' : 'light';
+}
+
+// --- Light/dark theme pairs -------------------------------------------------
+//
+// A user assigns one palette to the light half and one to the dark half. The
+// active palette is pair[preferredMode], so System mode flips between the two
+// (Kanagawa Lotus by day, Kanagawa Wave at night). Mode-restricted palettes are
+// only ever offered for the half they can render, which is why no mode needs to
+// be coerced any more.
+
+/** Which half of a light/dark pair a palette is assigned to. */
+export type ThemeHalf = 'light' | 'dark';
+
+/** A user's full appearance choice: which mode, and a palette for each half. */
+export interface ThemePair {
+  mode: Mode;
+  light: string;
+  dark: string;
+}
+
+/** The palette every fresh install starts on, in both halves. */
+export const DEFAULT_COLOR_THEME = 'plannotator';
+
+export const DEFAULT_THEME_PAIR: ThemePair = {
+  mode: 'dark',
+  light: DEFAULT_COLOR_THEME,
+  dark: DEFAULT_COLOR_THEME,
+};
+
+/** Return whether a palette is registered. */
+export function isKnownTheme(themeId: unknown): themeId is string {
+  return typeof themeId === 'string' && BUILT_IN_THEMES.some(({ id }) => id === themeId);
+}
+
+/** Return whether a palette can occupy one half of the pair. */
+export function themeSupportsHalf(themeId: string, half: ThemeHalf): boolean {
+  return getUnsupportedMode(themeId) !== half;
+}
+
+/** The palettes assignable to one half — `both` palettes appear in each. */
+export function themesForHalf(themes: ThemeInfo[], half: ThemeHalf): ThemeInfo[] {
+  return themes.filter(({ id }) => themeSupportsHalf(id, half));
+}
+
+/**
+ * Seed a pair from the single palette older versions persisted. A `both`
+ * palette takes over both halves; a mode-restricted one takes the half it
+ * supports and the other half falls back to the default palette.
+ */
+export function seedThemePair(colorThemeId: unknown, mode: Mode): ThemePair {
+  const id = isKnownTheme(colorThemeId) ? colorThemeId : DEFAULT_COLOR_THEME;
+  return {
+    mode,
+    light: themeSupportsHalf(id, 'light') ? id : DEFAULT_COLOR_THEME,
+    dark: themeSupportsHalf(id, 'dark') ? id : DEFAULT_COLOR_THEME,
+  };
+}
+
+/**
+ * Repair an untrusted pair (cookie, config.json, or an older release) so every
+ * half holds a registered palette that can actually render it.
+ */
+export function normalizeThemePair(
+  input: Partial<Record<keyof ThemePair, unknown>> | undefined,
+  fallback: ThemePair = DEFAULT_THEME_PAIR,
+): ThemePair {
+  const half = (key: ThemeHalf): string => {
+    const candidate = input?.[key];
+    if (isKnownTheme(candidate) && themeSupportsHalf(candidate, key)) return candidate;
+    return themeSupportsHalf(fallback[key], key) ? fallback[key] : DEFAULT_COLOR_THEME;
+  };
+  return {
+    mode: parseThemeMode(input?.mode, fallback.mode),
+    light: half('light'),
+    dark: half('dark'),
+  };
+}
+
+/** The palette a pair renders for the mode the user is actually seeing. */
+export function resolvePairTheme(pair: ThemePair, preferredMode: ThemeHalf): string {
+  return pair[preferredMode];
+}
+
+/* The pair a fresh install starts from. ThemeProvider installs its own props
+   here before the config store resolves, so a host embedding @plannotator/ui
+   keeps its `defaultTheme` / `defaultColorTheme` defaults. */
+let defaultThemePair: ThemePair = DEFAULT_THEME_PAIR;
+
+export function setDefaultThemePair(pair: ThemePair): void {
+  defaultThemePair = pair;
+}
+
+export function getDefaultThemePair(): ThemePair {
+  return defaultThemePair;
+}
+
+export function resetDefaultThemePair(): void {
+  defaultThemePair = DEFAULT_THEME_PAIR;
 }

--- a/packages/ui/utils/themeRegistry.ts
+++ b/packages/ui/utils/themeRegistry.ts
@@ -587,6 +587,31 @@ export function getUnsupportedMode(themeId: string): 'light' | 'dark' | null {
   return null;
 }
 
+/**
+ * Return whether a palette can honor a mode choice without coercion.
+ *
+ * @deprecated Every mode is always selectable now that a palette is assigned to
+ * one half of a light/dark pair: a palette that cannot render a mode simply
+ * never occupies that half. Use {@link themeSupportsHalf} to ask whether a
+ * palette may be ASSIGNED to a half. Kept for published consumers.
+ */
+export function isThemeModeAvailable(themeId: string, mode: Mode): boolean {
+  return mode === 'system' || getUnsupportedMode(themeId) !== mode;
+}
+
+/**
+ * Keep System intact while coercing an unsupported explicit mode.
+ *
+ * @deprecated Modes are no longer coerced. Assign the palette to the half it
+ * supports ({@link themeSupportsHalf}) and let {@link resolveThemeMode} handle
+ * rendering. Kept for published consumers.
+ */
+export function normalizeThemeMode(themeId: string, mode: Mode): Mode {
+  const unsupportedMode = getUnsupportedMode(themeId);
+  if (mode === 'system' || mode !== unsupportedMode) return mode;
+  return unsupportedMode === 'light' ? 'dark' : 'light';
+}
+
 /** Resolve the mode a palette actually renders. */
 export function resolveThemeMode(
   themeId: string,


### PR DESCRIPTION
**TLDR:** You can now pick which palette is your light theme and which is your dark theme, and System mode flips between the two as your OS scheme changes (Kanagawa Lotus by day, Kanagawa Wave at night). `ThemeProvider` stores `{ mode, light, dark }` instead of one palette plus a mode, the Settings Theme tab assigns one half at a time, and the Light/Dark/System buttons are permanently enabled because a dark-only palette simply never occupies the light slot. The pair persists to `~/.plannotator/config.json` under `theme`, so it survives the random port each hook invocation runs on.

This implements the design @kunaaal13 wrote in #1211, adopted nearly as written.

## What changed

- **`packages/ui/utils/themeRegistry.ts`**: pair helpers (`ThemePair`, `themesForHalf`, `themeSupportsHalf`, `seedThemePair`, `normalizeThemePair`, `resolvePairTheme`). `isThemeModeAvailable()` and `normalizeThemeMode()` are gone: there is nothing left to coerce.
- **`packages/ui/components/ThemeProvider.tsx`**: resolves `pair[preferredMode]` (`preferredMode` already resolved `system` against `prefers-color-scheme`) and exposes `lightTheme` / `darkTheme` / `setHalfTheme` alongside the existing `colorTheme` / `setColorTheme`.
- **`packages/ui/components/ThemeTab.tsx`**: a Light/Dark switch decides which half the grid is filling, the grid lists only the palettes that can render that half (from the registry's existing `modeSupport`, with `both` palettes appearing in each half using that mode's swatches), and a summary line names both halves with each side clickable to jump the switch. Same tab in both apps, plus the compact preview strip.
- **Mode buttons**: the disabled state and the "Not supported by the current color theme" tooltip are deleted from `ThemeTab`, `ModeToggle`, `PlanHeaderMenu`, and `ReviewHeaderMenu`.
- The colorblind palette from #1192 composes with no special casing: it is a `both` palette, so it is assignable to either or both halves.

Someone who never opens the Theme tab sees no change at all: the default pair is today's default palette in both halves.

## Config round-trip

The pair is one entry in the `SETTINGS` registry (`themePair`) with `serverKey: 'theme'`, so `configStore` handles cookie write, debounced `POST /api/config`, and the server override on `init()` exactly as it does for `diffOptions`.

Server changes **were** needed, and landed in both runtimes:

- `getServerConfig()` builds its payload from an explicit key list, so `theme` had to be added (`packages/shared/config.ts`, vendored to Pi by `vendor.sh`). `saveConfig()` also shallow-merges `theme` the way it merges `diffOptions`.
- `POST /api/config` allowlists each key it will persist, so `theme` had to be added to all seven handlers: `packages/server/{index,review,annotate,goal-setup}.ts` (Bun) and `apps/pi-extension/server/server{Plan,Review,Annotate}.ts` (Pi).

Verified live across two runtimes of the same binary: a pair chosen in an annotate session was written to `config.json` and picked up by a fresh code review session on a different port.

## Migration

- Cookies: `plannotator-theme` (mode) keeps its meaning and gains `plannotator-light-theme` / `plannotator-dark-theme`.
- A user coming from an older release has neither half, so both are seeded from their stored `plannotator-color-theme` palette: a `both` palette fills the whole pair, a mode-restricted one fills the half it supports while the other half falls back to `plannotator`.
- `ThemeProvider` keeps writing `plannotator-color-theme` with the palette actually on screen, so a version downgrade still finds a palette and never renders an unstyled first frame. The migrated pair is persisted before that mirror runs, since the mirror overwrites the key the migration was derived from.
- Anything unusable in a cookie or a hand-edited `config.json` (an unknown id, a dark-only palette in the light half, `mode: "sepia"`) is repaired rather than trusted.

## Syntax highlighting

No work needed, as the issue predicted, and confirmed live: `resolveSyntaxTheme()` / `SHIKI_THEME_MAP` are keyed on `(colorTheme, mode)`, and resolving the pair earlier hands them the right pair member. Flipping the OS scheme in a review swaps both the UI palette and the diff's matched syntax colors.

## Review findings addressed

An adversarial review of the first push returned BLOCK. All five findings are fixed in `ca80f44f`:

1. **Seeding wrote to the server (data loss).** `ThemeProvider` handed its resolved pair to the store through `configStore.set()`, which queues a debounced `POST /api/config`. `configStore.init()` applied the server config but never cancelled that queued write, so one cookie-less visit (fresh profile, incognito, cleared cookies) flushed a *default* pair to `config.json` after the real one had loaded, and the next session then restored those defaults over the user's cookies. Two fixes: a new `configStore.seed()` writes memory plus cookie and never the server (and never over a value `init()` already applied), and `init()` now retracts queued writes for the leaves the server just spoke for, which closes the same race for every server-synced setting instead of this one key. Audited the other `serverKey` settings: `displayName` generation is cookie-only, every other write is a user-action handler, and the review editor's panel-pair self-heal deliberately runs after `init()` on a genuinely conflicted persisted pair.
2. **Deleted public exports.** `isThemeModeAvailable()` and `normalizeThemeMode()` are restored as one-line wrappers carrying `@deprecated` notes that point at `themeSupportsHalf` / `resolveThemeMode`, since `packages/ui` exports `./utils/*`.
3. **`setColorTheme` semantics.** It now assigns exactly one half and changes nothing else: a both-mode palette goes to the half currently on screen (no longer clobbering the other half's assignment), a mode-restricted palette goes to the half it supports without pinning the mode (render-time resolution already keeps a System user on a drawable palette), and it persists through a new `configStore.setLocal()` so it stays cookie-only exactly as it was before the pair, unless a host installed its own `serverSync` transport.
4. **`storageKey` / `colorThemeStorageKey` ignored on the read path.** Both props are now honored when resolving the initial pair, so a host's stored pre-pair preference is migrated instead of discarded, and the mirror writes the host's keys rather than Plannotator's. The two halves have no pre-pair equivalent and stay on fixed keys; that limitation is documented on the props.
5. **Missing fresh-store test.** Added a mount against a genuinely cookie-less store with the config POSTs captured, pinning zero writes, plus a companion case pinning that a real choice still reaches `config.json`. The pre-seeding helper is kept for the other tests. Also added direct `setColorTheme` cases for all three semantics, a host-storage-keys migration case, and `configStore` seed/retract unit tests. Every new test fails against the code it replaces (verified by reverting each fix in turn).

Re-verified live afterwards: with `config.json` holding `{"theme":{"mode":"system","light":"rose-pine","dark":"kanagawa-wave"}}`, a brand new browser context made **zero** `POST /api/config` calls, left the file byte-identical, and still rendered the server-configured palette; the returning profile kept flipping Rosé Pine and Kanagawa Wave with the OS scheme, and assigning a half from Settings still round-trips to the file.

## Tests

`bun test` (3167 tests) and `DOM_TESTS=1 bun test packages/ui packages/review-editor packages/editor` (1013 tests) are green, as is `bun run typecheck`. New coverage:

- `packages/ui/components/ThemeProvider.test.tsx`: half filtering, migration seeding, pair repair, the pair flipping on a live `prefers-color-scheme` change, every mode staying selectable while a dark-only palette owns the dark half, and a `ThemeTab` walk that assigns each half from its own grid.
- `packages/ui/config/themePairSetting.test.ts`: cookie round-trip, legacy seeding, half rejection, the `theme` key round-trip in both directions, and the `configStore` seed / queued-write-retraction contracts.
- Review-driven cases listed under "Review findings addressed" above.

## Verified live

Built the real bundles (`bun run --cwd apps/review build && bun run build:hook`) and drove the built app against a scratch git repo with Playwright, screenshotting the Theme tab assigning the light half, assigning the dark half, and the summary with System active, plus the app flipping between Kanagawa Lotus and Kanagawa Wave as `prefers-color-scheme` is emulated in both the plan/annotate surface and the review surface. The first-run dialog chain still appears one dialog at a time with no stacking, and the theme announcement dialogs are untouched. Bundle delta: +2.9 kB raw, +1.4 kB gzip on each of the two single-file bundles.

Addresses part 1 of #1211. Parts 2 (custom user theme files) and 3 (font settings) stay open; the pair format part 2 depends on is what this PR establishes.

*AI-assisted.*
