### PR TITLE
feat(annotate): hit-test pinpoint targeting for raw-HTML sessions

### DIFF
--- a/packages/ui/components/html-viewer/bridge-script.ts
+++ b/packages/ui/components/html-viewer/bridge-script.ts
@@ -909,7 +909,7 @@ export const BRIDGE_SCRIPT = `(function() {
     var role = el.getAttribute && el.getAttribute('role');
     if (role && role.trim()) return truncateLabel(role.trim());
     var tokens = meaningfulClassTokens(el);
-    if (tokens.length) return tokens.join(' ');
+    if (tokens.length) return truncateLabel(tokens.join(' '));
     var text = (el.textContent || '').replace(/\\s+/g, ' ').trim();
     if (text && text.length <= MAX_HOVER_LABEL) return text;
     return 'container';
@@ -1015,6 +1015,10 @@ export const BRIDGE_SCRIPT = `(function() {
     if (pinpointReconcileRaf) return;
     pinpointReconcileRaf = requestAnimationFrame(function() {
       pinpointReconcileRaf = 0;
+      // Same point, possibly a different element after a scroll, resize, or
+      // layout-changing mutation (the body ResizeObserver also lands here) —
+      // the last-position cache must never answer the next probe.
+      invalidatePointerHitCache();
       renderPinBadges();
       if (pendingPinEl && pendingPinEl.isConnected) {
         positionPinpointBox(pendingPinEl);
@@ -1023,9 +1027,6 @@ export const BRIDGE_SCRIPT = `(function() {
       if (currentInputMethod !== 'pinpoint') return;
       if (vimEnabled && vimPhase !== 'inactive') return;
       if (lastPointer) {
-        // Same point, possibly a different element after the scroll — the
-        // last-position cache must not answer this probe.
-        invalidatePointerHitCache();
         updatePinpointHover(lastPointer.x, lastPointer.y, pinpointHover);
       }
     });
@@ -1125,27 +1126,6 @@ export const BRIDGE_SCRIPT = `(function() {
     return text.length > 180 ? text.slice(0, 180) : text;
   }
 
-  // Text-less elements (icon buttons, decorative chips) have no snapshot to
-  // verify against, so their weak anchors carry a shape signature instead:
-  // tagName + sorted class list + child count + 16px-bucketed width/height,
-  // stored in the anchor's text field behind a distinguishing prefix and
-  // compared whole-string on restore — the same fail-closed rule as text.
-  var ANCHOR_SHAPE_PREFIX = '[[pn-shape]]';
-
-  function anchorShapeSignature(el) {
-    var classes = [];
-    if (el.classList) {
-      for (var i = 0; i < el.classList.length; i++) classes.push(el.classList[i]);
-    }
-    classes.sort();
-    var r = el.getBoundingClientRect();
-    return ANCHOR_SHAPE_PREFIX
-      + el.tagName.toLowerCase()
-      + '|' + classes.join('.')
-      + '|' + (el.children ? el.children.length : 0)
-      + '|' + Math.round(r.width / 16) + 'x' + Math.round(r.height / 16);
-  }
-
   function uniquelySelects(selector, el) {
     try {
       var matches = document.querySelectorAll(selector);
@@ -1243,9 +1223,14 @@ export const BRIDGE_SCRIPT = `(function() {
     var selector = buildAnchorSelector(el);
     if (!selector) return null;
     var snapshot = anchorTextSnapshot(el);
-    // No text to snapshot: store the shape signature so a weak anchor for an
-    // icon button is verifiable instead of automatically dead.
-    if (!snapshot) snapshot = anchorShapeSignature(el);
+    // Text-less elements anchor ONLY through a stable-identity rung (#id or
+    // an author-controlled data-* identity attribute). A weak (positional /
+    // class) selector has nothing to verify against — identical siblings
+    // share every structural trait, so any derived signature would validate
+    // the WRONG element after a sibling is inserted or removed. A
+    // wrong-binding anchor is worse than no anchor: ship none and fail
+    // closed (the pin simply doesn't restore).
+    if (!snapshot && !anchorHasStableIdentity(selector, el)) return null;
     return {
       selector: selector,
       tagName: el.tagName.toLowerCase(),
@@ -1288,15 +1273,11 @@ export const BRIDGE_SCRIPT = `(function() {
     if (el.tagName.toLowerCase() !== anchor.tagName.toLowerCase()) return null;
     if (!anchorHasStableIdentity(anchor.selector, el)) {
       // Weak (positional / class / behavioral-attribute) anchor: the captured
-      // snapshot must exist and still match, or the anchor is rejected and
+      // text snapshot must exist and still match, or the anchor is rejected and
       // restoration falls back to text search. A missing or empty snapshot is a
-      // rejection, not an exemption. Shape-signature snapshots (text-less
-      // elements) verify the same fail-closed way: whole-string comparison
-      // against the candidate's re-derived signature.
+      // rejection, not an exemption.
       if (typeof anchor.text !== 'string' || !anchor.text) return null;
-      if (anchor.text.indexOf(ANCHOR_SHAPE_PREFIX) === 0) {
-        if (anchorShapeSignature(el) !== anchor.text) return null;
-      } else if (anchorTextSnapshot(el) !== anchor.text) return null;
+      if (anchorTextSnapshot(el) !== anchor.text) return null;
     }
     return el;
   }
@@ -1347,9 +1328,8 @@ export const BRIDGE_SCRIPT = `(function() {
     }
     var elText = capSelectionText((el.textContent || '').trim());
     // Text-less elements (icon buttons, decorative chips, empty containers)
-    // are still annotatable: describe the element instead of quoting it. The
-    // shape-signature anchor keeps restoration verifiable.
-    if (!elText) elText = '[element: ' + pinpointHoverLabel(el) + ']';
+    // are still annotatable: describe the element instead of quoting it.
+    if (!elText) elText = capSelectionText('[element: ' + pinpointHoverLabel(el) + ']');
     var r = el.getBoundingClientRect();
     pendingSelection = { element: true };
     pendingRange = null;
@@ -1364,9 +1344,12 @@ export const BRIDGE_SCRIPT = `(function() {
 
   document.addEventListener('click', function(e) {
     if (currentInputMethod !== 'pinpoint') return;
-    // Existing marks are handled by the mark-click listener; pin badges own
-    // their clicks.
-    if (e.target && e.target.closest && e.target.closest('.annotation-highlight[data-bind-id],[data-plannotator-pin-badge]')) return;
+    // Existing marks are handled by the mark-click listener.
+    if (e.target && e.target.closest && e.target.closest('.annotation-highlight[data-bind-id]')) return;
+    // Real pin badges (and any other viewer overlay) own their clicks —
+    // checked by IDENTITY, not selector, so a page element spoofing
+    // [data-plannotator-pin-badge] stays an ordinary annotatable target.
+    if (isViewerOverlayNode(e.target)) return;
     // Click what the hover box shows: the currently hovered element is the
     // target the user aimed at. Fall back to a fresh hit-test at the click
     // point (e.g. a click with no preceding mousemove).

--- a/packages/ui/components/html-viewer/bridge-script.ts
+++ b/packages/ui/components/html-viewer/bridge-script.ts
@@ -922,8 +922,8 @@ export const BRIDGE_SCRIPT = `(function() {
       pinpointLabelEl.setAttribute('data-plannotator-pinpoint-label', '');
       pinpointLabelEl.style.cssText = 'position:fixed;z-index:2147483647;pointer-events:none;display:none;font:600 11px/1.3 system-ui,-apple-system,sans-serif;padding:2px 7px;border-radius:5px;background:var(--pn-focus-highlight,#4493f8);color:#fff;white-space:nowrap;box-shadow:0 1px 5px rgba(0,0,0,.35);';
       overlayNodes.add(pinpointLabelEl);
-      document.body.appendChild(pinpointLabelEl);
     }
+    if (!pinpointLabelEl.isConnected) document.body.appendChild(pinpointLabelEl);
     return pinpointLabelEl;
   }
   function hidePinpointLabel() { if (pinpointLabelEl) pinpointLabelEl.style.display = 'none'; }

--- a/packages/ui/components/html-viewer/bridge-script.ts
+++ b/packages/ui/components/html-viewer/bridge-script.ts
@@ -573,14 +573,139 @@ export const BRIDGE_SCRIPT = `(function() {
     }
   });
 
-  // --- Pinpoint: hover to outline a whole element, click to pin it ---
-  // Reuses the normal selection pipeline — a pinpoint click sets the iframe
-  // selection over the element's text, then runs handleSelection() like a drag —
-  // but the hover visual is a dedicated fixed-position outline box (never a
-  // class write on the page's own elements), the click also serializes a CSS
-  // anchor for later restoration, and element-only pins (SVG etc.) get a
-  // numbered badge. Modeled on app-notes-extension + agentation.
+  // --- Pinpoint: hover to outline the element under the cursor, click to pin ---
+  // Hover is pure per-event hit-testing: deep elementFromPoint (piercing open
+  // shadow roots) picks the REAL element under the pointer — no tag whitelist,
+  // no has-text requirement — so styled div/span prototypes (chips, icon
+  // buttons, cards) are individually targetable. Scope control is mouse-only
+  // and geometric, matching the markdown pinpoint feel: the deepest element
+  // directly under the pointer wins, and pointing at a container's padding or
+  // any area not covered by a child selects the container. Elements under
+  // 16px on both axes promote to the nearest ancestor at least 16px on one
+  // axis (agentation's MIN_CAPTURE_SIZE pattern). The click reuses the normal
+  // selection pipeline — select the element's text and run handleSelection()
+  // like a drag — the hover visual is a dedicated fixed-position outline box
+  // (never a class write on the page's own elements), the click serializes a
+  // CSS anchor for later restoration, and element-only pins (SVG, icon
+  // buttons) get a numbered badge. The semantic target graph below survives
+  // as the vim-navigation vocabulary only; the pointer path never builds it.
   var PINPOINT_SKIP_SELECTOR = 'script,style,noscript,[data-plannotator-vim-ui],[data-plannotator-pin-badge],.annotation-highlight';
+
+  // Identity set of every overlay node the viewer creates inside the page
+  // (pin badges, pinpoint box/label, vim UI). Hit-testing excludes overlay
+  // nodes by IDENTITY, never by selector match, so page markup carrying our
+  // attribute names cannot spoof its way out of (or into) targeting.
+  var overlayNodes = new Set();
+
+  // Floor for hover targets (not a whitelist): a decorative dot or hairline
+  // under 16px on BOTH axes promotes to the nearest ancestor that is at least
+  // 16px on one axis, so tiny leaves stay clickable without precision-mousing.
+  var MIN_CAPTURE_SIZE = 16;
+
+  // Headless DOM test environments lay nothing out (every rect is 0x0); size
+  // rules only apply when the body actually has a laid-out box.
+  function layoutActive() {
+    return !!document.body && document.body.getBoundingClientRect().width > 0;
+  }
+
+  function deepElementFromPoint(x, y) {
+    var el = typeof document.elementFromPoint === 'function'
+      ? document.elementFromPoint(x, y)
+      : null;
+    var guard = 0;
+    while (
+      el
+      && el.shadowRoot
+      && typeof el.shadowRoot.elementFromPoint === 'function'
+      && guard++ < 24
+    ) {
+      var inner = el.shadowRoot.elementFromPoint(x, y);
+      if (!inner || inner === el) break;
+      el = inner;
+    }
+    return el;
+  }
+
+  function isViewerOverlayNode(node) {
+    var current = node;
+    var guard = 0;
+    while (current && guard++ < 200) {
+      if (overlayNodes.has(current)) return true;
+      current = current.parentElement
+        || (current.getRootNode && current.getRootNode().host)
+        || null;
+    }
+    return false;
+  }
+
+  function promoteTinyTarget(el) {
+    if (!layoutActive()) return el;
+    var r = el.getBoundingClientRect();
+    if (r.width >= MIN_CAPTURE_SIZE || r.height >= MIN_CAPTURE_SIZE) return el;
+    var current = el.parentElement;
+    while (current && current !== document.body && current !== document.documentElement) {
+      var cr = current.getBoundingClientRect();
+      if (cr.width >= MIN_CAPTURE_SIZE || cr.height >= MIN_CAPTURE_SIZE) return current;
+      current = current.parentElement;
+    }
+    return el;
+  }
+
+  // Resolve the pinpoint target at a viewport point. The deepest rendered
+  // element under the pointer wins; containers are selected by pointing at
+  // their uncovered area (padding, gaps), exactly like the markdown surface.
+  // fallbackNode covers engines without a real elementFromPoint (headless DOM
+  // tests) and the scroll reconcile, which re-resolves under a still cursor.
+  function resolvePinpointTargetAt(x, y, fallbackNode) {
+    var node = deepElementFromPoint(x, y);
+    if (!node || node === document.documentElement || node === document.body) {
+      node = fallbackNode || null;
+    }
+    while (node && node.nodeType === 3) node = node.parentNode;
+    if (!node || node.nodeType !== 1) return null;
+    if (node === document.documentElement || node === document.body) return null;
+    if (isViewerOverlayNode(node)) return null;
+    if (node.closest && node.closest('script,style,noscript')) return null;
+    // Annotation marks are viewer chrome wrapped around author text: treat
+    // them as transparent so hover names the author element beneath.
+    var mark = node.closest && node.closest('.annotation-highlight');
+    if (mark && mark.parentElement) node = mark.parentElement;
+    // SVG shape primitives promote to their nearest group: a <g> is the
+    // authored unit of an SVG diagram, and its <path> fragments are not
+    // individually meaningful annotation targets.
+    if (node.ownerSVGElement && node.closest) {
+      var svgGroup = node.closest('g');
+      if (svgGroup) node = svgGroup;
+    }
+    node = promoteTinyTarget(node);
+    if (node === document.body || node === document.documentElement) return null;
+    return node;
+  }
+
+  // Last-position reuse: a pointer that moved under 2px within 16ms resolves
+  // to the cached element instead of re-hit-testing. The scroll reconcile
+  // invalidates this cache — same point, different element after a scroll.
+  var lastPointerHit = null;
+  function pinpointLeafAt(x, y, fallbackNode) {
+    var now = typeof performance !== 'undefined' && performance.now
+      ? performance.now()
+      : Date.now();
+    if (
+      lastPointerHit
+      && Math.abs(x - lastPointerHit.x) <= 2
+      && Math.abs(y - lastPointerHit.y) <= 2
+      && now - lastPointerHit.t <= 16
+      && (!lastPointerHit.el || lastPointerHit.el.isConnected)
+    ) {
+      return lastPointerHit.el;
+    }
+    var el = resolvePinpointTargetAt(x, y, fallbackNode);
+    lastPointerHit = { x: x, y: y, t: now, el: el };
+    return el;
+  }
+  function invalidatePointerHitCache() {
+    lastPointerHit = null;
+  }
   var SEMANTIC_BLOCK_SELECTOR = 'h1,h2,h3,h4,h5,h6,p,li,pre,blockquote,figcaption,table,button,[data-annotate],svg g';
   var SEMANTIC_GROUP_SELECTOR = 'section,article,aside,nav,header,footer,ul,ol,figure,main';
   var SEMANTIC_INLINE_SELECTOR = 'a,em,strong,b,i,code,small,label,mark,sup,sub,u,abbr,time';
@@ -746,30 +871,62 @@ export const BRIDGE_SCRIPT = `(function() {
 
   // Floating label naming the element under the cursor (like the markdown overlay).
   var PINPOINT_LABELS = { H1:'Heading', H2:'Heading', H3:'Heading', H4:'Heading', H5:'Heading', H6:'Heading', P:'Paragraph', UL:'List', OL:'List', LI:'List item', A:'Link', BUTTON:'Button', IMG:'Image', TABLE:'Table', THEAD:'Table', TBODY:'Table', TR:'Row', TD:'Cell', TH:'Header cell', SECTION:'Section', NAV:'Navigation', HEADER:'Header', FOOTER:'Footer', ARTICLE:'Article', ASIDE:'Sidebar', BLOCKQUOTE:'Quote', PRE:'Code', CODE:'Code', FIGURE:'Figure', FIGCAPTION:'Caption', MAIN:'Main', FORM:'Form', INPUT:'Input', LABEL:'Label' };
+
+  var MAX_HOVER_LABEL = 40;
+  function truncateLabel(text) {
+    return text.length > MAX_HOVER_LABEL ? text.slice(0, MAX_HOVER_LABEL) : text;
+  }
+
+  // First 1-2 meaningful class tokens: split on whitespace/underscore/hyphen,
+  // drop tokens of 2 chars or fewer and CSS-module-hash-looking tokens, so a
+  // div.rowchip labels "rowchip" and styles_Card_ab12f labels "Card".
+  function meaningfulClassTokens(el) {
+    var out = [];
+    if (!el.classList || !el.classList.length) return out;
+    for (var i = 0; i < el.classList.length && out.length < 2; i++) {
+      var cls = el.classList[i];
+      if (isLikelyGeneratedClass(cls)) continue;
+      var parts = String(cls).split(/[\\s_-]+/);
+      for (var j = 0; j < parts.length && out.length < 2; j++) {
+        var token = parts[j];
+        if (token.length <= 2) continue;
+        if (/^[a-fA-F0-9]+$/.test(token) && token.length >= 5) continue;
+        if (/[0-9]{4,}/.test(token)) continue;
+        out.push(token);
+      }
+    }
+    return out;
+  }
+
+  // Label cascade for generic containers (div/span/custom elements):
+  // aria-label -> role -> meaningful class tokens -> own short text ->
+  // "container". Known semantic tags keep their human names above.
+  function pinpointHoverLabel(el) {
+    var known = PINPOINT_LABELS[el.tagName];
+    if (known) return known;
+    var aria = el.getAttribute && el.getAttribute('aria-label');
+    if (aria && aria.trim()) return truncateLabel(aria.trim());
+    var role = el.getAttribute && el.getAttribute('role');
+    if (role && role.trim()) return truncateLabel(role.trim());
+    var tokens = meaningfulClassTokens(el);
+    if (tokens.length) return tokens.join(' ');
+    var text = (el.textContent || '').replace(/\\s+/g, ' ').trim();
+    if (text && text.length <= MAX_HOVER_LABEL) return text;
+    return 'container';
+  }
+
   var pinpointLabelEl = null;
   function getPinpointLabelEl() {
     if (!pinpointLabelEl) {
       pinpointLabelEl = document.createElement('div');
       pinpointLabelEl.setAttribute('data-plannotator-pinpoint-label', '');
       pinpointLabelEl.style.cssText = 'position:fixed;z-index:2147483647;pointer-events:none;display:none;font:600 11px/1.3 system-ui,-apple-system,sans-serif;padding:2px 7px;border-radius:5px;background:var(--pn-focus-highlight,#4493f8);color:#fff;white-space:nowrap;box-shadow:0 1px 5px rgba(0,0,0,.35);';
+      overlayNodes.add(pinpointLabelEl);
       document.body.appendChild(pinpointLabelEl);
     }
     return pinpointLabelEl;
   }
   function hidePinpointLabel() { if (pinpointLabelEl) pinpointLabelEl.style.display = 'none'; }
-
-  var pointerSemanticGraph = null;
-  var pointerSemanticGraphRaf = 0;
-  function graphForPointerFrame() {
-    if (!pointerSemanticGraph) pointerSemanticGraph = buildSemanticTargetGraph();
-    if (!pointerSemanticGraphRaf) {
-      pointerSemanticGraphRaf = requestAnimationFrame(function() {
-        pointerSemanticGraph = null;
-        pointerSemanticGraphRaf = 0;
-      });
-    }
-    return pointerSemanticGraph;
-  }
 
   // Hover outline box: fixed-position, pointer-events none, sized to the
   // hovered element's live rect. The page DOM is never touched for hover.
@@ -779,6 +936,7 @@ export const BRIDGE_SCRIPT = `(function() {
       pinpointBoxEl = document.createElement('div');
       pinpointBoxEl.setAttribute('data-plannotator-pinpoint-box', '');
       pinpointBoxEl.setAttribute('data-plannotator-vim-ui', '');
+      overlayNodes.add(pinpointBoxEl);
     }
     if (!pinpointBoxEl.isConnected) document.body.appendChild(pinpointBoxEl);
     return pinpointBoxEl;
@@ -818,10 +976,9 @@ export const BRIDGE_SCRIPT = `(function() {
 
   // Identity-gated hover update (only restyle when the resolved element
   // changes); shared by mousemove and the scroll/resize reconcile pass.
-  function updatePinpointHover(node) {
-    var graph = graphForPointerFrame();
-    var target = resolveSemanticTarget(graph, node);
-    var el = target && target.element;
+  // Per-event hit-testing only — never builds the semantic graph.
+  function updatePinpointHover(x, y, fallbackNode) {
+    var el = pinpointLeafAt(x, y, fallbackNode);
     if (el !== pinpointHover) {
       pinpointHover = el;
       if (el && !pendingPinEl) {
@@ -837,7 +994,7 @@ export const BRIDGE_SCRIPT = `(function() {
       positionPinpointBox(el); // same element — keep the box glued while scrolling
     }
     if (!el || pendingPinEl) { hidePinpointLabel(); return; }
-    positionPinpointLabel(el, target.label || (PINPOINT_LABELS[el.tagName] || el.tagName.toLowerCase()));
+    positionPinpointLabel(el, pinpointHoverLabel(el));
   }
 
   var lastPointer = null;
@@ -845,9 +1002,9 @@ export const BRIDGE_SCRIPT = `(function() {
     lastPointer = { x: e.clientX, y: e.clientY };
     if (currentInputMethod !== 'pinpoint') return;
     if (vimEnabled && vimPhase !== 'inactive') return;
-    // Hit-test at the pointer instead of trusting e.target so the same code
-    // path serves the scroll re-hit-test below.
-    updatePinpointHover(document.elementFromPoint(e.clientX, e.clientY) || e.target);
+    // Hit-test at the pointer (e.target only backstops engines without
+    // elementFromPoint) so the same code path serves the scroll re-hit-test.
+    updatePinpointHover(e.clientX, e.clientY, e.target);
   });
 
   // rAF-coalesced reconcile: keeps the hover box under a stationary cursor
@@ -866,7 +1023,10 @@ export const BRIDGE_SCRIPT = `(function() {
       if (currentInputMethod !== 'pinpoint') return;
       if (vimEnabled && vimPhase !== 'inactive') return;
       if (lastPointer) {
-        updatePinpointHover(document.elementFromPoint(lastPointer.x, lastPointer.y));
+        // Same point, possibly a different element after the scroll — the
+        // last-position cache must not answer this probe.
+        invalidatePointerHitCache();
+        updatePinpointHover(lastPointer.x, lastPointer.y, pinpointHover);
       }
     });
   }
@@ -891,6 +1051,7 @@ export const BRIDGE_SCRIPT = `(function() {
       clickEvent.stopPropagation();
       parent.postMessage({ type: PREFIX + 'mark-click', id: id }, '*');
     });
+    overlayNodes.add(badge);
     document.body.appendChild(badge);
     pinRegistry.push({ id: id, element: element, anchor: anchor || null, badge: badge });
     renderPinBadges();
@@ -900,6 +1061,7 @@ export const BRIDGE_SCRIPT = `(function() {
       if (pinRegistry[i].id === id) {
         var badge = pinRegistry[i].badge;
         if (badge && badge.parentNode) badge.parentNode.removeChild(badge);
+        overlayNodes.delete(badge);
         pinRegistry.splice(i, 1);
       }
     }
@@ -909,6 +1071,7 @@ export const BRIDGE_SCRIPT = `(function() {
     for (var i = 0; i < pinRegistry.length; i++) {
       var badge = pinRegistry[i].badge;
       if (badge && badge.parentNode) badge.parentNode.removeChild(badge);
+      overlayNodes.delete(badge);
     }
     pinRegistry = [];
   }
@@ -955,11 +1118,32 @@ export const BRIDGE_SCRIPT = `(function() {
   // tag > tag:nth-of-type() path as the last resort. Restoration fails closed:
   // a weak (positional/class) selector must also match the captured text
   // snapshot, so a shifted list never mis-anchors an annotation.
-  var ANCHOR_IDENTITY_ATTRS = ['data-annotate', 'data-testid', 'data-test', 'aria-label', 'name', 'role', 'href', 'alt'];
+  var ANCHOR_IDENTITY_ATTRS = ['data-annotate', 'data-testid', 'data-test', 'data-test-id', 'data-cy', 'data-qa', 'aria-label', 'name', 'role', 'href', 'alt'];
 
   function anchorTextSnapshot(el) {
     var text = (el.textContent || '').replace(/\\s+/g, ' ').trim();
     return text.length > 180 ? text.slice(0, 180) : text;
+  }
+
+  // Text-less elements (icon buttons, decorative chips) have no snapshot to
+  // verify against, so their weak anchors carry a shape signature instead:
+  // tagName + sorted class list + child count + 16px-bucketed width/height,
+  // stored in the anchor's text field behind a distinguishing prefix and
+  // compared whole-string on restore — the same fail-closed rule as text.
+  var ANCHOR_SHAPE_PREFIX = '[[pn-shape]]';
+
+  function anchorShapeSignature(el) {
+    var classes = [];
+    if (el.classList) {
+      for (var i = 0; i < el.classList.length; i++) classes.push(el.classList[i]);
+    }
+    classes.sort();
+    var r = el.getBoundingClientRect();
+    return ANCHOR_SHAPE_PREFIX
+      + el.tagName.toLowerCase()
+      + '|' + classes.join('.')
+      + '|' + (el.children ? el.children.length : 0)
+      + '|' + Math.round(r.width / 16) + 'x' + Math.round(r.height / 16);
   }
 
   function uniquelySelects(selector, el) {
@@ -1058,10 +1242,14 @@ export const BRIDGE_SCRIPT = `(function() {
     if (!el || el.nodeType !== 1) return null;
     var selector = buildAnchorSelector(el);
     if (!selector) return null;
+    var snapshot = anchorTextSnapshot(el);
+    // No text to snapshot: store the shape signature so a weak anchor for an
+    // icon button is verifiable instead of automatically dead.
+    if (!snapshot) snapshot = anchorShapeSignature(el);
     return {
       selector: selector,
       tagName: el.tagName.toLowerCase(),
-      text: anchorTextSnapshot(el)
+      text: snapshot
     };
   }
 
@@ -1072,7 +1260,7 @@ export const BRIDGE_SCRIPT = `(function() {
   // name, alt) identify what an element does, not what it says, so they never
   // exempt an anchor from the text check: a regenerated page keeps its
   // role="button" while the button's meaning changes completely.
-  var STABLE_IDENTITY_ATTRS = ['data-annotate', 'data-testid', 'data-test'];
+  var STABLE_IDENTITY_ATTRS = ['data-annotate', 'data-testid', 'data-test', 'data-test-id', 'data-cy', 'data-qa'];
 
   function anchorHasStableIdentity(selector, el) {
     var canEscape = typeof CSS !== 'undefined' && CSS.escape;
@@ -1100,11 +1288,15 @@ export const BRIDGE_SCRIPT = `(function() {
     if (el.tagName.toLowerCase() !== anchor.tagName.toLowerCase()) return null;
     if (!anchorHasStableIdentity(anchor.selector, el)) {
       // Weak (positional / class / behavioral-attribute) anchor: the captured
-      // text snapshot must exist and still match, or the anchor is rejected and
+      // snapshot must exist and still match, or the anchor is rejected and
       // restoration falls back to text search. A missing or empty snapshot is a
-      // rejection, not an exemption.
+      // rejection, not an exemption. Shape-signature snapshots (text-less
+      // elements) verify the same fail-closed way: whole-string comparison
+      // against the candidate's re-derived signature.
       if (typeof anchor.text !== 'string' || !anchor.text) return null;
-      if (anchorTextSnapshot(el) !== anchor.text) return null;
+      if (anchor.text.indexOf(ANCHOR_SHAPE_PREFIX) === 0) {
+        if (anchorShapeSignature(el) !== anchor.text) return null;
+      } else if (anchorTextSnapshot(el) !== anchor.text) return null;
     }
     return el;
   }
@@ -1154,7 +1346,10 @@ export const BRIDGE_SCRIPT = `(function() {
       return posted;
     }
     var elText = capSelectionText((el.textContent || '').trim());
-    if (!elText) { clearPendingPin(); return false; }
+    // Text-less elements (icon buttons, decorative chips, empty containers)
+    // are still annotatable: describe the element instead of quoting it. The
+    // shape-signature anchor keeps restoration verifiable.
+    if (!elText) elText = '[element: ' + pinpointHoverLabel(el) + ']';
     var r = el.getBoundingClientRect();
     pendingSelection = { element: true };
     pendingRange = null;
@@ -1172,9 +1367,12 @@ export const BRIDGE_SCRIPT = `(function() {
     // Existing marks are handled by the mark-click listener; pin badges own
     // their clicks.
     if (e.target && e.target.closest && e.target.closest('.annotation-highlight[data-bind-id],[data-plannotator-pin-badge]')) return;
-    var clickGraph = buildSemanticTargetGraph();
-    var clickTarget = resolveSemanticTarget(clickGraph, e.target);
-    var el = clickTarget && clickTarget.element;
+    // Click what the hover box shows: the currently hovered element is the
+    // target the user aimed at. Fall back to a fresh hit-test at the click
+    // point (e.g. a click with no preceding mousemove).
+    var el = pinpointHover && pinpointHover.isConnected
+      ? pinpointHover
+      : resolvePinpointTargetAt(e.clientX, e.clientY, e.target);
     if (!el) return;
     // Suppress the page's own behavior (links, buttons) — we're annotating.
     e.preventDefault();
@@ -1724,6 +1922,7 @@ export const BRIDGE_SCRIPT = `(function() {
       cursor = document.createElement('div');
       cursor.setAttribute('data-plannotator-vim-cursor', '');
       cursor.setAttribute('data-plannotator-vim-ui', '');
+      overlayNodes.add(cursor);
       document.body.appendChild(cursor);
     }
     return cursor;
@@ -1735,6 +1934,7 @@ export const BRIDGE_SCRIPT = `(function() {
       badge = document.createElement('div');
       badge.setAttribute('data-plannotator-vim-badge', '');
       badge.setAttribute('data-plannotator-vim-ui', '');
+      overlayNodes.add(badge);
       document.body.appendChild(badge);
     }
     return badge;
@@ -1754,6 +1954,7 @@ export const BRIDGE_SCRIPT = `(function() {
       '<div data-vim-reticle-corner="bottom-right"></div>',
       '<div data-vim-reticle-label></div>'
     ].join('');
+    overlayNodes.add(reticle);
     document.body.appendChild(reticle);
     return reticle;
   }

--- a/packages/ui/components/html-viewer/htmlPinpointProtocol.test.tsx
+++ b/packages/ui/components/html-viewer/htmlPinpointProtocol.test.tsx
@@ -45,6 +45,18 @@ describe.if(hasDom)('parseHtmlElementAnchor (validated DTO)', () => {
       .toEqual({ selector: 'main', tagName: 'main' });
   });
 
+  test('accepts a shape-signature snapshot for text-less elements', () => {
+    // Text-less elements (icon buttons) store a '[[pn-shape]]'-prefixed
+    // signature in the text field; it rides through the same validated DTO
+    // and the same 400-char cap as ordinary text snapshots.
+    const shape = '[[pn-shape]]span|icon-close|0|2x2';
+    expect(hookModule!.parseHtmlElementAnchor({
+      selector: 'span.icon-close',
+      tagName: 'span',
+      text: shape,
+    })).toEqual({ selector: 'span.icon-close', tagName: 'span', text: shape });
+  });
+
   test('rejects non-records and missing/empty fields', () => {
     expect(hookModule!.parseHtmlElementAnchor(null)).toBeNull();
     expect(hookModule!.parseHtmlElementAnchor('main')).toBeNull();

--- a/packages/ui/components/html-viewer/htmlPinpointProtocol.test.tsx
+++ b/packages/ui/components/html-viewer/htmlPinpointProtocol.test.tsx
@@ -45,16 +45,16 @@ describe.if(hasDom)('parseHtmlElementAnchor (validated DTO)', () => {
       .toEqual({ selector: 'main', tagName: 'main' });
   });
 
-  test('accepts a shape-signature snapshot for text-less elements', () => {
-    // Text-less elements (icon buttons) store a '[[pn-shape]]'-prefixed
-    // signature in the text field; it rides through the same validated DTO
-    // and the same 400-char cap as ordinary text snapshots.
-    const shape = '[[pn-shape]]span|icon-close|0|2x2';
+  test('accepts an empty text snapshot (stable-identity text-less anchors)', () => {
+    // Text-less elements anchor only through a stable-identity selector
+    // (#id / data-* identity attrs) and carry an empty snapshot; the bridge
+    // treats an empty snapshot on a WEAK selector as a rejection at restore
+    // time, so passing it through the DTO is safe.
     expect(hookModule!.parseHtmlElementAnchor({
-      selector: 'span.icon-close',
+      selector: 'span[data-testid="close-btn"]',
       tagName: 'span',
-      text: shape,
-    })).toEqual({ selector: 'span.icon-close', tagName: 'span', text: shape });
+      text: '',
+    })).toEqual({ selector: 'span[data-testid="close-btn"]', tagName: 'span', text: '' });
   });
 
   test('rejects non-records and missing/empty fields', () => {

--- a/packages/ui/components/html-viewer/srcdoc.test.ts
+++ b/packages/ui/components/html-viewer/srcdoc.test.ts
@@ -965,6 +965,305 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     postBridge({ type: "plannotator-bridge-clear-marks" });
     document.body.replaceChildren();
   });
+
+  test("data-test-id/data-cy/data-qa are author-controlled identity attrs", () => {
+    // Same trust class as data-testid: the anchor resolves without a text
+    // check even after the element's content drifted completely.
+    document.body.innerHTML = '<div data-cy="metrics">Fresh content</div>';
+    postBridge({
+      type: "plannotator-bridge-find-and-mark",
+      id: "cy-anchor",
+      originalText: "Stale content gone from the page",
+      annotationType: "comment",
+      anchor: { selector: 'div[data-cy="metrics"]', tagName: "div", text: "Stale content gone from the page" },
+    });
+    expect(document.querySelector('[data-bind-id="cy-anchor"]')).toBeNull();
+    expect(document.querySelector("[data-plannotator-pin-badge]")).not.toBeNull();
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  // --- New hit-testing contract: hover targets the real element under the
+  // cursor (no tag whitelist, no has-text requirement). happy-dom has no
+  // layout, so document.elementFromPoint yields nothing and resolution runs
+  // from the event target — which in a real browser IS the deepest rendered
+  // element under the pointer, the exact geometry these tests model.
+
+  /** Signoff-page-shaped fixture: styled div/span chips, buttons, cards. */
+  const SIGNOFF_MARKUP = [
+    "<section><div class=\"frame\">",
+    "<div class=\"ihead\"><span class=\"dnum\">R1</span>",
+    "<span class=\"ibehav\">Empty library state</span></div>",
+    "<div class=\"rline\"><span class=\"rkey\">no-jargon</span>",
+    "<span class=\"rowchip\">adopted by 1</span></div>",
+    "<span class=\"btn primary\">Create</span>",
+    "</div></section>",
+  ].join("");
+
+  function hoverAt(el: Element, x: number, y: number) {
+    el.dispatchEvent(new MouseEvent("mousemove", {
+      bubbles: true,
+      cancelable: true,
+      clientX: x,
+      clientY: y,
+    }));
+  }
+
+  async function clickAndCollectSelection(el: Element, x: number, y: number) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const messages: Array<Record<string, unknown>> = [];
+    const collect = (event: MessageEvent) => {
+      const data = bridgeMessageData(event);
+      if (data?.type === "plannotator-bridge-selection") messages.push(data);
+    };
+    window.addEventListener("message", collect);
+    const click = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+      clientX: x,
+      clientY: y,
+    });
+    el.dispatchEvent(click);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    window.removeEventListener("message", collect);
+    return { click, messages };
+  }
+
+  test("chips and small buttons on div/span markup are individually targetable", async () => {
+    document.body.innerHTML = SIGNOFF_MARKUP;
+    postBridge({ type: "plannotator-bridge-set-vim-mode", enabled: false });
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "pinpoint" });
+
+    const chip = document.querySelector<HTMLElement>("span.rowchip");
+    if (!chip) throw new Error("chip fixture missing");
+
+    // Hover resolves the chip itself — not the enclosing section.
+    hoverAt(chip, 100, 100);
+    const box = document.querySelector<HTMLElement>("[data-plannotator-pinpoint-box]");
+    expect(box?.style.display).toBe("block");
+    expect(
+      document.querySelector<HTMLElement>("[data-plannotator-pinpoint-label]")?.textContent,
+    ).toBe("rowchip");
+    expect(chip.className).toBe("rowchip"); // page DOM untouched
+
+    const { click, messages } = await clickAndCollectSelection(chip, 100, 100);
+    expect(click.defaultPrevented).toBe(true);
+    expect(messages.length).toBe(1);
+    expect(messages[0]!.pinpoint).toBe(true);
+    expect(messages[0]!.text).toBe("adopted by 1");
+    const chipAnchor = messages[0]!.anchor as { selector: string; tagName: string; text?: string };
+    expect(chipAnchor.tagName).toBe("span");
+    const chipMatches = document.querySelectorAll(chipAnchor.selector);
+    expect(chipMatches.length).toBe(1);
+    expect(chipMatches[0]).toBe(chip);
+    postBridge({ type: "plannotator-bridge-cancel-selection" });
+
+    // The R1 chip and the small button resolve the same way.
+    const dnum = document.querySelector<HTMLElement>("span.dnum");
+    if (!dnum) throw new Error("dnum fixture missing");
+    hoverAt(dnum, 200, 100);
+    expect(
+      document.querySelector<HTMLElement>("[data-plannotator-pinpoint-label]")?.textContent,
+    ).toBe("dnum");
+    const dnumResult = await clickAndCollectSelection(dnum, 200, 100);
+    expect(dnumResult.messages.length).toBe(1);
+    expect(dnumResult.messages[0]!.text).toBe("R1");
+    postBridge({ type: "plannotator-bridge-cancel-selection" });
+
+    const btn = document.querySelector<HTMLElement>("span.btn");
+    if (!btn) throw new Error("button fixture missing");
+    hoverAt(btn, 300, 100);
+    expect(
+      document.querySelector<HTMLElement>("[data-plannotator-pinpoint-label]")?.textContent,
+    ).toBe("btn primary");
+    const btnResult = await clickAndCollectSelection(btn, 300, 100);
+    expect(btnResult.messages.length).toBe(1);
+    expect(btnResult.messages[0]!.text).toBe("Create");
+
+    postBridge({ type: "plannotator-bridge-cancel-selection" });
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
+    document.body.replaceChildren();
+  });
+
+  test("pointing at a container's uncovered area selects the container", async () => {
+    // The geometric scope rule (matches the markdown surface): the deepest
+    // element under the pointer wins, so a pointer over the card's padding —
+    // where the card itself is the deepest rendered element — selects the
+    // card, no keyboard or cycling involved.
+    document.body.innerHTML = SIGNOFF_MARKUP;
+    postBridge({ type: "plannotator-bridge-set-vim-mode", enabled: false });
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "pinpoint" });
+
+    const frame = document.querySelector<HTMLElement>("div.frame");
+    if (!frame) throw new Error("frame fixture missing");
+    hoverAt(frame, 400, 150);
+    expect(
+      document.querySelector<HTMLElement>("[data-plannotator-pinpoint-label]")?.textContent,
+    ).toBe("frame");
+    const { messages } = await clickAndCollectSelection(frame, 400, 150);
+    expect(messages.length).toBe(1);
+    expect((messages[0]!.anchor as { tagName: string }).tagName).toBe("div");
+    expect(String(messages[0]!.text)).toContain("no-jargon");
+
+    postBridge({ type: "plannotator-bridge-cancel-selection" });
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
+    document.body.replaceChildren();
+  });
+
+  test("tiny elements promote to the nearest ancestor with a >=16px axis", () => {
+    document.body.innerHTML = '<div class="card"><span class="dot"></span></div>';
+    const card = document.querySelector<HTMLElement>("div.card");
+    const dot = document.querySelector<HTMLElement>("span.dot");
+    if (!card || !dot) throw new Error("promotion fixture missing");
+
+    const mockRect = (x: number, y: number, width: number, height: number) => ({
+      x, y, width, height,
+      top: y, left: x, right: x + width, bottom: y + height,
+      toJSON: () => ({}),
+    }) as DOMRect;
+    const originalBodyRect = document.body.getBoundingClientRect;
+    document.body.getBoundingClientRect = () => mockRect(0, 0, 800, 600);
+    dot.getBoundingClientRect = () => mockRect(10, 10, 8, 8);
+    card.getBoundingClientRect = () => mockRect(5, 5, 200, 100);
+
+    try {
+      postBridge({ type: "plannotator-bridge-set-vim-mode", enabled: false });
+      postBridge({ type: "plannotator-bridge-set-input-method", method: "pinpoint" });
+      hoverAt(dot, 12, 12);
+      const box = document.querySelector<HTMLElement>("[data-plannotator-pinpoint-box]");
+      // The 8x8 dot is under 16px on both axes — the hover box outlines the
+      // 200x100 card instead (a floor, not a whitelist).
+      expect(box?.style.display).toBe("block");
+      expect(box?.style.left).toBe("5px");
+      expect(box?.style.width).toBe("200px");
+      expect(
+        document.querySelector<HTMLElement>("[data-plannotator-pinpoint-label]")?.textContent,
+      ).toBe("card");
+    } finally {
+      document.body.getBoundingClientRect = originalBodyRect;
+      postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
+      document.body.replaceChildren();
+    }
+  });
+
+  test("generic-container labels follow the aria-label/role/class/text cascade", () => {
+    document.body.innerHTML = [
+      '<div class="stage">',
+      '<div id="l-aria" aria-label="Close dialog" class="rowchip">x</div>',
+      '<div id="l-role" role="tablist" class="abc12345">x</div>',
+      '<div id="l-class" class="styles_Card_a1b2c3">x</div>',
+      '<span id="l-text">R9</span>',
+      '<div id="l-container"><span>This text is far too long to serve as a hover label for anything</span></div>',
+      "<p id=\"l-known\">Paragraph text</p>",
+      "</div>",
+    ].join("");
+    postBridge({ type: "plannotator-bridge-set-vim-mode", enabled: false });
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "pinpoint" });
+
+    const label = () =>
+      document.querySelector<HTMLElement>("[data-plannotator-pinpoint-label]")?.textContent;
+    const cases: Array<[string, string]> = [
+      ["#l-aria", "Close dialog"], // aria-label beats classes
+      ["#l-role", "tablist"], // role beats a hash-looking class
+      ["#l-class", "styles Card"], // meaningful tokens, hash token stripped
+      ["#l-text", "R9"], // short own text for class-less spans
+      ["#l-container", "container"], // nothing meaningful -> container
+      ["#l-known", "Paragraph"], // known tags keep their names
+    ];
+    let x = 10;
+    for (const [selector, expected] of cases) {
+      const el = document.querySelector<HTMLElement>(selector);
+      if (!el) throw new Error(`label fixture ${selector} missing`);
+      hoverAt(el, (x += 50), 40);
+      expect(label()).toBe(expected);
+    }
+
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
+    document.body.replaceChildren();
+  });
+
+  test("text-less elements pin through a fail-closed shape-signature anchor", async () => {
+    document.body.innerHTML = '<div class="toolbar"><span class="icon-close"></span><p>Sibling text</p></div>';
+    postBridge({ type: "plannotator-bridge-set-vim-mode", enabled: false });
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "pinpoint" });
+
+    const icon = document.querySelector<HTMLElement>("span.icon-close");
+    if (!icon) throw new Error("icon fixture missing");
+    hoverAt(icon, 60, 60);
+    const { click, messages } = await clickAndCollectSelection(icon, 60, 60);
+    expect(click.defaultPrevented).toBe(true);
+    expect(messages.length).toBe(1);
+    // No text to quote: the posted selection describes the element.
+    expect(messages[0]!.text).toBe("[element: icon close]");
+    const anchor = messages[0]!.anchor as { selector: string; tagName: string; text: string };
+    expect(anchor.tagName).toBe("span");
+    expect(anchor.text.startsWith("[[pn-shape]]")).toBe(true);
+    postBridge({ type: "plannotator-bridge-cancel-selection" });
+
+    // Round trip: the shape signature re-derives and matches, so the icon
+    // gets a pin badge even though its text search can never succeed.
+    postBridge({
+      type: "plannotator-bridge-find-and-mark",
+      id: "shape-pin",
+      originalText: "[element: icon close]",
+      annotationType: "comment",
+      anchor,
+    });
+    expect(document.querySelector("[data-plannotator-pin-badge]")).not.toBeNull();
+    expect(document.querySelector('[data-bind-id="shape-pin"]')).toBeNull();
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    expect(document.querySelector("[data-plannotator-pin-badge]")).toBeNull();
+
+    // Fail closed: the selector still matches, but the element's shape
+    // changed (a child appeared), so the signature no longer verifies and
+    // no pin lands anywhere.
+    icon.appendChild(document.createElement("i"));
+    postBridge({
+      type: "plannotator-bridge-find-and-mark",
+      id: "shape-stale",
+      originalText: "[element: icon close]",
+      annotationType: "comment",
+      anchor,
+    });
+    expect(document.querySelector("[data-plannotator-pin-badge]")).toBeNull();
+    expect(document.querySelector('[data-bind-id="shape-stale"]')).toBeNull();
+
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
+    document.body.replaceChildren();
+  });
+
+  test("hover hit-testing never storms document-wide queries per mousemove", () => {
+    // The old hover path rebuilt the semantic target graph (three
+    // document-wide querySelectorAll sweeps) on every pointer frame. The new
+    // path is per-event hit-testing: element identity plus closest() walks,
+    // zero document-wide queries. Graph builds remain click/vim-time only.
+    document.body.innerHTML = SIGNOFF_MARKUP;
+    postBridge({ type: "plannotator-bridge-set-vim-mode", enabled: false });
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "pinpoint" });
+
+    const targets = Array.from(document.querySelectorAll<HTMLElement>("span, div, section"));
+    const originalQsa = document.querySelectorAll.bind(document);
+    let documentWideQueries = 0;
+    (document as { querySelectorAll: typeof document.querySelectorAll }).querySelectorAll = ((
+      ...args: Parameters<typeof document.querySelectorAll>
+    ) => {
+      documentWideQueries += 1;
+      return originalQsa(...args);
+    }) as typeof document.querySelectorAll;
+
+    try {
+      let x = 0;
+      for (let i = 0; i < 30; i++) {
+        const el = targets[i % targets.length]!;
+        hoverAt(el, (x += 23), 90);
+      }
+      expect(documentWideQueries).toBe(0);
+    } finally {
+      (document as { querySelectorAll: typeof document.querySelectorAll }).querySelectorAll = originalQsa;
+      postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
+      document.body.replaceChildren();
+    }
+  });
 });
 
 describe("injectIntoHead", () => {

--- a/packages/ui/components/html-viewer/srcdoc.test.ts
+++ b/packages/ui/components/html-viewer/srcdoc.test.ts
@@ -1154,6 +1154,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       '<div id="l-class" class="styles_Card_a1b2c3">x</div>',
       '<span id="l-text">R9</span>',
       '<div id="l-container"><span>This text is far too long to serve as a hover label for anything</span></div>',
+      '<div id="l-long" class="extraverboseclasstokennameone extraverboseclasstokennametwo">x</div>',
       "<p id=\"l-known\">Paragraph text</p>",
       "</div>",
     ].join("");
@@ -1168,6 +1169,8 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       ["#l-class", "styles Card"], // meaningful tokens, hash token stripped
       ["#l-text", "R9"], // short own text for class-less spans
       ["#l-container", "container"], // nothing meaningful -> container
+      // Class-token labels obey the 40-char cap like every other rung.
+      ["#l-long", "extraverboseclasstokennameone extraverbo"],
       ["#l-known", "Paragraph"], // known tags keep their names
     ];
     let x = 10;
@@ -1182,52 +1185,155 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
-  test("text-less elements pin through a fail-closed shape-signature anchor", async () => {
-    document.body.innerHTML = '<div class="toolbar"><span class="icon-close"></span><p>Sibling text</p></div>';
+  test("text-less elements anchor only through a stable-identity rung", async () => {
+    // A text-less element has no snapshot to verify a weak anchor against, so
+    // it gets an anchor ONLY when the element itself carries stable identity
+    // (#id or an author-controlled data-* identity attribute). It is still
+    // annotatable either way — the selection describes the element.
+    document.body.innerHTML = [
+      '<div class="toolbar">',
+      '<span class="icon-close" data-testid="close-btn"></span>',
+      '<span class="icon-menu"></span>',
+      "<p>Sibling text</p></div>",
+    ].join("");
     postBridge({ type: "plannotator-bridge-set-vim-mode", enabled: false });
     postBridge({ type: "plannotator-bridge-set-input-method", method: "pinpoint" });
 
-    const icon = document.querySelector<HTMLElement>("span.icon-close");
-    if (!icon) throw new Error("icon fixture missing");
-    hoverAt(icon, 60, 60);
-    const { click, messages } = await clickAndCollectSelection(icon, 60, 60);
+    const close = document.querySelector<HTMLElement>("span.icon-close");
+    if (!close) throw new Error("icon fixture missing");
+    hoverAt(close, 60, 60);
+    const { click, messages } = await clickAndCollectSelection(close, 60, 60);
     expect(click.defaultPrevented).toBe(true);
     expect(messages.length).toBe(1);
     // No text to quote: the posted selection describes the element.
     expect(messages[0]!.text).toBe("[element: icon close]");
-    const anchor = messages[0]!.anchor as { selector: string; tagName: string; text: string };
-    expect(anchor.tagName).toBe("span");
-    expect(anchor.text.startsWith("[[pn-shape]]")).toBe(true);
+    const anchor = messages[0]!.anchor as { selector: string; tagName: string; text?: string };
+    expect(anchor.selector).toBe('span[data-testid="close-btn"]');
+    expect(anchor.text).toBe("");
     postBridge({ type: "plannotator-bridge-cancel-selection" });
 
-    // Round trip: the shape signature re-derives and matches, so the icon
-    // gets a pin badge even though its text search can never succeed.
+    // Round trip: the stable-identity anchor resolves without a text check,
+    // so the icon gets a pin badge even though text search can never succeed.
     postBridge({
       type: "plannotator-bridge-find-and-mark",
-      id: "shape-pin",
+      id: "identity-pin",
       originalText: "[element: icon close]",
       annotationType: "comment",
       anchor,
     });
     expect(document.querySelector("[data-plannotator-pin-badge]")).not.toBeNull();
-    expect(document.querySelector('[data-bind-id="shape-pin"]')).toBeNull();
+    expect(document.querySelector('[data-bind-id="identity-pin"]')).toBeNull();
     postBridge({ type: "plannotator-bridge-clear-marks" });
     expect(document.querySelector("[data-plannotator-pin-badge]")).toBeNull();
 
-    // Fail closed: the selector still matches, but the element's shape
-    // changed (a child appeared), so the signature no longer verifies and
-    // no pin lands anywhere.
-    icon.appendChild(document.createElement("i"));
+    // A text-less element with only classes (weak selector) ships NO anchor:
+    // there is nothing to verify against, and a wrong-binding anchor is
+    // worse than no anchor.
+    const menu = document.querySelector<HTMLElement>("span.icon-menu");
+    if (!menu) throw new Error("menu icon fixture missing");
+    hoverAt(menu, 90, 60);
+    const menuResult = await clickAndCollectSelection(menu, 90, 60);
+    expect(menuResult.messages.length).toBe(1);
+    expect(menuResult.messages[0]!.text).toBe("[element: icon menu]");
+    expect(menuResult.messages[0]!.anchor).toBeUndefined();
+
+    postBridge({ type: "plannotator-bridge-cancel-selection" });
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
+    document.body.replaceChildren();
+  });
+
+  test("identical text-less siblings fail closed instead of rebinding (D1)", async () => {
+    // Two structurally identical icons: any structure-derived signature
+    // (tag/classes/child count/size) is identical across them, so a
+    // positional selector whose sibling was removed would resolve to the
+    // WRONG element and still "verify". The contract is therefore: no anchor
+    // at all for weak text-less targets, and a crafted positional anchor
+    // with no snapshot never resolves.
+    document.body.innerHTML = [
+      '<div class="strip">',
+      '<span class="icon"></span>',
+      '<span class="icon"></span>',
+      "</div>",
+    ].join("");
+    postBridge({ type: "plannotator-bridge-set-vim-mode", enabled: false });
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "pinpoint" });
+
+    const second = document.querySelectorAll<HTMLElement>("span.icon")[1];
+    if (!second) throw new Error("sibling fixture missing");
+    hoverAt(second, 120, 60);
+    const { messages } = await clickAndCollectSelection(second, 120, 60);
+    expect(messages.length).toBe(1);
+    expect(messages[0]!.anchor).toBeUndefined();
+    postBridge({ type: "plannotator-bridge-cancel-selection" });
+
+    // The old-world failure mode, replayed: after the first icon is removed,
+    // span.icon:nth-of-type(2) is gone and span.icon:nth-of-type(1) IS a
+    // different element. A crafted positional anchor (empty snapshot) must
+    // resolve nothing — no pin, no mark, anywhere.
+    second.parentElement!.removeChild(document.querySelectorAll("span.icon")[0]!);
+    for (const selector of ["div.strip > span:nth-of-type(2)", "div.strip > span:nth-of-type(1)"]) {
+      postBridge({
+        type: "plannotator-bridge-find-and-mark",
+        id: `rebind-${selector}`,
+        originalText: "[element: icon]",
+        annotationType: "comment",
+        anchor: { selector, tagName: "span", text: "" },
+      });
+    }
+    expect(document.querySelector("[data-plannotator-pin-badge]")).toBeNull();
+    expect(document.querySelector("[data-bind-id]")).toBeNull();
+
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
+    document.body.replaceChildren();
+  });
+
+  test("badge click ownership is identity-gated, not selector-gated (D5)", async () => {
+    // A page element spoofing our badge attribute is NOT a viewer overlay:
+    // it hovers and annotates like any other element.
+    document.body.innerHTML = "<div data-plannotator-pin-badge class=\"fake-badge\">7</div><p id=\"pin-me\">Pinned text</p>";
+    postBridge({ type: "plannotator-bridge-set-vim-mode", enabled: false });
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "pinpoint" });
+
+    const spoof = document.querySelector<HTMLElement>("div.fake-badge");
+    if (!spoof) throw new Error("spoof fixture missing");
+    hoverAt(spoof, 40, 40);
+    expect(
+      document.querySelector<HTMLElement>("[data-plannotator-pinpoint-box]")?.style.display,
+    ).toBe("block");
+    const { click, messages } = await clickAndCollectSelection(spoof, 40, 40);
+    expect(click.defaultPrevented).toBe(true);
+    expect(messages.length).toBe(1);
+    expect(messages[0]!.text).toBe("7");
+
+    // A REAL badge still owns its click: it posts mark-click, not a selection.
     postBridge({
       type: "plannotator-bridge-find-and-mark",
-      id: "shape-stale",
-      originalText: "[element: icon close]",
+      id: "badge-owner",
+      originalText: "Text that exists nowhere on this page",
       annotationType: "comment",
-      anchor,
+      anchor: { selector: "#pin-me", tagName: "p" },
     });
-    expect(document.querySelector("[data-plannotator-pin-badge]")).toBeNull();
-    expect(document.querySelector('[data-bind-id="shape-stale"]')).toBeNull();
+    const realBadge = document.querySelector<HTMLElement>(
+      "[data-plannotator-pin-badge]:not(.fake-badge)",
+    );
+    if (!realBadge) throw new Error("real badge missing");
+    const collected: Array<Record<string, unknown>> = [];
+    const collect = (event: MessageEvent) => {
+      const data = bridgeMessageData(event);
+      if (
+        data?.type === "plannotator-bridge-selection"
+        || data?.type === "plannotator-bridge-mark-click"
+      ) collected.push(data);
+    };
+    window.addEventListener("message", collect);
+    realBadge.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    window.removeEventListener("message", collect);
+    expect(collected).toEqual([
+      { type: "plannotator-bridge-mark-click", id: "badge-owner" },
+    ]);
 
+    postBridge({ type: "plannotator-bridge-clear-marks" });
     postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
     document.body.replaceChildren();
   });


### PR DESCRIPTION
**TLDR:** Pinpoint mode in raw-HTML sessions now targets whatever is actually under the cursor instead of a hardcoded tag whitelist. Chips, icon buttons, and styled spans on div-based prototype pages become individually annotatable; containers select by pointing at their padding; everything is mouse-only. Twice adversarially reviewed; final verdict merge-safe.

*AI-assisted (research, implementation, and two adversarial review rounds).*

The old semantic whitelist (headings/paragraphs/tables/sections) made real prototype pages built from divs and spans resolve every hover to the enclosing section. After studying agentation and react-grab, hover now uses deep hit-testing (elementFromPoint through open shadow roots) with an identity-based exclusion set for viewer overlays, a 16px tiny-element promotion floor, and smart container labels (aria-label, then role, then meaningful class tokens). The interaction model matches markdown pinpoint: the deepest element under the pointer wins, and parents are selected via their uncovered area. No keyboard involvement anywhere.

The semantic graph survives untouched as the vim vocabulary and click-time parent resolver. The hover path no longer rebuilds it per frame: zero document-wide queries per mousemove (instrumented in tests), retiring the perf debt deferred from #1243.

Anchors keep every fail-closed property. data-test-id/data-cy/data-qa join the trusted identity attributes. Text-less elements are annotatable in-session and their pins restore only via stable identity; a shape-signature mechanism from the first iteration was removed after review proved it could rebind pins to identical siblings, and no anchor beats a wrong one.

Verified: 942 DOM tests pass (+10 net new covering chip targeting, container selection, tiny promotion, label caps, fail-closed identical-sibling anchors, badge-spoof clicks), typecheck clean, builds clean, and both real-world signoff pages validated end-to-end through live-served annotate sessions.