### PR TITLE
fix(review): show the full branch name when hovering the worktree switcher

### DIFF
--- a/packages/review-editor/components/WorktreePicker.tsx
+++ b/packages/review-editor/components/WorktreePicker.tsx
@@ -64,7 +64,7 @@ export const WorktreePicker: React.FC<WorktreePickerProps> = ({
           <button
             type="button"
             disabled={disabled}
-            title={active ? `Worktree: ${active.path}` : 'Main repository'}
+            title={active ? `${activeLabel} — ${active.path}` : mainLabel}
             className={`w-full flex items-center gap-1.5 px-2.5 py-1.5 rounded text-xs font-medium transition-colors focus:outline-none focus:ring-1 focus:ring-primary/50 disabled:opacity-50 disabled:cursor-not-allowed ${
               isCustom
                 ? 'bg-primary/10 border border-primary/30 text-foreground'
@@ -181,9 +181,9 @@ const WorktreeRow: React.FC<WorktreeRowProps> = ({ label, sublabel, isSelected, 
       )}
     </span>
     <div className="min-w-0 flex-1">
-      <div className="truncate">{label}</div>
+      <div className="truncate" title={label}>{label}</div>
       {sublabel && (
-        <div className="truncate text-[10px] text-muted-foreground">{sublabel}</div>
+        <div className="truncate text-[10px] text-muted-foreground" title={sublabel}>{sublabel}</div>
       )}
     </div>
   </button>


### PR DESCRIPTION
On a long branch name you can't tell which branch you're on from the worktree switcher button because it truncates its label to keep the toolbar compact. The trigger already had a native title, but it never showed the branch. On the current checkout it just said "Main repository", while on a worktree it showed the path rather than the branch, and the dropdown rows had no title at all.

The full name is now always one hover away because we put the full branch label into the button's title, add the worktree path when a worktree is active, and give each dropdown row a title for both its name and its path.

We stayed on the native `title` attribute rather than the styled `Tooltip` component because that's how the sibling PR and stacked-PR pickers already surface their truncated refs, and wrapping a tooltip trigger around the existing popover trigger would add nesting we don't need.
