### PR TITLE
fix(test): make the @pierre/diffs mock restore actually restore

### DIFF
--- a/packages/review-editor/components/AllFilesCodeView.lifecycle.test.tsx
+++ b/packages/review-editor/components/AllFilesCodeView.lifecycle.test.tsx
@@ -14,8 +14,15 @@ let scrollTargets: Array<Record<string, unknown>> = [];
 // a `processFile` that returns null. That leaked into
 // DiffViewer.fullContentSwap.test.tsx on the Linux runner (and not on macOS),
 // where it presented as a diff that silently never rendered.
-const realPierreDiffs = await import('@pierre/diffs');
-const realPierreDiffsReact = await import('@pierre/diffs/react');
+//
+// The SPREAD is load-bearing, exactly as configure.test.ts documents. A
+// namespace object is a live view of the module record, and `mock.module`
+// rewrites that record in place — so holding `await import(...)` and handing it
+// back later re-installs the STUBS as themselves and restores nothing. Spread
+// snapshots the real export values into a plain object at capture time, before
+// any stub exists.
+const realPierreDiffs = { ...(await import('@pierre/diffs')) };
+const realPierreDiffsReact = { ...(await import('@pierre/diffs/react')) };
 
 mock.module('../workerPool', () => ({
   useIsWorkerPoolReadyOrDisabled: () => true,
@@ -149,11 +156,37 @@ afterEach(async () => {
 });
 
 // Hand the real @pierre/diffs back to the process. Only the two library
-// specifiers are restored: the sibling-module mocks above name paths relative
-// to THIS file, so they cannot be reached by another file's imports.
+// specifiers are restored. The sibling-module mocks above are NOT scoped to
+// this file — `mock.module` resolves a relative specifier to an absolute module
+// path, so any later file importing packages/review-editor/workerPool,
+// hooks/usePierreTheme or components/ToolbarHost sees these stubs too. They are
+// left in place because workerPool cannot be captured here at all: it imports
+// the Vite-only `?worker&inline` virtual module, which bun cannot resolve.
+// Files that need the real ones must not share this process — that is what the
+// isolated "diff-renderer DOM tests" step in .github/workflows/test.yml is for.
 afterAll(() => {
   mock.module('@pierre/diffs', () => realPierreDiffs);
   mock.module('@pierre/diffs/react', () => realPierreDiffsReact);
+});
+
+// Guards the capture idiom itself. If the spreads above are ever reduced back
+// to a bare `await import(...)`, the "real" handles become live views of the
+// mocked module records and the afterAll restore silently degrades to a no-op —
+// which is how discardRestoreRender.test.tsx started seeing `processFile()`
+// return null on the runs where the runner walked this file first.
+describe('the @pierre/diffs restore handles', () => {
+  test('hold the real exports, not the stubs installed over them', async () => {
+    const stubbed = await import('@pierre/diffs');
+    const stubbedReact = await import('@pierre/diffs/react');
+
+    // The live namespaces are this file's stubs: `processFile: () => null`.
+    expect(stubbed.processFile.length).toBe(0);
+
+    // The captured handles must not have followed them.
+    expect(realPierreDiffs.processFile).not.toBe(stubbed.processFile);
+    expect(realPierreDiffs.processFile.length).toBe(2);
+    expect(realPierreDiffsReact.CodeView).not.toBe(stubbedReact.CodeView);
+  });
 });
 
 describe('AllFilesCodeView guide mount state', () => {


### PR DESCRIPTION
## TLDR

`AllFilesCodeView.lifecycle.test.tsx` never actually restored the real `@pierre/diffs` after its own `mock.module` stubs. Its "restore" captured the module namespace object, which is a live view of the module record that `mock.module` rewrites in place, so the captured handle was already the stub and handing it back re-installed the stubs as themselves. The stubs stayed live for the rest of the `bun test` process, and on runs where bun's file walk happened to load that file before `packages/review-editor/edit/discardRestoreRender.test.tsx`, that test's `processFile(...)` returned `null` and it failed on its very first assertion. The fix spread-snapshots the exports at capture time (the idiom `packages/ui/configure.test.ts` already documents) plus an in-file guard so the broken idiom cannot come back silently.

## Root cause

Two things had to line up.

**1. The restore was a no-op.** The file did:

```ts
const realPierreDiffs = await import('@pierre/diffs');
mock.module('@pierre/diffs', () => ({ processFile: () => null, ... }));
...
afterAll(() => { mock.module('@pierre/diffs', () => realPierreDiffs); });
```

An ES module namespace object is a live view of the module record. Bun's `mock.module` rewrites that record in place, so `realPierreDiffs.processFile` becomes the stub the instant the mock is installed. Verified directly:

```
captured namespace still real? false
captured processFile source () => null
```

So `afterAll` re-installed the stub as the "real" module, and every later file in the process that imported `@pierre/diffs` got `processFile: () => null` and a hunk-less `getSingularPatch`.

`packages/ui/configure.test.ts` already spells this out in a comment ("We MUST restore with captured real functions (not `{ ...storage }`) because spreading the live namespace after `mock.module()` returns the mocked version"), but this file used the broken shape.

**2. The file order is not the order the workflow lists.** Bun treats the positional args of `bun test` as filters and runs the matched files in filesystem-walk order (breadth first by directory), not in the order they are written in the workflow. Captured with `--reporter=junit` on the exact CI file list, the run order starts:

```
packages/ui/annotationDraftPersistence.test.tsx
packages/ui/markdownEditorFidelity.test.tsx
...
packages/review-editor/edit/discardRestoreRender.test.tsx
packages/review-editor/components/AllFilesCodeView.lifecycle.test.tsx
```

The relative order of `packages/review-editor/edit/` and `packages/review-editor/components/` comes out of the directory walk. On macOS/APFS `edit/` happened to come first, so the leak was invisible locally. On the Linux runner the ext4 directory hash order decides it, and it can differ per checkout, which is exactly the observed "fails on 548497e6 and b69742c3, passes on b0756770, fails on 9dc81695" pattern. Nothing about #1226 caused this; it only changed how many files the walk had to place.

The failing assertion is the first line of the test body, `expect(fileDiff).toBeTruthy()` on `processFile(PATCH, ...)`, which is why CI reported it at 0.33ms rather than as a timeout.

## Minimal reproduction

Two files. Ordering is forced by giving the mocking file a shallower path so the directory walk reaches it first (a straight copy of `AllFilesCodeView.lifecycle.test.tsx` placed at `packages/review-editor/`, with the relative specifiers re-pointed):

```
DOM_TESTS=1 bun test \
  packages/review-editor/zz_repro_lifecycle.test.tsx \
  packages/review-editor/edit/discardRestoreRender.test.tsx
```

## Fix

`packages/review-editor/components/AllFilesCodeView.lifecycle.test.tsx`:

- Capture the real exports as a plain snapshot before the stubs exist: `{ ...(await import('@pierre/diffs')) }`. Spread reads the namespace getters immediately, so the copy holds the real function references and `afterAll` now restores real behaviour.
- Add a test that asserts the captured handles are not the stubs. If the spreads are ever reduced back to a bare `await import(...)`, this file fails instead of some unrelated file downstream. Confirmed: removing the spreads makes it `(fail) the @pierre/diffs restore handles > hold the real exports, not the stubs installed over them`.
- Correct the comment claiming the relative-path sibling mocks (`../workerPool`, `../hooks/usePierreTheme`, `./ToolbarHost`) "cannot be reached by another file's imports". They can. `mock.module` resolves a relative specifier to an absolute module path; a two-file probe confirmed a later file in a different directory sees them. Those three are deliberately left unrestored because `workerPool` cannot be imported here at all under bun (it pulls the Vite-only `?worker&inline` virtual module), and the comment now says so and points at the isolated CI step that exists for it.

No production code changed, and no CI step changed. The existing isolated "diff-renderer DOM tests" step stays as it is, as defence in depth for the sibling mocks that genuinely cannot be restored.

## Evidence

Minimal repro, before the fix:

```
packages/review-editor/edit/discardRestoreRender.test.tsx:
error: expect(received).toBeTruthy()
Received: null
(fail) edit-mode Discard repaints the pristine diff (DOM) > pristine content is visible ... [0.27ms]
 2 pass
 1 fail
```

Same command, after the fix:

```
 4 pass
 0 fail
 16 expect() calls
```

Full "Run UI seam-contract + DOM tests" file list in one process, three consecutive runs on this branch:

```
run 1:  229 pass  0 fail   (38 files)
run 2:  229 pass  0 fail   (38 files)
run 3:  229 pass  0 fail   (38 files)
```

Isolated diff-renderer step: `8 pass  0 fail`. Full `bun test`: `2961 pass, 271 skip, 0 fail` across 271 files. `bun run typecheck`: clean.

## Does this remove the flake entirely

For this failure, yes. The leak was the whole mechanism, and with the restore working the stub is gone before any later file loads, in either walk order. The forced worst-case ordering that failed deterministically before now passes.

What it does not do is make the suite order-independent in general. Bun's file order still comes from the filesystem walk and is not stable across platforms, and the three sibling mocks in that file are still process-global. Nothing in the current CI list imports the real `packages/review-editor/workerPool`, `hooks/usePierreTheme` or `components/ToolbarHost`, so they are inert today, but a future test that does would hit the same class of problem. The new guard test catches the specific regression of reverting the capture idiom; it does not catch a brand new unrestored mock.
