### PR TITLE
feat(ui): add Shift+1-4 shortcuts to switch annotation mode

### DIFF
--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -117,6 +117,7 @@ import { modKey } from '@plannotator/ui/utils/platform';
 import {
   annotateSidebarShortcuts,
   useAnnotateSidebarShortcuts,
+  useAnnotationModeShortcuts,
   useDocumentViewShortcuts,
   useDoubleTapShortcuts,
 } from '@plannotator/ui/shortcuts';
@@ -2654,6 +2655,39 @@ const App: React.FC = () => {
   // Alt/Option key: hold to temporarily switch, double-tap to toggle
   useInputMethodSwitch(effectiveInputMethod, handleInputMethodChange);
 
+  // Gates both the toolstrip's own render and its shortcuts, so a mode can never
+  // change with no visible pill to report it.
+  const toolstripVisible = useMemo(
+    () =>
+      !goalSetupMode && !isPlanDiffActive && !archive.archiveMode && !isEditingMarkdown && !htmlChromeHidden
+      && (!isCompactTouchLayout || !(annotateSource === 'folder' && !markdown && !linkedDocHook.isActive)),
+    [
+      annotateSource,
+      archive.archiveMode,
+      goalSetupMode,
+      htmlChromeHidden,
+      isCompactTouchLayout,
+      isEditingMarkdown,
+      isPlanDiffActive,
+      linkedDocHook.isActive,
+      markdown,
+    ],
+  );
+
+  const canHandleAnnotationModeShortcut = useCallback(
+    (event: KeyboardEvent) => toolstripVisible && canHandleDocumentChromeShortcut(event),
+    [canHandleDocumentChromeShortcut, toolstripVisible],
+  );
+
+  useAnnotationModeShortcuts({
+    handlers: {
+      selectMarkupMode: { when: canHandleAnnotationModeShortcut, handle: () => handleEditorModeChange('selection') },
+      selectCommentMode: { when: canHandleAnnotationModeShortcut, handle: () => handleEditorModeChange('comment') },
+      selectRedlineMode: { when: canHandleAnnotationModeShortcut, handle: () => handleEditorModeChange('redline') },
+      selectQuickLabelMode: { when: canHandleAnnotationModeShortcut, handle: () => handleEditorModeChange('quickLabel') },
+    },
+  });
+
   // Check if we're in API mode (served from Bun hook server)
   // Skip if we loaded from a shared URL
   useEffect(() => {
@@ -5083,8 +5117,7 @@ const App: React.FC = () => {
                   comment/markup mode). Hidden during plan diff, and on HTML surfaces
                   when the header's "Hide tools" toggle is on (leaving the rendered HTML
                   free of overlay controls). On HTML it floats top-left over the doc. */}
-              {!goalSetupMode && !isPlanDiffActive && !archive.archiveMode && !isEditingMarkdown && !htmlChromeHidden &&
-                (!isCompactTouchLayout || !(annotateSource === 'folder' && !markdown && !linkedDocHook.isActive)) && (
+              {toolstripVisible && (
                 <div
                   data-print-hide
                   className={isHtmlSurface

--- a/packages/editor/shortcuts.ts
+++ b/packages/editor/shortcuts.ts
@@ -1,4 +1,5 @@
 import {
+  annotationModeShortcuts,
   annotationPanelShortcuts,
   annotationToolbarShortcuts,
   annotateSidebarShortcuts,
@@ -82,6 +83,7 @@ const annotateEditorSettingsShortcuts = defineShortcutScope({
 const sharedPlanSurfaceShortcuts = [
   documentViewShortcuts,
   inputMethodShortcuts,
+  annotationModeShortcuts,
   annotationToolbarShortcuts,
   viewerShortcuts,
   vimSelectionShortcuts,

--- a/packages/ui/components/AnnotationToolstrip.tsx
+++ b/packages/ui/components/AnnotationToolstrip.tsx
@@ -321,6 +321,7 @@ const ToolstripButton: React.FC<{
       onClick={onClick}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
+      aria-pressed={active}
       className={`relative flex items-center h-7 rounded-md overflow-hidden ${colorClass}`}
       style={{ width: currentWidth, transition }}
     >

--- a/packages/ui/components/KeyboardShortcuts.tsx
+++ b/packages/ui/components/KeyboardShortcuts.tsx
@@ -94,6 +94,7 @@ const documentViewShortcuts: ShortcutSection = {
 const annotationShortcuts: ShortcutSection = {
   title: 'Annotations',
   shortcuts: [
+    { keys: [shiftKey, '1-4'], desc: 'Switch annotation mode', hint: '1 Markup, 2 Comment, 3 Redline, 4 Label — matches the toolstrip order' },
     { keys: ['a-z'], desc: 'Start typing comment', hint: 'When the annotation toolbar is open, any letter key opens the comment editor with that character' },
     { keys: [altKey, '1-0'], desc: 'Apply quick label', hint: 'Instantly applies the Nth preset label (0 = 10th). When the label picker is open, bare digits also work.' },
     { keys: [modKey, enter], desc: 'Submit comment' },

--- a/packages/ui/shortcuts.test.ts
+++ b/packages/ui/shortcuts.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test';
 import { annotateSettingsShortcutRegistry, planEditorShortcuts, planReviewSettingsShortcutRegistry } from '../editor/shortcuts';
 import { reviewSettingsShortcutRegistry } from '../review-editor/shortcuts';
 import {
+  annotationModeShortcuts,
   createShortcutRegistry,
   defineShortcutScope,
   dispatchShortcutEvent,
@@ -129,6 +130,40 @@ describe('shortcuts', () => {
         .map(entry => `${entry.scopeId}.${entry.actionId}`);
       expect(claimants).toEqual(['document-view.toggleFocusMode']);
     }
+  });
+
+  // The mode switcher renders on both plan surfaces, so the scope has to reach
+  // both registries — and each digit has to stay a single claimant, since the
+  // dispatcher has no cross-scope arbitration.
+  it('binds annotation mode once on every plan surface', () => {
+    const expected = {
+      selectMarkupMode: ['Shift+1'],
+      selectCommentMode: ['Shift+2'],
+      selectRedlineMode: ['Shift+3'],
+      selectQuickLabelMode: ['Shift+4'],
+    };
+
+    for (const registry of [planReviewSettingsShortcutRegistry, annotateSettingsShortcutRegistry]) {
+      for (const [actionId, bindings] of Object.entries(expected)) {
+        expect(getShortcut(registry, 'annotation-mode', actionId)?.bindings).toEqual(bindings);
+
+        const claimants = listRegistryShortcuts(registry)
+          .filter(entry => entry.bindings.includes(bindings[0]))
+          .map(entry => `${entry.scopeId}.${entry.actionId}`);
+        expect(claimants).toEqual([`annotation-mode.${actionId}`]);
+      }
+    }
+  });
+
+  // The quick-label picker claims bare digits. Holding Shift has to steer the
+  // keystroke to the mode switcher instead of firing both.
+  it('does not fire the bare-digit label picker while Shift is held', () => {
+    const shiftedDigit = {
+      key: '!', code: 'Digit1', ctrlKey: false, metaKey: false, shiftKey: true, altKey: false,
+    } as KeyboardEvent;
+
+    expect(matchesShortcutBinding(shiftedDigit, '1-0')).toBe(false);
+    expect(matchesShortcutBinding(shiftedDigit, 'Shift+1')).toBe(true);
   });
 
   it('matches normalized runtime bindings', () => {
@@ -311,5 +346,52 @@ describe('shortcuts', () => {
 
     expect(handled).toBe(false);
     expect(preventDefaultCalls).toBe(0);
+  });
+
+  it('switches annotation mode on Shift+1-4 across keyboard layouts', () => {
+    const calls: string[] = [];
+    const handlers = {
+      selectMarkupMode: () => calls.push('selection'),
+      selectCommentMode: () => calls.push('comment'),
+      selectRedlineMode: () => calls.push('redline'),
+      selectQuickLabelMode: () => calls.push('quickLabel'),
+    };
+
+    let preventDefaultCalls = 0;
+    const preventDefault = () => {
+      preventDefaultCalls += 1;
+    };
+
+    // Shift+2 reports '@' on a US layout, so matching has to fall back to event.code.
+    const shiftedDigit = {
+      key: '@', code: 'Digit2', ctrlKey: false, metaKey: false, shiftKey: true, altKey: false, preventDefault,
+    } as unknown as KeyboardEvent;
+    expect(dispatchShortcutEvent(annotationModeShortcuts, handlers, shiftedDigit)).toBe(true);
+
+    const plainDigit = {
+      key: '3', code: 'Digit3', ctrlKey: false, metaKey: false, shiftKey: true, altKey: false, preventDefault,
+    } as unknown as KeyboardEvent;
+    expect(dispatchShortcutEvent(annotationModeShortcuts, handlers, plainDigit)).toBe(true);
+
+    expect(calls).toEqual(['comment', 'redline']);
+    expect(preventDefaultCalls).toBe(2);
+  });
+
+  it('leaves annotation mode alone when Alt is held', () => {
+    // AltGr sends Ctrl+Alt; the binding declares no Alt, so it must not fire.
+    const altGrEvent = {
+      key: '1', code: 'Digit1', ctrlKey: false, metaKey: false, shiftKey: true, altKey: true,
+      preventDefault: () => {
+        throw new Error('should not run');
+      },
+    } as unknown as KeyboardEvent;
+
+    const handled = dispatchShortcutEvent(annotationModeShortcuts, {
+      selectMarkupMode: () => {
+        throw new Error('should not run');
+      },
+    }, altGrEvent);
+
+    expect(handled).toBe(false);
   });
 });

--- a/packages/ui/shortcuts/index.ts
+++ b/packages/ui/shortcuts/index.ts
@@ -2,6 +2,7 @@ export * from './core';
 export * from './runtime';
 
 // plan-review scopes
+export { annotationModeShortcuts, useAnnotationModeShortcuts } from './plan-review/annotationMode.shortcuts';
 export { annotationToolbarShortcuts, useAnnotationToolbarShortcuts } from './plan-review/annotationToolbar.shortcuts';
 export { annotationPanelShortcuts, useAnnotationPanelShortcuts } from './plan-review/annotationPanel.shortcuts';
 export { commentPopoverShortcuts } from './plan-review/commentPopover.shortcuts';

--- a/packages/ui/shortcuts/plan-review/annotationMode.shortcuts.ts
+++ b/packages/ui/shortcuts/plan-review/annotationMode.shortcuts.ts
@@ -1,0 +1,47 @@
+import { defineShortcutScope } from '../core';
+import { createShortcutScopeHook } from '../runtime';
+
+// Shift+digit rather than mnemonic letters: bare letters are swallowed by
+// type-to-comment, bare digits by the label picker, Mod+digit by the browser's
+// tab switching, and Mod+Shift+3/4 by macOS screenshots. Follows the toolstrip
+// left to right.
+export const annotationModeShortcuts = defineShortcutScope({
+  id: 'annotation-mode',
+  title: 'Annotation Mode',
+  shortcuts: {
+    selectMarkupMode: {
+      description: 'Markup mode',
+      bindings: ['Shift+1'],
+      section: 'Annotations',
+      hint: 'Selecting text opens the annotation toolbar.',
+      preventDefault: true,
+      displayOrder: 1,
+    },
+    selectCommentMode: {
+      description: 'Comment mode',
+      bindings: ['Shift+2'],
+      section: 'Annotations',
+      hint: 'Selecting text opens the comment editor.',
+      preventDefault: true,
+      displayOrder: 2,
+    },
+    selectRedlineMode: {
+      description: 'Redline mode',
+      bindings: ['Shift+3'],
+      section: 'Annotations',
+      hint: 'Selecting text marks it for deletion.',
+      preventDefault: true,
+      displayOrder: 3,
+    },
+    selectQuickLabelMode: {
+      description: 'Label mode',
+      bindings: ['Shift+4'],
+      section: 'Annotations',
+      hint: 'Selecting text opens the quick label picker.',
+      preventDefault: true,
+      displayOrder: 4,
+    },
+  },
+});
+
+export const useAnnotationModeShortcuts = createShortcutScopeHook(annotationModeShortcuts);


### PR DESCRIPTION
Closes #1242.

Choosing the annotation mode in plan review was mouse-only — the four toolstrip buttons were the only way to move between **Markup**, **Comment**, **Redline** and **Label**. This adds `Shift+1-4`, following the toolstrip left to right.

## Why Shift+digits

`Alt+C` for comment would have been nicer to remember, but nearly every obvious key is already claimed:

| Candidate | Why not |
|---|---|
| bare letters | `annotationToolbar` binds `A-Z` to type-to-comment; vim also binds `c`/`d`/`m`/`t` |
| bare digits | quick-label picker (`1-0`), `Alt+1-0`, ImageAnnotator tools, vim `0` |
| `Mod+<digit>` | browser tab switching, not preventable |
| `Mod+Shift+<digit>` | `Cmd+Shift+3/4/5` are the macOS screenshot shortcuts, captured above the browser |
| `Mod+Shift+C/M/D` | DevTools, Chrome's profile switcher, bookmark-all-tabs |
| `Alt+<letter>` | `useInputMethodSwitch` flips Select↔Pinpoint on any `Alt` keydown, so every chord flickers the input method and writes storage twice |

`Shift+1-4` is free of OS and browser reservations on macOS, Windows and Linux, and can't double-fire with the bare-digit label picker: that binding declares no `Shift`, and the engine's `shiftMatches` (`core.ts:402`) rejects it once `shiftKey` is set.

That `Alt` behaviour looks like a pre-existing bug (`Alt+1-0` quick labels trigger the same flicker today), but it's independent of this change, so I've left it alone rather than widen the diff. Happy to open it separately if it's worth fixing.

## Implementation notes

- New scope `annotationMode.shortcuts.ts` under `plan-review/`, registered in `sharedPlanSurfaceShortcuts` so both the plan-review and annotate surfaces get it. Uses the existing `Annotations` section, so the docs page and section ordering are unchanged.
- No engine change needed: `getShortcutDigit` already falls back to `event.code`, so `Shift+2` matching token `2` works even though the layout reports `@`.
- Handlers write through the existing `handleEditorModeChange`, so the mode persists and every consumer re-renders from one call.
- The handlers share `canHandleDocumentChromeShortcut` and additionally gate on `toolstripVisible` — the five-condition check that decides whether the toolstrip renders, extracted into one memo now driving both the JSX and the guard. Without it the mode would change silently during plan diff, archive, markdown editing, goal setup, or with the HTML tools hidden, with no pill to report it. Suppression rather than a toast: in those states the mode is inapplicable anyway.
- `Alt` is excluded by the engine's own modifier matching (`requiresAlt === event.altKey`), so AltGr layouts can't fire these.
- Added the entry to `KeyboardShortcuts.tsx` by hand, since that panel isn't registry-driven.
- Added `aria-pressed` to the toolstrip buttons, so a keyboard-driven mode change is announced. Not `aria-label` — the labels collapse by `opacity`, not `display`, so they were already carrying the accessible name.

## Known limitation

In **HTML document mode** the content runs in a sandboxed iframe, and the bridge only forwards vim keys and one printable char — so these shortcuts don't fire while focus is inside the rendered document. Fixing it means a new bridge message plus plumbing through `useHtmlAnnotation` → `HtmlViewer` → `App`, which felt like it belonged in its own PR rather than doubling this one. Glad to follow up if you'd like it.

## Testing

`bun run typecheck` clean; `bun test` 3638 pass / 585 skip / 0 fail. Four tests in `packages/ui/shortcuts.test.ts` cover dispatch, the `event.code` fallback, inertness while `Alt` is held, the binds-once-on-every-plan-surface invariant, and that the bare-digit picker stays inert while `Shift` is held.

Verified by hand in `bun run dev:hook`: the active pill tracks each shortcut, each mode changes what a selection does, the mode survives a reload, and the shortcuts stay inert while typing in a comment.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
