### PR TITLE
fix(review): stop stubbing files whose worktree content the size probe cannot find

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,7 @@ jobs:
           packages/review-editor/components/guide/GuideView.test.tsx
           packages/review-editor/hooks/useReviewSearch.test.tsx
           packages/ui/components/AnnotationPanel.props.test.tsx
+          packages/review-editor/components/DiffViewer.binaryNotice.test.tsx
           packages/ui/components/Viewer.consumer.test.tsx
           packages/ui/components/Viewer.codeBlockHighlightSwap.test.tsx
           packages/ui/utils/codeBlockMark.test.ts

--- a/packages/review-editor/components/AllFilesCodeView.tsx
+++ b/packages/review-editor/components/AllFilesCodeView.tsx
@@ -21,6 +21,7 @@ import type {
   DiffAnnotationMetadata,
   TokenAnnotationMeta,
 } from '@plannotator/ui/types';
+import { isContentlessBinaryPatch } from '@plannotator/shared/diff-paths';
 import { CommentPopover } from '@plannotator/ui/components/CommentPopover';
 import { usePierreTheme } from '../hooks/usePierreTheme';
 import { useIsWorkerPoolReadyOrDisabled, useWorkerPoolThemeSync } from '../workerPool';
@@ -31,6 +32,7 @@ import { getDiffSelection, getLineNumberFromNode, getSideFromNode } from '../uti
 import { isContentConsistentWithPatch } from '../utils/patchConsistency';
 import { ToolbarHost, type ToolbarHostHandle } from './ToolbarHost';
 import { FileHeader } from './FileHeader';
+import { BinaryFileNotice } from './BinaryFileNotice';
 import { EditSessionHud } from './EditSessionHud';
 import { FileCommentBanner } from './FileCommentBanner';
 import { annotationMatchesPrScope, isFileScopedAnnotation, lineRangeForAnnotation } from '../utils/annotationScope';
@@ -2184,6 +2186,11 @@ export const AllFilesCodeView: React.FC<AllFilesCodeViewProps> = ({
         }
         onCollapseToggle={() => toggleItemCollapsed(item.id)}
         />
+        {/* A binary or unread file has no hunks to draw, so say so instead of
+            leaving a header with an empty body under it. */}
+        {!collapsed && isContentlessBinaryPatch(file.patch) && (
+          <BinaryFileNotice onHeightChange={() => refreshItem(item.id)} />
+        )}
         {/* EXPERIMENTAL edit-session HUD: session controls + state in a slim
             strip below the header, above the file content. Appears/disappears
             with session start/end, which both go through a version-bumped

--- a/packages/review-editor/components/BinaryFileNotice.tsx
+++ b/packages/review-editor/components/BinaryFileNotice.tsx
@@ -1,0 +1,31 @@
+import React, { useLayoutEffect } from 'react';
+
+/**
+ * Says why a file's card has no diff in it.
+ *
+ * A patch chunk with a binary marker and no hunks renders as an empty body:
+ * the card is a bare header with no counts and no reason, which reads as a
+ * broken diff. That shape covers genuine binary files and files the review
+ * core declined to read, so the copy commits to neither cause.
+ */
+export const BinaryFileNotice: React.FC<{
+  /** Re-measure hook for the virtualized all-files host, whose custom-header
+   *  slot heights are not auto-observed. */
+  onHeightChange?: () => void;
+}> = ({ onHeightChange }) => {
+  // Before paint, so the host re-measures without a one-frame overlap with the
+  // content below.
+  useLayoutEffect(() => {
+    onHeightChange?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div
+      data-binary-file-notice=""
+      className="px-4 py-2 text-xs leading-relaxed text-muted-foreground border-b border-border bg-muted/30"
+    >
+      Binary or oversized file, content not shown.
+    </div>
+  );
+};

--- a/packages/review-editor/components/DiffViewer.binaryNotice.test.tsx
+++ b/packages/review-editor/components/DiffViewer.binaryNotice.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * A file whose card has no diff in it must SAY so.
+ *
+ * A patch chunk carrying a binary marker and no hunks renders as an empty
+ * body, so the card is a bare header with no counts and no reason. That is
+ * what a file dropped by the review size probe looked like (#1167): reviewers
+ * saw an empty card and could approve without ever seeing the content.
+ *
+ * DOM-gated (DOM_TESTS=1) and registered in .github/workflows/test.yml's
+ * "Run UI seam-contract + DOM tests" step.
+ */
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+mock.module('../workerPool', () => ({
+  useIsWorkerPoolReadyOrDisabled: () => true,
+  useWorkerPoolThemeSync: () => {},
+}));
+
+mock.module('../hooks/usePierreTheme', () => ({
+  usePierreTheme: () => ({ type: 'light', css: '' }),
+}));
+
+mock.module('./ToolbarHost', () => ({
+  ToolbarHost: React.forwardRef(function MockToolbarHost() {
+    return null;
+  }),
+}));
+
+const { DiffViewer } = await import('./DiffViewer');
+
+const hasDom = typeof document !== 'undefined';
+
+// The shape the review core emits for a file it declined to read: rename
+// metadata, no hunks. Before the fix a renamed-and-edited file could land here
+// purely because its size probe could not find the worktree blob.
+const STUB_PATCH = [
+  'diff --git a/src/Card.tsx b/src/Panel.tsx',
+  'similarity index 94%',
+  'rename from src/Card.tsx',
+  'rename to src/Panel.tsx',
+  'index bab081fdb737..99fffbd3cac3 100644',
+  'Binary files a/src/Card.tsx and b/src/Panel.tsx differ',
+  '',
+].join('\n');
+
+const REAL_BINARY = [
+  'diff --git a/assets/logo.png b/assets/logo.png',
+  'index 1111111111aa..2222222222bb 100644',
+  'Binary files a/assets/logo.png and b/assets/logo.png differ',
+  '',
+].join('\n');
+
+const TEXT_PATCH = [
+  'diff --git a/calc.ts b/calc.ts',
+  'index 0000000..1111111 100644',
+  '--- a/calc.ts',
+  '+++ b/calc.ts',
+  '@@ -1,3 +1,3 @@',
+  ' const a = 1;',
+  '-const b = 1;',
+  '+const b = 2;',
+  ' const c = 3;',
+  '',
+].join('\n');
+
+const NOTICE_SELECTOR = '[data-binary-file-notice]';
+
+function view(patch: string, filePath: string) {
+  return (
+    <DiffViewer
+      patch={patch}
+      filePath={filePath}
+      diffStyle="unified"
+      annotations={[]}
+      selectedAnnotationId={null}
+      scrollTargetAnnotation={null}
+      pendingSelection={null}
+      onLineSelection={() => {}}
+      onAddAnnotation={() => {}}
+      onAddFileComment={() => {}}
+      onEditAnnotation={() => {}}
+      onSelectAnnotation={() => {}}
+      onDeleteAnnotation={() => {}}
+    />
+  );
+}
+
+describe.if(hasDom)('contentless binary card presentation (DOM)', () => {
+  let root: Root | null = null;
+  let host: HTMLDivElement | null = null;
+  const originalFetch = globalThis.fetch;
+
+  async function render(patch: string, filePath: string) {
+    // There is no expandable content for these shapes; keep the lookup inert.
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ oldContent: null, newContent: null }), {
+        headers: { 'content-type': 'application/json' },
+      })) as typeof fetch;
+
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    await act(async () => {
+      root!.render(view(patch, filePath));
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    });
+    return host;
+  }
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => root!.unmount());
+      root = null;
+    }
+    host?.remove();
+    host = null;
+    globalThis.fetch = originalFetch;
+  });
+
+  test('a hunkless stub explains its empty body', async () => {
+    const el = await render(STUB_PATCH, 'src/Panel.tsx');
+    const notice = el.querySelector(NOTICE_SELECTOR);
+    expect(notice).not.toBeNull();
+    expect(notice!.textContent).toContain('content not shown');
+  });
+
+  test('a genuine binary file explains its empty body too', async () => {
+    const el = await render(REAL_BINARY, 'assets/logo.png');
+    expect(el.querySelector(NOTICE_SELECTOR)).not.toBeNull();
+  });
+
+  test('an ordinary text diff is left alone', async () => {
+    const el = await render(TEXT_PATCH, 'calc.ts');
+    expect(el.querySelector(NOTICE_SELECTOR)).toBeNull();
+  });
+});

--- a/packages/review-editor/components/DiffViewer.tsx
+++ b/packages/review-editor/components/DiffViewer.tsx
@@ -13,7 +13,9 @@ import { ToolbarHost, type ToolbarHostHandle } from './ToolbarHost';
 import { OverlayScrollArea } from '@plannotator/ui/components/OverlayScrollArea';
 import { useOverlayViewport } from '@plannotator/ui/hooks/useOverlayViewport';
 import { FileHeader } from './FileHeader';
+import { BinaryFileNotice } from './BinaryFileNotice';
 import { FileCommentBanner } from './FileCommentBanner';
+import { isContentlessBinaryPatch } from '@plannotator/shared/diff-paths';
 import { isFileScopedAnnotation, lineRangeForAnnotation } from '../utils/annotationScope';
 import { lineAnnotationMetadata } from '../utils/annotationDisplay';
 import type { AnnotationScrollTarget } from '../types';
@@ -312,6 +314,9 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
 
   // Parse patch into FileDiffMetadata for @pierre/diffs FileDiff component
   const fileDiff = useMemo(() => getSingularPatch(patch), [patch]);
+
+  // Binary marker, no hunks: the body below renders nothing at all.
+  const isBinaryOnlyPatch = useMemo(() => isContentlessBinaryPatch(patch), [patch]);
 
   // Fetch full file contents for expandable context
   const [fileContents, setFileContents] = useState<{ forPath: string; old: string | null; new: string | null } | null>(null);
@@ -697,6 +702,9 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
         overflowX="scroll"
         onViewportReady={onViewportReady}
       >
+        {/* A binary or unread file has no hunks to draw, so say so instead of
+            leaving a header with an empty body under it. */}
+        {isBinaryOnlyPatch && <BinaryFileNotice />}
         <FileCommentBanner
           comments={fileComments}
           selectedAnnotationId={selectedAnnotationId}

--- a/packages/shared/diff-paths.test.ts
+++ b/packages/shared/diff-paths.test.ts
@@ -1,5 +1,80 @@
 import { describe, expect, test } from "bun:test";
-import { parseDiffFilePathLines, parsePatchPathToken, unquoteGitPath } from "./diff-paths";
+import {
+  isContentlessBinaryPatch,
+  parseDiffFilePathLines,
+  parsePatchPathToken,
+  unquoteGitPath,
+} from "./diff-paths";
+
+describe("isContentlessBinaryPatch", () => {
+  test("flags a git binary chunk with no hunks", () => {
+    expect(isContentlessBinaryPatch([
+      "diff --git a/logo.png b/logo.png",
+      "index 1111111111aa..2222222222bb 100644",
+      "Binary files a/logo.png and b/logo.png differ",
+      "",
+    ].join("\n"))).toBe(true);
+  });
+
+  test("flags a review stub for a file the server declined to read", () => {
+    expect(isContentlessBinaryPatch([
+      "diff --git a/src/Panel.tsx b/src/Panel.tsx",
+      "similarity index 94%",
+      "rename from src/Card.tsx",
+      "rename to src/Panel.tsx",
+      "index bab081fdb737..99fffbd3cac3 100644",
+      "Binary files a/src/Card.tsx and b/src/Panel.tsx differ",
+      "",
+    ].join("\n"))).toBe(true);
+  });
+
+  test("flags a literal GIT binary patch payload", () => {
+    expect(isContentlessBinaryPatch([
+      "diff --git a/logo.png b/logo.png",
+      "GIT binary patch",
+      "literal 12",
+      "",
+    ].join("\n"))).toBe(true);
+  });
+
+  test("does not flag a text patch", () => {
+    expect(isContentlessBinaryPatch([
+      "diff --git a/calc.ts b/calc.ts",
+      "--- a/calc.ts",
+      "+++ b/calc.ts",
+      "@@ -1,2 +1,2 @@",
+      "-const b = 1;",
+      "+const b = 2;",
+      "",
+    ].join("\n"))).toBe(false);
+  });
+
+  test("does not flag a text patch whose content mentions the binary marker", () => {
+    // Content lines always carry a +/-/space prefix, and the scan stops at the
+    // first hunk header, so quoted marker text cannot be mistaken for a header.
+    expect(isContentlessBinaryPatch([
+      "diff --git a/notes.md b/notes.md",
+      "--- a/notes.md",
+      "+++ b/notes.md",
+      "@@ -1,2 +1,2 @@",
+      "-old note",
+      "+Binary files a/x and b/x differ",
+      " GIT binary patch",
+      "",
+    ].join("\n"))).toBe(false);
+  });
+
+  test("does not flag a metadata-only chunk with no binary marker", () => {
+    // A pure mode change has no body either, but git says nothing about
+    // content there, so it keeps its existing rendering.
+    expect(isContentlessBinaryPatch([
+      "diff --git a/run.sh b/run.sh",
+      "old mode 100644",
+      "new mode 100755",
+      "",
+    ].join("\n"))).toBe(false);
+  });
+});
 
 describe("diff path parsing", () => {
   test("unquoteGitPath decodes octal (UTF-8 byte) escapes", () => {

--- a/packages/shared/diff-paths.ts
+++ b/packages/shared/diff-paths.ts
@@ -180,6 +180,30 @@ export function parseDiffFilePathLines(lines: string[]): DiffPathPair {
   return { oldPath, newPath };
 }
 
+/**
+ * True when a single file's patch chunk carries a binary marker and no hunks,
+ * so a diff renderer has literally nothing to draw for it.
+ *
+ * Git emits this shape for real binary files, and the review core emits it for
+ * files it declined to read (`buildOversizedTrackedStub`). Either way the card
+ * renders as a bare header with no counts and no body, which reads as a broken
+ * or empty diff rather than as content that was deliberately not shown.
+ *
+ * Scanning stops at the first hunk header: content lines always carry a `+`,
+ * `-`, or space prefix, so a `Binary files ` line at column zero before any
+ * `@@ ` can only be the extended header git (or the stub builder) wrote.
+ */
+export function isContentlessBinaryPatch(patch: string): boolean {
+  let hasBinaryMarker = false;
+  for (const line of patch.split("\n")) {
+    if (line.startsWith("@@ ")) return false;
+    if (line.startsWith("Binary files ") || line === "GIT binary patch") {
+      hasBinaryMarker = true;
+    }
+  }
+  return hasBinaryMarker;
+}
+
 export function parseDiffMetadataPathLines(lines: string[]): DiffPathPair {
   let oldPath: string | undefined;
   let newPath: string | undefined;

--- a/packages/shared/review-core.test.ts
+++ b/packages/shared/review-core.test.ts
@@ -818,11 +818,22 @@ describe("review-core", () => {
     }
   });
 
-  test("a single object the probe reports missing still excludes only that path", async () => {
+  test("a probed-oversized object excludes only its path, and a missing one none", async () => {
+    // Per-object evidence stays per-object: one oversized blob costs one path,
+    // never the whole review. An object the probe cannot SIZE is a different
+    // answer from one it sizes above the cap: `missing` is unknown, so that
+    // path keeps rendering under git's own core.bigFileThreshold bound.
     const smallOld = "1".repeat(40);
     const smallNew = "2".repeat(40);
-    const brokenOld = "3".repeat(40);
-    const brokenNew = "4".repeat(40);
+    const missingOld = "3".repeat(40);
+    const missingNew = "4".repeat(40);
+    const hugeOld = "5".repeat(40);
+    const hugeNew = "6".repeat(40);
+    const renderedPatch = [
+      "diff --git a/small.ts b/small.ts\n-old\n+new\n",
+      "diff --git a/unfetched.ts b/unfetched.ts\n-gone\n+restored\n",
+    ].join("");
+    const excludedPaths: string[] = [];
     const runtime: ReviewGitRuntime = {
       ...unavailableFileMethods,
       async runGit(args, options) {
@@ -830,7 +841,8 @@ describe("review-core", () => {
           return {
             stdout: [
               `:100644 100644 ${smallOld} ${smallNew} M\0small.ts\0`,
-              `:100644 100644 ${brokenOld} ${brokenNew} M\0broken.bin\0`,
+              `:100644 100644 ${missingOld} ${missingNew} M\0unfetched.ts\0`,
+              `:100644 100644 ${hugeOld} ${hugeNew} M\0huge.bin\0`,
             ].join(""),
             stderr: "",
             exitCode: 0,
@@ -839,16 +851,23 @@ describe("review-core", () => {
         if (args[0] === "cat-file" && args.some((arg) => arg.startsWith("--batch-check"))) {
           const input = (options as { stdin?: string } | undefined)?.stdin ?? "";
           return {
-            stdout: input.trim().split("\n").filter(Boolean).map((objectId) =>
-              objectId === brokenNew ? `${objectId} missing` : `${objectId} blob 10`,
-            ).join("\n"),
+            stdout: input.trim().split("\n").filter(Boolean).map((objectId) => {
+              if (objectId === missingNew) return `${objectId} missing`;
+              if (objectId === hugeNew) {
+                return `${objectId} blob ${MAX_REVIEW_FILE_CONTENT_BYTES + 1}`;
+              }
+              return `${objectId} blob 10`;
+            }).join("\n"),
             stderr: "",
             exitCode: 0,
           };
         }
         if (args[0] === "rev-parse") return { stdout: "/repo\n", stderr: "", exitCode: 0 };
         if (args[0] === "diff") {
-          return { stdout: "diff --git a/small.ts b/small.ts\n-old\n+new\n", stderr: "", exitCode: 0 };
+          excludedPaths.push(
+            ...args.filter((arg) => arg.startsWith(":(top,exclude,literal)")),
+          );
+          return { stdout: renderedPatch, stderr: "", exitCode: 0 };
         }
         throw new Error(`Unexpected git command: ${args.join(" ")}`);
       },
@@ -860,7 +879,12 @@ describe("review-core", () => {
     const result = await runGitDiff(runtime, "staged", "main", "/repo");
 
     expect(result.patch).toContain("+new");
-    expect(result.patch).toContain("Binary files a/broken.bin and b/broken.bin differ");
+    expect(result.patch).toContain("Binary files a/huge.bin and b/huge.bin differ");
+    expect(excludedPaths).toEqual([":(top,exclude,literal)huge.bin"]);
+    // The unfetchable object's path is not stubbed away: git renders it, and
+    // a git that truly cannot read it fails loudly instead of blanking it.
+    expect(result.patch).toContain("+restored");
+    expect(result.patch).not.toContain("Binary files a/unfetched.ts");
     expect(result.patch).not.toContain("Binary files a/small.ts");
   });
 
@@ -938,6 +962,90 @@ describe("review-core", () => {
     expect(second).not.toBeNull();
     expect(second).not.toBe(first);
   }, 20_000);
+
+  test("renders a renamed file whose edited worktree blob the probe cannot find", async () => {
+    // Rename/copy detection makes git hash the WORKING-TREE content and print
+    // that hash in --raw output, but the blob is never written to the object
+    // database. The size probe answers `missing` for it. Treating that as
+    // "oversized" dropped the whole renamed file out of the review (#1167).
+    const repoDir = initRepo();
+    mkdirSync(join(repoDir, "src"));
+    const original = Array.from({ length: 40 }, (_, index) => `line ${index + 1}`).join("\n");
+    writeFileSync(join(repoDir, "src/Card.tsx"), `${original}\n`, "utf-8");
+    git(repoDir, ["add", "-A"]);
+    git(repoDir, ["commit", "-m", "add card"]);
+    const base = git(repoDir, ["rev-parse", "HEAD"]);
+    git(repoDir, ["mv", "src/Card.tsx", "src/Panel.tsx"]);
+    git(repoDir, ["commit", "-m", "rename card to panel"]);
+    writeFileSync(
+      join(repoDir, "src/Panel.tsx"),
+      `${original}\nline 41 unstaged\n`,
+      "utf-8",
+    );
+
+    const runtime = makeConfigForwardingRuntime(repoDir);
+    const patch = await getWorkingTreeDiffFromBase(runtime, base);
+
+    expect(patch).toContain("+line 41 unstaged");
+    expect(patch).not.toContain("Binary files");
+  }, 20_000);
+
+  test("renders a tracked add whose worktree blob the probe cannot find", async () => {
+    // A delete/add pair also feeds rename detection, so the added path carries
+    // a real-but-unwritten worktree hash in --raw output.
+    const repoDir = initRepo();
+    const base = git(repoDir, ["rev-parse", "HEAD"]);
+    writeFileSync(join(repoDir, "replacement.txt"), "fresh content\n", "utf-8");
+    git(repoDir, ["rm", "-q", "tracked.txt"]);
+    git(repoDir, ["add", "-A"]);
+    git(repoDir, ["commit", "-m", "replace tracked file"]);
+    writeFileSync(join(repoDir, "replacement.txt"), "fresh content\nedited later\n", "utf-8");
+
+    const runtime = makeConfigForwardingRuntime(repoDir);
+    const patch = await getWorkingTreeDiffFromBase(runtime, base);
+
+    expect(patch).toContain("+fresh content");
+    expect(patch).toContain("+edited later");
+    expect(patch).not.toContain("Binary files");
+  }, 20_000);
+
+  test("renders a file whose index blob is missing from the object database", async () => {
+    // Partial clones (and pruned object databases) can report `missing` for an
+    // index blob git can still diff perfectly well from the working tree.
+    const repoDir = initRepo();
+    writeFileSync(join(repoDir, "added.txt"), "content from the index\n", "utf-8");
+    git(repoDir, ["add", "added.txt"]);
+    const blobId = git(repoDir, ["rev-parse", ":added.txt"]);
+    rmSync(join(repoDir, ".git", "objects", blobId.slice(0, 2), blobId.slice(2)), { force: true });
+
+    const runtime = makeConfigForwardingRuntime(repoDir);
+    const result = await runGitDiff(runtime, "uncommitted", "main");
+
+    expect(result.patch).toContain("+content from the index");
+    expect(result.patch).not.toContain("Binary files");
+  }, 20_000);
+
+  test("still stubs an oversized worktree file whose blob the probe cannot find", async () => {
+    // The size probe cannot bound this file (its hash is missing) and
+    // core.bigFileThreshold does not bound working-tree sides, so the
+    // filesystem stat has to be the authoritative bound.
+    const repoDir = initRepo();
+    const largeSize = MAX_REVIEW_FILE_CONTENT_BYTES + 1;
+    writeFileSync(join(repoDir, "old-big.txt"), "a".repeat(largeSize), "utf-8");
+    git(repoDir, ["add", "-A"]);
+    git(repoDir, ["commit", "-m", "add big file"]);
+    const base = git(repoDir, ["rev-parse", "HEAD"]);
+    git(repoDir, ["mv", "old-big.txt", "new-big.txt"]);
+    git(repoDir, ["commit", "-m", "rename big file"]);
+    writeFileSync(join(repoDir, "new-big.txt"), "b".repeat(largeSize), "utf-8");
+
+    const runtime = makeConfigForwardingRuntime(repoDir);
+    const patch = await getWorkingTreeDiffFromBase(runtime, base);
+
+    expect(patch).toContain("Binary files");
+    expect(patch).not.toContain("bbbbbbbbbb");
+    expect(patch.length).toBeLessThan(4_000);
+  }, 40_000);
 
   test("synthesizes quoted rename and copy metadata from raw status details", async () => {
     const renamedFrom = 'old "rename" path';

--- a/packages/shared/review-core.ts
+++ b/packages/shared/review-core.ts
@@ -831,19 +831,25 @@ function isGitlink(entry: RawDiffEntry): boolean {
  * oversized replaced the whole review with binary stubs on one failed probe.
  * Working-tree sizes come from filesystem stat and never from this probe.
  *
- * The per-object doors stay conservative on a probe that ran: an object the
- * batch reports as `missing`, omits from its output, or answers with an
- * unparseable/negative size maps to infinity. That is evidence about one
- * object only, and excluding just its path keeps the stub's rename/copy/mode
- * metadata rendering while the rest of the diff stays intact.
+ * A probe that ran answers per object with a size or with `null`, which means
+ * "unknown", never "oversized": an object the batch reports as `missing`,
+ * omits from its output, or answers with an unparseable/negative size has no
+ * usable size. `missing` is routine for tree-vs-worktree diffs — every path
+ * pulled into rename/copy detection gets its WORKING-TREE content hashed by
+ * git and that hash printed in `--raw` output without ever being written to
+ * the object database — and it also happens in partial clones. Mapping those
+ * to infinity excluded files git can plainly diff, so a renamed-and-edited
+ * file rendered as an empty binary stub (#1167). Callers bound an unknown new
+ * side by filesystem stat, and every ODB blob stays bounded by
+ * `core.bigFileThreshold` (`BOUNDED_DIFF_GIT_CONFIG`).
  */
 async function getGitObjectSizes(
   runtime: ReviewGitRuntime,
   objectIds: string[],
   cwd?: string,
-): Promise<Map<string, number> | null> {
+): Promise<Map<string, number | null> | null> {
   const uniqueObjectIds = [...new Set(objectIds.filter((objectId) => !isNullObjectId(objectId)))];
-  const sizes = new Map<string, number>();
+  const sizes = new Map<string, number | null>();
   if (uniqueObjectIds.length === 0) return sizes;
 
   const result = await runtime.runGit(
@@ -861,13 +867,10 @@ async function getGitObjectSizes(
     const [objectId, objectType, objectSize] = line.split(" ");
     if (!objectId || objectType === "missing") continue;
     const size = Number(objectSize);
-    sizes.set(
-      objectId,
-      Number.isFinite(size) && size >= 0 ? size : Number.POSITIVE_INFINITY,
-    );
+    sizes.set(objectId, Number.isFinite(size) && size >= 0 ? size : null);
   }
   for (const objectId of uniqueObjectIds) {
-    if (!sizes.has(objectId)) sizes.set(objectId, Number.POSITIVE_INFINITY);
+    if (!sizes.has(objectId)) sizes.set(objectId, null);
   }
   return sizes;
 }
@@ -1025,19 +1028,28 @@ async function buildBoundedTrackedDiff(
   //    the file for the index line and content-based binary detection wins),
   //    but their sizes come from filesystem stat, not the probe, so that
   //    exclusion door keeps working below regardless of the probe outcome.
+  //  - An id the probe answered for but could not size (`missing`, omitted,
+  //    unparseable) is unknown, not oversized. git prints such an id for every
+  //    worktree path that rename/copy detection hashed, and for blobs a
+  //    partial clone has not fetched; a file git can plainly diff must never
+  //    be replaced by a content-free binary stub (#1167).
+  const probedSize = (objectId: string): number | null =>
+    isNullObjectId(objectId) || objectSizes === null
+      ? null
+      : objectSizes.get(objectId) ?? null;
   for (const entry of entries) {
     if (isGitlink(entry)) continue;
-    const oldSize = isNullObjectId(entry.oldObjectId)
-      ? null
-      : objectSizes === null
-        ? null
-        : objectSizes.get(entry.oldObjectId) ?? Number.POSITIVE_INFINITY;
-    const newObjectSize = isNullObjectId(entry.newObjectId)
-      ? null
-      : objectSizes === null
-        ? null
-        : objectSizes.get(entry.newObjectId) ?? Number.POSITIVE_INFINITY;
-    const workingTreeInfo = isNullObjectId(entry.newObjectId)
+    const oldSize = probedSize(entry.oldObjectId);
+    const newObjectSize = probedSize(entry.newObjectId);
+    // The working-tree file is what git formats whenever the new side has no
+    // readable object behind it: an unhashed worktree side (all-zero id), or
+    // an id the probe that RAN could not find. Either way its stat size is the
+    // authoritative bound. A probe that FAILED outright says nothing about any
+    // single object, so those ids keep relying on core.bigFileThreshold rather
+    // than on a working-tree file that may not be the diff's new side at all.
+    const newSideUnreadable = isNullObjectId(entry.newObjectId)
+      || (objectSizes !== null && newObjectSize === null);
+    const workingTreeInfo = newSideUnreadable
       ? await getWorkingTreeFileInfo(runtime, root, entry.newPath)
       : null;
     const newSize = newObjectSize ?? workingTreeInfo?.size ?? null;
@@ -1055,14 +1067,18 @@ async function buildBoundedTrackedDiff(
         `large:${entry.newPath}:${workingTreeInfo.size}:${workingTreeInfo.mtimeMs}`,
       );
     }
-    const workingObjectId = !fingerprintMode && workingTreeInfo && entry.newPath
+    // Only an all-zero new side needs a synthesized content-sensitive id. When
+    // git printed a real id it already hashed this exact working-tree content,
+    // so the stub keeps it instead of re-hashing an oversized file.
+    const workingObjectId = !fingerprintMode
+      && isNullObjectId(entry.newObjectId)
+      && workingTreeInfo
+      && entry.newPath
       ? await hashOversizedWorkingTreeFile(runtime, entry.newPath, workingTreeInfo, cwd)
       : null;
     oversized.push({
       ...entry,
-      newObjectId: newObjectSize === null && workingObjectId
-        ? workingObjectId
-        : entry.newObjectId,
+      newObjectId: workingObjectId ?? entry.newObjectId,
     });
   }
 


### PR DESCRIPTION
## TLDR

In v0.26.0 and v0.26.1, code review silently drops file content from diffs. A file that was renamed and then edited, and any file in a partial clone whose blob is not local, renders as an empty card: no hunks, no counts, no explanation. `/api/file-content` then refuses it as binary, so there is no way to recover the content in the UI. A reviewer can approve a change without ever seeing it.

On the harness fixture the renamed-and-edited `Panel.tsx` (a real `+8/-2`) shows as `h0 +0/-0` on both released versions. Nothing in the product says anything is missing.

## Mechanism

`buildBoundedTrackedDiff` (`packages/shared/review-core.ts`) runs an oversized preflight: `git diff --no-textconv --raw -z --no-abbrev <base>`, then batch-probes every object id with `cat-file --batch-check`.

For tree-vs-worktree diffs, any path pulled into rename/copy detection has its **working-tree** content hashed by git, and that computed hash is printed in `--raw` output. The blob is never written to the object database. `getGitObjectSizes` skipped `missing` answers, and the backfill loop mapped every id it had no size for to `Number.POSITIVE_INFINITY`.

The consumer only opened the filesystem-stat door for all-zero object ids (`isNullObjectId`), so those entries were read as oversized, excluded with a `:(top,exclude,literal)` pathspec, and replaced by `buildOversizedTrackedStub`: zero hunks plus `Binary files ... differ`. The client parsed that to 0/0 and rendered a header with an empty body, and the `isBinaryPatchFile` gate in `/api/file-content` (both the Bun server and the Pi mirror) then returned nulls.

Verified affected shapes:

- committed or staged rename plus an unstaged edit (R stub)
- tracked add plus an unstaged edit while rename detection is active (A stub)
- copies
- index blobs missing from the object database, for example a partial clone with an unreachable promisor (M stub)
- old-side blobs not yet fetched in a partial clone

Affected views: since-base, uncommitted, unstaged, and the GitButler and jj callers of `getWorkingTreeDiffFromBase`. Affected versions: v0.26.0, v0.26.1, and dev.

## The fix

**1. The stat door now covers unreadable new sides, not just unhashed ones.** `workingTreeInfo` is resolved whenever the new side has no readable object behind it: an all-zero id, or an id the probe that ran could not find. The working-tree file is exactly what git formats for those entries, so its stat size is the authoritative bound. This is the invariant already documented above the loop: `core.bigFileThreshold` does not bound working-tree sides, so their sizes have to come from stat.

**2. Missing means unknown-but-bounded, never infinite.** `getGitObjectSizes` now returns `Map<string, number | null>`, where `null` is "the probe ran and could not size this object" (missing, omitted, or an unparseable size). An unknown blob size reads as not-oversized, which is safe because every rendered diff already carries `BOUNDED_DIFF_GIT_CONFIG` (`core.bigFileThreshold`, from #1205), so git itself stubs oversized object-database content. A missing blob must never stub a file git can plainly diff. If git genuinely cannot produce the content (a dead promisor), the diff now fails loudly through `assertGitSuccess` rather than silently blanking a file. Genuinely oversized files still stub, via real probe sizes and the stat door.

The door being closed is the **per-object missing** door only. #1205's invariants are preserved exactly:

- the batch-failure degraded path is untouched: a probe that fails outright still says nothing about any single object, so those ids keep relying on `core.bigFileThreshold` rather than on a working-tree file that may not even be the diff's new side (a staged or commit-to-commit diff's new side is not the worktree).
- the fingerprint null-means-fresh contract is untouched.
- the memory bound itself is untouched.
- oversized stubs keep their content-sensitive id: a synthesized worktree hash is now used only when git printed no id at all. When git printed a real id it had already hashed that exact worktree content, so the stub keeps it instead of re-hashing a multi-megabyte file.

**3. An empty card now says why it is empty.** New shared predicate `isContentlessBinaryPatch` in `packages/shared/diff-paths.ts` (binary marker, no hunks) plus a small `BinaryFileNotice` component, mounted in both the all-files view (`AllFilesCodeView`) and the single-file viewer (`DiffViewer`). Copy: "Binary or oversized file, content not shown." This is defense in depth: whatever the cause, a card with no body now states that content was not shown instead of reading as "no changes here".

## Failing-then-passing proof

New tests drive the real `runGitDiff` / `getWorkingTreeDiffFromBase` against scratch git repos built to the reproduction shapes.

| test | unfixed | fixed |
|---|---|---|
| renders a renamed file whose edited worktree blob the probe cannot find | FAIL: got `similarity index 94% / rename ... / Binary files a/src/Card.tsx and b/src/Panel.tsx differ` | PASS |
| renders a tracked add whose worktree blob the probe cannot find | FAIL: got `new file mode 100644 / Binary files /dev/null and b/replacement.txt differ` | PASS |
| renders a file whose index blob is missing from the object database | FAIL: got `new file mode 100644 / Binary files /dev/null and b/added.txt differ` | PASS |
| still stubs an oversized worktree file whose blob the probe cannot find (5 MB+, rename-detected, id missing) | PASS (guard) | PASS |
| DiffViewer DOM: a hunkless stub explains its empty body / a genuine binary explains its empty body | FAIL (no notice in the DOM) | PASS |

The #1205 test `a single object the probe reports missing still excludes only that path` asserted the exact door being closed, so it is rewritten rather than deleted, and it now covers strictly more: a probed-**oversized** object still excludes only its own path (asserted on the emitted pathspec list), while a **missing** one excludes nothing and keeps rendering. Plus six unit tests for `isContentlessBinaryPatch`, including a text patch whose content quotes the binary marker.

Full runs: `bun test` 2936 pass / 0 fail; `bun test apps/pi-extension` 177 pass / 0 fail (Pi vendors `review-core.ts` and `diff-paths.ts` verbatim through `vendor.sh`, so parity is automatic); `bun run typecheck` clean; `bun run --cwd apps/review build` then `bun run build:hook` both clean.

## Version-matrix harness (dev, same fixture, since-base)

| metric | v0.24.2 | v0.25.1 | v0.26.0 | v0.26.1 | dev before | dev after | git truth |
|---|---|---|---|---|---|---|---|
| total + | 35 | 35 | 26 | 26 | 26 | **34** | 35 (tracked +25, plus untracked) |
| total - | 22 | 22 | 20 | 20 | 20 | **22** | 22 |
| `Panel.tsx` (renamed + edited) | R h2 +8/-2 | R h2 +8/-2 | R(bin) h0 +0/-0 | R(bin) h0 +0/-0 | R(bin) h0 +0/-0 | **R h2 +8/-2** | R050 |
| binary-stub files | none | none | 6MB file; Panel.tsx | 6MB file; Panel.tsx | 6MB file; Panel.tsx | **6MB file only** | n/a |
| `/api/file-content` on Panel.tsx | old=279ch new=413ch | old=279ch new=413ch | null, null | null, null | null, null | **old=279ch new=413ch** | n/a |
| big-file representation | M h1 +1/-0 | M h1 +1/-0 | binary stub | binary stub | binary stub | binary stub | M +1/-0 |

dev now matches git ground truth on every file, with one deliberate difference: the 6 MB file stays a binary stub, which is #1205's memory bound doing its job. That single stubbed line is the whole +34 vs +35 gap. The renamed file is back to real content and its file-content probe is non-null again.

## Lineage

#1167 is the size-cap work this preflight came from; #1205 made the memory bound git-native (`core.bigFileThreshold`) so a failed probe stops blanking the whole review. This change closes the remaining per-object door, the `missing` one, and keeps the memory bound exactly where #1205 put it.

## Merged with #1219

#1219 landed first, so main is merged in here and the predicted overlap is resolved in this branch. Rule applied: **specific beats general, and the two never stack.**

- `packages/shared/diff-paths.ts` keeps both detectors, ordered specific then general. `isOversizedReviewStubPatch` (marker-based, from #1219) stays first; `isContentlessBinaryPatch` follows as the documented fallback, with a note that callers ask the marker first. No duplicate helpers.
- Both mount points (`AllFilesCodeView` and `DiffViewer`) render **exactly one** notice: a marker-carrying stub gets #1219's `OversizedFileNotice`, which knows the file is over the size cap; anything else hunkless and binary (a genuine binary, or a stub shape the marker does not cover) gets `BinaryFileNotice`. The fallback is explicitly gated on the marker so the two can never both appear on one card.
- `review-core.ts` merged without conflict: #1219's marker injection is in `buildOversizedTrackedStub`, this change is in `getGitObjectSizes` and the preflight loop.
- The new DOM test moved into #1219's isolated real-renderer CI step rather than the shared list, for the reason that step exists. #1219's `afterAll` restore of the leaked `mock.module('@pierre/diffs')` in `AllFilesCodeView.lifecycle.test.tsx` is untouched.

A new DOM case pins the harmonization directly: a marker-carrying stub renders exactly one oversized notice and zero fallback notices.

Post-merge verification: `bun test` 2938 pass / 0 fail; all three DOM CI steps green, with the shared list and the isolated diff-renderer step each run forward and reversed (226 pass, 8 pass, 6 pass); typecheck clean; review and hook builds clean. The harness re-run on dev still reports +34/-22, `Panel.tsx` back to `R h2 +8/-2` with real content, `bigassets/metrics-6mb.txt` the only remaining stub, and its served patch carries #1219's marker, so it renders the specific size-cap notice rather than the fallback.

AI-assisted.
