### PR TITLE
fix(marketing): redirect self-hosting guide to canonical docs

### DIFF
--- a/apps/marketing/cloudfront/url-rewrite.js
+++ b/apps/marketing/cloudfront/url-rewrite.js
@@ -24,7 +24,7 @@ function handler(event) {
     '/docs/guides/opencode-migration-0-19-1': 'https://docs.plannotator.ai/open-source/agents/opencode',
     '/docs/guides/opencode': 'https://docs.plannotator.ai/open-source/agents/opencode',
     '/docs/guides/remote-and-devcontainers': 'https://docs.plannotator.ai/open-source/troubleshooting#remote-ssh-and-development-containers',
-    '/docs/guides/self-hosting': 'https://docs.plannotator.ai/open-source/workflows/sharing#use-your-own-share-services',
+    '/docs/guides/self-hosting': 'https://docs.plannotator.ai/open-source/self-hosting',
     '/docs/guides/sharing-and-collaboration': 'https://docs.plannotator.ai/open-source/workflows/sharing',
     '/docs/guides/troubleshooting': 'https://docs.plannotator.ai/open-source/troubleshooting',
     '/docs/integrations/external-annotations-api': 'https://docs.plannotator.ai/open-source/reference/external-annotations',

--- a/apps/marketing/cloudfront/url-rewrite.test.ts
+++ b/apps/marketing/cloudfront/url-rewrite.test.ts
@@ -37,6 +37,19 @@ describe('marketing CloudFront URL handling', () => {
     );
   });
 
+  test('redirects the legacy self-hosting guide directly to its canonical Docs page', () => {
+    const result = run('/docs/guides/self-hosting') as {
+      statusCode: number;
+      headers: Record<string, { value: string }>;
+    };
+
+    expect(result.statusCode).toBe(301);
+    expect(result.headers.location.value).toBe(
+      'https://docs.plannotator.ai/open-source/self-hosting',
+    );
+    expect(run('/docs/guides/self-hosting/')).toEqual(result);
+  });
+
   test('redirects the old sharing article directly to the current sharing guide', () => {
     const result = run('/blog/sharing-plans-with-your-team') as {
       statusCode: number;


### PR DESCRIPTION
## Summary

- redirect the legacy `/docs/guides/self-hosting` route directly to `https://docs.plannotator.ai/open-source/self-hosting`
- keep the existing 301 response, cache policy, and trailing-slash normalization
- add a focused test for the exact target and trailing-slash variant

The destination shipped in `plannotator/docs` PR #34 and now returns HTTP 200. This change does not modify the marketing hero, static pages, assets, metadata, or any other redirect.

## Verification

- `bun test apps/marketing/cloudfront/url-rewrite.test.ts`: 6 pass, 0 fail
- `node --check apps/marketing/cloudfront/url-rewrite.js`: passed
- `bun run build:marketing`: passed, 40 pages built
- `git diff --check`: passed
- CloudFront Function source: 4,414 bytes, below the tested 10,000-byte limit
- `https://docs.plannotator.ai/open-source/self-hosting`: HTTP 200 with the expected self-hosting title and canonical URL

The currently deployed legacy route still returns the old sharing-anchor target. After this PR is reviewed, merged, and deployed, the CloudFront Function will return the new canonical Docs URL in the same single 301 hop.
