### PR TITLE
feat(annotate): placed comment markers for raw-HTML annotation

### DIFF
--- a/packages/ui/components/html-viewer/HtmlViewer.tsx
+++ b/packages/ui/components/html-viewer/HtmlViewer.tsx
@@ -48,6 +48,12 @@ import {
 
 const PREFIX = "plannotator-bridge-";
 
+// Mirror of the bridge's MAX_SYNC_ANNOTATIONS: the bridge truncates the
+// synced numbering list at this bound, so the sender truncates AFTER the
+// stable sort too — the first 512 numbers then agree on both sides instead
+// of the bridge silently dropping an arbitrary tail.
+const MAX_SYNC_ANNOTATIONS = 512;
+
 function readThemeTokens(): Record<string, string> {
   const style = getComputedStyle(document.documentElement);
   const tokens: Record<string, string> = {};
@@ -447,6 +453,7 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
       const ordered = annotations
         .filter((ann) => ann.type !== AnnotationType.GLOBAL_COMMENT)
         .sort((a, b) => a.createdA - b.createdA)
+        .slice(0, MAX_SYNC_ANNOTATIONS)
         .map((ann, index) => ({ id: ann.id, number: index + 1 }));
       iframeRef.current?.contentWindow?.postMessage(
         { type: `${PREFIX}sync-annotations`, annotations: ordered },

--- a/packages/ui/components/html-viewer/HtmlViewer.tsx
+++ b/packages/ui/components/html-viewer/HtmlViewer.tsx
@@ -437,6 +437,23 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
       }
     }, [iframeReadyVersion]); // eslint-disable-line react-hooks/exhaustive-deps
 
+    // Placed-marker numbering is parent-authoritative: sync the ORDERED
+    // saved-annotation collection (the panel's createdA order, index + 1,
+    // global comments excluded — they have no page location) so every marker
+    // shows its annotation's display number, and renumbers on delete. The
+    // bridge's own registration order is only a pre-sync fallback.
+    useEffect(() => {
+      if (iframeReadyVersion === 0) return;
+      const ordered = annotations
+        .filter((ann) => ann.type !== AnnotationType.GLOBAL_COMMENT)
+        .sort((a, b) => a.createdA - b.createdA)
+        .map((ann, index) => ({ id: ann.id, number: index + 1 }));
+      iframeRef.current?.contentWindow?.postMessage(
+        { type: `${PREFIX}sync-annotations`, annotations: ordered },
+        "*",
+      );
+    }, [iframeReadyVersion, annotations]);
+
     // Tell the bridge the current input method (drag vs pinpoint). Re-posts on
     // ready (fresh iframe) and whenever the user switches it in the toolstrip.
     useEffect(() => {

--- a/packages/ui/components/html-viewer/bridge-script.ts
+++ b/packages/ui/components/html-viewer/bridge-script.ts
@@ -1638,22 +1638,32 @@ export const BRIDGE_SCRIPT = `(function() {
     });
   }
 
-  // All client rects for a range: zero-size filtered, containment filtered.
-  // NOT capped here — the marker anchor needs the TRUE last rect even when
-  // painting is capped at MAX_HIGHLIGHT_RECTS.
+  // Client rects for a range, BOUNDED at the source: a huge drag-selection or
+  // redline can yield thousands of client rects (only the selection TEXT is
+  // capped, never the Range extent), and this runs per range target per rAF
+  // reconcile and per click hit-test. Only the paintable prefix (at most
+  // MAX_HIGHLIGHT_RECTS) is ever materialized — so the zero-size and
+  // containment filters below operate on at most 48 entries — and the
+  // marker's TRUE last rect (m12) is read directly by index off the live
+  // DOMRectList, never by collecting the whole list.
   function rangeClientRects(range) {
     var out = [];
-    if (!range) return out;
+    var lastRaw = null;
+    if (!range) return { rects: out, last: null };
     if (typeof range.getClientRects === 'function') {
       try {
         var list = range.getClientRects();
-        for (var i = 0; i < list.length; i++) out.push(list[i]);
+        for (var i = 0; i < list.length && out.length < MAX_HIGHLIGHT_RECTS; i++) out.push(list[i]);
+        if (list.length) lastRaw = list[list.length - 1];
       } catch (ex) {}
     }
     if (!out.length && typeof range.getBoundingClientRect === 'function') {
       try {
         var bounds = range.getBoundingClientRect();
-        if (bounds) out.push(bounds);
+        if (bounds) {
+          out.push(bounds);
+          if (!lastRaw) lastRaw = bounds;
+        }
       } catch (ex2) {}
     }
     if (layoutActive()) {
@@ -1662,13 +1672,15 @@ export const BRIDGE_SCRIPT = `(function() {
       });
       out = dropContainerRects(out);
     }
-    return out;
+    return { rects: out, last: lastRaw };
   }
 
   // Range paint/projection geometry, shared by the overlay render, the print
   // layer, and highlight click hit-testing: clip-tested painted rects
   // (capped), the TRUE last client rect (marker anchor — never the capped
-  // list's 48th rect), and the clipped union (marker association).
+  // list's 48th rect), and the clipped union (marker association; extended
+  // to the last rect so the tail of a cap-truncated selection still
+  // associates its marker).
   function rangeVisualGeometry(range) {
     var rangeEl = range && range.startContainer
       ? (range.startContainer.nodeType === 1
@@ -1678,7 +1690,8 @@ export const BRIDGE_SCRIPT = `(function() {
     if (rangeEl && targetStyleHidden(rangeEl)) {
       return { paint: [], last: null, vis: null, hidden: true };
     }
-    var all = rangeClientRects(range);
+    var collected = rangeClientRects(range);
+    var all = collected.rects;
     if (!all.length) return { paint: [], last: null, vis: null, hidden: false };
     var bounds = clipBoundsFor(rangeEl);
     var paint = [];
@@ -1686,7 +1699,13 @@ export const BRIDGE_SCRIPT = `(function() {
       var clipped = clipRect(all[i], bounds);
       if (clipped) paint.push(clipped);
     }
-    var union = unionOfRects(all);
+    var last = collected.last;
+    if (layoutActive() && last && !(last.width || 0) && !(last.height || 0)) {
+      // A zero-size trailing rect (collapsed tail) has no visual anchor —
+      // fall back to the last collected paintable rect.
+      last = all[all.length - 1];
+    }
+    var union = unionOfRects(last ? all.concat([last]) : all);
     var vis = bounds
       ? {
         left: Math.max(union.left, bounds.left),
@@ -1695,7 +1714,7 @@ export const BRIDGE_SCRIPT = `(function() {
         bottom: Math.min(union.bottom, bounds.bottom)
       }
       : union;
-    return { paint: paint, last: all[all.length - 1], vis: vis, hidden: false };
+    return { paint: paint, last: last, vis: vis, hidden: false };
   }
 
   function unionOfRects(rects) {

--- a/packages/ui/components/html-viewer/bridge-script.ts
+++ b/packages/ui/components/html-viewer/bridge-script.ts
@@ -1493,6 +1493,15 @@ export const BRIDGE_SCRIPT = `(function() {
       || willChange.indexOf('perspective') >= 0
       || willChange.indexOf('filter') >= 0
     ) return true;
+    var containValue = ' ' + (style.contain || '') + ' ';
+    if (
+      containValue.indexOf(' layout ') >= 0
+      || containValue.indexOf(' paint ') >= 0
+      || containValue.indexOf(' strict ') >= 0
+      || containValue.indexOf(' content ') >= 0
+    ) return true;
+    var containerType = style.containerType || '';
+    if (containerType === 'size' || containerType === 'inline-size') return true;
     return false;
   }
 
@@ -1566,12 +1575,18 @@ export const BRIDGE_SCRIPT = `(function() {
   }
 
   // Unresolved-for-display: a target whose box exists but is invisible
-  // (visibility:hidden/collapse, display:none, opacity:0) keeps a full-size
-  // rect, so without this gate markers, focus rects, and highlights would
-  // render over whatever visible content stacks in the same box (e.g.
-  // carousel slides toggled via visibility). display:none targets already
-  // report empty client rects, but visibility and opacity do not. Checked
-  // per reconcile frame, only for targets that passed the cheaper gates.
+  // (visibility:hidden/collapse, display:none) keeps a full-size rect, so
+  // without this gate markers, focus rects, and highlights would render over
+  // whatever visible content stacks in the same box (e.g. carousel slides
+  // toggled via visibility). display:none targets already report empty
+  // client rects, but visibility does not. Checked per reconcile frame, only
+  // for targets that passed the cheaper gates.
+  //
+  // Deliberately NO opacity:0 leg: computed opacity does not inherit, so a
+  // container faded to opacity:0 leaves descendants at computed 1 and would
+  // not be caught anyway — while the legitimate invisible-hit-target pattern
+  // (<input type=file style="opacity:0;position:absolute;inset:0"> over a
+  // styled control) SHOULD keep its marker exactly over the visible control.
   function targetStyleHidden(el) {
     if (!el || !layoutActive()) return false;
     var style = null;
@@ -1579,8 +1594,6 @@ export const BRIDGE_SCRIPT = `(function() {
     if (!style) return false;
     if (style.visibility === 'hidden' || style.visibility === 'collapse') return true;
     if (style.display === 'none') return true;
-    var opacity = parseFloat(style.opacity);
-    if (!isNaN(opacity) && opacity === 0) return true;
     return false;
   }
 
@@ -1854,9 +1867,12 @@ export const BRIDGE_SCRIPT = `(function() {
         ? annNumbers.get(record.id)
         : fallbackNumbers.get(record.id);
       var focused = focusedAnnotationId === record.id;
-      // One marker per RESOLVED element per record: two anchors of one
-      // annotation re-resolving to the same element must not render two
-      // coincident same-number markers that then spread apart.
+      // One PLACED marker per resolved element per record: two anchors of
+      // one annotation re-resolving to the same element must not render two
+      // coincident same-number markers that then spread apart. Dedup runs
+      // among placed (visible) markers only — a target whose own point is
+      // clipped away must not consume the element's slot and suppress a
+      // sibling target whose point IS visible.
       var seenRecordElements = [];
       for (var targetIndex = 0; targetIndex < record.targets.length; targetIndex++) {
         var target = record.targets[targetIndex];
@@ -1867,11 +1883,6 @@ export const BRIDGE_SCRIPT = `(function() {
             markers.push({ key: markerKey, id: record.id, number: number, hidden: true });
             continue;
           }
-          if (seenRecordElements.indexOf(el) >= 0) {
-            markers.push({ key: markerKey, id: record.id, number: number, hidden: true });
-            continue;
-          }
-          seenRecordElements.push(el);
           var rect = el.getBoundingClientRect();
           var zeroSize = layoutActive() && !(rect.width || 0) && !(rect.height || 0);
           var styleHidden = !zeroSize && targetStyleHidden(el);
@@ -1881,7 +1892,9 @@ export const BRIDGE_SCRIPT = `(function() {
             rect.left + point.x * (rect.width || 0),
             rect.top + point.y * (rect.height || 0)
           );
+          if (placed && seenRecordElements.indexOf(el) >= 0) placed = null;
           if (placed) {
+            seenRecordElements.push(el);
             markers.push({ key: markerKey, id: record.id, number: number, x: placed.x, y: placed.y });
             if (focused) {
               // The focus flash is a painted rect too: clip-test it like

--- a/packages/ui/components/html-viewer/bridge-script.ts
+++ b/packages/ui/components/html-viewer/bridge-script.ts
@@ -3880,4 +3880,24 @@ export const BRIDGE_SCRIPT = `(function() {
   } else {
     onReady();
   }
+
+  // Test-only introspection: the DOM suites assert committed-range EXTENT
+  // (which exact text a committed annotation's range binds), which has no
+  // other observable in the overlay model. Exposes nothing the same-realm
+  // page could not already derive — the overlay root is open, highlight
+  // geometry mirrors the ranges, and the text is the page's own content.
+  window.__plannotatorBridgeInternals = {
+    committedRanges: function(id) {
+      var record = findAnnRecord(id);
+      if (!record) return [];
+      var out = [];
+      for (var i = 0; i < record.targets.length; i++) {
+        var target = record.targets[i];
+        if (target.kind === 'range' && target.range) {
+          try { out.push(target.range.cloneRange()); } catch (ex) {}
+        }
+      }
+      return out;
+    }
+  };
 })();`;

--- a/packages/ui/components/html-viewer/bridge-script.ts
+++ b/packages/ui/components/html-viewer/bridge-script.ts
@@ -15,31 +15,10 @@
  * viewer must never depend on — or collide with — the author's namespace.
  */
 export const ANNOTATION_HIGHLIGHT_CSS = `
-.annotation-highlight {
-  border-radius: 2px;
-  padding: 0 2px;
-  margin: 0 -2px;
-  cursor: pointer;
-}
-.annotation-highlight.deletion {
-  background: oklch(from var(--pn-destructive, #c0392b) l c h / 0.35);
-  text-decoration: line-through;
-  text-decoration-color: var(--pn-destructive, #c0392b);
-  text-decoration-thickness: 2px;
-}
-.annotation-highlight.comment {
-  background: oklch(0.70 0.18 60 / 0.3);
-  border-bottom: 2px solid var(--pn-accent, #d97757);
-}
-.annotation-highlight.focused {
-  background: oklch(from var(--pn-focus-highlight, #4493f8) l c h / 0.45) !important;
-  box-shadow: 0 0 8px oklch(from var(--pn-focus-highlight, #4493f8) l c h / 0.4);
-  border-bottom: 2px solid var(--pn-focus-highlight, #4493f8);
-  filter: none;
-}
-.annotation-highlight:hover {
-  filter: brightness(1.2);
-}
+/* Committed annotation visuals (highlight rectangles + numbered placed
+ * markers) render inside a shadow-rooted fixed overlay host — see OVERLAY_CSS
+ * in the bridge script. Nothing annotation-related is ever wrapped into or
+ * styled onto the author's own elements. */
 /* Vim pinpoint target tint. The MOUSE pinpoint path no longer mutates author
  * elements — it draws the dedicated overlay box below — but keyboard (vim)
  * navigation keeps this class-based visual. */
@@ -75,55 +54,25 @@ export const ANNOTATION_HIGHLIGHT_CSS = `
   from { opacity: 0; transform: scale(0.985); }
   to { opacity: 1; transform: scale(1); }
 }
-/* Numbered pin badges for committed element annotations. */
-[data-plannotator-pin-badge] {
-  position: fixed;
-  z-index: 2147483644;
-  width: 18px;
-  height: 18px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 999px;
-  transform: translate(-50%, -50%);
-  background: var(--pn-accent, #d97757);
-  color: #fff;
-  font: 700 10px/1 system-ui, -apple-system, sans-serif;
-  box-shadow: 0 2px 6px rgba(0,0,0,.25), inset 0 0 0 1px rgba(0,0,0,.06);
-  pointer-events: auto;
-  cursor: pointer !important;
-  user-select: none;
-  animation: pn-pin-badge-in 0.25s cubic-bezier(0.22, 1, 0.36, 1) both;
-}
-@keyframes pn-pin-badge-in {
-  from { opacity: 0; transform: translate(-50%, -50%) scale(0.3); }
-  to { opacity: 1; transform: translate(-50%, -50%) scale(1); }
-}
-/* Pinpoint mode affordance: crosshair everywhere (existing marks and badges
- * stay pointer via their own !important rules below). */
+/* Pinpoint mode affordance: crosshair everywhere. Placed markers live in the
+ * shadow overlay and keep their own pointer cursor there. */
 body[data-plannotator-pinpoint-cursor],
 body[data-plannotator-pinpoint-cursor] * {
   cursor: crosshair !important;
 }
-body[data-plannotator-pinpoint-cursor] .annotation-highlight,
-body[data-plannotator-pinpoint-cursor] [data-plannotator-pin-badge] {
-  cursor: pointer !important;
-}
 @media (prefers-reduced-motion: reduce) {
-  [data-plannotator-pinpoint-box].pn-pin-enter,
-  [data-plannotator-pin-badge] {
+  [data-plannotator-pinpoint-box].pn-pin-enter {
     animation: none;
   }
 }
 @media print {
-  /* Viewer overlays are review chrome, not page content: never bake pin
-     badges, pinpoint boxes/labels, or vim UI into a printed page. The outer
-     app chrome is print-hidden by print.css, but this CSS lives inside the
-     iframe's own document and must carry its own rule. Inline annotation
-     <mark>s stay visible in print on purpose, matching markdown documents. */
+  /* Viewer overlays are review chrome, not page content: never bake pinpoint
+     boxes/labels or vim UI into a printed page. The outer app chrome is
+     print-hidden by print.css, but this CSS lives inside the iframe's own
+     document and must carry its own rule. The annotation overlay host carries
+     its own print rule inside its shadow root. */
   [data-plannotator-pinpoint-box],
   [data-plannotator-pinpoint-label],
-  [data-plannotator-pin-badge],
   [data-plannotator-vim-ui],
   [data-plannotator-vim-cursor] {
     display: none !important;
@@ -304,6 +253,7 @@ export const BRIDGE_SCRIPT = `(function() {
   var pendingPinAnchor = null; // serialized anchor for the pending pin
   var pendingPinKey = null; // target key for the primary pinpoint target (multi-select)
   var pendingPinLabel = null; // semantic label captured for the primary target
+  var pendingPinPoint = null; // normalized {x,y} click point inside the pinned element's rect
   var pendingPinViaPinpoint = false; // pinpoint drafts survive scroll-out (see postSelectionRect)
   // Multi-select is ARMED EXPLICITLY by the parent (arm-multi-select), and only
   // when the comment composer owns the draft. The bridge must never accept a
@@ -338,7 +288,6 @@ export const BRIDGE_SCRIPT = `(function() {
 
   document.addEventListener('mouseup', function(e) {
     if (currentInputMethod === 'pinpoint') return; // pinpoint uses click, not drag-select
-    if (e.target && e.target.closest && e.target.closest('.annotation-highlight')) return;
     setTimeout(handleSelection, 10);
   });
 
@@ -369,6 +318,7 @@ export const BRIDGE_SCRIPT = `(function() {
         pendingRange = null;
         clearMultiTargets();
         clearPendingPin();
+        renderAnnotationOverlay();
       }
       return false;
     }
@@ -397,6 +347,7 @@ export const BRIDGE_SCRIPT = `(function() {
       targetLabel: (extras && extras.targetLabel) || undefined,
       rect: { top: rect.top, left: rect.left, width: rect.width, height: rect.height }
     }, '*');
+    renderAnnotationOverlay(); // draft selection highlight (overlay-projected)
     return true;
   }
 
@@ -422,6 +373,7 @@ export const BRIDGE_SCRIPT = `(function() {
       pendingSelection = null;
       pendingRange = null;
       clearPendingPin();
+      renderAnnotationOverlay();
       return;
     }
     parent.postMessage({
@@ -444,24 +396,61 @@ export const BRIDGE_SCRIPT = `(function() {
       var id = e.data.id;
       var annType = e.data.annotationType || 'comment';
       if (pendingSelection) {
-        // Text selections wrap a <mark>; element pinpoints (e.g. SVG nodes) carry
-        // no range, so there's no inline mark to apply — instead the pinned
-        // element gets a numbered pin badge anchored to its box.
+        var record = null;
+        // Text selections register a live range (overlay highlight); element
+        // pinpoints (e.g. SVG nodes) carry no range and register the pinned
+        // element with the user's selected point. The page DOM is untouched.
         if (pendingSelection.startContainerPath) {
-          applyMark(id, annType, pendingSelection);
+          var committedRange = buildPendingRange(pendingSelection);
+          if (pendingPinEl) {
+            record = ensureAnnRecord(id, annType, {
+              originalText: pendingSelection.text || '',
+              anchor: pendingPinAnchor,
+              additionalAnchors: null
+            });
+            addElementTarget(record, pendingPinEl, pendingPinAnchor, pendingPinPoint);
+            if (committedRange) addRangeTarget(record, committedRange, pendingSelection.text || '', true);
+          } else if (committedRange) {
+            record = ensureAnnRecord(id, annType, {
+              originalText: pendingSelection.text || '',
+              anchor: null,
+              additionalAnchors: null
+            });
+            addRangeTarget(record, committedRange, pendingSelection.text || '', false);
+          }
           if (
             vimActionReturn
             && (vimActionReturn.phase === 'visual' || vimActionReturn.phase === 'visual-block')
           ) {
-            vimActionReturn.range = committedMarkRange(id) || vimActionReturn.range;
+            vimActionReturn.range = committedRangeClone(id) || vimActionReturn.range;
           }
         } else if (pendingPinEl) {
-          registerPin(id, pendingPinEl, pendingPinAnchor);
+          record = ensureAnnRecord(id, annType, {
+            originalText: '',
+            anchor: pendingPinAnchor,
+            additionalAnchors: null
+          });
+          addElementTarget(record, pendingPinEl, pendingPinAnchor, pendingPinPoint);
         }
-        // Every additional multi-select target gets a pin under the SAME
-        // annotation id — all of them share one badge number.
-        for (var mtIndex = 0; mtIndex < pendingMultiTargets.length; mtIndex++) {
-          registerPin(id, pendingMultiTargets[mtIndex].el, pendingMultiTargets[mtIndex].anchor);
+        // Every additional multi-select target registers under the SAME
+        // annotation id — all of its markers share one comment number.
+        if (pendingMultiTargets.length) {
+          if (!record) {
+            record = ensureAnnRecord(id, annType, {
+              originalText: '',
+              anchor: pendingPinAnchor,
+              additionalAnchors: null
+            });
+          }
+          var extraAnchorList = [];
+          for (var mtIndex = 0; mtIndex < pendingMultiTargets.length; mtIndex++) {
+            var mt = pendingMultiTargets[mtIndex];
+            addElementTarget(record, mt.el, mt.anchor, mt.point);
+            if (mt.anchor) extraAnchorList.push(mt.anchor);
+          }
+          if (record.params) {
+            record.params.additionalAnchors = extraAnchorList.length ? extraAnchorList : null;
+          }
         }
         pendingSelection = null;
         pendingRange = null;
@@ -470,54 +459,17 @@ export const BRIDGE_SCRIPT = `(function() {
       clearMultiTargets();
       clearPendingPin();
       restoreVimSemanticTarget();
+      renderAnnotationOverlay();
     }
 
     else if (type === PREFIX + 'find-and-mark') {
-      // Anchor-first restoration: resolve the serialized element anchor and scope
-      // the text search to it; a resolved element whose text drifted still gets a
-      // pin badge. Document-wide text search remains the fallback (and the only
-      // path for anchor-less annotations, e.g. from shared URLs).
-      var restoreType = e.data.annotationType || 'comment';
-      var anchorEl = resolveAnchorElement(e.data.anchor);
-      var found = false;
-      var isSvgAnchor = anchorEl && (anchorEl.ownerSVGElement || anchorEl.tagName.toLowerCase() === 'svg');
-      if (isSvgAnchor) {
-        // SVG content never takes an inline <mark> (it would un-render the
-        // text) — a resolved SVG anchor is always a pin, and the HTML-oriented
-        // text search below could only mis-mark unrelated HTML text.
-        registerPin(e.data.id, anchorEl, e.data.anchor);
-        found = true;
-      }
-      if (!found && anchorEl) {
-        found = findTextAndMark(e.data.id, e.data.originalText, restoreType, anchorEl);
-      }
-      if (!found) {
-        // Document-wide text search runs BEFORE the pin fallback: if the
-        // annotated text moved elsewhere in a regenerated page, the annotation
-        // follows the text rather than badging the stale container.
-        found = findTextAndMark(e.data.id, e.data.originalText, restoreType);
-      }
-      if (!found && anchorEl) {
-        // Element still resolves but its text is gone everywhere: badge the
-        // element itself as the last resort.
-        registerPin(e.data.id, anchorEl, e.data.anchor);
-        found = true;
-      }
-      // Multi-target annotations: every additional anchor that still resolves
-      // gets a pin under the same id (same badge number). Anchor-only — a
-      // stale anchor simply doesn't restore (fail closed), the primary's text
-      // fallback is never reused here because an excerpt search could mis-mark.
-      var extraAnchors = e.data.additionalAnchors;
-      if (extraAnchors && extraAnchors.length) {
-        var extraCount = Math.min(extraAnchors.length, MAX_MULTI_TARGETS);
-        for (var extraIndex = 0; extraIndex < extraCount; extraIndex++) {
-          var extraEl = resolveAnchorElement(extraAnchors[extraIndex]);
-          if (extraEl) {
-            registerPin(e.data.id, extraEl, extraAnchors[extraIndex]);
-            found = true;
-          }
-        }
-      }
+      var found = restoreAnnotation(
+        e.data.id,
+        e.data.annotationType || 'comment',
+        typeof e.data.originalText === 'string' ? e.data.originalText : '',
+        e.data.anchor,
+        e.data.additionalAnchors
+      );
       parent.postMessage({
         type: PREFIX + 'mark-applied',
         id: e.data.id,
@@ -526,14 +478,40 @@ export const BRIDGE_SCRIPT = `(function() {
     }
 
     else if (type === PREFIX + 'remove-mark') {
-      removeMark(e.data.id);
-      unregisterPin(e.data.id);
+      removeAnnRecord(e.data.id);
+      renderAnnotationOverlay();
     }
 
     else if (type === PREFIX + 'clear-marks') {
-      var marks = document.querySelectorAll('.annotation-highlight[data-bind-id]');
-      for (var i = marks.length - 1; i >= 0; i--) unwrapMark(marks[i]);
-      clearAllPins();
+      annRecords = [];
+      focusedAnnotationId = null;
+      renderAnnotationOverlay();
+    }
+
+    else if (type === PREFIX + 'sync-annotations') {
+      // Parent-authoritative numbering: the ordered saved-annotation list
+      // (index + 1 in the panel's collection). Bounded and shape-checked —
+      // malformed entries are skipped, a malformed list is ignored outright.
+      var syncList = e.data.annotations;
+      if (syncList && typeof syncList.length === 'number') {
+        var nextNumbers = new Map();
+        var syncCount = Math.min(syncList.length, MAX_SYNC_ANNOTATIONS);
+        for (var syncIndex = 0; syncIndex < syncCount; syncIndex++) {
+          var syncEntry = syncList[syncIndex];
+          if (!syncEntry || typeof syncEntry.id !== 'string' || !syncEntry.id || syncEntry.id.length > 256) continue;
+          var syncNumber = syncEntry.number;
+          if (
+            typeof syncNumber !== 'number'
+            || !isFinite(syncNumber)
+            || syncNumber < 1
+            || syncNumber > 100000
+            || Math.floor(syncNumber) !== syncNumber
+          ) continue;
+          nextNumbers.set(syncEntry.id, syncNumber);
+        }
+        annNumbers = nextNumbers;
+        renderAnnotationOverlay();
+      }
     }
 
     else if (type === PREFIX + 'cancel-selection') {
@@ -544,6 +522,7 @@ export const BRIDGE_SCRIPT = `(function() {
       clearPendingPin();
       window.getSelection().removeAllRanges();
       restoreVimSemanticTarget();
+      renderAnnotationOverlay();
     }
 
     else if (type === PREFIX + 'arm-multi-select') {
@@ -572,29 +551,15 @@ export const BRIDGE_SCRIPT = `(function() {
     }
 
     else if (type === PREFIX + 'scroll-to') {
-      var mark = document.querySelector('[data-bind-id="' + e.data.id + '"]');
-      if (mark) {
-        mark.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        mark.classList.add('focused');
-        setTimeout(function() { mark.classList.remove('focused'); }, 2000);
-      } else {
-        // Pin-only annotation (no inline mark): scroll its element into view and
-        // flash the pinned outline over it.
-        var pin = findPin(e.data.id);
-        if (pin && pin.element && pin.element.isConnected) {
-          pin.element.scrollIntoView({ behavior: 'smooth', block: 'center' });
-          flashPinnedBox(pin.element);
-        }
-      }
+      // Selecting an annotation scrolls its first resolved target into view
+      // and flashes the overlay focus highlight over EVERY rect of EVERY
+      // target — never a class write on page elements, and never only the
+      // first fragment of a multi-paragraph selection.
+      scrollToAnnotation(e.data.id);
     }
 
     else if (type === PREFIX + 'focus-mark') {
-      var all = document.querySelectorAll('.annotation-highlight');
-      for (var j = 0; j < all.length; j++) all[j].classList.remove('focused');
-      if (e.data.id) {
-        var target = document.querySelector('[data-bind-id="' + e.data.id + '"]');
-        if (target) target.classList.add('focused');
-      }
+      focusAnnotationRecord(typeof e.data.id === 'string' ? e.data.id : null, false);
     }
 
     else if (type === PREFIX + 'set-input-method') {
@@ -657,7 +622,7 @@ export const BRIDGE_SCRIPT = `(function() {
   // CSS anchor for later restoration, and element-only pins (SVG, icon
   // buttons) get a numbered badge. The semantic target graph below survives
   // as the vim-navigation vocabulary only; the pointer path never builds it.
-  var PINPOINT_SKIP_SELECTOR = 'script,style,noscript,[data-plannotator-vim-ui],[data-plannotator-pin-badge],.annotation-highlight';
+  var PINPOINT_SKIP_SELECTOR = 'script,style,noscript,[data-plannotator-vim-ui]';
 
   // Identity set of every overlay node the viewer creates inside the page
   // (pin badges, pinpoint box/label, vim UI). Hit-testing excludes overlay
@@ -726,6 +691,12 @@ export const BRIDGE_SCRIPT = `(function() {
   // tests) and the scroll reconcile, which re-resolves under a still cursor.
   function resolvePinpointTargetAt(x, y, fallbackNode) {
     var node = deepElementFromPoint(x, y);
+    if (node && isViewerOverlayNode(node)) {
+      // A placed marker owns its clicks, but hit-testing for a NEW selection
+      // must reach the page beneath it: temporarily yield marker hit targets
+      // and probe again (identity-gated, never selector-gated).
+      node = withMarkersYielded(function() { return deepElementFromPoint(x, y); });
+    }
     if (!node || node === document.documentElement || node === document.body) {
       node = fallbackNode || null;
     }
@@ -734,10 +705,6 @@ export const BRIDGE_SCRIPT = `(function() {
     if (node === document.documentElement || node === document.body) return null;
     if (isViewerOverlayNode(node)) return null;
     if (node.closest && node.closest('script,style,noscript')) return null;
-    // Annotation marks are viewer chrome wrapped around author text: treat
-    // them as transparent so hover names the author element beneath.
-    var mark = node.closest && node.closest('.annotation-highlight');
-    if (mark && mark.parentElement) node = mark.parentElement;
     // SVG shape primitives promote to their nearest group: a <g> is the
     // authored unit of an SVG diagram, and its <path> fragments are not
     // individually meaningful annotation targets.
@@ -1096,7 +1063,7 @@ export const BRIDGE_SCRIPT = `(function() {
       // layout-changing mutation (the body ResizeObserver also lands here) —
       // the last-position cache must never answer the next probe.
       invalidatePointerHitCache();
-      renderPinBadges();
+      renderAnnotationOverlay();
       positionMultiTargetBoxes();
       if (pendingPinEl && pendingPinEl.isConnected) {
         positionPinpointBox(pendingPinEl);
@@ -1112,94 +1079,646 @@ export const BRIDGE_SCRIPT = `(function() {
   window.addEventListener('scroll', schedulePinpointReconcile, { passive: true, capture: true });
   window.addEventListener('resize', schedulePinpointReconcile, { passive: true });
 
-  // --- Pin badges: numbered markers for element-only annotations ---
-  var pinRegistry = []; // { id, element, anchor, badge }
-  function findPin(id) {
-    for (var i = 0; i < pinRegistry.length; i++) {
-      if (pinRegistry[i].id === id) return pinRegistry[i];
+  // --- Annotation overlay: anchors are data, markers are projections ---
+  // Committed annotations never write into the visited page's DOM. Durable
+  // data (anchor selectors, original text, normalized selected point) is
+  // re-resolved to live targets on demand and projected as disposable
+  // artifacts — highlight rectangles and numbered placed-marker buttons —
+  // into a fixed, pointer-transparent, shadow-rooted overlay host appended
+  // to the root element (outside <body>, outside page layout). Only marker
+  // buttons accept pointer input; everything else is hit-transparent.
+  var MARKER_EDGE_INSET = 29;      // full marker stays reachable at viewport edges
+  var MARKER_SPREAD_STEP = 12.5;   // horizontal step for coincident markers
+  var MARKER_SPREAD_EDGE = 28.5;   // effective edge clamp while spreading
+  var MARKER_ASSOC_TOLERANCE = 16; // clamped point must stay this close to the visible target
+  var MAX_HIGHLIGHT_RECTS = 48;    // highlight rects drawn per range target
+  var MAX_SYNC_ANNOTATIONS = 512;  // parent-synced numbering entries
+
+  // Style isolation only (not a security boundary): the shadow root keeps the
+  // page's CSS off the overlay and the overlay's CSS off the page.
+  var OVERLAY_CSS = [
+    '.pn-layer { position: fixed; inset: 0; pointer-events: none; }',
+    '.pn-hl { position: fixed; pointer-events: none; border-radius: 2px; box-sizing: border-box; }',
+    '.pn-hl-comment { background: oklch(0.70 0.18 60 / 0.28); border-bottom: 2px solid var(--pn-accent, #d97757); }',
+    '.pn-hl-deletion { background: oklch(from var(--pn-destructive, #c0392b) l c h / 0.28); background-image: linear-gradient(to bottom, transparent calc(50% - 1px), var(--pn-destructive, #c0392b) calc(50% - 1px), var(--pn-destructive, #c0392b) calc(50% + 1px), transparent calc(50% + 1px)); }',
+    '.pn-hl-focus { background: oklch(from var(--pn-focus-highlight, #4493f8) l c h / 0.35); box-shadow: 0 0 8px oklch(from var(--pn-focus-highlight, #4493f8) l c h / 0.4); }',
+    '.pn-hl-draft { background: oklch(from var(--pn-focus-highlight, #4493f8) l c h / 0.22); }',
+    '.pn-marker { position: fixed; width: 25px; height: 25px; border: 0; padding: 0; margin: 0; background: transparent; transform: translate(-50%, -50%); pointer-events: auto; cursor: pointer; display: flex; align-items: center; justify-content: center; animation: pn-marker-in 0.2s ease-out both; }',
+    '.pn-marker[data-selected="true"] { transform: translate(-50%, -50%) scale(1.08); }',
+    '.pn-marker-icon { pointer-events: none; display: block; position: absolute; top: 0; left: 0; width: 100%; height: 100%; filter: drop-shadow(0 1px 3px rgba(0,0,0,.3)); }',
+    '.pn-marker-icon path { fill: var(--pn-accent, #d97757); stroke: #fff; stroke-width: 1.65; }',
+    '.pn-marker-num { pointer-events: none; position: relative; transform: translate(-0.5px, -1.5px); color: #fff; font: 700 10px/1 system-ui, -apple-system, sans-serif; user-select: none; }',
+    '@keyframes pn-marker-in { from { opacity: 0; } to { opacity: 1; } }',
+    '@media (prefers-reduced-motion: reduce) { .pn-marker { animation: none; } }',
+    ':host([data-pn-hittest]) .pn-marker, [data-plannotator-overlay-host][data-pn-hittest] .pn-marker { pointer-events: none !important; }',
+    '@media print { .pn-layer { display: none !important; } }'
+  ].join('\\n');
+
+  // Product-owned speech-bubble marker (26x25 box, accent fill, white stroke).
+  var MARKER_SVG = '<svg class="pn-marker-icon" viewBox="0 0 26 25" aria-hidden="true" focusable="false"><path d="M13 1.1C6.55 1.1 1.4 5.83 1.4 11.62c0 3.62 2.02 6.8 5.08 8.68l-0.85 3.5 4.28-2.02c1.01 0.25 2.05 0.38 3.09 0.38 6.45 0 11.6-4.73 11.6-10.54C24.6 5.83 19.45 1.1 13 1.1Z"/></svg>';
+
+  var overlayHostEl = null;
+  var overlayRootEl = null; // shadow root, or the host itself when unavailable
+  var highlightsLayerEl = null;
+  var markersLayerEl = null;
+
+  function ensureOverlayHost() {
+    if (!overlayHostEl) {
+      overlayHostEl = document.createElement('div');
+      overlayHostEl.setAttribute('data-plannotator-overlay-host', '');
+      var hostStyle = overlayHostEl.style;
+      hostStyle.setProperty('position', 'fixed', 'important');
+      hostStyle.setProperty('top', '0', 'important');
+      hostStyle.setProperty('left', '0', 'important');
+      hostStyle.setProperty('right', '0', 'important');
+      hostStyle.setProperty('bottom', '0', 'important');
+      hostStyle.setProperty('z-index', '2147483647', 'important');
+      hostStyle.setProperty('pointer-events', 'none', 'important');
+      overlayNodes.add(overlayHostEl);
+      var root = overlayHostEl;
+      if (overlayHostEl.attachShadow) {
+        try { root = overlayHostEl.attachShadow({ mode: 'open' }); } catch (ex) {}
+      }
+      overlayRootEl = root;
+      var style = document.createElement('style');
+      style.textContent = OVERLAY_CSS;
+      root.appendChild(style);
+      highlightsLayerEl = document.createElement('div');
+      highlightsLayerEl.className = 'pn-layer';
+      highlightsLayerEl.setAttribute('data-pn-highlights', '');
+      root.appendChild(highlightsLayerEl);
+      markersLayerEl = document.createElement('div');
+      markersLayerEl.className = 'pn-layer';
+      markersLayerEl.setAttribute('data-pn-markers', '');
+      root.appendChild(markersLayerEl);
+    }
+    // Host lives on the root element, not in <body>: the page's own layout
+    // never contains or reflows around it, and the body MutationObserver
+    // never sees overlay writes.
+    if (!overlayHostEl.isConnected) {
+      (document.documentElement || document.body).appendChild(overlayHostEl);
+    }
+    return overlayHostEl;
+  }
+
+  // Hit-test yielding: marker buttons accept pointer input, so a bare
+  // elementFromPoint over one would resolve overlay chrome instead of the
+  // page. Temporarily disable marker hit targets so probes reach beneath.
+  function withMarkersYielded(fn) {
+    if (!overlayHostEl || !overlayHostEl.isConnected) return fn();
+    overlayHostEl.setAttribute('data-pn-hittest', '');
+    try {
+      return fn();
+    } finally {
+      overlayHostEl.removeAttribute('data-pn-hittest');
+    }
+  }
+
+  // One record per committed annotation. Its targets are live projections;
+  // its params are the durable data they re-resolve from after mutations.
+  var annRecords = []; // { id, annType, params: { originalText, anchor, additionalAnchors }, targets }
+  var annNumbers = null; // Map(id -> display number) synced from the parent's ordered collection
+  var focusedAnnotationId = null;
+  var focusFlashTimer = 0;
+  var markerButtons = new Map(); // "id::targetIndex" -> <button>
+
+  function findAnnRecord(id) {
+    for (var i = 0; i < annRecords.length; i++) {
+      if (annRecords[i].id === id) return annRecords[i];
     }
     return null;
   }
-  function registerPin(id, element, anchor) {
-    // One annotation may legitimately cover several elements (multi-select),
-    // so dedup by (id, element) — and by (id, anchor) so a re-resolved anchor
-    // can't double-badge the same logical target — never by id alone.
-    for (var existing = 0; existing < pinRegistry.length; existing++) {
-      if (pinRegistry[existing].id !== id) continue;
-      if (pinRegistry[existing].element === element) return;
-      if (anchor && anchorsEqual(pinRegistry[existing].anchor, anchor)) return;
+
+  function ensureAnnRecord(id, annType, params) {
+    var existing = findAnnRecord(id);
+    if (existing) return existing;
+    var record = { id: id, annType: annType || 'comment', params: params || null, targets: [] };
+    annRecords.push(record);
+    return record;
+  }
+
+  function removeAnnRecord(id) {
+    for (var i = annRecords.length - 1; i >= 0; i--) {
+      if (annRecords[i].id === id) annRecords.splice(i, 1);
     }
-    var badge = document.createElement('div');
-    badge.setAttribute('data-plannotator-pin-badge', '');
-    badge.setAttribute('data-plannotator-vim-ui', '');
-    badge.addEventListener('click', function(clickEvent) {
+    if (focusedAnnotationId === id) focusedAnnotationId = null;
+  }
+
+  function validNormalizedPoint(p) {
+    if (!p || typeof p.x !== 'number' || typeof p.y !== 'number') return null;
+    if (!isFinite(p.x) || !isFinite(p.y)) return null;
+    return { x: Math.max(0, Math.min(1, p.x)), y: Math.max(0, Math.min(1, p.y)) };
+  }
+
+  function normalizedPointOf(anchor, point) {
+    return validNormalizedPoint(point) || (anchor ? validNormalizedPoint(anchor.point) : null);
+  }
+
+  function addElementTarget(record, element, anchor, point) {
+    if (!element) return false;
+    // One annotation may cover several elements (multi-select): dedup by
+    // (id, element) and (id, anchor) so a re-resolved anchor can't
+    // double-mark the same logical target — never by id alone.
+    for (var i = 0; i < record.targets.length; i++) {
+      var t = record.targets[i];
+      if (t.kind !== 'element') continue;
+      if (t.element === element) return false;
+      if (anchor && anchorsEqual(t.anchor, anchor)) return false;
+    }
+    record.targets.push({
+      kind: 'element',
+      element: element,
+      anchor: anchor || null,
+      point: normalizedPointOf(anchor, point)
+    });
+    return true;
+  }
+
+  function addRangeTarget(record, range, text, markerless) {
+    if (!range) return false;
+    record.targets.push({ kind: 'range', range: range, text: text || '', markerless: !!markerless });
+    return true;
+  }
+
+  function rangeAlive(range) {
+    if (!range) return false;
+    try {
+      var s = range.startContainer;
+      var e = range.endContainer;
+      if (!s || !e) return false;
+      if (typeof s.isConnected === 'boolean' && !s.isConnected) return false;
+      if (typeof e.isConnected === 'boolean' && !e.isConnected) return false;
+      return true;
+    } catch (ex) {
+      return false;
+    }
+  }
+
+  // Resolve one contiguous document Range for the first occurrence of text.
+  // Overlay-owned text (labels, vim chrome) is skipped by IDENTITY so viewer
+  // chrome can never satisfy a page-text search.
+  function findTextRange(text, root) {
+    var scope = root || document.body;
+    if (!text || !scope) return null;
+    var walker = document.createTreeWalker(scope, NodeFilter.SHOW_TEXT, null);
+    var buffer = '';
+    var nodes = [];
+    while (walker.nextNode()) {
+      var current = walker.currentNode;
+      if (current.parentElement && isViewerOverlayNode(current.parentElement)) continue;
+      nodes.push({ node: current, start: buffer.length });
+      buffer += current.textContent;
+    }
+    var idx = buffer.indexOf(text);
+    if (idx === -1) return null;
+    var endIdx = idx + text.length;
+    var startEntry = null;
+    var endEntry = null;
+    for (var i = 0; i < nodes.length; i++) {
+      var entry = nodes[i];
+      var nodeEnd = entry.start + entry.node.length;
+      if (!startEntry && idx < nodeEnd) startEntry = entry;
+      if (endIdx <= nodeEnd) { endEntry = entry; break; }
+    }
+    if (!startEntry || !endEntry) return null;
+    try {
+      var range = document.createRange();
+      range.setStart(startEntry.node, idx - startEntry.start);
+      range.setEnd(endEntry.node, endIdx - endEntry.start);
+      return range;
+    } catch (ex) {
+      return null;
+    }
+  }
+
+  /**
+   * Restore ladder (fail-closed, matches the old find-and-mark contract):
+   * resolved SVG anchors are element targets; a resolved anchor scopes the
+   * text search (element marker + markerless highlight range); the
+   * document-wide text search runs BEFORE the element fallback so text that
+   * moved elsewhere is followed rather than pinning a stale container; a
+   * resolved element whose text is gone everywhere is the last resort.
+   * Additional anchors restore anchor-only — a stale anchor simply doesn't
+   * restore.
+   */
+  function restoreAnnotation(id, annType, originalText, anchor, additionalAnchors) {
+    removeAnnRecord(id); // a fresh restore is authoritative for its id
+    var record = ensureAnnRecord(id, annType, {
+      originalText: originalText || '',
+      anchor: anchor || null,
+      additionalAnchors: additionalAnchors || null
+    });
+    var found = false;
+    var anchorEl = resolveAnchorElement(anchor);
+    var isSvgAnchor = anchorEl && (anchorEl.ownerSVGElement || anchorEl.tagName.toLowerCase() === 'svg');
+    if (isSvgAnchor) {
+      found = addElementTarget(record, anchorEl, anchor, null);
+    } else if (anchorEl) {
+      var scopedRange = findTextRange(originalText, anchorEl);
+      if (scopedRange) {
+        // Pinpoint-with-text: the element owns the placed marker (at the
+        // stored selected point); the scoped range paints the highlight.
+        found = addElementTarget(record, anchorEl, anchor, null);
+        addRangeTarget(record, scopedRange, originalText, true);
+      }
+    }
+    if (!found) {
+      var docRange = findTextRange(originalText, null);
+      if (docRange) {
+        addRangeTarget(record, docRange, originalText, false);
+        found = true;
+      }
+    }
+    if (!found && anchorEl) {
+      found = addElementTarget(record, anchorEl, anchor, null);
+    }
+    if (additionalAnchors && additionalAnchors.length) {
+      var extraCount = Math.min(additionalAnchors.length, MAX_MULTI_TARGETS);
+      for (var extraIndex = 0; extraIndex < extraCount; extraIndex++) {
+        var extraEl = resolveAnchorElement(additionalAnchors[extraIndex]);
+        if (extraEl && addElementTarget(record, extraEl, additionalAnchors[extraIndex], null)) {
+          found = true;
+        }
+      }
+    }
+    if (!record.targets.length) removeAnnRecord(id);
+    renderAnnotationOverlay();
+    return found;
+  }
+
+  // Re-resolve stale live targets from durable data. Element targets
+  // re-acquire through their anchor; range targets re-run the text search
+  // (anchor-scoped first). Unresolvable targets stay hidden — never guessed.
+  function refreshRecordTargets(record) {
+    for (var i = 0; i < record.targets.length; i++) {
+      var target = record.targets[i];
+      if (target.kind === 'element') {
+        if ((!target.element || !target.element.isConnected) && target.anchor) {
+          target.element = resolveAnchorElement(target.anchor);
+        }
+      } else if (!rangeAlive(target.range)) {
+        target.range = null;
+        if (target.text) {
+          var scopeEl = record.params && record.params.anchor
+            ? resolveAnchorElement(record.params.anchor)
+            : null;
+          target.range = (scopeEl && findTextRange(target.text, scopeEl))
+            || findTextRange(target.text, null);
+        }
+      }
+    }
+  }
+
+  function committedRangeClone(id) {
+    var record = findAnnRecord(id);
+    if (!record) return null;
+    for (var i = 0; i < record.targets.length; i++) {
+      var target = record.targets[i];
+      if (target.kind === 'range' && rangeAlive(target.range)) {
+        try { return target.range.cloneRange(); } catch (ex) {}
+      }
+    }
+    return null;
+  }
+
+  function buildPendingRange(selData) {
+    try {
+      var startNode = resolveNodePath(selData.startContainerPath);
+      var endNode = resolveNodePath(selData.endContainerPath);
+      if (!startNode || !endNode) return null;
+      var range = document.createRange();
+      range.setStart(startNode, selData.startOffset);
+      range.setEnd(endNode, selData.endOffset);
+      return range;
+    } catch (ex) {
+      return null;
+    }
+  }
+
+  function rectRight(r) { return typeof r.right === 'number' ? r.right : r.left + (r.width || 0); }
+  function rectBottom(r) { return typeof r.bottom === 'number' ? r.bottom : r.top + (r.height || 0); }
+
+  // Intersect a target rect with every clipping/scroll ancestor so a marker
+  // is never shown for content its container has scrolled or clipped away.
+  function clippedTargetRect(el, rect) {
+    if (!layoutActive()) return rect;
+    var left = rect.left;
+    var top = rect.top;
+    var right = rectRight(rect);
+    var bottom = rectBottom(rect);
+    var current = el ? el.parentElement : null;
+    var guard = 0;
+    while (
+      current
+      && current !== document.body
+      && current !== document.documentElement
+      && guard++ < 200
+    ) {
+      var style = null;
+      try { style = window.getComputedStyle(current); } catch (ex) { break; }
+      var overflowX = (style && (style.overflowX || style.overflow)) || '';
+      var overflowY = (style && (style.overflowY || style.overflow)) || '';
+      var clipsX = overflowX && overflowX !== 'visible';
+      var clipsY = overflowY && overflowY !== 'visible';
+      if (clipsX || clipsY) {
+        var cr = current.getBoundingClientRect();
+        if (clipsX) { left = Math.max(left, cr.left); right = Math.min(right, rectRight(cr)); }
+        if (clipsY) { top = Math.max(top, cr.top); bottom = Math.min(bottom, rectBottom(cr)); }
+      }
+      current = current.parentElement;
+    }
+    return { left: left, top: top, right: right, bottom: bottom, width: right - left, height: bottom - top };
+  }
+
+  /**
+   * Project a raw marker point against the target's visible geometry:
+   * omit when the target has no visible intersection with the viewport,
+   * clamp so the full marker stays reachable at viewport edges, and omit
+   * when the clamped point is no longer visibly associated with the target
+   * (clipped/scrolled away). Never guesses a position.
+   */
+  function markerViewportPoint(visRect, rawX, rawY) {
+    if (!layoutActive()) return { x: rawX, y: rawY };
+    var vw = window.innerWidth;
+    var vh = window.innerHeight;
+    var visLeft = Math.max(visRect.left, 0);
+    var visTop = Math.max(visRect.top, 0);
+    var visRight = Math.min(rectRight(visRect), vw);
+    var visBottom = Math.min(rectBottom(visRect), vh);
+    if (visRight <= visLeft || visBottom <= visTop) return null;
+    var x = Math.max(MARKER_EDGE_INSET, Math.min(rawX, vw - MARKER_EDGE_INSET));
+    var y = Math.max(MARKER_EDGE_INSET, Math.min(rawY, vh - MARKER_EDGE_INSET));
+    var dx = x < visLeft ? visLeft - x : x > visRight ? x - visRight : 0;
+    var dy = y < visTop ? visTop - y : y > visBottom ? y - visBottom : 0;
+    if (dx > MARKER_ASSOC_TOLERANCE || dy > MARKER_ASSOC_TOLERANCE) return null;
+    return { x: x, y: y };
+  }
+
+  function rangeClientRects(range) {
+    var out = [];
+    if (!range) return out;
+    if (typeof range.getClientRects === 'function') {
+      try {
+        var list = range.getClientRects();
+        for (var i = 0; i < list.length && out.length < MAX_HIGHLIGHT_RECTS; i++) out.push(list[i]);
+      } catch (ex) {}
+    }
+    if (!out.length && typeof range.getBoundingClientRect === 'function') {
+      try {
+        var bounds = range.getBoundingClientRect();
+        if (bounds) out.push(bounds);
+      } catch (ex2) {}
+    }
+    if (layoutActive()) {
+      out = out.filter(function(rect) {
+        return (rect.width || 0) > 0 || (rect.height || 0) > 0;
+      });
+    }
+    return out;
+  }
+
+  function unionOfRects(rects) {
+    var left = Infinity;
+    var top = Infinity;
+    var right = -Infinity;
+    var bottom = -Infinity;
+    for (var i = 0; i < rects.length; i++) {
+      left = Math.min(left, rects[i].left);
+      top = Math.min(top, rects[i].top);
+      right = Math.max(right, rectRight(rects[i]));
+      bottom = Math.max(bottom, rectBottom(rects[i]));
+    }
+    return { left: left, top: top, right: right, bottom: bottom, width: right - left, height: bottom - top };
+  }
+
+  var highlightPool = [];
+  var highlightUsed = 0;
+  function takeHighlightRect(className, rect, annId) {
+    var div = highlightPool[highlightUsed];
+    if (!div) {
+      div = document.createElement('div');
+      overlayNodes.add(div);
+      highlightPool.push(div);
+      highlightsLayerEl.appendChild(div);
+    }
+    highlightUsed += 1;
+    div.className = 'pn-hl ' + className;
+    if (annId) div.setAttribute('data-annotation-id', annId);
+    else div.removeAttribute('data-annotation-id');
+    div.style.display = 'block';
+    div.style.left = rect.left + 'px';
+    div.style.top = rect.top + 'px';
+    div.style.width = (rect.width || 0) + 'px';
+    div.style.height = (rect.height || 0) + 'px';
+  }
+  function hideUnusedHighlights() {
+    for (var i = highlightUsed; i < highlightPool.length; i++) {
+      highlightPool[i].style.display = 'none';
+    }
+  }
+
+  function makeMarkerButton(annId) {
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'pn-marker';
+    btn.setAttribute('data-plannotator-marker', '');
+    btn.setAttribute('data-annotation-id', annId);
+    btn.innerHTML = MARKER_SVG + '<span class="pn-marker-num"></span>';
+    btn.addEventListener('click', function(clickEvent) {
       clickEvent.preventDefault();
       clickEvent.stopPropagation();
-      parent.postMessage({ type: PREFIX + 'mark-click', id: id }, '*');
+      parent.postMessage({ type: PREFIX + 'mark-click', id: annId }, '*');
     });
-    overlayNodes.add(badge);
-    document.body.appendChild(badge);
-    pinRegistry.push({ id: id, element: element, anchor: anchor || null, badge: badge });
-    renderPinBadges();
+    overlayNodes.add(btn);
+    return btn;
   }
-  function unregisterPin(id) {
-    for (var i = pinRegistry.length - 1; i >= 0; i--) {
-      if (pinRegistry[i].id === id) {
-        var badge = pinRegistry[i].badge;
-        if (badge && badge.parentNode) badge.parentNode.removeChild(badge);
-        overlayNodes.delete(badge);
-        pinRegistry.splice(i, 1);
-      }
+
+  function placeMarkers(markers) {
+    // Coincident markers (same rounded x:y) spread horizontally around the
+    // shared point, ordered deterministically by (number, id). This is a
+    // collision rule for coincident points only, not general label layout.
+    var groups = new Map();
+    var i;
+    for (i = 0; i < markers.length; i++) {
+      var m = markers[i];
+      if (m.hidden) continue;
+      var key = Math.round(m.x) + ':' + Math.round(m.y);
+      var group = groups.get(key);
+      if (!group) { group = []; groups.set(key, group); }
+      group.push(m);
     }
-    renderPinBadges();
-  }
-  function clearAllPins() {
-    for (var i = 0; i < pinRegistry.length; i++) {
-      var badge = pinRegistry[i].badge;
-      if (badge && badge.parentNode) badge.parentNode.removeChild(badge);
-      overlayNodes.delete(badge);
-    }
-    pinRegistry = [];
-  }
-  function renderPinBadges() {
-    // Number by FIRST-SEEN annotation id, not by registry entry: a
-    // multi-target annotation has several pins that all share one number.
-    var pinNumbers = new Map();
-    for (var i = 0; i < pinRegistry.length; i++) {
-      var pin = pinRegistry[i];
-      if ((!pin.element || !pin.element.isConnected) && pin.anchor) {
-        // The page re-rendered under the pin — re-acquire through the anchor.
-        pin.element = resolveAnchorElement(pin.anchor);
+    groups.forEach(function(group) {
+      if (group.length < 2) return;
+      group.sort(function(a, b) {
+        if (a.number !== b.number) return a.number - b.number;
+        return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+      });
+      var vw = layoutActive() ? window.innerWidth : 0;
+      for (var gi = 0; gi < group.length; gi++) {
+        var spreadX = group[gi].x + (gi - (group.length - 1) / 2) * MARKER_SPREAD_STEP;
+        if (vw) spreadX = Math.max(MARKER_SPREAD_EDGE, Math.min(spreadX, vw - MARKER_SPREAD_EDGE));
+        group[gi].x = spreadX;
       }
-      // Number by registry (creation) order, independent of visibility.
-      if (!pinNumbers.has(pin.id)) pinNumbers.set(pin.id, pinNumbers.size + 1);
-      pin.badge.textContent = String(pinNumbers.get(pin.id));
-      if (!pin.element || !pin.element.isConnected) {
-        pin.badge.style.display = 'none';
+    });
+    var usedKeys = {};
+    for (i = 0; i < markers.length; i++) {
+      var marker = markers[i];
+      usedKeys[marker.key] = true;
+      var btn = markerButtons.get(marker.key);
+      if (marker.hidden) {
+        // Unresolved or visually detached target: omit the marker rather
+        // than leave a bubble floating over unrelated content.
+        if (btn) btn.style.display = 'none';
         continue;
       }
-      var r = pin.element.getBoundingClientRect();
-      // A 0x0 rect means the element isn't rendered (display:none) — but only
-      // in engines that lay out at all (body has size), so headless DOM test
-      // environments where every rect is 0x0 don't hide everything.
-      var zeroSize = !r.width && !r.height
-        && document.body.getBoundingClientRect().width > 0;
-      if (zeroSize || r.bottom < 0 || r.top > window.innerHeight) {
-        pin.badge.style.display = 'none';
-        continue;
+      if (!btn) {
+        btn = makeMarkerButton(marker.id);
+        markerButtons.set(marker.key, btn);
+        markersLayerEl.appendChild(btn);
       }
-      pin.badge.style.display = 'flex';
-      pin.badge.style.left = Math.min(r.right, window.innerWidth - 4) + 'px';
-      pin.badge.style.top = Math.max(4, r.top) + 'px';
+      btn.style.display = 'flex';
+      btn.style.left = marker.x + 'px';
+      btn.style.top = marker.y + 'px';
+      btn.setAttribute('data-selected', focusedAnnotationId === marker.id ? 'true' : 'false');
+      btn.setAttribute('aria-label', 'Comment ' + marker.number);
+      var num = btn.querySelector('.pn-marker-num');
+      if (num) num.textContent = String(marker.number);
+    }
+    markerButtons.forEach(function(btn, key) {
+      if (usedKeys[key]) return;
+      if (btn.parentNode) btn.parentNode.removeChild(btn);
+      overlayNodes.delete(btn);
+      markerButtons.delete(key);
+    });
+  }
+
+  function renderAnnotationOverlay() {
+    var hasDraftRange = !!(pendingSelection && pendingRange);
+    if (!annRecords.length && !hasDraftRange && !overlayHostEl) return;
+    ensureOverlayHost();
+    highlightUsed = 0;
+    var markers = [];
+    // Fallback numbering by first-seen registration order — used only until
+    // the parent's ordered sync arrives. Numbering NEVER derives from target
+    // count: every target of one annotation shares one number.
+    var fallbackNumbers = new Map();
+    for (var f = 0; f < annRecords.length; f++) {
+      if (!fallbackNumbers.has(annRecords[f].id)) {
+        fallbackNumbers.set(annRecords[f].id, fallbackNumbers.size + 1);
+      }
+    }
+    for (var recordIndex = 0; recordIndex < annRecords.length; recordIndex++) {
+      var record = annRecords[recordIndex];
+      refreshRecordTargets(record);
+      var number = annNumbers && annNumbers.has(record.id)
+        ? annNumbers.get(record.id)
+        : fallbackNumbers.get(record.id);
+      var focused = focusedAnnotationId === record.id;
+      for (var targetIndex = 0; targetIndex < record.targets.length; targetIndex++) {
+        var target = record.targets[targetIndex];
+        var markerKey = record.id + '::' + targetIndex;
+        if (target.kind === 'element') {
+          var el = target.element;
+          if (!el || !el.isConnected) {
+            markers.push({ key: markerKey, id: record.id, number: number, hidden: true });
+            continue;
+          }
+          var rect = el.getBoundingClientRect();
+          var zeroSize = layoutActive() && !(rect.width || 0) && !(rect.height || 0);
+          var point = target.point || { x: 0.5, y: 0.5 };
+          var placed = zeroSize ? null : markerViewportPoint(
+            clippedTargetRect(el, rect),
+            rect.left + point.x * (rect.width || 0),
+            rect.top + point.y * (rect.height || 0)
+          );
+          if (placed) {
+            markers.push({ key: markerKey, id: record.id, number: number, x: placed.x, y: placed.y });
+            if (focused) takeHighlightRect('pn-hl-focus', rect, record.id);
+          } else {
+            markers.push({ key: markerKey, id: record.id, number: number, hidden: true });
+          }
+        } else {
+          var rects = rangeClientRects(target.range);
+          for (var rectIndex = 0; rectIndex < rects.length; rectIndex++) {
+            takeHighlightRect(
+              record.annType === 'deletion' ? 'pn-hl-deletion' : 'pn-hl-comment',
+              rects[rectIndex],
+              record.id
+            );
+            if (focused) takeHighlightRect('pn-hl-focus', rects[rectIndex], record.id);
+          }
+          if (!target.markerless) {
+            var rangePlaced = null;
+            if (rects.length) {
+              var last = rects[rects.length - 1];
+              var rangeEl = target.range && target.range.startContainer
+                ? (target.range.startContainer.nodeType === 1
+                  ? target.range.startContainer
+                  : target.range.startContainer.parentElement)
+                : null;
+              rangePlaced = markerViewportPoint(
+                clippedTargetRect(rangeEl, unionOfRects(rects)),
+                rectRight(last),
+                last.top + (last.height || 0) / 2
+              );
+            }
+            if (rangePlaced) {
+              markers.push({ key: markerKey, id: record.id, number: number, x: rangePlaced.x, y: rangePlaced.y });
+            } else {
+              markers.push({ key: markerKey, id: record.id, number: number, hidden: true });
+            }
+          }
+        }
+      }
+    }
+    // Draft selection highlight: overlay-projected rectangles from the live
+    // pending range — the page's own DOM is never mutated for draft state.
+    if (hasDraftRange) {
+      var draftRects = rangeClientRects(pendingRange);
+      for (var draftIndex = 0; draftIndex < draftRects.length; draftIndex++) {
+        takeHighlightRect('pn-hl-draft', draftRects[draftIndex], '');
+      }
+    }
+    hideUnusedHighlights();
+    placeMarkers(markers);
+  }
+
+  function focusAnnotationRecord(id, flash) {
+    if (focusFlashTimer) {
+      clearTimeout(focusFlashTimer);
+      focusFlashTimer = 0;
+    }
+    focusedAnnotationId = id || null;
+    renderAnnotationOverlay();
+    if (id && flash) {
+      focusFlashTimer = setTimeout(function() {
+        focusFlashTimer = 0;
+        if (focusedAnnotationId === id) {
+          focusedAnnotationId = null;
+          renderAnnotationOverlay();
+        }
+      }, 2000);
     }
   }
-  function flashPinnedBox(el) {
-    var box = getPinpointBoxEl();
-    box.setAttribute('data-pinned', '');
-    positionPinpointBox(el);
-    setTimeout(function() {
-      if (!pendingPinEl) hidePinpointBox();
-    }, 1200);
+
+  function scrollToAnnotation(id) {
+    var record = findAnnRecord(id);
+    if (!record) return;
+    refreshRecordTargets(record);
+    var scrollEl = null;
+    for (var i = 0; i < record.targets.length && !scrollEl; i++) {
+      var target = record.targets[i];
+      if (target.kind === 'element' && target.element && target.element.isConnected) {
+        scrollEl = target.element;
+      } else if (target.kind === 'range' && rangeAlive(target.range)) {
+        var node = target.range.startContainer;
+        scrollEl = node.nodeType === 1 ? node : node.parentElement;
+      }
+    }
+    if (scrollEl) {
+      try { scrollEl.scrollIntoView({ behavior: 'smooth', block: 'center' }); } catch (ex) {}
+    }
+    focusAnnotationRecord(id, true);
   }
 
   // --- Element anchors: verified-unique CSS selectors for restoration ---
@@ -1376,9 +1895,24 @@ export const BRIDGE_SCRIPT = `(function() {
     pendingPinAnchor = null;
     pendingPinKey = null;
     pendingPinLabel = null;
+    pendingPinPoint = null;
     pendingPinViaPinpoint = false;
     multiSelectArmed = false;
     hidePinpointBox();
+  }
+
+  /** Normalize a client-coordinate click into the element's rect (0..1 on
+   *  each axis; zero-size axes read 0.5). This is the durable "selected
+   *  point" a placed marker reprojects from after layout changes. */
+  function normalizePointInElement(el, clientPoint) {
+    if (!el || !clientPoint) return null;
+    if (typeof clientPoint.x !== 'number' || typeof clientPoint.y !== 'number') return null;
+    if (!isFinite(clientPoint.x) || !isFinite(clientPoint.y)) return null;
+    if (!layoutActive()) return null; // no geometry to normalize against
+    var r = el.getBoundingClientRect();
+    var x = (r.width || 0) === 0 ? 0.5 : (clientPoint.x - r.left) / r.width;
+    var y = (r.height || 0) === 0 ? 0.5 : (clientPoint.y - r.top) / r.height;
+    return { x: Math.max(0, Math.min(1, x)), y: Math.max(0, Math.min(1, y)) };
   }
 
   // --- Multi-select (shift-click): several elements, ONE draft comment ---
@@ -1466,6 +2000,7 @@ export const BRIDGE_SCRIPT = `(function() {
         clearMultiTargets();
         clearPendingPin();
         try { window.getSelection().removeAllRanges(); } catch (ex) {}
+        renderAnnotationOverlay();
         if (echo) parent.postMessage({ type: PREFIX + 'multi-target-removed', key: key }, '*');
         return;
       }
@@ -1475,6 +2010,7 @@ export const BRIDGE_SCRIPT = `(function() {
       pendingPinAnchor = next.anchor;
       pendingPinKey = next.key;
       pendingPinLabel = next.label;
+      pendingPinPoint = next.point || null;
       // A promoted primary commits as an element pin: the original text
       // selection belonged to the removed element and no longer applies.
       pendingSelection = { element: true };
@@ -1484,6 +2020,7 @@ export const BRIDGE_SCRIPT = `(function() {
       mainBox.setAttribute('data-pinned', '');
       mainBox.classList.remove('pn-pin-enter');
       if (pendingPinEl && pendingPinEl.isConnected) positionPinpointBox(pendingPinEl);
+      renderAnnotationOverlay();
       if (echo) parent.postMessage({ type: PREFIX + 'multi-target-removed', key: key }, '*');
       return;
     }
@@ -1500,7 +2037,7 @@ export const BRIDGE_SCRIPT = `(function() {
   /** Shift-click toggle: add the element to the draft, or remove it if it is
    *  already selected (dedup by DOM identity first, then by anchor equality
    *  so a re-rendered page cannot double-select the same logical element). */
-  function toggleMultiTarget(el) {
+  function toggleMultiTarget(el, clickPoint) {
     if (!el) return;
     if (el === pendingPinEl) {
       removeMultiTargetByKey(pendingPinKey, true);
@@ -1527,11 +2064,13 @@ export const BRIDGE_SCRIPT = `(function() {
     }
     // Cap at the source: never grow the draft past the parent-side DTO cap.
     if (pendingMultiTargets.length >= MAX_MULTI_TARGETS) return;
+    var point = normalizePointInElement(el, clickPoint);
+    if (anchor && point) anchor.point = point;
     var label = pinpointHoverLabel(el);
     var text = elementTargetText(el, label);
     var key = makeTargetKey();
     var box = createMultiTargetBox(el);
-    pendingMultiTargets.push({ key: key, el: el, anchor: anchor, label: label, text: text, box: box });
+    pendingMultiTargets.push({ key: key, el: el, anchor: anchor, label: label, text: text, point: point, box: box });
     parent.postMessage({
       type: PREFIX + 'multi-target-added',
       key: key,
@@ -1616,7 +2155,7 @@ export const BRIDGE_SCRIPT = `(function() {
   // whose <text> doesn't select like HTML text). Either way the element stays
   // outlined ("pinned") while the composer is open, and a serialized CSS anchor
   // rides along so the annotation can restore to this exact element later.
-  function annotateElement(el, modeOverride, viaPinpoint) {
+  function annotateElement(el, modeOverride, viaPinpoint, clickPoint) {
     if (!el) return false;
     pinpointHover = null;
     hidePinpointLabel();
@@ -1631,6 +2170,11 @@ export const BRIDGE_SCRIPT = `(function() {
     pendingPinAnchor = buildElementAnchor(el);
     pendingPinKey = makeTargetKey();
     pendingPinLabel = pinpointHoverLabel(el);
+    // The user's selected point, normalized inside the element's rect. It
+    // rides the durable anchor so restoration reprojects the marker at the
+    // same relative spot; keyboard entry (vim) has no pointer and defaults.
+    pendingPinPoint = normalizePointInElement(el, clickPoint);
+    if (pendingPinAnchor && pendingPinPoint) pendingPinAnchor.point = pendingPinPoint;
     pendingPinViaPinpoint = !!viaPinpoint;
     var extras = {
       anchor: pendingPinAnchor,
@@ -1684,11 +2228,9 @@ export const BRIDGE_SCRIPT = `(function() {
 
   document.addEventListener('click', function(e) {
     if (currentInputMethod !== 'pinpoint') return;
-    // Existing marks are handled by the mark-click listener.
-    if (e.target && e.target.closest && e.target.closest('.annotation-highlight[data-bind-id]')) return;
-    // Real pin badges (and any other viewer overlay) own their clicks —
+    // Real placed markers (and any other viewer overlay) own their clicks —
     // checked by IDENTITY, not selector, so a page element spoofing
-    // [data-plannotator-pin-badge] stays an ordinary annotatable target.
+    // [data-plannotator-marker] stays an ordinary annotatable target.
     if (isViewerOverlayNode(e.target)) return;
     // Shift-click while an ARMED pinpoint draft is open: toggle the element
     // in/out of the SAME draft comment instead of replacing the selection.
@@ -1700,7 +2242,7 @@ export const BRIDGE_SCRIPT = `(function() {
       hideMultiHoverBox();
       hidePinpointLabel();
       var multiEl = resolvePinpointTargetAt(e.clientX, e.clientY, e.target);
-      if (multiEl) toggleMultiTarget(multiEl);
+      if (multiEl) toggleMultiTarget(multiEl, { x: e.clientX, y: e.clientY });
       return;
     }
     // Click what the hover box shows: the currently hovered element is the
@@ -1713,7 +2255,7 @@ export const BRIDGE_SCRIPT = `(function() {
     // Suppress the page's own behavior (links, buttons) — we're annotating.
     e.preventDefault();
     e.stopPropagation();
-    annotateElement(el, undefined, true);
+    annotateElement(el, undefined, true, { x: e.clientX, y: e.clientY });
   }, true);
 
   // Escape while pinpointing (outside vim, which has its own ladder): cancel a
@@ -1728,6 +2270,7 @@ export const BRIDGE_SCRIPT = `(function() {
       clearMultiTargets();
       clearPendingPin();
       window.getSelection().removeAllRanges();
+      renderAnnotationOverlay();
     } else if (currentInputMethod === 'pinpoint') {
       clearPinpointHover();
     }
@@ -1739,24 +2282,12 @@ export const BRIDGE_SCRIPT = `(function() {
   // run first; an active text selection is respected, not clobbered.
   document.addEventListener('click', function(e) {
     if (currentInputMethod === 'pinpoint') return; // pinpoint handler covers this
+    if (isViewerOverlayNode(e.target)) return; // placed markers own their clicks
     var t = e.target && e.target.closest && e.target.closest('[data-annotate]');
     if (!t) return;
-    if (e.target.closest('.annotation-highlight[data-bind-id]')) return;
     var s = window.getSelection();
     if (s && !s.isCollapsed && (s.toString() || '').trim()) return; // respect a drag-selection
-    annotateElement(t);
-  });
-
-  // --- Mark Click ---
-  document.addEventListener('click', function(e) {
-    var mark = e.target.closest ? e.target.closest('.annotation-highlight[data-bind-id]') : null;
-    if (mark) {
-      e.stopPropagation();
-      parent.postMessage({
-        type: PREFIX + 'mark-click',
-        id: mark.getAttribute('data-bind-id')
-      }, '*');
-    }
+    annotateElement(t, undefined, undefined, { x: e.clientX, y: e.clientY });
   });
 
   // --- Optional Vim navigation ---
@@ -2189,21 +2720,6 @@ export const BRIDGE_SCRIPT = `(function() {
       visualBlockAnchorEl: vimVisualBlockAnchorEl,
       range: range
     };
-  }
-
-  function committedMarkRange(id) {
-    var marks = document.querySelectorAll('[data-bind-id="' + id + '"]');
-    if (!marks.length) return null;
-    var first = marks[0];
-    var last = marks[marks.length - 1];
-    var range = document.createRange();
-    try {
-      range.setStart(first, 0);
-      range.setEnd(last, last.childNodes.length);
-      return range;
-    } catch (ex) {
-      return null;
-    }
   }
 
   function beginVimAction(mode) {
@@ -2642,6 +3158,7 @@ export const BRIDGE_SCRIPT = `(function() {
         pendingSelection = null;
         pendingRange = null;
         restoreVimSemanticTarget();
+        renderAnnotationOverlay();
         handled = true;
       } else if (vimPhase === 'visual') {
         var visualSelection = window.getSelection();
@@ -2920,112 +3437,6 @@ export const BRIDGE_SCRIPT = `(function() {
     return path;
   }
 
-  function applyMark(id, annType, selData) {
-    try {
-      var startNode = resolveNodePath(selData.startContainerPath);
-      var endNode = resolveNodePath(selData.endContainerPath);
-      if (!startNode || !endNode) return;
-
-      var range = document.createRange();
-      range.setStart(startNode, selData.startOffset);
-      range.setEnd(endNode, selData.endOffset);
-      wrapRangeInMarks(range, id, annType);
-    } catch (ex) { /* range may be stale */ }
-  }
-
-  function wrapRangeInMarks(range, id, annType) {
-    var walker = document.createTreeWalker(
-      range.commonAncestorContainer.nodeType === 1 ? range.commonAncestorContainer : range.commonAncestorContainer.parentNode,
-      NodeFilter.SHOW_TEXT,
-      null
-    );
-
-    var textNodes = [];
-    while (walker.nextNode()) {
-      if (range.intersectsNode(walker.currentNode)) {
-        textNodes.push(walker.currentNode);
-      }
-    }
-
-    for (var i = 0; i < textNodes.length; i++) {
-      var tn = textNodes[i];
-      var start = (tn === range.startContainer) ? range.startOffset : 0;
-      var end = (tn === range.endContainer) ? range.endOffset : tn.length;
-      if (start >= end) continue;
-
-      var markRange = document.createRange();
-      markRange.setStart(tn, start);
-      markRange.setEnd(tn, end);
-
-      var mark = document.createElement('mark');
-      mark.className = 'annotation-highlight ' + annType;
-      mark.setAttribute('data-bind-id', id);
-      markRange.surroundContents(mark);
-    }
-
-    var rect = document.querySelector('[data-bind-id="' + id + '"]');
-    if (rect) {
-      var r = rect.getBoundingClientRect();
-      parent.postMessage({
-        type: PREFIX + 'mark-created',
-        id: id,
-        rect: { top: r.top, left: r.left, width: r.width, height: r.height }
-      }, '*');
-    }
-  }
-
-  function findTextAndMark(id, originalText, annType, root) {
-    var walker = document.createTreeWalker(root || document.body, NodeFilter.SHOW_TEXT, null);
-    var buffer = '';
-    var nodes = [];
-    while (walker.nextNode()) {
-      nodes.push({ node: walker.currentNode, start: buffer.length });
-      buffer += walker.currentNode.textContent;
-    }
-    var idx = buffer.indexOf(originalText);
-    if (idx === -1) return false;
-
-    var endIdx = idx + originalText.length;
-    var slices = [];
-    for (var i = 0; i < nodes.length; i++) {
-      var entry = nodes[i];
-      var nodeEnd = entry.start + entry.node.length;
-      if (nodeEnd <= idx) continue;
-      if (entry.start >= endIdx) break;
-
-      var start = Math.max(0, idx - entry.start);
-      var end = Math.min(entry.node.length, endIdx - entry.start);
-      if (start >= end) continue;
-      slices.push({ node: entry.node, start: start, end: end });
-    }
-    for (var j = slices.length - 1; j >= 0; j--) {
-      try {
-        var s = slices[j];
-        var markRange = document.createRange();
-        markRange.setStart(s.node, s.start);
-        markRange.setEnd(s.node, s.end);
-
-        var mark = document.createElement('mark');
-        mark.className = 'annotation-highlight ' + annType;
-        mark.setAttribute('data-bind-id', id);
-        markRange.surroundContents(mark);
-      } catch (ex) { /* node may have been mutated by a prior wrap */ }
-    }
-    return slices.length > 0;
-  }
-
-  function removeMark(id) {
-    var marks = document.querySelectorAll('[data-bind-id="' + id + '"]');
-    for (var i = marks.length - 1; i >= 0; i--) unwrapMark(marks[i]);
-  }
-
-  function unwrapMark(mark) {
-    var parent = mark.parentNode;
-    while (mark.firstChild) parent.insertBefore(mark.firstChild, mark);
-    parent.removeChild(mark);
-    parent.normalize();
-  }
-
   function resolveNodePath(path) {
     var node = document.body;
     for (var i = 0; i < path.length; i++) {
@@ -3033,6 +3444,40 @@ export const BRIDGE_SCRIPT = `(function() {
       node = node.childNodes[path[i]];
     }
     return node;
+  }
+
+  // Framework rerenders and inline edits invalidate resolved geometry.
+  // Coalesced through the same rAF reconcile as scroll/resize — never polled.
+  // Mutations whose targets are all viewer overlay nodes are ignored by
+  // IDENTITY: our own light-DOM box/label style writes must never schedule
+  // the frame that caused them (that would degenerate into a rAF loop).
+  var pageMutationObserver = null;
+  function watchPageMutations() {
+    if (pageMutationObserver || typeof MutationObserver === 'undefined' || !document.body) return;
+    pageMutationObserver = new MutationObserver(function(mutations) {
+      for (var i = 0; i < mutations.length; i++) {
+        if (!isViewerOverlayNode(mutations[i].target)) {
+          schedulePinpointReconcile();
+          return;
+        }
+      }
+    });
+    pageMutationObserver.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      characterData: true
+    });
+  }
+
+  // Animations/transitions move geometry without mutations or scroll events:
+  // reconcile when they settle (end or cancel), matching the reference
+  // invalidation set. Capture phase so non-bubbling targets still count.
+  var settleEvents = ['animationend', 'animationcancel', 'transitionend', 'transitioncancel'];
+  for (var settleIndex = 0; settleIndex < settleEvents.length; settleIndex++) {
+    document.addEventListener(settleEvents[settleIndex], function() {
+      schedulePinpointReconcile();
+    }, { capture: true, passive: true });
   }
 
   function onReady() {
@@ -3043,6 +3488,7 @@ export const BRIDGE_SCRIPT = `(function() {
         schedulePinpointReconcile();
       }).observe(document.body);
     }
+    watchPageMutations();
     parent.postMessage({ type: PREFIX + 'ready' }, '*');
   }
   if (document.readyState === 'loading') {

--- a/packages/ui/components/html-viewer/bridge-script.ts
+++ b/packages/ui/components/html-viewer/bridge-script.ts
@@ -493,6 +493,7 @@ export const BRIDGE_SCRIPT = `(function() {
 
     else if (type === PREFIX + 'clear-marks') {
       annRecords = [];
+      annNumbers = null; // stale synced numbers must not leak onto future records
       focusedAnnotationId = null;
       renderAnnotationOverlay();
     }
@@ -693,14 +694,39 @@ export const BRIDGE_SCRIPT = `(function() {
     return el;
   }
 
+  // The placed-marker button the most recent raw (pre-yield) probe landed
+  // on, if any. Hover uses it to advertise the MARKER's identity instead of
+  // the page element beneath it — the marker owns the click, so the hover
+  // label must never promise an annotate action the click won't perform.
+  var lastRawHitMarker = null;
+
+  function committedMarkerButtonFrom(node) {
+    var current = node;
+    var guard = 0;
+    while (current && guard++ < 24) {
+      if (
+        current.nodeType === 1
+        && overlayNodes.has(current)
+        && current.hasAttribute
+        && current.hasAttribute('data-plannotator-marker')
+      ) return current;
+      current = current.parentElement
+        || (current.getRootNode && current.getRootNode().host)
+        || null;
+    }
+    return null;
+  }
+
   // Resolve the pinpoint target at a viewport point. The deepest rendered
   // element under the pointer wins; containers are selected by pointing at
   // their uncovered area (padding, gaps), exactly like the markdown surface.
   // fallbackNode covers engines without a real elementFromPoint (headless DOM
   // tests) and the scroll reconcile, which re-resolves under a still cursor.
   function resolvePinpointTargetAt(x, y, fallbackNode) {
+    lastRawHitMarker = null;
     var node = deepElementFromPoint(x, y);
     if (node && isViewerOverlayNode(node)) {
+      lastRawHitMarker = committedMarkerButtonFrom(node);
       // A placed marker owns its clicks, but hit-testing for a NEW selection
       // must reach the page beneath it: temporarily yield marker hit targets
       // and probe again (identity-gated, never selector-gated).
@@ -741,10 +767,11 @@ export const BRIDGE_SCRIPT = `(function() {
       && now - lastPointerHit.t <= 16
       && (!lastPointerHit.el || lastPointerHit.el.isConnected)
     ) {
+      lastRawHitMarker = lastPointerHit.marker || null;
       return lastPointerHit.el;
     }
     var el = resolvePinpointTargetAt(x, y, fallbackNode);
-    lastPointerHit = { x: x, y: y, t: now, el: el };
+    lastPointerHit = { x: x, y: y, t: now, el: el, marker: lastRawHitMarker };
     return el;
   }
   function invalidatePointerHitCache() {
@@ -967,7 +994,14 @@ export const BRIDGE_SCRIPT = `(function() {
       pinpointLabelEl.style.cssText = 'position:fixed;z-index:2147483647;pointer-events:none;display:none;font:600 11px/1.3 system-ui,-apple-system,sans-serif;padding:2px 7px;border-radius:5px;background:var(--pn-focus-highlight,#4493f8);color:#fff;white-space:nowrap;box-shadow:0 1px 5px rgba(0,0,0,.35);';
       overlayNodes.add(pinpointLabelEl);
     }
-    if (!pinpointLabelEl.isConnected) document.body.appendChild(pinpointLabelEl);
+    // Paint order at equal z-index follows DOM order: the label must sit
+    // AFTER the marker overlay host on the root element or marker bubbles
+    // occlude it. Re-append whenever it is not the last child (appendChild
+    // moves an already-connected node).
+    var labelRoot = document.documentElement || document.body;
+    if (labelRoot && (!pinpointLabelEl.isConnected || pinpointLabelEl.nextSibling)) {
+      labelRoot.appendChild(pinpointLabelEl);
+    }
     return pinpointLabelEl;
   }
   function hidePinpointLabel() { if (pinpointLabelEl) pinpointLabelEl.style.display = 'none'; }
@@ -1023,6 +1057,17 @@ export const BRIDGE_SCRIPT = `(function() {
   // Per-event hit-testing only — never builds the semantic graph.
   function updatePinpointHover(x, y, fallbackNode) {
     var el = pinpointLeafAt(x, y, fallbackNode);
+    // The 25px marker bubble owns clicks over it (they select its comment),
+    // so hover must advertise the MARKER's own identity — no annotate box,
+    // label "Comment N" — never the element beneath. Moving off the bubble
+    // restores normal element hover/annotate.
+    if (lastRawHitMarker && !pendingPinEl) {
+      var markerLabel = lastRawHitMarker.getAttribute('aria-label') || 'Comment';
+      pinpointHover = null;
+      hidePinpointBox();
+      positionPinpointLabel(lastRawHitMarker, markerLabel);
+      return;
+    }
     if (el !== pinpointHover) {
       pinpointHover = el;
       if (el && !pendingPinEl) {
@@ -1166,6 +1211,11 @@ export const BRIDGE_SCRIPT = `(function() {
     // never sees overlay writes.
     if (!overlayHostEl.isConnected) {
       (document.documentElement || document.body).appendChild(overlayHostEl);
+      // Keep the pinpoint hover label painting ABOVE markers: it must stay
+      // after the host in DOM order (equal z-index resolves by paint order).
+      if (pinpointLabelEl && pinpointLabelEl.isConnected) {
+        (document.documentElement || document.body).appendChild(pinpointLabelEl);
+      }
     }
     return overlayHostEl;
   }
@@ -2462,15 +2512,62 @@ export const BRIDGE_SCRIPT = `(function() {
   // Author opt-in: a plain click on any element tagged [data-annotate] pops the
   // toolbar — no pinpoint mode. Lets an HTML doc (e.g. a flow graph) wire its own
   // nodes to Plannotator's toolbar. Bubble phase so the page's own click handlers
-  // run first; an active text selection is respected, not clobbered.
+  // run first; an active text selection is respected, not clobbered. A click on
+  // a committed highlight selects the annotation instead (the pre-overlay
+  // handler deferred to '.annotation-highlight' the same way).
   document.addEventListener('click', function(e) {
     if (currentInputMethod === 'pinpoint') return; // pinpoint handler covers this
     if (isViewerOverlayNode(e.target)) return; // placed markers own their clicks
     var t = e.target && e.target.closest && e.target.closest('[data-annotate]');
     if (!t) return;
+    if (committedHighlightAt(e.clientX, e.clientY)) return; // mark-click handler owns it
     var s = window.getSelection();
     if (s && !s.isCollapsed && (s.toString() || '').trim()) return; // respect a drag-selection
     annotateElement(t, undefined, undefined, { x: e.clientX, y: e.clientY });
+  });
+
+  // --- Mark Click ---
+  // Pre-overlay, committed highlights were inline marks with cursor:pointer
+  // and their own click handler: clicking anywhere on a highlighted passage
+  // posted mark-click and selected the annotation in the panel. Overlay
+  // highlight rects are pointer-transparent (page pass-through must remain),
+  // so the affordance is restored by hit-testing the click point against the
+  // painted committed range rects. Bubble phase, exactly like the old
+  // handler: the capture-phase pinpoint annotate click stopPropagation()s
+  // first (pinpoint flows keep owning their clicks, as pre-overlay), and
+  // marker buttons stop propagation before this can run.
+  function committedHighlightAt(x, y) {
+    var best = null;
+    for (var recordIndex = 0; recordIndex < annRecords.length; recordIndex++) {
+      var record = annRecords[recordIndex];
+      for (var targetIndex = 0; targetIndex < record.targets.length; targetIndex++) {
+        var target = record.targets[targetIndex];
+        if (target.kind !== 'range' || !rangeAlive(target.range)) continue;
+        var geometry = rangeVisualGeometry(target.range);
+        for (var i = 0; i < geometry.paint.length; i++) {
+          var rect = geometry.paint[i];
+          if ((rect.width || 0) <= 0 || (rect.height || 0) <= 0) continue;
+          if (x < rect.left || x > rectRight(rect) || y < rect.top || y > rectBottom(rect)) continue;
+          var area = (rect.width || 0) * (rect.height || 0);
+          // Smallest rect wins on overlap; ties go to the later-painted
+          // (topmost) annotation.
+          if (!best || area <= best.area) best = { id: record.id, area: area };
+        }
+      }
+    }
+    return best ? best.id : null;
+  }
+
+  document.addEventListener('click', function(e) {
+    if (e.shiftKey) return; // shift belongs to multi-select
+    if (isViewerOverlayNode(e.target)) return; // markers own their clicks
+    if (pendingPinEl) return; // an open pinpoint draft owns the surface
+    var s = window.getSelection();
+    if (s && !s.isCollapsed && (s.toString() || '').trim()) return; // end of a drag-selection
+    var hitId = committedHighlightAt(e.clientX, e.clientY);
+    if (!hitId) return;
+    e.stopPropagation();
+    parent.postMessage({ type: PREFIX + 'mark-click', id: hitId }, '*');
   });
 
   // --- Optional Vim navigation ---

--- a/packages/ui/components/html-viewer/bridge-script.ts
+++ b/packages/ui/components/html-viewer/bridge-script.ts
@@ -3764,18 +3764,44 @@ export const BRIDGE_SCRIPT = `(function() {
   // IDENTITY: our own light-DOM box/label style writes must never schedule
   // the frame that caused them (that would degenerate into a rAF loop).
   var pageMutationObserver = null;
+
+  // A mutation is viewer-owned when its target is an overlay node OR it is a
+  // childList change whose added/removed nodes are ALL overlay nodes (the
+  // overlay host / hover label / print layer being appended to the root
+  // element, pinned boxes entering <body>). Those writes must neither bump
+  // the re-search generation nor schedule the reconcile frame that caused
+  // them.
+  function isOverlayOnlyMutation(mutation) {
+    if (isViewerOverlayNode(mutation.target)) return true;
+    if (mutation.type !== 'childList') return false;
+    var added = mutation.addedNodes || [];
+    var removed = mutation.removedNodes || [];
+    if (!added.length && !removed.length) return false;
+    for (var i = 0; i < added.length; i++) {
+      if (!isViewerOverlayNode(added[i])) return false;
+    }
+    for (var j = 0; j < removed.length; j++) {
+      if (!isViewerOverlayNode(removed[j])) return false;
+    }
+    return true;
+  }
+
   function watchPageMutations() {
-    if (pageMutationObserver || typeof MutationObserver === 'undefined' || !document.body) return;
+    if (pageMutationObserver || typeof MutationObserver === 'undefined' || !document.documentElement) return;
     pageMutationObserver = new MutationObserver(function(mutations) {
       for (var i = 0; i < mutations.length; i++) {
-        if (!isViewerOverlayNode(mutations[i].target)) {
+        if (!isOverlayOnlyMutation(mutations[i])) {
           domGeneration += 1; // page text may have changed: unlock dead-target re-search
           schedulePinpointReconcile();
           return;
         }
       }
     });
-    pageMutationObserver.observe(document.body, {
+    // Observe the ROOT element, not <body>: a page that swaps the <body>
+    // element itself (documentElement.replaceChild) produces no record on a
+    // body-scoped observer, permanently locking dead-target re-search behind
+    // a generation that never advances.
+    pageMutationObserver.observe(document.documentElement, {
       childList: true,
       subtree: true,
       attributes: true,
@@ -3832,13 +3858,22 @@ export const BRIDGE_SCRIPT = `(function() {
   var PRINT_HL_COMMENT = 'background:oklch(0.70 0.18 60 / 0.28);border-bottom:2px solid var(--pn-accent, #d97757);';
   var PRINT_HL_DELETION = 'background:oklch(from var(--pn-destructive, #c0392b) l c h / 0.28);background-image:linear-gradient(to bottom, transparent calc(50% - 1px), var(--pn-destructive, #c0392b) calc(50% - 1px), var(--pn-destructive, #c0392b) calc(50% + 1px), transparent calc(50% + 1px));';
   var printLayerEl = null;
+  var retiredPrintLayerEl = null;
 
   function teardownPrintLayer() {
+    // Deregister the PREVIOUSLY retired layer now: its removal's mutation
+    // record has long been delivered. The layer removed below must STAY
+    // overlay-registered until then — the observer's overlay-only filter
+    // sees removal records asynchronously and must still recognize the node.
+    if (retiredPrintLayerEl) {
+      overlayNodes.delete(retiredPrintLayerEl);
+      retiredPrintLayerEl = null;
+    }
     if (!printLayerEl) return;
     try {
       if (printLayerEl.parentNode) printLayerEl.parentNode.removeChild(printLayerEl);
     } catch (ex) {}
-    overlayNodes.delete(printLayerEl);
+    retiredPrintLayerEl = printLayerEl;
     printLayerEl = null;
   }
 
@@ -3874,7 +3909,14 @@ export const BRIDGE_SCRIPT = `(function() {
       if (!layer.childNodes.length) return;
       overlayNodes.add(layer);
       printLayerEl = layer;
-      document.body.appendChild(layer);
+      // Root element, NOT <body>: a page styling body { position: relative }
+      // would make body's padding box the containing block and shift every
+      // stripe by body's document offset. On <html> the containing block is
+      // the initial containing block (matching the viewport+scroll
+      // coordinates computed above) in the overwhelmingly common case where
+      // html itself is not positioned; a positioned documentElement is
+      // accepted as out of scope.
+      (document.documentElement || document.body).appendChild(layer);
     } catch (exBuild) {
       try { teardownPrintLayer(); } catch (exDown) {}
     }

--- a/packages/ui/components/html-viewer/bridge-script.ts
+++ b/packages/ui/components/html-viewer/bridge-script.ts
@@ -1346,24 +1346,40 @@ export const BRIDGE_SCRIPT = `(function() {
     return found;
   }
 
+  // Unresolvable-target re-search is GENERATION-gated: findTextRange is a
+  // whole-document TreeWalker sweep (and anchor re-resolution a document
+  // query + text snapshot), while refreshRecordTargets runs on every
+  // scroll/resize rAF and every body mutation. A page with one stale
+  // annotation plus scrolling must not do O(document-text) work per frame
+  // forever. The counter advances only on signals that can change text
+  // (page mutations, settle events, frame loads); scroll and resize alone
+  // never unlock a re-search — geometry changes, text doesn't.
+  var domGeneration = 1;
+
   // Re-resolve stale live targets from durable data. Element targets
   // re-acquire through their anchor; range targets re-run the text search
-  // (anchor-scoped first). Unresolvable targets stay hidden — never guessed.
+  // (anchor-scoped first). Unresolvable targets stay hidden — never guessed
+  // — and cache the generation of their last failed search so they retry
+  // only after the document could actually have changed.
   function refreshRecordTargets(record) {
     for (var i = 0; i < record.targets.length; i++) {
       var target = record.targets[i];
       if (target.kind === 'element') {
         if ((!target.element || !target.element.isConnected) && target.anchor) {
+          if (target.failedGeneration === domGeneration) continue;
           target.element = resolveAnchorElement(target.anchor);
+          target.failedGeneration = target.element ? 0 : domGeneration;
         }
       } else if (!rangeAlive(target.range)) {
         target.range = null;
         if (target.text) {
+          if (target.failedGeneration === domGeneration) continue;
           var scopeEl = record.params && record.params.anchor
             ? resolveAnchorElement(record.params.anchor)
             : null;
           target.range = (scopeEl && findTextRange(target.text, scopeEl))
             || findTextRange(target.text, null);
+          target.failedGeneration = target.range ? 0 : domGeneration;
         }
       }
     }
@@ -1398,15 +1414,46 @@ export const BRIDGE_SCRIPT = `(function() {
   function rectRight(r) { return typeof r.right === 'number' ? r.right : r.left + (r.width || 0); }
   function rectBottom(r) { return typeof r.bottom === 'number' ? r.bottom : r.top + (r.height || 0); }
 
-  // Intersect a target rect with every clipping/scroll ancestor so a marker
-  // is never shown for content its container has scrolled or clipped away.
-  function clippedTargetRect(el, rect) {
-    if (!layoutActive()) return rect;
-    var left = rect.left;
-    var top = rect.top;
-    var right = rectRight(rect);
-    var bottom = rectBottom(rect);
-    var current = el ? el.parentElement : null;
+  // Ancestors that establish the containing block for FIXED-position
+  // descendants (transform / perspective / filter / backdrop-filter /
+  // will-change of those). Overflow clipping only applies to a fixed target
+  // when the clipper is in its containing-block chain, so plain static
+  // clippers must be skipped for fixed targets — a fully visible
+  // position:fixed element inside an overflow:hidden ancestor would
+  // otherwise be intersected away and omitted forever.
+  function establishesFixedContainingBlock(style) {
+    if (!style) return false;
+    if (style.transform && style.transform !== 'none') return true;
+    if (style.perspective && style.perspective !== 'none') return true;
+    if (style.filter && style.filter !== 'none') return true;
+    var backdrop = style.backdropFilter || style.webkitBackdropFilter || '';
+    if (backdrop && backdrop !== 'none') return true;
+    var willChange = style.willChange || '';
+    if (
+      willChange.indexOf('transform') >= 0
+      || willChange.indexOf('perspective') >= 0
+      || willChange.indexOf('filter') >= 0
+    ) return true;
+    return false;
+  }
+
+  // Viewport-space clip window from the element's clipping/scroll ancestor
+  // chain, or null when nothing clips. Shared by marker projection AND every
+  // painted highlight rect: content an inner scroll container has scrolled
+  // away must never paint stripes over unrelated content outside its box.
+  function clipBoundsFor(el) {
+    if (!layoutActive() || !el) return null;
+    var left = -Infinity;
+    var top = -Infinity;
+    var right = Infinity;
+    var bottom = Infinity;
+    var clipped = false;
+    var fixedSkip = false;
+    try {
+      var ownStyle = window.getComputedStyle(el);
+      fixedSkip = !!ownStyle && ownStyle.position === 'fixed';
+    } catch (exOwn) {}
+    var current = el.parentElement;
     var guard = 0;
     while (
       current
@@ -1416,25 +1463,73 @@ export const BRIDGE_SCRIPT = `(function() {
     ) {
       var style = null;
       try { style = window.getComputedStyle(current); } catch (ex) { break; }
+      // Once the fixed target's containing block is reached, that ancestor
+      // and everything above it clip normally (the containing block itself
+      // participates in ordinary flow).
+      if (fixedSkip && establishesFixedContainingBlock(style)) fixedSkip = false;
       var overflowX = (style && (style.overflowX || style.overflow)) || '';
       var overflowY = (style && (style.overflowY || style.overflow)) || '';
       var clipsX = overflowX && overflowX !== 'visible';
       var clipsY = overflowY && overflowY !== 'visible';
-      if (clipsX || clipsY) {
+      if ((clipsX || clipsY) && !fixedSkip) {
         var cr = current.getBoundingClientRect();
-        if (clipsX) { left = Math.max(left, cr.left); right = Math.min(right, rectRight(cr)); }
-        if (clipsY) { top = Math.max(top, cr.top); bottom = Math.min(bottom, rectBottom(cr)); }
+        if (clipsX) { left = Math.max(left, cr.left); right = Math.min(right, rectRight(cr)); clipped = true; }
+        if (clipsY) { top = Math.max(top, cr.top); bottom = Math.min(bottom, rectBottom(cr)); clipped = true; }
       }
       current = current.parentElement;
     }
+    return clipped ? { left: left, top: top, right: right, bottom: bottom } : null;
+  }
+
+  // Intersect one paintable rect with a clip window; null when nothing
+  // visible survives (the rect is DROPPED, never painted degenerate).
+  function clipRect(rect, bounds) {
+    if (!bounds) return rect;
+    var left = Math.max(rect.left, bounds.left);
+    var top = Math.max(rect.top, bounds.top);
+    var right = Math.min(rectRight(rect), bounds.right);
+    var bottom = Math.min(rectBottom(rect), bounds.bottom);
+    if (right <= left || bottom <= top) return null;
     return { left: left, top: top, right: right, bottom: bottom, width: right - left, height: bottom - top };
+  }
+
+  // Intersect a target rect with its clip chain for MARKER projection. May
+  // return a degenerate rect — markerViewportPoint reads that as "no visible
+  // intersection" and omits.
+  function clippedTargetRect(el, rect) {
+    var bounds = clipBoundsFor(el);
+    if (!bounds) return rect;
+    var left = Math.max(rect.left, bounds.left);
+    var top = Math.max(rect.top, bounds.top);
+    var right = Math.min(rectRight(rect), bounds.right);
+    var bottom = Math.min(rectBottom(rect), bounds.bottom);
+    return { left: left, top: top, right: right, bottom: bottom, width: right - left, height: bottom - top };
+  }
+
+  // Unresolved-for-display: a target whose box exists but is invisible
+  // (visibility:hidden/collapse, display:none, opacity:0) keeps a full-size
+  // rect, so without this gate markers, focus rects, and highlights would
+  // render over whatever visible content stacks in the same box (e.g.
+  // carousel slides toggled via visibility). display:none targets already
+  // report empty client rects, but visibility and opacity do not. Checked
+  // per reconcile frame, only for targets that passed the cheaper gates.
+  function targetStyleHidden(el) {
+    if (!el || !layoutActive()) return false;
+    var style = null;
+    try { style = window.getComputedStyle(el); } catch (ex) { return false; }
+    if (!style) return false;
+    if (style.visibility === 'hidden' || style.visibility === 'collapse') return true;
+    if (style.display === 'none') return true;
+    var opacity = parseFloat(style.opacity);
+    if (!isNaN(opacity) && opacity === 0) return true;
+    return false;
   }
 
   /**
    * Project a raw marker point against the target's visible geometry:
    * omit when the target has no visible intersection with the viewport,
    * clamp so the full marker stays reachable at viewport edges, and omit
-   * when the clamped point is no longer visibly associated with the target
+   * when the point is no longer visibly associated with the target
    * (clipped/scrolled away). Never guesses a position.
    */
   function markerViewportPoint(visRect, rawX, rawY) {
@@ -1446,21 +1541,54 @@ export const BRIDGE_SCRIPT = `(function() {
     var visRight = Math.min(rectRight(visRect), vw);
     var visBottom = Math.min(rectBottom(visRect), vh);
     if (visRight <= visLeft || visBottom <= visTop) return null;
+    // Association is tested against the UNCLAMPED point: viewport edges CLAMP
+    // (never omit — a fully visible element flush against the edge keeps its
+    // marker even though the 29px inset moves it inward), while clip/scroll
+    // detachment — a raw point no longer near the visible target geometry —
+    // omits. The clamp below is rendering-only.
+    var dx = rawX < visLeft ? visLeft - rawX : rawX > visRight ? rawX - visRight : 0;
+    var dy = rawY < visTop ? visTop - rawY : rawY > visBottom ? rawY - visBottom : 0;
+    if (dx > MARKER_ASSOC_TOLERANCE || dy > MARKER_ASSOC_TOLERANCE) return null;
     var x = Math.max(MARKER_EDGE_INSET, Math.min(rawX, vw - MARKER_EDGE_INSET));
     var y = Math.max(MARKER_EDGE_INSET, Math.min(rawY, vh - MARKER_EDGE_INSET));
-    var dx = x < visLeft ? visLeft - x : x > visRight ? x - visRight : 0;
-    var dy = y < visTop ? visTop - y : y > visBottom ? y - visBottom : 0;
-    if (dx > MARKER_ASSOC_TOLERANCE || dy > MARKER_ASSOC_TOLERANCE) return null;
     return { x: x, y: y };
   }
 
+  // Containment filter: Range.getClientRects() returns BOTH a fully-contained
+  // element's border box AND its line rects, so multi-paragraph selections
+  // would double-paint stacked translucent rects (and redlines duplicate
+  // strike lines). Drop any rect that strictly contains a smaller rect in
+  // the same list.
+  function dropContainerRects(rects) {
+    if (rects.length < 2) return rects;
+    return rects.filter(function(a) {
+      var aArea = (a.width || 0) * (a.height || 0);
+      for (var i = 0; i < rects.length; i++) {
+        var b = rects[i];
+        if (b === a) continue;
+        var bArea = (b.width || 0) * (b.height || 0);
+        if (bArea >= aArea) continue; // only a STRICTLY larger box is a container
+        if (
+          a.left <= b.left
+          && a.top <= b.top
+          && rectRight(a) >= rectRight(b)
+          && rectBottom(a) >= rectBottom(b)
+        ) return false;
+      }
+      return true;
+    });
+  }
+
+  // All client rects for a range: zero-size filtered, containment filtered.
+  // NOT capped here — the marker anchor needs the TRUE last rect even when
+  // painting is capped at MAX_HIGHLIGHT_RECTS.
   function rangeClientRects(range) {
     var out = [];
     if (!range) return out;
     if (typeof range.getClientRects === 'function') {
       try {
         var list = range.getClientRects();
-        for (var i = 0; i < list.length && out.length < MAX_HIGHLIGHT_RECTS; i++) out.push(list[i]);
+        for (var i = 0; i < list.length; i++) out.push(list[i]);
       } catch (ex) {}
     }
     if (!out.length && typeof range.getBoundingClientRect === 'function') {
@@ -1473,8 +1601,42 @@ export const BRIDGE_SCRIPT = `(function() {
       out = out.filter(function(rect) {
         return (rect.width || 0) > 0 || (rect.height || 0) > 0;
       });
+      out = dropContainerRects(out);
     }
     return out;
+  }
+
+  // Range paint/projection geometry, shared by the overlay render, the print
+  // layer, and highlight click hit-testing: clip-tested painted rects
+  // (capped), the TRUE last client rect (marker anchor — never the capped
+  // list's 48th rect), and the clipped union (marker association).
+  function rangeVisualGeometry(range) {
+    var rangeEl = range && range.startContainer
+      ? (range.startContainer.nodeType === 1
+        ? range.startContainer
+        : range.startContainer.parentElement)
+      : null;
+    if (rangeEl && targetStyleHidden(rangeEl)) {
+      return { paint: [], last: null, vis: null, hidden: true };
+    }
+    var all = rangeClientRects(range);
+    if (!all.length) return { paint: [], last: null, vis: null, hidden: false };
+    var bounds = clipBoundsFor(rangeEl);
+    var paint = [];
+    for (var i = 0; i < all.length && paint.length < MAX_HIGHLIGHT_RECTS; i++) {
+      var clipped = clipRect(all[i], bounds);
+      if (clipped) paint.push(clipped);
+    }
+    var union = unionOfRects(all);
+    var vis = bounds
+      ? {
+        left: Math.max(union.left, bounds.left),
+        top: Math.max(union.top, bounds.top),
+        right: Math.min(union.right, bounds.right),
+        bottom: Math.min(union.bottom, bounds.bottom)
+      }
+      : union;
+    return { paint: paint, last: all[all.length - 1], vis: vis, hidden: false };
   }
 
   function unionOfRects(rects) {
@@ -1614,6 +1776,10 @@ export const BRIDGE_SCRIPT = `(function() {
         ? annNumbers.get(record.id)
         : fallbackNumbers.get(record.id);
       var focused = focusedAnnotationId === record.id;
+      // One marker per RESOLVED element per record: two anchors of one
+      // annotation re-resolving to the same element must not render two
+      // coincident same-number markers that then spread apart.
+      var seenRecordElements = [];
       for (var targetIndex = 0; targetIndex < record.targets.length; targetIndex++) {
         var target = record.targets[targetIndex];
         var markerKey = record.id + '::' + targetIndex;
@@ -1623,43 +1789,49 @@ export const BRIDGE_SCRIPT = `(function() {
             markers.push({ key: markerKey, id: record.id, number: number, hidden: true });
             continue;
           }
+          if (seenRecordElements.indexOf(el) >= 0) {
+            markers.push({ key: markerKey, id: record.id, number: number, hidden: true });
+            continue;
+          }
+          seenRecordElements.push(el);
           var rect = el.getBoundingClientRect();
           var zeroSize = layoutActive() && !(rect.width || 0) && !(rect.height || 0);
+          var styleHidden = !zeroSize && targetStyleHidden(el);
           var point = target.point || { x: 0.5, y: 0.5 };
-          var placed = zeroSize ? null : markerViewportPoint(
+          var placed = zeroSize || styleHidden ? null : markerViewportPoint(
             clippedTargetRect(el, rect),
             rect.left + point.x * (rect.width || 0),
             rect.top + point.y * (rect.height || 0)
           );
           if (placed) {
             markers.push({ key: markerKey, id: record.id, number: number, x: placed.x, y: placed.y });
-            if (focused) takeHighlightRect('pn-hl-focus', rect, record.id);
+            if (focused) {
+              // The focus flash is a painted rect too: clip-test it like
+              // every other highlight so it never flashes over content
+              // outside the target's scroll container.
+              var focusRect = clipRect(rect, clipBoundsFor(el));
+              if (focusRect) takeHighlightRect('pn-hl-focus', focusRect, record.id);
+            }
           } else {
             markers.push({ key: markerKey, id: record.id, number: number, hidden: true });
           }
         } else {
-          var rects = rangeClientRects(target.range);
-          for (var rectIndex = 0; rectIndex < rects.length; rectIndex++) {
+          var geometry = rangeVisualGeometry(target.range);
+          for (var rectIndex = 0; rectIndex < geometry.paint.length; rectIndex++) {
             takeHighlightRect(
               record.annType === 'deletion' ? 'pn-hl-deletion' : 'pn-hl-comment',
-              rects[rectIndex],
+              geometry.paint[rectIndex],
               record.id
             );
-            if (focused) takeHighlightRect('pn-hl-focus', rects[rectIndex], record.id);
+            if (focused) takeHighlightRect('pn-hl-focus', geometry.paint[rectIndex], record.id);
           }
           if (!target.markerless) {
             var rangePlaced = null;
-            if (rects.length) {
-              var last = rects[rects.length - 1];
-              var rangeEl = target.range && target.range.startContainer
-                ? (target.range.startContainer.nodeType === 1
-                  ? target.range.startContainer
-                  : target.range.startContainer.parentElement)
-                : null;
+            if (geometry.last && geometry.vis) {
               rangePlaced = markerViewportPoint(
-                clippedTargetRect(rangeEl, unionOfRects(rects)),
-                rectRight(last),
-                last.top + (last.height || 0) / 2
+                geometry.vis,
+                rectRight(geometry.last),
+                geometry.last.top + (geometry.last.height || 0) / 2
               );
             }
             if (rangePlaced) {
@@ -1673,10 +1845,12 @@ export const BRIDGE_SCRIPT = `(function() {
     }
     // Draft selection highlight: overlay-projected rectangles from the live
     // pending range — the page's own DOM is never mutated for draft state.
+    // Clip-tested like committed rects (M1): a draft inside a scrolled inner
+    // container must not stripe content outside the container's box.
     if (hasDraftRange) {
-      var draftRects = rangeClientRects(pendingRange);
-      for (var draftIndex = 0; draftIndex < draftRects.length; draftIndex++) {
-        takeHighlightRect('pn-hl-draft', draftRects[draftIndex], '');
+      var draftGeometry = rangeVisualGeometry(pendingRange);
+      for (var draftIndex = 0; draftIndex < draftGeometry.paint.length; draftIndex++) {
+        takeHighlightRect('pn-hl-draft', draftGeometry.paint[draftIndex], '');
       }
     }
     hideUnusedHighlights();
@@ -3457,6 +3631,7 @@ export const BRIDGE_SCRIPT = `(function() {
     pageMutationObserver = new MutationObserver(function(mutations) {
       for (var i = 0; i < mutations.length; i++) {
         if (!isViewerOverlayNode(mutations[i].target)) {
+          domGeneration += 1; // page text may have changed: unlock dead-target re-search
           schedulePinpointReconcile();
           return;
         }
@@ -3473,12 +3648,37 @@ export const BRIDGE_SCRIPT = `(function() {
   // Animations/transitions move geometry without mutations or scroll events:
   // reconcile when they settle (end or cancel), matching the reference
   // invalidation set. Capture phase so non-bubbling targets still count.
+  // Viewer-owned light-DOM chrome (pin-enter, vim reticle) settling is
+  // identity-filtered out: our own overlay animations must never schedule
+  // redundant reconciles of the frames they themselves caused.
   var settleEvents = ['animationend', 'animationcancel', 'transitionend', 'transitioncancel'];
   for (var settleIndex = 0; settleIndex < settleEvents.length; settleIndex++) {
-    document.addEventListener(settleEvents[settleIndex], function() {
+    document.addEventListener(settleEvents[settleIndex], function(e) {
+      if (e && e.target && isViewerOverlayNode(e.target)) return;
+      domGeneration += 1; // a settled page animation can land text-affecting state
       schedulePinpointReconcile();
     }, { capture: true, passive: true });
   }
+
+  // Reflow WITHOUT mutation/scroll/animation still moves geometry: a web-font
+  // swap or an image loading into a fixed-height container reflows silently.
+  // Both change GEOMETRY, not text — they schedule a reconcile but never bump
+  // the re-search generation (a dead target stays dead through them).
+  if (
+    document.fonts
+    && document.fonts.ready
+    && typeof document.fonts.ready.then === 'function'
+  ) {
+    document.fonts.ready.then(function() { schedulePinpointReconcile(); }).catch(function() {});
+  }
+  document.addEventListener('load', function(e) {
+    if (!e || !e.target || e.target === document || isViewerOverlayNode(e.target)) return;
+    // A (same-origin) frame load is a text-capable invalidation; image and
+    // media loads are geometry-only.
+    var tag = e.target.tagName || '';
+    if (tag === 'IFRAME' || tag === 'FRAME') domGeneration += 1;
+    schedulePinpointReconcile();
+  }, { capture: true, passive: true });
 
   function onReady() {
     if (typeof ResizeObserver !== 'undefined' && document.body) {

--- a/packages/ui/components/html-viewer/bridge-script.ts
+++ b/packages/ui/components/html-viewer/bridge-script.ts
@@ -78,6 +78,15 @@ body[data-plannotator-pinpoint-cursor] * {
     display: none !important;
   }
 }
+/* Print-parity layer: committed highlight rects re-projected into an
+ * absolute-positioned light-DOM layer built on beforeprint and torn down on
+ * afterprint (the fixed overlay cannot paginate). Guarded here so it can
+ * never flash on screen even if an afterprint teardown is missed. */
+@media screen {
+  [data-plannotator-print-layer] {
+    display: none !important;
+  }
+}
 body[data-plannotator-vim-focus-owner]:focus {
   outline: none !important;
 }
@@ -3679,6 +3688,84 @@ export const BRIDGE_SCRIPT = `(function() {
     if (tag === 'IFRAME' || tag === 'FRAME') domGeneration += 1;
     schedulePinpointReconcile();
   }, { capture: true, passive: true });
+
+  // --- Print parity ---
+  // Pre-overlay, inline annotation marks stayed visible in print ON PURPOSE
+  // (matching markdown documents); only pin badges were print-hidden. The
+  // fixed overlay cannot paginate (fixed-position layers repeat or clip per
+  // printed page), so print parity is restored by re-projecting the
+  // committed highlight rects into a temporary ABSOLUTE-positioned light-DOM
+  // layer in document coordinates (viewport rect + scroll offset), appended
+  // to <body> so it paginates with the content. Markers stay print-hidden —
+  // badges were print-hidden pre-overlay too; parity is highlights-print,
+  // markers-don't. Fail-safe: any error tears the layer down and printing
+  // proceeds without annotation visuals.
+  var PRINT_HL_COMMENT = 'background:oklch(0.70 0.18 60 / 0.28);border-bottom:2px solid var(--pn-accent, #d97757);';
+  var PRINT_HL_DELETION = 'background:oklch(from var(--pn-destructive, #c0392b) l c h / 0.28);background-image:linear-gradient(to bottom, transparent calc(50% - 1px), var(--pn-destructive, #c0392b) calc(50% - 1px), var(--pn-destructive, #c0392b) calc(50% + 1px), transparent calc(50% + 1px));';
+  var printLayerEl = null;
+
+  function teardownPrintLayer() {
+    if (!printLayerEl) return;
+    try {
+      if (printLayerEl.parentNode) printLayerEl.parentNode.removeChild(printLayerEl);
+    } catch (ex) {}
+    overlayNodes.delete(printLayerEl);
+    printLayerEl = null;
+  }
+
+  function buildPrintLayer() {
+    teardownPrintLayer();
+    try {
+      if (!annRecords.length || !document.body) return;
+      var layer = document.createElement('div');
+      layer.setAttribute('data-plannotator-print-layer', '');
+      layer.style.cssText = 'position:absolute;left:0;top:0;width:0;height:0;overflow:visible;pointer-events:none;';
+      var sx = window.scrollX || 0;
+      var sy = window.scrollY || 0;
+      for (var recordIndex = 0; recordIndex < annRecords.length; recordIndex++) {
+        var record = annRecords[recordIndex];
+        refreshRecordTargets(record);
+        for (var targetIndex = 0; targetIndex < record.targets.length; targetIndex++) {
+          var target = record.targets[targetIndex];
+          if (target.kind !== 'range' || !rangeAlive(target.range)) continue;
+          var geometry = rangeVisualGeometry(target.range);
+          for (var i = 0; i < geometry.paint.length; i++) {
+            var rect = geometry.paint[i];
+            var div = document.createElement('div');
+            div.style.cssText = 'position:absolute;pointer-events:none;border-radius:2px;box-sizing:border-box;'
+              + (record.annType === 'deletion' ? PRINT_HL_DELETION : PRINT_HL_COMMENT);
+            div.style.left = (rect.left + sx) + 'px';
+            div.style.top = (rect.top + sy) + 'px';
+            div.style.width = (rect.width || 0) + 'px';
+            div.style.height = (rect.height || 0) + 'px';
+            layer.appendChild(div);
+          }
+        }
+      }
+      if (!layer.childNodes.length) return;
+      overlayNodes.add(layer);
+      printLayerEl = layer;
+      document.body.appendChild(layer);
+    } catch (exBuild) {
+      try { teardownPrintLayer(); } catch (exDown) {}
+    }
+  }
+
+  window.addEventListener('beforeprint', buildPrintLayer);
+  window.addEventListener('afterprint', teardownPrintLayer);
+  if (typeof window.matchMedia === 'function') {
+    // Safari fires the print media-query transition without beforeprint in
+    // some paths; mirror the layer lifecycle on it.
+    try {
+      var printMedia = window.matchMedia('print');
+      var onPrintMediaChange = function(mediaEvent) {
+        if (mediaEvent && mediaEvent.matches) buildPrintLayer();
+        else teardownPrintLayer();
+      };
+      if (printMedia.addEventListener) printMedia.addEventListener('change', onPrintMediaChange);
+      else if (printMedia.addListener) printMedia.addListener(onPrintMediaChange);
+    } catch (exMedia) {}
+  }
 
   function onReady() {
     if (typeof ResizeObserver !== 'undefined' && document.body) {

--- a/packages/ui/components/html-viewer/htmlPinpointProtocol.test.tsx
+++ b/packages/ui/components/html-viewer/htmlPinpointProtocol.test.tsx
@@ -448,7 +448,7 @@ describe.if(hasDom)('multi-target bridge message validation (trust boundary)', (
       key: 'ht-7',
       text: 'Create',
       anchor: { selector: 'span.btn', tagName: 'span', text: 'Create', point: { x: 'evil', y: 0.2 } },
-    }) as { anchor?: { point?: unknown } };
+    }) as { anchor?: { selector: string; tagName: string; text?: string; point?: unknown } };
     expect(bad.anchor).toEqual({ selector: 'span.btn', tagName: 'span', text: 'Create' });
     expect(bad.anchor?.point).toBeUndefined();
   });

--- a/packages/ui/components/html-viewer/htmlPinpointProtocol.test.tsx
+++ b/packages/ui/components/html-viewer/htmlPinpointProtocol.test.tsx
@@ -81,6 +81,42 @@ describe.if(hasDom)('parseHtmlElementAnchor (validated DTO)', () => {
       text: 'x'.repeat(401),
     })).toBeNull();
   });
+
+  test('carries a valid normalized marker point through validation', () => {
+    expect(hookModule!.parseHtmlElementAnchor({
+      selector: '#geo',
+      tagName: 'div',
+      point: { x: 0.25, y: 0.5 },
+    })).toEqual({ selector: '#geo', tagName: 'div', point: { x: 0.25, y: 0.5 } });
+  });
+
+  test('clamps out-of-range point values into 0..1', () => {
+    expect(hookModule!.parseHtmlElementAnchor({
+      selector: '#geo',
+      tagName: 'div',
+      point: { x: 7, y: -3 },
+    })).toEqual({ selector: '#geo', tagName: 'div', point: { x: 1, y: 0 } });
+  });
+
+  test('drops a malformed point without rejecting the anchor it rides on', () => {
+    for (const point of [
+      { x: 'left', y: 0.5 },
+      { x: Infinity, y: 0.5 },
+      { x: NaN, y: 0.5 },
+      { x: 0.5 },
+      'center',
+      42,
+      null,
+    ]) {
+      const parsed = hookModule!.parseHtmlElementAnchor({
+        selector: '#geo',
+        tagName: 'div',
+        point,
+      });
+      expect(parsed).toEqual({ selector: '#geo', tagName: 'div' });
+      expect((parsed as { point?: unknown }).point).toBeUndefined();
+    }
+  });
 });
 
 describe.if(hasDom)('parseBridgeMessage selection additions', () => {
@@ -247,6 +283,122 @@ describe.if(hasDom)('pinpoint click-to-pin flow', () => {
     expect(added.length).toBe(1);
     expect(added[0]!.htmlAnchor).toBeUndefined();
   });
+
+  test('the anchor point (selected relative point) rides onto the committed annotation', async () => {
+    const added: Annotation[] = [];
+    const { postSelection } = await mountViewer({
+      mode: 'redline',
+      onAdd: (ann) => added.push(ann),
+    });
+    await postSelection({
+      ...selectionMessage,
+      anchor: { ...selectionMessage.anchor, point: { x: 0.75, y: 0.1 } },
+      pinpoint: true,
+    });
+    expect(added.length).toBe(1);
+    expect(added[0]!.htmlAnchor?.point).toEqual({ x: 0.75, y: 0.1 });
+  });
+
+  test('a hostile anchor point is dropped while the anchor itself commits', async () => {
+    const added: Annotation[] = [];
+    const { postSelection } = await mountViewer({
+      mode: 'redline',
+      onAdd: (ann) => added.push(ann),
+    });
+    await postSelection({
+      ...selectionMessage,
+      anchor: { ...selectionMessage.anchor, point: { x: 'evil', y: [1] } },
+      pinpoint: true,
+    });
+    expect(added.length).toBe(1);
+    expect(added[0]!.htmlAnchor).toEqual({
+      selector: 'p:nth-of-type(1)',
+      tagName: 'p',
+      text: 'Pinpoint target',
+    });
+    expect(added[0]!.htmlAnchor?.point).toBeUndefined();
+  });
+});
+
+describe.if(hasDom)('ordered saved-annotation sync (placed-marker numbering)', () => {
+  async function mountWithAnnotations(annotations: Annotation[]) {
+    if (!htmlViewerModule) throw new Error('DOM test environment is not registered');
+    const HtmlViewer = htmlViewerModule.HtmlViewer;
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    mountedRoots.push(root);
+    await act(async () => {
+      root.render(
+        <HtmlViewer
+          rawHtml="<html><body><p>Sync target</p></body></html>"
+          annotations={annotations}
+          onAddAnnotation={() => {}}
+          onSelectAnnotation={() => {}}
+          selectedAnnotationId={null}
+          mode="selection"
+          inputMethod="pinpoint"
+        />,
+      );
+    });
+    const iframe = host.querySelector<HTMLIFrameElement>('iframe');
+    if (!iframe?.contentWindow) throw new Error('HTML iframe missing');
+    const postedToIframe: Array<Record<string, unknown>> = [];
+    const realPost = iframe.contentWindow.postMessage.bind(iframe.contentWindow);
+    (iframe.contentWindow as unknown as { postMessage: (data: unknown) => void }).postMessage =
+      ((data: unknown, ...rest: unknown[]) => {
+        if (data && typeof data === 'object') postedToIframe.push(data as Record<string, unknown>);
+        return (realPost as (...args: unknown[]) => unknown)(data, ...rest);
+      }) as typeof iframe.contentWindow.postMessage;
+    const postReady = async () => {
+      await act(async () => {
+        window.dispatchEvent(new MessageEvent('message', {
+          source: iframe.contentWindow,
+          data: { type: 'plannotator-bridge-ready' },
+        }));
+      });
+    };
+    return { postReady, postedToIframe };
+  }
+
+  function ann(id: string, createdA: number, type = 'COMMENT' as Annotation['type']): Annotation {
+    return {
+      id,
+      blockId: '',
+      startOffset: 0,
+      endOffset: 0,
+      type,
+      originalText: 'x',
+      createdA,
+    } as Annotation;
+  }
+
+  test('on bridge ready, the ordered collection syncs as index+1 numbers (globals excluded)', async () => {
+    const { AnnotationType } = await import('../../types');
+    const annotations = [
+      ann('global-1', 5, AnnotationType.GLOBAL_COMMENT),
+      ann('ann-late', 20),
+      ann('ann-early', 10),
+    ];
+    const { postReady, postedToIframe } = await mountWithAnnotations(annotations);
+    await postReady();
+    const syncs = postedToIframe.filter(
+      (m) => m.type === 'plannotator-bridge-sync-annotations',
+    );
+    expect(syncs.length).toBeGreaterThanOrEqual(1);
+    // Ordered by createdA (the panel's order), numbered index+1, no globals.
+    expect(syncs.at(-1)!.annotations).toEqual([
+      { id: 'ann-early', number: 1 },
+      { id: 'ann-late', number: 2 },
+    ]);
+  });
+
+  test('no sync is posted before the bridge is ready', async () => {
+    const { postedToIframe } = await mountWithAnnotations([ann('a', 1)]);
+    expect(
+      postedToIframe.some((m) => m.type === 'plannotator-bridge-sync-annotations'),
+    ).toBe(false);
+  });
 });
 
 describe.if(hasDom)('multi-target bridge message validation (trust boundary)', () => {
@@ -281,6 +433,24 @@ describe.if(hasDom)('multi-target bridge message validation (trust boundary)', (
       key: 'ht-2',
       text: 42,
     })).toBeNull();
+  });
+
+  test('multi-target-added: anchor point validates like the primary anchor point', () => {
+    const good = hookModule!.parseBridgeMessage({
+      type: 'plannotator-bridge-multi-target-added',
+      key: 'ht-6',
+      text: 'Create',
+      anchor: { selector: 'span.btn', tagName: 'span', text: 'Create', point: { x: 0.9, y: 0.2 } },
+    }) as { anchor?: { point?: { x: number; y: number } } };
+    expect(good.anchor?.point).toEqual({ x: 0.9, y: 0.2 });
+    const bad = hookModule!.parseBridgeMessage({
+      type: 'plannotator-bridge-multi-target-added',
+      key: 'ht-7',
+      text: 'Create',
+      anchor: { selector: 'span.btn', tagName: 'span', text: 'Create', point: { x: 'evil', y: 0.2 } },
+    }) as { anchor?: { point?: unknown } };
+    expect(bad.anchor).toEqual({ selector: 'span.btn', tagName: 'span', text: 'Create' });
+    expect(bad.anchor?.point).toBeUndefined();
   });
 
   test('multi-target-added: hostile label is truncated, hostile anchor dropped, text capped', () => {

--- a/packages/ui/components/html-viewer/htmlPinpointProtocol.test.tsx
+++ b/packages/ui/components/html-viewer/htmlPinpointProtocol.test.tsx
@@ -399,6 +399,41 @@ describe.if(hasDom)('ordered saved-annotation sync (placed-marker numbering)', (
       postedToIframe.some((m) => m.type === 'plannotator-bridge-sync-annotations'),
     ).toBe(false);
   });
+
+  test('the sync feed truncates to 512 entries AFTER the stable sort (m2)', async () => {
+    // The bridge caps its numbering map at 512; without a sender-side slice
+    // the bridge would keep an arbitrary tail whose numbers disagree with
+    // the panel. Slicing after the sort keeps the first 512 numbers equal on
+    // both sides. createdA descends here, so the sort must run before the
+    // slice for bulk-519 (oldest) to survive as number 1.
+    const annotations = Array.from({ length: 520 }, (_, i) => ann(`bulk-${i}`, 1000 - i));
+    const { postReady, postedToIframe } = await mountWithAnnotations(annotations);
+    await postReady();
+    const syncs = postedToIframe.filter(
+      (m) => m.type === 'plannotator-bridge-sync-annotations',
+    );
+    const list = syncs.at(-1)!.annotations as Array<{ id: string; number: number }>;
+    expect(list.length).toBe(512);
+    expect(list[0]).toEqual({ id: 'bulk-519', number: 1 });
+    expect(list[511]).toEqual({ id: 'bulk-8', number: 512 });
+  });
+});
+
+describe.if(hasDom)('mark-click validation (trust boundary)', () => {
+  test('mark-click ids are capped at 256 chars like the bridge sync cap (m1)', () => {
+    expect(hookModule!.parseBridgeMessage({
+      type: 'plannotator-bridge-mark-click',
+      id: 'x'.repeat(256),
+    })).toEqual({ type: 'plannotator-bridge-mark-click', id: 'x'.repeat(256) });
+    expect(hookModule!.parseBridgeMessage({
+      type: 'plannotator-bridge-mark-click',
+      id: 'x'.repeat(257),
+    })).toBeNull();
+    expect(hookModule!.parseBridgeMessage({
+      type: 'plannotator-bridge-mark-click',
+      id: 42,
+    })).toBeNull();
+  });
 });
 
 describe.if(hasDom)('multi-target bridge message validation (trust boundary)', () => {

--- a/packages/ui/components/html-viewer/srcdoc.test.ts
+++ b/packages/ui/components/html-viewer/srcdoc.test.ts
@@ -2874,6 +2874,46 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     postBridge({ type: "plannotator-bridge-clear-marks" });
     document.body.replaceChildren();
   });
+
+  test("rect collection is capped at 48 with the containment filter, marker at the true tail (perf bound)", () => {
+    document.body.innerHTML = "<p>Huge wrapped selection</p>";
+    const originalGetClientRects = Range.prototype.getClientRects;
+    withLayout(() => {
+      // 60 rects: index 0 is a border box strictly containing lines 1..10;
+      // only the first 48 may ever be materialized (a huge selection can
+      // yield thousands of rects per reconcile frame), the containment
+      // filter runs on that capped list, and the marker still anchors the
+      // TRUE final rect read by index off the live list.
+      const rects: DOMRect[] = [rectOf(10, 10, 100, 50)];
+      for (let i = 1; i < 60; i++) rects.push(rectOf(10, 10 + (i - 1) * 5, 100, 5));
+      (Range.prototype as unknown as { getClientRects: () => DOMRect[] }).getClientRects = () =>
+        rects;
+      try {
+        postBridge({
+          type: "plannotator-bridge-find-and-mark",
+          id: "huge-ann",
+          originalText: "Huge wrapped selection",
+          annotationType: "comment",
+        });
+        const painted = visibleHighlights("pn-hl-comment").filter(
+          (el) => el.getAttribute("data-annotation-id") === "huge-ann",
+        );
+        // 48 collected minus the containment-dropped border box.
+        expect(painted.length).toBe(47);
+        expect(painted.some((el) => el.style.height === "50px")).toBe(false);
+        // True tail: rects[59] (top 300, height 5) — not the 48th entry.
+        const hugeMarkers = markersFor("huge-ann");
+        expect(hugeMarkers.length).toBe(1);
+        expect(hugeMarkers[0]!.style.left).toBe("110px");
+        expect(hugeMarkers[0]!.style.top).toBe("302.5px");
+      } finally {
+        (Range.prototype as { getClientRects: typeof originalGetClientRects }).getClientRects =
+          originalGetClientRects;
+      }
+    });
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
 });
 
 describe("injectIntoHead", () => {

--- a/packages/ui/components/html-viewer/srcdoc.test.ts
+++ b/packages/ui/components/html-viewer/srcdoc.test.ts
@@ -1883,6 +1883,444 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       document.body.replaceChildren();
     }
   });
+
+  // --- Placed-marker overlay: geometry, lifecycle, and isolation ------------
+
+  const rectOf = (x: number, y: number, width: number, height: number) => ({
+    x, y, width, height,
+    top: y, left: x, right: x + width, bottom: y + height,
+    toJSON: () => ({}),
+  }) as DOMRect;
+
+  /** Enable "layout" in happy-dom: give the body a real rect. */
+  function withLayout(run: () => void) {
+    const originalBodyRect = document.body.getBoundingClientRect;
+    document.body.getBoundingClientRect = () => rectOf(0, 0, 1024, 768);
+    try {
+      run();
+    } finally {
+      document.body.getBoundingClientRect = originalBodyRect;
+    }
+  }
+
+  test("annotation overlay is layout-neutral: page DOM untouched, host outside body, pointer-transparent", () => {
+    document.body.innerHTML = [
+      '<div id="hero"><p class="intro">Anchor target text</p><p>Second paragraph</p></div>',
+    ].join("");
+    const pageSnapshot = document.body.innerHTML;
+
+    postBridge({
+      type: "plannotator-bridge-find-and-mark",
+      id: "neutral-a",
+      originalText: "Anchor target text",
+      annotationType: "comment",
+      anchor: { selector: "#hero", tagName: "div" },
+    });
+    postBridge({
+      type: "plannotator-bridge-find-and-mark",
+      id: "neutral-b",
+      originalText: "Second paragraph",
+      annotationType: "deletion",
+    });
+    postBridge({
+      type: "plannotator-bridge-sync-annotations",
+      annotations: [{ id: "neutral-a", number: 1 }, { id: "neutral-b", number: 2 }],
+    });
+    postBridge({ type: "plannotator-bridge-focus-mark", id: "neutral-b" });
+    collectScrollTargets(() => {
+      postBridge({ type: "plannotator-bridge-scroll-to", id: "neutral-a" });
+    });
+
+    // The author DOM is byte-identical after restore + sync + focus + scroll.
+    expect(document.body.innerHTML).toBe(pageSnapshot);
+    // Overlay artifacts live OUTSIDE the page's layout, on the root element.
+    const host = overlayHost();
+    if (!host) throw new Error("overlay host missing");
+    expect(host.parentElement).toBe(document.documentElement);
+    expect(document.body.contains(host)).toBe(false);
+    expect(document.body.querySelector("[data-plannotator-marker]")).toBeNull();
+    expect(host.style.position).toBe("fixed");
+    expect(host.style.pointerEvents).toBe("none");
+    expect(host.style.zIndex).toBe("2147483647");
+    // Markers render (numbered, accessible buttons) despite touching nothing.
+    expect(markersFor("neutral-a").length).toBe(1);
+    expect(markersFor("neutral-b").length).toBe(1);
+
+    postBridge({ type: "plannotator-bridge-focus-mark", id: null });
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  test("marker reprojects the stored relative point against fresh geometry (no stored pixels)", () => {
+    document.body.innerHTML = '<div id="geo">Geo target</div>';
+    const geo = document.querySelector<HTMLElement>("#geo")!;
+    withLayout(() => {
+      geo.getBoundingClientRect = () => rectOf(100, 50, 200, 100);
+      postBridge({
+        type: "plannotator-bridge-find-and-mark",
+        id: "geo-ann",
+        originalText: "Text that exists nowhere on this page",
+        annotationType: "comment",
+        anchor: { selector: "#geo", tagName: "div", point: { x: 0.25, y: 0.5 } },
+      });
+      const first = markersFor("geo-ann");
+      expect(first.length).toBe(1);
+      expect(first[0]!.style.left).toBe("150px");
+      expect(first[0]!.style.top).toBe("100px");
+
+      // The element moves and resizes (responsive rerender): the marker
+      // reprojects the NORMALIZED point against the new rect — it never
+      // reuses the old pixels.
+      geo.getBoundingClientRect = () => rectOf(300, 50, 100, 100);
+      postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+      const moved = markersFor("geo-ann");
+      expect(moved.length).toBe(1);
+      expect(moved[0]!.style.left).toBe("325px");
+      expect(moved[0]!.style.top).toBe("100px");
+    });
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  test("pinpoint click captures the normalized selected point onto the posted anchor", async () => {
+    document.body.innerHTML = '<p id="cap">Capture me</p>';
+    const cap = document.querySelector<HTMLElement>("#cap")!;
+    postBridge({ type: "plannotator-bridge-set-vim-mode", enabled: false });
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "pinpoint" });
+    const originalBodyRect = document.body.getBoundingClientRect;
+    document.body.getBoundingClientRect = () => rectOf(0, 0, 1024, 768);
+    cap.getBoundingClientRect = () => rectOf(100, 50, 200, 100);
+    try {
+      const { messages } = await clickAndCollectSelection(cap, 150, 100);
+      expect(messages.length).toBe(1);
+      const anchor = messages[0]!.anchor as { point?: { x: number; y: number } };
+      expect(anchor.point).toEqual({ x: 0.25, y: 0.5 });
+
+      // Committing places the marker at the captured point's projection.
+      postBridge({
+        type: "plannotator-bridge-create-mark",
+        id: "cap-ann",
+        annotationType: "comment",
+      });
+      const committed = markersFor("cap-ann");
+      expect(committed.length).toBe(1);
+      expect(committed[0]!.style.left).toBe("150px");
+      expect(committed[0]!.style.top).toBe("100px");
+    } finally {
+      document.body.getBoundingClientRect = originalBodyRect;
+    }
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
+    document.body.replaceChildren();
+  });
+
+  test("unresolved targets omit their markers instead of guessing", () => {
+    document.body.innerHTML = '<div data-testid="vanishing">Now you see me</div>';
+    postBridge({
+      type: "plannotator-bridge-find-and-mark",
+      id: "vanish-ann",
+      originalText: "Text that exists nowhere on this page",
+      annotationType: "comment",
+      anchor: { selector: 'div[data-testid="vanishing"]', tagName: "div" },
+    });
+    expect(markersFor("vanish-ann").length).toBe(1);
+
+    // The page rerenders without the element: the anchor no longer resolves,
+    // so the marker is omitted — never left floating over unrelated content.
+    document.body.innerHTML = "<p>Completely different content</p>";
+    postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+    expect(markersFor("vanish-ann").length).toBe(0);
+    // The annotation record survives (it stays reachable via the panel), so
+    // a page that brings the element back re-resolves and re-renders it.
+    document.body.innerHTML = '<div data-testid="vanishing">Back again</div>';
+    postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+    expect(markersFor("vanish-ann").length).toBe(1);
+
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  test("targets scrolled or clipped out of the viewport omit their markers", () => {
+    document.body.innerHTML = '<div id="offscreen">Off screen</div>';
+    const el = document.querySelector<HTMLElement>("#offscreen")!;
+    withLayout(() => {
+      el.getBoundingClientRect = () => rectOf(100, -500, 200, 100); // above viewport
+      postBridge({
+        type: "plannotator-bridge-find-and-mark",
+        id: "off-ann",
+        originalText: "Text that exists nowhere on this page",
+        annotationType: "comment",
+        anchor: { selector: "#offscreen", tagName: "div" },
+      });
+      expect(markersFor("off-ann").length).toBe(0);
+
+      el.getBoundingClientRect = () => rectOf(100, 2000, 200, 100); // below viewport
+      postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+      expect(markersFor("off-ann").length).toBe(0);
+
+      el.getBoundingClientRect = () => rectOf(100, 300, 200, 100); // scrolled back in
+      postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+      expect(markersFor("off-ann").length).toBe(1);
+    });
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  test("edge clamping keeps the full marker reachable; visually detached clamps are omitted", () => {
+    document.body.innerHTML = '<div id="edge">Edge</div><div id="sliver">S</div>';
+    const edge = document.querySelector<HTMLElement>("#edge")!;
+    const sliver = document.querySelector<HTMLElement>("#sliver")!;
+    withLayout(() => {
+      // A point at the exact left edge clamps to the 29px inset and stays
+      // associated with its (40px-wide) target.
+      edge.getBoundingClientRect = () => rectOf(0, 40, 40, 40);
+      postBridge({
+        type: "plannotator-bridge-find-and-mark",
+        id: "edge-ann",
+        originalText: "Text that exists nowhere on this page",
+        annotationType: "comment",
+        anchor: { selector: "#edge", tagName: "div", point: { x: 0, y: 0.5 } },
+      });
+      const clamped = markersFor("edge-ann");
+      expect(clamped.length).toBe(1);
+      expect(clamped[0]!.style.left).toBe("29px");
+      expect(clamped[0]!.style.top).toBe("60px");
+
+      // A 4px corner sliver cannot host a clamped marker without visually
+      // detaching from it (29 - 4 > tolerance): omit rather than guess.
+      sliver.getBoundingClientRect = () => rectOf(0, 2, 4, 4);
+      postBridge({
+        type: "plannotator-bridge-find-and-mark",
+        id: "sliver-ann",
+        originalText: "Text that exists nowhere on this page either",
+        annotationType: "comment",
+        anchor: { selector: "#sliver", tagName: "div" },
+      });
+      expect(markersFor("sliver-ann").length).toBe(0);
+    });
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  test("coincident markers spread horizontally and deterministically", () => {
+    document.body.innerHTML = [
+      '<div data-testid="co-a">A</div>',
+      '<div data-testid="co-b">B</div>',
+    ].join("");
+    const a = document.querySelector<HTMLElement>('div[data-testid="co-a"]')!;
+    const b = document.querySelector<HTMLElement>('div[data-testid="co-b"]')!;
+    withLayout(() => {
+      a.getBoundingClientRect = () => rectOf(100, 100, 50, 50);
+      b.getBoundingClientRect = () => rectOf(100, 100, 50, 50);
+      for (const [id, selector] of [["co-1", 'div[data-testid="co-a"]'], ["co-2", 'div[data-testid="co-b"]']] as const) {
+        postBridge({
+          type: "plannotator-bridge-find-and-mark",
+          id,
+          originalText: "Text that exists nowhere on this page",
+          annotationType: "comment",
+          anchor: { selector, tagName: "div" },
+        });
+      }
+      // Same rounded point (125,125): the group spreads by 12.5px steps,
+      // centered on the shared point, ordered by comment number.
+      const one = markersFor("co-1");
+      const two = markersFor("co-2");
+      expect(one.length).toBe(1);
+      expect(two.length).toBe(1);
+      expect(one[0]!.style.left).toBe("118.75px");
+      expect(two[0]!.style.left).toBe("131.25px");
+      expect(one[0]!.style.top).toBe("125px");
+      expect(two[0]!.style.top).toBe("125px");
+      // Deterministic: a re-render yields identical placement.
+      postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+      expect(markersFor("co-1")[0]!.style.left).toBe("118.75px");
+      expect(markersFor("co-2")[0]!.style.left).toBe("131.25px");
+    });
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  test("parent-synced numbering overrides registration order and renumbers markers", () => {
+    document.body.innerHTML = [
+      '<div data-testid="n-a">A</div>',
+      '<div data-testid="n-b">B</div>',
+    ].join("");
+    for (const [id, selector] of [["n-1", 'div[data-testid="n-a"]'], ["n-2", 'div[data-testid="n-b"]']] as const) {
+      postBridge({
+        type: "plannotator-bridge-find-and-mark",
+        id,
+        originalText: "Text that exists nowhere on this page",
+        annotationType: "comment",
+        anchor: { selector, tagName: "div" },
+      });
+    }
+    // Pre-sync fallback: registration order.
+    expect(markerNumber(markersFor("n-1")[0]!)).toBe("1");
+    expect(markerNumber(markersFor("n-2")[0]!)).toBe("2");
+
+    // The parent's ordered collection is authoritative — numbers follow it.
+    postBridge({
+      type: "plannotator-bridge-sync-annotations",
+      annotations: [{ id: "n-2", number: 1 }, { id: "n-1", number: 2 }],
+    });
+    expect(markerNumber(markersFor("n-2")[0]!)).toBe("1");
+    expect(markersFor("n-2")[0]!.getAttribute("aria-label")).toBe("Comment 1");
+    expect(markerNumber(markersFor("n-1")[0]!)).toBe("2");
+    expect(markersFor("n-1")[0]!.getAttribute("aria-label")).toBe("Comment 2");
+
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  test("malformed sync payloads are ignored or skipped at the bridge boundary", () => {
+    document.body.innerHTML = [
+      '<div data-testid="m-a">A</div>',
+      '<div data-testid="m-b">B</div>',
+    ].join("");
+    for (const [id, selector] of [["m-1", 'div[data-testid="m-a"]'], ["m-2", 'div[data-testid="m-b"]']] as const) {
+      postBridge({
+        type: "plannotator-bridge-find-and-mark",
+        id,
+        originalText: "Text that exists nowhere on this page",
+        annotationType: "comment",
+        anchor: { selector, tagName: "div" },
+      });
+    }
+    postBridge({
+      type: "plannotator-bridge-sync-annotations",
+      annotations: [{ id: "m-1", number: 5 }, { id: "m-2", number: 6 }],
+    });
+    expect(markerNumber(markersFor("m-1")[0]!)).toBe("5");
+
+    // A completely malformed list leaves the previous numbering untouched.
+    postBridge({ type: "plannotator-bridge-sync-annotations", annotations: 42 });
+    postBridge({ type: "plannotator-bridge-sync-annotations" });
+    expect(markerNumber(markersFor("m-1")[0]!)).toBe("5");
+    expect(markerNumber(markersFor("m-2")[0]!)).toBe("6");
+
+    // Junk entries are skipped; only well-formed (id, integer >= 1) apply.
+    postBridge({
+      type: "plannotator-bridge-sync-annotations",
+      annotations: [
+        { id: "m-1", number: 7 },
+        { id: "m-2", number: 0 },
+        { id: "m-2", number: 2.5 },
+        { id: "m-2", number: -3 },
+        { id: 5, number: 2 },
+        "junk",
+        { id: "x".repeat(300), number: 2 },
+      ],
+    });
+    expect(markerNumber(markersFor("m-1")[0]!)).toBe("7");
+    // m-2 fell back to registration order (2), not a hostile number.
+    expect(markerNumber(markersFor("m-2")[0]!)).toBe("2");
+
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  test("focus highlight covers EVERY rect of a multi-paragraph selection (partial-blue regression)", () => {
+    document.body.innerHTML = "<p>Alpha beta gamma delta</p>";
+    const originalGetClientRects = Range.prototype.getClientRects;
+    const originalBodyRect = document.body.getBoundingClientRect;
+    document.body.getBoundingClientRect = () => rectOf(0, 0, 1024, 768);
+    // A wrapped multi-line/multi-paragraph selection yields SEVERAL client
+    // rects. The old .focused class landed on querySelector's FIRST inline
+    // mark only; the overlay must cover every rect.
+    (Range.prototype as { getClientRects: () => DOMRect[] }).getClientRects = () => [
+      rectOf(10, 10, 100, 20),
+      rectOf(10, 40, 80, 20),
+    ];
+    try {
+      postBridge({
+        type: "plannotator-bridge-find-and-mark",
+        id: "focus-multi",
+        originalText: "Alpha beta gamma delta",
+        annotationType: "comment",
+      });
+      // Persistent comment highlight paints both rects.
+      const commentRects = visibleHighlights("pn-hl-comment").filter(
+        (el) => el.getAttribute("data-annotation-id") === "focus-multi",
+      );
+      expect(commentRects.length).toBe(2);
+
+      postBridge({ type: "plannotator-bridge-focus-mark", id: "focus-multi" });
+      const focusRects = visibleHighlights("pn-hl-focus").filter(
+        (el) => el.getAttribute("data-annotation-id") === "focus-multi",
+      );
+      expect(focusRects.length).toBe(2);
+      expect(focusRects.map((el) => el.style.top).sort()).toEqual(["10px", "40px"]);
+
+      postBridge({ type: "plannotator-bridge-focus-mark", id: null });
+      expect(visibleHighlights("pn-hl-focus").length).toBe(0);
+    } finally {
+      (Range.prototype as { getClientRects: typeof originalGetClientRects }).getClientRects =
+        originalGetClientRects;
+      document.body.getBoundingClientRect = originalBodyRect;
+    }
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  test("draft selection highlight is overlay-projected and clears on cancel", async () => {
+    document.body.innerHTML = "<p>Draft highlight target</p>";
+    postBridge({ type: "plannotator-bridge-set-vim-mode", enabled: false });
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
+    const p = document.querySelector("p")!;
+    const range = document.createRange();
+    range.selectNodeContents(p);
+    const sel = window.getSelection()!;
+    sel.removeAllRanges();
+    sel.addRange(range);
+    p.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true }));
+    await new Promise((resolve) => setTimeout(resolve, 25)); // handleSelection debounce
+
+    expect(visibleHighlights("pn-hl-draft").length).toBeGreaterThanOrEqual(1);
+    // Draft state never mutates the page.
+    expect(document.body.innerHTML).toBe("<p>Draft highlight target</p>");
+
+    postBridge({ type: "plannotator-bridge-cancel-selection" });
+    expect(visibleHighlights("pn-hl-draft").length).toBe(0);
+    document.body.replaceChildren();
+  });
+
+  test("hit-testing for new selections yields placed markers to reach the page beneath", () => {
+    document.body.innerHTML = '<p id="beneath">Beneath text</p><div data-testid="hit">H</div>';
+    postBridge({ type: "plannotator-bridge-set-vim-mode", enabled: false });
+    // Materialize the overlay host + a marker.
+    postBridge({
+      type: "plannotator-bridge-find-and-mark",
+      id: "hit-ann",
+      originalText: "Text that exists nowhere on this page",
+      annotationType: "comment",
+      anchor: { selector: 'div[data-testid="hit"]', tagName: "div" },
+    });
+    const host = overlayHost();
+    if (!host) throw new Error("overlay host missing");
+    const beneath = document.querySelector<HTMLElement>("#beneath")!;
+    const originalElementFromPoint = document.elementFromPoint;
+    // Simulate the real browser: the probe lands on the overlay host while
+    // markers accept hits, and on the page element once they are yielded.
+    (document as { elementFromPoint: typeof document.elementFromPoint }).elementFromPoint = () =>
+      host.hasAttribute("data-pn-hittest") ? beneath : host;
+    try {
+      postBridge({ type: "plannotator-bridge-set-input-method", method: "pinpoint" });
+      hoverAt(beneath, 77, 77);
+      const label = document.querySelector<HTMLElement>("[data-plannotator-pinpoint-label]");
+      expect(label?.style.display).toBe("block");
+      expect(label?.textContent).toBe("Paragraph");
+      const box = document.querySelector<HTMLElement>("[data-plannotator-pinpoint-box]");
+      expect(box?.style.display).toBe("block");
+      // The yield is transient: hit-testing restored marker interactivity.
+      expect(host.hasAttribute("data-pn-hittest")).toBe(false);
+    } finally {
+      (document as { elementFromPoint: typeof document.elementFromPoint }).elementFromPoint =
+        originalElementFromPoint;
+    }
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
 });
 
 describe("injectIntoHead", () => {

--- a/packages/ui/components/html-viewer/srcdoc.test.ts
+++ b/packages/ui/components/html-viewer/srcdoc.test.ts
@@ -190,6 +190,17 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     );
   }
 
+  /** Committed range targets for one annotation id (cloned), via the
+   * bridge's test-only introspection hook. Range EXTENT — which exact text a
+   * committed annotation binds — has no other observable in the overlay
+   * model (happy-dom lays nothing out, so highlight geometry is all 0x0). */
+  function committedRanges(id: string): Range[] {
+    const internals = (window as unknown as {
+      __plannotatorBridgeInternals?: { committedRanges: (annId: string) => Range[] };
+    }).__plannotatorBridgeInternals;
+    return internals ? internals.committedRanges(id) : [];
+  }
+
   /** Record every element scrollIntoView lands on across one action. */
   function collectScrollTargets(action: () => void): Element[] {
     const scrolled: Element[] = [];
@@ -757,6 +768,12 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     expect(document.querySelector("[data-plannotator-vim-badge]")?.textContent)
       .toBe("VISUAL · SELECT");
     expect(window.getSelection()?.toString()).toBe("Alpha ");
+    // Committed range EXTENT: the record's range binds exactly the visual
+    // selection ("Alpha ") — the pre-overlay test verified the inline mark
+    // wrapped exactly this text.
+    const committedVisualRanges = committedRanges("vim-committed-range");
+    expect(committedVisualRanges.length).toBe(1);
+    expect(committedVisualRanges[0]!.toString()).toBe("Alpha ");
     // The committed annotation renders as an overlay marker + highlight —
     // never as inline markup inside the page.
     expect(markersFor("vim-committed-range").length).toBe(1);
@@ -812,6 +829,11 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     expect(document.querySelector("[data-plannotator-vim-badge]")?.textContent)
       .toBe("VISUAL BLOCK · SELECT");
     expect(window.getSelection()?.toString()).toBe("Whole block target");
+    // Committed range EXTENT: the whole-block commit binds exactly the
+    // block's text, not merely "some range that produced one marker".
+    const committedBlockRanges = committedRanges("vim-committed-block-range");
+    expect(committedBlockRanges.length).toBe(1);
+    expect(committedBlockRanges[0]!.toString()).toBe("Whole block target");
     expect(markersFor("vim-committed-block-range").length).toBe(1);
     expect(document.querySelector("[data-bind-id]")).toBeNull();
 
@@ -898,6 +920,15 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
         (el) => el.getAttribute("data-annotation-id") === "pin-restore",
       ),
     ).toBe(true);
+    // Committed range EXTENT: the restored scoped text range binds INSIDE
+    // the anchored element and covers exactly the stored text. The scroll
+    // proxy below only checks the ELEMENT target — without this, the range
+    // could bind anywhere in the document and still pass.
+    const restoredRanges = committedRanges("pin-restore");
+    expect(restoredRanges.length).toBe(1);
+    expect(restoredRanges[0]!.toString()).toBe("Anchor target text");
+    expect(target.contains(restoredRanges[0]!.startContainer)).toBe(true);
+    expect(target.contains(restoredRanges[0]!.endContainer)).toBe(true);
     // Scrolling the annotation lands on the anchored element itself.
     const anchoredScroll = collectScrollTargets(() => {
       postBridge({ type: "plannotator-bridge-scroll-to", id: "pin-restore" });
@@ -2332,6 +2363,509 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       expect(box?.style.display).toBe("block");
       // The yield is transient: hit-testing restored marker interactivity.
       expect(host.hasAttribute("data-pn-hittest")).toBe(false);
+    } finally {
+      (document as { elementFromPoint: typeof document.elementFromPoint }).elementFromPoint =
+        originalElementFromPoint;
+    }
+    // String-level guard: happy-dom cannot honor pointer-events, and the
+    // elementFromPoint mock above IMPLEMENTS the yield keyed on the
+    // data-pn-hittest attribute — a typo in the CSS rule would still pass
+    // it. The exact rule must ship in the overlay CSS.
+    expect(BRIDGE_SCRIPT).toContain(
+      ":host([data-pn-hittest]) .pn-marker, [data-plannotator-overlay-host][data-pn-hittest] .pn-marker { pointer-events: none !important; }",
+    );
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  // --- Fix-round regressions: clipping, visibility, search gating, print,
+  // --- click-to-select, containment, dedup, numbering, marker anchoring ----
+
+  test("highlight rects are clip-tested against inner scroll containers (M1)", () => {
+    document.body.innerHTML =
+      '<div id="scroller"><p id="clipped-p">Clipped highlight text</p></div>';
+    const scroller = document.querySelector<HTMLElement>("#scroller")!;
+    const clippedP = document.querySelector<HTMLElement>("#clipped-p")!;
+    scroller.style.overflow = "hidden";
+    const originalGetClientRects = Range.prototype.getClientRects;
+    withLayout(() => {
+      scroller.getBoundingClientRect = () => rectOf(0, 0, 200, 100);
+      clippedP.getBoundingClientRect = () => rectOf(0, 50, 200, 120);
+      (Range.prototype as unknown as { getClientRects: () => DOMRect[] }).getClientRects = () => [
+        rectOf(0, 50, 200, 20), // fully inside the container
+        rectOf(0, 90, 200, 20), // straddles the container edge -> trimmed to 10px
+        rectOf(0, 150, 200, 20), // fully scrolled past the edge -> dropped
+      ];
+      try {
+        postBridge({
+          type: "plannotator-bridge-find-and-mark",
+          id: "clip-hl",
+          originalText: "Clipped highlight text",
+          annotationType: "comment",
+        });
+        const painted = visibleHighlights("pn-hl-comment")
+          .filter((el) => el.getAttribute("data-annotation-id") === "clip-hl")
+          .map((el) => ({ top: el.style.top, height: el.style.height }))
+          .sort((a, b) => parseFloat(a.top) - parseFloat(b.top));
+        expect(painted).toEqual([
+          { top: "50px", height: "20px" },
+          { top: "90px", height: "10px" },
+        ]);
+        // The focus flash paints the same clip-tested rects.
+        postBridge({ type: "plannotator-bridge-focus-mark", id: "clip-hl" });
+        const focusRects = visibleHighlights("pn-hl-focus").filter(
+          (el) => el.getAttribute("data-annotation-id") === "clip-hl",
+        );
+        expect(focusRects.length).toBe(2);
+        postBridge({ type: "plannotator-bridge-focus-mark", id: null });
+      } finally {
+        (Range.prototype as { getClientRects: typeof originalGetClientRects }).getClientRects =
+          originalGetClientRects;
+      }
+    });
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  test("style-hidden targets are unresolved-for-display (M2 visibility gate)", () => {
+    document.body.innerHTML = '<div id="slide">Slide content</div>';
+    const slide = document.querySelector<HTMLElement>("#slide")!;
+    withLayout(() => {
+      slide.getBoundingClientRect = () => rectOf(100, 100, 200, 100);
+      postBridge({
+        type: "plannotator-bridge-find-and-mark",
+        id: "vis-ann",
+        originalText: "Text that exists nowhere on this page",
+        annotationType: "comment",
+        anchor: { selector: "#slide", tagName: "div" },
+      });
+      expect(markersFor("vis-ann").length).toBe(1);
+
+      // visibility:hidden keeps a full-size rect — the marker must not
+      // render over whatever visible content stacks in the same box.
+      slide.style.visibility = "hidden";
+      postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+      expect(markersFor("vis-ann").length).toBe(0);
+      slide.style.visibility = "";
+
+      slide.style.opacity = "0";
+      postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+      expect(markersFor("vis-ann").length).toBe(0);
+      slide.style.opacity = "";
+
+      postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+      expect(markersFor("vis-ann").length).toBe(1);
+    });
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  test("dead-target re-search is generation-gated, never per-render (M3)", () => {
+    document.body.innerHTML = "<p>Ephemeral searchable text</p>";
+    postBridge({
+      type: "plannotator-bridge-find-and-mark",
+      id: "gen-ann",
+      originalText: "Ephemeral searchable text",
+      annotationType: "comment",
+    });
+    expect(
+      visibleHighlights("pn-hl-comment").some(
+        (el) => el.getAttribute("data-annotation-id") === "gen-ann",
+      ),
+    ).toBe(true);
+
+    // The text disappears; the next invalidation triggers ONE failed search.
+    document.body.innerHTML = "<p>Different content</p>";
+    bumpDomGeneration();
+    postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+
+    // Repeated renders WITHOUT a new text-capable invalidation must not
+    // re-run the whole-document sweep (findTextRange = createTreeWalker).
+    const originalCreateTreeWalker = document.createTreeWalker.bind(document);
+    let sweeps = 0;
+    (document as { createTreeWalker: typeof document.createTreeWalker }).createTreeWalker = ((
+      ...args: Parameters<typeof document.createTreeWalker>
+    ) => {
+      sweeps += 1;
+      return originalCreateTreeWalker(...args);
+    }) as typeof document.createTreeWalker;
+    try {
+      for (let i = 0; i < 5; i++) {
+        postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+      }
+      expect(sweeps).toBe(0);
+
+      // A text-capable invalidation unlocks exactly one more search…
+      bumpDomGeneration();
+      postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+      expect(sweeps).toBeGreaterThan(0);
+      const afterUnlock = sweeps;
+      // …whose failure is cached again for that generation.
+      postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+      expect(sweeps).toBe(afterUnlock);
+    } finally {
+      (document as { createTreeWalker: typeof document.createTreeWalker }).createTreeWalker =
+        originalCreateTreeWalker;
+    }
+
+    // The text returning re-resolves after the next invalidation.
+    document.body.innerHTML = "<p>Ephemeral searchable text</p>";
+    bumpDomGeneration();
+    postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+    expect(
+      visibleHighlights("pn-hl-comment").some(
+        (el) => el.getAttribute("data-annotation-id") === "gen-ann",
+      ),
+    ).toBe(true);
+
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  test("printing re-projects committed highlights into a paginating absolute layer (M4)", () => {
+    document.body.innerHTML = "<p>Printable highlight text</p>";
+    const originalGetClientRects = Range.prototype.getClientRects;
+    withLayout(() => {
+      (Range.prototype as unknown as { getClientRects: () => DOMRect[] }).getClientRects = () => [
+        rectOf(10, 20, 100, 20),
+      ];
+      try {
+        postBridge({
+          type: "plannotator-bridge-find-and-mark",
+          id: "print-ann",
+          originalText: "Printable highlight text",
+          annotationType: "comment",
+        });
+        window.dispatchEvent(new Event("beforeprint"));
+        const layer = document.body.querySelector<HTMLElement>(
+          "[data-plannotator-print-layer]",
+        );
+        if (!layer) throw new Error("print layer missing");
+        // Absolute (not fixed) so it paginates with the content.
+        expect(layer.style.position).toBe("absolute");
+        const stripes = Array.from(layer.children) as HTMLElement[];
+        expect(stripes.length).toBe(1);
+        expect(stripes[0]!.style.position).toBe("absolute");
+        expect(stripes[0]!.style.left).toBe("10px");
+        expect(stripes[0]!.style.top).toBe("20px");
+        expect(stripes[0]!.style.width).toBe("100px");
+        expect(stripes[0]!.style.height).toBe("20px");
+        // Highlights print; markers don't (parity with pre-overlay badges).
+        expect(layer.querySelector("button")).toBeNull();
+        window.dispatchEvent(new Event("afterprint"));
+        expect(document.body.querySelector("[data-plannotator-print-layer]")).toBeNull();
+      } finally {
+        (Range.prototype as { getClientRects: typeof originalGetClientRects }).getClientRects =
+          originalGetClientRects;
+      }
+    });
+    // The injected CSS guards the layer against ever painting on screen.
+    expect(ANNOTATION_HIGHLIGHT_CSS).toContain("[data-plannotator-print-layer]");
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  test("clicking a committed highlight selects its annotation (M5 click-to-select)", async () => {
+    document.body.innerHTML = "<p>big highlight target</p><p>small nested note</p>";
+    postBridge({ type: "plannotator-bridge-set-vim-mode", enabled: false });
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
+    const originalGetClientRects = Range.prototype.getClientRects;
+    const originalBodyRect = document.body.getBoundingClientRect;
+    document.body.getBoundingClientRect = () => rectOf(0, 0, 1024, 768);
+    (Range.prototype as unknown as { getClientRects: (this: Range) => DOMRect[] }).getClientRects =
+      function (this: Range) {
+        return this.toString().indexOf("small") >= 0
+          ? [rectOf(40, 20, 60, 12)]
+          : [rectOf(10, 10, 300, 100)];
+      };
+    const clickBody = (x: number, y: number, shift = false) => {
+      document.body.dispatchEvent(new MouseEvent("click", {
+        bubbles: true,
+        cancelable: true,
+        clientX: x,
+        clientY: y,
+        shiftKey: shift,
+      }));
+    };
+    try {
+      postBridge({
+        type: "plannotator-bridge-find-and-mark",
+        id: "click-big",
+        originalText: "big highlight target",
+        annotationType: "comment",
+      });
+      postBridge({
+        type: "plannotator-bridge-find-and-mark",
+        id: "click-small",
+        originalText: "small nested note",
+        annotationType: "comment",
+      });
+
+      // Inside both rects: the smallest highlight wins the overlap.
+      const overlapping = await collectMessages(
+        ["plannotator-bridge-mark-click"],
+        () => clickBody(50, 25),
+      );
+      expect(overlapping).toEqual([
+        { type: "plannotator-bridge-mark-click", id: "click-small" },
+      ]);
+
+      // Inside only the big rect.
+      const bigOnly = await collectMessages(
+        ["plannotator-bridge-mark-click"],
+        () => clickBody(200, 90),
+      );
+      expect(bigOnly).toEqual([
+        { type: "plannotator-bridge-mark-click", id: "click-big" },
+      ]);
+
+      // Outside every rect: page clicks pass through untouched.
+      const missed = await collectMessages(
+        ["plannotator-bridge-mark-click"],
+        () => clickBody(600, 600),
+      );
+      expect(missed.length).toBe(0);
+
+      // Shift-clicks belong to multi-select, never click-to-select.
+      const shifted = await collectMessages(
+        ["plannotator-bridge-mark-click"],
+        () => clickBody(50, 25, true),
+      );
+      expect(shifted.length).toBe(0);
+    } finally {
+      (Range.prototype as { getClientRects: typeof originalGetClientRects }).getClientRects =
+        originalGetClientRects;
+      document.body.getBoundingClientRect = originalBodyRect;
+    }
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  test("fixed-position targets ignore static overflow clippers (m3)", () => {
+    document.body.innerHTML =
+      '<div id="wrap"><div id="fixed-el">Pinned banner</div></div>';
+    const wrap = document.querySelector<HTMLElement>("#wrap")!;
+    const fixedEl = document.querySelector<HTMLElement>("#fixed-el")!;
+    wrap.style.overflow = "hidden";
+    fixedEl.style.position = "fixed";
+    withLayout(() => {
+      wrap.getBoundingClientRect = () => rectOf(0, 0, 100, 50);
+      // Fully visible in the viewport but entirely outside the static
+      // clipper's box: overflow clipping does not apply to a fixed target
+      // whose containing-block chain skips the clipper.
+      fixedEl.getBoundingClientRect = () => rectOf(300, 300, 200, 50);
+      postBridge({
+        type: "plannotator-bridge-find-and-mark",
+        id: "fixed-ann",
+        originalText: "Text that exists nowhere on this page",
+        annotationType: "comment",
+        anchor: { selector: "#fixed-el", tagName: "div" },
+      });
+      expect(markersFor("fixed-ann").length).toBe(1);
+
+      // Same geometry with static positioning: the clipper applies and the
+      // detached marker is omitted (clip-container omission preserved).
+      fixedEl.style.position = "";
+      postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+      expect(markersFor("fixed-ann").length).toBe(0);
+    });
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  test("markers omit when the target scrolls out of its clip container (omission preserved)", () => {
+    document.body.innerHTML =
+      '<div id="clipwrap"><div id="clipped-el">Clipped away</div></div>';
+    const clipwrap = document.querySelector<HTMLElement>("#clipwrap")!;
+    const clippedEl = document.querySelector<HTMLElement>("#clipped-el")!;
+    clipwrap.style.overflow = "hidden";
+    withLayout(() => {
+      clipwrap.getBoundingClientRect = () => rectOf(0, 0, 200, 100);
+      clippedEl.getBoundingClientRect = () => rectOf(0, 150, 200, 50); // scrolled past the edge
+      postBridge({
+        type: "plannotator-bridge-find-and-mark",
+        id: "clip-omit",
+        originalText: "Text that exists nowhere on this page",
+        annotationType: "comment",
+        anchor: { selector: "#clipped-el", tagName: "div" },
+      });
+      expect(markersFor("clip-omit").length).toBe(0);
+
+      clippedEl.getBoundingClientRect = () => rectOf(0, 20, 200, 50); // scrolled back in
+      postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+      expect(markersFor("clip-omit").length).toBe(1);
+    });
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  test("border boxes that duplicate line rects are dropped (m7 containment filter)", () => {
+    document.body.innerHTML = "<p>Redline paragraph text</p>";
+    const originalGetClientRects = Range.prototype.getClientRects;
+    withLayout(() => {
+      // Range.getClientRects() returns BOTH the contained element's border
+      // box AND its line boxes; painting all three double-paints the
+      // translucent fill and duplicates the strike line.
+      (Range.prototype as unknown as { getClientRects: () => DOMRect[] }).getClientRects = () => [
+        rectOf(10, 10, 300, 60), // border box containing both lines
+        rectOf(10, 10, 300, 20), // line 1
+        rectOf(10, 40, 200, 20), // line 2
+      ];
+      try {
+        postBridge({
+          type: "plannotator-bridge-find-and-mark",
+          id: "redline-ann",
+          originalText: "Redline paragraph text",
+          annotationType: "deletion",
+        });
+        const painted = visibleHighlights("pn-hl-deletion").filter(
+          (el) => el.getAttribute("data-annotation-id") === "redline-ann",
+        );
+        expect(painted.length).toBe(2);
+        expect(painted.map((el) => el.style.height)).toEqual(["20px", "20px"]);
+      } finally {
+        (Range.prototype as { getClientRects: typeof originalGetClientRects }).getClientRects =
+          originalGetClientRects;
+      }
+    });
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  test("anchors re-resolving to one element render one marker (m10 refresh dedup)", () => {
+    document.body.innerHTML =
+      '<div id="m10-a">First</div><div data-testid="m10-b">Second</div>';
+    postBridge({
+      type: "plannotator-bridge-find-and-mark",
+      id: "dedup-ann",
+      originalText: "Text that exists nowhere on this page",
+      annotationType: "comment",
+      anchor: { selector: "#m10-a", tagName: "div" },
+      additionalAnchors: [{ selector: 'div[data-testid="m10-b"]', tagName: "div" }],
+    });
+    expect(markersFor("dedup-ann").length).toBe(2);
+
+    // The page rerenders so BOTH anchors resolve to the same element: only
+    // one marker may render (coincident same-number markers would spread).
+    document.body.innerHTML = '<div id="m10-a" data-testid="m10-b">Merged</div>';
+    bumpDomGeneration();
+    postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+    expect(markersFor("dedup-ann").length).toBe(1);
+
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  test("clear-marks clears synced numbering (m11)", () => {
+    document.body.innerHTML = '<div id="renum">Target</div>';
+    postBridge({
+      type: "plannotator-bridge-find-and-mark",
+      id: "renum-ann",
+      originalText: "Text that exists nowhere on this page",
+      annotationType: "comment",
+      anchor: { selector: "#renum", tagName: "div" },
+    });
+    postBridge({
+      type: "plannotator-bridge-sync-annotations",
+      annotations: [{ id: "renum-ann", number: 7 }],
+    });
+    expect(markerNumber(markersFor("renum-ann")[0]!)).toBe("7");
+
+    // clear-marks then re-register the SAME id: the stale synced number must
+    // not leak — fallback numbering restarts at 1.
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    postBridge({
+      type: "plannotator-bridge-find-and-mark",
+      id: "renum-ann",
+      originalText: "Text that exists nowhere on this page",
+      annotationType: "comment",
+      anchor: { selector: "#renum", tagName: "div" },
+    });
+    expect(markerNumber(markersFor("renum-ann")[0]!)).toBe("1");
+
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  test("marker anchors to the TRUE last client rect past the paint cap (m12)", () => {
+    document.body.innerHTML = "<p>Long wrapped selection</p>";
+    const originalGetClientRects = Range.prototype.getClientRects;
+    withLayout(() => {
+      const rects: DOMRect[] = [];
+      for (let i = 0; i < 60; i++) rects.push(rectOf(10, 10 + i * 5, 100, 5));
+      (Range.prototype as unknown as { getClientRects: () => DOMRect[] }).getClientRects = () =>
+        rects;
+      try {
+        postBridge({
+          type: "plannotator-bridge-find-and-mark",
+          id: "long-ann",
+          originalText: "Long wrapped selection",
+          annotationType: "comment",
+        });
+        // Painting caps at 48 rects…
+        const painted = visibleHighlights("pn-hl-comment").filter(
+          (el) => el.getAttribute("data-annotation-id") === "long-ann",
+        );
+        expect(painted.length).toBe(48);
+        // …but the marker sits at the selection TAIL (60th rect), not at the
+        // 48th rect mid-selection.
+        const longMarkers = markersFor("long-ann");
+        expect(longMarkers.length).toBe(1);
+        expect(longMarkers[0]!.style.left).toBe("110px");
+        expect(longMarkers[0]!.style.top).toBe("307.5px");
+      } finally {
+        (Range.prototype as { getClientRects: typeof originalGetClientRects }).getClientRects =
+          originalGetClientRects;
+      }
+    });
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  test("pinpoint hover over a placed marker advertises the marker, not the element beneath (m6)", () => {
+    document.body.innerHTML = '<p id="under">Beneath paragraph</p><div id="m6-t">Marked</div>';
+    postBridge({ type: "plannotator-bridge-set-vim-mode", enabled: false });
+    postBridge({
+      type: "plannotator-bridge-find-and-mark",
+      id: "hover-ann",
+      originalText: "Text that exists nowhere on this page",
+      annotationType: "comment",
+      anchor: { selector: "#m6-t", tagName: "div" },
+    });
+    postBridge({
+      type: "plannotator-bridge-sync-annotations",
+      annotations: [{ id: "hover-ann", number: 3 }],
+    });
+    const markerBtn = markersFor("hover-ann")[0];
+    if (!markerBtn) throw new Error("marker missing");
+    const originalElementFromPoint = document.elementFromPoint;
+    (document as { elementFromPoint: typeof document.elementFromPoint }).elementFromPoint = () =>
+      markerBtn as unknown as Element;
+    try {
+      postBridge({ type: "plannotator-bridge-set-input-method", method: "pinpoint" });
+      hoverAt(document.body, 60, 60);
+      // Hover shows the MARKER's identity (the click selects its comment)…
+      const label = document.querySelector<HTMLElement>("[data-plannotator-pinpoint-label]");
+      expect(label?.style.display).toBe("block");
+      expect(label?.textContent).toBe("Comment 3");
+      // …with no annotate affordance for the element beneath.
+      const box = document.querySelector<HTMLElement>("[data-plannotator-pinpoint-box]");
+      expect(box?.style.display ?? "none").toBe("none");
+      // m8: the label paints AFTER the overlay host (equal z-index resolves
+      // by DOM order), so marker bubbles can never occlude it.
+      const host = overlayHost()!;
+      expect(label!.parentElement).toBe(document.documentElement);
+      expect(
+        (label!.compareDocumentPosition(host) & Node.DOCUMENT_POSITION_PRECEDING) !== 0,
+      ).toBe(true);
+
+      // Moving off the bubble restores normal element hover/annotate.
+      const under = document.querySelector<HTMLElement>("#under")!;
+      (document as { elementFromPoint: typeof document.elementFromPoint }).elementFromPoint =
+        () => under;
+      hoverAt(under, 200, 200);
+      expect(label?.textContent).toBe("Paragraph");
     } finally {
       (document as { elementFromPoint: typeof document.elementFromPoint }).elementFromPoint =
         originalElementFromPoint;

--- a/packages/ui/components/html-viewer/srcdoc.test.ts
+++ b/packages/ui/components/html-viewer/srcdoc.test.ts
@@ -2227,7 +2227,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     // A wrapped multi-line/multi-paragraph selection yields SEVERAL client
     // rects. The old .focused class landed on querySelector's FIRST inline
     // mark only; the overlay must cover every rect.
-    (Range.prototype as { getClientRects: () => DOMRect[] }).getClientRects = () => [
+    (Range.prototype as unknown as { getClientRects: () => DOMRect[] }).getClientRects = () => [
       rectOf(10, 10, 100, 20),
       rectOf(10, 40, 80, 20),
     ];

--- a/packages/ui/components/html-viewer/srcdoc.test.ts
+++ b/packages/ui/components/html-viewer/srcdoc.test.ts
@@ -149,6 +149,62 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     );
   }
 
+  // --- Annotation overlay helpers -------------------------------------------
+  // Committed annotation visuals live in a shadow-rooted overlay host on the
+  // root element; nothing annotation-related is written into the page's DOM.
+
+  function overlayHost(): HTMLElement | null {
+    return document.querySelector<HTMLElement>("[data-plannotator-overlay-host]");
+  }
+
+  function overlayRoot(): ParentNode | null {
+    const host = overlayHost();
+    if (!host) return null;
+    return host.shadowRoot ?? host;
+  }
+
+  function allMarkers(): HTMLButtonElement[] {
+    const root = overlayRoot();
+    if (!root) return [];
+    return Array.from(root.querySelectorAll<HTMLButtonElement>("button[data-plannotator-marker]"));
+  }
+
+  function visibleMarkers(): HTMLButtonElement[] {
+    return allMarkers().filter((b) => b.style.display !== "none");
+  }
+
+  function markersFor(id: string): HTMLButtonElement[] {
+    return visibleMarkers().filter((b) => b.getAttribute("data-annotation-id") === id);
+  }
+
+  function markerNumber(button: HTMLButtonElement): string {
+    return button.querySelector(".pn-marker-num")?.textContent ?? "";
+  }
+
+  function visibleHighlights(cls?: string): HTMLElement[] {
+    const root = overlayRoot();
+    if (!root) return [];
+    const selector = cls ? `.pn-hl.${cls}` : ".pn-hl";
+    return Array.from(root.querySelectorAll<HTMLElement>(selector)).filter(
+      (el) => el.style.display !== "none",
+    );
+  }
+
+  /** Record every element scrollIntoView lands on across one action. */
+  function collectScrollTargets(action: () => void): Element[] {
+    const scrolled: Element[] = [];
+    const original = Element.prototype.scrollIntoView;
+    Element.prototype.scrollIntoView = function (this: Element) {
+      scrolled.push(this);
+    };
+    try {
+      action();
+    } finally {
+      Element.prototype.scrollIntoView = original;
+    }
+    return scrolled;
+  }
+
   test("author root only receives --pn-* on theme flip; opt-in restores bare push", () => {
     const root = document.documentElement;
 
@@ -701,10 +757,18 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     expect(document.querySelector("[data-plannotator-vim-badge]")?.textContent)
       .toBe("VISUAL · SELECT");
     expect(window.getSelection()?.toString()).toBe("Alpha ");
+    // The committed annotation renders as an overlay marker + highlight —
+    // never as inline markup inside the page.
+    expect(markersFor("vim-committed-range").length).toBe(1);
     expect(
-      document.querySelector('[data-bind-id="vim-committed-range"]')?.textContent,
-    ).toBe("Alpha ");
+      visibleHighlights("pn-hl-comment").some(
+        (el) => el.getAttribute("data-annotation-id") === "vim-committed-range",
+      ),
+    ).toBe(true);
+    expect(document.querySelector("[data-bind-id]")).toBeNull();
+    expect(document.querySelector("mark")).toBeNull();
 
+    postBridge({ type: "plannotator-bridge-clear-marks" });
     postBridge({
       type: "plannotator-bridge-set-vim-mode",
       enabled: false,
@@ -748,10 +812,10 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     expect(document.querySelector("[data-plannotator-vim-badge]")?.textContent)
       .toBe("VISUAL BLOCK · SELECT");
     expect(window.getSelection()?.toString()).toBe("Whole block target");
-    expect(
-      document.querySelector('[data-bind-id="vim-committed-block-range"]')?.textContent,
-    ).toBe("Whole block target");
+    expect(markersFor("vim-committed-block-range").length).toBe(1);
+    expect(document.querySelector("[data-bind-id]")).toBeNull();
 
+    postBridge({ type: "plannotator-bridge-clear-marks" });
     postBridge({
       type: "plannotator-bridge-set-vim-mode",
       enabled: false,
@@ -815,7 +879,12 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
 
     postBridge({ type: "plannotator-bridge-cancel-selection" });
 
-    // Anchor-first restore: find-and-mark scoped to the resolved element.
+    // Restoration writes NOTHING into the page: every restore below must
+    // leave the author DOM byte-identical.
+    const pageSnapshot = document.body.innerHTML;
+
+    // Anchor-first restore: the resolved element owns the placed marker and
+    // the scoped text range paints the overlay highlight.
     postBridge({
       type: "plannotator-bridge-find-and-mark",
       id: "pin-restore",
@@ -823,13 +892,23 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       annotationType: "comment",
       anchor,
     });
-    const mark = document.querySelector('[data-bind-id="pin-restore"]');
-    expect(mark?.textContent).toBe("Anchor target text");
-    expect(target.contains(mark)).toBe(true);
+    expect(markersFor("pin-restore").length).toBe(1);
+    expect(
+      visibleHighlights("pn-hl-comment").some(
+        (el) => el.getAttribute("data-annotation-id") === "pin-restore",
+      ),
+    ).toBe(true);
+    // Scrolling the annotation lands on the anchored element itself.
+    const anchoredScroll = collectScrollTargets(() => {
+      postBridge({ type: "plannotator-bridge-scroll-to", id: "pin-restore" });
+    });
+    expect(anchoredScroll[0]).toBe(target);
+    expect(document.body.innerHTML).toBe(pageSnapshot);
     postBridge({ type: "plannotator-bridge-remove-mark", id: "pin-restore" });
+    expect(markersFor("pin-restore").length).toBe(0);
 
     // Text drift under a STABLE anchor (#id): the element still identifies
-    // itself, so when the text is gone everywhere it gets a numbered pin badge
+    // itself, so when the text is gone everywhere it gets a placed marker
     // (still counts as restored).
     postBridge({
       type: "plannotator-bridge-find-and-mark",
@@ -838,10 +917,12 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       annotationType: "comment",
       anchor: { selector: "#hero", tagName: "div" },
     });
-    const badge = document.querySelector<HTMLElement>("[data-plannotator-pin-badge]");
-    if (!badge) throw new Error("pin badge missing");
-    expect(badge.textContent).toBe("1");
-    expect(document.querySelector('[data-bind-id="pin-badge"]')).toBeNull();
+    const driftMarkers = markersFor("pin-badge");
+    expect(driftMarkers.length).toBe(1);
+    expect(markerNumber(driftMarkers[0]!)).toBe("1");
+    expect(driftMarkers[0]!.getAttribute("aria-label")).toBe("Comment 1");
+    expect(driftMarkers[0]!.tagName).toBe("BUTTON");
+    expect(document.body.innerHTML).toBe(pageSnapshot);
 
     // A weak anchor with NO text snapshot is rejected outright (a missing
     // snapshot is a rejection, not an exemption): restoration falls back to
@@ -853,9 +934,13 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       annotationType: "comment",
       anchor: { selector: anchor.selector, tagName: "p" },
     });
-    const fallbackMark = document.querySelector('[data-bind-id="pin-no-snapshot"]');
-    expect(fallbackMark?.textContent).toBe("Second paragraph");
-    expect(target.contains(fallbackMark)).toBe(false);
+    expect(markersFor("pin-no-snapshot").length).toBe(1);
+    const fallbackScroll = collectScrollTargets(() => {
+      postBridge({ type: "plannotator-bridge-scroll-to", id: "pin-no-snapshot" });
+    });
+    // The text was found in the SECOND paragraph, not the anchored element.
+    expect(fallbackScroll[0]?.textContent).toBe("Second paragraph");
+    expect(fallbackScroll[0]).not.toBe(target);
     postBridge({ type: "plannotator-bridge-remove-mark", id: "pin-no-snapshot" });
 
     // Fail-closed anchors: a weak selector whose text snapshot no longer
@@ -867,12 +952,16 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       annotationType: "comment",
       anchor: { selector: anchor.selector, tagName: "p", text: "Stale snapshot" },
     });
-    const staleMark = document.querySelector('[data-bind-id="pin-stale"]');
-    expect(staleMark?.textContent).toBe("Second paragraph");
-    expect(target.contains(staleMark)).toBe(false);
+    expect(markersFor("pin-stale").length).toBe(1);
+    const staleScroll = collectScrollTargets(() => {
+      postBridge({ type: "plannotator-bridge-scroll-to", id: "pin-stale" });
+    });
+    expect(staleScroll[0]?.textContent).toBe("Second paragraph");
+    expect(staleScroll[0]).not.toBe(target);
+    expect(document.body.innerHTML).toBe(pageSnapshot);
 
     postBridge({ type: "plannotator-bridge-clear-marks" });
-    expect(document.querySelector("[data-plannotator-pin-badge]")).toBeNull();
+    expect(visibleMarkers().length).toBe(0);
     postBridge({
       type: "plannotator-bridge-set-input-method",
       method: "drag",
@@ -941,16 +1030,17 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       annotationType: "comment",
       anchor: { selector: 'button[role="button"]', tagName: "button", text: "Save draft" },
     });
-    const mark = document.querySelector('[data-bind-id="role-anchor"]');
-    expect(mark?.textContent).toBe("Save draft");
-    expect(document.querySelector("button")?.contains(mark)).toBe(false);
-    expect(document.querySelector("p")?.contains(mark)).toBe(true);
-    expect(document.querySelector("[data-plannotator-pin-badge]")).toBeNull();
+    expect(markersFor("role-anchor").length).toBe(1);
+    const roleScroll = collectScrollTargets(() => {
+      postBridge({ type: "plannotator-bridge-scroll-to", id: "role-anchor" });
+    });
+    // The annotation followed the TEXT into the paragraph — never the button.
+    expect(roleScroll[0]?.tagName).toBe("P");
     postBridge({ type: "plannotator-bridge-clear-marks" });
 
     // data-* attributes ARE author-controlled identity: a data-testid anchor
     // whose text drifted still resolves, and with the text gone everywhere the
-    // element gets the pin badge.
+    // element gets the placed marker.
     document.body.innerHTML = '<div data-testid="stats">New numbers</div>';
     postBridge({
       type: "plannotator-bridge-find-and-mark",
@@ -959,9 +1049,11 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       annotationType: "comment",
       anchor: { selector: 'div[data-testid="stats"]', tagName: "div", text: "Old numbers" },
     });
-    expect(document.querySelector('[data-bind-id="data-anchor"]')).toBeNull();
-    const dataBadge = document.querySelector<HTMLElement>("[data-plannotator-pin-badge]");
-    expect(dataBadge).not.toBeNull();
+    expect(markersFor("data-anchor").length).toBe(1);
+    const dataScroll = collectScrollTargets(() => {
+      postBridge({ type: "plannotator-bridge-scroll-to", id: "data-anchor" });
+    });
+    expect(dataScroll[0]).toBe(document.querySelector('div[data-testid="stats"]'));
     postBridge({ type: "plannotator-bridge-clear-marks" });
     document.body.replaceChildren();
   });
@@ -977,8 +1069,8 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       annotationType: "comment",
       anchor: { selector: 'div[data-cy="metrics"]', tagName: "div", text: "Stale content gone from the page" },
     });
-    expect(document.querySelector('[data-bind-id="cy-anchor"]')).toBeNull();
-    expect(document.querySelector("[data-plannotator-pin-badge]")).not.toBeNull();
+    expect(markersFor("cy-anchor").length).toBe(1);
+    expect(document.querySelector("[data-bind-id]")).toBeNull();
     postBridge({ type: "plannotator-bridge-clear-marks" });
     document.body.replaceChildren();
   });
@@ -1213,7 +1305,8 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     postBridge({ type: "plannotator-bridge-cancel-selection" });
 
     // Round trip: the stable-identity anchor resolves without a text check,
-    // so the icon gets a pin badge even though text search can never succeed.
+    // so the icon gets a placed marker even though text search can never
+    // succeed ("[element: icon close]" appears nowhere in the page).
     postBridge({
       type: "plannotator-bridge-find-and-mark",
       id: "identity-pin",
@@ -1221,10 +1314,10 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       annotationType: "comment",
       anchor,
     });
-    expect(document.querySelector("[data-plannotator-pin-badge]")).not.toBeNull();
-    expect(document.querySelector('[data-bind-id="identity-pin"]')).toBeNull();
+    expect(markersFor("identity-pin").length).toBe(1);
+    expect(document.querySelector("[data-bind-id]")).toBeNull();
     postBridge({ type: "plannotator-bridge-clear-marks" });
-    expect(document.querySelector("[data-plannotator-pin-badge]")).toBeNull();
+    expect(visibleMarkers().length).toBe(0);
 
     // A text-less element with only classes (weak selector) ships NO anchor:
     // there is nothing to verify against, and a wrong-binding anchor is
@@ -1280,21 +1373,21 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
         anchor: { selector, tagName: "span", text: "" },
       });
     }
-    expect(document.querySelector("[data-plannotator-pin-badge]")).toBeNull();
+    expect(visibleMarkers().length).toBe(0);
     expect(document.querySelector("[data-bind-id]")).toBeNull();
 
     postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
     document.body.replaceChildren();
   });
 
-  test("badge click ownership is identity-gated, not selector-gated (D5)", async () => {
-    // A page element spoofing our badge attribute is NOT a viewer overlay:
+  test("marker click ownership is identity-gated, not selector-gated (D5)", async () => {
+    // A page element spoofing our marker attributes is NOT a viewer overlay:
     // it hovers and annotates like any other element.
-    document.body.innerHTML = "<div data-plannotator-pin-badge class=\"fake-badge\">7</div><p id=\"pin-me\">Pinned text</p>";
+    document.body.innerHTML = "<div data-plannotator-marker class=\"fake-marker\">7</div><p id=\"pin-me\">Pinned text</p>";
     postBridge({ type: "plannotator-bridge-set-vim-mode", enabled: false });
     postBridge({ type: "plannotator-bridge-set-input-method", method: "pinpoint" });
 
-    const spoof = document.querySelector<HTMLElement>("div.fake-badge");
+    const spoof = document.querySelector<HTMLElement>("div.fake-marker");
     if (!spoof) throw new Error("spoof fixture missing");
     hoverAt(spoof, 40, 40);
     expect(
@@ -1305,7 +1398,8 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     expect(messages.length).toBe(1);
     expect(messages[0]!.text).toBe("7");
 
-    // A REAL badge still owns its click: it posts mark-click, not a selection.
+    // A REAL placed marker owns its click: it posts mark-click (which the
+    // parent maps to focusing the annotation in the panel), not a selection.
     postBridge({
       type: "plannotator-bridge-find-and-mark",
       id: "badge-owner",
@@ -1313,10 +1407,8 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       annotationType: "comment",
       anchor: { selector: "#pin-me", tagName: "p" },
     });
-    const realBadge = document.querySelector<HTMLElement>(
-      "[data-plannotator-pin-badge]:not(.fake-badge)",
-    );
-    if (!realBadge) throw new Error("real badge missing");
+    const realMarker = markersFor("badge-owner")[0];
+    if (!realMarker) throw new Error("real marker missing");
     const collected: Array<Record<string, unknown>> = [];
     const collect = (event: MessageEvent) => {
       const data = bridgeMessageData(event);
@@ -1326,7 +1418,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       ) collected.push(data);
     };
     window.addEventListener("message", collect);
-    realBadge.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    realMarker.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
     await new Promise((resolve) => setTimeout(resolve, 0));
     window.removeEventListener("message", collect);
     expect(collected).toEqual([
@@ -1467,16 +1559,18 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       annotationType: "comment",
     });
 
-    // Primary keeps its text mark (or pin); beta + gamma each get a pin —
-    // and every badge for this annotation shows the SAME number.
-    const badges = Array.from(
-      document.querySelectorAll<HTMLElement>("[data-plannotator-pin-badge]"),
-    );
-    expect(badges.length).toBeGreaterThanOrEqual(2);
-    for (const badge of badges) expect(badge.textContent).toBe("1");
+    // Primary + beta + gamma all render placed markers under the SAME id —
+    // and every marker for this grouped annotation shows the SAME number.
+    // Numbering derives from the annotation collection, never target count.
+    const commitMarkers = markersFor("multi-commit");
+    expect(commitMarkers.length).toBeGreaterThanOrEqual(2);
+    for (const marker of commitMarkers) {
+      expect(markerNumber(marker)).toBe("1");
+      expect(marker.getAttribute("aria-label")).toBe("Comment 1");
+    }
     expect(pinnedBoxCount()).toBe(0); // draft state fully cleared
 
-    // A SECOND annotation numbers 2 — multi-target pins consumed only one slot.
+    // A SECOND annotation numbers 2 — multi-target markers consumed one slot.
     postBridge({
       type: "plannotator-bridge-find-and-mark",
       id: "second-ann",
@@ -1484,10 +1578,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       annotationType: "comment",
       anchor: { selector: "#hero", tagName: "div" },
     });
-    const allBadges = Array.from(
-      document.querySelectorAll<HTMLElement>("[data-plannotator-pin-badge]"),
-    );
-    const numbers = allBadges.map((b) => b.textContent);
+    const numbers = visibleMarkers().map((b) => markerNumber(b));
     expect(numbers).toContain("2");
     expect(numbers.filter((n) => n === "1").length).toBeGreaterThanOrEqual(2);
     expect(numbers.filter((n) => n === "2").length).toBe(1);
@@ -1513,15 +1604,18 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     expect(removals[0]!.key).toBe(primaryKey);
     expect(pinnedBoxCount()).toBe(1); // only the promoted primary's main box
 
-    // Committing now pins the PROMOTED element (beta), not alpha.
+    // Committing now marks the PROMOTED element (beta), not alpha.
     postBridge({
       type: "plannotator-bridge-create-mark",
       id: "promoted-commit",
       annotationType: "comment",
     });
-    const badge = document.querySelector<HTMLElement>("[data-plannotator-pin-badge]");
-    expect(badge).not.toBeNull();
-    expect(document.querySelector('[data-bind-id="promoted-commit"]')).toBeNull();
+    const promotedMarkers = markersFor("promoted-commit");
+    expect(promotedMarkers.length).toBe(1);
+    const promotedScroll = collectScrollTargets(() => {
+      postBridge({ type: "plannotator-bridge-scroll-to", id: "promoted-commit" });
+    });
+    expect(promotedScroll[0]).toBe(document.querySelector("p.beta"));
     postBridge({ type: "plannotator-bridge-clear-marks" });
 
     // Fresh draft with ONLY a primary: shift-clicking it cancels the draft —
@@ -1539,8 +1633,8 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       id: "cancelled-commit",
       annotationType: "comment",
     });
-    expect(document.querySelector('[data-bind-id="cancelled-commit"]')).toBeNull();
-    expect(document.querySelector("[data-plannotator-pin-badge]")).toBeNull();
+    expect(markersFor("cancelled-commit").length).toBe(0);
+    expect(visibleMarkers().length).toBe(0);
 
     postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
     document.body.replaceChildren();
@@ -1571,9 +1665,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       id: "unarmed-commit",
       annotationType: "comment",
     });
-    expect(
-      document.querySelectorAll("[data-plannotator-pin-badge]").length,
-    ).toBeLessThanOrEqual(1);
+    expect(markersFor("unarmed-commit").length).toBeLessThanOrEqual(1);
 
     postBridge({ type: "plannotator-bridge-clear-marks" });
     postBridge({ type: "plannotator-bridge-cancel-selection" });
@@ -1623,9 +1715,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       id: "stale-arm-commit",
       annotationType: "comment",
     });
-    expect(
-      document.querySelectorAll("[data-plannotator-pin-badge]").length,
-    ).toBeLessThanOrEqual(1);
+    expect(markersFor("stale-arm-commit").length).toBeLessThanOrEqual(1);
 
     postBridge({ type: "plannotator-bridge-clear-marks" });
     postBridge({ type: "plannotator-bridge-cancel-selection" });
@@ -1660,8 +1750,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       id: "resync-commit",
       annotationType: "comment",
     });
-    const badge = document.querySelector<HTMLElement>("[data-plannotator-pin-badge]");
-    expect(badge).not.toBeNull();
+    expect(markersFor("resync-commit").length).toBe(1);
     postBridge({ type: "plannotator-bridge-clear-marks" });
     postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
     void betaKey;
@@ -1739,19 +1828,26 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       ],
     });
 
-    // Primary restored as an inline mark inside alpha.
-    const mark = document.querySelector('[data-bind-id="restore-multi"]');
-    expect(mark?.textContent).toBe("Alpha text");
-    // Beta restored as a pin sharing the annotation's number; gamma failed closed.
-    const badges = Array.from(
-      document.querySelectorAll<HTMLElement>("[data-plannotator-pin-badge]"),
-    );
-    expect(badges.length).toBe(1);
-    expect(badges[0]!.textContent).toBe("1");
+    // Primary restored as an anchored element marker + overlay highlight;
+    // beta restored as a marker sharing the SAME number; gamma failed closed
+    // (stale snapshot resolves nothing — no marker, no mis-highlight).
+    const restoreMarkers = markersFor("restore-multi");
+    expect(restoreMarkers.length).toBe(2);
+    for (const marker of restoreMarkers) expect(markerNumber(marker)).toBe("1");
+    expect(
+      visibleHighlights("pn-hl-comment").some(
+        (el) => el.getAttribute("data-annotation-id") === "restore-multi",
+      ),
+    ).toBe(true);
+    expect(document.querySelector("[data-bind-id]")).toBeNull();
 
     postBridge({ type: "plannotator-bridge-remove-mark", id: "restore-multi" });
-    expect(document.querySelector('[data-bind-id="restore-multi"]')).toBeNull();
-    expect(document.querySelector("[data-plannotator-pin-badge]")).toBeNull();
+    expect(markersFor("restore-multi").length).toBe(0);
+    expect(
+      visibleHighlights().some(
+        (el) => el.getAttribute("data-annotation-id") === "restore-multi",
+      ),
+    ).toBe(false);
     document.body.replaceChildren();
   });
 

--- a/packages/ui/components/html-viewer/srcdoc.test.ts
+++ b/packages/ui/components/html-viewer/srcdoc.test.ts
@@ -2449,9 +2449,14 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       expect(markersFor("vis-ann").length).toBe(0);
       slide.style.visibility = "";
 
+      // opacity:0 deliberately does NOT hide the marker: it is the standard
+      // invisible-hit-target pattern (transparent input over a styled
+      // control) where the annotation legitimately sits over the visible
+      // control — and computed opacity doesn't inherit, so an opacity gate
+      // wouldn't catch faded containers' descendants anyway.
       slide.style.opacity = "0";
       postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
-      expect(markersFor("vis-ann").length).toBe(0);
+      expect(markersFor("vis-ann").length).toBe(1);
       slide.style.opacity = "";
 
       postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
@@ -2669,6 +2674,14 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       fixedEl.style.position = "";
       postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
       expect(markersFor("fixed-ann").length).toBe(0);
+
+      // contain:layout makes the clipper a fixed containing block: its
+      // overflow clipping then APPLIES to the fixed target again (5a).
+      fixedEl.style.position = "fixed";
+      wrap.style.contain = "layout";
+      postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+      expect(markersFor("fixed-ann").length).toBe(0);
+      wrap.style.contain = "";
     });
     postBridge({ type: "plannotator-bridge-clear-marks" });
     document.body.replaceChildren();
@@ -2910,6 +2923,44 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
         (Range.prototype as { getClientRects: typeof originalGetClientRects }).getClientRects =
           originalGetClientRects;
       }
+    });
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  test("dedup keeps the VISIBLE marker when a hidden sibling target shares the element (5b)", () => {
+    document.body.innerHTML =
+      '<div id="m10-a">First</div><div data-testid="m10-b">Second</div>';
+    postBridge({
+      type: "plannotator-bridge-find-and-mark",
+      id: "dedup-vis",
+      originalText: "Text that exists nowhere on this page",
+      annotationType: "comment",
+      anchor: { selector: "#m10-a", tagName: "div", point: { x: 0.05, y: 0.5 } },
+      additionalAnchors: [
+        { selector: 'div[data-testid="m10-b"]', tagName: "div", point: { x: 0.75, y: 0.5 } },
+      ],
+    });
+    // Both anchors re-resolve to ONE merged element inside a clipper that
+    // hides the FIRST target's point but not the second's: dedup must run
+    // among PLACED markers, keeping the visible one — not consume the
+    // element's slot on the hidden first target and render nothing.
+    document.body.innerHTML =
+      '<div id="m10-wrap"><div id="m10-a" data-testid="m10-b">Merged</div></div>';
+    const wrap = document.querySelector<HTMLElement>("#m10-wrap")!;
+    const merged = document.querySelector<HTMLElement>("#m10-a")!;
+    wrap.style.overflow = "hidden";
+    withLayout(() => {
+      wrap.getBoundingClientRect = () => rectOf(100, 0, 100, 100);
+      merged.getBoundingClientRect = () => rectOf(0, 0, 200, 50);
+      bumpDomGeneration();
+      postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+      const dedupMarkers = markersFor("dedup-vis");
+      expect(dedupMarkers.length).toBe(1);
+      // The SECOND target's point (x 0.75 -> 150px) survived; y 25 clamps
+      // to the 29px viewport inset (rendering-only clamp).
+      expect(dedupMarkers[0]!.style.left).toBe("150px");
+      expect(dedupMarkers[0]!.style.top).toBe("29px");
     });
     postBridge({ type: "plannotator-bridge-clear-marks" });
     document.body.replaceChildren();

--- a/packages/ui/components/html-viewer/srcdoc.test.ts
+++ b/packages/ui/components/html-viewer/srcdoc.test.ts
@@ -136,9 +136,46 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       : null;
   }
 
+  /** The bridge's page MutationObservers, captured at load: callback plus
+   * every observe() target. happy-dom stops delivering mutation records once
+   * the overlay host holds an SVG marker button (environment bug — see
+   * bumpDomGeneration), so observer-scope tests assert the observed target
+   * and drive the captured callback with synthetic records directly. */
+  const capturedObservers: Array<{
+    callback: (mutations: MutationRecord[], observer: MutationObserver) => void;
+    targets: Node[];
+  }> = [];
+
   beforeAll(() => {
-    new Function(BRIDGE_SCRIPT)();
+    const RealMutationObserver = globalThis.MutationObserver;
+    (globalThis as unknown as { MutationObserver: unknown }).MutationObserver =
+      class CapturingMutationObserver extends RealMutationObserver {
+        private readonly entry: { callback: MutationCallback; targets: Node[] };
+        constructor(callback: MutationCallback) {
+          super(callback);
+          this.entry = { callback, targets: [] };
+          capturedObservers.push(this.entry as (typeof capturedObservers)[number]);
+        }
+        override observe(target: Node, options?: MutationObserverInit) {
+          this.entry.targets.push(target);
+          super.observe(target, options);
+        }
+      };
+    try {
+      new Function(BRIDGE_SCRIPT)();
+    } finally {
+      (globalThis as unknown as { MutationObserver: unknown }).MutationObserver =
+        RealMutationObserver;
+    }
   });
+
+  /** Deliver synthetic mutation records straight to the bridge's page
+   * observer (bypassing happy-dom's broken delivery). */
+  function deliverPageMutations(records: Array<Partial<MutationRecord>>) {
+    const observer = capturedObservers[0];
+    if (!observer) throw new Error("bridge page observer was not captured");
+    observer.callback(records as MutationRecord[], null as unknown as MutationObserver);
+  }
 
   function postBridge(data: Record<string, unknown>) {
     window.dispatchEvent(
@@ -2543,10 +2580,14 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
           annotationType: "comment",
         });
         window.dispatchEvent(new Event("beforeprint"));
-        const layer = document.body.querySelector<HTMLElement>(
+        const layer = document.querySelector<HTMLElement>(
           "[data-plannotator-print-layer]",
         );
         if (!layer) throw new Error("print layer missing");
+        // On the ROOT element (not <body>): a page styling body
+        // { position: relative } would otherwise shift every stripe by
+        // body's document offset.
+        expect(layer.parentElement).toBe(document.documentElement);
         // Absolute (not fixed) so it paginates with the content.
         expect(layer.style.position).toBe("absolute");
         const stripes = Array.from(layer.children) as HTMLElement[];
@@ -2559,7 +2600,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
         // Highlights print; markers don't (parity with pre-overlay badges).
         expect(layer.querySelector("button")).toBeNull();
         window.dispatchEvent(new Event("afterprint"));
-        expect(document.body.querySelector("[data-plannotator-print-layer]")).toBeNull();
+        expect(document.querySelector("[data-plannotator-print-layer]")).toBeNull();
       } finally {
         (Range.prototype as { getClientRects: typeof originalGetClientRects }).getClientRects =
           originalGetClientRects;
@@ -2924,6 +2965,93 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
           originalGetClientRects;
       }
     });
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  test("the page observer watches documentElement; body swaps unlock re-search (M3 scope)", () => {
+    const observer = capturedObservers[0];
+    if (!observer) throw new Error("bridge page observer was not captured");
+    // Scope: a body-scoped observer sees NO record when the page swaps the
+    // <body> element itself (documentElement.replaceChild), permanently
+    // locking dead-target re-search behind a generation that never advances.
+    expect(observer.targets).toContain(document.documentElement);
+    for (const observed of observer.targets) {
+      expect(observed.nodeName).not.toBe("BODY");
+    }
+
+    document.body.innerHTML = "<p>Body swap text</p>";
+    postBridge({
+      type: "plannotator-bridge-find-and-mark",
+      id: "swap-ann",
+      originalText: "Body swap text",
+      annotationType: "comment",
+    });
+    expect(
+      visibleHighlights("pn-hl-comment").some(
+        (el) => el.getAttribute("data-annotation-id") === "swap-ann",
+      ),
+    ).toBe(true);
+
+    // The body is swapped for an interim skeleton: the record lands on
+    // documentElement. The free retry runs against the skeleton and fails.
+    document.body.innerHTML = "<p>interim skeleton</p>";
+    deliverPageMutations([{
+      type: "childList",
+      target: document.documentElement,
+      addedNodes: [document.body] as unknown as NodeList,
+      removedNodes: [] as unknown as NodeList,
+    }]);
+    postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+    expect(
+      visibleHighlights("pn-hl-comment").some(
+        (el) => el.getAttribute("data-annotation-id") === "swap-ann",
+      ),
+    ).toBe(false);
+
+    // Overlay-only childList writes on the root (host/label/print-layer
+    // appends) must NOT bump the generation: no re-search may run.
+    const host = overlayHost();
+    if (!host) throw new Error("overlay host missing");
+    const originalCreateTreeWalker = document.createTreeWalker.bind(document);
+    let sweeps = 0;
+    (document as { createTreeWalker: typeof document.createTreeWalker }).createTreeWalker = ((
+      ...args: Parameters<typeof document.createTreeWalker>
+    ) => {
+      sweeps += 1;
+      return originalCreateTreeWalker(...args);
+    }) as typeof document.createTreeWalker;
+    try {
+      deliverPageMutations([{
+        type: "childList",
+        target: document.documentElement,
+        addedNodes: [host] as unknown as NodeList,
+        removedNodes: [] as unknown as NodeList,
+      }]);
+      postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+      postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+      expect(sweeps).toBe(0);
+    } finally {
+      (document as { createTreeWalker: typeof document.createTreeWalker }).createTreeWalker =
+        originalCreateTreeWalker;
+    }
+
+    // The text returns inside the (new) body — inside the documentElement
+    // observer's subtree — and the next real record unlocks re-search.
+    document.body.innerHTML = "<p>Body swap text</p>";
+    deliverPageMutations([{
+      type: "childList",
+      target: document.documentElement,
+      addedNodes: [document.body] as unknown as NodeList,
+      removedNodes: [] as unknown as NodeList,
+    }]);
+    postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+    expect(
+      visibleHighlights("pn-hl-comment").some(
+        (el) => el.getAttribute("data-annotation-id") === "swap-ann",
+      ),
+    ).toBe(true);
+
     postBridge({ type: "plannotator-bridge-clear-marks" });
     document.body.replaceChildren();
   });

--- a/packages/ui/components/html-viewer/srcdoc.test.ts
+++ b/packages/ui/components/html-viewer/srcdoc.test.ts
@@ -2014,6 +2014,16 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
+  /** Advance the bridge's re-search generation like a real invalidation
+   * signal would. Dead-target re-resolution is generation-gated (M3): only
+   * text-capable signals (page mutations, settle events, frame loads) unlock
+   * it. happy-dom's MutationObserver stops delivering once the overlay host
+   * holds an SVG marker (environment bug — real browsers are unaffected), so
+   * tests use the settle-event signal, which is synchronous and equivalent. */
+  function bumpDomGeneration() {
+    document.body.dispatchEvent(new Event("animationend", { bubbles: true }));
+  }
+
   test("unresolved targets omit their markers instead of guessing", () => {
     document.body.innerHTML = '<div data-testid="vanishing">Now you see me</div>';
     postBridge({
@@ -2028,11 +2038,13 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     // The page rerenders without the element: the anchor no longer resolves,
     // so the marker is omitted — never left floating over unrelated content.
     document.body.innerHTML = "<p>Completely different content</p>";
+    bumpDomGeneration();
     postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
     expect(markersFor("vanish-ann").length).toBe(0);
     // The annotation record survives (it stays reachable via the panel), so
     // a page that brings the element back re-resolves and re-renders it.
     document.body.innerHTML = '<div data-testid="vanishing">Back again</div>';
+    bumpDomGeneration();
     postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
     expect(markersFor("vanish-ann").length).toBe(1);
 
@@ -2086,8 +2098,12 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       expect(clamped[0]!.style.left).toBe("29px");
       expect(clamped[0]!.style.top).toBe("60px");
 
-      // A 4px corner sliver cannot host a clamped marker without visually
-      // detaching from it (29 - 4 > tolerance): omit rather than guess.
+      // A fully visible 4px corner sliver still gets its marker: viewport
+      // edges CLAMP, never omit (per the contract only clip-container
+      // detachment omits). The raw point (2,4) sits inside the visible rect,
+      // so association holds and the 29px inset is rendering-only. The old
+      // behavior measured association AFTER clamping, creating a dead band
+      // where fully visible edge-flush elements lost their markers.
       sliver.getBoundingClientRect = () => rectOf(0, 2, 4, 4);
       postBridge({
         type: "plannotator-bridge-find-and-mark",
@@ -2096,7 +2112,10 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
         annotationType: "comment",
         anchor: { selector: "#sliver", tagName: "div" },
       });
-      expect(markersFor("sliver-ann").length).toBe(0);
+      const sliverMarkers = markersFor("sliver-ann");
+      expect(sliverMarkers.length).toBe(1);
+      expect(sliverMarkers[0]!.style.left).toBe("29px");
+      expect(sliverMarkers[0]!.style.top).toBe("29px");
     });
     postBridge({ type: "plannotator-bridge-clear-marks" });
     document.body.replaceChildren();

--- a/packages/ui/components/html-viewer/useHtmlAnnotation.ts
+++ b/packages/ui/components/html-viewer/useHtmlAnnotation.ts
@@ -132,6 +132,27 @@ export function capSelectionText(text: string): string {
   return text.slice(0, cut);
 }
 
+/**
+ * Validate a bridge-posted normalized marker point. Fail-closed but additive:
+ * a malformed point is DROPPED (the marker falls back to the target-rect
+ * default) without rejecting the anchor it rides on; finite values are
+ * clamped into the normalized 0..1 range.
+ */
+function parseAnchorPoint(value: unknown): { x: number; y: number } | undefined {
+  if (!isRecord(value)) return undefined;
+  const { x, y } = value;
+  if (
+    typeof x !== "number" || !Number.isFinite(x)
+    || typeof y !== "number" || !Number.isFinite(y)
+  ) {
+    return undefined;
+  }
+  return {
+    x: Math.min(1, Math.max(0, x)),
+    y: Math.min(1, Math.max(0, y)),
+  };
+}
+
 /** Validate a bridge-posted element anchor. Exported for protocol tests. */
 export function parseHtmlElementAnchor(value: unknown): HtmlElementAnchor | null {
   if (!isRecord(value)) return null;
@@ -146,9 +167,10 @@ export function parseHtmlElementAnchor(value: unknown): HtmlElementAnchor | null
   ) {
     return null;
   }
-  if (text === undefined) return { selector, tagName };
+  const point = parseAnchorPoint(value.point);
+  if (text === undefined) return { selector, tagName, ...(point ? { point } : {}) };
   if (typeof text !== "string" || text.length > MAX_ANCHOR_TEXT_LENGTH) return null;
-  return { selector, tagName, text };
+  return { selector, tagName, text, ...(point ? { point } : {}) };
 }
 
 function parseTargetKey(value: unknown): string | null {

--- a/packages/ui/components/html-viewer/useHtmlAnnotation.ts
+++ b/packages/ui/components/html-viewer/useHtmlAnnotation.ts
@@ -252,7 +252,10 @@ export function parseBridgeMessage(value: unknown): BridgeMessage | null {
         ? { type: value.type, key: value.key }
         : null;
     case `${PREFIX}mark-click`:
-      return typeof value.id === "string"
+      // The id is page-controlled like every other bridge string: cap it like
+      // the bridge's own sync validation does (256) so a hostile page cannot
+      // ship an unbounded string into parent state via a forged mark-click.
+      return typeof value.id === "string" && value.id.length <= 256
         ? { type: value.type, id: value.id }
         : null;
     case `${PREFIX}resize`:

--- a/packages/ui/types.ts
+++ b/packages/ui/types.ts
@@ -97,6 +97,15 @@ export interface HtmlElementAnchor {
   selector: string;
   tagName: string;
   text?: string;
+  /**
+   * The user's selected point inside the target element's rect, normalized to
+   * 0..1 on each axis. Placed comment markers reproject it against the
+   * element's CURRENT rect, so the marker follows the element through
+   * responsive movement instead of pinning stale pixels. Additive — anchors
+   * without one (older records, keyboard-driven selections) fall back to the
+   * target rect center.
+   */
+  point?: { x: number; y: number };
 }
 
 /**


### PR DESCRIPTION
**TLDR:** Raw-HTML annotate no longer writes highlight state into the page's DOM. Annotations are now rendered as placed comment markers: numbered bubble buttons projected into a fixed, pointer-transparent overlay, positioned at the exact point you selected, re-resolved live as the page scrolls, mutates, or reflows. This fixes both reported highlight bugs (partial blue on multi-paragraph selections, and layout breakage on some pages) at their shared root cause, because nothing mutates author content anymore.

> Label: AI-assisted. Implemented and hardened by agents under maintainer direction; adversarially reviewed in three passes before this PR was opened.

## What changed

- **Durable anchor vs disposable marker.** The persisted thing is the anchor (`HtmlElementAnchor`, extended with an optional normalized `point` capturing where inside the target you clicked). The visible bubble is a projection computed fresh every frame from the re-resolved live target. Nothing ever restores stored screen coordinates.
- **Overlay host.** A shadow-rooted fixed host on `documentElement` (`pointer-events: none`, maximal z-index) contains highlight rects and marker buttons. Only marker buttons accept pointer input; the page never reflows or shifts.
- **Markers.** Real `<button>`s with Plannotator-branded SVG speech bubbles, accessible labels (`Comment N`), centered on the selected relative point via `translate(-50%, -50%)`. Grouped (shift-click multi-target) annotations show the same number on every target. Clicking a marker, or the highlighted text itself, selects the annotation in the panel.
- **Geometry discipline.** Reprojection preserves your selected point through rerenders and responsive movement. Markers and highlight rects are clip-tested against scroll containers; unresolved or visually detached targets omit their marker rather than guessing. Viewport edges clamp (29px inset); coincident markers spread deterministically (12.5px steps). Invalidation is rAF-coalesced off mutations, scroll, resize, animation settle, font and image loads; dead-target re-search is generation-gated so stale annotations cannot trigger per-frame document scans.
- **Selection highlights** (committed, focus flash, drafts) are overlay-projected rects from `getClientRects`, clip-tested, with a containment filter that removes double-painted border boxes on multi-block redlines.
- **Print parity.** Committed highlights still print (as before), via a temporary absolute-coordinate print layer built on `beforeprint`; markers stay print-hidden like the old badges.
- **Protocol.** New parent-to-bridge `sync-annotations` message (parent-authoritative numbering, bounded 512 both sides, shape-validated); anchor `point` validated fail-closed on both sides; `mark-click` ids capped at 256. The point field is placement-only and cannot influence element resolution.

## What did not change

- Markdown annotate mode, plan review, and code review are untouched.
- The shift-click multi-select contracts (arm handshake, per-draft arming reset, 16-target caps on both sides, primary promotion, composer yield, first-keystroke guard) and the pinpoint hit-testing rework are preserved and re-verified by their suites.
- Anchors remain fail-closed: an unresolvable anchor means no marker, never a guess; the annotation stays reachable from the panel.

## Review process

Three adversarial review lenses (geometry/lifecycle, protocol/security against hostile documents, regressions/test honesty) produced 6 majors and 12 minors; all were fixed, then a dedicated verification pass audited the fix commits themselves and found 1 major and 3 minors, also fixed. 28 targeted mutations were used to prove the new regression tests fail against broken code.

## Validation

- `bun run typecheck` clean
- Full `bun test`: 3144 pass, 0 fail
- CI-shaped DOM runs (`DOM_TESTS=1`): 175 + 6 + 8 pass, 0 fail; srcdoc suite 39 to 66 tests, protocol suite 30 to 40
- Bridge template-string constraints verified by parsing the emitted script (no backticks, no `${`)

Known trade-offs, documented in code: happy-dom cannot exercise real multi-line client rects or `elementFromPoint`, so a manual browser pass on pages with nested scrollers, sticky targets, and zoom is recommended before release; annotations past 512 fall back to registration-order numbering.
