### PR TITLE
fix(ci): bump Bun build pin to 1.3.14 for sandbox env loading (#1249)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: 1.3.11
+          bun-version: 1.3.14
 
       - name: Install dependencies
         run: bun install
@@ -61,7 +61,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: 1.3.11
+          bun-version: 1.3.14
 
       - name: Install dependencies
         run: bun install
@@ -139,6 +139,12 @@ jobs:
             binary: plannotator-linux-x64
           - os: windows-latest
             binary: plannotator-win32-x64.exe
+          # macOS leg exists so a Bun cross-compile signing regression (the
+          # 1.3.12 linker-signature loss, #541: binaries SIGKILLed on launch)
+          # can never ship silently again. Executing the binary at all is the
+          # assertion; the env smoke below rides along.
+          - os: macos-latest
+            binary: plannotator-darwin-arm64
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -287,6 +293,23 @@ jobs:
 
           # 4. terminal: exercises managed WebTUI runtime + compiled sidecar import.
           smoke_test_agent_terminal
+
+          # 5. #1249 regression: env vars must load even when a cwd ancestor
+          # is unreadable (the OS-sandbox case: the project dir is granted but
+          # an ancestor is not). Bun <= 1.3.11 loaded an EMPTY process.env
+          # there, silently ignoring every PLANNOTATOR_* variable. The server
+          # responding on the fixed PLANNOTATOR_PORT proves the variable was
+          # actually read from inside the guarded cwd.
+          guard_root="$(mktemp -d)"
+          mkdir -p "$guard_root/parent/child"
+          printf '# env smoke\n' > "$guard_root/parent/child/doc.md"
+          chmod 311 "$guard_root/parent"
+          (
+            cd "$guard_root/parent/child"
+            smoke_test_server "annotate under unreadable ancestor" 19503 "/api/plan" \
+              "$GITHUB_WORKSPACE/$BINARY" annotate doc.md
+          )
+          chmod 755 "$guard_root/parent"
 
       - name: Smoke-test binary
         if: runner.os == 'Windows'
@@ -650,7 +673,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: 1.3.11
+          bun-version: 1.3.14
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -912,7 +935,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: 1.3.11
+          bun-version: 1.3.14
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:


### PR DESCRIPTION
**TLDR:** Fixes #1249: binaries built with Bun 1.3.11 load an empty process.env under an unreadable cwd ancestor (the OS-sandbox case), silently ignoring every PLANNOTATOR_* variable. Pin bumped to 1.3.14 after verifying the signing regression that motivated the 1.3.11 pin is gone; release smoke gains a macOS leg and an unreadable-ancestor env check so neither regression class can ship silently again.

*AI-assisted (verification and fix).*

Verification performed locally:
- Env fix: a Bun 1.3.14 build sees PLANNOTATOR_* under a chmod-311 ancestor (the invalid-port warning fires, which requires reading the variable). The reporter's repro shows 1.3.11 builds do not.
- Signing (the reason for the old pin, #541): a 1.3.14 cross-compiled darwin-arm64 binary carries the identical linker-signed CodeDirectory structure as the shipped known-good v0.26.5 binary and executes cleanly on macOS 26.3. The codesign --verify "invalid signature" result is expected on ALL working Bun binaries (the appended JS bundle is outside the signed pages) and is not the SIGKILL discriminator.

Ships as v0.26.6 immediately after merge.