### PR TITLE
test(install): give the PowerShell scanner tests room for pwsh cold start

### DIFF
--- a/scripts/install.test.ts
+++ b/scripts/install.test.ts
@@ -2248,6 +2248,12 @@ test("PowerShell scanner coverage must not silently vanish on CI", () => {
   }
 });
 
+// Each of these tests spawns PowerShell. The first spawn in the process pays
+// pwsh's cold start (assembly load + JIT), which on a loaded CI runner exceeds
+// bun's 5s default and fails whichever test happens to run first - a flake with
+// no relation to the code under test. Warm spawns finish in ~300ms.
+const PWSH_SCANNER_TIMEOUT_MS = 60_000;
+
 describe.skipIf(!pwshBin)("attestation bundle scanner under PowerShell (M7)", () => {
   const fixtureRaw = readFileSync(ATTESTATION_FIXTURE, "utf-8");
   const fixture = JSON.parse(fixtureRaw);
@@ -2268,7 +2274,7 @@ describe.skipIf(!pwshBin)("attestation bundle scanner under PowerShell (M7)", ()
         // bundle object the response carried.
         expect(JSON.parse(lines[i])).toEqual(fixture.attestations[i].bundle);
       }
-    });
+    }, PWSH_SCANNER_TIMEOUT_MS);
 
     test(`${name}: date-shaped strings survive untouched (DateTime coercion guard)`, () => {
       // A ConvertFrom-Json/ConvertTo-Json round trip would parse this into
@@ -2277,7 +2283,7 @@ describe.skipIf(!pwshBin)("attestation bundle scanner under PowerShell (M7)", ()
       const synthetic = '{"attestations":[{"bundle_url":"https://x.test/a","bundle":{"ts":"2026-01-02T03:04:05.000Z","integratedTime":"1785415430"}}]}';
       const lines = runScanner(body, synthetic);
       expect(lines).toEqual(['{"ts":"2026-01-02T03:04:05.000Z","integratedTime":"1785415430"}']);
-    });
+    }, PWSH_SCANNER_TIMEOUT_MS);
 
     test(`${name}: braces and escaped quotes inside string values do not derail the depth scan`, () => {
       const bundle = { weird: 'a}b{c"}{', nested: { deep: "{{{}}}" } };
@@ -2286,6 +2292,6 @@ describe.skipIf(!pwshBin)("attestation bundle scanner under PowerShell (M7)", ()
       expect(lines.length).toBe(1);
       expect(JSON.parse(lines[0])).toEqual(bundle);
       expect(synthetic).toContain(lines[0]);
-    });
+    }, PWSH_SCANNER_TIMEOUT_MS);
   }
 });


### PR DESCRIPTION
**TLDR:** A flaky test was failing CI on unrelated PRs. The first PowerShell spawn in the test process is slower than bun's 5 second default timeout on a loaded runner, so whichever scanner test ran first timed out. The six scanner tests now carry an explicit 60 second budget.

## What was happening

`attestation bundle scanner under PowerShell (M7) > install.ps1 inline scanner: byte-stable extraction of the real attestations response` failed on two different PRs today, neither of which touches the installers:

- #1225 (server URL host override), failed once then passed on rerun
- #1223 (a three line JSX change from an outside contributor)

The log is explicit: `this test timed out after 5000ms`. Its five sibling tests, which spawn PowerShell the same way, pass in roughly 300ms each. The difference is that the first spawn in the process pays pwsh's cold start (assembly load plus JIT). On a busy runner that exceeds the default budget, and whichever test happens to run first absorbs it.

Nothing about the code under test is involved, which is what makes it expensive: it reads as a real failure on someone else's PR.

## The change

One constant plus a third argument on the six tests in that describe block. No assertion changes, no behavior changes. Warm spawns still finish in about 300ms, so the larger budget costs nothing when things are healthy and only absorbs the cold start when it is slow.

## Verification

`bun test scripts/install.test.ts` locally: 116 pass, 6 skip, 0 fail. The scanner tests skip on machines with no PowerShell, which is why the existing `PowerShell scanner coverage must not silently vanish on CI` guard exists; that guard is untouched and still fails loudly if CI ever loses pwsh.