### PR TITLE
feat(annotate): pinpoint-first raw-HTML sessions with element anchors and a minimal-first render

### DIFF
--- a/packages/editor/App.htmlHideTools.test.tsx
+++ b/packages/editor/App.htmlHideTools.test.tsx
@@ -1,6 +1,11 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, describe, expect, test } from "bun:test";
 import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
+import {
+  resetStorageBackend,
+  setStorageBackend,
+  type StorageBackend,
+} from "@plannotator/ui/utils/storage";
 
 const hasDom = typeof document !== "undefined";
 
@@ -16,6 +21,22 @@ const originalFetch = globalThis.fetch;
 const originalEventSource = globalThis.EventSource;
 
 const RAW_HTML = "<h1>Rendered page</h1><p>Body copy.</p>";
+
+// In-memory storage backend (the codebase-standard persistence-test pattern):
+// keeps values across mounts within a test, so a remount simulates the next
+// session with the same cookies.
+const memory = new Map<string, string>();
+const memoryBackend: StorageBackend = {
+  getItem: (key) => memory.get(key) ?? null,
+  setItem: (key, value) => void memory.set(key, value),
+  removeItem: (key) => void memory.delete(key),
+};
+
+function seedAnnouncementsSeen(): void {
+  memory.set("plannotator-look-feel-announcement-seen", "2");
+  memory.set("plannotator-vim-mode-announcement-seen", "2");
+  memory.set("plannotator-plan-ai-announcement-seen", "1");
+}
 
 class SilentEventSource {
   static readonly CONNECTING = 0;
@@ -82,7 +103,7 @@ async function settle(): Promise<void> {
   });
 }
 
-async function mountHtmlAnnotate(): Promise<void> {
+async function mountHtmlAnnotate(expectButton: string): Promise<void> {
   globalThis.fetch = annotateFetch;
   // SAFETY: the App only uses EventSource's constructor, handlers, and close;
   // this test double implements those browser-facing members without I/O.
@@ -93,24 +114,53 @@ async function mountHtmlAnnotate(): Promise<void> {
   await act(async () => {
     root?.render(<App />);
   });
-  for (let attempt = 0; attempt < 20 && !findButton("Hide tools"); attempt += 1) {
+  for (let attempt = 0; attempt < 20 && !findButton(expectButton); attempt += 1) {
     await settle();
   }
 }
 
-afterEach(async () => {
+async function unmountHtmlAnnotate(): Promise<void> {
   if (root) await act(async () => root?.unmount());
   root = null;
   host?.remove();
   host = null;
+}
+
+afterEach(async () => {
+  await unmountHtmlAnnotate();
   globalThis.fetch = originalFetch;
   globalThis.EventSource = originalEventSource;
+  memory.clear();
+  resetStorageBackend();
   if (hasDom) document.body.replaceChildren();
 });
 
-describe.if(hasDom)("HTML annotate hide-tools", () => {
+afterAll(() => {
+  resetStorageBackend();
+});
+
+describe.if(hasDom)("HTML annotate chrome (minimal-first render + persistence)", () => {
+  test("first-ever HTML session opens minimal: all chrome hidden, Show tools discoverable", async () => {
+    setStorageBackend(memoryBackend);
+    seedAnnouncementsSeen();
+    await mountHtmlAnnotate("Show tools");
+
+    // Nothing the hide-tools toggle controls may be mounted on first paint.
+    expect(sidebarTabs()).toBeNull();
+    const show = findButton("Show tools");
+    if (!show) throw new Error('"Show tools" affordance did not render on first run');
+
+    await act(async () => show.click());
+    expect(sidebarTabs()).not.toBeNull();
+    expect(findButton("Hide tools")).not.toBeUndefined();
+  });
+
   test("hiding tools removes the collapsed sidebar tab flags, showing tools restores them", async () => {
-    await mountHtmlAnnotate();
+    setStorageBackend(memoryBackend);
+    seedAnnouncementsSeen();
+    // Simulate a returning user who previously showed tools.
+    memory.set("plannotator-html-chrome", JSON.stringify({ toolsHidden: false, sidebarOpen: false }));
+    await mountHtmlAnnotate("Hide tools");
 
     const strip = sidebarTabs();
     if (!strip) throw new Error("Collapsed sidebar tab flags did not render");
@@ -131,12 +181,44 @@ describe.if(hasDom)("HTML annotate hide-tools", () => {
     expect(sidebarTabs()).not.toBeNull();
   });
 
-  test("the sidebar is still reachable by keyboard while tools are hidden", async () => {
-    await mountHtmlAnnotate();
+  test("a 'user showed tools' state persists across a fresh mount", async () => {
+    setStorageBackend(memoryBackend);
+    seedAnnouncementsSeen();
+    await mountHtmlAnnotate("Show tools");
+
+    const show = findButton("Show tools");
+    if (!show) throw new Error('"Show tools" toggle did not render');
+    await act(async () => show.click());
+    expect(sidebarTabs()).not.toBeNull();
+
+    // Next session (fresh mount, same persisted prefs): opens exactly as left.
+    await unmountHtmlAnnotate();
+    await mountHtmlAnnotate("Hide tools");
+    expect(findButton("Hide tools")).not.toBeUndefined();
+    expect(sidebarTabs()).not.toBeNull();
+  });
+
+  test("a 'user re-hid everything' state persists across a fresh mount", async () => {
+    setStorageBackend(memoryBackend);
+    seedAnnouncementsSeen();
+    memory.set("plannotator-html-chrome", JSON.stringify({ toolsHidden: false, sidebarOpen: false }));
+    await mountHtmlAnnotate("Hide tools");
 
     const hide = findButton("Hide tools");
     if (!hide) throw new Error('"Hide tools" toggle did not render');
     await act(async () => hide.click());
+    expect(sidebarTabs()).toBeNull();
+
+    await unmountHtmlAnnotate();
+    await mountHtmlAnnotate("Show tools");
+    expect(findButton("Show tools")).not.toBeUndefined();
+    expect(sidebarTabs()).toBeNull();
+  });
+
+  test("the sidebar is still reachable by keyboard while tools are hidden", async () => {
+    setStorageBackend(memoryBackend);
+    seedAnnouncementsSeen();
+    await mountHtmlAnnotate("Show tools");
     expect(sidebarTabs()).toBeNull();
 
     await act(async () => {

--- a/packages/editor/App.htmlHideTools.test.tsx
+++ b/packages/editor/App.htmlHideTools.test.tsx
@@ -181,6 +181,34 @@ describe.if(hasDom)("HTML annotate chrome (minimal-first render + persistence)",
     expect(sidebarTabs()).not.toBeNull();
   });
 
+  test("the restore commit never writes stale pre-restore values to the cookie", async () => {
+    // The chrome writer runs in the same commit as the restore effect, before
+    // the restored state has landed. If it saved there, a returning user's
+    // remembered state would be transiently inverted in the cookie — and a
+    // page ending between the two writes would freeze the inversion. Instrument
+    // every chrome write: no write may ever carry a state other than the
+    // remembered one, because this session never changes any chrome.
+    const chromeWrites: string[] = [];
+    setStorageBackend({
+      getItem: (key) => memory.get(key) ?? null,
+      setItem: (key, value) => {
+        if (key === "plannotator-html-chrome") chromeWrites.push(value);
+        memory.set(key, value);
+      },
+      removeItem: (key) => void memory.delete(key),
+    });
+    seedAnnouncementsSeen();
+    const remembered = JSON.stringify({ toolsHidden: false, sidebarOpen: true });
+    memory.set("plannotator-html-chrome", remembered);
+    await mountHtmlAnnotate("Hide tools");
+    await settle();
+
+    for (const write of chromeWrites) {
+      expect(JSON.parse(write)).toEqual(JSON.parse(remembered));
+    }
+    expect(memory.get("plannotator-html-chrome")).toBe(remembered);
+  });
+
   test("a 'user showed tools' state persists across a fresh mount", async () => {
     setStorageBackend(memoryBackend);
     seedAnnouncementsSeen();

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -450,6 +450,9 @@ const App: React.FC = () => {
   // Gate for the chrome-persistence writer: only start saving once the persisted
   // state has been applied, so a pre-restore render can't clobber the cookie.
   const htmlChromeRestoredRef = useRef(false);
+  // The restore's own commit still renders pre-restore values; the writer
+  // consumes this flag to skip that exact run (see the save effect).
+  const skipNextHtmlChromeSaveRef = useRef(false);
   // Every overlay the document surface paints over a rendered HTML page — the
   // toolstrip and the collapsed sidebar tab flags — drops out together, so the
   // page really gets the whole viewport. The header's "Show tools" button stays
@@ -1626,6 +1629,7 @@ const App: React.FC = () => {
     if (!isHtmlSurface || wasHtml) return;
     if (archive.archiveMode || goalSetupMode || annotateSource === 'folder') return;
     const chrome = getHtmlChromeState();
+    skipNextHtmlChromeSaveRef.current = true;
     setHtmlToolsHidden(chrome.toolsHidden);
     if (chrome.sidebarOpen) sidebar.open();
     else sidebar.close();
@@ -1649,6 +1653,17 @@ const App: React.FC = () => {
   // the HTML surface, so a linked markdown doc's sidebar use never writes here.
   useEffect(() => {
     if (!isHtmlSurface || !htmlChromeRestoredRef.current) return;
+    // The restore effect flips htmlChromeRestoredRef synchronously, but its
+    // state updates land a commit LATER — a save in the restore commit itself
+    // would still see pre-restore values and clobber the remembered state
+    // (self-corrected next flush, but a page ending in between would freeze
+    // the inverted value). Skip exactly that one run. If the restore changed
+    // any state, the changed deps re-run this effect and save then; if it
+    // changed nothing, the cookie already holds exactly those values.
+    if (skipNextHtmlChromeSaveRef.current) {
+      skipNextHtmlChromeSaveRef.current = false;
+      return;
+    }
     saveHtmlChromeState({ toolsHidden: htmlToolsHidden, sidebarOpen: sidebar.isOpen });
   }, [isHtmlSurface, htmlToolsHidden, sidebar.isOpen]);
 

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -1591,16 +1591,9 @@ const App: React.FC = () => {
 
     initialSidebarPreferenceAppliedRef.current = true;
     if (archive.archiveMode || goalSetupMode || annotateSource === 'folder') return;
-    if (renderAs === 'html') {
-      // Restore the chrome the user last left an HTML session with (first-ever
-      // run: everything hidden, sidebar closed — a minimal "just the page" paint).
-      const chrome = getHtmlChromeState();
-      setHtmlToolsHidden(chrome.toolsHidden);
-      if (chrome.sidebarOpen) sidebar.open();
-      else sidebar.close();
-      htmlChromeRestoredRef.current = true;
-      return;
-    }
+    // HTML chrome is owned by the surface-transition effect below, which also
+    // covers linked .html docs opened from a markdown session.
+    if (renderAs === 'html') return;
     if (uiPrefs.tocEnabled && hasTocEntries) {
       sidebar.open('toc');
     }
@@ -1618,10 +1611,42 @@ const App: React.FC = () => {
     wideModeType,
   ]);
 
+  // Restore-on-entry: every time the session transitions ONTO an HTML surface
+  // (a root raw-HTML session, or a linked .html doc opened from markdown),
+  // apply the chrome the user last left an HTML session with (first-ever run:
+  // everything hidden, sidebar closed — a minimal "just the page" paint).
+  // Re-restoring on each entry is also what keeps a markdown surface's sidebar
+  // state from leaking into the HTML cookie on the way back.
+  const prevHtmlChromeSurfaceRef = useRef(false);
+  useEffect(() => {
+    if (isLoading || isLoadingShared) return;
+    if (wideModeType !== null) return;
+    const wasHtml = prevHtmlChromeSurfaceRef.current;
+    prevHtmlChromeSurfaceRef.current = isHtmlSurface;
+    if (!isHtmlSurface || wasHtml) return;
+    if (archive.archiveMode || goalSetupMode || annotateSource === 'folder') return;
+    const chrome = getHtmlChromeState();
+    setHtmlToolsHidden(chrome.toolsHidden);
+    if (chrome.sidebarOpen) sidebar.open();
+    else sidebar.close();
+    htmlChromeRestoredRef.current = true;
+  }, [
+    annotateSource,
+    archive.archiveMode,
+    goalSetupMode,
+    isHtmlSurface,
+    isLoading,
+    isLoadingShared,
+    sidebar.close,
+    sidebar.open,
+    wideModeType,
+  ]);
+
   // Persist the chrome the user leaves an HTML session in (tools visibility +
   // sidebar open), so the next raw-HTML session opens exactly as they left this
   // one. Gated on the restore having run — a pre-restore render must not save
-  // the transient defaults over the user's remembered state.
+  // the transient defaults over the user's remembered state — and on being ON
+  // the HTML surface, so a linked markdown doc's sidebar use never writes here.
   useEffect(() => {
     if (!isHtmlSurface || !htmlChromeRestoredRef.current) return;
     saveHtmlChromeState({ toolsHidden: htmlToolsHidden, sidebarOpen: sidebar.isOpen });

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -49,6 +49,7 @@ import { buildDefaultPrompt, useAIChat } from '@plannotator/ui/hooks/useAIChat';
 import { getUIPreferences, type UIPreferences, type PlanWidth } from '@plannotator/ui/utils/uiPreferences';
 import { getEditorMode, saveEditorMode } from '@plannotator/ui/utils/editorMode';
 import { getInputMethod, saveInputMethod } from '@plannotator/ui/utils/inputMethod';
+import { getHtmlChromeState, saveHtmlChromeState } from '@plannotator/ui/utils/htmlChrome';
 import { useInputMethodSwitch } from '@plannotator/ui/hooks/useInputMethodSwitch';
 import { usePrintMode } from '@plannotator/ui/hooks/usePrintMode';
 import { requestVimDocumentFocus } from '@plannotator/ui/hooks/useVimDocumentFocus';
@@ -443,7 +444,12 @@ const App: React.FC = () => {
   const [convertHtml, setConvertHtml] = useState(false);
   // Hide the floating HTML annotation controls (toolstrip + action cluster) so the
   // user can read the rendered page unobstructed. Selections/annotations are unaffected.
+  // First-ever HTML session opens minimal (everything hidden); afterwards the user's
+  // last chrome state is restored from the persisted cookie (see utils/htmlChrome.ts).
   const [htmlToolsHidden, setHtmlToolsHidden] = useState(false);
+  // Gate for the chrome-persistence writer: only start saving once the persisted
+  // state has been applied, so a pre-restore render can't clobber the cookie.
+  const htmlChromeRestoredRef = useRef(false);
   // Every overlay the document surface paints over a rendered HTML page — the
   // toolstrip and the collapsed sidebar tab flags — drops out together, so the
   // page really gets the whole viewport. The header's "Show tools" button stays
@@ -1586,7 +1592,13 @@ const App: React.FC = () => {
     initialSidebarPreferenceAppliedRef.current = true;
     if (archive.archiveMode || goalSetupMode || annotateSource === 'folder') return;
     if (renderAs === 'html') {
-      sidebar.close();
+      // Restore the chrome the user last left an HTML session with (first-ever
+      // run: everything hidden, sidebar closed — a minimal "just the page" paint).
+      const chrome = getHtmlChromeState();
+      setHtmlToolsHidden(chrome.toolsHidden);
+      if (chrome.sidebarOpen) sidebar.open();
+      else sidebar.close();
+      htmlChromeRestoredRef.current = true;
       return;
     }
     if (uiPrefs.tocEnabled && hasTocEntries) {
@@ -1605,6 +1617,15 @@ const App: React.FC = () => {
     uiPrefs.tocEnabled,
     wideModeType,
   ]);
+
+  // Persist the chrome the user leaves an HTML session in (tools visibility +
+  // sidebar open), so the next raw-HTML session opens exactly as they left this
+  // one. Gated on the restore having run — a pre-restore render must not save
+  // the transient defaults over the user's remembered state.
+  useEffect(() => {
+    if (!isHtmlSurface || !htmlChromeRestoredRef.current) return;
+    saveHtmlChromeState({ toolsHidden: htmlToolsHidden, sidebarOpen: sidebar.isOpen });
+  }, [isHtmlSurface, htmlToolsHidden, sidebar.isOpen]);
 
   const ensureShareLink = useCallback(async (): Promise<string | null> => {
     const existing = shortShareUrl || shareUrl;
@@ -2405,8 +2426,21 @@ const App: React.FC = () => {
 
   const handleInputMethodChange = (method: InputMethod) => {
     setInputMethod(method);
-    saveInputMethod(method);
+    // Surface-scoped persistence: an explicit choice made on the HTML surface
+    // sticks for HTML sessions only; markdown keeps its own preference.
+    saveInputMethod(method, isHtmlSurface ? 'html' : 'markdown');
   };
+
+  // Raw-HTML surfaces resolve their own input-method preference (default:
+  // Pinpoint — see utils/inputMethod.ts for the persistence decision). Applied
+  // whenever the surface flips (session load or linked-doc navigation), so a
+  // markdown-era "drag" cookie never suppresses the HTML default.
+  const prevSurfaceRef = useRef(isHtmlSurface);
+  useEffect(() => {
+    if (prevSurfaceRef.current === isHtmlSurface) return;
+    prevSurfaceRef.current = isHtmlSurface;
+    setInputMethod(getInputMethod(isHtmlSurface ? 'html' : 'markdown'));
+  }, [isHtmlSurface]);
 
   // Alt/Option key: hold to temporarily switch, double-tap to toggle
   useInputMethodSwitch(inputMethod, handleInputMethodChange);

--- a/packages/ui/components/html-viewer/bridge-script.ts
+++ b/packages/ui/components/html-viewer/bridge-script.ts
@@ -40,6 +40,9 @@ export const ANNOTATION_HIGHLIGHT_CSS = `
 .annotation-highlight:hover {
   filter: brightness(1.2);
 }
+/* Vim pinpoint target tint. The MOUSE pinpoint path no longer mutates author
+ * elements — it draws the dedicated overlay box below — but keyboard (vim)
+ * navigation keeps this class-based visual. */
 .plannotator-pinpoint-hover {
   background-color: oklch(from var(--pn-focus-highlight, #4493f8) l c h / 0.12) !important;
   border-radius: 3px;
@@ -48,6 +51,69 @@ export const ANNOTATION_HIGHLIGHT_CSS = `
 /* SVG groups can't render a CSS background, so use a soft glow instead. */
 .plannotator-pinpoint-hover:is(g, svg) {
   filter: drop-shadow(0 0 4px oklch(from var(--pn-focus-highlight, #4493f8) l c h / 0.55));
+}
+/* Mouse pinpoint hover: a fixed-position outline box sized to the hovered
+ * element's rect. Never a class/style write on the page's own elements. */
+[data-plannotator-pinpoint-box] {
+  position: fixed;
+  z-index: 2147483643;
+  pointer-events: none;
+  display: none;
+  box-sizing: border-box;
+  border: 2px solid oklch(from var(--pn-focus-highlight, #4493f8) l c h / 0.85);
+  border-radius: 5px;
+  background: oklch(from var(--pn-focus-highlight, #4493f8) l c h / 0.06);
+}
+[data-plannotator-pinpoint-box].pn-pin-enter {
+  animation: pn-pinpoint-in 0.12s ease-out;
+}
+[data-plannotator-pinpoint-box][data-pinned] {
+  border-color: var(--pn-accent, #d97757);
+  background: oklch(from var(--pn-accent, #d97757) l c h / 0.08);
+}
+@keyframes pn-pinpoint-in {
+  from { opacity: 0; transform: scale(0.985); }
+  to { opacity: 1; transform: scale(1); }
+}
+/* Numbered pin badges for committed element annotations. */
+[data-plannotator-pin-badge] {
+  position: fixed;
+  z-index: 2147483644;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  transform: translate(-50%, -50%);
+  background: var(--pn-accent, #d97757);
+  color: #fff;
+  font: 700 10px/1 system-ui, -apple-system, sans-serif;
+  box-shadow: 0 2px 6px rgba(0,0,0,.25), inset 0 0 0 1px rgba(0,0,0,.06);
+  pointer-events: auto;
+  cursor: pointer !important;
+  user-select: none;
+  animation: pn-pin-badge-in 0.25s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+@keyframes pn-pin-badge-in {
+  from { opacity: 0; transform: translate(-50%, -50%) scale(0.3); }
+  to { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+}
+/* Pinpoint mode affordance: crosshair everywhere (existing marks and badges
+ * stay pointer via their own !important rules below). */
+body[data-plannotator-pinpoint-cursor],
+body[data-plannotator-pinpoint-cursor] * {
+  cursor: crosshair !important;
+}
+body[data-plannotator-pinpoint-cursor] .annotation-highlight,
+body[data-plannotator-pinpoint-cursor] [data-plannotator-pin-badge] {
+  cursor: pointer !important;
+}
+@media (prefers-reduced-motion: reduce) {
+  [data-plannotator-pinpoint-box].pn-pin-enter,
+  [data-plannotator-pin-badge] {
+    animation: none;
+  }
 }
 body[data-plannotator-vim-focus-owner]:focus {
   outline: none !important;
@@ -220,6 +286,8 @@ export const BRIDGE_SCRIPT = `(function() {
   // --- Selection ---
   var pendingSelection = null;
   var pendingRange = null; // live range for the pending selection (scroll tracking)
+  var pendingPinEl = null; // element pinned by a pinpoint click (outline + scroll tracking)
+  var pendingPinAnchor = null; // serialized anchor for the pending pin
   var currentInputMethod = 'drag'; // 'drag' = text selection, 'pinpoint' = click an element
   var pinpointHover = null;
   var vimEnabled = false;
@@ -247,7 +315,7 @@ export const BRIDGE_SCRIPT = `(function() {
     setTimeout(handleSelection, 10);
   });
 
-  function handleSelection(modeOverride) {
+  function handleSelection(modeOverride, extras) {
     var sel = window.getSelection();
     if (!sel || sel.isCollapsed || !sel.rangeCount) {
       // Trailing clear from a plain-click element annotation — consume it once.
@@ -256,6 +324,7 @@ export const BRIDGE_SCRIPT = `(function() {
         parent.postMessage({ type: PREFIX + 'selection-clear' }, '*');
         pendingSelection = null;
         pendingRange = null;
+        clearPendingPin();
       }
       return false;
     }
@@ -278,6 +347,8 @@ export const BRIDGE_SCRIPT = `(function() {
       type: PREFIX + 'selection',
       text: text,
       modeOverride: modeOverride || undefined,
+      anchor: (extras && extras.anchor) || undefined,
+      pinpoint: (extras && extras.pinpoint) || undefined,
       rect: { top: rect.top, left: rect.left, width: rect.width, height: rect.height }
     }, '*');
     return true;
@@ -289,13 +360,17 @@ export const BRIDGE_SCRIPT = `(function() {
   var scrollRaf = 0;
   function postSelectionRect() {
     scrollRaf = 0;
-    if (!pendingSelection || !pendingRange) return;
-    var r = pendingRange.getBoundingClientRect();
+    if (!pendingSelection) return;
+    // Element pins carry no live range — track the pinned element's box instead.
+    var tracked = pendingRange || (pendingPinEl && pendingPinEl.isConnected ? pendingPinEl : null);
+    if (!tracked) return;
+    var r = tracked.getBoundingClientRect();
     if (r.bottom < 0 || r.top > window.innerHeight) {
       // Selection scrolled out of view — close the toolbar (matches markdown).
       parent.postMessage({ type: PREFIX + 'selection-clear' }, '*');
       pendingSelection = null;
       pendingRange = null;
+      clearPendingPin();
       return;
     }
     parent.postMessage({
@@ -319,8 +394,8 @@ export const BRIDGE_SCRIPT = `(function() {
       var annType = e.data.annotationType || 'comment';
       if (pendingSelection) {
         // Text selections wrap a <mark>; element pinpoints (e.g. SVG nodes) carry
-        // no range, so there's no inline mark to apply — the annotation is still
-        // captured on the parent side from the posted text.
+        // no range, so there's no inline mark to apply — instead the pinned
+        // element gets a numbered pin badge anchored to its box.
         if (pendingSelection.startContainerPath) {
           applyMark(id, annType, pendingSelection);
           if (
@@ -329,16 +404,39 @@ export const BRIDGE_SCRIPT = `(function() {
           ) {
             vimActionReturn.range = committedMarkRange(id) || vimActionReturn.range;
           }
+        } else if (pendingPinEl) {
+          registerPin(id, pendingPinEl, pendingPinAnchor);
         }
         pendingSelection = null;
         pendingRange = null;
         window.getSelection().removeAllRanges();
       }
+      clearPendingPin();
       restoreVimSemanticTarget();
     }
 
     else if (type === PREFIX + 'find-and-mark') {
-      var found = findTextAndMark(e.data.id, e.data.originalText, e.data.annotationType || 'comment');
+      // Anchor-first restoration: resolve the serialized element anchor and scope
+      // the text search to it; a resolved element whose text drifted still gets a
+      // pin badge. Document-wide text search remains the fallback (and the only
+      // path for anchor-less annotations, e.g. from shared URLs).
+      var restoreType = e.data.annotationType || 'comment';
+      var anchorEl = resolveAnchorElement(e.data.anchor);
+      var found = false;
+      if (anchorEl) {
+        // SVG content never takes an inline <mark> (it would un-render the
+        // text) — an SVG anchor is always a pin.
+        if (!anchorEl.ownerSVGElement && anchorEl.tagName.toLowerCase() !== 'svg') {
+          found = findTextAndMark(e.data.id, e.data.originalText, restoreType, anchorEl);
+        }
+        if (!found) {
+          registerPin(e.data.id, anchorEl, e.data.anchor);
+          found = true;
+        }
+      }
+      if (!found) {
+        found = findTextAndMark(e.data.id, e.data.originalText, restoreType);
+      }
       parent.postMessage({
         type: PREFIX + 'mark-applied',
         id: e.data.id,
@@ -348,17 +446,20 @@ export const BRIDGE_SCRIPT = `(function() {
 
     else if (type === PREFIX + 'remove-mark') {
       removeMark(e.data.id);
+      unregisterPin(e.data.id);
     }
 
     else if (type === PREFIX + 'clear-marks') {
       var marks = document.querySelectorAll('.annotation-highlight[data-bind-id]');
       for (var i = marks.length - 1; i >= 0; i--) unwrapMark(marks[i]);
+      clearAllPins();
     }
 
     else if (type === PREFIX + 'cancel-selection') {
       pendingSelection = null;
       pendingRange = null;
       skipNextClear = false;
+      clearPendingPin();
       window.getSelection().removeAllRanges();
       restoreVimSemanticTarget();
     }
@@ -369,6 +470,14 @@ export const BRIDGE_SCRIPT = `(function() {
         mark.scrollIntoView({ behavior: 'smooth', block: 'center' });
         mark.classList.add('focused');
         setTimeout(function() { mark.classList.remove('focused'); }, 2000);
+      } else {
+        // Pin-only annotation (no inline mark): scroll its element into view and
+        // flash the pinned outline over it.
+        var pin = findPin(e.data.id);
+        if (pin && pin.element && pin.element.isConnected) {
+          pin.element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          flashPinnedBox(pin.element);
+        }
       }
     }
 
@@ -383,9 +492,11 @@ export const BRIDGE_SCRIPT = `(function() {
 
     else if (type === PREFIX + 'set-input-method') {
       currentInputMethod = e.data.method === 'pinpoint' ? 'pinpoint' : 'drag';
-      if (currentInputMethod !== 'pinpoint') {
-        if (pinpointHover) { pinpointHover.classList.remove('plannotator-pinpoint-hover'); pinpointHover = null; }
-        if (pinpointLabelEl) pinpointLabelEl.style.display = 'none';
+      if (currentInputMethod === 'pinpoint') {
+        if (document.body) document.body.setAttribute('data-plannotator-pinpoint-cursor', '');
+      } else {
+        if (document.body) document.body.removeAttribute('data-plannotator-pinpoint-cursor');
+        clearPinpointHover();
       }
       if (vimEnabled) updateVimUi();
     }
@@ -423,10 +534,14 @@ export const BRIDGE_SCRIPT = `(function() {
     }
   });
 
-  // --- Pinpoint: hover to outline a whole element, click to select its text ---
-  // Reuses the normal selection pipeline — a pinpoint click just sets the iframe
-  // selection over the element's text, then runs handleSelection() like a drag.
-  var PINPOINT_SKIP_SELECTOR = 'script,style,noscript,[data-plannotator-vim-ui],.annotation-highlight';
+  // --- Pinpoint: hover to outline a whole element, click to pin it ---
+  // Reuses the normal selection pipeline — a pinpoint click sets the iframe
+  // selection over the element's text, then runs handleSelection() like a drag —
+  // but the hover visual is a dedicated fixed-position outline box (never a
+  // class write on the page's own elements), the click also serializes a CSS
+  // anchor for later restoration, and element-only pins (SVG etc.) get a
+  // numbered badge. Modeled on app-notes-extension + agentation.
+  var PINPOINT_SKIP_SELECTOR = 'script,style,noscript,[data-plannotator-vim-ui],[data-plannotator-pin-badge],.annotation-highlight';
   var SEMANTIC_BLOCK_SELECTOR = 'h1,h2,h3,h4,h5,h6,p,li,pre,blockquote,figcaption,table,button,[data-annotate],svg g';
   var SEMANTIC_GROUP_SELECTOR = 'section,article,aside,nav,header,footer,ul,ol,figure,main';
   var SEMANTIC_INLINE_SELECTOR = 'a,em,strong,b,i,code,small,label,mark,sup,sub,u,abbr,time';
@@ -617,34 +732,336 @@ export const BRIDGE_SCRIPT = `(function() {
     return pointerSemanticGraph;
   }
 
-  document.addEventListener('mousemove', function(e) {
-    if (currentInputMethod !== 'pinpoint') return;
-    if (vimEnabled && vimPhase !== 'inactive') return;
-    var pointerGraph = graphForPointerFrame();
-    var pointerTarget = resolveSemanticTarget(pointerGraph, e.target);
-    var el = pointerTarget && pointerTarget.element;
-    if (el !== pinpointHover) {
-      if (pinpointHover) pinpointHover.classList.remove('plannotator-pinpoint-hover');
-      pinpointHover = el;
-      if (el) el.classList.add('plannotator-pinpoint-hover');
+  // Hover outline box: fixed-position, pointer-events none, sized to the
+  // hovered element's live rect. The page DOM is never touched for hover.
+  var pinpointBoxEl = null;
+  function getPinpointBoxEl() {
+    if (!pinpointBoxEl) {
+      pinpointBoxEl = document.createElement('div');
+      pinpointBoxEl.setAttribute('data-plannotator-pinpoint-box', '');
+      pinpointBoxEl.setAttribute('data-plannotator-vim-ui', '');
     }
-    if (!el) { hidePinpointLabel(); return; }
+    if (!pinpointBoxEl.isConnected) document.body.appendChild(pinpointBoxEl);
+    return pinpointBoxEl;
+  }
+  function positionPinpointBox(el) {
+    var r = el.getBoundingClientRect();
+    var box = getPinpointBoxEl();
+    box.style.display = 'block';
+    box.style.left = r.left + 'px';
+    box.style.top = r.top + 'px';
+    box.style.width = r.width + 'px';
+    box.style.height = r.height + 'px';
+  }
+  function hidePinpointBox() {
+    if (pinpointBoxEl) {
+      pinpointBoxEl.style.display = 'none';
+      pinpointBoxEl.removeAttribute('data-pinned');
+      pinpointBoxEl.classList.remove('pn-pin-enter');
+    }
+  }
+  function clearPinpointHover() {
+    pinpointHover = null;
+    if (!pendingPinEl) hidePinpointBox();
+    hidePinpointLabel();
+  }
+  function positionPinpointLabel(el, labelText) {
     var r = el.getBoundingClientRect();
     var lbl = getPinpointLabelEl();
-    lbl.textContent = PINPOINT_LABELS[el.tagName] || el.tagName.toLowerCase();
+    lbl.textContent = labelText;
     lbl.style.display = 'block';
+    // Flip below the element when the pill would leave the viewport top.
     var top = r.top - 22;
-    lbl.style.top = (top < 2 ? r.top + 2 : top) + 'px';
-    lbl.style.left = Math.max(2, r.left) + 'px';
+    if (top < 2) top = Math.min(r.bottom + 4, window.innerHeight - 24);
+    lbl.style.top = top + 'px';
+    lbl.style.left = Math.max(2, Math.min(r.left, window.innerWidth - 120)) + 'px';
+  }
+
+  // Identity-gated hover update (only restyle when the resolved element
+  // changes); shared by mousemove and the scroll/resize reconcile pass.
+  function updatePinpointHover(node) {
+    var graph = graphForPointerFrame();
+    var target = resolveSemanticTarget(graph, node);
+    var el = target && target.element;
+    if (el !== pinpointHover) {
+      pinpointHover = el;
+      if (el && !pendingPinEl) {
+        var box = getPinpointBoxEl();
+        box.classList.remove('pn-pin-enter');
+        void box.offsetWidth; // restart the enter animation
+        box.classList.add('pn-pin-enter');
+        positionPinpointBox(el);
+      } else if (!pendingPinEl) {
+        hidePinpointBox();
+      }
+    } else if (el && !pendingPinEl) {
+      positionPinpointBox(el); // same element — keep the box glued while scrolling
+    }
+    if (!el || pendingPinEl) { hidePinpointLabel(); return; }
+    positionPinpointLabel(el, target.label || (PINPOINT_LABELS[el.tagName] || el.tagName.toLowerCase()));
+  }
+
+  var lastPointer = null;
+  document.addEventListener('mousemove', function(e) {
+    lastPointer = { x: e.clientX, y: e.clientY };
+    if (currentInputMethod !== 'pinpoint') return;
+    if (vimEnabled && vimPhase !== 'inactive') return;
+    // Hit-test at the pointer instead of trusting e.target so the same code
+    // path serves the scroll re-hit-test below.
+    updatePinpointHover(document.elementFromPoint(e.clientX, e.clientY) || e.target);
   });
 
-  // Pop the toolbar for a whole element: select its text if possible (so a <mark>
-  // can wrap it), else post its text + box directly so the toolbar still anchors
-  // (e.g. an SVG node, whose <text> doesn't select like HTML text).
-  function annotateElement(el, modeOverride) {
+  // rAF-coalesced reconcile: keeps the hover box under a stationary cursor
+  // while the page scrolls, tracks the pinned element, and repositions pin
+  // badges. Capture-phase scroll so inner scroll containers count too.
+  var pinpointReconcileRaf = 0;
+  function schedulePinpointReconcile() {
+    if (pinpointReconcileRaf) return;
+    pinpointReconcileRaf = requestAnimationFrame(function() {
+      pinpointReconcileRaf = 0;
+      renderPinBadges();
+      if (pendingPinEl && pendingPinEl.isConnected) {
+        positionPinpointBox(pendingPinEl);
+        return;
+      }
+      if (currentInputMethod !== 'pinpoint') return;
+      if (vimEnabled && vimPhase !== 'inactive') return;
+      if (lastPointer) {
+        updatePinpointHover(document.elementFromPoint(lastPointer.x, lastPointer.y));
+      }
+    });
+  }
+  window.addEventListener('scroll', schedulePinpointReconcile, { passive: true, capture: true });
+  window.addEventListener('resize', schedulePinpointReconcile, { passive: true });
+
+  // --- Pin badges: numbered markers for element-only annotations ---
+  var pinRegistry = []; // { id, element, anchor, badge }
+  function findPin(id) {
+    for (var i = 0; i < pinRegistry.length; i++) {
+      if (pinRegistry[i].id === id) return pinRegistry[i];
+    }
+    return null;
+  }
+  function registerPin(id, element, anchor) {
+    if (findPin(id)) return;
+    var badge = document.createElement('div');
+    badge.setAttribute('data-plannotator-pin-badge', '');
+    badge.setAttribute('data-plannotator-vim-ui', '');
+    badge.addEventListener('click', function(clickEvent) {
+      clickEvent.preventDefault();
+      clickEvent.stopPropagation();
+      parent.postMessage({ type: PREFIX + 'mark-click', id: id }, '*');
+    });
+    document.body.appendChild(badge);
+    pinRegistry.push({ id: id, element: element, anchor: anchor || null, badge: badge });
+    renderPinBadges();
+  }
+  function unregisterPin(id) {
+    for (var i = pinRegistry.length - 1; i >= 0; i--) {
+      if (pinRegistry[i].id === id) {
+        var badge = pinRegistry[i].badge;
+        if (badge && badge.parentNode) badge.parentNode.removeChild(badge);
+        pinRegistry.splice(i, 1);
+      }
+    }
+    renderPinBadges();
+  }
+  function clearAllPins() {
+    for (var i = 0; i < pinRegistry.length; i++) {
+      var badge = pinRegistry[i].badge;
+      if (badge && badge.parentNode) badge.parentNode.removeChild(badge);
+    }
+    pinRegistry = [];
+  }
+  function renderPinBadges() {
+    for (var i = 0; i < pinRegistry.length; i++) {
+      var pin = pinRegistry[i];
+      if ((!pin.element || !pin.element.isConnected) && pin.anchor) {
+        // The page re-rendered under the pin — re-acquire through the anchor.
+        pin.element = resolveAnchorElement(pin.anchor);
+      }
+      // Number by registry (creation) order, independent of visibility.
+      pin.badge.textContent = String(i + 1);
+      if (!pin.element || !pin.element.isConnected) {
+        pin.badge.style.display = 'none';
+        continue;
+      }
+      var r = pin.element.getBoundingClientRect();
+      // A 0x0 rect means the element isn't rendered (display:none) — but only
+      // in engines that lay out at all (body has size), so headless DOM test
+      // environments where every rect is 0x0 don't hide everything.
+      var zeroSize = !r.width && !r.height
+        && document.body.getBoundingClientRect().width > 0;
+      if (zeroSize || r.bottom < 0 || r.top > window.innerHeight) {
+        pin.badge.style.display = 'none';
+        continue;
+      }
+      pin.badge.style.display = 'flex';
+      pin.badge.style.left = Math.min(r.right, window.innerWidth - 4) + 'px';
+      pin.badge.style.top = Math.max(4, r.top) + 'px';
+    }
+  }
+  function flashPinnedBox(el) {
+    var box = getPinpointBoxEl();
+    box.setAttribute('data-pinned', '');
+    positionPinpointBox(el);
+    setTimeout(function() {
+      if (!pendingPinEl) hidePinpointBox();
+    }, 1200);
+  }
+
+  // --- Element anchors: verified-unique CSS selectors for restoration ---
+  // Semantic ladder (id → identity attribute → meaningful classes), each rung
+  // proved unique with a real query before acceptance; positional
+  // tag > tag:nth-of-type() path as the last resort. Restoration fails closed:
+  // a weak (positional/class) selector must also match the captured text
+  // snapshot, so a shifted list never mis-anchors an annotation.
+  var ANCHOR_IDENTITY_ATTRS = ['data-annotate', 'data-testid', 'data-test', 'aria-label', 'name', 'role', 'href', 'alt'];
+
+  function anchorTextSnapshot(el) {
+    var text = (el.textContent || '').replace(/\\s+/g, ' ').trim();
+    return text.length > 180 ? text.slice(0, 180) : text;
+  }
+
+  function uniquelySelects(selector, el) {
+    try {
+      var matches = document.querySelectorAll(selector);
+      return matches.length === 1 && matches[0] === el;
+    } catch (ex) {
+      return false;
+    }
+  }
+
+  function escapeAttrValue(value) {
+    return '"' + value.replace(/\\\\/g, '\\\\\\\\').replace(/"/g, '\\\\"') + '"';
+  }
+
+  function isLikelyGeneratedClass(name) {
+    if (name.length > 36) return true;
+    if (/^[a-f0-9]{8,}$/i.test(name)) return true;
+    if (/[A-Za-z]+[_-][A-Za-z]*[0-9]{4,}/.test(name)) return true;
+    return false;
+  }
+
+  function semanticSelectorFor(el) {
+    var tag = el.tagName.toLowerCase();
+    var canEscape = typeof CSS !== 'undefined' && CSS.escape;
+    if (el.id && canEscape) {
+      var idSel = '#' + CSS.escape(el.id);
+      if (uniquelySelects(idSel, el)) return idSel;
+    }
+    for (var i = 0; i < ANCHOR_IDENTITY_ATTRS.length; i++) {
+      var name = ANCHOR_IDENTITY_ATTRS[i];
+      var value = el.getAttribute && el.getAttribute(name);
+      if (!value) continue;
+      value = value.trim();
+      if (!value || value.length > 240 || value.indexOf('\\n') >= 0) continue;
+      var attrSel = tag + '[' + name + '=' + escapeAttrValue(value) + ']';
+      if (uniquelySelects(attrSel, el)) return attrSel;
+    }
+    if (canEscape && el.classList && el.classList.length) {
+      var meaningful = [];
+      for (var c = 0; c < el.classList.length && meaningful.length < 2; c++) {
+        var cls = el.classList[c];
+        if (isLikelyGeneratedClass(cls)) continue;
+        meaningful.push('.' + CSS.escape(cls));
+      }
+      if (meaningful.length) {
+        var classSel = tag + meaningful.join('');
+        if (uniquelySelects(classSel, el)) return classSel;
+      }
+    }
+    return null;
+  }
+
+  function buildAnchorSelector(el) {
+    var path = [];
+    var current = el;
+    while (current && current.nodeType === 1 && current !== document.body && current !== document.documentElement) {
+      var semantic = semanticSelectorFor(current);
+      if (semantic) {
+        path.unshift(semantic);
+        return path.join(' > ');
+      }
+      var segment = current.tagName.toLowerCase();
+      var parentEl = current.parentElement;
+      if (parentEl) {
+        var sameTag = [];
+        for (var i = 0; i < parentEl.children.length; i++) {
+          if (parentEl.children[i].tagName === current.tagName) sameTag.push(parentEl.children[i]);
+        }
+        if (sameTag.length > 1) segment += ':nth-of-type(' + (sameTag.indexOf(current) + 1) + ')';
+      }
+      path.unshift(segment);
+      var candidate = path.join(' > ');
+      if (uniquelySelects(candidate, el)) return candidate;
+      current = parentEl;
+    }
+    return path.length ? path.join(' > ') : null;
+  }
+
+  function buildElementAnchor(el) {
+    if (!el || el.nodeType !== 1) return null;
+    var selector = buildAnchorSelector(el);
+    if (!selector) return null;
+    return {
+      selector: selector,
+      tagName: el.tagName.toLowerCase(),
+      text: anchorTextSnapshot(el)
+    };
+  }
+
+  function anchorHasStableIdentity(selector) {
+    var segments = selector.split(' > ');
+    var last = segments[segments.length - 1] || '';
+    return last.indexOf('#') === 0 || last.indexOf('[') >= 0;
+  }
+
+  function resolveAnchorElement(anchor) {
+    if (!anchor || typeof anchor.selector !== 'string' || !anchor.selector || typeof anchor.tagName !== 'string') return null;
+    var matches;
+    try {
+      matches = document.querySelectorAll(anchor.selector);
+    } catch (ex) {
+      return null;
+    }
+    if (matches.length !== 1) return null;
+    var el = matches[0];
+    if (el.tagName.toLowerCase() !== anchor.tagName.toLowerCase()) return null;
+    if (
+      !anchorHasStableIdentity(anchor.selector)
+      && typeof anchor.text === 'string' && anchor.text
+      && anchorTextSnapshot(el) !== anchor.text
+    ) {
+      return null;
+    }
+    return el;
+  }
+
+  function clearPendingPin() {
+    pendingPinEl = null;
+    pendingPinAnchor = null;
+    hidePinpointBox();
+  }
+
+  // Pin an element: select its text if possible (so a <mark> can wrap it), else
+  // post its text + box directly so the toolbar still anchors (e.g. an SVG node,
+  // whose <text> doesn't select like HTML text). Either way the element stays
+  // outlined ("pinned") while the composer is open, and a serialized CSS anchor
+  // rides along so the annotation can restore to this exact element later.
+  function annotateElement(el, modeOverride, viaPinpoint) {
     if (!el) return false;
-    if (pinpointHover) { pinpointHover.classList.remove('plannotator-pinpoint-hover'); pinpointHover = null; }
+    pinpointHover = null;
     hidePinpointLabel();
+    pendingPinEl = el;
+    pendingPinAnchor = buildElementAnchor(el);
+    var extras = { anchor: pendingPinAnchor, pinpoint: !!viaPinpoint };
+    // Pinned outline: stronger accent box that tracks the element until the
+    // composer resolves (create-mark or cancel-selection).
+    var box = getPinpointBoxEl();
+    box.setAttribute('data-pinned', '');
+    box.classList.remove('pn-pin-enter');
+    positionPinpointBox(el);
     // SVG content can't hold an HTML <mark> wrapper — wrapping an SVG <text> in a
     // <mark> un-renders it (the text disappears). So never text-wrap SVG: treat it
     // as a whole-element annotation (post its text + box, no mark). HTML elements
@@ -660,23 +1077,30 @@ export const BRIDGE_SCRIPT = `(function() {
         txt = (sel.toString() || '').trim();
       } catch (ex) {}
     }
-    if (txt) return handleSelection(modeOverride);
+    if (txt) {
+      var posted = handleSelection(modeOverride, extras);
+      if (!posted) clearPendingPin();
+      return posted;
+    }
     var elText = (el.textContent || '').trim();
-    if (!elText) return false;
+    if (!elText) { clearPendingPin(); return false; }
     var r = el.getBoundingClientRect();
     pendingSelection = { element: true };
     pendingRange = null;
     skipNextClear = true; // don't let this click's mouseup clear the toolbar we just opened
     parent.postMessage({ type: PREFIX + 'selection', text: elText,
       modeOverride: modeOverride || undefined,
+      anchor: pendingPinAnchor || undefined,
+      pinpoint: !!viaPinpoint || undefined,
       rect: { top: r.top, left: r.left, width: r.width, height: r.height } }, '*');
     return true;
   }
 
   document.addEventListener('click', function(e) {
     if (currentInputMethod !== 'pinpoint') return;
-    // Existing marks are handled by the mark-click listener.
-    if (e.target && e.target.closest && e.target.closest('.annotation-highlight[data-bind-id]')) return;
+    // Existing marks are handled by the mark-click listener; pin badges own
+    // their clicks.
+    if (e.target && e.target.closest && e.target.closest('.annotation-highlight[data-bind-id],[data-plannotator-pin-badge]')) return;
     var clickGraph = buildSemanticTargetGraph();
     var clickTarget = resolveSemanticTarget(clickGraph, e.target);
     var el = clickTarget && clickTarget.element;
@@ -684,8 +1108,24 @@ export const BRIDGE_SCRIPT = `(function() {
     // Suppress the page's own behavior (links, buttons) — we're annotating.
     e.preventDefault();
     e.stopPropagation();
-    annotateElement(el);
+    annotateElement(el, undefined, true);
   }, true);
+
+  // Escape while pinpointing (outside vim, which has its own ladder): cancel a
+  // pending pin, else just drop the hover outline.
+  document.addEventListener('keydown', function(e) {
+    if (e.key !== 'Escape' || vimEnabled) return;
+    if (pendingSelection) {
+      parent.postMessage({ type: PREFIX + 'selection-clear' }, '*');
+      pendingSelection = null;
+      pendingRange = null;
+      skipNextClear = false;
+      clearPendingPin();
+      window.getSelection().removeAllRanges();
+    } else if (currentInputMethod === 'pinpoint') {
+      clearPinpointHover();
+    }
+  });
 
   // Author opt-in: a plain click on any element tagged [data-annotate] pops the
   // toolbar — no pinpoint mode. Lets an HTML doc (e.g. a flow graph) wire its own
@@ -1014,10 +1454,7 @@ export const BRIDGE_SCRIPT = `(function() {
   }
 
   function setVimPinpointTarget(target) {
-    if (pinpointHover) {
-      pinpointHover.classList.remove('plannotator-pinpoint-hover');
-      pinpointHover = null;
-    }
+    clearPinpointHover();
     if (vimPinpointEl) vimPinpointEl.classList.remove('plannotator-pinpoint-hover');
     vimVisualBlockAnchorEl = null;
     vimPinpointEl = target ? target.element : null;
@@ -1828,10 +2265,7 @@ export const BRIDGE_SCRIPT = `(function() {
   // then continue through their existing handlers.
   document.addEventListener('mousedown', function(e) {
     if (!vimEnabled || isVimEditableTarget(e.target)) return;
-    if (pinpointHover) {
-      pinpointHover.classList.remove('plannotator-pinpoint-hover');
-      pinpointHover = null;
-    }
+    clearPinpointHover();
     if (vimPinpointEl) vimPinpointEl.classList.remove('plannotator-pinpoint-hover');
     vimPinpointEl = null;
     vimVisualBlockAnchorEl = null;
@@ -1931,8 +2365,8 @@ export const BRIDGE_SCRIPT = `(function() {
     }
   }
 
-  function findTextAndMark(id, originalText, annType) {
-    var walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null);
+  function findTextAndMark(id, originalText, annType, root) {
+    var walker = document.createTreeWalker(root || document.body, NodeFilter.SHOW_TEXT, null);
     var buffer = '';
     var nodes = [];
     while (walker.nextNode()) {
@@ -1997,6 +2431,7 @@ export const BRIDGE_SCRIPT = `(function() {
       new ResizeObserver(function() {
         postResize();
         scheduleVimUiUpdate();
+        schedulePinpointReconcile();
       }).observe(document.body);
     }
     parent.postMessage({ type: PREFIX + 'ready' }, '*');

--- a/packages/ui/components/html-viewer/bridge-script.ts
+++ b/packages/ui/components/html-viewer/bridge-script.ts
@@ -315,6 +315,16 @@ export const BRIDGE_SCRIPT = `(function() {
     setTimeout(handleSelection, 10);
   });
 
+  // The page fully controls element text, so everything posted as a selection
+  // is bounded here before it crosses the bridge (the parent enforces the same
+  // cap on its side of the trust boundary). One pinpoint click on a huge
+  // <pre>/<table> must not ship megabytes into drafts, feedback, or share URLs.
+  var MAX_SELECTION_TEXT = 10000;
+
+  function capSelectionText(text) {
+    return text.length > MAX_SELECTION_TEXT ? text.slice(0, MAX_SELECTION_TEXT) : text;
+  }
+
   function handleSelection(modeOverride, extras) {
     var sel = window.getSelection();
     if (!sel || sel.isCollapsed || !sel.rangeCount) {
@@ -330,7 +340,7 @@ export const BRIDGE_SCRIPT = `(function() {
     }
     skipNextClear = false; // a real text selection happened
     var range = sel.getRangeAt(0);
-    var text = sel.toString().trim();
+    var text = capSelectionText(sel.toString().trim());
     if (!text) return false;
 
     var rect = range.getBoundingClientRect();
@@ -423,19 +433,28 @@ export const BRIDGE_SCRIPT = `(function() {
       var restoreType = e.data.annotationType || 'comment';
       var anchorEl = resolveAnchorElement(e.data.anchor);
       var found = false;
-      if (anchorEl) {
+      var isSvgAnchor = anchorEl && (anchorEl.ownerSVGElement || anchorEl.tagName.toLowerCase() === 'svg');
+      if (isSvgAnchor) {
         // SVG content never takes an inline <mark> (it would un-render the
-        // text) — an SVG anchor is always a pin.
-        if (!anchorEl.ownerSVGElement && anchorEl.tagName.toLowerCase() !== 'svg') {
-          found = findTextAndMark(e.data.id, e.data.originalText, restoreType, anchorEl);
-        }
-        if (!found) {
-          registerPin(e.data.id, anchorEl, e.data.anchor);
-          found = true;
-        }
+        // text) — a resolved SVG anchor is always a pin, and the HTML-oriented
+        // text search below could only mis-mark unrelated HTML text.
+        registerPin(e.data.id, anchorEl, e.data.anchor);
+        found = true;
+      }
+      if (!found && anchorEl) {
+        found = findTextAndMark(e.data.id, e.data.originalText, restoreType, anchorEl);
       }
       if (!found) {
+        // Document-wide text search runs BEFORE the pin fallback: if the
+        // annotated text moved elsewhere in a regenerated page, the annotation
+        // follows the text rather than badging the stale container.
         found = findTextAndMark(e.data.id, e.data.originalText, restoreType);
+      }
+      if (!found && anchorEl) {
+        // Element still resolves but its text is gone everywhere: badge the
+        // element itself as the last resort.
+        registerPin(e.data.id, anchorEl, e.data.anchor);
+        found = true;
       }
       parent.postMessage({
         type: PREFIX + 'mark-applied',
@@ -997,7 +1016,11 @@ export const BRIDGE_SCRIPT = `(function() {
       if (uniquelySelects(candidate, el)) return candidate;
       current = parentEl;
     }
-    return path.length ? path.join(' > ') : null;
+    // Reaching here means every candidate — including the full body-rooted
+    // path — failed the uniqueness query. A known-ambiguous selector must not
+    // ship as an anchor: no anchor (text-search restoration) beats one that
+    // can bind to the wrong element after a re-render.
+    return null;
   }
 
   function buildElementAnchor(el) {
@@ -1011,10 +1034,26 @@ export const BRIDGE_SCRIPT = `(function() {
     };
   }
 
-  function anchorHasStableIdentity(selector) {
-    var segments = selector.split(' > ');
-    var last = segments[segments.length - 1] || '';
-    return last.indexOf('#') === 0 || last.indexOf('[') >= 0;
+  // Stable identity: the selector IS the resolved element's own #id or data-*
+  // rung, re-derived from the element itself and compared whole — never parsed
+  // out of the selector string (an attribute value containing ' > ' or '#'
+  // would fool a string parse). Behavioral attributes (role, href, aria-label,
+  // name, alt) identify what an element does, not what it says, so they never
+  // exempt an anchor from the text check: a regenerated page keeps its
+  // role="button" while the button's meaning changes completely.
+  var STABLE_IDENTITY_ATTRS = ['data-annotate', 'data-testid', 'data-test'];
+
+  function anchorHasStableIdentity(selector, el) {
+    var canEscape = typeof CSS !== 'undefined' && CSS.escape;
+    if (el.id && canEscape && selector === '#' + CSS.escape(el.id)) return true;
+    var tag = el.tagName.toLowerCase();
+    for (var i = 0; i < STABLE_IDENTITY_ATTRS.length; i++) {
+      var name = STABLE_IDENTITY_ATTRS[i];
+      var value = el.getAttribute && el.getAttribute(name);
+      if (!value) continue;
+      if (selector === tag + '[' + name + '=' + escapeAttrValue(value.trim()) + ']') return true;
+    }
+    return false;
   }
 
   function resolveAnchorElement(anchor) {
@@ -1028,12 +1067,13 @@ export const BRIDGE_SCRIPT = `(function() {
     if (matches.length !== 1) return null;
     var el = matches[0];
     if (el.tagName.toLowerCase() !== anchor.tagName.toLowerCase()) return null;
-    if (
-      !anchorHasStableIdentity(anchor.selector)
-      && typeof anchor.text === 'string' && anchor.text
-      && anchorTextSnapshot(el) !== anchor.text
-    ) {
-      return null;
+    if (!anchorHasStableIdentity(anchor.selector, el)) {
+      // Weak (positional / class / behavioral-attribute) anchor: the captured
+      // text snapshot must exist and still match, or the anchor is rejected and
+      // restoration falls back to text search. A missing or empty snapshot is a
+      // rejection, not an exemption.
+      if (typeof anchor.text !== 'string' || !anchor.text) return null;
+      if (anchorTextSnapshot(el) !== anchor.text) return null;
     }
     return el;
   }
@@ -1082,7 +1122,7 @@ export const BRIDGE_SCRIPT = `(function() {
       if (!posted) clearPendingPin();
       return posted;
     }
-    var elText = (el.textContent || '').trim();
+    var elText = capSelectionText((el.textContent || '').trim());
     if (!elText) { clearPendingPin(); return false; }
     var r = el.getBoundingClientRect();
     pendingSelection = { element: true };

--- a/packages/ui/components/html-viewer/htmlPinpointProtocol.test.tsx
+++ b/packages/ui/components/html-viewer/htmlPinpointProtocol.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * Bridge-protocol contract for HTML pinpoint mode (DOM-gated).
+ *
+ * The bridge script runs inside a sandboxed iframe rendering arbitrary HTML,
+ * so everything it posts must be validated and size-capped before it reaches
+ * React state or the annotation model. These tests cover the pinpoint
+ * additions: the element-anchor DTO, the pinpoint click-to-pin flow (straight
+ * to the comment composer, skipping the toolbar), and anchor propagation onto
+ * created annotations.
+ */
+import { afterEach, describe, expect, test } from 'bun:test';
+import React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import type { Annotation } from '../../types';
+
+const hasDom = typeof document !== 'undefined';
+const hookModule = hasDom ? await import('./useHtmlAnnotation') : null;
+const htmlViewerModule = hasDom ? await import('./HtmlViewer') : null;
+
+// Unmount every root before clearing the DOM: leaving HtmlViewer instances
+// mounted would keep their window message listeners alive and leak into other
+// test files sharing this process.
+const mountedRoots: Array<{ unmount: () => void }> = [];
+
+afterEach(async () => {
+  if (!hasDom) return;
+  await act(async () => {
+    for (const root of mountedRoots.splice(0)) root.unmount();
+  });
+  document.body.replaceChildren();
+});
+
+describe.if(hasDom)('parseHtmlElementAnchor (validated DTO)', () => {
+  test('accepts a well-formed anchor', () => {
+    expect(hookModule!.parseHtmlElementAnchor({
+      selector: '#hero > p:nth-of-type(2)',
+      tagName: 'p',
+      text: 'Some text',
+    })).toEqual({ selector: '#hero > p:nth-of-type(2)', tagName: 'p', text: 'Some text' });
+  });
+
+  test('accepts an anchor without a text snapshot', () => {
+    expect(hookModule!.parseHtmlElementAnchor({ selector: 'main', tagName: 'main' }))
+      .toEqual({ selector: 'main', tagName: 'main' });
+  });
+
+  test('rejects non-records and missing/empty fields', () => {
+    expect(hookModule!.parseHtmlElementAnchor(null)).toBeNull();
+    expect(hookModule!.parseHtmlElementAnchor('main')).toBeNull();
+    expect(hookModule!.parseHtmlElementAnchor({})).toBeNull();
+    expect(hookModule!.parseHtmlElementAnchor({ selector: '', tagName: 'p' })).toBeNull();
+    expect(hookModule!.parseHtmlElementAnchor({ selector: 'p' })).toBeNull();
+    expect(hookModule!.parseHtmlElementAnchor({ selector: 'p', tagName: 42 })).toBeNull();
+  });
+
+  test('rejects oversized fields (size caps)', () => {
+    expect(hookModule!.parseHtmlElementAnchor({
+      selector: 'x'.repeat(1025),
+      tagName: 'p',
+    })).toBeNull();
+    expect(hookModule!.parseHtmlElementAnchor({
+      selector: 'p',
+      tagName: 'x'.repeat(65),
+    })).toBeNull();
+    expect(hookModule!.parseHtmlElementAnchor({
+      selector: 'p',
+      tagName: 'p',
+      text: 'x'.repeat(401),
+    })).toBeNull();
+  });
+});
+
+describe.if(hasDom)('parseBridgeMessage selection additions', () => {
+  const rect = { top: 10, left: 10, width: 100, height: 20 };
+
+  test('carries a validated anchor and the pinpoint flag', () => {
+    const parsed = hookModule!.parseBridgeMessage({
+      type: 'plannotator-bridge-selection',
+      text: 'Hello',
+      rect,
+      anchor: { selector: 'p.intro', tagName: 'p', text: 'Hello' },
+      pinpoint: true,
+    });
+    expect(parsed).toMatchObject({
+      text: 'Hello',
+      pinpoint: true,
+      anchor: { selector: 'p.intro', tagName: 'p', text: 'Hello' },
+    });
+  });
+
+  test('a malformed anchor is dropped without rejecting the selection', () => {
+    const parsed = hookModule!.parseBridgeMessage({
+      type: 'plannotator-bridge-selection',
+      text: 'Hello',
+      rect,
+      anchor: { selector: 42 },
+      pinpoint: 'yes',
+    });
+    expect(parsed).toMatchObject({ text: 'Hello', pinpoint: false });
+    expect((parsed as { anchor?: unknown }).anchor).toBeUndefined();
+  });
+});
+
+describe.if(hasDom)('pinpoint click-to-pin flow', () => {
+  async function mountViewer(options: {
+    mode: 'selection' | 'redline';
+    onAdd: (ann: Annotation) => void;
+  }) {
+    if (!htmlViewerModule) throw new Error('DOM test environment is not registered');
+    const HtmlViewer = htmlViewerModule.HtmlViewer;
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    mountedRoots.push(root);
+    await act(async () => {
+      root.render(
+        <HtmlViewer
+          rawHtml="<html><body><p>Pinpoint target</p></body></html>"
+          annotations={[]}
+          onAddAnnotation={options.onAdd}
+          onSelectAnnotation={() => {}}
+          selectedAnnotationId={null}
+          mode={options.mode}
+          inputMethod="pinpoint"
+        />,
+      );
+    });
+    const iframe = host.querySelector<HTMLIFrameElement>('iframe');
+    if (!iframe?.contentWindow) throw new Error('HTML iframe missing');
+    const postSelection = async (data: Record<string, unknown>) => {
+      await act(async () => {
+        window.dispatchEvent(new MessageEvent('message', {
+          source: iframe.contentWindow,
+          data,
+        }));
+      });
+    };
+    return { postSelection };
+  }
+
+  const selectionMessage = {
+    type: 'plannotator-bridge-selection',
+    text: 'Pinpoint target',
+    rect: { top: 10, left: 10, width: 120, height: 24 },
+    anchor: { selector: 'p:nth-of-type(1)', tagName: 'p', text: 'Pinpoint target' },
+  };
+
+  test('a pinpoint selection opens the comment composer, not the toolbar', async () => {
+    const { postSelection } = await mountViewer({ mode: 'selection', onAdd: () => {} });
+    await postSelection({ ...selectionMessage, pinpoint: true });
+    expect(document.querySelector('[data-comment-popover]')).not.toBeNull();
+    expect(document.querySelector('.annotation-toolbar')).toBeNull();
+  });
+
+  test('a plain drag selection still opens the markup toolbar', async () => {
+    const { postSelection } = await mountViewer({ mode: 'selection', onAdd: () => {} });
+    await postSelection({ ...selectionMessage, anchor: undefined });
+    expect(document.querySelector('.annotation-toolbar')).not.toBeNull();
+    expect(document.querySelector('[data-comment-popover]')).toBeNull();
+  });
+
+  test('redline pinpoint commits an annotation carrying the element anchor', async () => {
+    const added: Annotation[] = [];
+    const { postSelection } = await mountViewer({
+      mode: 'redline',
+      onAdd: (ann) => added.push(ann),
+    });
+    await postSelection({ ...selectionMessage, pinpoint: true });
+    expect(added.length).toBe(1);
+    expect(added[0]!.originalText).toBe('Pinpoint target');
+    expect(added[0]!.htmlAnchor).toEqual({
+      selector: 'p:nth-of-type(1)',
+      tagName: 'p',
+      text: 'Pinpoint target',
+    });
+  });
+
+  test('a selection with a malformed anchor commits without one', async () => {
+    const added: Annotation[] = [];
+    const { postSelection } = await mountViewer({
+      mode: 'redline',
+      onAdd: (ann) => added.push(ann),
+    });
+    await postSelection({
+      ...selectionMessage,
+      anchor: { selector: 'x'.repeat(2000), tagName: 'p' },
+      pinpoint: true,
+    });
+    expect(added.length).toBe(1);
+    expect(added[0]!.htmlAnchor).toBeUndefined();
+  });
+});

--- a/packages/ui/components/html-viewer/htmlPinpointProtocol.test.tsx
+++ b/packages/ui/components/html-viewer/htmlPinpointProtocol.test.tsx
@@ -100,6 +100,27 @@ describe.if(hasDom)('parseBridgeMessage selection additions', () => {
     expect(parsed).toMatchObject({ text: 'Hello', pinpoint: false });
     expect((parsed as { anchor?: unknown }).anchor).toBeUndefined();
   });
+
+  test('selection text is truncated at the parse boundary, not rejected', () => {
+    // The page controls element text entirely, so one pinpoint click on a huge
+    // <pre> could otherwise ship an unbounded string into React state, drafts,
+    // exported feedback, and share URLs.
+    const cap = hookModule!.MAX_SELECTION_TEXT_LENGTH;
+    const parsed = hookModule!.parseBridgeMessage({
+      type: 'plannotator-bridge-selection',
+      text: 'x'.repeat(cap + 590_000),
+      rect,
+    });
+    expect(parsed).not.toBeNull();
+    expect((parsed as { text: string }).text.length).toBe(cap);
+    // At or under the cap passes through untouched.
+    const exact = hookModule!.parseBridgeMessage({
+      type: 'plannotator-bridge-selection',
+      text: 'y'.repeat(cap),
+      rect,
+    });
+    expect((exact as { text: string }).text).toBe('y'.repeat(cap));
+  });
 });
 
 describe.if(hasDom)('pinpoint click-to-pin flow', () => {

--- a/packages/ui/components/html-viewer/srcdoc.test.ts
+++ b/packages/ui/components/html-viewer/srcdoc.test.ts
@@ -758,6 +758,112 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     });
     document.body.replaceChildren();
   });
+
+  test("pinpoint click posts an anchored selection and never mutates the hovered element", async () => {
+    document.body.innerHTML = [
+      '<div id="hero"><p class="intro">Anchor target text</p><p>Second paragraph</p></div>',
+    ].join("");
+    postBridge({
+      type: "plannotator-bridge-set-vim-mode",
+      enabled: false,
+    });
+    postBridge({
+      type: "plannotator-bridge-set-input-method",
+      method: "pinpoint",
+    });
+    // Mode affordance: crosshair cursor attribute while pinpoint is active.
+    expect(document.body.hasAttribute("data-plannotator-pinpoint-cursor")).toBe(true);
+
+    const target = document.querySelector<HTMLElement>("p.intro");
+    if (!target) throw new Error("target paragraph missing");
+
+    // Hover: the overlay box appears; the page element gains no class/style.
+    target.dispatchEvent(new MouseEvent("mousemove", { bubbles: true, cancelable: true }));
+    const box = document.querySelector<HTMLElement>("[data-plannotator-pinpoint-box]");
+    if (!box) throw new Error("pinpoint hover box missing");
+    expect(box.style.display).toBe("block");
+    expect(target.className).toBe("intro");
+    expect(target.getAttribute("style")).toBeNull();
+
+    // Click-to-pin: posts a selection carrying a validated anchor + pinpoint flag.
+    // Flush selection posts queued by earlier tests before collecting.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const messages: Array<Record<string, unknown>> = [];
+    const collect = (event: MessageEvent) => {
+      const data = bridgeMessageData(event);
+      if (data?.type === "plannotator-bridge-selection") messages.push(data);
+    };
+    window.addEventListener("message", collect);
+    const click = new MouseEvent("click", { bubbles: true, cancelable: true });
+    target.dispatchEvent(click);
+    // postMessage delivery is task-queued — let it flush before collecting.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    window.removeEventListener("message", collect);
+
+    expect(click.defaultPrevented).toBe(true); // page behavior suppressed
+    expect(messages.length).toBe(1);
+    const posted = messages[0]!;
+    expect(posted.pinpoint).toBe(true);
+    expect(posted.text).toBe("Anchor target text");
+    const anchor = posted.anchor as { selector: string; tagName: string; text?: string };
+    expect(anchor.tagName).toBe("p");
+    expect(anchor.text).toBe("Anchor target text");
+    // The serialized selector must uniquely resolve back to the pinned element.
+    const matches = document.querySelectorAll(anchor.selector);
+    expect(matches.length).toBe(1);
+    expect(matches[0]).toBe(target);
+
+    postBridge({ type: "plannotator-bridge-cancel-selection" });
+
+    // Anchor-first restore: find-and-mark scoped to the resolved element.
+    postBridge({
+      type: "plannotator-bridge-find-and-mark",
+      id: "pin-restore",
+      originalText: "Anchor target text",
+      annotationType: "comment",
+      anchor,
+    });
+    const mark = document.querySelector('[data-bind-id="pin-restore"]');
+    expect(mark?.textContent).toBe("Anchor target text");
+    expect(target.contains(mark)).toBe(true);
+    postBridge({ type: "plannotator-bridge-remove-mark", id: "pin-restore" });
+
+    // Text drift under a resolvable anchor: no inline mark, but a numbered pin
+    // badge on the element (still counts as restored).
+    postBridge({
+      type: "plannotator-bridge-find-and-mark",
+      id: "pin-badge",
+      originalText: "Text that no longer exists anywhere",
+      annotationType: "comment",
+      anchor: { selector: anchor.selector, tagName: "p" },
+    });
+    const badge = document.querySelector<HTMLElement>("[data-plannotator-pin-badge]");
+    if (!badge) throw new Error("pin badge missing");
+    expect(badge.textContent).toBe("1");
+    expect(document.querySelector('[data-bind-id="pin-badge"]')).toBeNull();
+
+    // Fail-closed anchors: a weak selector whose text snapshot no longer
+    // matches must not resolve (falls back to document-wide text search).
+    postBridge({
+      type: "plannotator-bridge-find-and-mark",
+      id: "pin-stale",
+      originalText: "Second paragraph",
+      annotationType: "comment",
+      anchor: { selector: anchor.selector, tagName: "p", text: "Stale snapshot" },
+    });
+    const staleMark = document.querySelector('[data-bind-id="pin-stale"]');
+    expect(staleMark?.textContent).toBe("Second paragraph");
+    expect(target.contains(staleMark)).toBe(false);
+
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    expect(document.querySelector("[data-plannotator-pin-badge]")).toBeNull();
+    postBridge({
+      type: "plannotator-bridge-set-input-method",
+      method: "drag",
+    });
+    expect(document.body.hasAttribute("data-plannotator-pinpoint-cursor")).toBe(false);
+    document.body.replaceChildren();
+  });
 });
 
 describe("injectIntoHead", () => {

--- a/packages/ui/components/html-viewer/srcdoc.test.ts
+++ b/packages/ui/components/html-viewer/srcdoc.test.ts
@@ -828,19 +828,35 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     expect(target.contains(mark)).toBe(true);
     postBridge({ type: "plannotator-bridge-remove-mark", id: "pin-restore" });
 
-    // Text drift under a resolvable anchor: no inline mark, but a numbered pin
-    // badge on the element (still counts as restored).
+    // Text drift under a STABLE anchor (#id): the element still identifies
+    // itself, so when the text is gone everywhere it gets a numbered pin badge
+    // (still counts as restored).
     postBridge({
       type: "plannotator-bridge-find-and-mark",
       id: "pin-badge",
       originalText: "Text that no longer exists anywhere",
       annotationType: "comment",
-      anchor: { selector: anchor.selector, tagName: "p" },
+      anchor: { selector: "#hero", tagName: "div" },
     });
     const badge = document.querySelector<HTMLElement>("[data-plannotator-pin-badge]");
     if (!badge) throw new Error("pin badge missing");
     expect(badge.textContent).toBe("1");
     expect(document.querySelector('[data-bind-id="pin-badge"]')).toBeNull();
+
+    // A weak anchor with NO text snapshot is rejected outright (a missing
+    // snapshot is a rejection, not an exemption): restoration falls back to
+    // the document-wide text search instead of trusting the element.
+    postBridge({
+      type: "plannotator-bridge-find-and-mark",
+      id: "pin-no-snapshot",
+      originalText: "Second paragraph",
+      annotationType: "comment",
+      anchor: { selector: anchor.selector, tagName: "p" },
+    });
+    const fallbackMark = document.querySelector('[data-bind-id="pin-no-snapshot"]');
+    expect(fallbackMark?.textContent).toBe("Second paragraph");
+    expect(target.contains(fallbackMark)).toBe(false);
+    postBridge({ type: "plannotator-bridge-remove-mark", id: "pin-no-snapshot" });
 
     // Fail-closed anchors: a weak selector whose text snapshot no longer
     // matches must not resolve (falls back to document-wide text search).
@@ -862,6 +878,47 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       method: "drag",
     });
     expect(document.body.hasAttribute("data-plannotator-pinpoint-cursor")).toBe(false);
+    document.body.replaceChildren();
+  });
+
+  test("behavioral-attribute anchors never bypass the text check", () => {
+    // Regenerated page: the button kept its role but its meaning flipped; the
+    // annotated text moved into a sibling paragraph. The role anchor must NOT
+    // resolve (role names behavior, not content) — the annotation follows the
+    // text via the document-wide search, and no pin lands on the button.
+    document.body.innerHTML = [
+      '<button role="button">Delete everything</button>',
+      "<p>Save draft</p>",
+    ].join("");
+    postBridge({
+      type: "plannotator-bridge-find-and-mark",
+      id: "role-anchor",
+      originalText: "Save draft",
+      annotationType: "comment",
+      anchor: { selector: 'button[role="button"]', tagName: "button", text: "Save draft" },
+    });
+    const mark = document.querySelector('[data-bind-id="role-anchor"]');
+    expect(mark?.textContent).toBe("Save draft");
+    expect(document.querySelector("button")?.contains(mark)).toBe(false);
+    expect(document.querySelector("p")?.contains(mark)).toBe(true);
+    expect(document.querySelector("[data-plannotator-pin-badge]")).toBeNull();
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+
+    // data-* attributes ARE author-controlled identity: a data-testid anchor
+    // whose text drifted still resolves, and with the text gone everywhere the
+    // element gets the pin badge.
+    document.body.innerHTML = '<div data-testid="stats">New numbers</div>';
+    postBridge({
+      type: "plannotator-bridge-find-and-mark",
+      id: "data-anchor",
+      originalText: "Old numbers",
+      annotationType: "comment",
+      anchor: { selector: 'div[data-testid="stats"]', tagName: "div", text: "Old numbers" },
+    });
+    expect(document.querySelector('[data-bind-id="data-anchor"]')).toBeNull();
+    const dataBadge = document.querySelector<HTMLElement>("[data-plannotator-pin-badge]");
+    expect(dataBadge).not.toBeNull();
+    postBridge({ type: "plannotator-bridge-clear-marks" });
     document.body.replaceChildren();
   });
 });

--- a/packages/ui/components/html-viewer/useHtmlAnnotation.ts
+++ b/packages/ui/components/html-viewer/useHtmlAnnotation.ts
@@ -80,6 +80,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 const MAX_ANCHOR_SELECTOR_LENGTH = 1024;
 const MAX_ANCHOR_TAG_LENGTH = 64;
 const MAX_ANCHOR_TEXT_LENGTH = 400;
+// Selection text is page-controlled too (a pinpoint click posts the element's
+// entire textContent), so it gets the same treatment: truncated here — not
+// rejected, a legitimate huge selection still annotates — before it can reach
+// React state, drafts, exported feedback, or a share URL. Mirrors
+// MAX_SELECTION_TEXT in bridge-script.ts; this side is the authoritative one.
+export const MAX_SELECTION_TEXT_LENGTH = 10000;
 
 /** Validate a bridge-posted element anchor. Exported for protocol tests. */
 export function parseHtmlElementAnchor(value: unknown): HtmlElementAnchor | null {
@@ -121,7 +127,9 @@ export function parseBridgeMessage(value: unknown): BridgeMessage | null {
       if (typeof value.text !== "string" || !rect) return null;
       return {
         type: value.type,
-        text: value.text,
+        text: value.text.length > MAX_SELECTION_TEXT_LENGTH
+          ? value.text.slice(0, MAX_SELECTION_TEXT_LENGTH)
+          : value.text,
         rect,
         modeOverride: parseEditorMode(value.modeOverride),
         anchor: parseHtmlElementAnchor(value.anchor) ?? undefined,

--- a/packages/ui/components/html-viewer/useHtmlAnnotation.ts
+++ b/packages/ui/components/html-viewer/useHtmlAnnotation.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef, type RefObject } from "react";
-import { AnnotationType, type Annotation, type EditorMode, type ImageAttachment } from "../../types";
+import { AnnotationType, type Annotation, type EditorMode, type HtmlElementAnchor, type ImageAttachment } from "../../types";
 import type { QuickLabel } from "../../utils/quickLabels";
 import { getIdentity } from "../../utils/identity";
 import type {
@@ -23,6 +23,10 @@ interface BridgeSelectionMessage {
   text: string;
   rect: BridgeRect;
   modeOverride?: EditorMode;
+  /** Serialized element anchor (pinpoint clicks) — validated, size-capped. */
+  anchor?: HtmlElementAnchor;
+  /** True when the selection came from a pinpoint click on an element. */
+  pinpoint?: boolean;
 }
 
 interface BridgeRect {
@@ -70,6 +74,32 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
+// Size caps for the anchor DTO — the bridge script runs inside a sandboxed
+// iframe rendering arbitrary HTML, so everything it posts is validated and
+// bounded before it can reach React state or the annotation model.
+const MAX_ANCHOR_SELECTOR_LENGTH = 1024;
+const MAX_ANCHOR_TAG_LENGTH = 64;
+const MAX_ANCHOR_TEXT_LENGTH = 400;
+
+/** Validate a bridge-posted element anchor. Exported for protocol tests. */
+export function parseHtmlElementAnchor(value: unknown): HtmlElementAnchor | null {
+  if (!isRecord(value)) return null;
+  const { selector, tagName, text } = value;
+  if (
+    typeof selector !== "string"
+    || selector.length === 0
+    || selector.length > MAX_ANCHOR_SELECTOR_LENGTH
+    || typeof tagName !== "string"
+    || tagName.length === 0
+    || tagName.length > MAX_ANCHOR_TAG_LENGTH
+  ) {
+    return null;
+  }
+  if (text === undefined) return { selector, tagName };
+  if (typeof text !== "string" || text.length > MAX_ANCHOR_TEXT_LENGTH) return null;
+  return { selector, tagName, text };
+}
+
 function parseBridgeRect(value: unknown): BridgeRect | null {
   if (!isRecord(value)) return null;
   const { top, left, width, height } = value;
@@ -81,7 +111,8 @@ function parseBridgeRect(value: unknown): BridgeRect | null {
     : null;
 }
 
-function parseBridgeMessage(value: unknown): BridgeMessage | null {
+/** Validate any bridge message. Exported for protocol tests. */
+export function parseBridgeMessage(value: unknown): BridgeMessage | null {
   if (!isRecord(value) || typeof value.type !== "string") return null;
 
   switch (value.type) {
@@ -93,6 +124,8 @@ function parseBridgeMessage(value: unknown): BridgeMessage | null {
         text: value.text,
         rect,
         modeOverride: parseEditorMode(value.modeOverride),
+        anchor: parseHtmlElementAnchor(value.anchor) ?? undefined,
+        pinpoint: value.pinpoint === true,
       };
     }
     case `${PREFIX}selection-clear`:
@@ -141,6 +174,9 @@ export function useHtmlAnnotation({
   const [quickLabelPicker, setQuickLabelPicker] = useState<QuickLabelPickerState | null>(null);
 
   const pendingTextRef = useRef<string>("");
+  // Element anchor for the pending pinpoint selection — committed onto the
+  // annotation so restoration can resolve the exact element again.
+  const pendingAnchorRef = useRef<HtmlElementAnchor | null>(null);
   const enabledRef = useRef(enabled);
   enabledRef.current = enabled;
   const modeRef = useRef(mode);
@@ -208,6 +244,7 @@ export function useHtmlAnnotation({
 
       if (type === `${PREFIX}selection`) {
         pendingTextRef.current = message.text;
+        pendingAnchorRef.current = message.anchor ?? null;
         const anchor = positionAnchor(message.rect);
         if (!anchor) return;
 
@@ -225,9 +262,16 @@ export function useHtmlAnnotation({
             originalText: message.text,
             author: getIdentity(),
             createdA: Date.now(),
+            htmlAnchor: message.anchor,
           });
           pendingTextRef.current = "";
-        } else if (currentMode === "comment") {
+          pendingAnchorRef.current = null;
+        } else if (
+          currentMode === "comment"
+          // Pinpoint click-to-pin: the click already chose the target, so skip
+          // the intermediate toolbar and go straight to the comment composer.
+          || (message.pinpoint && currentMode === "selection")
+        ) {
           // Release iframe focus so the popover's textarea autofocus lands in the
           // parent (otherwise the iframe keeps focus and swallows further keys).
           iframeRef.current?.blur();
@@ -257,6 +301,7 @@ export function useHtmlAnnotation({
         // not drop the annotation on submit. It's overwritten on the next selection.
         if (!commentPopoverRef.current && !quickLabelPickerRef.current) {
           pendingTextRef.current = "";
+          pendingAnchorRef.current = null;
         }
       }
 
@@ -315,6 +360,7 @@ export function useHtmlAnnotation({
     setCommentPopover(null);
     setQuickLabelPicker(null);
     pendingTextRef.current = "";
+    pendingAnchorRef.current = null;
     anchorRef.current?.remove();
     anchorRef.current = null;
     postToIframe(iframeRef.current, { type: `${PREFIX}cancel-selection` });
@@ -351,10 +397,12 @@ export function useHtmlAnnotation({
         originalText: text,
         author: getIdentity(),
         createdA: Date.now(),
+        htmlAnchor: pendingAnchorRef.current ?? undefined,
       });
 
       setToolbarState(null);
       pendingTextRef.current = "";
+      pendingAnchorRef.current = null;
     },
     [iframeRef],
   );
@@ -392,10 +440,12 @@ export function useHtmlAnnotation({
         author: getIdentity(),
         createdA: Date.now(),
         images,
+        htmlAnchor: pendingAnchorRef.current ?? undefined,
       });
 
       setCommentPopover(null);
       pendingTextRef.current = "";
+      pendingAnchorRef.current = null;
     },
     [iframeRef],
   );
@@ -404,12 +454,14 @@ export function useHtmlAnnotation({
     postToIframe(iframeRef.current, { type: `${PREFIX}cancel-selection` });
     setCommentPopover(null);
     pendingTextRef.current = "";
+    pendingAnchorRef.current = null;
   }, [iframeRef]);
 
   const handleToolbarClose = useCallback(() => {
     postToIframe(iframeRef.current, { type: `${PREFIX}cancel-selection` });
     setToolbarState(null);
     pendingTextRef.current = "";
+    pendingAnchorRef.current = null;
   }, [iframeRef]);
 
   const applyQuickLabel = useCallback(
@@ -431,9 +483,11 @@ export function useHtmlAnnotation({
         quickLabelTip: label.tip,
         author: getIdentity(),
         createdA: Date.now(),
+        htmlAnchor: pendingAnchorRef.current ?? undefined,
       });
       clearState();
       pendingTextRef.current = "";
+      pendingAnchorRef.current = null;
     },
     [iframeRef],
   );
@@ -452,6 +506,7 @@ export function useHtmlAnnotation({
     postToIframe(iframeRef.current, { type: `${PREFIX}cancel-selection` });
     setQuickLabelPicker(null);
     pendingTextRef.current = "";
+    pendingAnchorRef.current = null;
   }, [iframeRef]);
 
   const removeHighlight = useCallback(
@@ -475,6 +530,9 @@ export function useHtmlAnnotation({
           id: ann.id,
           originalText: ann.originalText,
           annotationType: annType,
+          // Anchor-first restore: the bridge resolves the serialized element
+          // and scopes the text search to it, falling back to document-wide.
+          anchor: ann.htmlAnchor,
         });
       }
     },

--- a/packages/ui/types.ts
+++ b/packages/ui/types.ts
@@ -79,9 +79,23 @@ export interface Annotation {
     displayMode: boolean;
   }>; // math elements covered by a mixed text+formula selection
   prUrl?: string; // code-review PR mode: the PR this note belongs to, so it isn't shown/exported against another PR after an in-place switch
+  htmlAnchor?: HtmlElementAnchor; // raw-HTML pinpoint: serialized element anchor for reliable restoration
   // web-highlighter metadata for cross-element selections
   startMeta?: AnnotationTextMeta;
   endMeta?: AnnotationTextMeta;
+}
+
+/**
+ * Serialized element anchor for annotations created on the raw-HTML surface
+ * (pinpoint mode). Built inside the sandboxed viewer bridge: a verified-unique
+ * CSS selector plus a fingerprint (tag + normalized text snapshot) used to
+ * fail closed when a weak selector no longer matches the same content.
+ * Additive — annotations without one restore via document-wide text search.
+ */
+export interface HtmlElementAnchor {
+  selector: string;
+  tagName: string;
+  text?: string;
 }
 
 export type AlertKind = 'note' | 'tip' | 'warning' | 'caution' | 'important';

--- a/packages/ui/utils/htmlChrome.test.ts
+++ b/packages/ui/utils/htmlChrome.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Chrome persistence for raw-HTML annotate sessions (DOM-gated).
+ *
+ * Contract under test: the FIRST-EVER HTML session opens minimal (all chrome
+ * hidden, sidebar closed); from then on a session opens with exactly the
+ * chrome state the user last left — showing tools persists across a fresh
+ * mount, and re-hiding them persists too.
+ */
+import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
+import { resetStorageBackend, setStorageBackend, type StorageBackend } from './storage';
+
+const hasDom = typeof document !== 'undefined';
+const htmlChromeModule = hasDom ? await import('./htmlChrome') : null;
+
+// In-memory storage so tests don't depend on happy-dom cookie semantics
+// (the codebase-standard pattern for persistence tests).
+const memory = new Map<string, string>();
+const memoryBackend: StorageBackend = {
+  getItem: (key) => memory.get(key) ?? null,
+  setItem: (key, value) => void memory.set(key, value),
+  removeItem: (key) => void memory.delete(key),
+};
+
+beforeEach(() => {
+  if (!hasDom) return;
+  memory.clear();
+  setStorageBackend(memoryBackend);
+});
+
+afterAll(() => {
+  resetStorageBackend();
+});
+
+describe.if(hasDom)('resolveHtmlChromeState (pure)', () => {
+  test('first run (nothing saved): everything hidden', () => {
+    expect(htmlChromeModule!.resolveHtmlChromeState(null)).toEqual({
+      toolsHidden: true,
+      sidebarOpen: false,
+    });
+  });
+
+  test('malformed cookie values fall back to the minimal default', () => {
+    expect(htmlChromeModule!.resolveHtmlChromeState('not-json')).toEqual({
+      toolsHidden: true,
+      sidebarOpen: false,
+    });
+    expect(htmlChromeModule!.resolveHtmlChromeState('"just-a-string"')).toEqual({
+      toolsHidden: true,
+      sidebarOpen: false,
+    });
+    expect(htmlChromeModule!.resolveHtmlChromeState('{"toolsHidden":"yes"}')).toEqual({
+      toolsHidden: true,
+      sidebarOpen: false,
+    });
+  });
+
+  test('partial state merges over the defaults', () => {
+    expect(htmlChromeModule!.resolveHtmlChromeState('{"toolsHidden":false}')).toEqual({
+      toolsHidden: false,
+      sidebarOpen: false,
+    });
+  });
+});
+
+describe.if(hasDom)('getHtmlChromeState / saveHtmlChromeState (cookie round trip)', () => {
+  test('first run reads the minimal default', () => {
+    expect(htmlChromeModule!.getHtmlChromeState()).toEqual({
+      toolsHidden: true,
+      sidebarOpen: false,
+    });
+  });
+
+  test('a "user showed tools" state persists across a fresh mount', () => {
+    // Session 1: user shows tools and opens the sidebar, then leaves.
+    htmlChromeModule!.saveHtmlChromeState({ toolsHidden: false, sidebarOpen: true });
+    // Session 2 (fresh mount, same cookies): opens exactly as left.
+    expect(htmlChromeModule!.getHtmlChromeState()).toEqual({
+      toolsHidden: false,
+      sidebarOpen: true,
+    });
+  });
+
+  test('a "user re-hid everything" state persists too', () => {
+    htmlChromeModule!.saveHtmlChromeState({ toolsHidden: false, sidebarOpen: true });
+    htmlChromeModule!.saveHtmlChromeState({ toolsHidden: true, sidebarOpen: false });
+    expect(htmlChromeModule!.getHtmlChromeState()).toEqual({
+      toolsHidden: true,
+      sidebarOpen: false,
+    });
+  });
+});

--- a/packages/ui/utils/htmlChrome.ts
+++ b/packages/ui/utils/htmlChrome.ts
@@ -1,0 +1,59 @@
+import { storage } from './storage';
+
+/**
+ * Cross-session chrome visibility for raw-HTML annotate sessions.
+ *
+ * A raw-HTML session should open as close to "just the page" as possible, so
+ * the FIRST-EVER open hides everything the header's "Hide tools" toggle
+ * controls (toolstrip, tongue tabs, floating action cluster) and keeps the
+ * sidebar closed. From then on the session opens with exactly the chrome the
+ * user last left: showing tools persists, re-hiding them persists, and the
+ * sidebar's open state rides along. Persisted as a cookie (like every other
+ * cross-session UI pref — hook servers run on random ports, and cookies are
+ * scoped by domain, not port). Markdown sessions are untouched.
+ */
+
+const STORAGE_KEY = 'plannotator-html-chrome';
+
+export interface HtmlChromeState {
+  /** The header "Hide tools" toggle — true hides all annotation chrome. */
+  toolsHidden: boolean;
+  /** Whether the left sidebar was open when the user last left. */
+  sidebarOpen: boolean;
+}
+
+/** First-run default: minimal paint — everything hidden. */
+export const DEFAULT_HTML_CHROME_STATE: HtmlChromeState = {
+  toolsHidden: true,
+  sidebarOpen: false,
+};
+
+/** Pure resolution logic (exported for tests): raw cookie value → state. */
+export function resolveHtmlChromeState(raw: string | null): HtmlChromeState {
+  if (!raw) return DEFAULT_HTML_CHROME_STATE;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null) {
+      return DEFAULT_HTML_CHROME_STATE;
+    }
+    const record = parsed as Record<string, unknown>;
+    return {
+      toolsHidden: typeof record.toolsHidden === 'boolean'
+        ? record.toolsHidden
+        : DEFAULT_HTML_CHROME_STATE.toolsHidden,
+      sidebarOpen: typeof record.sidebarOpen === 'boolean'
+        ? record.sidebarOpen
+        : DEFAULT_HTML_CHROME_STATE.sidebarOpen,
+    };
+  } catch {
+    return DEFAULT_HTML_CHROME_STATE;
+  }
+}
+
+export function getHtmlChromeState(): HtmlChromeState {
+  return resolveHtmlChromeState(storage.getItem(STORAGE_KEY));
+}
+
+export function saveHtmlChromeState(state: HtmlChromeState): void {
+  storage.setItem(STORAGE_KEY, JSON.stringify(state));
+}

--- a/packages/ui/utils/inputMethod.test.ts
+++ b/packages/ui/utils/inputMethod.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Pinpoint default resolution for the raw-HTML annotate surface (DOM-gated).
+ *
+ * Decision under test: HTML sessions keep a SEPARATE input-method preference
+ * from markdown sessions. First-ever HTML session defaults to Pinpoint even
+ * when a markdown-era "drag" cookie exists; an explicit choice made inside an
+ * HTML session persists for later HTML sessions only.
+ */
+import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
+import { resetStorageBackend, setStorageBackend, type StorageBackend } from './storage';
+
+const hasDom = typeof document !== 'undefined';
+const inputMethodModule = hasDom ? await import('./inputMethod') : null;
+
+// In-memory storage so tests don't depend on happy-dom cookie semantics
+// (the codebase-standard pattern for persistence tests).
+const memory = new Map<string, string>();
+const memoryBackend: StorageBackend = {
+  getItem: (key) => memory.get(key) ?? null,
+  setItem: (key, value) => void memory.set(key, value),
+  removeItem: (key) => void memory.delete(key),
+};
+
+beforeEach(() => {
+  if (!hasDom) return;
+  memory.clear();
+  setStorageBackend(memoryBackend);
+});
+
+afterAll(() => {
+  resetStorageBackend();
+});
+
+describe.if(hasDom)('resolveInputMethod (pure)', () => {
+  test('HTML surface with nothing saved defaults to pinpoint', () => {
+    expect(inputMethodModule!.resolveInputMethod('html', null, null)).toBe('pinpoint');
+  });
+
+  test('markdown surface with nothing saved keeps the drag default', () => {
+    expect(inputMethodModule!.resolveInputMethod('markdown', null, null)).toBe('drag');
+  });
+
+  test('a markdown-era saved preference never suppresses the HTML default', () => {
+    expect(inputMethodModule!.resolveInputMethod('html', 'drag', null)).toBe('pinpoint');
+  });
+
+  test('an explicit HTML-session choice wins over the HTML default', () => {
+    expect(inputMethodModule!.resolveInputMethod('html', null, 'drag')).toBe('drag');
+    expect(inputMethodModule!.resolveInputMethod('html', 'pinpoint', 'drag')).toBe('drag');
+  });
+
+  test('HTML choice never leaks into markdown resolution', () => {
+    expect(inputMethodModule!.resolveInputMethod('markdown', null, 'pinpoint')).toBe('drag');
+    expect(inputMethodModule!.resolveInputMethod('markdown', 'pinpoint', 'drag')).toBe('pinpoint');
+  });
+
+  test('garbage saved values fall back to the surface default', () => {
+    expect(inputMethodModule!.resolveInputMethod('html', 'bogus', 'bogus')).toBe('pinpoint');
+    expect(inputMethodModule!.resolveInputMethod('markdown', 'bogus', 'bogus')).toBe('drag');
+  });
+});
+
+describe.if(hasDom)('getInputMethod / saveInputMethod (cookie round trip)', () => {
+  test('first run: HTML resolves pinpoint, markdown resolves drag', () => {
+    expect(inputMethodModule!.getInputMethod('html')).toBe('pinpoint');
+    expect(inputMethodModule!.getInputMethod('markdown')).toBe('drag');
+    expect(inputMethodModule!.getInputMethod()).toBe('drag');
+  });
+
+  test('saving on the HTML surface persists for HTML only', () => {
+    inputMethodModule!.saveInputMethod('drag', 'html');
+    expect(inputMethodModule!.getInputMethod('html')).toBe('drag');
+    expect(inputMethodModule!.getInputMethod('markdown')).toBe('drag');
+
+    inputMethodModule!.saveInputMethod('pinpoint', 'html');
+    expect(inputMethodModule!.getInputMethod('html')).toBe('pinpoint');
+    expect(inputMethodModule!.getInputMethod('markdown')).toBe('drag');
+  });
+
+  test('saving on the markdown surface leaves the HTML default intact', () => {
+    inputMethodModule!.saveInputMethod('drag', 'markdown');
+    expect(inputMethodModule!.getInputMethod('markdown')).toBe('drag');
+    expect(inputMethodModule!.getInputMethod('html')).toBe('pinpoint');
+  });
+});

--- a/packages/ui/utils/inputMethod.ts
+++ b/packages/ui/utils/inputMethod.ts
@@ -2,16 +2,53 @@ import { storage } from './storage';
 import type { InputMethod } from '../types';
 
 const STORAGE_KEY = 'plannotator-input-method';
+const HTML_STORAGE_KEY = 'plannotator-input-method-html';
 const DEFAULT_METHOD: InputMethod = 'drag';
+/**
+ * Raw-HTML sessions default to Pinpoint: arbitrary pages are element-shaped,
+ * not prose-shaped, so click-an-element is the natural first gesture.
+ */
+const DEFAULT_HTML_METHOD: InputMethod = 'pinpoint';
 
-export function getInputMethod(): InputMethod {
-  const stored = storage.getItem(STORAGE_KEY);
-  if (stored === 'drag' || stored === 'pinpoint') {
-    return stored;
-  }
-  return DEFAULT_METHOD;
+/** Which document surface the input method applies to. */
+export type InputMethodSurface = 'markdown' | 'html';
+
+function parseInputMethod(value: string | null): InputMethod | null {
+  return value === 'drag' || value === 'pinpoint' ? value : null;
 }
 
-export function saveInputMethod(method: InputMethod): void {
-  storage.setItem(STORAGE_KEY, method);
+/**
+ * Pure resolution logic (exported for tests).
+ *
+ * Persistence decision: the two surfaces keep SEPARATE preferences. The legacy
+ * shared key was only ever written from markdown sessions, so honoring it for
+ * HTML would let a markdown-era "drag" choice silently suppress the new HTML
+ * default. HTML sessions therefore read/write their own key: first run
+ * defaults to Pinpoint, and an explicit switch made inside an HTML session
+ * wins on every later HTML session — without touching the markdown default.
+ */
+export function resolveInputMethod(
+  surface: InputMethodSurface,
+  savedShared: string | null,
+  savedHtml: string | null,
+): InputMethod {
+  if (surface === 'html') {
+    return parseInputMethod(savedHtml) ?? DEFAULT_HTML_METHOD;
+  }
+  return parseInputMethod(savedShared) ?? DEFAULT_METHOD;
+}
+
+export function getInputMethod(surface: InputMethodSurface = 'markdown'): InputMethod {
+  return resolveInputMethod(
+    surface,
+    storage.getItem(STORAGE_KEY),
+    storage.getItem(HTML_STORAGE_KEY),
+  );
+}
+
+export function saveInputMethod(
+  method: InputMethod,
+  surface: InputMethodSurface = 'markdown',
+): void {
+  storage.setItem(surface === 'html' ? HTML_STORAGE_KEY : STORAGE_KEY, method);
 }


### PR DESCRIPTION
**TLDR:** Raw-HTML annotate sessions now open as just the page (all chrome hidden on first run, last-used chrome remembered afterwards), default to Pinpoint, and get rebuilt pinpoint mechanics: overlay-based hover highlighting, click-to-pin straight into the comment popover, serialized CSS element anchors for reliable restoration, and numbered pin badges for element-only annotations. UI-only; no server changes. Markdown sessions are untouched.

## What changed

### 1. Pinpoint is the HTML default
- `packages/ui/utils/inputMethod.ts` resolves the input method per surface. HTML sessions read/write their own cookie (`plannotator-input-method-html`) and default to Pinpoint when nothing is saved.
- Decision: the legacy shared key is ignored for HTML. It was only ever written from markdown sessions, so honoring it would let a markdown-era "drag" cookie silently suppress the new HTML default for every existing user. An explicit switch made inside an HTML session persists for HTML sessions only (mirrors the per-origin AI provider pattern).

### 2. Rebuilt pinpoint mechanics (bridge script)
All inside the sandboxed iframe bridge (`packages/ui/components/html-viewer/bridge-script.ts`); only validated, size-capped DTOs cross postMessage.

- Hover is now a dedicated fixed-position outline box + element label. The page's own elements are never touched (the old implementation wrote a class onto author DOM on every hover). Vim navigation keeps its class-based target tint.
- Hit-testing via `elementFromPoint` at the pointer, snapped to the nearest semantic target (Plannotator's existing block/inline/cell graph, so pins land on meaningful elements rather than bare wrappers).
- A rAF-coalesced reconcile pass (capture-phase scroll + resize + ResizeObserver) keeps the hover box glued under a stationary cursor while the page scrolls, tracks the pinned element, and repositions pin badges.
- Click-to-pin: capture-phase click suppresses page behavior, outlines the element in the pinned (accent) style while composing, and goes straight to the existing comment popover, skipping the intermediate toolbar. Crosshair cursor while pinpoint is active; Escape cancels the pending pin or drops the hover.
- Element anchors: each pin serializes a verified-unique CSS selector (semantic ladder: id, then identity attributes like `data-testid`/`aria-label`/`href`, then meaningful classes with generated-class filtering, then a `tag > tag:nth-of-type()` path, every rung proved unique with a real query) plus a tag + normalized text snapshot fingerprint. Restoration is anchor-first and fails closed: a weak positional selector must also match the text snapshot, otherwise it falls back to the existing document-wide text search. Annotations without anchors (older drafts, share links) restore exactly as before.
- Numbered pin badges: element pins that cannot take an inline `<mark>` (SVG nodes, drifted text) previously had no visual at all after commit. They now get a numbered badge anchored to the element box, re-acquired through the anchor after client-side re-renders, clickable to select the annotation.
- Data model: `Annotation.htmlAnchor` added additively (`packages/ui/types.ts`). Exported feedback, drafts (full JSON, carries the field automatically), and share links (compact tuples, restore via text search) keep working.

### 3. Minimal-first render with remembered chrome
- First-ever raw-HTML session opens with everything the "Hide tools" toggle controls hidden, plus the sidebar closed. The header "Show tools" affordance stays visible and Mod+B still opens the sidebar.
- From then on, sessions open with exactly the chrome the user last left (tools visibility + sidebar open state), persisted as a JSON cookie (`plannotator-html-chrome` in `packages/ui/utils/htmlChrome.ts`), following the cookie-persistence pattern from CLAUDE.md. A pre-restore render can never clobber the saved state (writer is gated on the restore having applied).

## What we took from each reference

**app-notes-extension:**
- The hover visual: a fixed-position border box sized to the element's live rect, `pointer-events: none`, never a style/class write on the page. Label pill with flip-below-when-clipped and horizontal clamping.
- Identity-gated hover updates (only restyle when the resolved element changes) and the rAF-coalesced reconcile worker fed by capture-phase scroll + resize that re-hit-tests at the last pointer position, so the outline follows the element under a stationary cursor during scroll.
- The anchor design: verify-as-you-generate selectors (every semantic rung proved unique with a real query before acceptance, `:nth-of-type` only when needed), generated-class filtering, and fail-closed restoration where strictness scales inversely with selector strength (weak selectors must also match the captured text snapshot; a shifted list never mis-anchors).
- Re-acquiring a pinned element through its anchor after the page re-renders under it.

**agentation:**
- The crosshair cursor affordance while pinpoint mode is active, via an attribute-scoped `cursor: crosshair !important` rule.
- The numbered marker badges: small circular badges, creation-order numbering, pop-in animation, hidden (not chased) when their element is offscreen or unrendered.
- Capture-phase click interception with `preventDefault` so links/buttons never fire while annotating, and the pin-first-then-comment flow where the click immediately opens the comment input.
- The hover enter animation (subtle scale + fade) and the `prefers-reduced-motion` opt-out.

Deliberately not copied: agentation's coordinate-only anchors (x% + document-y px, no selector; they cannot survive reflow) and app-notes' deepest-element-always targeting (a bare `<span>` or icon `<svg>` is a poor annotation target; Plannotator's semantic-target snap handles nested elements better for this use case).

## Two-runtime check
UI-only: changes live in `packages/ui` and `packages/editor`. No endpoints added or changed, so nothing to mirror in the Pi server. Both runtimes serve the same rebuilt HTML bundle. No new directories with Tailwind classes (bridge CSS is inline in the srcdoc injection), so no `@source` changes.

## Tests

`DOM_TESTS=1 bun test packages/ui packages/editor`:

```
 908 pass
 0 fail
 2922 expect() calls
Ran 908 tests across 94 files. [19.67s]
```

`bunx tsc --noEmit -p packages/ui/tsconfig.json`: clean, exit 0.

New DOM-gated coverage:
- `packages/ui/utils/inputMethod.test.ts`: pinpoint default resolution (HTML vs markdown vs saved prefs, garbage values, cookie round trips, no cross-surface leakage).
- `packages/ui/utils/htmlChrome.test.ts`: chrome-hidden first-run default, malformed cookie fallback, "user showed tools" and "user re-hid" states persisting across a fresh mount.
- `packages/editor/App.htmlHideTools.test.tsx`: full-App mounts covering the minimal first paint, the Show/Hide toggle, both persistence directions across remounts, and keyboard sidebar reachability while hidden.
- `packages/ui/components/html-viewer/htmlPinpointProtocol.test.tsx`: anchor DTO validation (size caps, malformed rejection), pinpoint selections opening the comment composer while drag selections keep the toolbar, and anchor propagation onto committed annotations.
- `packages/ui/components/html-viewer/srcdoc.test.ts`: bridge-level test against the real evaluated bridge script; a pinpoint click posts an anchored selection without mutating the hovered element, anchor-first find-and-mark, pin badge on text drift, and fail-closed stale anchors.

## Recording

A 17s Playwright headless recording drives the real built annotate UI (`bun run --cwd apps/review build && bun run build:hook`, then `plannotator annotate sample-page.html`) through: minimal first paint (no chrome), pinpoint hover highlighting across elements, click-to-pin, comment save, a second pin, and the Show tools reveal. See the follow-up comment for the video, or the local path in the review handoff.
