### PR TITLE
Fix Pi feedback delivery after reload

### DIFF
--- a/apps/pi-extension/current-pi-session.test.ts
+++ b/apps/pi-extension/current-pi-session.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import {
+	getPiSessionIdentity,
+	notifyCurrentPiSession,
+	registerCurrentPiSession,
+	sendUserMessageToCurrentPiSession,
+	type CurrentPiSessionRegistration,
+} from "./current-pi-session.ts";
+
+const registrations: CurrentPiSessionRegistration[] = [];
+
+afterEach(() => {
+	for (const registration of registrations.splice(0)) registration.clear();
+});
+
+function createContext(sessionId: string, notifications: string[]): ExtensionContext {
+	return {
+		cwd: "/tmp",
+		mode: "tui",
+		sessionManager: {
+			getSessionId: () => sessionId,
+			getSessionFile: () => `/tmp/${sessionId}.jsonl`,
+			getSessionName: () => sessionId,
+		},
+		ui: { notify: (message: string) => notifications.push(message) },
+	} as unknown as ExtensionContext;
+}
+
+function registerSessionRuntime(
+	sessionId: string,
+	messages: string[],
+	notifications: string[],
+): { registration: CurrentPiSessionRegistration; ctx: ExtensionContext } {
+	const pi = {
+		sendUserMessage: (content: string) => messages.push(content),
+	} as unknown as ExtensionAPI;
+	const registration = registerCurrentPiSession(pi);
+	registrations.push(registration);
+	const ctx = createContext(sessionId, notifications);
+	registration.update(ctx);
+	return { registration, ctx };
+}
+
+describe("current Pi session feedback routing", () => {
+	test("reload routes feedback to the replacement runtime with the same session ID", () => {
+		const oldMessages: string[] = [];
+		const oldNotifications: string[] = [];
+		const oldRuntime = registerSessionRuntime("same-session", oldMessages, oldNotifications);
+		const origin = getPiSessionIdentity(oldRuntime.ctx);
+
+		const replacementMessages: string[] = [];
+		const replacementNotifications: string[] = [];
+		registerSessionRuntime("same-session", replacementMessages, replacementNotifications);
+		oldRuntime.registration.clear();
+
+		const result = sendUserMessageToCurrentPiSession(
+			"annotation feedback",
+			{ deliverAs: "followUp" },
+			origin,
+		);
+
+		expect(result).toEqual({ ok: true });
+		expect(notifyCurrentPiSession("feedback delivered", "info", origin)).toBe(true);
+		expect(oldMessages).toEqual([]);
+		expect(oldNotifications).toEqual([]);
+		expect(replacementMessages).toEqual(["annotation feedback"]);
+		expect(replacementNotifications).toEqual(["feedback delivered"]);
+	});
+});

--- a/apps/pi-extension/current-pi-session.ts
+++ b/apps/pi-extension/current-pi-session.ts
@@ -26,6 +26,8 @@ export type CurrentPiSessionRegistration = {
 };
 
 export type PiSessionIdentity = {
+	/** In-process extension runtime identity; changes on reload even when the Pi session ID does not. */
+	runtimeToken?: symbol;
 	sessionId?: string;
 	sessionFile?: string;
 	sessionName?: string;
@@ -72,8 +74,9 @@ function getErrorMessage(err: unknown): string {
 	return err instanceof Error ? err.message : String(err);
 }
 
-export function getPiSessionIdentity(ctx: ExtensionContext): PiSessionIdentity {
+export function getPiSessionIdentity(ctx: ExtensionContext, runtimeToken = getStore().current?.token): PiSessionIdentity {
 	return {
+		runtimeToken,
 		sessionId: ctx.sessionManager.getSessionId(),
 		sessionFile: ctx.sessionManager.getSessionFile(),
 		sessionName: ctx.sessionManager.getSessionName(),
@@ -83,6 +86,7 @@ export function getPiSessionIdentity(ctx: ExtensionContext): PiSessionIdentity {
 
 function isDifferentSession(origin: PiSessionIdentity, current: PiSessionIdentity | undefined): boolean {
 	if (!current) return false;
+	if (origin.runtimeToken && current.runtimeToken) return origin.runtimeToken !== current.runtimeToken;
 	if (origin.sessionId && current.sessionId) return origin.sessionId !== current.sessionId;
 	if (origin.sessionFile && current.sessionFile) return origin.sessionFile !== current.sessionFile;
 	return false;
@@ -99,7 +103,7 @@ function setCurrentPiSession(token: symbol, pi: ExtensionAPI, ctx?: ExtensionCon
 		current.notify = (message, type = "info") => {
 			ctx.ui.notify(message, type);
 		};
-		current.identity = getPiSessionIdentity(ctx);
+		current.identity = getPiSessionIdentity(ctx, token);
 	}
 	getStore().current = current;
 }


### PR DESCRIPTION
## Problem

A Plannotator browser tab can outlive a Pi `/reload`. When its feedback arrives, the old callback correctly finds a newly registered Pi runtime, but `current-pi-session.ts` rejects that runtime as `same-session` because reload preserves the Pi session ID and file.

The callback then falls through to the stale captured `pi` object and reports:

> This extension ctx is stale after session replacement or reload.

The notification fallback fails for the same reason.

## Fix

Track the in-process extension runtime token as part of `PiSessionIdentity`. A reload now counts as a different active runtime even when its persistent session ID is unchanged. Existing session-ID/file comparison remains the fallback for identities without runtime tokens.

## Test

Added a regression test that registers a replacement runtime with the same session ID and verifies both feedback and notification delivery go only to the replacement.

```text
1 pass
0 fail
6 expect() calls
```

Focused command:

```bash
cd /tmp
npx --yes bun test /tmp/plannotator-debug/apps/pi-extension/current-pi-session.test.ts
```
