### PR TITLE
fix(annotate): hide the collapsed sidebar tab flags when tools are hidden

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,6 +98,7 @@ jobs:
           packages/ui/components/DocBadges.test.tsx
           packages/editor/planDiffAutoExit.test.tsx
           packages/editor/App.archiveReadOnly.test.tsx
+          packages/editor/App.htmlHideTools.test.tsx
           packages/editor/actionsLabelMode.test.ts
 
   opencode-v2:

--- a/packages/editor/App.htmlHideTools.test.tsx
+++ b/packages/editor/App.htmlHideTools.test.tsx
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+const hasDom = typeof document !== "undefined";
+
+if (hasDom) {
+  document.cookie = "plannotator-look-feel-announcement-seen=2; path=/";
+  document.cookie = "plannotator-vim-mode-announcement-seen=2; path=/";
+  document.cookie = "plannotator-plan-ai-announcement-seen=1; path=/";
+}
+
+const appModule = hasDom ? await import("./App") : null;
+const App = appModule?.default as typeof import("./App")["default"];
+const originalFetch = globalThis.fetch;
+const originalEventSource = globalThis.EventSource;
+
+const RAW_HTML = "<h1>Rendered page</h1><p>Body copy.</p>";
+
+class SilentEventSource {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
+
+  readonly CONNECTING = 0;
+  readonly OPEN = 1;
+  readonly CLOSED = 2;
+  readonly readyState = SilentEventSource.OPEN;
+  readonly url: string;
+  readonly withCredentials = false;
+  onerror: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onopen: ((event: Event) => void) | null = null;
+
+  constructor(url: string | URL) {
+    this.url = String(url);
+  }
+
+  addEventListener(): void {}
+  close(): void {}
+  dispatchEvent(): boolean { return true; }
+  removeEventListener(): void {}
+}
+
+let root: Root | null = null;
+let host: HTMLElement | null = null;
+
+const htmlAnnotatePlan = {
+  plan: "",
+  origin: "codex",
+  mode: "annotate",
+  filePath: "/tmp/page.html",
+  renderAs: "html",
+  rawHtml: RAW_HTML,
+  sharingEnabled: false,
+  serverConfig: {},
+};
+
+const annotateFetch: typeof fetch = async (input) => {
+  const rawUrl = input instanceof Request ? input.url : String(input);
+  if (rawUrl.startsWith("https://api.github.com/")) return new Response(null, { status: 404 });
+
+  const url = new URL(rawUrl, "http://localhost");
+  if (url.pathname === "/api/plan") return Response.json(htmlAnnotatePlan);
+  if (url.pathname === "/api/ai/capabilities") return Response.json({ available: false, providers: [] });
+  if (url.pathname === "/api/draft") return Response.json({ error: "Not found" }, { status: 404 });
+  return Response.json({});
+};
+
+function findButton(label: string): HTMLButtonElement | undefined {
+  return Array.from(document.querySelectorAll("button"))
+    .find((button) => button.textContent?.trim() === label);
+}
+
+function sidebarTabs(): HTMLElement | null {
+  return document.querySelector<HTMLElement>('[data-sidebar-tabs="true"]');
+}
+
+async function settle(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function mountHtmlAnnotate(): Promise<void> {
+  globalThis.fetch = annotateFetch;
+  // SAFETY: the App only uses EventSource's constructor, handlers, and close;
+  // this test double implements those browser-facing members without I/O.
+  globalThis.EventSource = SilentEventSource as unknown as typeof EventSource;
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  root = createRoot(host);
+  await act(async () => {
+    root?.render(<App />);
+  });
+  for (let attempt = 0; attempt < 20 && !findButton("Hide tools"); attempt += 1) {
+    await settle();
+  }
+}
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  root = null;
+  host?.remove();
+  host = null;
+  globalThis.fetch = originalFetch;
+  globalThis.EventSource = originalEventSource;
+  if (hasDom) document.body.replaceChildren();
+});
+
+describe.if(hasDom)("HTML annotate hide-tools", () => {
+  test("hiding tools removes the collapsed sidebar tab flags, showing tools restores them", async () => {
+    await mountHtmlAnnotate();
+
+    const strip = sidebarTabs();
+    if (!strip) throw new Error("Collapsed sidebar tab flags did not render");
+    expect(strip.querySelectorAll("button").length).toBeGreaterThan(0);
+
+    const hide = findButton("Hide tools");
+    if (!hide) throw new Error('"Hide tools" toggle did not render');
+    await act(async () => hide.click());
+
+    // Unmounted, not merely invisible: nothing focusable may survive in the tab
+    // order, and no hover/click target may sit over the rendered page.
+    expect(sidebarTabs()).toBeNull();
+
+    const show = findButton("Show tools");
+    if (!show) throw new Error('"Show tools" toggle is not reachable while tools are hidden');
+    await act(async () => show.click());
+
+    expect(sidebarTabs()).not.toBeNull();
+  });
+
+  test("the sidebar is still reachable by keyboard while tools are hidden", async () => {
+    await mountHtmlAnnotate();
+
+    const hide = findButton("Hide tools");
+    if (!hide) throw new Error('"Hide tools" toggle did not render');
+    await act(async () => hide.click());
+    expect(sidebarTabs()).toBeNull();
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "b", metaKey: true, bubbles: true }));
+    });
+    await settle();
+
+    expect(findButton("Contents")).not.toBeUndefined();
+  });
+});

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -438,6 +438,11 @@ const App: React.FC = () => {
   // Hide the floating HTML annotation controls (toolstrip + action cluster) so the
   // user can read the rendered page unobstructed. Selections/annotations are unaffected.
   const [htmlToolsHidden, setHtmlToolsHidden] = useState(false);
+  // Every overlay the document surface paints over a rendered HTML page — the
+  // toolstrip and the collapsed sidebar tab flags — drops out together, so the
+  // page really gets the whole viewport. The header's "Show tools" button stays
+  // put, and Mod+B still opens the sidebar, so neither can be locked away.
+  const htmlChromeHidden = isHtmlSurface && htmlToolsHidden;
   const [imageBaseDir, setImageBaseDir] = useState<string | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -4258,7 +4263,7 @@ const App: React.FC = () => {
             </div>
           )}
           {/* Left Sidebar: collapsed tab flags (when sidebar is closed) */}
-          {wideModeType === null && !sidebar.isOpen && !goalSetupMode && !isAgentTerminalOpen && (
+          {wideModeType === null && !sidebar.isOpen && !goalSetupMode && !isAgentTerminalOpen && !htmlChromeHidden && (
             <SidebarTabs
               activeTab={sidebar.activeTab}
               onToggleTab={toggleSidebarTab}
@@ -4407,7 +4412,7 @@ const App: React.FC = () => {
                   comment/markup mode). Hidden during plan diff, and on HTML surfaces
                   when the header's "Hide tools" toggle is on (leaving the rendered HTML
                   free of overlay controls). On HTML it floats top-left over the doc. */}
-              {!goalSetupMode && !isPlanDiffActive && !archive.archiveMode && !isEditingMarkdown && !(isHtmlSurface && htmlToolsHidden) && (
+              {!goalSetupMode && !isPlanDiffActive && !archive.archiveMode && !isEditingMarkdown && !htmlChromeHidden && (
                 <div
                   data-print-hide
                   className={isHtmlSurface


### PR DESCRIPTION
## TLDR

`Hide tools` on a rendered HTML annotate session left the collapsed sidebar tab flags stuck to the left edge, so the page never actually went full screen. They now unmount with the rest of the overlay chrome and come back with `Show tools`.

## Before / after

The header toggle is `htmlToolsHidden` in `packages/editor/App.tsx` (label: `Hide tools` / `Show tools`, rendered by `AppHeader` only when `htmlSurface` is true). It already hid two things:

- the floating `AnnotationToolstrip`
- the `HtmlViewer` action cluster (`hideControls`)

It did not hide `SidebarTabs` (`packages/ui/components/sidebar/SidebarTabs.tsx`), the collapsed tab strip that renders `absolute left-0 top-0` whenever the sidebar is closed. Those are the "tongue" tabs: Table of Contents, Versions, Messages, Files, and the Agent TUI flag.

After: the same toggle drops the tab strip too. Both guards now read one derived value:

```ts
const htmlChromeHidden = isHtmlSurface && htmlToolsHidden;
```

The strip is unmounted, not faded or `pointer-events: none`, so its buttons leave the tab order entirely and nothing invisible remains hoverable or clickable over the page.

## Scope decision

Applied to every surface where the toggle can exist, which today means HTML render sessions only.

`htmlToolsHidden` is not a global chrome state. `AppHeader` renders the button behind `htmlSurface && onToggleHtmlTools`, so plan review, markdown annotate, and archive have no hide-tools affordance at all and are untouched by this change. Keeping the `isHtmlSurface` factor in the derived value (rather than testing `htmlToolsHidden` alone) preserves that boundary if the state is ever reused, and it matches the guard the toolstrip was already using.

I did not extend hide-tools to markdown surfaces. That would be a new feature, not this bug, and the centered markdown column does not have the same edge-to-edge claim on the viewport that a raw HTML page does.

## No lockout

Two independent ways back, neither of which the toggle hides:

1. The header itself is never hidden, and the button flips to `Show tools` in place.
2. `Mod+B` (`toggleContents` in `packages/ui/shortcuts/plan-review/sidebar.shortcuts.ts`) still opens the sidebar while tools are hidden. `Mod+Shift+B` for Files and `Shift Shift` for the Agent TUI are likewise unaffected.

The second test in the new file asserts exactly this: hide tools, confirm the strip is gone, press `Mod+B`, confirm the sidebar opens.

## Files touched

- `packages/editor/App.tsx` - derived `htmlChromeHidden`; applied to the `SidebarTabs` render and reused at the existing toolstrip guard
- `packages/editor/App.htmlHideTools.test.tsx` - new DOM test, modeled on `App.archiveReadOnly.test.tsx`
- `.github/workflows/test.yml` - registered the new file in the `DOM_TESTS=1` step (the default `bun test` run skips DOM tests by design)

## Tests

- `bun run typecheck` clean
- `bun test` 2938 pass, 271 skip, 0 fail
- `DOM_TESTS=1 bun test packages/editor/App.htmlHideTools.test.tsx` 2 pass
- Verified the new tests fail against the unpatched `App.tsx`, so they are not vacuous
- Ran the new file in one process alongside `App.archiveReadOnly.test.tsx`, `planDiffAutoExit.test.tsx`, and `actionsLabelMode.test.ts` to check for cross-file interference

No server change. The toggle is component-local state, never persisted and never sent anywhere, so the two-runtime rule does not apply. `apps/pi-extension/vendor.sh` vendors only server and shared modules, so Pi picks this up from the same editor build.

## Please eyeball in the browser

I cannot see the UI, so worth a quick look:

- `plannotator annotate somefile.html`, hit `Hide tools`, confirm the left edge is genuinely clean with no residual sliver or hover target
- `Show tools` restores both the strip and the toolstrip
- The toolstrip's HTML-mode offset (`left-3` when the sidebar is open, `left-10` when closed) is unchanged, but confirm nothing shifted for the visible-tools case
- With the sidebar open, hide tools: the open sidebar deliberately stays put (the strip only exists while the sidebar is closed). Confirm that reads as intended rather than as a missed case