### PR TITLE
fix(vim): preserve plan position on refocus

### DIFF
--- a/packages/ui/hooks/useVimSelection.test.tsx
+++ b/packages/ui/hooks/useVimSelection.test.tsx
@@ -11,6 +11,7 @@ interface VimHarnessProps {
   enabled: boolean;
   hudEnabled?: boolean;
   blocked?: boolean;
+  scrollViewport?: HTMLElement | null;
   onRange: (text: string, mode?: EditorMode) => void;
 }
 
@@ -18,12 +19,14 @@ function VimHarness({
   enabled,
   hudEnabled = false,
   blocked = false,
+  scrollViewport,
   onRange,
 }: VimHarnessProps) {
   if (!hookModule) throw new Error('DOM test environment is not registered');
   const articleRef = useRef<HTMLElement | null>(null);
   const vim = hookModule.useVimSelection({
     containerRef: articleRef,
+    scrollViewport,
     enabled,
     hudEnabled,
     blocked,
@@ -286,6 +289,41 @@ describe.if(hasDom)('useVimSelection', () => {
 
     act(() => root.unmount());
     outside.remove();
+  });
+
+  test('preserves the native viewport position when document focus returns', () => {
+    const viewport = document.createElement('main');
+    document.body.appendChild(viewport);
+    Object.defineProperty(viewport, 'clientHeight', { configurable: true, value: 400 });
+    viewport.scrollTop = 320;
+    viewport.getBoundingClientRect = () => new DOMRect(0, 0, 800, 400);
+
+    const { article, root, host } = mountHarness({
+      enabled: true,
+      scrollViewport: viewport,
+      onRange: () => {},
+    });
+    article.getBoundingClientRect = () => new DOMRect(0, -320, 800, 2000);
+
+    const intro = host.querySelector<HTMLElement>('[data-block-id="intro"]');
+    const matrix = host.querySelector<HTMLElement>('[data-block-id="matrix"] table');
+    const code = host.querySelector<HTMLElement>('[data-block-id="code"]');
+    if (!intro || !matrix || !code) throw new Error('Missing semantic target fixture');
+    intro.getBoundingClientRect = () => new DOMRect(0, -300, 400, 40);
+    matrix.getBoundingClientRect = () => new DOMRect(0, 180, 400, 40);
+    code.getBoundingClientRect = () => new DOMRect(0, 800, 400, 40);
+
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    act(() => outside.focus());
+    act(() => article.focus());
+
+    expect(article.dataset.targetKey).toBe('matrix:table');
+    expect(viewport.scrollTop).toBe(320);
+
+    act(() => root.unmount());
+    outside.remove();
+    viewport.remove();
   });
 
   test('starts with block focus, refines through inline to text, and preserves controls', () => {

--- a/packages/ui/hooks/useVimSelection.ts
+++ b/packages/ui/hooks/useVimSelection.ts
@@ -287,7 +287,7 @@ export function useVimSelection({
     const container = containerRef.current;
     if (!container) return null;
     const graph = buildSemanticTargetGraph(container);
-    const initial = findInitialSemanticTarget(graph);
+    const initial = findInitialSemanticTarget(graph, scrollViewportRef.current);
     if (!initial) return null;
     const next: VimBlockState = { phase: 'block', targetKey: initial.key };
     setState(next);
@@ -661,7 +661,12 @@ export function useVimSelection({
     if (key === 'G') {
       updateTextState(graph, {
         ...current,
-        cursor: moveTextPosition(graph.container, current.cursor, 'document-end'),
+        cursor: moveTextPosition(
+          graph.container,
+          current.cursor,
+          'document-end',
+          scrollViewportRef.current,
+        ),
       });
       return true;
     }
@@ -687,7 +692,12 @@ export function useVimSelection({
           graph,
           current.targetKey,
           nativePosition
-            ?? moveTextPosition(graph.container, current.cursor, fallback),
+            ?? moveTextPosition(
+              graph.container,
+              current.cursor,
+              fallback,
+              scrollViewportRef.current,
+            ),
           direction,
         ),
       });
@@ -695,7 +705,12 @@ export function useVimSelection({
     }
     const motion = motionFromTextKey(key);
     if (!motion) return false;
-    const nextPosition = moveTextPosition(graph.container, current.cursor, motion);
+    const nextPosition = moveTextPosition(
+      graph.container,
+      current.cursor,
+      motion,
+      scrollViewportRef.current,
+    );
     updateTextState(graph, {
       ...current,
       cursor: motion === 'block-backward' || motion === 'block-forward'
@@ -823,12 +838,13 @@ export function useVimSelection({
           graph.container,
           current.cursor,
           end ? 'document-end' : 'document-start',
+          scrollViewportRef.current,
         ),
       });
       return true;
     }
     const currentTarget = resolveSemanticTarget(graph, targetKeyForState(current))
-      ?? findInitialSemanticTarget(graph);
+      ?? findInitialSemanticTarget(graph, scrollViewportRef.current);
     if (!currentTarget) return false;
     setSemanticTarget(moveSemanticTarget(
       graph,

--- a/packages/ui/utils/blockTargeting.ts
+++ b/packages/ui/utils/blockTargeting.ts
@@ -360,9 +360,9 @@ export function getOwningBlockTarget(
 /** Pick the block nearest the visible center of the document viewport. */
 export function findInitialSemanticTarget(
   graph: SemanticTargetGraph,
+  scrollViewport?: HTMLElement | null,
 ): SemanticTarget | null {
-  const viewport = graph.container.closest<HTMLElement>('[data-overlayscrollbars-viewport]');
-  const viewportRect = (viewport ?? graph.container).getBoundingClientRect();
+  const viewportRect = (scrollViewport ?? graph.container).getBoundingClientRect();
   const centerY = viewportRect.top + viewportRect.height / 2;
   return graph.blockKeys
     .map((key) => resolveSemanticTarget(graph, key))

--- a/packages/ui/utils/vimNavigation.ts
+++ b/packages/ui/utils/vimNavigation.ts
@@ -128,15 +128,20 @@ function findBlock(container: HTMLElement, blockId: string): HTMLElement | null 
   return null;
 }
 
-function getViewportCenterY(container: HTMLElement): number {
-  const viewport = container.closest<HTMLElement>('[data-overlayscrollbars-viewport]');
-  const rect = (viewport ?? container).getBoundingClientRect();
+function getViewportCenterY(
+  container: HTMLElement,
+  scrollViewport?: HTMLElement | null,
+): number {
+  const rect = (scrollViewport ?? container).getBoundingClientRect();
   return rect.top + rect.height / 2;
 }
 
 /** Pick the first text cursor nearest the visible center of the document. */
-export function findInitialTextPosition(container: HTMLElement): VimTextPosition | null {
-  const centerY = getViewportCenterY(container);
+export function findInitialTextPosition(
+  container: HTMLElement,
+  scrollViewport?: HTMLElement | null,
+): VimTextPosition | null {
+  const centerY = getViewportCenterY(container, scrollViewport);
   const candidates = getBlockElements(container)
     .map((block) => ({ block, position: getPositionAtBlockBoundary(block, 'start') }))
     .filter((candidate): candidate is { block: HTMLElement; position: VimTextPosition } =>
@@ -378,9 +383,10 @@ export function moveTextPosition(
   container: HTMLElement,
   position: VimTextPosition,
   motion: VimTextMotion,
+  scrollViewport?: HTMLElement | null,
 ): VimTextPosition {
   const currentBlock = findBlock(container, position.blockId);
-  if (!currentBlock) return findInitialTextPosition(container) ?? position;
+  if (!currentBlock) return findInitialTextPosition(container, scrollViewport) ?? position;
   const currentText = getBlockText(currentBlock);
   const nextOffset = moveWithinBlock(currentText, position.textOffset, motion);
   if (nextOffset !== null) {
@@ -397,7 +403,7 @@ export function moveTextPosition(
   }
 
   const blockIndex = blocks.indexOf(currentBlock);
-  if (blockIndex < 0) return findInitialTextPosition(container) ?? position;
+  if (blockIndex < 0) return findInitialTextPosition(container, scrollViewport) ?? position;
   if (motion === 'block-backward' || motion === 'block-forward') {
     const delta = motion === 'block-backward' ? -1 : 1;
     const nextBlock = blocks[Math.max(0, Math.min(blocks.length - 1, blockIndex + delta))];


### PR DESCRIPTION
## Summary

Fixes Vim-enabled plan review jumping away from the reader's position after refocus.

## Before this fix

1. Enable **Vim controls**.
2. Open a long plan and scroll away from its midpoint.
3. Click the plan body to give it keyboard focus.
4. Switch to another application, then return to Plannotator.
5. The plan jumps to another block instead of staying where you left it.

Initial targeting still searched for the removed `[data-overlayscrollbars-viewport]` attribute, fell back to measuring the full article, and scrolled the wrong block into view. This passes the native scroll viewport directly into semantic/text targeting and adds a refocus regression test.

Follow-up to #1154.

## Validation

- 41 focused Vim tests pass
- UI type checks and builds pass
- Chrome on macOS: six real Chrome → Finder → Chrome cycles across the plan, all with `0px` scroll delta
