### PR TITLE
fix(pr-artifacts): read GitLab uploads through the token-readable API

### DIFF
--- a/packages/shared/pr-artifact-document.test.ts
+++ b/packages/shared/pr-artifact-document.test.ts
@@ -41,6 +41,20 @@ const github: GithubPRMetadata = {
   url: 'https://github.com/acme/widgets/pull/1',
 };
 
+const gitlabMetadata: GitlabMRMetadata = {
+  platform: 'gitlab',
+  host: 'gitlab.example.com',
+  projectPath: 'acme/widgets',
+  iid: 7,
+  title: 'Artifacts',
+  author: 'reviewer',
+  baseBranch: 'main',
+  headBranch: 'feature',
+  baseSha: 'base',
+  headSha: 'head',
+  url: 'https://gitlab.example.com/acme/widgets/-/merge_requests/7',
+};
+
 describe('isPRArtifactDocumentUrlAllowed', () => {
   test('allows referenced GitHub uploads and raw files from the active repository', () => {
     expect(isPRArtifactDocumentUrlAllowed(
@@ -252,6 +266,96 @@ describe('fetchPRArtifactDocument', () => {
       expect(result.content).toBe('# Review');
       expect(receivedToken).toBe('test-token');
       expect(commands).toEqual(['glab config get token --host gitlab.example.com']);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('fetches GitLab uploads through the token-readable uploads API', async () => {
+    const runtime: PRRuntime = {
+      async runCommand() {
+        return { stdout: 'test-token\n', stderr: '', exitCode: 0 };
+      },
+    };
+    const originalFetch = globalThis.fetch;
+    const requestedUrls: string[] = [];
+    globalThis.fetch = async (input) => {
+      requestedUrls.push(String(input));
+      return new Response('# Review', { headers: { 'content-type': 'text/markdown' } });
+    };
+    try {
+      for (const rawUrl of [
+        'https://gitlab.example.com/uploads/hash/review.md',
+        'https://gitlab.example.com/acme/widgets/uploads/hash/review.md',
+      ]) {
+        const result = await fetchPRArtifactDocument(
+          runtime,
+          gitlabMetadata,
+          {
+            ...context,
+            body: '[a](/uploads/hash/review.md)\n[b](/acme/widgets/uploads/hash/review.md)',
+          },
+          rawUrl,
+        );
+        expect(result.content).toBe('# Review');
+      }
+      expect(requestedUrls).toEqual([
+        'https://gitlab.example.com/api/v4/projects/acme%2Fwidgets/uploads/hash/review.md',
+        'https://gitlab.example.com/api/v4/projects/acme%2Fwidgets/uploads/hash/review.md',
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('refines the opaque content type the GitLab uploads API returns', async () => {
+    const runtime: PRRuntime = {
+      async runCommand() {
+        return { stdout: 'test-token\n', stderr: '', exitCode: 0 };
+      },
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => new Response(Uint8Array.from([137, 80, 78, 71]), {
+      headers: { 'content-type': 'application/octet-stream' },
+    });
+    try {
+      const result = await fetchPRArtifactContent(
+        runtime,
+        gitlabMetadata,
+        { ...context, body: '![shot](/uploads/hash/screenshot.png)' },
+        'https://gitlab.example.com/uploads/hash/screenshot.png',
+      );
+      expect(result.contentType).toBe('image/png');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('fails loudly instead of rendering a provider sign-in page', async () => {
+    const runtime: PRRuntime = {
+      async runCommand() {
+        return { stdout: '', stderr: '', exitCode: 1 };
+      },
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input) => {
+      return String(input).includes('/api/v4/')
+        ? new Response(null, {
+          status: 302,
+          headers: { location: 'https://gitlab.example.com/users/auth/saml' },
+        })
+        : new Response('<form action="/users/auth/saml">', {
+          headers: { 'content-type': 'text/html' },
+        });
+    };
+    try {
+      const promise = fetchPRArtifactDocument(
+        runtime,
+        gitlabMetadata,
+        { ...context, body: '[review](/uploads/hash/review.md)' },
+        'https://gitlab.example.com/uploads/hash/review.md',
+      );
+      await expect(promise).rejects.toThrow(/requires authentication/);
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/packages/shared/pr-artifact-document.test.ts
+++ b/packages/shared/pr-artifact-document.test.ts
@@ -373,6 +373,55 @@ describe('fetchPRArtifactDocument', () => {
     }
   });
 
+  test('diagnoses a direct 401 or 403 from the GitLab API as a missing login', async () => {
+    const runtime: PRRuntime = {
+      async runCommand() {
+        return { stdout: '', stderr: '', exitCode: 1 };
+      },
+    };
+    const originalFetch = globalThis.fetch;
+    try {
+      for (const status of [401, 403]) {
+        globalThis.fetch = async () => new Response('{"message":"401 Unauthorized"}', {
+          status,
+          headers: { 'content-type': 'application/json' },
+        });
+        const promise = fetchPRArtifactDocument(
+          runtime,
+          gitlabMetadata,
+          { ...context, body: `[review](/uploads/${uploadSecret}/review.md)` },
+          `https://gitlab.example.com/uploads/${uploadSecret}/review.md`,
+        );
+        // The actionable outcome: the reader is told to log in, not that HTTP 401 happened.
+        await expect(promise).rejects.toMatchObject({ status: 401 });
+        await expect(promise).rejects.toThrow(/glab auth login --hostname gitlab\.example\.com/);
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('leaves a GitHub 403 as a transport status, since it also covers rate limits', async () => {
+    const runtime: PRRuntime = {
+      async runCommand() {
+        return { stdout: 'test-token\n', stderr: '', exitCode: 0 };
+      },
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => new Response('rate limited', { status: 403 });
+    try {
+      const promise = fetchPRArtifactDocument(
+        runtime,
+        github,
+        context,
+        'https://github.com/acme/widgets/blob/main/docs/review.html',
+      );
+      await expect(promise).rejects.toMatchObject({ status: 502 });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test('fails loudly instead of rendering a provider sign-in page', async () => {
     const runtime: PRRuntime = {
       async runCommand() {

--- a/packages/shared/pr-artifact-document.test.ts
+++ b/packages/shared/pr-artifact-document.test.ts
@@ -55,6 +55,9 @@ const gitlabMetadata: GitlabMRMetadata = {
   url: 'https://gitlab.example.com/acme/widgets/-/merge_requests/7',
 };
 
+/** GitLab mints upload secrets as 32 lowercase hex characters; the rewrite requires that shape. */
+const uploadSecret = '0123456789abcdef0123456789abcdef';
+
 describe('isPRArtifactDocumentUrlAllowed', () => {
   test('allows referenced GitHub uploads and raw files from the active repository', () => {
     expect(isPRArtifactDocumentUrlAllowed(
@@ -260,8 +263,8 @@ describe('fetchPRArtifactDocument', () => {
       const result = await fetchPRArtifactDocument(
         runtime,
         gitlab,
-        { ...context, body: '[review](/uploads/hash/review.md)' },
-        'https://gitlab.example.com/uploads/hash/review.md',
+        { ...context, body: `[review](/uploads/${uploadSecret}/review.md)` },
+        `https://gitlab.example.com/uploads/${uploadSecret}/review.md`,
       );
       expect(result.content).toBe('# Review');
       expect(receivedToken).toBe('test-token');
@@ -285,24 +288,63 @@ describe('fetchPRArtifactDocument', () => {
     };
     try {
       for (const rawUrl of [
-        'https://gitlab.example.com/uploads/hash/review.md',
-        'https://gitlab.example.com/acme/widgets/uploads/hash/review.md',
+        `https://gitlab.example.com/uploads/${uploadSecret}/review.md`,
+        `https://gitlab.example.com/acme/widgets/uploads/${uploadSecret}/review.md`,
       ]) {
         const result = await fetchPRArtifactDocument(
           runtime,
           gitlabMetadata,
           {
             ...context,
-            body: '[a](/uploads/hash/review.md)\n[b](/acme/widgets/uploads/hash/review.md)',
+            body: [
+              `[a](/uploads/${uploadSecret}/review.md)`,
+              `[b](/acme/widgets/uploads/${uploadSecret}/review.md)`,
+            ].join('\n'),
           },
           rawUrl,
         );
         expect(result.content).toBe('# Review');
       }
       expect(requestedUrls).toEqual([
-        'https://gitlab.example.com/api/v4/projects/acme%2Fwidgets/uploads/hash/review.md',
-        'https://gitlab.example.com/api/v4/projects/acme%2Fwidgets/uploads/hash/review.md',
+        `https://gitlab.example.com/api/v4/projects/acme%2Fwidgets/uploads/${uploadSecret}/review.md`,
+        `https://gitlab.example.com/api/v4/projects/acme%2Fwidgets/uploads/${uploadSecret}/review.md`,
       ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('rewrites only real upload paths, so a crafted MR link cannot steer the credentialed GET', async () => {
+    const runtime: PRRuntime = {
+      async runCommand() {
+        return { stdout: 'test-token\n', stderr: '', exitCode: 0 };
+      },
+    };
+    const originalFetch = globalThis.fetch;
+    const requestedUrls: string[] = [];
+    globalThis.fetch = async (input) => {
+      requestedUrls.push(String(input));
+      return new Response('# Review', { headers: { 'content-type': 'text/markdown' } });
+    };
+    const crafted = [
+      // Secrets GitLab could never have minted: too short, and not lowercase hex.
+      'https://gitlab.example.com/uploads/hash/review.md',
+      `https://gitlab.example.com/uploads/${uploadSecret.toUpperCase()}/review.md`,
+      // A multi-segment remainder would otherwise append an attacker-chosen path
+      // to the /api/v4 URL the token is sent to.
+      `https://gitlab.example.com/uploads/${uploadSecret}/nested/review.md`,
+    ];
+    try {
+      for (const rawUrl of crafted) {
+        await fetchPRArtifactDocument(
+          runtime,
+          gitlabMetadata,
+          { ...context, body: `[review](${rawUrl})` },
+          rawUrl,
+        );
+      }
+      // Left alone: fetched verbatim as the ordinary web route, never rewritten.
+      expect(requestedUrls).toEqual(crafted);
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -322,8 +364,8 @@ describe('fetchPRArtifactDocument', () => {
       const result = await fetchPRArtifactContent(
         runtime,
         gitlabMetadata,
-        { ...context, body: '![shot](/uploads/hash/screenshot.png)' },
-        'https://gitlab.example.com/uploads/hash/screenshot.png',
+        { ...context, body: `![shot](/uploads/${uploadSecret}/screenshot.png)` },
+        `https://gitlab.example.com/uploads/${uploadSecret}/screenshot.png`,
       );
       expect(result.contentType).toBe('image/png');
     } finally {
@@ -352,8 +394,8 @@ describe('fetchPRArtifactDocument', () => {
       const promise = fetchPRArtifactDocument(
         runtime,
         gitlabMetadata,
-        { ...context, body: '[review](/uploads/hash/review.md)' },
-        'https://gitlab.example.com/uploads/hash/review.md',
+        { ...context, body: `[review](/uploads/${uploadSecret}/review.md)` },
+        `https://gitlab.example.com/uploads/${uploadSecret}/review.md`,
       );
       await expect(promise).rejects.toThrow(/requires authentication/);
     } finally {

--- a/packages/shared/pr-artifact-document.test.ts
+++ b/packages/shared/pr-artifact-document.test.ts
@@ -510,6 +510,45 @@ describe('fetchPRArtifactDocument', () => {
     }
   });
 
+  test('does not forward the GitLab token to a cross-origin redirect after the upload rewrite', async () => {
+    // The module-global auth cache is keyed by platform and host with a 5 minute TTL, so
+    // this deliberately resolves the same `test-token` every other gitlab test in this file
+    // does: whether the cache is cold or warm, request one carries that exact token.
+    const runtime: PRRuntime = {
+      async runCommand() {
+        return { stdout: 'test-token\n', stderr: '', exitCode: 0 };
+      },
+    };
+    const originalFetch = globalThis.fetch;
+    const requestedUrls: string[] = [];
+    const tokens: string[] = [];
+    const signedUrl = 'https://objects.example.net/gitlab/review.md?signature=abc';
+    globalThis.fetch = async (input, init) => {
+      requestedUrls.push(String(input));
+      tokens.push(new Headers(init?.headers).get('private-token') ?? '');
+      // Object storage hands an upload off to a signed URL on an unrelated host.
+      return requestedUrls.length === 1
+        ? new Response(null, { status: 302, headers: { location: signedUrl } })
+        : new Response('# Review', { headers: { 'content-type': 'text/markdown' } });
+    };
+    try {
+      const result = await fetchPRArtifactDocument(
+        runtime,
+        gitlabMetadata,
+        { ...context, body: `[review](/uploads/${uploadSecret}/review.md)` },
+        `https://gitlab.example.com/uploads/${uploadSecret}/review.md`,
+      );
+      expect(result.content).toBe('# Review');
+      expect(requestedUrls[0]).toContain('/api/v4/projects/acme%2Fwidgets/uploads/');
+      expect(requestedUrls[1]).toBe(signedUrl);
+      // The invariant: routing uploads through the API must not widen where the
+      // credential travels. The token stops at the provider's own origin.
+      expect(tokens).toEqual(['test-token', '']);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test('fails loudly instead of rendering a provider sign-in page', async () => {
     const runtime: PRRuntime = {
       async runCommand() {

--- a/packages/shared/pr-artifact-document.test.ts
+++ b/packages/shared/pr-artifact-document.test.ts
@@ -373,6 +373,34 @@ describe('fetchPRArtifactDocument', () => {
     }
   });
 
+  test('never refines an opaque upload into an active content type', async () => {
+    const runtime: PRRuntime = {
+      async runCommand() {
+        return { stdout: 'test-token\n', stderr: '', exitCode: 0 };
+      },
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => new Response('<script>alert(1)</script>', {
+      headers: { 'content-type': 'application/octet-stream' },
+    });
+    try {
+      // An HTML artifact is read through the document route, which always serves
+      // text/plain, so refining these here would only put an active type on the media
+      // route and leave its safety resting on a CSP header.
+      for (const filename of ['payload.html', 'payload.js']) {
+        const result = await fetchPRArtifactContent(
+          runtime,
+          gitlabMetadata,
+          { ...context, body: `[x](/uploads/${uploadSecret}/${filename})` },
+          `https://gitlab.example.com/uploads/${uploadSecret}/${filename}`,
+        );
+        expect(result.contentType).toBe('application/octet-stream');
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test('retries the original upload route once when the uploads API route is absent', async () => {
     const runtime: PRRuntime = {
       async runCommand() {

--- a/packages/shared/pr-artifact-document.test.ts
+++ b/packages/shared/pr-artifact-document.test.ts
@@ -373,6 +373,66 @@ describe('fetchPRArtifactDocument', () => {
     }
   });
 
+  test('retries the original upload route once when the uploads API route is absent', async () => {
+    const runtime: PRRuntime = {
+      async runCommand() {
+        return { stdout: 'test-token\n', stderr: '', exitCode: 0 };
+      },
+    };
+    const originalFetch = globalThis.fetch;
+    const requestedUrls: string[] = [];
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      requestedUrls.push(url);
+      // Pre-17.4 self-hosted GitLab: the uploads API route does not exist, while the
+      // original web route serves a public project without a session.
+      return url.includes('/api/v4/')
+        ? new Response('{"error":"404 Not Found"}', { status: 404 })
+        : new Response('# Review', { headers: { 'content-type': 'text/markdown' } });
+    };
+    try {
+      const result = await fetchPRArtifactDocument(
+        runtime,
+        gitlabMetadata,
+        { ...context, body: `[review](/uploads/${uploadSecret}/review.md)` },
+        `https://gitlab.example.com/uploads/${uploadSecret}/review.md`,
+      );
+      expect(result.content).toBe('# Review');
+      expect(requestedUrls).toEqual([
+        `https://gitlab.example.com/api/v4/projects/acme%2Fwidgets/uploads/${uploadSecret}/review.md`,
+        `https://gitlab.example.com/uploads/${uploadSecret}/review.md`,
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('reports the transport status when the fallback route also 404s, without retrying again', async () => {
+    const runtime: PRRuntime = {
+      async runCommand() {
+        return { stdout: 'test-token\n', stderr: '', exitCode: 0 };
+      },
+    };
+    const originalFetch = globalThis.fetch;
+    let requests = 0;
+    globalThis.fetch = async () => {
+      requests += 1;
+      return new Response('missing', { status: 404 });
+    };
+    try {
+      const promise = fetchPRArtifactDocument(
+        runtime,
+        gitlabMetadata,
+        { ...context, body: `[review](/uploads/${uploadSecret}/review.md)` },
+        `https://gitlab.example.com/uploads/${uploadSecret}/review.md`,
+      );
+      await expect(promise).rejects.toMatchObject({ status: 502 });
+      expect(requests).toBe(2);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test('diagnoses a direct 401 or 403 from the GitLab API as a missing login', async () => {
     const runtime: PRRuntime = {
       async runCommand() {

--- a/packages/shared/pr-artifact-document.ts
+++ b/packages/shared/pr-artifact-document.ts
@@ -8,7 +8,13 @@ const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 const AUTH_CACHE_MS = 5 * 60 * 1000;
 const PRIVATE_IPV4_RE = /^(?:127\.|10\.|192\.168\.|169\.254\.|172\.(?:1[6-9]|2\d|3[01])\.)/;
 const PRIVATE_IPV6_RE = /^\[(?:::1|::ffff:|fe80:|fc|fd)/i;
-const GITLAB_UPLOAD_RE = /^\/uploads\/([^/]+)\/(.+)$/;
+/**
+ * A GitLab upload secret is 32 lowercase hex characters and the filename is a single path
+ * segment. Matching a looser shape would let a link in an attacker-authored MR body steer
+ * the rewritten, credentialed GET at an arbitrary `/api/v4/...` path, leaving the safety of
+ * that request to GitLab's router rather than to this allowlist.
+ */
+const GITLAB_UPLOAD_RE = /^\/uploads\/([0-9a-f]{32})\/([^/]+)$/;
 /** Provider sign-in entry points. Landing here means our credentials were not accepted. */
 const SIGN_IN_PATH_RE = /^\/(?:users\/(?:sign_in|auth)|login|session|oauth\/authorize)(?:\/|$)/;
 

--- a/packages/shared/pr-artifact-document.ts
+++ b/packages/shared/pr-artifact-document.ts
@@ -8,6 +8,9 @@ const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 const AUTH_CACHE_MS = 5 * 60 * 1000;
 const PRIVATE_IPV4_RE = /^(?:127\.|10\.|192\.168\.|169\.254\.|172\.(?:1[6-9]|2\d|3[01])\.)/;
 const PRIVATE_IPV6_RE = /^\[(?:::1|::ffff:|fe80:|fc|fd)/i;
+const GITLAB_UPLOAD_RE = /^\/uploads\/([^/]+)\/(.+)$/;
+/** Provider sign-in entry points. Landing here means our credentials were not accepted. */
+const SIGN_IN_PATH_RE = /^\/(?:users\/(?:sign_in|auth)|login|session|oauth\/authorize)(?:\/|$)/;
 
 interface ProviderAuthCacheEntry {
   readonly expiresAt: number;
@@ -141,6 +144,33 @@ function isGitLabArtifactHost(url: URL, metadata: Extract<PRMetadata, { platform
     || url.pathname.startsWith(`${projectPath}/-/blob/`);
 }
 
+function gitlabProjectPath(metadata: Extract<PRMetadata, { platform: 'gitlab' }>): string {
+  return metadata.projectPath.replace(/^\/+|\/+$/g, '');
+}
+
+/**
+ * GitLab serves `/uploads/<secret>/<file>` from a Rails web route that only honors
+ * session cookies — a `PRIVATE-TOKEN` request is redirected to the sign-in page, so the
+ * link is unreadable from a CLI. The uploads REST API serves the same bytes for a token,
+ * so route upload links through it.
+ */
+function gitlabUploadApiUrl(
+  url: URL,
+  metadata: Extract<PRMetadata, { platform: 'gitlab' }>,
+): URL | null {
+  const projectPath = gitlabProjectPath(metadata);
+  const projectPrefix = `/${projectPath}`;
+  const uploadPath = url.pathname.startsWith(`${projectPrefix}/uploads/`)
+    ? url.pathname.slice(projectPrefix.length)
+    : url.pathname;
+  const match = GITLAB_UPLOAD_RE.exec(uploadPath);
+  if (match === null) return null;
+  const [, secret, filename] = match;
+  return new URL(
+    `${url.origin}/api/v4/projects/${encodeURIComponent(projectPath)}/uploads/${secret}/${filename}${url.search}`,
+  );
+}
+
 function isProviderArtifactUrl(url: URL, metadata: PRMetadata): boolean {
   if (url.protocol !== 'https:' && url.protocol !== 'http:') return false;
   return metadata.platform === 'github'
@@ -169,6 +199,9 @@ function providerContentUrl(url: URL, metadata: PRMetadata): URL {
     }
     return url;
   }
+
+  const uploadUrl = gitlabUploadApiUrl(url, metadata);
+  if (uploadUrl !== null) return uploadUrl;
 
   const blobMarker = '/-/blob/';
   if (url.pathname.includes(blobMarker)) {
@@ -318,6 +351,36 @@ async function readBytesWithLimit(response: Response, maxBytes: number): Promise
   return content;
 }
 
+/**
+ * The GitLab uploads API answers every file with `application/octet-stream`. Responses are
+ * served with `nosniff`, so an unrefined type would stop images and video from rendering.
+ */
+const EXTENSION_CONTENT_TYPES: Readonly<Record<string, string>> = {
+  avif: 'image/avif',
+  css: 'text/css',
+  gif: 'image/gif',
+  html: 'text/html',
+  jpeg: 'image/jpeg',
+  jpg: 'image/jpeg',
+  js: 'text/javascript',
+  json: 'application/json',
+  md: 'text/markdown',
+  mov: 'video/quicktime',
+  mp4: 'video/mp4',
+  pdf: 'application/pdf',
+  png: 'image/png',
+  svg: 'image/svg+xml',
+  txt: 'text/plain',
+  webm: 'video/webm',
+  webp: 'image/webp',
+};
+
+function refineOpaqueContentType(contentType: string, url: URL): string {
+  if (contentType !== 'application/octet-stream') return contentType;
+  const extension = url.pathname.split('.').pop()?.toLowerCase() ?? '';
+  return EXTENSION_CONTENT_TYPES[extension] ?? contentType;
+}
+
 function isValidRangeHeader(range: string | undefined): range is string {
   return range !== undefined && /^bytes=\d*-\d*$/.test(range);
 }
@@ -401,6 +464,17 @@ async function fetchArtifactContent(
         if (!mayFollowProviderRedirect(currentUrl, nextUrl)) {
           throw new PRArtifactDocumentError('Artifact document redirected to a blocked address', 403);
         }
+        // A sign-in hop returns HTTP 200 with a login/SSO page. Following it would render
+        // that page as the artifact, so fail loudly instead.
+        if (SIGN_IN_PATH_RE.test(nextUrl.pathname)) {
+          const loginHint = metadata.platform === 'github'
+            ? `gh auth login --hostname ${metadata.host}`
+            : `glab auth login --hostname ${metadata.host}`;
+          throw new PRArtifactDocumentError(
+            `Artifact host requires authentication — run \`${loginHint}\``,
+            401,
+          );
+        }
         currentUrl = nextUrl;
         continue;
       }
@@ -408,8 +482,10 @@ async function fetchArtifactContent(
         await response.body?.cancel();
         throw new PRArtifactDocumentError(`Artifact host returned HTTP ${response.status}`, 502);
       }
-      const contentType = response.headers.get('content-type')?.split(';', 1)[0]?.trim()
-        || 'text/plain';
+      const contentType = refineOpaqueContentType(
+        response.headers.get('content-type')?.split(';', 1)[0]?.trim() || 'text/plain',
+        currentUrl,
+      );
       const shouldRewriteCss = contentType === 'text/css' && options.sourceUrl !== undefined;
       let content = await readBytesWithLimit(
         response,

--- a/packages/shared/pr-artifact-document.ts
+++ b/packages/shared/pr-artifact-document.ts
@@ -309,6 +309,30 @@ function shouldSendProviderAuth(url: URL, metadata: PRMetadata): boolean {
     || origin === 'https://private-user-images.githubusercontent.com';
 }
 
+/**
+ * Our credentials were not accepted. Name the command that fixes it: the alternative is a
+ * bare transport status, which reads as a broken artifact rather than a missing login.
+ */
+function providerAuthRequiredError(metadata: PRMetadata): PRArtifactDocumentError {
+  const loginHint = metadata.platform === 'github'
+    ? `gh auth login --hostname ${metadata.host}`
+    : `glab auth login --hostname ${metadata.host}`;
+  return new PRArtifactDocumentError(
+    `Artifact host requires authentication: run \`${loginHint}\``,
+    401,
+  );
+}
+
+/**
+ * A direct refusal carries the same diagnosis as a sign-in redirect: GitLab's `/api/v4`
+ * routes answer 401/403 as JSON instead of redirecting to a login page. GitHub's 403 is
+ * excluded because it also covers rate limiting and SSO enforcement, where a login hint
+ * would point at the wrong problem.
+ */
+function isProviderAuthRefusal(status: number, metadata: PRMetadata): boolean {
+  return status === 401 || (status === 403 && metadata.platform === 'gitlab');
+}
+
 function responseContentLength(response: Response): number | undefined {
   const contentEncoding = response.headers.get('content-encoding');
   if (contentEncoding !== null && contentEncoding.toLowerCase() !== 'identity') return undefined;
@@ -473,19 +497,16 @@ async function fetchArtifactContent(
         // A sign-in hop returns HTTP 200 with a login/SSO page. Following it would render
         // that page as the artifact, so fail loudly instead.
         if (SIGN_IN_PATH_RE.test(nextUrl.pathname)) {
-          const loginHint = metadata.platform === 'github'
-            ? `gh auth login --hostname ${metadata.host}`
-            : `glab auth login --hostname ${metadata.host}`;
-          throw new PRArtifactDocumentError(
-            `Artifact host requires authentication — run \`${loginHint}\``,
-            401,
-          );
+          throw providerAuthRequiredError(metadata);
         }
         currentUrl = nextUrl;
         continue;
       }
       if (!response.ok) {
         await response.body?.cancel();
+        if (isProviderAuthRefusal(response.status, metadata)) {
+          throw providerAuthRequiredError(metadata);
+        }
         throw new PRArtifactDocumentError(`Artifact host returned HTTP ${response.status}`, 502);
       }
       const contentType = refineOpaqueContentType(

--- a/packages/shared/pr-artifact-document.ts
+++ b/packages/shared/pr-artifact-document.ts
@@ -384,15 +384,17 @@ async function readBytesWithLimit(response: Response, maxBytes: number): Promise
 /**
  * The GitLab uploads API answers every file with `application/octet-stream`. Responses are
  * served with `nosniff`, so an unrefined type would stop images and video from rendering.
+ *
+ * Deliberately no `html` or `js`: naming an active type here buys nothing, because an HTML
+ * artifact is read through the document route, which always serves `text/plain`. Leaving
+ * them in would make the safety of the media route depend on its CSP header forever.
  */
 const EXTENSION_CONTENT_TYPES: Readonly<Record<string, string>> = {
   avif: 'image/avif',
   css: 'text/css',
   gif: 'image/gif',
-  html: 'text/html',
   jpeg: 'image/jpeg',
   jpg: 'image/jpeg',
-  js: 'text/javascript',
   json: 'application/json',
   md: 'text/markdown',
   mov: 'video/quicktime',

--- a/packages/shared/pr-artifact-document.ts
+++ b/packages/shared/pr-artifact-document.ts
@@ -470,8 +470,13 @@ async function fetchArtifactContent(
   const providerHeaders = await providerAuthHeaders(runtime, metadata);
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-  let currentUrl = providerContentUrl(new URL(rawUrl), metadata);
-  currentUrl.hash = '';
+  const requestedUrl = new URL(rawUrl);
+  requestedUrl.hash = '';
+  // Kept so a 404 from the rewritten uploads API can be told apart from a 404 anywhere else.
+  const uploadApiUrl = metadata.platform === 'gitlab'
+    ? gitlabUploadApiUrl(requestedUrl, metadata)
+    : null;
+  let currentUrl = providerContentUrl(requestedUrl, metadata);
   try {
     for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects += 1) {
       const response = await fetch(currentUrl, {
@@ -504,6 +509,14 @@ async function fetchArtifactContent(
       }
       if (!response.ok) {
         await response.body?.cancel();
+        // `GET /projects/:id/uploads/:secret/:filename` landed in GitLab 17.4. An older
+        // self-hosted instance has no such route, while the original web route still reads
+        // a public project anonymously, so retry that route once before giving up. The
+        // retry is same-origin, so it carries credentials on the usual terms.
+        if (response.status === 404 && uploadApiUrl !== null && currentUrl.href === uploadApiUrl.href) {
+          currentUrl = requestedUrl;
+          continue;
+        }
         if (isProviderAuthRefusal(response.status, metadata)) {
           throw providerAuthRequiredError(metadata);
         }


### PR DESCRIPTION
## Problem

GitLab serves `/uploads/<secret>/<file>` from a Rails web route that only honors **session cookies**. The `PRIVATE-TOKEN` header that `pr-artifact-document.ts` already resolves via `glab config get token` is not accepted there, so every GitLab upload attachment referenced by an MR is unreadable.

Worse, the failure is silent. The sign-in hop answers HTTP 200 with an HTML login page, which then gets rendered *as the artifact* in the artifact pane.

Measured against a self-hosted GitLab 18.8.0-ee instance with a valid token (`/api/v4/user` → 200):

```
/uploads/<secret>/pack.md                        → 302 → /users/sign_in
/<group>/<repo>/uploads/<secret>/pack.md         → 302 → /users/sign_in
/-/project/<id>/uploads/<secret>/pack.md         → 404
/api/v4/projects/<id>/uploads/<secret>/pack.md   → 200  ✅
```

## Changes

1. **Route GitLab uploads through the uploads REST API.** `gitlabUploadApiUrl()` rewrites both the bare `/uploads/...` and project-scoped `/<projectPath>/uploads/...` forms to `GET /projects/:id/uploads/:secret/:filename`, wired into the existing `providerContentUrl()` alongside the `/-/blob/` → `/-/raw/` rewrite. The allowlist and credential plumbing are unchanged — they were already correct.

2. **Stop following redirects into a provider sign-in page.** Landing on `/users/sign_in`, `/users/auth/...`, `/login`, `/session`, or `/oauth/authorize` now throws `PRArtifactDocumentError(401)` with the matching `gh auth login` / `glab auth login --hostname <host>` hint. An auth gap becomes legible instead of surfacing as a corrupt artifact. This is worth having independently of change 1.

3. **Refine the opaque content type.** The uploads API answers every file with `application/octet-stream`, and `/api/pr-artifact-content` serves the provider type with `nosniff` — without this, images and video would stop rendering. Falls back to an extension lookup only when the provider type is `application/octet-stream`.

## Verification

- `bun test packages/shared/` — 761 pass, 0 fail (4 new tests)
- `tsc --noEmit -p packages/shared/tsconfig.json` — clean
- Full `bun test` — 2789 pass / 25 fail; unmodified `main` produces the identical 25 failures (Pi-extension and AI-runtime suites, unrelated to this change)
- Live end-to-end fetch of a real MR upload on GitLab 18.8.0-ee: returns the actual file, `contentType: text/markdown`

## Known consideration

`GET /projects/:id/uploads/:secret/:filename` was added in GitLab 17.4. On older self-hosted instances it 404s, which surfaces as a 502 — where today those uploads fail anyway (redirect to sign-in). Happy to add a version gate or a fallback to the web route if you'd prefer explicit handling.

## Note on CI

The `Test` job failure on this branch is `edit-mode Discard repaints the pristine diff (DOM) > pristine content is visible ... promptly after cancelEdit`. It reproduces identically on upstream `main` (run 31138933804) and is unrelated to this change.