### PR TITLE
feat(annotate): shift-click multi-element selection for raw-HTML pinpoint

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -63,7 +63,7 @@
     },
     "apps/opencode-plugin": {
       "name": "@plannotator/opencode",
-      "version": "0.26.7",
+      "version": "0.26.1",
       "devDependencies": {
         "@opencode-ai/plugin": "0.0.0-next-16775",
         "@plannotator/server": "workspace:*",
@@ -80,7 +80,7 @@
     },
     "apps/pi-extension": {
       "name": "@plannotator/pi-extension",
-      "version": "0.26.7",
+      "version": "0.26.1",
       "dependencies": {
         "@joplin/turndown-plugin-gfm": "^1.0.64",
         "@pierre/diffs": "1.3.2",
@@ -218,7 +218,7 @@
     },
     "packages/server": {
       "name": "@plannotator/server",
-      "version": "0.26.7",
+      "version": "0.26.1",
       "dependencies": {
         "@pierre/diffs": "1.3.2",
         "@plannotator/ai": "workspace:*",

--- a/bun.lock
+++ b/bun.lock
@@ -63,7 +63,7 @@
     },
     "apps/opencode-plugin": {
       "name": "@plannotator/opencode",
-      "version": "0.26.1",
+      "version": "0.26.7",
       "devDependencies": {
         "@opencode-ai/plugin": "0.0.0-next-16775",
         "@plannotator/server": "workspace:*",
@@ -80,7 +80,7 @@
     },
     "apps/pi-extension": {
       "name": "@plannotator/pi-extension",
-      "version": "0.26.1",
+      "version": "0.26.7",
       "dependencies": {
         "@joplin/turndown-plugin-gfm": "^1.0.64",
         "@pierre/diffs": "1.3.2",
@@ -218,7 +218,7 @@
     },
     "packages/server": {
       "name": "@plannotator/server",
-      "version": "0.26.1",
+      "version": "0.26.7",
       "dependencies": {
         "@pierre/diffs": "1.3.2",
         "@plannotator/ai": "workspace:*",

--- a/packages/ui/components/CommentPopover.multiTarget.test.tsx
+++ b/packages/ui/components/CommentPopover.multiTarget.test.tsx
@@ -164,6 +164,30 @@ describe.if(hasDom)('CommentPopover multi-target seams', () => {
     expect(focused.defaultPrevented).toBe(false);
   });
 
+  test('stray keys insert at the remembered caret, not end-of-text', async () => {
+    await mountPopover({ targetChips: CHIPS, captureStrayKeys: true });
+    const el = textarea();
+    // Type 'held' through React, then park the caret between 'he' and 'ld'.
+    const setter = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(el), 'value')?.set;
+    await act(async () => {
+      setter?.call(el, 'held');
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    el.selectionStart = el.selectionEnd = 2;
+    el.blur();
+
+    const stray = new KeyboardEvent('keydown', { key: 'X', bubbles: true, cancelable: true });
+    await act(async () => {
+      document.body.dispatchEvent(stray);
+    });
+    expect(stray.defaultPrevented).toBe(true);
+    expect(el.value).toBe('heXld');
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(() => r(null)));
+    });
+    expect(el.selectionStart).toBe(3);
+  });
+
   test('yieldState drives fade and click-through classes with a reduced-motion-aware style', async () => {
     await mountPopover({ targetChips: CHIPS, yieldState: 'none' });
     expect(popoverEl().className).toContain('pn-composer-yieldable');

--- a/packages/ui/components/CommentPopover.multiTarget.test.tsx
+++ b/packages/ui/components/CommentPopover.multiTarget.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * CommentPopover multi-target seams (all opt-in, default off):
+ *  - target chips render (primary first) with remove + hover handlers
+ *  - refocusToken returns focus to the textarea
+ *  - captureStrayKeys routes a window-level stray printable keydown into the
+ *    textarea so the first keystroke after a shift-click is never lost
+ *  - yieldState applies the fade / click-through classes
+ *  - with none of the props set, none of the new DOM appears (byte-identical
+ *    default composer)
+ *
+ * Requires DOM — runs under bun test with the happy-dom preload (DOM_TESTS=1).
+ */
+import { afterEach, describe, expect, test } from 'bun:test';
+import React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { CommentPopover, type CommentTargetChip } from './CommentPopover';
+
+const hasDom = typeof document !== 'undefined';
+
+let root: Root | null = null;
+let host: HTMLDivElement | null = null;
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => {
+      root!.unmount();
+    });
+    root = null;
+  }
+  host?.remove();
+  host = null;
+  if (hasDom) document.body.innerHTML = '';
+});
+
+type PopoverProps = Partial<React.ComponentProps<typeof CommentPopover>>;
+
+async function mountPopover(props: PopoverProps = {}) {
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  root = createRoot(host);
+  await act(async () => {
+    root!.render(
+      <CommentPopover
+        anchorRect={new DOMRect(100, 100, 50, 20)}
+        contextText="Selected text"
+        isGlobal={false}
+        onSubmit={() => {}}
+        onClose={() => {}}
+        {...props}
+      />,
+    );
+  });
+}
+
+async function remount(props: PopoverProps) {
+  await act(async () => {
+    root!.render(
+      <CommentPopover
+        anchorRect={new DOMRect(100, 100, 50, 20)}
+        contextText="Selected text"
+        isGlobal={false}
+        onSubmit={() => {}}
+        onClose={() => {}}
+        {...props}
+      />,
+    );
+  });
+}
+
+function popoverEl(): HTMLElement {
+  const el = document.querySelector<HTMLElement>('[data-comment-popover]');
+  if (!el) throw new Error('popover missing');
+  return el;
+}
+
+function textarea(): HTMLTextAreaElement {
+  const el = document.querySelector<HTMLTextAreaElement>('[data-comment-popover] textarea');
+  if (!el) throw new Error('textarea missing');
+  return el;
+}
+
+const CHIPS: CommentTargetChip[] = [
+  { key: 't1', label: 'Paragraph', excerpt: 'Primary text' },
+  { key: 't2', label: 'Button', excerpt: 'Create' },
+];
+
+describe.if(hasDom)('CommentPopover multi-target seams', () => {
+  test('default composer renders none of the multi-target DOM', async () => {
+    await mountPopover();
+    expect(document.querySelector('[data-target-chips]')).toBeNull();
+    expect(popoverEl().className).not.toContain('pn-composer-yield');
+  });
+
+  test('chips render primary-first with working remove and hover handlers', async () => {
+    const removed: string[] = [];
+    const hovered: string[] = [];
+    await mountPopover({
+      targetChips: CHIPS,
+      onRemoveTargetChip: (key) => removed.push(key),
+      onHoverTargetChip: (key) => hovered.push(key),
+    });
+
+    const chips = Array.from(document.querySelectorAll<HTMLElement>('[data-target-chip]'));
+    expect(chips.length).toBe(2);
+    expect(chips[0]!.getAttribute('data-target-chip-primary')).toBe('true');
+    expect(chips[0]!.textContent).toContain('Paragraph');
+    expect(chips[1]!.textContent).toContain('Create');
+
+    await act(async () => {
+      chips[1]!.dispatchEvent(new MouseEvent('mouseenter', { bubbles: false }));
+    });
+    // React attaches mouseenter via its own delegation of mouseout/mouseover;
+    // fall back to mouseover which React maps for onMouseEnter in tests.
+    if (hovered.length === 0) {
+      await act(async () => {
+        chips[1]!.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+      });
+    }
+    expect(hovered).toContain('t2');
+
+    const removeButton = document.querySelector<HTMLButtonElement>('[data-target-chip-remove="t2"]');
+    if (!removeButton) throw new Error('remove button missing');
+    await act(async () => {
+      removeButton.click();
+    });
+    expect(removed).toEqual(['t2']);
+  });
+
+  test('refocusToken bump returns focus to the textarea', async () => {
+    await mountPopover({ targetChips: CHIPS, refocusToken: 0 });
+    textarea().blur();
+    document.body.focus();
+    expect(document.activeElement).not.toBe(textarea());
+    await remount({ targetChips: CHIPS, refocusToken: 1 });
+    expect(document.activeElement).toBe(textarea());
+  });
+
+  test('captureStrayKeys routes a body-targeted printable keydown into the textarea', async () => {
+    await mountPopover({ targetChips: CHIPS, captureStrayKeys: true });
+    const el = textarea();
+    el.blur();
+    const stray = new KeyboardEvent('keydown', {
+      key: 'h',
+      bubbles: true,
+      cancelable: true,
+    });
+    await act(async () => {
+      document.body.dispatchEvent(stray);
+    });
+    expect(stray.defaultPrevented).toBe(true);
+    expect(el.value).toBe('h');
+    expect(document.activeElement).toBe(el);
+
+    // A keydown already headed somewhere useful is left alone.
+    const focused = new KeyboardEvent('keydown', {
+      key: 'i',
+      bubbles: true,
+      cancelable: true,
+    });
+    await act(async () => {
+      el.dispatchEvent(focused);
+    });
+    expect(focused.defaultPrevented).toBe(false);
+  });
+
+  test('yieldState drives fade and click-through classes with a reduced-motion-aware style', async () => {
+    await mountPopover({ targetChips: CHIPS, yieldState: 'none' });
+    expect(popoverEl().className).toContain('pn-composer-yieldable');
+    expect(popoverEl().className).not.toContain('pn-composer-yield-near');
+
+    await remount({ targetChips: CHIPS, yieldState: 'near' });
+    expect(popoverEl().className).toContain('pn-composer-yield-near');
+
+    await remount({ targetChips: CHIPS, yieldState: 'over' });
+    expect(popoverEl().className).toContain('pn-composer-yield-over');
+
+    const style = Array.from(document.querySelectorAll('style'))
+      .map((s) => s.textContent ?? '')
+      .find((s) => s.includes('pn-composer-yieldable'));
+    expect(style).toBeDefined();
+    expect(style).toContain('pointer-events: none');
+    expect(style).toContain('prefers-reduced-motion: reduce');
+    expect(style).toContain('180ms');
+  });
+});

--- a/packages/ui/components/CommentPopover.tsx
+++ b/packages/ui/components/CommentPopover.tsx
@@ -253,9 +253,13 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
 
   // First-keystroke guard: while the draft is open, a printable keydown that
   // lands nowhere (focus fell back to <body> after an iframe interaction)
-  // routes into the textarea instead of vanishing. Capture phase, so a
-  // parent-level global shortcut cannot both fire and have its character
-  // appended; the character lands at the textarea's remembered caret.
+  // routes into the textarea instead of vanishing. Runs in capture phase so
+  // it claims the key before the app's shortcut dispatcher; the character
+  // lands at the textarea's remembered caret. Note that preventDefault here
+  // does not stop the dispatcher (it deliberately ignores defaultPrevented,
+  // see shortcuts/runtime.ts) — this guard is only safe because the
+  // plan-review scopes bind no bare printable single key. Any future single-
+  // key binding on this surface must be reconciled with this handler.
   useEffect(() => {
     if (!captureStrayKeys) return;
     const handler = (e: KeyboardEvent) => {

--- a/packages/ui/components/CommentPopover.tsx
+++ b/packages/ui/components/CommentPopover.tsx
@@ -22,6 +22,18 @@ export type CommentAskAIHandler = (
   context: CommentAskAIContext,
 ) => boolean | void | Promise<boolean | void>;
 
+/** One selected target of a multi-target draft comment (HTML pinpoint multi-select). */
+export interface CommentTargetChip {
+  key: string;
+  /** Semantic label (hover-label cascade), e.g. "Button" / "rowchip". */
+  label?: string;
+  /** Short text excerpt of the target element. */
+  excerpt: string;
+}
+
+/** Composer-yield stage while the user is shift-selecting (see composerYield.ts). */
+export type CommentPopoverYieldState = 'none' | 'near' | 'over';
+
 interface CommentPopoverProps {
   /** Element to anchor the popover near (re-reads position on scroll) */
   anchorEl?: HTMLElement;
@@ -51,6 +63,22 @@ interface CommentPopoverProps {
   askAIDisabled?: boolean;
   /** Opt-in: `/` and `$` skill-reference autocomplete (document UI surfaces). Off by default. */
   skillReferences?: boolean;
+  /** Opt-in (HTML multi-select): selected targets rendered as horizontally
+   *  scrollable chips above the textarea. Absent → byte-identical composer. */
+  targetChips?: CommentTargetChip[];
+  /** Remove a chip's target while composing. */
+  onRemoveTargetChip?: (key: string) => void;
+  /** Chip hover — host flashes the corresponding element in the page. */
+  onHoverTargetChip?: (key: string) => void;
+  /** Opt-in: bump to return focus to the textarea (after a shift-click add/remove). */
+  refocusToken?: number;
+  /** Opt-in: while open, a window-level printable keydown that would otherwise
+   *  go nowhere (focus on <body>) routes into the textarea, so the first
+   *  keystroke after a shift-click is never lost. */
+  captureStrayKeys?: boolean;
+  /** Opt-in composer yield while shift-selecting: 'near' fades the composer,
+   *  'over' makes it near-invisible and click-through. Undefined → no-op. */
+  yieldState?: CommentPopoverYieldState;
 }
 
 const MAX_POPOVER_WIDTH = 384;
@@ -102,6 +130,12 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
   askAIContext,
   askAIDisabled = false,
   skillReferences = false,
+  targetChips,
+  onRemoveTargetChip,
+  onHoverTargetChip,
+  refocusToken,
+  captureStrayKeys = false,
+  yieldState,
 }) => {
   const [mode, setMode] = useState<'popover' | 'dialog'>('popover');
   const initialDraft = draftKey ? draftStore.get(draftKey) : undefined;
@@ -207,6 +241,101 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
     return () => document.removeEventListener('pointerdown', handlePointerDown, true);
   }, [mode, onClose]);
 
+  // Focus choreography (multi-select): after a shift-click adds/removes a
+  // target, focus returns to the textarea so typing continues uninterrupted.
+  const refocusSeenRef = useRef(refocusToken);
+  useEffect(() => {
+    if (refocusToken === undefined || refocusToken === refocusSeenRef.current) return;
+    refocusSeenRef.current = refocusToken;
+    const el = textareaRef.current;
+    if (!el) return;
+    el.focus();
+    el.selectionStart = el.selectionEnd = el.value.length;
+  }, [refocusToken]);
+
+  // First-keystroke guard: while the draft is open, a printable keydown that
+  // lands nowhere (focus fell back to <body> after an iframe interaction)
+  // routes into the textarea instead of vanishing.
+  useEffect(() => {
+    if (!captureStrayKeys) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      if (!e.key || e.key.length !== 1) return;
+      const target = e.target;
+      const strayed =
+        target === null
+        || target === document.body
+        || target === document.documentElement;
+      if (!strayed) return;
+      const el = textareaRef.current;
+      if (!el || document.activeElement === el) return;
+      e.preventDefault();
+      const key = e.key;
+      setText((prev) => prev + key);
+      el.focus();
+      requestAnimationFrame(() => {
+        el.selectionStart = el.selectionEnd = el.value.length;
+      });
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [captureStrayKeys]);
+
+  // Composer yield (multi-select): fade near the pointer, click-through over
+  // it. Class-driven so prefers-reduced-motion can kill the transition.
+  const yieldClass = yieldState === undefined
+    ? ''
+    : ` pn-composer-yieldable${yieldState === 'over' ? ' pn-composer-yield-over' : yieldState === 'near' ? ' pn-composer-yield-near' : ''}`;
+  const yieldStyleBlock = yieldState === undefined ? null : (
+    <style>{`
+      .pn-composer-yieldable { transition: opacity 180ms ease; }
+      @media (prefers-reduced-motion: reduce) {
+        .pn-composer-yieldable { transition: none; }
+      }
+      .pn-composer-yield-near { opacity: 0.4; }
+      .pn-composer-yield-over { opacity: 0.05; pointer-events: none; }
+    `}</style>
+  );
+
+  // Selected-target chips (multi-select): horizontally scrollable, primary
+  // first; each removable while composing.
+  const chipsRow = targetChips && targetChips.length > 0 ? (
+    <div
+      data-target-chips="true"
+      className="flex items-center gap-1.5 px-3 pt-2 overflow-x-auto whitespace-nowrap"
+    >
+      {targetChips.map((chip, i) => (
+        <span
+          key={chip.key}
+          data-target-chip={chip.key}
+          data-target-chip-primary={i === 0 ? 'true' : undefined}
+          onMouseEnter={() => onHoverTargetChip?.(chip.key)}
+          className={`inline-flex items-center gap-1 shrink-0 max-w-[180px] rounded-full border px-2 py-0.5 text-[10px] ${
+            i === 0
+              ? 'border-primary/50 bg-primary/10 text-foreground'
+              : 'border-border bg-muted/50 text-muted-foreground'
+          }`}
+        >
+          <span className="font-semibold text-primary">{chip.label || 'Element'}</span>
+          <span className="truncate">{chip.excerpt}</span>
+          {onRemoveTargetChip && (
+            <button
+              type="button"
+              data-target-chip-remove={chip.key}
+              onClick={() => onRemoveTargetChip(chip.key)}
+              title="Remove this target"
+              className="shrink-0 rounded-full p-0.5 hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          )}
+        </span>
+      ))}
+    </div>
+  ) : null;
+
   const handleSubmit = useCallback(() => {
     const canSubmitEmpty = allowEmptySubmit && initialText.trim().length > 0;
     if (hasUnsavedContent || canSubmitEmpty) {
@@ -285,12 +414,13 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
         {/* Dialog card */}
         <div
           ref={popoverRef}
-          className="relative w-full max-w-xl bg-popover border border-border rounded-xl shadow-2xl flex flex-col"
+          className={`relative w-full max-w-xl bg-popover border border-border rounded-xl shadow-2xl flex flex-col${yieldClass}`}
           style={{
             animation: 'comment-dialog-in 0.15s ease-out',
           }}
           onPointerDown={(e) => e.stopPropagation()}
         >
+          {yieldStyleBlock}
           <style>{`
             @keyframes comment-dialog-in {
               from { opacity: 0; transform: scale(0.95); }
@@ -320,6 +450,8 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
               </button>
             </div>
           </div>
+
+          {chipsRow}
 
           {/* Textarea */}
           <div className="relative px-4 py-3 flex-1">
@@ -404,7 +536,7 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
       <div
         ref={popoverRef}
         data-comment-popover="true"
-      className="fixed z-[100] bg-popover border border-border rounded-xl shadow-2xl flex flex-col"
+      className={`fixed z-[100] bg-popover border border-border rounded-xl shadow-2xl flex flex-col${yieldClass}`}
       style={dragPosition
         ? { top: dragPosition.top, left: dragPosition.left, width: position.width }
         : {
@@ -429,6 +561,7 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
           to { opacity: 1; transform: translateY(-100%); }
         }
       `}</style>
+      {yieldStyleBlock}
 
       {/* Header (draggable) */}
       <div className="flex items-center justify-between px-3 py-2 border-b border-border/50" {...dragHandleProps}>
@@ -452,6 +585,8 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
           </button>
         </div>
       </div>
+
+      {chipsRow}
 
       {/* Textarea */}
       <div className="relative px-3 py-2">

--- a/packages/ui/components/CommentPopover.tsx
+++ b/packages/ui/components/CommentPopover.tsx
@@ -243,19 +243,19 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
 
   // Focus choreography (multi-select): after a shift-click adds/removes a
   // target, focus returns to the textarea so typing continues uninterrupted.
+  // Focus only — the caret stays wherever the user left it mid-edit.
   const refocusSeenRef = useRef(refocusToken);
   useEffect(() => {
     if (refocusToken === undefined || refocusToken === refocusSeenRef.current) return;
     refocusSeenRef.current = refocusToken;
-    const el = textareaRef.current;
-    if (!el) return;
-    el.focus();
-    el.selectionStart = el.selectionEnd = el.value.length;
+    textareaRef.current?.focus();
   }, [refocusToken]);
 
   // First-keystroke guard: while the draft is open, a printable keydown that
   // lands nowhere (focus fell back to <body> after an iframe interaction)
-  // routes into the textarea instead of vanishing.
+  // routes into the textarea instead of vanishing. Capture phase, so a
+  // parent-level global shortcut cannot both fire and have its character
+  // appended; the character lands at the textarea's remembered caret.
   useEffect(() => {
     if (!captureStrayKeys) return;
     const handler = (e: KeyboardEvent) => {
@@ -271,14 +271,16 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
       if (!el || document.activeElement === el) return;
       e.preventDefault();
       const key = e.key;
-      setText((prev) => prev + key);
+      const start = el.selectionStart ?? el.value.length;
+      const end = el.selectionEnd ?? start;
+      setText((prev) => prev.slice(0, start) + key + prev.slice(end));
       el.focus();
       requestAnimationFrame(() => {
-        el.selectionStart = el.selectionEnd = el.value.length;
+        el.selectionStart = el.selectionEnd = start + 1;
       });
     };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
+    window.addEventListener('keydown', handler, true);
+    return () => window.removeEventListener('keydown', handler, true);
   }, [captureStrayKeys]);
 
   // Composer yield (multi-select): fade near the pointer, click-through over
@@ -412,15 +414,18 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
         <div className="absolute inset-0 bg-background/80 backdrop-blur-sm" />
 
         {/* Dialog card */}
+        {/* The expanded dialog deliberately does not yield: it is an explicit
+            full-screen compose surface, and its backdrop wrapper (which carries
+            data-comment-popover) spans the viewport, so proximity is
+            meaningless there. */}
         <div
           ref={popoverRef}
-          className={`relative w-full max-w-xl bg-popover border border-border rounded-xl shadow-2xl flex flex-col${yieldClass}`}
+          className="relative w-full max-w-xl bg-popover border border-border rounded-xl shadow-2xl flex flex-col"
           style={{
             animation: 'comment-dialog-in 0.15s ease-out',
           }}
           onPointerDown={(e) => e.stopPropagation()}
         >
-          {yieldStyleBlock}
           <style>{`
             @keyframes comment-dialog-in {
               from { opacity: 0; transform: scale(0.95); }

--- a/packages/ui/components/html-viewer/HtmlViewer.tsx
+++ b/packages/ui/components/html-viewer/HtmlViewer.tsx
@@ -24,10 +24,19 @@ import {
 } from "../../utils/vimHud";
 import { AnnotationToolbar } from "../AnnotationToolbar";
 import { AttachmentsButton } from "../AttachmentsButton";
-import { CommentPopover, type CommentAskAIHandler } from "../CommentPopover";
+import {
+  CommentPopover,
+  type CommentAskAIHandler,
+  type CommentTargetChip,
+} from "../CommentPopover";
 import { FloatingQuickLabelPicker } from "../FloatingQuickLabelPicker";
 import { VimKeyHud } from "../VimKeyHud";
 import type { ViewerHandle } from "../Viewer";
+import {
+  computeComposerYield,
+  distanceToRect,
+  type ComposerYieldState,
+} from "./composerYield";
 import { useHtmlAnnotation } from "./useHtmlAnnotation";
 import {
   THEME_TOKENS,
@@ -235,6 +244,36 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
       setIframeHeight(height);
     }, []);
 
+    // Composer yield while shift-selecting (multi-target drafts): fade the
+    // composer as the pointer approaches, click-through when over it. Pointer
+    // positions arrive from parent mousemoves AND from the bridge (the iframe
+    // consumes moves over the page, so the bridge relays them).
+    const [composerYield, setComposerYield] = useState<ComposerYieldState>("none");
+    const composerYieldRef = useRef(composerYield);
+    composerYieldRef.current = composerYield;
+    const shiftHeldRef = useRef(false);
+
+    const handleYieldPointer = useCallback((clientX: number, clientY: number) => {
+      if (!shiftHeldRef.current) return;
+      const popover = document.querySelector("[data-comment-popover]");
+      if (!popover) return;
+      const rect = popover.getBoundingClientRect();
+      const next = computeComposerYield(
+        composerYieldRef.current,
+        distanceToRect(clientX, clientY, rect),
+      );
+      if (next !== composerYieldRef.current) setComposerYield(next);
+    }, []);
+
+    const handleBridgePointer = useCallback(
+      (x: number, y: number) => {
+        const iframeRect = iframeRef.current?.getBoundingClientRect();
+        if (!iframeRect) return;
+        handleYieldPointer(iframeRect.left + x, iframeRect.top + y);
+      },
+      [handleYieldPointer],
+    );
+
     const hook = useHtmlAnnotation({
       iframeRef,
       enabled: !readOnly,
@@ -244,7 +283,55 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
       selectedAnnotationId,
       mode,
       onResize: handleResize,
+      onBridgePointer: handleBridgePointer,
     });
+
+    const multiSelectActive = !readOnly && !!hook.commentPopover && hook.draftTargets.length > 0;
+
+    // Track Shift while a multi-select draft composer is open; releasing it
+    // (or losing window focus) always restores the composer.
+    useEffect(() => {
+      if (!multiSelectActive) {
+        shiftHeldRef.current = false;
+        setComposerYield("none");
+        return;
+      }
+      const down = (e: KeyboardEvent) => {
+        if (e.key === "Shift") shiftHeldRef.current = true;
+      };
+      const release = () => {
+        shiftHeldRef.current = false;
+        setComposerYield("none");
+      };
+      const up = (e: KeyboardEvent) => {
+        if (e.key === "Shift") release();
+      };
+      const move = (e: MouseEvent) => {
+        // Parent-side pointer (over app chrome or the composer itself).
+        if (e.shiftKey) shiftHeldRef.current = true;
+        handleYieldPointer(e.clientX, e.clientY);
+      };
+      window.addEventListener("keydown", down);
+      window.addEventListener("keyup", up);
+      window.addEventListener("blur", release);
+      window.addEventListener("mousemove", move);
+      return () => {
+        window.removeEventListener("keydown", down);
+        window.removeEventListener("keyup", up);
+        window.removeEventListener("blur", release);
+        window.removeEventListener("mousemove", move);
+      };
+    }, [multiSelectActive, handleYieldPointer]);
+
+    // Chip data for the composer: semantic label + short excerpt per target.
+    const targetChips = useMemo<CommentTargetChip[] | undefined>(() => {
+      if (!hook.draftTargets.length) return undefined;
+      return hook.draftTargets.map((t) => ({
+        key: t.key,
+        label: t.label,
+        excerpt: t.text.replace(/\s+/g, " ").trim().slice(0, 80),
+      }));
+    }, [hook.draftTargets]);
 
     useEffect(() => {
       function handler(e: MessageEvent<unknown>) {
@@ -606,6 +693,12 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
                 label: "Selected HTML",
                 text: hook.commentPopover.selectedText ?? hook.commentPopover.contextText,
               }}
+              targetChips={targetChips}
+              onRemoveTargetChip={targetChips ? hook.removeDraftTarget : undefined}
+              onHoverTargetChip={targetChips ? hook.flashDraftTarget : undefined}
+              refocusToken={targetChips ? hook.composerFocusToken : undefined}
+              captureStrayKeys={multiSelectActive}
+              yieldState={multiSelectActive ? composerYield : undefined}
             />,
             document.body,
           )}

--- a/packages/ui/components/html-viewer/HtmlViewer.tsx
+++ b/packages/ui/components/html-viewer/HtmlViewer.tsx
@@ -266,7 +266,16 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
     }, []);
 
     const handleBridgePointer = useCallback(
-      (x: number, y: number) => {
+      (x: number, y: number, shift: boolean) => {
+        // The bridge is the only observer of Shift while the pointer lives
+        // inside the sandbox (parent keydowns don't fire there, and window
+        // blur clears our local flag when focus enters the iframe) — so the
+        // relayed shift state arms/disarms the yield directly.
+        shiftHeldRef.current = shift;
+        if (!shift) {
+          setComposerYield("none");
+          return;
+        }
         const iframeRect = iframeRef.current?.getBoundingClientRect();
         if (!iframeRect) return;
         handleYieldPointer(iframeRect.left + x, iframeRect.top + y);

--- a/packages/ui/components/html-viewer/bridge-script.ts
+++ b/packages/ui/components/html-viewer/bridge-script.ts
@@ -407,10 +407,11 @@ export const BRIDGE_SCRIPT = `(function() {
     if (!tracked) return;
     var r = tracked.getBoundingClientRect();
     if (r.bottom < 0 || r.top > window.innerHeight) {
-      // Multi-select drafts survive scrolling: the user is expected to roam
-      // the page shift-clicking distant elements, so the primary leaving the
-      // viewport must not tear the draft down.
-      if (pendingMultiTargets.length > 0) return;
+      // Pinpoint drafts survive scrolling: the user is expected to roam the
+      // page (especially to shift-click distant elements into the draft), so
+      // the pinned primary leaving the viewport must not tear the draft down.
+      // Drag selections keep the existing close-on-scroll-out behavior.
+      if (pendingPinViaPinpoint || pendingMultiTargets.length > 0) return;
       // Selection scrolled out of view — close the toolbar (matches markdown).
       parent.postMessage({ type: PREFIX + 'selection-clear' }, '*');
       pendingSelection = null;

--- a/packages/ui/components/html-viewer/bridge-script.ts
+++ b/packages/ui/components/html-viewer/bridge-script.ts
@@ -304,7 +304,12 @@ export const BRIDGE_SCRIPT = `(function() {
   var pendingPinAnchor = null; // serialized anchor for the pending pin
   var pendingPinKey = null; // target key for the primary pinpoint target (multi-select)
   var pendingPinLabel = null; // semantic label captured for the primary target
-  var pendingPinViaPinpoint = false; // multi-select only arms for pinpoint-click drafts
+  var pendingPinViaPinpoint = false; // pinpoint drafts survive scroll-out (see postSelectionRect)
+  // Multi-select is ARMED EXPLICITLY by the parent (arm-multi-select), and only
+  // when the comment composer owns the draft. The bridge must never accept a
+  // shift-toggle the parent would not mirror (e.g. quickLabel-mode drafts):
+  // what the user sees pinned and what the annotation saves must never diverge.
+  var multiSelectArmed = false;
   // Shift-click multi-select: additional elements joined to the SAME draft
   // comment while the composer is open. Each entry owns a pinned outline box.
   var pendingMultiTargets = []; // { key, el, anchor, label, text, box }
@@ -541,9 +546,24 @@ export const BRIDGE_SCRIPT = `(function() {
       restoreVimSemanticTarget();
     }
 
+    else if (type === PREFIX + 'arm-multi-select') {
+      // Parent arms shift-multi-select for the draft it is mirroring in the
+      // comment composer. The key must name the CURRENT primary so a stale
+      // arm from a previous draft can never arm a new one.
+      if (
+        pendingPinEl
+        && pendingPinViaPinpoint
+        && typeof e.data.key === 'string'
+        && e.data.key === pendingPinKey
+      ) {
+        multiSelectArmed = true;
+      }
+    }
+
     else if (type === PREFIX + 'remove-target') {
-      // Parent-initiated removal (chip X button): the parent already updated
-      // its own list, so no echo — both sides promote deterministically.
+      // Parent-initiated removal (chip X button), or the parent's echo of a
+      // bridge-side removal. Idempotent: an already-removed key is a no-op,
+      // which also resyncs the two sides after a forged removal message.
       removeMultiTargetByKey(typeof e.data.key === 'string' ? e.data.key : '', false);
     }
 
@@ -1053,9 +1073,11 @@ export const BRIDGE_SCRIPT = `(function() {
     // Hit-test at the pointer (e.target only backstops engines without
     // elementFromPoint) so the same code path serves the scroll re-hit-test.
     updatePinpointHover(e.clientX, e.clientY, e.target);
-    if (pendingPinEl && pendingPinViaPinpoint) {
-      // Composer yield needs the pointer even while it is inside this iframe.
-      schedulePointerRelay(e.clientX, e.clientY);
+    if (pendingPinEl && multiSelectArmed) {
+      // Composer yield needs the pointer even while it is inside this iframe;
+      // the shift state rides along because the parent cannot observe
+      // modifiers held while focus/pointer live in the sandbox.
+      schedulePointerRelay(e.clientX, e.clientY, e.shiftKey);
       // Shift-hover preview: outline what the next shift-click would toggle.
       if (e.shiftKey) updateMultiHover(e.clientX, e.clientY, e.target);
       else hideMultiHoverBox();
@@ -1355,6 +1377,7 @@ export const BRIDGE_SCRIPT = `(function() {
     pendingPinKey = null;
     pendingPinLabel = null;
     pendingPinViaPinpoint = false;
+    multiSelectArmed = false;
     hidePinpointBox();
   }
 
@@ -1573,8 +1596,8 @@ export const BRIDGE_SCRIPT = `(function() {
   // composer fades / becomes click-through as the pointer approaches it).
   var pointerRelayRaf = 0;
   var pointerRelayPos = null;
-  function schedulePointerRelay(x, y) {
-    pointerRelayPos = { x: x, y: y };
+  function schedulePointerRelay(x, y, shift) {
+    pointerRelayPos = { x: x, y: y, shift: !!shift };
     if (pointerRelayRaf) return;
     pointerRelayRaf = requestAnimationFrame(function() {
       pointerRelayRaf = 0;
@@ -1582,7 +1605,8 @@ export const BRIDGE_SCRIPT = `(function() {
       parent.postMessage({
         type: PREFIX + 'pointer',
         x: pointerRelayPos.x,
-        y: pointerRelayPos.y
+        y: pointerRelayPos.y,
+        shift: pointerRelayPos.shift
       }, '*');
     });
   }
@@ -1660,9 +1684,11 @@ export const BRIDGE_SCRIPT = `(function() {
     // checked by IDENTITY, not selector, so a page element spoofing
     // [data-plannotator-pin-badge] stays an ordinary annotatable target.
     if (isViewerOverlayNode(e.target)) return;
-    // Shift-click while a pinpoint draft is open: toggle the element in/out of
-    // the SAME draft comment instead of replacing the selection.
-    if (e.shiftKey && pendingPinEl && pendingPinViaPinpoint && pendingSelection) {
+    // Shift-click while an ARMED pinpoint draft is open: toggle the element
+    // in/out of the SAME draft comment instead of replacing the selection.
+    // Unarmed drafts (modes the parent does not mirror, e.g. quickLabel)
+    // treat shift-click exactly like a plain click.
+    if (e.shiftKey && pendingPinEl && multiSelectArmed && pendingSelection) {
       e.preventDefault();
       e.stopPropagation();
       hideMultiHoverBox();

--- a/packages/ui/components/html-viewer/bridge-script.ts
+++ b/packages/ui/components/html-viewer/bridge-script.ts
@@ -302,6 +302,14 @@ export const BRIDGE_SCRIPT = `(function() {
   var pendingRange = null; // live range for the pending selection (scroll tracking)
   var pendingPinEl = null; // element pinned by a pinpoint click (outline + scroll tracking)
   var pendingPinAnchor = null; // serialized anchor for the pending pin
+  var pendingPinKey = null; // target key for the primary pinpoint target (multi-select)
+  var pendingPinLabel = null; // semantic label captured for the primary target
+  var pendingPinViaPinpoint = false; // multi-select only arms for pinpoint-click drafts
+  // Shift-click multi-select: additional elements joined to the SAME draft
+  // comment while the composer is open. Each entry owns a pinned outline box.
+  var pendingMultiTargets = []; // { key, el, anchor, label, text, box }
+  var multiTargetSeq = 0;
+  var MAX_MULTI_TARGETS = 16;
   var currentInputMethod = 'drag'; // 'drag' = text selection, 'pinpoint' = click an element
   var pinpointHover = null;
   var vimEnabled = false;
@@ -354,6 +362,7 @@ export const BRIDGE_SCRIPT = `(function() {
         parent.postMessage({ type: PREFIX + 'selection-clear' }, '*');
         pendingSelection = null;
         pendingRange = null;
+        clearMultiTargets();
         clearPendingPin();
       }
       return false;
@@ -379,6 +388,8 @@ export const BRIDGE_SCRIPT = `(function() {
       modeOverride: modeOverride || undefined,
       anchor: (extras && extras.anchor) || undefined,
       pinpoint: (extras && extras.pinpoint) || undefined,
+      targetKey: (extras && extras.targetKey) || undefined,
+      targetLabel: (extras && extras.targetLabel) || undefined,
       rect: { top: rect.top, left: rect.left, width: rect.width, height: rect.height }
     }, '*');
     return true;
@@ -396,6 +407,10 @@ export const BRIDGE_SCRIPT = `(function() {
     if (!tracked) return;
     var r = tracked.getBoundingClientRect();
     if (r.bottom < 0 || r.top > window.innerHeight) {
+      // Multi-select drafts survive scrolling: the user is expected to roam
+      // the page shift-clicking distant elements, so the primary leaving the
+      // viewport must not tear the draft down.
+      if (pendingMultiTargets.length > 0) return;
       // Selection scrolled out of view — close the toolbar (matches markdown).
       parent.postMessage({ type: PREFIX + 'selection-clear' }, '*');
       pendingSelection = null;
@@ -437,10 +452,16 @@ export const BRIDGE_SCRIPT = `(function() {
         } else if (pendingPinEl) {
           registerPin(id, pendingPinEl, pendingPinAnchor);
         }
+        // Every additional multi-select target gets a pin under the SAME
+        // annotation id — all of them share one badge number.
+        for (var mtIndex = 0; mtIndex < pendingMultiTargets.length; mtIndex++) {
+          registerPin(id, pendingMultiTargets[mtIndex].el, pendingMultiTargets[mtIndex].anchor);
+        }
         pendingSelection = null;
         pendingRange = null;
         window.getSelection().removeAllRanges();
       }
+      clearMultiTargets();
       clearPendingPin();
       restoreVimSemanticTarget();
     }
@@ -476,6 +497,21 @@ export const BRIDGE_SCRIPT = `(function() {
         registerPin(e.data.id, anchorEl, e.data.anchor);
         found = true;
       }
+      // Multi-target annotations: every additional anchor that still resolves
+      // gets a pin under the same id (same badge number). Anchor-only — a
+      // stale anchor simply doesn't restore (fail closed), the primary's text
+      // fallback is never reused here because an excerpt search could mis-mark.
+      var extraAnchors = e.data.additionalAnchors;
+      if (extraAnchors && extraAnchors.length) {
+        var extraCount = Math.min(extraAnchors.length, MAX_MULTI_TARGETS);
+        for (var extraIndex = 0; extraIndex < extraCount; extraIndex++) {
+          var extraEl = resolveAnchorElement(extraAnchors[extraIndex]);
+          if (extraEl) {
+            registerPin(e.data.id, extraEl, extraAnchors[extraIndex]);
+            found = true;
+          }
+        }
+      }
       parent.postMessage({
         type: PREFIX + 'mark-applied',
         id: e.data.id,
@@ -498,9 +534,20 @@ export const BRIDGE_SCRIPT = `(function() {
       pendingSelection = null;
       pendingRange = null;
       skipNextClear = false;
+      clearMultiTargets();
       clearPendingPin();
       window.getSelection().removeAllRanges();
       restoreVimSemanticTarget();
+    }
+
+    else if (type === PREFIX + 'remove-target') {
+      // Parent-initiated removal (chip X button): the parent already updated
+      // its own list, so no echo — both sides promote deterministically.
+      removeMultiTargetByKey(typeof e.data.key === 'string' ? e.data.key : '', false);
+    }
+
+    else if (type === PREFIX + 'flash-target') {
+      flashMultiTarget(typeof e.data.key === 'string' ? e.data.key : '');
     }
 
     else if (type === PREFIX + 'scroll-to') {
@@ -1005,6 +1052,13 @@ export const BRIDGE_SCRIPT = `(function() {
     // Hit-test at the pointer (e.target only backstops engines without
     // elementFromPoint) so the same code path serves the scroll re-hit-test.
     updatePinpointHover(e.clientX, e.clientY, e.target);
+    if (pendingPinEl && pendingPinViaPinpoint) {
+      // Composer yield needs the pointer even while it is inside this iframe.
+      schedulePointerRelay(e.clientX, e.clientY);
+      // Shift-hover preview: outline what the next shift-click would toggle.
+      if (e.shiftKey) updateMultiHover(e.clientX, e.clientY, e.target);
+      else hideMultiHoverBox();
+    }
   });
 
   // rAF-coalesced reconcile: keeps the hover box under a stationary cursor
@@ -1020,6 +1074,7 @@ export const BRIDGE_SCRIPT = `(function() {
       // the last-position cache must never answer the next probe.
       invalidatePointerHitCache();
       renderPinBadges();
+      positionMultiTargetBoxes();
       if (pendingPinEl && pendingPinEl.isConnected) {
         positionPinpointBox(pendingPinEl);
         return;
@@ -1043,7 +1098,14 @@ export const BRIDGE_SCRIPT = `(function() {
     return null;
   }
   function registerPin(id, element, anchor) {
-    if (findPin(id)) return;
+    // One annotation may legitimately cover several elements (multi-select),
+    // so dedup by (id, element) — and by (id, anchor) so a re-resolved anchor
+    // can't double-badge the same logical target — never by id alone.
+    for (var existing = 0; existing < pinRegistry.length; existing++) {
+      if (pinRegistry[existing].id !== id) continue;
+      if (pinRegistry[existing].element === element) return;
+      if (anchor && anchorsEqual(pinRegistry[existing].anchor, anchor)) return;
+    }
     var badge = document.createElement('div');
     badge.setAttribute('data-plannotator-pin-badge', '');
     badge.setAttribute('data-plannotator-vim-ui', '');
@@ -1077,6 +1139,9 @@ export const BRIDGE_SCRIPT = `(function() {
     pinRegistry = [];
   }
   function renderPinBadges() {
+    // Number by FIRST-SEEN annotation id, not by registry entry: a
+    // multi-target annotation has several pins that all share one number.
+    var pinNumbers = new Map();
     for (var i = 0; i < pinRegistry.length; i++) {
       var pin = pinRegistry[i];
       if ((!pin.element || !pin.element.isConnected) && pin.anchor) {
@@ -1084,7 +1149,8 @@ export const BRIDGE_SCRIPT = `(function() {
         pin.element = resolveAnchorElement(pin.anchor);
       }
       // Number by registry (creation) order, independent of visibility.
-      pin.badge.textContent = String(i + 1);
+      if (!pinNumbers.has(pin.id)) pinNumbers.set(pin.id, pinNumbers.size + 1);
+      pin.badge.textContent = String(pinNumbers.get(pin.id));
       if (!pin.element || !pin.element.isConnected) {
         pin.badge.style.display = 'none';
         continue;
@@ -1285,7 +1351,239 @@ export const BRIDGE_SCRIPT = `(function() {
   function clearPendingPin() {
     pendingPinEl = null;
     pendingPinAnchor = null;
+    pendingPinKey = null;
+    pendingPinLabel = null;
+    pendingPinViaPinpoint = false;
     hidePinpointBox();
+  }
+
+  // --- Multi-select (shift-click): several elements, ONE draft comment ---
+
+  function makeTargetKey() {
+    multiTargetSeq += 1;
+    return 'ht-' + multiTargetSeq;
+  }
+
+  function anchorsEqual(a, b) {
+    return !!a && !!b
+      && a.selector === b.selector
+      && a.tagName === b.tagName
+      && (a.text || '') === (b.text || '');
+  }
+
+  // Per-target pinned outline boxes. The primary keeps the main pinpoint box;
+  // each additional target gets its own (same attribute so the CSS applies,
+  // identity-tracked in overlayNodes like every viewer overlay).
+  function createMultiTargetBox(el) {
+    var box = document.createElement('div');
+    box.setAttribute('data-plannotator-pinpoint-box', '');
+    box.setAttribute('data-plannotator-vim-ui', '');
+    box.setAttribute('data-pinned', '');
+    overlayNodes.add(box);
+    document.body.appendChild(box);
+    positionBoxToEl(box, el);
+    return box;
+  }
+
+  function positionBoxToEl(box, el) {
+    var r = el.getBoundingClientRect();
+    box.style.display = 'block';
+    box.style.left = r.left + 'px';
+    box.style.top = r.top + 'px';
+    box.style.width = r.width + 'px';
+    box.style.height = r.height + 'px';
+  }
+
+  function destroyMultiTargetBox(box) {
+    if (!box) return;
+    if (box.parentNode) box.parentNode.removeChild(box);
+    overlayNodes.delete(box);
+  }
+
+  function clearMultiTargets() {
+    for (var i = 0; i < pendingMultiTargets.length; i++) {
+      destroyMultiTargetBox(pendingMultiTargets[i].box);
+    }
+    pendingMultiTargets = [];
+    hideMultiHoverBox();
+  }
+
+  function positionMultiTargetBoxes() {
+    for (var i = 0; i < pendingMultiTargets.length; i++) {
+      var entry = pendingMultiTargets[i];
+      if (entry.el && entry.el.isConnected) positionBoxToEl(entry.box, entry.el);
+      else entry.box.style.display = 'none';
+    }
+  }
+
+  // Element text for an additional target: same capping and text-less
+  // description used by the primary element path in annotateElement.
+  function elementTargetText(el, label) {
+    var text = capSelectionText((el.textContent || '').trim());
+    if (!text) text = capSelectionText('[element: ' + label + ']');
+    return text;
+  }
+
+  /**
+   * Remove one draft target by key. Removing the primary promotes the first
+   * remaining additional target to primary (it commits as an element pin);
+   * removing the final target cancels the whole draft. When echo is true
+   * (bridge-initiated toggle-off) the removal is posted to the parent, which
+   * performs the identical deterministic update on its chip list.
+   */
+  function removeMultiTargetByKey(key, echo) {
+    if (!key) return;
+    if (key === pendingPinKey) {
+      if (!pendingMultiTargets.length) {
+        // Last target gone — the draft is cancelled.
+        pendingSelection = null;
+        pendingRange = null;
+        skipNextClear = false;
+        clearMultiTargets();
+        clearPendingPin();
+        try { window.getSelection().removeAllRanges(); } catch (ex) {}
+        if (echo) parent.postMessage({ type: PREFIX + 'multi-target-removed', key: key }, '*');
+        return;
+      }
+      var next = pendingMultiTargets.shift();
+      destroyMultiTargetBox(next.box);
+      pendingPinEl = next.el;
+      pendingPinAnchor = next.anchor;
+      pendingPinKey = next.key;
+      pendingPinLabel = next.label;
+      // A promoted primary commits as an element pin: the original text
+      // selection belonged to the removed element and no longer applies.
+      pendingSelection = { element: true };
+      pendingRange = null;
+      try { window.getSelection().removeAllRanges(); } catch (ex2) {}
+      var mainBox = getPinpointBoxEl();
+      mainBox.setAttribute('data-pinned', '');
+      mainBox.classList.remove('pn-pin-enter');
+      if (pendingPinEl && pendingPinEl.isConnected) positionPinpointBox(pendingPinEl);
+      if (echo) parent.postMessage({ type: PREFIX + 'multi-target-removed', key: key }, '*');
+      return;
+    }
+    for (var i = 0; i < pendingMultiTargets.length; i++) {
+      if (pendingMultiTargets[i].key === key) {
+        destroyMultiTargetBox(pendingMultiTargets[i].box);
+        pendingMultiTargets.splice(i, 1);
+        if (echo) parent.postMessage({ type: PREFIX + 'multi-target-removed', key: key }, '*');
+        return;
+      }
+    }
+  }
+
+  /** Shift-click toggle: add the element to the draft, or remove it if it is
+   *  already selected (dedup by DOM identity first, then by anchor equality
+   *  so a re-rendered page cannot double-select the same logical element). */
+  function toggleMultiTarget(el) {
+    if (!el) return;
+    if (el === pendingPinEl) {
+      removeMultiTargetByKey(pendingPinKey, true);
+      return;
+    }
+    for (var i = 0; i < pendingMultiTargets.length; i++) {
+      if (pendingMultiTargets[i].el === el) {
+        removeMultiTargetByKey(pendingMultiTargets[i].key, true);
+        return;
+      }
+    }
+    var anchor = buildElementAnchor(el);
+    if (anchor) {
+      if (anchorsEqual(anchor, pendingPinAnchor)) {
+        removeMultiTargetByKey(pendingPinKey, true);
+        return;
+      }
+      for (var j = 0; j < pendingMultiTargets.length; j++) {
+        if (anchorsEqual(anchor, pendingMultiTargets[j].anchor)) {
+          removeMultiTargetByKey(pendingMultiTargets[j].key, true);
+          return;
+        }
+      }
+    }
+    // Cap at the source: never grow the draft past the parent-side DTO cap.
+    if (pendingMultiTargets.length >= MAX_MULTI_TARGETS) return;
+    var label = pinpointHoverLabel(el);
+    var text = elementTargetText(el, label);
+    var key = makeTargetKey();
+    var box = createMultiTargetBox(el);
+    pendingMultiTargets.push({ key: key, el: el, anchor: anchor, label: label, text: text, box: box });
+    parent.postMessage({
+      type: PREFIX + 'multi-target-added',
+      key: key,
+      label: label,
+      text: text,
+      anchor: anchor || undefined
+    }, '*');
+  }
+
+  /** Chip hover in the composer: flash the corresponding pinned outline. */
+  function flashMultiTarget(key) {
+    var el = null;
+    var box = null;
+    if (key && key === pendingPinKey) {
+      el = pendingPinEl;
+      box = getPinpointBoxEl();
+    } else {
+      for (var i = 0; i < pendingMultiTargets.length; i++) {
+        if (pendingMultiTargets[i].key === key) {
+          el = pendingMultiTargets[i].el;
+          box = pendingMultiTargets[i].box;
+          break;
+        }
+      }
+    }
+    if (!el || !el.isConnected || !box) return;
+    positionBoxToEl(box, el);
+    box.classList.remove('pn-pin-enter');
+    void box.offsetWidth; // restart the enter animation as the flash
+    box.classList.add('pn-pin-enter');
+    var r = el.getBoundingClientRect();
+    if (r.bottom < 0 || r.top > window.innerHeight) {
+      try { el.scrollIntoView({ behavior: 'smooth', block: 'nearest' }); } catch (ex) {}
+    }
+  }
+
+  // Shift-hover preview while a draft is pinned: shows what the next
+  // shift-click would add. A separate box — the main one tracks the primary.
+  var multiHoverBoxEl = null;
+  function getMultiHoverBoxEl() {
+    if (!multiHoverBoxEl) {
+      multiHoverBoxEl = document.createElement('div');
+      multiHoverBoxEl.setAttribute('data-plannotator-pinpoint-box', '');
+      multiHoverBoxEl.setAttribute('data-plannotator-vim-ui', '');
+      overlayNodes.add(multiHoverBoxEl);
+    }
+    if (!multiHoverBoxEl.isConnected) document.body.appendChild(multiHoverBoxEl);
+    return multiHoverBoxEl;
+  }
+  function hideMultiHoverBox() {
+    if (multiHoverBoxEl) multiHoverBoxEl.style.display = 'none';
+  }
+  function updateMultiHover(x, y, fallbackNode) {
+    var el = pinpointLeafAt(x, y, fallbackNode);
+    if (!el || el === pendingPinEl) { hideMultiHoverBox(); hidePinpointLabel(); return; }
+    positionBoxToEl(getMultiHoverBoxEl(), el);
+    positionPinpointLabel(el, pinpointHoverLabel(el));
+  }
+
+  // Composer-yield support: while a pinned draft is open the parent needs the
+  // pointer position even though the pointer is inside this iframe (the
+  // composer fades / becomes click-through as the pointer approaches it).
+  var pointerRelayRaf = 0;
+  var pointerRelayPos = null;
+  function schedulePointerRelay(x, y) {
+    pointerRelayPos = { x: x, y: y };
+    if (pointerRelayRaf) return;
+    pointerRelayRaf = requestAnimationFrame(function() {
+      pointerRelayRaf = 0;
+      if (!pendingPinEl || !pointerRelayPos) return;
+      parent.postMessage({
+        type: PREFIX + 'pointer',
+        x: pointerRelayPos.x,
+        y: pointerRelayPos.y
+      }, '*');
+    });
   }
 
   // Pin an element: select its text if possible (so a <mark> can wrap it), else
@@ -1297,9 +1595,18 @@ export const BRIDGE_SCRIPT = `(function() {
     if (!el) return false;
     pinpointHover = null;
     hidePinpointLabel();
+    clearMultiTargets(); // a new primary starts a fresh draft
     pendingPinEl = el;
     pendingPinAnchor = buildElementAnchor(el);
-    var extras = { anchor: pendingPinAnchor, pinpoint: !!viaPinpoint };
+    pendingPinKey = makeTargetKey();
+    pendingPinLabel = pinpointHoverLabel(el);
+    pendingPinViaPinpoint = !!viaPinpoint;
+    var extras = {
+      anchor: pendingPinAnchor,
+      pinpoint: !!viaPinpoint,
+      targetKey: pendingPinKey,
+      targetLabel: pendingPinLabel
+    };
     // Pinned outline: stronger accent box that tracks the element until the
     // composer resolves (create-mark or cancel-selection).
     var box = getPinpointBoxEl();
@@ -1338,6 +1645,8 @@ export const BRIDGE_SCRIPT = `(function() {
       modeOverride: modeOverride || undefined,
       anchor: pendingPinAnchor || undefined,
       pinpoint: !!viaPinpoint || undefined,
+      targetKey: pendingPinKey || undefined,
+      targetLabel: pendingPinLabel || undefined,
       rect: { top: r.top, left: r.left, width: r.width, height: r.height } }, '*');
     return true;
   }
@@ -1350,6 +1659,17 @@ export const BRIDGE_SCRIPT = `(function() {
     // checked by IDENTITY, not selector, so a page element spoofing
     // [data-plannotator-pin-badge] stays an ordinary annotatable target.
     if (isViewerOverlayNode(e.target)) return;
+    // Shift-click while a pinpoint draft is open: toggle the element in/out of
+    // the SAME draft comment instead of replacing the selection.
+    if (e.shiftKey && pendingPinEl && pendingPinViaPinpoint && pendingSelection) {
+      e.preventDefault();
+      e.stopPropagation();
+      hideMultiHoverBox();
+      hidePinpointLabel();
+      var multiEl = resolvePinpointTargetAt(e.clientX, e.clientY, e.target);
+      if (multiEl) toggleMultiTarget(multiEl);
+      return;
+    }
     // Click what the hover box shows: the currently hovered element is the
     // target the user aimed at. Fall back to a fresh hit-test at the click
     // point (e.g. a click with no preceding mousemove).
@@ -1372,6 +1692,7 @@ export const BRIDGE_SCRIPT = `(function() {
       pendingSelection = null;
       pendingRange = null;
       skipNextClear = false;
+      clearMultiTargets();
       clearPendingPin();
       window.getSelection().removeAllRanges();
     } else if (currentInputMethod === 'pinpoint') {

--- a/packages/ui/components/html-viewer/bridge-script.ts
+++ b/packages/ui/components/html-viewer/bridge-script.ts
@@ -1621,6 +1621,12 @@ export const BRIDGE_SCRIPT = `(function() {
     pinpointHover = null;
     hidePinpointLabel();
     clearMultiTargets(); // a new primary starts a fresh draft
+    // Arming is per-draft, never sticky: the parent re-arms via
+    // arm-multi-select keyed to THIS draft's target key if (and only if) the
+    // comment composer owns it. Without this reset, a mode switch between
+    // drafts (comment -> quick label) leaves a stale arm and the bridge
+    // accumulates pins the saved annotation will not carry.
+    multiSelectArmed = false;
     pendingPinEl = el;
     pendingPinAnchor = buildElementAnchor(el);
     pendingPinKey = makeTargetKey();

--- a/packages/ui/components/html-viewer/composerYield.test.ts
+++ b/packages/ui/components/html-viewer/composerYield.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Composer-yield hysteresis contract: the composer fades as the pointer
+ * approaches (~near), goes click-through when over, and does NOT fully
+ * restore until the pointer has moved well away (48px past the rect) or the
+ * state machine is reset — preventing flicker at the borders.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  COMPOSER_YIELD_NEAR_ENTER_PX,
+  COMPOSER_YIELD_NEAR_EXIT_PX,
+  COMPOSER_YIELD_OVER_EXIT_PX,
+  computeComposerYield,
+  distanceToRect,
+} from "./composerYield";
+
+const RECT = { left: 100, top: 100, right: 300, bottom: 200 };
+
+describe("distanceToRect", () => {
+  test("inside is 0; outside is the shortest edge distance", () => {
+    expect(distanceToRect(150, 150, RECT)).toBe(0);
+    expect(distanceToRect(100, 100, RECT)).toBe(0); // on the corner
+    expect(distanceToRect(50, 150, RECT)).toBe(50); // straight left
+    expect(distanceToRect(150, 40, RECT)).toBe(60); // straight above
+    expect(distanceToRect(70, 60, RECT)).toBe(50); // 30-40-50 diagonal corner
+  });
+});
+
+describe("computeComposerYield", () => {
+  test("far pointer stays none; approaching enters near; over the rect goes over", () => {
+    expect(computeComposerYield("none", COMPOSER_YIELD_NEAR_ENTER_PX + 1)).toBe("none");
+    expect(computeComposerYield("none", COMPOSER_YIELD_NEAR_ENTER_PX)).toBe("near");
+    expect(computeComposerYield("near", 10)).toBe("near");
+    expect(computeComposerYield("near", 0)).toBe("over");
+    expect(computeComposerYield("none", 0)).toBe("over");
+  });
+
+  test("hysteresis: over holds until the pointer clears the exit band", () => {
+    expect(computeComposerYield("over", COMPOSER_YIELD_OVER_EXIT_PX)).toBe("over");
+    expect(computeComposerYield("over", COMPOSER_YIELD_OVER_EXIT_PX + 1)).toBe("near");
+    expect(computeComposerYield("over", COMPOSER_YIELD_NEAR_EXIT_PX + 1)).toBe("none");
+  });
+
+  test("hysteresis: near exits later than it enters (no flicker at the border)", () => {
+    const betweenEnterAndExit = COMPOSER_YIELD_NEAR_ENTER_PX + 5;
+    expect(betweenEnterAndExit).toBeLessThanOrEqual(COMPOSER_YIELD_NEAR_EXIT_PX);
+    expect(computeComposerYield("none", betweenEnterAndExit)).toBe("none"); // not yet entered
+    expect(computeComposerYield("near", betweenEnterAndExit)).toBe("near"); // but doesn't drop out
+    expect(computeComposerYield("near", COMPOSER_YIELD_NEAR_EXIT_PX + 1)).toBe("none");
+  });
+});

--- a/packages/ui/components/html-viewer/composerYield.ts
+++ b/packages/ui/components/html-viewer/composerYield.ts
@@ -1,0 +1,51 @@
+/**
+ * Composer-yield state machine for shift-click multi-select.
+ *
+ * While Shift is held during an HTML pinpoint draft, the comment composer must
+ * get out of the way of the pointer: fade to ~40% as the pointer approaches,
+ * and to near-zero + click-through (pointer-events: none) when the pointer is
+ * over it — the DOM equivalent of Codex's setIgnoreMouseEvents click-through
+ * popup, so the shift-click lands on the iframe beneath.
+ *
+ * Restoration uses hysteresis so the composer doesn't flicker at the border:
+ * once 'over', the pointer must clear the composer by OVER_EXIT px before the
+ * state drops back, and 'near' persists until NEAR_EXIT px (> NEAR_ENTER).
+ */
+
+export type ComposerYieldState = "none" | "near" | "over";
+
+/** Distance (px from the composer rect) at which the composer starts fading. */
+export const COMPOSER_YIELD_NEAR_ENTER_PX = 80;
+/** Distance the pointer must exceed before a faded composer fully restores. */
+export const COMPOSER_YIELD_NEAR_EXIT_PX = 96;
+/** Distance the pointer must clear a click-through composer by to restore. */
+export const COMPOSER_YIELD_OVER_EXIT_PX = 48;
+
+/** Shortest distance from a point to a rect's edge; <= 0 means inside. */
+export function distanceToRect(
+  x: number,
+  y: number,
+  rect: { left: number; top: number; right: number; bottom: number },
+): number {
+  const dx = Math.max(rect.left - x, 0, x - rect.right);
+  const dy = Math.max(rect.top - y, 0, y - rect.bottom);
+  if (dx === 0 && dy === 0) return 0;
+  return Math.hypot(dx, dy);
+}
+
+/** Next yield state for a pointer at `distance` px from the composer rect. */
+export function computeComposerYield(
+  prev: ComposerYieldState,
+  distance: number,
+): ComposerYieldState {
+  if (distance <= 0) return "over";
+  if (prev === "over") {
+    // Hysteresis: don't restore until the pointer has moved well away.
+    if (distance <= COMPOSER_YIELD_OVER_EXIT_PX) return "over";
+    return distance <= COMPOSER_YIELD_NEAR_EXIT_PX ? "near" : "none";
+  }
+  if (prev === "near") {
+    return distance <= COMPOSER_YIELD_NEAR_EXIT_PX ? "near" : "none";
+  }
+  return distance <= COMPOSER_YIELD_NEAR_ENTER_PX ? "near" : "none";
+}

--- a/packages/ui/components/html-viewer/htmlPinpointProtocol.test.tsx
+++ b/packages/ui/components/html-viewer/htmlPinpointProtocol.test.tsx
@@ -248,3 +248,307 @@ describe.if(hasDom)('pinpoint click-to-pin flow', () => {
     expect(added[0]!.htmlAnchor).toBeUndefined();
   });
 });
+
+describe.if(hasDom)('multi-target bridge message validation (trust boundary)', () => {
+  test('multi-target-added: well-formed DTO passes with validated anchor', () => {
+    expect(hookModule!.parseBridgeMessage({
+      type: 'plannotator-bridge-multi-target-added',
+      key: 'ht-2',
+      label: 'Button',
+      text: 'Create',
+      anchor: { selector: 'span.btn', tagName: 'span', text: 'Create' },
+    })).toEqual({
+      type: 'plannotator-bridge-multi-target-added',
+      key: 'ht-2',
+      label: 'Button',
+      text: 'Create',
+      anchor: { selector: 'span.btn', tagName: 'span', text: 'Create' },
+    });
+  });
+
+  test('multi-target-added: missing/oversized key or text rejects the message', () => {
+    expect(hookModule!.parseBridgeMessage({
+      type: 'plannotator-bridge-multi-target-added',
+      text: 'Create',
+    })).toBeNull();
+    expect(hookModule!.parseBridgeMessage({
+      type: 'plannotator-bridge-multi-target-added',
+      key: 'x'.repeat(65),
+      text: 'Create',
+    })).toBeNull();
+    expect(hookModule!.parseBridgeMessage({
+      type: 'plannotator-bridge-multi-target-added',
+      key: 'ht-2',
+      text: 42,
+    })).toBeNull();
+  });
+
+  test('multi-target-added: hostile label is truncated, hostile anchor dropped, text capped', () => {
+    const parsed = hookModule!.parseBridgeMessage({
+      type: 'plannotator-bridge-multi-target-added',
+      key: 'ht-3',
+      label: 'L'.repeat(500),
+      text: 'x'.repeat(hookModule!.MAX_SELECTION_TEXT_LENGTH + 5000),
+      anchor: { selector: 'x'.repeat(2000), tagName: 'p' },
+    }) as { label?: string; text: string; anchor?: unknown };
+    expect(parsed).not.toBeNull();
+    expect(parsed.label!.length).toBe(64);
+    expect(parsed.text.length).toBe(hookModule!.MAX_SELECTION_TEXT_LENGTH);
+    expect(parsed.anchor).toBeUndefined();
+  });
+
+  test('multi-target-removed and pointer messages validate their fields', () => {
+    expect(hookModule!.parseBridgeMessage({
+      type: 'plannotator-bridge-multi-target-removed',
+      key: 'ht-2',
+    })).toEqual({ type: 'plannotator-bridge-multi-target-removed', key: 'ht-2' });
+    expect(hookModule!.parseBridgeMessage({
+      type: 'plannotator-bridge-multi-target-removed',
+      key: 7,
+    })).toBeNull();
+    expect(hookModule!.parseBridgeMessage({
+      type: 'plannotator-bridge-pointer',
+      x: 12,
+      y: 34,
+    })).toEqual({ type: 'plannotator-bridge-pointer', x: 12, y: 34 });
+    expect(hookModule!.parseBridgeMessage({
+      type: 'plannotator-bridge-pointer',
+      x: Infinity,
+      y: 1,
+    })).toBeNull();
+  });
+
+  test('selection: targetKey validated, targetLabel truncated', () => {
+    const rect = { top: 10, left: 10, width: 100, height: 20 };
+    const parsed = hookModule!.parseBridgeMessage({
+      type: 'plannotator-bridge-selection',
+      text: 'Hello',
+      rect,
+      pinpoint: true,
+      targetKey: 'ht-1',
+      targetLabel: 'Z'.repeat(200),
+    }) as { targetKey?: string; targetLabel?: string };
+    expect(parsed.targetKey).toBe('ht-1');
+    expect(parsed.targetLabel!.length).toBe(64);
+    const badKey = hookModule!.parseBridgeMessage({
+      type: 'plannotator-bridge-selection',
+      text: 'Hello',
+      rect,
+      pinpoint: true,
+      targetKey: 'x'.repeat(65),
+    }) as { targetKey?: string };
+    expect(badKey.targetKey).toBeUndefined();
+  });
+});
+
+describe.if(hasDom)('multi-target composer flow (chips, promotion, submit)', () => {
+  async function mountViewer(onAdd: (ann: Annotation) => void) {
+    if (!htmlViewerModule) throw new Error('DOM test environment is not registered');
+    const HtmlViewer = htmlViewerModule.HtmlViewer;
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    mountedRoots.push(root);
+    await act(async () => {
+      root.render(
+        <HtmlViewer
+          rawHtml="<html><body><p>Pinpoint target</p></body></html>"
+          annotations={[]}
+          onAddAnnotation={onAdd}
+          onSelectAnnotation={() => {}}
+          selectedAnnotationId={null}
+          mode="selection"
+          inputMethod="pinpoint"
+        />,
+      );
+    });
+    const iframe = host.querySelector<HTMLIFrameElement>('iframe');
+    if (!iframe?.contentWindow) throw new Error('HTML iframe missing');
+    const post = async (data: Record<string, unknown>) => {
+      await act(async () => {
+        window.dispatchEvent(new MessageEvent('message', {
+          source: iframe.contentWindow,
+          data,
+        }));
+      });
+    };
+    return { post };
+  }
+
+  const rect = { top: 10, left: 10, width: 120, height: 24 };
+
+  function primarySelection(overrides: Record<string, unknown> = {}) {
+    return {
+      type: 'plannotator-bridge-selection',
+      text: 'Primary text',
+      rect,
+      pinpoint: true,
+      targetKey: 'ht-1',
+      targetLabel: 'Paragraph',
+      anchor: { selector: 'p.primary', tagName: 'p', text: 'Primary text' },
+      ...overrides,
+    };
+  }
+
+  function addedTarget(key: string, text: string) {
+    return {
+      type: 'plannotator-bridge-multi-target-added',
+      key,
+      label: 'Button',
+      text,
+      anchor: { selector: `span[data-testid="${key}"]`, tagName: 'span', text },
+    };
+  }
+
+  function chips(): HTMLElement[] {
+    return Array.from(document.querySelectorAll<HTMLElement>('[data-target-chip]'));
+  }
+
+  async function typeComment(value: string) {
+    const el = document.querySelector<HTMLTextAreaElement>('[data-comment-popover] textarea');
+    if (!el) throw new Error('composer textarea missing');
+    const setter = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(el), 'value')?.set;
+    await act(async () => {
+      if (setter) setter.call(el, value);
+      else el.value = value;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+  }
+
+  async function save() {
+    const button = Array.from(
+      document.querySelectorAll<HTMLButtonElement>('[data-comment-popover] button'),
+    ).find((b) => b.textContent === 'Save');
+    if (!button) throw new Error('Save button missing');
+    await act(async () => {
+      button.click();
+    });
+  }
+
+  test('pinpoint draft renders a primary chip; shift-adds append chips and submit as ONE comment', async () => {
+    const added: Annotation[] = [];
+    const { post } = await mountViewer((ann) => added.push(ann));
+    await post(primarySelection());
+    expect(document.querySelector('[data-comment-popover]')).not.toBeNull();
+    expect(chips().length).toBe(1);
+    expect(chips()[0]!.getAttribute('data-target-chip-primary')).toBe('true');
+
+    await post(addedTarget('ht-2', 'Create'));
+    await post(addedTarget('ht-3', 'Cancel'));
+    expect(chips().length).toBe(3);
+
+    await typeComment('Unify these buttons');
+    await save();
+
+    expect(added.length).toBe(1);
+    const ann = added[0]!;
+    expect(ann.text).toBe('Unify these buttons');
+    expect(ann.originalText).toBe('Primary text');
+    expect(ann.htmlAnchor).toEqual({ selector: 'p.primary', tagName: 'p', text: 'Primary text' });
+    expect(ann.htmlAdditionalTargets).toEqual([
+      {
+        label: 'Button',
+        text: 'Create',
+        anchor: { selector: 'span[data-testid="ht-2"]', tagName: 'span', text: 'Create' },
+      },
+      {
+        label: 'Button',
+        text: 'Cancel',
+        anchor: { selector: 'span[data-testid="ht-3"]', tagName: 'span', text: 'Cancel' },
+      },
+    ]);
+    // Draft state cleared with the submit.
+    expect(document.querySelector('[data-comment-popover]')).toBeNull();
+  });
+
+  test('single-target pinpoint submit carries NO additional-targets array', async () => {
+    const added: Annotation[] = [];
+    const { post } = await mountViewer((ann) => added.push(ann));
+    await post(primarySelection());
+    await typeComment('Just this one');
+    await save();
+    expect(added.length).toBe(1);
+    expect(added[0]!.htmlAdditionalTargets).toBeUndefined();
+  });
+
+  test('removing the primary promotes the next target onto the comment', async () => {
+    const added: Annotation[] = [];
+    const { post } = await mountViewer((ann) => added.push(ann));
+    await post(primarySelection());
+    await post(addedTarget('ht-2', 'Create'));
+    expect(chips().length).toBe(2);
+
+    // Bridge-echoed removal of the primary (shift-click toggle-off).
+    await post({ type: 'plannotator-bridge-multi-target-removed', key: 'ht-1' });
+    expect(chips().length).toBe(1);
+    expect(chips()[0]!.getAttribute('data-target-chip')).toBe('ht-2');
+    expect(chips()[0]!.getAttribute('data-target-chip-primary')).toBe('true');
+
+    await typeComment('Promoted');
+    await save();
+    expect(added.length).toBe(1);
+    expect(added[0]!.originalText).toBe('Create'); // the promoted target's text
+    expect(added[0]!.htmlAnchor).toEqual({
+      selector: 'span[data-testid="ht-2"]',
+      tagName: 'span',
+      text: 'Create',
+    });
+    expect(added[0]!.htmlAdditionalTargets).toBeUndefined();
+  });
+
+  test('removing the final target cancels the draft (composer closes)', async () => {
+    const { post } = await mountViewer(() => {});
+    await post(primarySelection());
+    expect(document.querySelector('[data-comment-popover]')).not.toBeNull();
+    await post({ type: 'plannotator-bridge-multi-target-removed', key: 'ht-1' });
+    expect(document.querySelector('[data-comment-popover]')).toBeNull();
+    expect(chips().length).toBe(0);
+  });
+
+  test('chip remove button removes that target from the draft', async () => {
+    const added: Annotation[] = [];
+    const { post } = await mountViewer((ann) => added.push(ann));
+    await post(primarySelection());
+    await post(addedTarget('ht-2', 'Create'));
+    expect(chips().length).toBe(2);
+
+    const removeButton = document.querySelector<HTMLButtonElement>(
+      '[data-target-chip-remove="ht-2"]',
+    );
+    if (!removeButton) throw new Error('chip remove button missing');
+    await act(async () => {
+      removeButton.click();
+    });
+    expect(chips().length).toBe(1);
+
+    await typeComment('Back to one');
+    await save();
+    expect(added[0]!.htmlAdditionalTargets).toBeUndefined();
+  });
+
+  test('the additional-target array is capped at 16 at the trust boundary', async () => {
+    const added: Annotation[] = [];
+    const { post } = await mountViewer((ann) => added.push(ann));
+    await post(primarySelection());
+    for (let i = 0; i < 25; i++) {
+      await post(addedTarget(`flood-${i}`, `Target ${i}`));
+    }
+    expect(chips().length).toBe(17); // primary + 16
+
+    await typeComment('Capped');
+    await save();
+    expect(added[0]!.htmlAdditionalTargets!.length).toBe(16);
+  });
+
+  test('adds are ignored when no pinpoint draft is open (drag selections stay single-target)', async () => {
+    const { post } = await mountViewer(() => {});
+    // Drag selection (no pinpoint flag): opens the toolbar, arms nothing.
+    await post({
+      type: 'plannotator-bridge-selection',
+      text: 'Dragged text',
+      rect,
+    });
+    await post(addedTarget('ht-9', 'Stray'));
+    expect(chips().length).toBe(0);
+  });
+});

--- a/packages/ui/components/html-viewer/htmlPinpointProtocol.test.tsx
+++ b/packages/ui/components/html-viewer/htmlPinpointProtocol.test.tsx
@@ -310,12 +310,52 @@ describe.if(hasDom)('multi-target bridge message validation (trust boundary)', (
       type: 'plannotator-bridge-pointer',
       x: 12,
       y: 34,
-    })).toEqual({ type: 'plannotator-bridge-pointer', x: 12, y: 34 });
+      shift: true,
+    })).toEqual({ type: 'plannotator-bridge-pointer', x: 12, y: 34, shift: true });
+    // shift is a strict boolean: absent or truthy-but-not-true reads false.
+    expect(hookModule!.parseBridgeMessage({
+      type: 'plannotator-bridge-pointer',
+      x: 12,
+      y: 34,
+    })).toEqual({ type: 'plannotator-bridge-pointer', x: 12, y: 34, shift: false });
+    expect(hookModule!.parseBridgeMessage({
+      type: 'plannotator-bridge-pointer',
+      x: 12,
+      y: 34,
+      shift: 1,
+    })).toEqual({ type: 'plannotator-bridge-pointer', x: 12, y: 34, shift: false });
     expect(hookModule!.parseBridgeMessage({
       type: 'plannotator-bridge-pointer',
       x: Infinity,
       y: 1,
     })).toBeNull();
+  });
+
+  test('hostile labels with newlines are collapsed at the trust boundary (D2)', () => {
+    const parsed = hookModule!.parseBridgeMessage({
+      type: 'plannotator-bridge-multi-target-added',
+      key: 'ht-4',
+      label: 'Save\n## INJECTED HEADING',
+      text: 'Save',
+    }) as { label?: string };
+    expect(parsed.label).toBe('Save ## INJECTED HEADING');
+    const selection = hookModule!.parseBridgeMessage({
+      type: 'plannotator-bridge-selection',
+      text: 'Save',
+      rect: { top: 1, left: 1, width: 10, height: 10 },
+      pinpoint: true,
+      targetKey: 'ht-1',
+      targetLabel: '  a\r\n\tb  ',
+    }) as { targetLabel?: string };
+    expect(selection.targetLabel).toBe('a b');
+    // Whitespace-only labels vanish instead of becoming empty brackets.
+    const blank = hookModule!.parseBridgeMessage({
+      type: 'plannotator-bridge-multi-target-added',
+      key: 'ht-5',
+      label: ' \n\t ',
+      text: 'x',
+    }) as { label?: string };
+    expect(blank.label).toBeUndefined();
   });
 
   test('selection: targetKey validated, targetLabel truncated', () => {
@@ -342,7 +382,10 @@ describe.if(hasDom)('multi-target bridge message validation (trust boundary)', (
 });
 
 describe.if(hasDom)('multi-target composer flow (chips, promotion, submit)', () => {
-  async function mountViewer(onAdd: (ann: Annotation) => void) {
+  async function mountViewer(
+    onAdd: (ann: Annotation) => void,
+    mode: 'selection' | 'quickLabel' = 'selection',
+  ) {
     if (!htmlViewerModule) throw new Error('DOM test environment is not registered');
     const HtmlViewer = htmlViewerModule.HtmlViewer;
     const host = document.createElement('div');
@@ -357,13 +400,22 @@ describe.if(hasDom)('multi-target composer flow (chips, promotion, submit)', () 
           onAddAnnotation={onAdd}
           onSelectAnnotation={() => {}}
           selectedAnnotationId={null}
-          mode="selection"
+          mode={mode}
           inputMethod="pinpoint"
         />,
       );
     });
     const iframe = host.querySelector<HTMLIFrameElement>('iframe');
     if (!iframe?.contentWindow) throw new Error('HTML iframe missing');
+    // Record everything the parent posts INTO the iframe (arm-multi-select,
+    // remove-target echoes, ...) by wrapping contentWindow.postMessage.
+    const postedToIframe: Array<Record<string, unknown>> = [];
+    const realPost = iframe.contentWindow.postMessage.bind(iframe.contentWindow);
+    (iframe.contentWindow as unknown as { postMessage: (data: unknown) => void }).postMessage =
+      ((data: unknown, ...rest: unknown[]) => {
+        if (data && typeof data === 'object') postedToIframe.push(data as Record<string, unknown>);
+        return (realPost as (...args: unknown[]) => unknown)(data, ...rest);
+      }) as typeof iframe.contentWindow.postMessage;
     const post = async (data: Record<string, unknown>) => {
       await act(async () => {
         window.dispatchEvent(new MessageEvent('message', {
@@ -372,7 +424,7 @@ describe.if(hasDom)('multi-target composer flow (chips, promotion, submit)', () 
         }));
       });
     };
-    return { post };
+    return { post, postedToIframe };
   }
 
   const rect = { top: 10, left: 10, width: 120, height: 24 };
@@ -541,7 +593,7 @@ describe.if(hasDom)('multi-target composer flow (chips, promotion, submit)', () 
   });
 
   test('adds are ignored when no pinpoint draft is open (drag selections stay single-target)', async () => {
-    const { post } = await mountViewer(() => {});
+    const { post, postedToIframe } = await mountViewer(() => {});
     // Drag selection (no pinpoint flag): opens the toolbar, arms nothing.
     await post({
       type: 'plannotator-bridge-selection',
@@ -550,5 +602,67 @@ describe.if(hasDom)('multi-target composer flow (chips, promotion, submit)', () 
     });
     await post(addedTarget('ht-9', 'Stray'));
     expect(chips().length).toBe(0);
+    expect(postedToIframe.some((m) => m.type === 'plannotator-bridge-arm-multi-select')).toBe(false);
+  });
+
+  test('the composer flow arms the bridge with the primary key (D1)', async () => {
+    const armed = await mountViewer(() => {});
+    await armed.post(primarySelection());
+    expect(armed.postedToIframe).toContainEqual({
+      type: 'plannotator-bridge-arm-multi-select',
+      key: 'ht-1',
+    });
+  });
+
+  test('quickLabel-mode drafts never arm the bridge and never build chips (D1)', async () => {
+    // quickLabel mode: the pinpoint draft opens the label picker, which the
+    // parent does NOT mirror as targets — so it must never arm the bridge,
+    // and stray adds must not build chips.
+    const quick = await mountViewer(() => {}, 'quickLabel');
+    await quick.post(primarySelection());
+    expect(document.querySelector('[data-comment-popover]')).toBe(null);
+    expect(
+      quick.postedToIframe.some((m) => m.type === 'plannotator-bridge-arm-multi-select'),
+    ).toBe(false);
+    await quick.post(addedTarget('ht-2', 'Create'));
+    expect(chips().length).toBe(0);
+  });
+
+  test('a forged multi-target-removed still echoes remove-target to resync the bridge (D4)', async () => {
+    const added: Annotation[] = [];
+    const { post, postedToIframe } = await mountViewer((ann) => added.push(ann));
+    await post(primarySelection());
+    await post(addedTarget('ht-2', 'Create'));
+    expect(chips().length).toBe(2);
+
+    // Hostile page forges the removal of the primary — the bridge never
+    // performed it. The parent promotes AND echoes remove-target so the
+    // bridge converges on the same promotion (idempotent if it already had).
+    await post({ type: 'plannotator-bridge-multi-target-removed', key: 'ht-1' });
+    expect(chips().length).toBe(1);
+    expect(chips()[0]!.getAttribute('data-target-chip')).toBe('ht-2');
+    expect(postedToIframe).toContainEqual({
+      type: 'plannotator-bridge-remove-target',
+      key: 'ht-1',
+    });
+  });
+
+  test('bridge pointer messages with shift drive the composer yield (D3)', async () => {
+    const { post } = await mountViewer(() => {});
+    await post(primarySelection());
+    const popover = document.querySelector<HTMLElement>('[data-comment-popover]');
+    if (!popover) throw new Error('composer missing');
+    expect(popover.className).toContain('pn-composer-yieldable');
+    expect(popover.className).not.toContain('pn-composer-yield-over');
+
+    // Pointer over the composer (happy-dom rects are 0x0 at the origin) with
+    // shift held — relayed FROM THE BRIDGE, no parent keydown involved.
+    await post({ type: 'plannotator-bridge-pointer', x: 0, y: 0, shift: true });
+    expect(popover.className).toContain('pn-composer-yield-over');
+
+    // Shift released (still reported by the bridge): the composer restores.
+    await post({ type: 'plannotator-bridge-pointer', x: 0, y: 0, shift: false });
+    expect(popover.className).not.toContain('pn-composer-yield-over');
+    expect(popover.className).not.toContain('pn-composer-yield-near');
   });
 });

--- a/packages/ui/components/html-viewer/srcdoc.test.ts
+++ b/packages/ui/components/html-viewer/srcdoc.test.ts
@@ -1338,6 +1338,289 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
+  // --- Shift-click multi-select: several elements, ONE draft comment ---
+
+  const MULTI_MARKUP = [
+    '<div id="hero">',
+    '<p class="alpha">Alpha text</p>',
+    '<p class="beta">Beta text</p>',
+    '<p class="gamma">Gamma text</p>',
+    "</div>",
+  ].join("");
+
+  type BridgeData = Record<string, unknown>;
+
+  /** Collect bridge messages of the given types across one synchronous action. */
+  async function collectMessages(
+    types: string[],
+    action: () => void,
+  ): Promise<BridgeData[]> {
+    await new Promise((resolve) => setTimeout(resolve, 0)); // flush queued posts
+    const messages: BridgeData[] = [];
+    const collect = (event: MessageEvent) => {
+      const data = bridgeMessageData(event);
+      if (data && types.includes(String(data.type))) messages.push(data);
+    };
+    window.addEventListener("message", collect);
+    action();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    window.removeEventListener("message", collect);
+    return messages;
+  }
+
+  function clickAt(el: Element, x: number, y: number, shift: boolean) {
+    el.dispatchEvent(new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+      clientX: x,
+      clientY: y,
+      shiftKey: shift,
+    }));
+  }
+
+  function pinnedBoxCount(): number {
+    return document.querySelectorAll("[data-plannotator-pinpoint-box][data-pinned]").length;
+  }
+
+  async function startMultiDraft(): Promise<{
+    primaryKey: string;
+    keys: Map<string, string>; // className -> target key
+  }> {
+    postBridge({ type: "plannotator-bridge-set-vim-mode", enabled: false });
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "pinpoint" });
+    const alpha = document.querySelector<HTMLElement>("p.alpha")!;
+    const selections = await collectMessages(
+      ["plannotator-bridge-selection"],
+      () => clickAt(alpha, 20, 20, false),
+    );
+    expect(selections.length).toBe(1);
+    expect(selections[0]!.pinpoint).toBe(true);
+    expect(typeof selections[0]!.targetKey).toBe("string");
+    expect(selections[0]!.targetLabel).toBe("Paragraph");
+    const keys = new Map<string, string>();
+    keys.set("alpha", String(selections[0]!.targetKey));
+    return { primaryKey: String(selections[0]!.targetKey), keys };
+  }
+
+  test("shift-click adds targets to the SAME draft and toggles them off again", async () => {
+    document.body.innerHTML = MULTI_MARKUP;
+    const { keys } = await startMultiDraft();
+    const beta = document.querySelector<HTMLElement>("p.beta")!;
+    const gamma = document.querySelector<HTMLElement>("p.gamma")!;
+
+    // Shift-click beta: joins the draft, posts a validated target DTO, and
+    // gets its own pinned outline box (primary keeps the main box).
+    const added = await collectMessages(
+      ["plannotator-bridge-multi-target-added"],
+      () => clickAt(beta, 40, 40, true),
+    );
+    expect(added.length).toBe(1);
+    expect(added[0]!.label).toBe("Paragraph");
+    expect(added[0]!.text).toBe("Beta text");
+    const betaAnchor = added[0]!.anchor as { selector: string };
+    const betaMatches = document.querySelectorAll(betaAnchor.selector);
+    expect(betaMatches.length).toBe(1);
+    expect(betaMatches[0]).toBe(beta);
+    keys.set("beta", String(added[0]!.key));
+    expect(pinnedBoxCount()).toBe(2);
+
+    const addedGamma = await collectMessages(
+      ["plannotator-bridge-multi-target-added"],
+      () => clickAt(gamma, 60, 60, true),
+    );
+    expect(addedGamma.length).toBe(1);
+    expect(pinnedBoxCount()).toBe(3);
+
+    // Shift-click beta AGAIN: toggle-off by DOM identity — the removal is
+    // echoed to the parent and beta's outline box disappears.
+    const removed = await collectMessages(
+      ["plannotator-bridge-multi-target-added", "plannotator-bridge-multi-target-removed"],
+      () => clickAt(beta, 40, 40, true),
+    );
+    expect(removed.length).toBe(1);
+    expect(removed[0]!.type).toBe("plannotator-bridge-multi-target-removed");
+    expect(removed[0]!.key).toBe(keys.get("beta"));
+    expect(pinnedBoxCount()).toBe(2);
+
+    postBridge({ type: "plannotator-bridge-cancel-selection" });
+    expect(pinnedBoxCount()).toBe(0);
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
+    document.body.replaceChildren();
+  });
+
+  test("create-mark commits every draft target under ONE id with ONE badge number", async () => {
+    document.body.innerHTML = MULTI_MARKUP;
+    await startMultiDraft();
+    clickAt(document.querySelector("p.beta")!, 40, 40, true);
+    clickAt(document.querySelector("p.gamma")!, 60, 60, true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    postBridge({
+      type: "plannotator-bridge-create-mark",
+      id: "multi-commit",
+      annotationType: "comment",
+    });
+
+    // Primary keeps its text mark (or pin); beta + gamma each get a pin —
+    // and every badge for this annotation shows the SAME number.
+    const badges = Array.from(
+      document.querySelectorAll<HTMLElement>("[data-plannotator-pin-badge]"),
+    );
+    expect(badges.length).toBeGreaterThanOrEqual(2);
+    for (const badge of badges) expect(badge.textContent).toBe("1");
+    expect(pinnedBoxCount()).toBe(0); // draft state fully cleared
+
+    // A SECOND annotation numbers 2 — multi-target pins consumed only one slot.
+    postBridge({
+      type: "plannotator-bridge-find-and-mark",
+      id: "second-ann",
+      originalText: "Text that exists nowhere on this page",
+      annotationType: "comment",
+      anchor: { selector: "#hero", tagName: "div" },
+    });
+    const allBadges = Array.from(
+      document.querySelectorAll<HTMLElement>("[data-plannotator-pin-badge]"),
+    );
+    const numbers = allBadges.map((b) => b.textContent);
+    expect(numbers).toContain("2");
+    expect(numbers.filter((n) => n === "1").length).toBeGreaterThanOrEqual(2);
+    expect(numbers.filter((n) => n === "2").length).toBe(1);
+
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
+    document.body.replaceChildren();
+  });
+
+  test("removing the primary promotes the next target; removing the last cancels", async () => {
+    document.body.innerHTML = MULTI_MARKUP;
+    const { primaryKey } = await startMultiDraft();
+    const beta = document.querySelector<HTMLElement>("p.beta")!;
+    clickAt(beta, 40, 40, true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Shift-click the PRIMARY: it is removed and beta is promoted.
+    const removals = await collectMessages(
+      ["plannotator-bridge-multi-target-removed"],
+      () => clickAt(document.querySelector("p.alpha")!, 20, 20, true),
+    );
+    expect(removals.length).toBe(1);
+    expect(removals[0]!.key).toBe(primaryKey);
+    expect(pinnedBoxCount()).toBe(1); // only the promoted primary's main box
+
+    // Committing now pins the PROMOTED element (beta), not alpha.
+    postBridge({
+      type: "plannotator-bridge-create-mark",
+      id: "promoted-commit",
+      annotationType: "comment",
+    });
+    const badge = document.querySelector<HTMLElement>("[data-plannotator-pin-badge]");
+    expect(badge).not.toBeNull();
+    expect(document.querySelector('[data-bind-id="promoted-commit"]')).toBeNull();
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+
+    // Fresh draft with ONLY a primary: shift-clicking it cancels the draft —
+    // a later create-mark must commit nothing.
+    const again = await startMultiDraft();
+    const cancel = await collectMessages(
+      ["plannotator-bridge-multi-target-removed"],
+      () => clickAt(document.querySelector("p.alpha")!, 20, 20, true),
+    );
+    expect(cancel.length).toBe(1);
+    expect(cancel[0]!.key).toBe(again.primaryKey);
+    expect(pinnedBoxCount()).toBe(0);
+    postBridge({
+      type: "plannotator-bridge-create-mark",
+      id: "cancelled-commit",
+      annotationType: "comment",
+    });
+    expect(document.querySelector('[data-bind-id="cancelled-commit"]')).toBeNull();
+    expect(document.querySelector("[data-plannotator-pin-badge]")).toBeNull();
+
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
+    document.body.replaceChildren();
+  });
+
+  test("parent-initiated remove-target mirrors without echoing back", async () => {
+    document.body.innerHTML = MULTI_MARKUP;
+    await startMultiDraft();
+    const added = await collectMessages(
+      ["plannotator-bridge-multi-target-added"],
+      () => clickAt(document.querySelector("p.beta")!, 40, 40, true),
+    );
+    const betaKey = String(added[0]!.key);
+    expect(pinnedBoxCount()).toBe(2);
+
+    const echoes = await collectMessages(
+      ["plannotator-bridge-multi-target-removed"],
+      () => postBridge({ type: "plannotator-bridge-remove-target", key: betaKey }),
+    );
+    expect(echoes.length).toBe(0); // the parent already updated its own list
+    expect(pinnedBoxCount()).toBe(1);
+
+    // flash-target on the survivor must not throw or change draft state.
+    postBridge({ type: "plannotator-bridge-flash-target", key: betaKey });
+    expect(pinnedBoxCount()).toBe(1);
+
+    postBridge({ type: "plannotator-bridge-cancel-selection" });
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
+    document.body.replaceChildren();
+  });
+
+  test("the multi-target draft is capped at 16 additional targets in the bridge", async () => {
+    const paragraphs: string[] = [];
+    for (let i = 0; i < 20; i++) paragraphs.push(`<p class="cap-${i}">Cap target ${i}</p>`);
+    document.body.innerHTML = `<div id="cap-stage">${paragraphs.join("")}</div>`;
+    postBridge({ type: "plannotator-bridge-set-vim-mode", enabled: false });
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "pinpoint" });
+    clickAt(document.querySelector("p.cap-0")!, 10, 10, false); // primary
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const added = await collectMessages(
+      ["plannotator-bridge-multi-target-added"],
+      () => {
+        for (let i = 1; i < 20; i++) {
+          clickAt(document.querySelector(`p.cap-${i}`)!, 10 + i, 10, true);
+        }
+      },
+    );
+    expect(added.length).toBe(16);
+
+    postBridge({ type: "plannotator-bridge-cancel-selection" });
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
+    document.body.replaceChildren();
+  });
+
+  test("find-and-mark restores additional anchors as same-numbered pins, fail-closed", async () => {
+    document.body.innerHTML = MULTI_MARKUP;
+    postBridge({
+      type: "plannotator-bridge-find-and-mark",
+      id: "restore-multi",
+      originalText: "Alpha text",
+      annotationType: "comment",
+      anchor: { selector: "p.alpha", tagName: "p", text: "Alpha text" },
+      additionalAnchors: [
+        { selector: "p.beta", tagName: "p", text: "Beta text" },
+        // Stale snapshot: this anchor must NOT resolve (no pin, no mis-mark).
+        { selector: "p.gamma", tagName: "p", text: "Stale snapshot" },
+      ],
+    });
+
+    // Primary restored as an inline mark inside alpha.
+    const mark = document.querySelector('[data-bind-id="restore-multi"]');
+    expect(mark?.textContent).toBe("Alpha text");
+    // Beta restored as a pin sharing the annotation's number; gamma failed closed.
+    const badges = Array.from(
+      document.querySelectorAll<HTMLElement>("[data-plannotator-pin-badge]"),
+    );
+    expect(badges.length).toBe(1);
+    expect(badges[0]!.textContent).toBe("1");
+
+    postBridge({ type: "plannotator-bridge-remove-mark", id: "restore-multi" });
+    expect(document.querySelector('[data-bind-id="restore-multi"]')).toBeNull();
+    expect(document.querySelector("[data-plannotator-pin-badge]")).toBeNull();
+    document.body.replaceChildren();
+  });
+
   test("hover hit-testing never storms document-wide queries per mousemove", () => {
     // The old hover path rebuilt the semantic target graph (three
     // document-wide querySelectorAll sweeps) on every pointer frame. The new

--- a/packages/ui/components/html-viewer/srcdoc.test.ts
+++ b/packages/ui/components/html-viewer/srcdoc.test.ts
@@ -1595,6 +1595,44 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
+  test("arming is per-draft: a NEW draft after an armed one starts unarmed (D1-R)", async () => {
+    // The stale-arm regression: comment-mode draft gets armed, the user
+    // switches to a mode the parent does not mirror (quick label posts
+    // nothing to the bridge), then starts a NEW draft with a plain click.
+    // Without a per-draft reset the old arm leaks into the new draft and the
+    // bridge accumulates outlines/pins the saved annotation will not carry.
+    document.body.innerHTML = MULTI_MARKUP;
+    const { primaryKey } = await startMultiDraft(); // armed comment draft
+    postBridge({ type: "plannotator-bridge-arm-multi-select", key: primaryKey });
+
+    // New draft via plain click (no cancel-selection, no re-arm) — exactly
+    // what a toolbar mode change followed by a pinpoint click produces.
+    const beta = document.querySelector<HTMLElement>("p.beta")!;
+    await collectMessages(["plannotator-bridge-selection"], () => clickAt(beta, 40, 40, false));
+
+    // Shift-click on the unarmed new draft must NOT add a target.
+    const added = await collectMessages(
+      ["plannotator-bridge-multi-target-added"],
+      () => clickAt(document.querySelector("p.gamma") ?? document.querySelector("p.alpha")!, 40, 40, true),
+    );
+    expect(added.length).toBe(0);
+
+    // Committing the new draft registers at most its own primary: no orphans.
+    postBridge({
+      type: "plannotator-bridge-create-mark",
+      id: "stale-arm-commit",
+      annotationType: "comment",
+    });
+    expect(
+      document.querySelectorAll("[data-plannotator-pin-badge]").length,
+    ).toBeLessThanOrEqual(1);
+
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    postBridge({ type: "plannotator-bridge-cancel-selection" });
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
+    document.body.replaceChildren();
+  });
+
   test("remove-target is idempotent and resyncs a forged primary removal (D4)", async () => {
     document.body.innerHTML = MULTI_MARKUP;
     const { primaryKey } = await startMultiDraft();

--- a/packages/ui/components/html-viewer/srcdoc.test.ts
+++ b/packages/ui/components/html-viewer/srcdoc.test.ts
@@ -1382,7 +1382,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     return document.querySelectorAll("[data-plannotator-pinpoint-box][data-pinned]").length;
   }
 
-  async function startMultiDraft(): Promise<{
+  async function startMultiDraft(options?: { arm?: boolean }): Promise<{
     primaryKey: string;
     keys: Map<string, string>; // className -> target key
   }> {
@@ -1397,9 +1397,15 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     expect(selections[0]!.pinpoint).toBe(true);
     expect(typeof selections[0]!.targetKey).toBe("string");
     expect(selections[0]!.targetLabel).toBe("Paragraph");
+    const primaryKey = String(selections[0]!.targetKey);
+    // The parent arms multi-select only when its comment composer mirrors the
+    // draft — replayed here unless the test wants an UNARMED draft.
+    if (options?.arm !== false) {
+      postBridge({ type: "plannotator-bridge-arm-multi-select", key: primaryKey });
+    }
     const keys = new Map<string, string>();
-    keys.set("alpha", String(selections[0]!.targetKey));
-    return { primaryKey: String(selections[0]!.targetKey), keys };
+    keys.set("alpha", primaryKey);
+    return { primaryKey, keys };
   }
 
   test("shift-click adds targets to the SAME draft and toggles them off again", async () => {
@@ -1540,6 +1546,90 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
+  test("UNARMED pinpoint drafts refuse the shift-toggle (D1: quickLabel-style modes)", async () => {
+    // The parent only mirrors targets while the comment composer owns the
+    // draft; quickLabel/redline drafts never send arm-multi-select. A
+    // shift-click on such a draft must NOT accumulate bridge-side targets the
+    // saved annotation would not carry — it behaves as a plain click.
+    document.body.innerHTML = MULTI_MARKUP;
+    await startMultiDraft({ arm: false });
+    const beta = document.querySelector<HTMLElement>("p.beta")!;
+
+    const messages = await collectMessages(
+      ["plannotator-bridge-multi-target-added", "plannotator-bridge-selection"],
+      () => clickAt(beta, 40, 40, true),
+    );
+    // No multi-target-added; the shift-click replaced the draft instead.
+    expect(messages.length).toBe(1);
+    expect(messages[0]!.type).toBe("plannotator-bridge-selection");
+    expect(messages[0]!.text).toBe("Beta text");
+    expect(pinnedBoxCount()).toBe(1); // only the (new) primary's main box
+
+    // Committing registers nothing beyond the new primary — no orphan pins.
+    postBridge({
+      type: "plannotator-bridge-create-mark",
+      id: "unarmed-commit",
+      annotationType: "comment",
+    });
+    expect(
+      document.querySelectorAll("[data-plannotator-pin-badge]").length,
+    ).toBeLessThanOrEqual(1);
+
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    postBridge({ type: "plannotator-bridge-cancel-selection" });
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
+    document.body.replaceChildren();
+  });
+
+  test("a stale or mismatched arm key never arms a draft", async () => {
+    document.body.innerHTML = MULTI_MARKUP;
+    await startMultiDraft({ arm: false });
+    postBridge({ type: "plannotator-bridge-arm-multi-select", key: "not-the-primary" });
+    const messages = await collectMessages(
+      ["plannotator-bridge-multi-target-added"],
+      () => clickAt(document.querySelector("p.beta")!, 40, 40, true),
+    );
+    expect(messages.length).toBe(0);
+    postBridge({ type: "plannotator-bridge-cancel-selection" });
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
+    document.body.replaceChildren();
+  });
+
+  test("remove-target is idempotent and resyncs a forged primary removal (D4)", async () => {
+    document.body.innerHTML = MULTI_MARKUP;
+    const { primaryKey } = await startMultiDraft();
+    const added = await collectMessages(
+      ["plannotator-bridge-multi-target-added"],
+      () => clickAt(document.querySelector("p.beta")!, 40, 40, true),
+    );
+    const betaKey = String(added[0]!.key);
+    expect(pinnedBoxCount()).toBe(2);
+
+    // Forged-removal scenario: the parent believed the primary was removed
+    // (hostile multi-target-removed) and echoes remove-target back. The
+    // bridge, which never removed it, now performs the SAME promotion —
+    // both sides converge on beta as the primary.
+    postBridge({ type: "plannotator-bridge-remove-target", key: primaryKey });
+    expect(pinnedBoxCount()).toBe(1);
+
+    // Idempotency: the same removal again (double echo) is a no-op.
+    postBridge({ type: "plannotator-bridge-remove-target", key: primaryKey });
+    expect(pinnedBoxCount()).toBe(1);
+
+    // Committing pins the promoted element (beta), matching the parent model.
+    postBridge({
+      type: "plannotator-bridge-create-mark",
+      id: "resync-commit",
+      annotationType: "comment",
+    });
+    const badge = document.querySelector<HTMLElement>("[data-plannotator-pin-badge]");
+    expect(badge).not.toBeNull();
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
+    void betaKey;
+    document.body.replaceChildren();
+  });
+
   test("parent-initiated remove-target mirrors without echoing back", async () => {
     document.body.innerHTML = MULTI_MARKUP;
     await startMultiDraft();
@@ -1572,8 +1662,14 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.innerHTML = `<div id="cap-stage">${paragraphs.join("")}</div>`;
     postBridge({ type: "plannotator-bridge-set-vim-mode", enabled: false });
     postBridge({ type: "plannotator-bridge-set-input-method", method: "pinpoint" });
-    clickAt(document.querySelector("p.cap-0")!, 10, 10, false); // primary
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    const primarySelections = await collectMessages(
+      ["plannotator-bridge-selection"],
+      () => clickAt(document.querySelector("p.cap-0")!, 10, 10, false), // primary
+    );
+    postBridge({
+      type: "plannotator-bridge-arm-multi-select",
+      key: String(primarySelections[0]!.targetKey),
+    });
 
     const added = await collectMessages(
       ["plannotator-bridge-multi-target-added"],

--- a/packages/ui/components/html-viewer/useHtmlAnnotation.ts
+++ b/packages/ui/components/html-viewer/useHtmlAnnotation.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef, type RefObject } from "react";
-import { AnnotationType, type Annotation, type EditorMode, type HtmlElementAnchor, type ImageAttachment } from "../../types";
+import { AnnotationType, type Annotation, type EditorMode, type HtmlAnnotationTarget, type HtmlElementAnchor, type ImageAttachment } from "../../types";
 import type { QuickLabel } from "../../utils/quickLabels";
 import { getIdentity } from "../../utils/identity";
 import type {
@@ -27,6 +27,26 @@ interface BridgeSelectionMessage {
   anchor?: HtmlElementAnchor;
   /** True when the selection came from a pinpoint click on an element. */
   pinpoint?: boolean;
+  /** Bridge-assigned key for the primary target (multi-select bookkeeping). */
+  targetKey?: string;
+  /** Semantic label from the pinpoint hover cascade (chips + export). */
+  targetLabel?: string;
+}
+
+/** One draft target in an in-flight multi-select comment. Index 0 is primary. */
+export interface HtmlDraftTarget {
+  key: string;
+  label?: string;
+  text: string;
+  anchor: HtmlElementAnchor | null;
+}
+
+interface BridgeMultiTargetAddedMessage {
+  type: `${typeof PREFIX}multi-target-added`;
+  key: string;
+  label?: string;
+  text: string;
+  anchor?: HtmlElementAnchor;
 }
 
 interface BridgeRect {
@@ -38,6 +58,9 @@ interface BridgeRect {
 
 type BridgeMessage =
   | BridgeSelectionMessage
+  | BridgeMultiTargetAddedMessage
+  | { type: `${typeof PREFIX}multi-target-removed`; key: string }
+  | { type: `${typeof PREFIX}pointer`; x: number; y: number }
   | { type: `${typeof PREFIX}selection-clear` }
   | { type: `${typeof PREFIX}selection-rect`; rect: BridgeRect }
   | { type: `${typeof PREFIX}keytype`; key: string }
@@ -55,6 +78,10 @@ export interface UseHtmlAnnotationOptions {
   selectedAnnotationId: string | null;
   mode: EditorMode;
   onResize?: (height: number) => void;
+  /** Validated pointer positions relayed from inside the iframe while a
+   *  pinpoint draft is open (iframe-local viewport coordinates). Drives the
+   *  composer-yield fade in the host component. */
+  onBridgePointer?: (x: number, y: number) => void;
 }
 
 function postToIframe(iframe: HTMLIFrameElement | null, msg: Record<string, unknown>) {
@@ -80,6 +107,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 const MAX_ANCHOR_SELECTOR_LENGTH = 1024;
 const MAX_ANCHOR_TAG_LENGTH = 64;
 const MAX_ANCHOR_TEXT_LENGTH = 400;
+// Multi-select caps: the additional-target array is bounded at the trust
+// boundary (a hostile page cannot grow a draft past this), and the bridge's
+// short target keys / 40-char hover labels get generous-but-hard ceilings.
+export const MAX_ADDITIONAL_TARGETS = 16;
+const MAX_TARGET_KEY_LENGTH = 64;
+const MAX_TARGET_LABEL_LENGTH = 64;
 // Selection text is page-controlled too (a pinpoint click posts the element's
 // entire textContent), so it gets the same treatment: truncated here — not
 // rejected, a legitimate huge selection still annotates — before it can reach
@@ -116,6 +149,19 @@ export function parseHtmlElementAnchor(value: unknown): HtmlElementAnchor | null
   return { selector, tagName, text };
 }
 
+function parseTargetKey(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 && value.length <= MAX_TARGET_KEY_LENGTH
+    ? value
+    : null;
+}
+
+function parseTargetLabel(value: unknown): string | undefined {
+  if (typeof value !== "string" || value.length === 0) return undefined;
+  return value.length > MAX_TARGET_LABEL_LENGTH
+    ? value.slice(0, MAX_TARGET_LABEL_LENGTH)
+    : value;
+}
+
 function parseBridgeRect(value: unknown): BridgeRect | null {
   if (!isRecord(value)) return null;
   const { top, left, width, height } = value;
@@ -142,8 +188,30 @@ export function parseBridgeMessage(value: unknown): BridgeMessage | null {
         modeOverride: parseEditorMode(value.modeOverride),
         anchor: parseHtmlElementAnchor(value.anchor) ?? undefined,
         pinpoint: value.pinpoint === true,
+        targetKey: parseTargetKey(value.targetKey) ?? undefined,
+        targetLabel: parseTargetLabel(value.targetLabel),
       };
     }
+    case `${PREFIX}multi-target-added`: {
+      const key = parseTargetKey(value.key);
+      if (!key || typeof value.text !== "string") return null;
+      return {
+        type: value.type,
+        key,
+        label: parseTargetLabel(value.label),
+        text: capSelectionText(value.text),
+        anchor: parseHtmlElementAnchor(value.anchor) ?? undefined,
+      };
+    }
+    case `${PREFIX}multi-target-removed`: {
+      const key = parseTargetKey(value.key);
+      return key ? { type: value.type, key } : null;
+    }
+    case `${PREFIX}pointer`:
+      return typeof value.x === "number" && Number.isFinite(value.x)
+        && typeof value.y === "number" && Number.isFinite(value.y)
+        ? { type: value.type, x: value.x, y: value.y }
+        : null;
     case `${PREFIX}selection-clear`:
       return { type: value.type };
     case `${PREFIX}selection-rect`: {
@@ -181,18 +249,34 @@ export function useHtmlAnnotation({
   selectedAnnotationId,
   mode,
   onResize,
+  onBridgePointer,
 }: UseHtmlAnnotationOptions): Omit<
   UseAnnotationHighlighterReturn,
   "highlighterRef" | "highlightRange" | "highlightMathElement"
-> {
+> & {
+  /** In-flight multi-select targets (index 0 = primary); empty outside pinpoint drafts. */
+  draftTargets: HtmlDraftTarget[];
+  /** Remove one draft target (chip X). Removing the last cancels the draft. */
+  removeDraftTarget: (key: string) => void;
+  /** Flash a draft target's pinned outline in the page (chip hover). */
+  flashDraftTarget: (key: string) => void;
+  /** Bumped after every target add/remove so the composer can refocus its textarea. */
+  composerFocusToken: number;
+} {
   const [toolbarState, setToolbarState] = useState<ToolbarState | null>(null);
   const [commentPopover, setCommentPopover] = useState<CommentPopoverState | null>(null);
   const [quickLabelPicker, setQuickLabelPicker] = useState<QuickLabelPickerState | null>(null);
+  const [draftTargets, setDraftTargets] = useState<HtmlDraftTarget[]>([]);
+  const [composerFocusToken, setComposerFocusToken] = useState(0);
 
   const pendingTextRef = useRef<string>("");
   // Element anchor for the pending pinpoint selection — committed onto the
   // annotation so restoration can resolve the exact element again.
   const pendingAnchorRef = useRef<HtmlElementAnchor | null>(null);
+  const draftTargetsRef = useRef<HtmlDraftTarget[]>(draftTargets);
+  draftTargetsRef.current = draftTargets;
+  const onBridgePointerRef = useRef(onBridgePointer);
+  onBridgePointerRef.current = onBridgePointer;
   const enabledRef = useRef(enabled);
   enabledRef.current = enabled;
   const modeRef = useRef(mode);
@@ -214,6 +298,46 @@ export function useHtmlAnnotation({
   onSelectRef.current = onSelectAnnotation;
 
   const anchorRef = useRef<HTMLDivElement | null>(null);
+
+  /**
+   * Remove one draft target. Removing the primary promotes the next remaining
+   * target (the composer's context text and pending anchor follow it);
+   * removing the final target cancels the draft. The bridge performs the same
+   * deterministic update on its side — `fromBridge` says who already did.
+   */
+  const applyTargetRemoval = useCallback(
+    (key: string, fromBridge: boolean) => {
+      const targets = draftTargetsRef.current;
+      const index = targets.findIndex((t) => t.key === key);
+      if (index < 0) return;
+      if (!fromBridge) {
+        postToIframe(iframeRef.current, { type: `${PREFIX}remove-target`, key });
+      }
+      const remaining = targets.filter((t) => t.key !== key);
+      if (remaining.length === 0) {
+        // Final target removed — the draft is cancelled (bridge side already
+        // tore down its pinned state via toggle-off or the remove-target post).
+        setDraftTargets([]);
+        setCommentPopover(null);
+        pendingTextRef.current = "";
+        pendingAnchorRef.current = null;
+        return;
+      }
+      if (index === 0) {
+        // Primary removed — promote the next target: the comment's quoted
+        // text and restoration anchor now belong to it.
+        const next = remaining[0]!;
+        pendingTextRef.current = next.text;
+        pendingAnchorRef.current = next.anchor;
+        setCommentPopover((prev) =>
+          prev ? { ...prev, contextText: next.text, selectedText: next.text } : prev,
+        );
+      }
+      setDraftTargets(remaining);
+      setComposerFocusToken((t) => t + 1);
+    },
+    [iframeRef],
+  );
 
   const getOrCreateAnchor = useCallback(() => {
     if (!anchorRef.current) {
@@ -261,6 +385,7 @@ export function useHtmlAnnotation({
       if (type === `${PREFIX}selection`) {
         pendingTextRef.current = message.text;
         pendingAnchorRef.current = message.anchor ?? null;
+        setDraftTargets([]); // a new selection always starts a fresh draft
         const anchor = positionAnchor(message.rect);
         if (!anchor) return;
 
@@ -296,6 +421,18 @@ export function useHtmlAnnotation({
             contextText: message.text,
             selectedText: message.text,
           });
+          // Pinpoint drafts arm shift-click multi-select: the clicked element
+          // becomes the primary target of the (single) draft comment.
+          if (message.pinpoint && message.targetKey) {
+            setDraftTargets([
+              {
+                key: message.targetKey,
+                label: message.targetLabel,
+                text: message.text,
+                anchor: message.anchor ?? null,
+              },
+            ]);
+          }
         } else if (currentMode === "quickLabel") {
           setQuickLabelPicker({
             anchorEl: anchor,
@@ -308,6 +445,38 @@ export function useHtmlAnnotation({
             selectionText: message.text,
           });
         }
+      }
+
+      if (type === `${PREFIX}multi-target-added`) {
+        // Only meaningful while a pinpoint draft composer is open. The array
+        // cap is enforced HERE, at the trust boundary — a hostile page cannot
+        // grow the draft past MAX_ADDITIONAL_TARGETS extra targets.
+        const targets = draftTargetsRef.current;
+        if (
+          commentPopoverRef.current
+          && targets.length > 0
+          && targets.length < 1 + MAX_ADDITIONAL_TARGETS
+          && !targets.some((t) => t.key === message.key)
+        ) {
+          setDraftTargets([
+            ...targets,
+            {
+              key: message.key,
+              label: message.label,
+              text: message.text,
+              anchor: message.anchor ?? null,
+            },
+          ]);
+          setComposerFocusToken((t) => t + 1);
+        }
+      }
+
+      if (type === `${PREFIX}multi-target-removed`) {
+        applyTargetRemoval(message.key, true);
+      }
+
+      if (type === `${PREFIX}pointer`) {
+        onBridgePointerRef.current?.(message.x, message.y);
       }
 
       if (type === `${PREFIX}selection-clear`) {
@@ -368,13 +537,14 @@ export function useHtmlAnnotation({
         anchorRef.current = null;
       }
     };
-  }, [iframeRef, positionAnchor, onResize, getOrCreateAnchor]);
+  }, [iframeRef, positionAnchor, onResize, getOrCreateAnchor, applyTargetRemoval]);
 
   useEffect(() => {
     if (enabled) return;
     setToolbarState(null);
     setCommentPopover(null);
     setQuickLabelPicker(null);
+    setDraftTargets([]);
     pendingTextRef.current = "";
     pendingAnchorRef.current = null;
     anchorRef.current?.remove();
@@ -443,6 +613,17 @@ export function useHtmlAnnotation({
       const text = commentPopoverRef.current?.selectedText || pendingTextRef.current;
       if (!text) return;
 
+      // Multi-select: everything past the primary rides on the SAME comment.
+      const targets = draftTargetsRef.current;
+      const additionalTargets: HtmlAnnotationTarget[] | undefined =
+        targets.length > 1
+          ? targets.slice(1, 1 + MAX_ADDITIONAL_TARGETS).map((t) => ({
+              label: t.label,
+              text: t.text,
+              anchor: t.anchor ?? undefined,
+            }))
+          : undefined;
+
       const id = nextHtmlAnnId();
       postToIframe(iframeRef.current, { type: `${PREFIX}create-mark`, id, annotationType: "comment" });
       onAddRef.current?.({
@@ -457,9 +638,11 @@ export function useHtmlAnnotation({
         createdA: Date.now(),
         images,
         htmlAnchor: pendingAnchorRef.current ?? undefined,
+        htmlAdditionalTargets: additionalTargets,
       });
 
       setCommentPopover(null);
+      setDraftTargets([]);
       pendingTextRef.current = "";
       pendingAnchorRef.current = null;
     },
@@ -469,9 +652,25 @@ export function useHtmlAnnotation({
   const handleCommentClose = useCallback(() => {
     postToIframe(iframeRef.current, { type: `${PREFIX}cancel-selection` });
     setCommentPopover(null);
+    setDraftTargets([]);
     pendingTextRef.current = "";
     pendingAnchorRef.current = null;
   }, [iframeRef]);
+
+  const removeDraftTarget = useCallback(
+    (key: string) => {
+      if (!enabledRef.current) return;
+      applyTargetRemoval(key, false);
+    },
+    [applyTargetRemoval],
+  );
+
+  const flashDraftTarget = useCallback(
+    (key: string) => {
+      postToIframe(iframeRef.current, { type: `${PREFIX}flash-target`, key });
+    },
+    [iframeRef],
+  );
 
   const handleToolbarClose = useCallback(() => {
     postToIframe(iframeRef.current, { type: `${PREFIX}cancel-selection` });
@@ -541,6 +740,12 @@ export function useHtmlAnnotation({
       for (const ann of anns) {
         if (ann.type === AnnotationType.GLOBAL_COMMENT) continue;
         const annType = ann.type === AnnotationType.DELETION ? "deletion" : "comment";
+        // Multi-target annotations restore every additional target as a pin
+        // under the same id (same badge number). Anchor-only and capped.
+        const additionalAnchors = (ann.htmlAdditionalTargets ?? [])
+          .map((t) => t.anchor)
+          .filter((a): a is HtmlElementAnchor => !!a)
+          .slice(0, MAX_ADDITIONAL_TARGETS);
         postToIframe(iframeRef.current, {
           type: `${PREFIX}find-and-mark`,
           id: ann.id,
@@ -549,6 +754,7 @@ export function useHtmlAnnotation({
           // Anchor-first restore: the bridge resolves the serialized element
           // and scopes the text search to it, falling back to document-wide.
           anchor: ann.htmlAnchor,
+          additionalAnchors: additionalAnchors.length ? additionalAnchors : undefined,
         });
       }
     },
@@ -570,5 +776,9 @@ export function useHtmlAnnotation({
     removeHighlight,
     clearAllHighlights,
     applyAnnotations,
+    draftTargets,
+    removeDraftTarget,
+    flashDraftTarget,
+    composerFocusToken,
   };
 }

--- a/packages/ui/components/html-viewer/useHtmlAnnotation.ts
+++ b/packages/ui/components/html-viewer/useHtmlAnnotation.ts
@@ -60,7 +60,7 @@ type BridgeMessage =
   | BridgeSelectionMessage
   | BridgeMultiTargetAddedMessage
   | { type: `${typeof PREFIX}multi-target-removed`; key: string }
-  | { type: `${typeof PREFIX}pointer`; x: number; y: number }
+  | { type: `${typeof PREFIX}pointer`; x: number; y: number; shift: boolean }
   | { type: `${typeof PREFIX}selection-clear` }
   | { type: `${typeof PREFIX}selection-rect`; rect: BridgeRect }
   | { type: `${typeof PREFIX}keytype`; key: string }
@@ -79,9 +79,11 @@ export interface UseHtmlAnnotationOptions {
   mode: EditorMode;
   onResize?: (height: number) => void;
   /** Validated pointer positions relayed from inside the iframe while a
-   *  pinpoint draft is open (iframe-local viewport coordinates). Drives the
-   *  composer-yield fade in the host component. */
-  onBridgePointer?: (x: number, y: number) => void;
+   *  pinpoint draft is open (iframe-local viewport coordinates), with the
+   *  Shift state observed by the iframe (the parent cannot see modifiers
+   *  held while the pointer lives in the sandbox). Drives the composer-yield
+   *  fade in the host component. */
+  onBridgePointer?: (x: number, y: number, shift: boolean) => void;
 }
 
 function postToIframe(iframe: HTMLIFrameElement | null, msg: Record<string, unknown>) {
@@ -156,10 +158,15 @@ function parseTargetKey(value: unknown): string | null {
 }
 
 function parseTargetLabel(value: unknown): string | undefined {
-  if (typeof value !== "string" || value.length === 0) return undefined;
-  return value.length > MAX_TARGET_LABEL_LENGTH
-    ? value.slice(0, MAX_TARGET_LABEL_LENGTH)
-    : value;
+  if (typeof value !== "string") return undefined;
+  // Labels derive from page-controlled attributes (aria-label etc.), so a
+  // hostile page can embed newlines that would become real markdown structure
+  // in the exported feedback — collapse ALL whitespace at the trust boundary.
+  const collapsed = value.replace(/\s+/g, " ").trim();
+  if (!collapsed) return undefined;
+  return collapsed.length > MAX_TARGET_LABEL_LENGTH
+    ? collapsed.slice(0, MAX_TARGET_LABEL_LENGTH)
+    : collapsed;
 }
 
 function parseBridgeRect(value: unknown): BridgeRect | null {
@@ -210,7 +217,7 @@ export function parseBridgeMessage(value: unknown): BridgeMessage | null {
     case `${PREFIX}pointer`:
       return typeof value.x === "number" && Number.isFinite(value.x)
         && typeof value.y === "number" && Number.isFinite(value.y)
-        ? { type: value.type, x: value.x, y: value.y }
+        ? { type: value.type, x: value.x, y: value.y, shift: value.shift === true }
         : null;
     case `${PREFIX}selection-clear`:
       return { type: value.type };
@@ -303,16 +310,17 @@ export function useHtmlAnnotation({
    * Remove one draft target. Removing the primary promotes the next remaining
    * target (the composer's context text and pending anchor follow it);
    * removing the final target cancels the draft. The bridge performs the same
-   * deterministic update on its side — `fromBridge` says who already did.
+   * deterministic update on its side, so `remove-target` is ALWAYS posted:
+   * for chip removals it drives the bridge, and for bridge-echoed removals it
+   * is an idempotent no-op — which also resyncs the two sides if a hostile
+   * page forged the removal message the bridge never actually performed.
    */
   const applyTargetRemoval = useCallback(
-    (key: string, fromBridge: boolean) => {
+    (key: string) => {
       const targets = draftTargetsRef.current;
       const index = targets.findIndex((t) => t.key === key);
       if (index < 0) return;
-      if (!fromBridge) {
-        postToIframe(iframeRef.current, { type: `${PREFIX}remove-target`, key });
-      }
+      postToIframe(iframeRef.current, { type: `${PREFIX}remove-target`, key });
       const remaining = targets.filter((t) => t.key !== key);
       if (remaining.length === 0) {
         // Final target removed — the draft is cancelled (bridge side already
@@ -422,7 +430,10 @@ export function useHtmlAnnotation({
             selectedText: message.text,
           });
           // Pinpoint drafts arm shift-click multi-select: the clicked element
-          // becomes the primary target of the (single) draft comment.
+          // becomes the primary target of the (single) draft comment. The
+          // bridge only accepts shift-toggles once THIS explicit arm arrives,
+          // so drafts the composer does not mirror (quickLabel, redline) can
+          // never accumulate pins the saved annotation would not carry.
           if (message.pinpoint && message.targetKey) {
             setDraftTargets([
               {
@@ -432,6 +443,10 @@ export function useHtmlAnnotation({
                 anchor: message.anchor ?? null,
               },
             ]);
+            postToIframe(iframeRef.current, {
+              type: `${PREFIX}arm-multi-select`,
+              key: message.targetKey,
+            });
           }
         } else if (currentMode === "quickLabel") {
           setQuickLabelPicker({
@@ -472,11 +487,11 @@ export function useHtmlAnnotation({
       }
 
       if (type === `${PREFIX}multi-target-removed`) {
-        applyTargetRemoval(message.key, true);
+        applyTargetRemoval(message.key);
       }
 
       if (type === `${PREFIX}pointer`) {
-        onBridgePointerRef.current?.(message.x, message.y);
+        onBridgePointerRef.current?.(message.x, message.y, message.shift);
       }
 
       if (type === `${PREFIX}selection-clear`) {
@@ -660,7 +675,7 @@ export function useHtmlAnnotation({
   const removeDraftTarget = useCallback(
     (key: string) => {
       if (!enabledRef.current) return;
-      applyTargetRemoval(key, false);
+      applyTargetRemoval(key);
     },
     [applyTargetRemoval],
   );

--- a/packages/ui/hooks/useAnnotationDraft.seam.test.tsx
+++ b/packages/ui/hooks/useAnnotationDraft.seam.test.tsx
@@ -167,4 +167,75 @@ describe('DraftTransport seam', () => {
 
     await session.unmount();
   });
+
+  test.skipIf(!hasDom)('multi-target HTML annotations round-trip the draft transport verbatim', async () => {
+    const MULTI_ANNOTATION: Annotation = {
+      id: 'ann-multi-1',
+      blockId: '',
+      startOffset: 0,
+      endOffset: 0,
+      type: AnnotationType.COMMENT,
+      text: 'Unify these',
+      originalText: 'Primary chip',
+      createdA: Date.now(),
+      htmlAnchor: { selector: 'p.primary', tagName: 'p', text: 'Primary chip' },
+      htmlAdditionalTargets: [
+        {
+          label: 'Button',
+          text: 'Create',
+          anchor: { selector: 'span.btn', tagName: 'span', text: 'Create' },
+        },
+        { label: 'rowchip', text: 'adopted by 1' }, // fail-closed target, no anchor
+      ],
+    };
+
+    // Save side: the annotation (with its targets) appears in the save body.
+    const { transport, state } = makeFakeTransport();
+    setDraftTransport(transport);
+    const session = await mountHook({
+      annotations: [MULTI_ANNOTATION],
+      globalAttachments: [],
+      isApiMode: true,
+      isSharedSession: false,
+      submitted: false,
+    });
+    await tick(50);
+    await act(async () => {
+      session.result.current!.scheduleDraftSave();
+    });
+    await tick(600);
+    expect(state.saved.length).toBeGreaterThanOrEqual(1);
+    const savedBody = state.saved.at(-1) as { annotations: Annotation[] };
+    expect(savedBody.annotations[0]!.htmlAdditionalTargets)
+      .toEqual(MULTI_ANNOTATION.htmlAdditionalTargets);
+    await session.unmount();
+
+    // Restore side: a stored draft hands the targets back untouched.
+    const restoreTransport: DraftTransport = {
+      load: async () => ({
+        data: {
+          annotations: [MULTI_ANNOTATION],
+          globalAttachments: [],
+          ts: Date.now(),
+        },
+        generation: 1,
+      }),
+      save: async () => {},
+      remove: async () => {},
+    };
+    setDraftTransport(restoreTransport);
+    const restoreSession = await mountHook({
+      annotations: [],
+      globalAttachments: [],
+      isApiMode: true,
+      isSharedSession: false,
+      submitted: false,
+    });
+    await tick(50);
+    expect(restoreSession.result.current!.draftBanner?.count).toBe(1);
+    const restored = restoreSession.result.current!.restoreDraft();
+    expect(restored.annotations[0]!.htmlAdditionalTargets)
+      .toEqual(MULTI_ANNOTATION.htmlAdditionalTargets);
+    await restoreSession.unmount();
+  });
 });

--- a/packages/ui/types.ts
+++ b/packages/ui/types.ts
@@ -80,6 +80,7 @@ export interface Annotation {
   }>; // math elements covered by a mixed text+formula selection
   prUrl?: string; // code-review PR mode: the PR this note belongs to, so it isn't shown/exported against another PR after an in-place switch
   htmlAnchor?: HtmlElementAnchor; // raw-HTML pinpoint: serialized element anchor for reliable restoration
+  htmlAdditionalTargets?: HtmlAnnotationTarget[]; // raw-HTML shift-click multi-select: extra elements this one comment covers (primary stays htmlAnchor/originalText)
   // web-highlighter metadata for cross-element selections
   startMeta?: AnnotationTextMeta;
   endMeta?: AnnotationTextMeta;
@@ -96,6 +97,22 @@ export interface HtmlElementAnchor {
   selector: string;
   tagName: string;
   text?: string;
+}
+
+/**
+ * One additional element covered by a multi-target raw-HTML pinpoint comment
+ * (shift-click multi-select). Carries what the export and composer chips need
+ * even when anchoring failed closed: the semantic label from the pinpoint
+ * hover cascade and the element's text (or `[element: …]` description).
+ * Additive — annotations without the array behave exactly as before.
+ */
+export interface HtmlAnnotationTarget {
+  /** Semantic label from the hover-label cascade (e.g. "Button", "rowchip"). */
+  label?: string;
+  /** The target element's capped text, or an element description when text-less. */
+  text: string;
+  /** Element anchor for restoration; absent when the bridge failed closed. */
+  anchor?: HtmlElementAnchor;
 }
 
 export type AlertKind = 'note' | 'tip' | 'warning' | 'caution' | 'important';

--- a/packages/ui/utils/parser.test.ts
+++ b/packages/ui/utils/parser.test.ts
@@ -1752,6 +1752,53 @@ describe("exportAnnotations — line labels", () => {
   });
 });
 
+describe("exportAnnotations — multi-target raw-HTML comments", () => {
+  // HTML-surface annotations have blockId '' — no blocks apply.
+  const htmlAnn = (extra: object = {}) => ({
+    blockId: "",
+    startOffset: 0,
+    endOffset: 0,
+    type: "COMMENT",
+    text: "Unify these",
+    originalText: "Primary chip",
+    ...extra,
+  });
+
+  test("additional targets are listed with label + excerpt, primary first", () => {
+    const output = exportAnnotations([], [htmlAnn({
+      htmlAdditionalTargets: [
+        { label: "Button", text: "Create", anchor: { selector: "span.btn", tagName: "span", text: "Create" } },
+        // Fail-closed target (no anchor) still exports its label + text.
+        { label: "rowchip", text: "adopted   by 1" },
+      ],
+    })]);
+    expect(output).toContain('Feedback on: "Primary chip"');
+    expect(output).toContain("Also applies to 2 more elements:");
+    expect(output.indexOf("Primary chip")).toBeLessThan(output.indexOf("Also applies"));
+    expect(output).toContain('- [Button] "Create"');
+    expect(output).toContain('- [rowchip] "adopted by 1"'); // whitespace collapsed
+  });
+
+  test("long excerpts are clipped and label-less targets still list", () => {
+    const output = exportAnnotations([], [htmlAnn({
+      htmlAdditionalTargets: [{ text: "x".repeat(300) }],
+    })]);
+    expect(output).toContain("Also applies to 1 more element:");
+    expect(output).toContain(`- "${"x".repeat(120)}…"`);
+  });
+
+  test("single-target output is byte-identical to the pre-feature format", () => {
+    const single = exportAnnotations([], [htmlAnn()]);
+    const empty = exportAnnotations([], [htmlAnn({ htmlAdditionalTargets: [] })]);
+    expect(single).toBe(empty);
+    expect(single).not.toContain("Also applies");
+    expect(single).toBe(
+      "# Plan Feedback\n\nI've reviewed this plan and have 1 piece of feedback:\n\n" +
+      "## 1. Feedback on: \"Primary chip\"\n> Unify these\n\n---\n",
+    );
+  });
+});
+
 describe("parseMarkdownToBlocks — non-markdown plain text (#1029)", () => {
   /**
    * Annotate now accepts YAML/JSON/TOML-style config files and renders them

--- a/packages/ui/utils/parser.test.ts
+++ b/packages/ui/utils/parser.test.ts
@@ -1777,6 +1777,24 @@ describe("exportAnnotations — multi-target raw-HTML comments", () => {
     expect(output.indexOf("Primary chip")).toBeLessThan(output.indexOf("Also applies"));
     expect(output).toContain('- [Button] "Create"');
     expect(output).toContain('- [rowchip] "adopted by 1"'); // whitespace collapsed
+    // A blank line separates the block from the `> comment` blockquote above,
+    // or markdown lazy continuation folds it INTO the quote.
+    expect(output).toContain('> Unify these\n\n**Also applies');
+  });
+
+  test("hostile labels with newlines cannot inject markdown structure into the export", () => {
+    // Labels come from page-controlled attributes (aria-label). The DTO
+    // boundary collapses whitespace, but persisted pre-fix drafts bypass it —
+    // the exporter must collapse again so no line in agent-read feedback
+    // starts with attacker-controlled markdown.
+    const output = exportAnnotations([], [htmlAnn({
+      htmlAdditionalTargets: [
+        { label: "Save\n## INJECTED HEADING", text: "Save\n# ALSO INJECTED" },
+      ],
+    })]);
+    expect(output).toContain('- [Save ## INJECTED HEADING] "Save # ALSO INJECTED"');
+    expect(output).not.toContain("\n## INJECTED");
+    expect(output).not.toContain("\n# ALSO");
   });
 
   test("long excerpts are clipped and label-less targets still list", () => {

--- a/packages/ui/utils/parser.ts
+++ b/packages/ui/utils/parser.ts
@@ -1098,6 +1098,25 @@ const blockEndLine = (block: Block): number => {
 
 /** Resolve the source-line label for a single annotation.
  *  Returns null for global comments, diff-view annotations, or missing blocks. */
+/** Multi-target raw-HTML comments: list every ADDITIONAL element the one
+ *  comment covers (the primary target is already quoted as `originalText`),
+ *  labeled with the semantic hover label plus a short excerpt so the agent
+ *  reading the feedback sees every referenced element. Emits nothing for
+ *  single-target annotations, keeping their output byte-identical. */
+const additionalTargetsExportBlock = (ann: any): string => {
+  const targets = ann?.htmlAdditionalTargets;
+  if (!Array.isArray(targets) || targets.length === 0) return '';
+  let block = `**Also applies to ${targets.length} more element${targets.length > 1 ? 's' : ''}:**\n`;
+  targets.forEach((target: any) => {
+    const label = typeof target?.label === 'string' && target.label ? `[${target.label}] ` : '';
+    const raw = typeof target?.text === 'string' ? target.text : '';
+    const excerpt = raw.replace(/\s+/g, ' ').trim();
+    const clipped = excerpt.length > 120 ? `${excerpt.slice(0, 120)}…` : excerpt;
+    block += `- ${label}"${clipped}"\n`;
+  });
+  return block;
+};
+
 const lineLabelForAnnotation = (blocks: Block[], ann: any): string | null => {
   if (!ann.blockId || ann.type === 'GLOBAL_COMMENT') return null;
   if (typeof ann.blockId === 'string' && ann.blockId.startsWith('diff-block-')) return null;
@@ -1187,6 +1206,9 @@ export const exportAnnotations = (
         output += `> ${ann.text}\n`;
         break;
     }
+
+    // Multi-target raw-HTML comments list every additional covered element.
+    output += additionalTargetsExportBlock(ann);
 
     // Skill references in the comment text (no-op unless a catalog is
     // registered). An annotation carrying a `source` arrived through the
@@ -1288,6 +1310,9 @@ export const exportLinkedDocAnnotations = (
           output += `> ${ann.text}\n`;
           break;
       }
+
+      // Multi-target raw-HTML comments list every additional covered element.
+      output += additionalTargetsExportBlock(ann);
 
       // External (tool-sourced) comments list skills but never inject.
       output += skillReferenceExportBlock(ann.text, injectedSkills, { external: !!ann.source });

--- a/packages/ui/utils/parser.ts
+++ b/packages/ui/utils/parser.ts
@@ -1106,9 +1106,16 @@ const blockEndLine = (block: Block): number => {
 const additionalTargetsExportBlock = (ann: any): string => {
   const targets = ann?.htmlAdditionalTargets;
   if (!Array.isArray(targets) || targets.length === 0) return '';
-  let block = `**Also applies to ${targets.length} more element${targets.length > 1 ? 's' : ''}:**\n`;
+  // Leading blank line: the preceding comment line is a `> blockquote`, and
+  // markdown lazy continuation would otherwise fold this block into it.
+  let block = `\n**Also applies to ${targets.length} more element${targets.length > 1 ? 's' : ''}:**\n`;
   targets.forEach((target: any) => {
-    const label = typeof target?.label === 'string' && target.label ? `[${target.label}] ` : '';
+    // Labels and texts are page-controlled (aria-label etc.). The DTO
+    // boundary already collapses label whitespace; do it here again (defense
+    // in depth) so persisted pre-fix data can never smuggle newlines — and
+    // with them fake markdown structure — into agent-read feedback.
+    const rawLabel = typeof target?.label === 'string' ? target.label.replace(/\s+/g, ' ').trim() : '';
+    const label = rawLabel ? `[${rawLabel}] ` : '';
     const raw = typeof target?.text === 'string' ? target.text : '';
     const excerpt = raw.replace(/\s+/g, ' ').trim();
     const clipped = excerpt.length > 120 ? `${excerpt.slice(0, 120)}…` : excerpt;

--- a/packages/ui/utils/sharing.multiTarget.test.ts
+++ b/packages/ui/utils/sharing.multiTarget.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Share-URL contract for multi-target HTML annotations: element anchors are
+ * deliberately dropped from share payloads (they are meaningless in another
+ * viewer's DOM), and htmlAdditionalTargets follow the exact same rule — the
+ * compact tuple format never carries them. The COMMENT itself (text, quoted
+ * primary text, author, images) still shares.
+ */
+import { describe, expect, test } from "bun:test";
+import { AnnotationType, type Annotation } from "../types";
+import { fromShareable, toShareable } from "./sharing";
+
+const MULTI: Annotation = {
+  id: "ann-1",
+  blockId: "",
+  startOffset: 0,
+  endOffset: 0,
+  type: AnnotationType.COMMENT,
+  text: "Unify these",
+  originalText: "Primary chip",
+  createdA: 1,
+  author: "reviewer",
+  htmlAnchor: { selector: "p.primary", tagName: "p", text: "Primary chip" },
+  htmlAdditionalTargets: [
+    { label: "Button", text: "Create", anchor: { selector: "span.btn", tagName: "span", text: "Create" } },
+  ],
+};
+
+describe("sharing — multi-target annotations", () => {
+  test("toShareable serializes the comment without anchors or additional targets", () => {
+    const shareable = toShareable([MULTI]);
+    expect(shareable).toEqual([["C", "Primary chip", "Unify these", "reviewer", undefined]]);
+    expect(JSON.stringify(shareable)).not.toContain("htmlAdditionalTargets");
+    expect(JSON.stringify(shareable)).not.toContain("selector");
+  });
+
+  test("round trip keeps the comment but has no target array", () => {
+    const restored = fromShareable(toShareable([MULTI]));
+    expect(restored.length).toBe(1);
+    expect(restored[0]!.text).toBe("Unify these");
+    expect(restored[0]!.originalText).toBe("Primary chip");
+    expect(restored[0]!.htmlAnchor).toBeUndefined();
+    expect(restored[0]!.htmlAdditionalTargets).toBeUndefined();
+  });
+});


### PR DESCRIPTION
**TLDR:** In raw-HTML annotate sessions, shift-clicking additional elements adds them to the same comment draft — one comment covering multiple targets, with chips in the composer, hover-to-highlight, and per-target pins that share one number. Mouse-only. Adapted from Codex's browser annotation multi-select. Built and hardened across three adversarial review rounds; final verdict merge-safe.

*AI-assisted (research, implementation, and three adversarial review rounds).*

First pinpoint click opens the comment composer with a primary target; shift-clicking another element adds it to the same draft; shift-clicking a selected element toggles it off; removing the primary promotes the next; removing the last cancels. Selected targets render as horizontally scrollable chips (label + excerpt, remove button, hover flashes the element in the page). While shift-selecting, the composer fades and goes click-through so the click lands on the element beneath, restoring with hysteresis — our DOM equivalent of Codex's click-through popup. Focus returns to the textarea after each selection and the first keystroke is never lost.

Exported feedback lists the primary plus every additional target so the agent sees all referenced elements; single-target output is byte-identical to today. Drafts carry the targets; share URLs drop anchors exactly as they already do; multi-target restore places all pins under one number, fail-closed per target.

Trust boundary: three new bridge messages, all validated and capped parent-side (16-target cap enforced independently of the source, anchors through the existing DTO, labels whitespace-collapsed so a page aria-label can't inject markdown into feedback). An explicit parent-armed handshake keyed per draft ensures the bridge can never accumulate visual state the saved annotation won't carry — the one architectural fix from review.

Deliberately out of scope (follow-ups): rectangular region selection; drag/text selections stay single-target.

Verified: 986 DOM tests pass (+11 covering add/toggle/promotion/cancel, cap enforcement, DTO validation, export, draft round trip, multi-target restore, the arm handshake, forged-message resync, and the yield machine), both typechecks clean, review build clean, and both signoff pages validated end-to-end through headless Chrome.