### PR TITLE
fix: QA-gate hardening for the v0.26.8 feature set (overlay perf, numbering, OpenCode 2 parity)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -510,8 +510,22 @@ interface Annotation {
   source?: string; // External tool identifier (e.g., "eslint") — set when annotation comes from external API
   diffContext?: 'added' | 'removed' | 'modified'; // Set when annotation created in plan diff view
   htmlAnchor?: HtmlElementAnchor; // Raw-HTML pinpoint: serialized element anchor for reliable restoration
+  htmlAdditionalTargets?: HtmlAnnotationTarget[]; // Raw-HTML shift-click multi-select: extra elements this one comment covers
   startMeta?: { parentTagName; parentIndex; textOffset };
   endMeta?: { parentTagName; parentIndex; textOffset };
+}
+
+interface HtmlElementAnchor {
+  selector: string; // verified-unique CSS selector built in the viewer bridge
+  tagName: string;
+  text?: string; // normalized text snapshot; weak selectors fail closed against it
+  point?: { x: number; y: number }; // normalized (0..1) selected point inside the element's rect, used by placed markers to reproject against the element's current geometry
+}
+
+interface HtmlAnnotationTarget {
+  label?: string; // semantic label from the pinpoint hover cascade (e.g. "Button")
+  text: string; // capped element text, or an element description when text-less
+  anchor?: HtmlElementAnchor; // absent when anchoring failed closed
 }
 
 interface Block {
@@ -550,6 +564,10 @@ interface Block {
 **Redline mode:** User selects text → auto-creates DELETION annotation
 
 Text highlighting uses `web-highlighter` library. Code blocks use manual `<mark>` wrapping (web-highlighter can't select inside `<pre>`).
+
+**Raw-HTML annotate:** the sandboxed viewer never mutates the visited page's DOM. Committed annotations render as numbered placed comment markers plus overlay-projected highlight rectangles inside a shadow-rooted fixed overlay host: the durable anchor data (element selector, text snapshot, normalized selected point) is persisted, and the markers/highlights are disposable projections re-resolved from it on every reconcile. Shift-click multi-select joins additional elements to one comment (`htmlAdditionalTargets`).
+
+Known limitation: printing a raw-HTML annotate session prints highlight stripes from a best-effort absolute-coordinate layer and is degraded inside the iframe (pre-existing); element-only targets (SVG anchors, multi-select additional element targets) have no print representation.
 
 ## Keyboard Shortcuts
 
@@ -606,6 +624,8 @@ type ShareableAnnotation =
 2. Find text positions in rendered DOM via text search
 3. Apply `<mark>` highlights
 4. Clear hash from URL (prevents re-parse on refresh)
+
+Known limitation: share links intentionally do not carry HTML element anchors or additional multi-select targets. Restore on the raw-HTML surface is text-search based; this is the contract asserted by `sharing.multiTarget.test.ts`.
 
 ## Settings Persistence
 

--- a/apps/opencode-plugin/server.test.ts
+++ b/apps/opencode-plugin/server.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import serverPlugin from "./server";
+import serverPlugin, {
+  pushComposedSystemReminder,
+  replacePlanningSystemParts,
+} from "./server";
 
 const originalAllowSubagents = process.env.PLANNOTATOR_ALLOW_SUBAGENTS;
 
@@ -136,13 +139,18 @@ describe("OpenCode V2 server plugin", () => {
     };
     await hook?.(planningEvent);
 
-    expect(planningEvent.system.slice(0, 2).map((part) => part.text)).toEqual([
-      "Base system prompt",
-      "Earlier plugin prompt",
-    ]);
-    expect(planningEvent.system.some((part) => part.text.startsWith("## Plannotator"))).toBe(true);
-    expect(planningEvent.system[0]?.metadata).toEqual({ source: "base" });
-    expect(planningEvent.system[1]?.cache).toEqual({ type: "ephemeral" });
+    // #1114: the planning path emits ONE composed system part (multi-part
+    // system arrays corrupt Qwen3.x Jinja chat templates). Existing text
+    // survives, in order, ahead of the planning prompt.
+    expect(planningEvent.system.length).toBe(1);
+    const composedText = planningEvent.system[0]!.text;
+    expect(composedText).toContain("Base system prompt");
+    expect(composedText).toContain("Earlier plugin prompt");
+    expect(composedText).toContain("## Plannotator");
+    expect(composedText.indexOf("Base system prompt"))
+      .toBeLessThan(composedText.indexOf("Earlier plugin prompt"));
+    expect(composedText.indexOf("Earlier plugin prompt"))
+      .toBeLessThan(composedText.indexOf("## Plannotator"));
     expect(planningEvent.tools.plan_exit.description).toContain("Use submit_plan instead");
     expect(planningEvent.tools.todowrite.description).toContain("use submit_plan instead");
 
@@ -190,5 +198,68 @@ describe("OpenCode V2 server plugin", () => {
 
     await testContext.getSessionContextHook()?.(event);
     expect(event.tools.submit_plan).toBeUndefined();
+  });
+
+  test("generic reminder composes into the existing part instead of pushing a second one", async () => {
+    process.env.PLANNOTATOR_ALLOW_SUBAGENTS = "1";
+    const testContext = createContext(
+      { workflow: "all-agents" },
+      [{ id: "helper", mode: "primary", hidden: false }],
+    );
+    await serverPlugin.setup(testContext.context as never);
+    const event = {
+      agent: "helper",
+      system: [{ type: "text" as const, text: "Base system prompt" }],
+      messages: [],
+      tools: {
+        submit_plan: { description: "Submit", input: {} },
+      },
+    };
+
+    await testContext.getSessionContextHook()?.(event);
+    // #1114: a second system part corrupts Qwen3.x Jinja templates.
+    expect(event.system.length).toBe(1);
+    expect(event.system[0]!.text).toContain("Base system prompt");
+    expect(event.system[0]!.text).toContain("## Plan Submission");
+    expect(event.system[0]!.text.indexOf("Base system prompt"))
+      .toBeLessThan(event.system[0]!.text.indexOf("## Plan Submission"));
+  });
+});
+
+describe("system part consolidation (#1114 regression class)", () => {
+  // The bug class flagged in #1114's review: truncating the system array
+  // BEFORE composing silently drops the host's entire system prompt. These
+  // fail if either helper is reordered to `system.length = 0` first.
+
+  test("replacePlanningSystemParts composes existing text before truncating", () => {
+    const system = [
+      { type: "text" as const, text: "Host base rules" },
+      { type: "text" as const, text: "STRICTLY FORBIDDEN: ANY file edits.\nKeep plans concise." },
+    ];
+    replacePlanningSystemParts(system, ["## Plannotator planning prompt"]);
+    expect(system.length).toBe(1);
+    const text = system[0]!.text;
+    // Pre-existing prompt text survives the consolidation (compose ran first).
+    expect(text).toContain("Host base rules");
+    expect(text).toContain("Keep plans concise.");
+    expect(text).toContain("## Plannotator planning prompt");
+    expect(text.indexOf("Host base rules")).toBeLessThan(text.indexOf("Keep plans concise."));
+    expect(text.indexOf("Keep plans concise.")).toBeLessThan(text.indexOf("## Plannotator planning prompt"));
+    // Conflicting plan-mode rules are still stripped.
+    expect(text).not.toContain("STRICTLY FORBIDDEN");
+  });
+
+  test("pushComposedSystemReminder keeps prior parts' text before the reminder", () => {
+    const system = [
+      { type: "text" as const, text: "Host base rules" },
+      { type: "text" as const, text: "Second host part" },
+    ];
+    pushComposedSystemReminder(system, "## Plan Submission reminder");
+    expect(system.length).toBe(1);
+    const text = system[0]!.text;
+    expect(text).toContain("Host base rules");
+    expect(text).toContain("Second host part");
+    expect(text.endsWith("## Plan Submission reminder")).toBe(true);
+    expect(text.indexOf("Host base rules")).toBeLessThan(text.indexOf("Second host part"));
   });
 });

--- a/apps/opencode-plugin/server.ts
+++ b/apps/opencode-plugin/server.ts
@@ -5,7 +5,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { loadConfig, resolveSharingEnabled } from "@plannotator/shared/config";
 import { readImprovementHook } from "@plannotator/shared/improvement-hooks";
 import { composeImproveContext } from "@plannotator/shared/pfm-reminder";
-import { stripConflictingPlanModeRules } from "./plan-mode";
+import { composeSystemPrompt, stripConflictingPlanModeRules } from "./plan-mode";
 import {
   isPlanningAgent,
   normalizeWorkflowOptions,
@@ -129,7 +129,7 @@ const serverPlugin = {
           workflowOptions,
         )) return;
 
-        event.system.push({ type: "text", text: getGenericPlanReminder() });
+        pushComposedSystemReminder(event.system, getGenericPlanReminder());
       });
     }
 
@@ -344,19 +344,40 @@ async function runPlanReview(input: {
   });
 }
 
-function replacePlanningSystemParts(
-  system: Array<{ type: "text"; text: string; [key: string]: unknown }>,
+type SystemPart = { type: "text"; text: string; [key: string]: unknown };
+
+/**
+ * Replace the system array with ONE composed text part (#1114): multiple
+ * system parts corrupt Qwen3.x Jinja chat templates, which render each part
+ * as its own system message. Mirrors the V1 entry (index.ts) exactly —
+ * stripped existing text first, then the additions, joined by blank lines.
+ *
+ * Order matters: the existing texts are read and composed BEFORE the array is
+ * truncated. Reordering to `system.length = 0` first silently drops the
+ * host's entire system prompt (the bug class flagged in #1114's review).
+ */
+export function replacePlanningSystemParts(
+  system: SystemPart[],
   additions: string[],
 ): void {
-  const existing = system.flatMap((part) => {
-    const text = stripConflictingPlanModeRules([part.text])[0];
-    return text ? [{ ...part, text }] : [];
-  });
+  const stripped = stripConflictingPlanModeRules(system.map((part) => part.text));
+  const composed = composeSystemPrompt([], [...stripped, ...additions.filter(Boolean)]);
   system.length = 0;
-  system.push(
-    ...existing,
-    ...additions.filter(Boolean).map((text) => ({ type: "text" as const, text })),
-  );
+  system.push(...composed.map((text) => ({ type: "text" as const, text })));
+}
+
+/**
+ * Append a reminder by composing it into a single system part (#1114) instead
+ * of pushing a separate part — same Jinja-template rationale as above, and
+ * the same compose-before-truncate ordering requirement.
+ */
+export function pushComposedSystemReminder(
+  system: SystemPart[],
+  reminder: string,
+): void {
+  const composed = composeSystemPrompt(system.map((part) => part.text), [reminder]);
+  system.length = 0;
+  system.push(...composed.map((text) => ({ type: "text" as const, text })));
 }
 
 function replaceStrictPlanReminder(messages: unknown[]): void {

--- a/apps/opencode-plugin/server.ts
+++ b/apps/opencode-plugin/server.ts
@@ -355,6 +355,9 @@ type SystemPart = { type: "text"; text: string; [key: string]: unknown };
  * Order matters: the existing texts are read and composed BEFORE the array is
  * truncated. Reordering to `system.length = 0` first silently drops the
  * host's entire system prompt (the bug class flagged in #1114's review).
+ *
+ * Accepted trade-off: consolidation flattens per-part metadata (e.g.
+ * third-party cache hints) — template integrity beats part-level caching.
  */
 export function replacePlanningSystemParts(
   system: SystemPart[],

--- a/bun.lock
+++ b/bun.lock
@@ -63,7 +63,7 @@
     },
     "apps/opencode-plugin": {
       "name": "@plannotator/opencode",
-      "version": "0.26.1",
+      "version": "0.26.7",
       "devDependencies": {
         "@opencode-ai/plugin": "0.0.0-next-16775",
         "@plannotator/server": "workspace:*",
@@ -80,7 +80,7 @@
     },
     "apps/pi-extension": {
       "name": "@plannotator/pi-extension",
-      "version": "0.26.1",
+      "version": "0.26.7",
       "dependencies": {
         "@joplin/turndown-plugin-gfm": "^1.0.64",
         "@pierre/diffs": "1.3.2",
@@ -218,7 +218,7 @@
     },
     "packages/server": {
       "name": "@plannotator/server",
-      "version": "0.26.1",
+      "version": "0.26.7",
       "dependencies": {
         "@pierre/diffs": "1.3.2",
         "@plannotator/ai": "workspace:*",

--- a/packages/ui/components/html-viewer/HtmlViewer.tsx
+++ b/packages/ui/components/html-viewer/HtmlViewer.tsx
@@ -440,7 +440,8 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
 
     // Placed-marker numbering is parent-authoritative and matches the
     // numbers exportAnnotations writes into the submitted feedback: the full
-    // createdA-sorted list INCLUDING globals is numbered index + 1, and
+    // list INCLUDING globals is numbered by ARRAY position (the export's
+    // effective order — its sort keys tie for raw-HTML annotations), and
     // globals then ship no entry (no page location) — see buildSyncNumbering
     // for the contract. Renumbers on delete; the bridge's own registration
     // order is only a pre-sync fallback.

--- a/packages/ui/components/html-viewer/HtmlViewer.tsx
+++ b/packages/ui/components/html-viewer/HtmlViewer.tsx
@@ -37,6 +37,7 @@ import {
   distanceToRect,
   type ComposerYieldState,
 } from "./composerYield";
+import { buildSyncNumbering } from "./annotationNumbering";
 import { useHtmlAnnotation } from "./useHtmlAnnotation";
 import {
   THEME_TOKENS,
@@ -47,12 +48,6 @@ import {
 } from "./srcdoc";
 
 const PREFIX = "plannotator-bridge-";
-
-// Mirror of the bridge's MAX_SYNC_ANNOTATIONS: the bridge truncates the
-// synced numbering list at this bound, so the sender truncates AFTER the
-// stable sort too — the first 512 numbers then agree on both sides instead
-// of the bridge silently dropping an arbitrary tail.
-const MAX_SYNC_ANNOTATIONS = 512;
 
 function readThemeTokens(): Record<string, string> {
   const style = getComputedStyle(document.documentElement);
@@ -443,20 +438,16 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
       }
     }, [iframeReadyVersion]); // eslint-disable-line react-hooks/exhaustive-deps
 
-    // Placed-marker numbering is parent-authoritative: sync the ORDERED
-    // saved-annotation collection (the panel's createdA order, index + 1,
-    // global comments excluded — they have no page location) so every marker
-    // shows its annotation's display number, and renumbers on delete. The
-    // bridge's own registration order is only a pre-sync fallback.
+    // Placed-marker numbering is parent-authoritative and matches the
+    // numbers exportAnnotations writes into the submitted feedback: the full
+    // createdA-sorted list INCLUDING globals is numbered index + 1, and
+    // globals then ship no entry (no page location) — see buildSyncNumbering
+    // for the contract. Renumbers on delete; the bridge's own registration
+    // order is only a pre-sync fallback.
     useEffect(() => {
       if (iframeReadyVersion === 0) return;
-      const ordered = annotations
-        .filter((ann) => ann.type !== AnnotationType.GLOBAL_COMMENT)
-        .sort((a, b) => a.createdA - b.createdA)
-        .slice(0, MAX_SYNC_ANNOTATIONS)
-        .map((ann, index) => ({ id: ann.id, number: index + 1 }));
       iframeRef.current?.contentWindow?.postMessage(
-        { type: `${PREFIX}sync-annotations`, annotations: ordered },
+        { type: `${PREFIX}sync-annotations`, annotations: buildSyncNumbering(annotations) },
         "*",
       );
     }, [iframeReadyVersion, annotations]);

--- a/packages/ui/components/html-viewer/annotationNumbering.test.ts
+++ b/packages/ui/components/html-viewer/annotationNumbering.test.ts
@@ -1,0 +1,105 @@
+/**
+ * On-page marker numbers must agree with the numbers the agent reads:
+ * exportAnnotations (packages/ui/utils/parser.ts) numbers `## N.` sections
+ * across the FULL annotation list including global comments, so the sync
+ * payload must derive each marker's number from that same ordering. A sync
+ * that excludes globals BEFORE numbering makes on-page "Comment 2" read
+ * `## 3.` in the feedback — the exact confusion this suite guards against.
+ */
+import { describe, expect, test } from "bun:test";
+import type { Annotation } from "../../types";
+import { AnnotationType } from "../../types";
+import { exportAnnotations } from "../../utils/parser";
+import { MAX_SYNC_ANNOTATIONS, buildSyncNumbering } from "./annotationNumbering";
+
+function htmlComment(id: string, createdA: number, originalText: string): Annotation {
+  return {
+    id,
+    blockId: "",
+    startOffset: 0,
+    endOffset: 0,
+    type: AnnotationType.COMMENT,
+    text: `note about ${originalText}`,
+    originalText,
+    createdA,
+  } as Annotation;
+}
+
+function globalComment(id: string, createdA: number, text: string): Annotation {
+  return {
+    id,
+    blockId: "",
+    startOffset: 0,
+    endOffset: 0,
+    type: AnnotationType.GLOBAL_COMMENT,
+    text,
+    originalText: "",
+    createdA,
+  } as Annotation;
+}
+
+/** The `## N.` number of the export section containing `needle`. */
+function exportNumberOf(output: string, needle: string): number {
+  const sections = output.split(/^## /m).slice(1);
+  const section = sections.find((s) => s.includes(needle));
+  if (!section) throw new Error(`no export section contains: ${needle}`);
+  return Number.parseInt(section, 10);
+}
+
+describe("buildSyncNumbering", () => {
+  test("a mixed list yields on-page numbers identical to exportAnnotations output", () => {
+    const annotations = [
+      htmlComment("ann-a", 100, "alpha passage"),
+      globalComment("glob", 200, "overall global note"),
+      htmlComment("ann-b", 300, "beta passage"),
+    ];
+
+    const payload = buildSyncNumbering(annotations);
+    // Globals occupy a number but ship no entry (no page location): the
+    // on-page markers show 1 and 3, leaving the gap where the global sits.
+    expect(payload).toEqual([
+      { id: "ann-a", number: 1 },
+      { id: "ann-b", number: 3 },
+    ]);
+
+    const output = exportAnnotations([], annotations, [], "Plan Feedback", "plan");
+    expect(exportNumberOf(output, "alpha passage")).toBe(1);
+    expect(exportNumberOf(output, "overall global note")).toBe(2);
+    expect(exportNumberOf(output, "beta passage")).toBe(3);
+
+    // The payload numbers ARE the export numbers, entry by entry.
+    const needleById: Record<string, string> = {
+      "ann-a": "alpha passage",
+      "ann-b": "beta passage",
+    };
+    for (const entry of payload) {
+      expect(exportNumberOf(output, needleById[entry.id]!)).toBe(entry.number);
+    }
+  });
+
+  test("numbers follow createdA order, not array order", () => {
+    const annotations = [
+      htmlComment("late", 300, "late passage"),
+      globalComment("glob", 100, "first global"),
+      htmlComment("early", 200, "early passage"),
+    ];
+    expect(buildSyncNumbering(annotations)).toEqual([
+      { id: "early", number: 2 },
+      { id: "late", number: 3 },
+    ]);
+  });
+
+  test("truncates AFTER the stable sort at the bridge cap", () => {
+    const annotations = Array.from({ length: MAX_SYNC_ANNOTATIONS + 8 }, (_, i) =>
+      htmlComment(`bulk-${i}`, 1000 - i, `passage ${i}`),
+    );
+    const payload = buildSyncNumbering(annotations);
+    expect(payload.length).toBe(MAX_SYNC_ANNOTATIONS);
+    // Oldest annotation (highest index, lowest createdA) survives as number 1.
+    expect(payload[0]).toEqual({ id: `bulk-${MAX_SYNC_ANNOTATIONS + 7}`, number: 1 });
+    expect(payload[MAX_SYNC_ANNOTATIONS - 1]).toEqual({
+      id: "bulk-8",
+      number: MAX_SYNC_ANNOTATIONS,
+    });
+  });
+});

--- a/packages/ui/components/html-viewer/annotationNumbering.test.ts
+++ b/packages/ui/components/html-viewer/annotationNumbering.test.ts
@@ -77,29 +77,61 @@ describe("buildSyncNumbering", () => {
     }
   });
 
-  test("numbers follow createdA order, not array order", () => {
+  test("interleaved external annotations: numbers follow ARRAY order and agree with the export", () => {
+    // External annotations arrive with server-stamped createdA values that
+    // can interleave with local timestamps, but they are APPENDED to the
+    // combined list — and exportAnnotations' sort keys tie for every
+    // raw-HTML annotation (blockId "", startOffset 0), so the export numbers
+    // the ARRAY order. A createdA sort here would renumber the external
+    // annotation 2 while the export calls it `## 3.`.
+    const external = {
+      ...htmlComment("ext", 200, "external passage"),
+      source: "eslint",
+    } as Annotation;
     const annotations = [
-      htmlComment("late", 300, "late passage"),
-      globalComment("glob", 100, "first global"),
-      htmlComment("early", 200, "early passage"),
+      htmlComment("loc-a", 100, "alpha passage"),
+      htmlComment("loc-b", 300, "beta passage"),
+      external, // appended after loc-b despite the earlier createdA
     ];
-    expect(buildSyncNumbering(annotations)).toEqual([
-      { id: "early", number: 2 },
-      { id: "late", number: 3 },
+
+    const payload = buildSyncNumbering(annotations);
+    expect(payload).toEqual([
+      { id: "loc-a", number: 1 },
+      { id: "loc-b", number: 2 },
+      { id: "ext", number: 3 },
     ]);
+
+    const output = exportAnnotations([], annotations, [], "Plan Feedback", "plan");
+    expect(exportNumberOf(output, "alpha passage")).toBe(1);
+    expect(exportNumberOf(output, "beta passage")).toBe(2);
+    expect(exportNumberOf(output, "external passage")).toBe(3);
+    const needleById: Record<string, string> = {
+      "loc-a": "alpha passage",
+      "loc-b": "beta passage",
+      ext: "external passage",
+    };
+    for (const entry of payload) {
+      expect(exportNumberOf(output, needleById[entry.id]!)).toBe(entry.number);
+    }
   });
 
-  test("truncates AFTER the stable sort at the bridge cap", () => {
-    const annotations = Array.from({ length: MAX_SYNC_ANNOTATIONS + 8 }, (_, i) =>
-      htmlComment(`bulk-${i}`, 1000 - i, `passage ${i}`),
-    );
+  test("the entry cap applies AFTER dropping globals, so globals never waste sync capacity", () => {
+    // One global up front plus MAX + 1 non-globals: the global occupies
+    // number 1 but ships no entry, and the cap keeps a full 512 non-globals
+    // — including the one the export numbers at position 513. Slicing before
+    // the filter would ship only 511 non-globals and strand that entry.
+    const annotations: Annotation[] = [
+      globalComment("glob", 0, "leading global"),
+      ...Array.from({ length: MAX_SYNC_ANNOTATIONS + 1 }, (_, i) =>
+        htmlComment(`bulk-${i}`, i + 1, `passage ${i}`),
+      ),
+    ];
     const payload = buildSyncNumbering(annotations);
     expect(payload.length).toBe(MAX_SYNC_ANNOTATIONS);
-    // Oldest annotation (highest index, lowest createdA) survives as number 1.
-    expect(payload[0]).toEqual({ id: `bulk-${MAX_SYNC_ANNOTATIONS + 7}`, number: 1 });
+    expect(payload[0]).toEqual({ id: "bulk-0", number: 2 });
     expect(payload[MAX_SYNC_ANNOTATIONS - 1]).toEqual({
-      id: "bulk-8",
-      number: MAX_SYNC_ANNOTATIONS,
+      id: `bulk-${MAX_SYNC_ANNOTATIONS - 1}`,
+      number: MAX_SYNC_ANNOTATIONS + 1,
     });
   });
 });

--- a/packages/ui/components/html-viewer/annotationNumbering.ts
+++ b/packages/ui/components/html-viewer/annotationNumbering.ts
@@ -1,0 +1,29 @@
+import type { Annotation } from "../../types";
+import { AnnotationType } from "../../types";
+
+/** Mirror of the bridge's MAX_SYNC_ANNOTATIONS: the bridge truncates the
+ * synced numbering list at this bound, so the sender truncates AFTER the
+ * stable sort too — the first 512 numbers then agree on both sides instead
+ * of the bridge silently dropping an arbitrary tail. */
+export const MAX_SYNC_ANNOTATIONS = 512;
+
+/**
+ * Placed-marker numbers for the bridge sync, derived from the SAME ordering
+ * `exportAnnotations` (packages/ui/utils/parser.ts) numbers the submitted
+ * feedback with: the FULL createdA-sorted list INCLUDING global comments.
+ * Global comments occupy a number (they get their own `## N.` section in the
+ * feedback) but ship no sync entry — they have no page location — so the
+ * on-page numbers show gaps where globals sit. That is correct: an on-page
+ * "Comment 3" must read `## 3.` in the feedback the agent receives, never
+ * shift down because a global comment sat between them.
+ */
+export function buildSyncNumbering(
+  annotations: readonly Annotation[],
+): Array<{ id: string; number: number }> {
+  return [...annotations]
+    .sort((a, b) => a.createdA - b.createdA)
+    .slice(0, MAX_SYNC_ANNOTATIONS)
+    .map((ann, index) => ({ ann, number: index + 1 }))
+    .filter(({ ann }) => ann.type !== AnnotationType.GLOBAL_COMMENT)
+    .map(({ ann, number }) => ({ id: ann.id, number }));
+}

--- a/packages/ui/components/html-viewer/annotationNumbering.ts
+++ b/packages/ui/components/html-viewer/annotationNumbering.ts
@@ -2,28 +2,36 @@ import type { Annotation } from "../../types";
 import { AnnotationType } from "../../types";
 
 /** Mirror of the bridge's MAX_SYNC_ANNOTATIONS: the bridge truncates the
- * synced numbering list at this bound, so the sender truncates AFTER the
- * stable sort too — the first 512 numbers then agree on both sides instead
- * of the bridge silently dropping an arbitrary tail. */
+ * synced numbering list at this many ENTRIES, so the sender ships at most
+ * this many (after globals are dropped) and both sides keep the same set.
+ * Numbers themselves are array positions and may exceed this value; the
+ * bridge's own number bound (100000) accepts them. */
 export const MAX_SYNC_ANNOTATIONS = 512;
 
 /**
- * Placed-marker numbers for the bridge sync, derived from the SAME ordering
- * `exportAnnotations` (packages/ui/utils/parser.ts) numbers the submitted
- * feedback with: the FULL createdA-sorted list INCLUDING global comments.
+ * Placed-marker numbers for the bridge sync, derived from the SAME effective
+ * ordering `exportAnnotations` (packages/ui/utils/parser.ts) numbers the
+ * submitted feedback with. exportAnnotations sorts by (block index, start
+ * offset) and every raw-HTML annotation ties on both keys (blockId "",
+ * startOffset 0) — including externally submitted ones, whose server-stamped
+ * createdA can interleave arbitrarily with local timestamps — so its stable
+ * sort numbers the list in ARRAY order. Numbering here is therefore by array
+ * position of the input (the combined [...local, ...external] list the App
+ * feeds both consumers), never by createdA: an on-page "Comment 3" must read
+ * `## 3.` in the feedback the agent receives.
+ *
  * Global comments occupy a number (they get their own `## N.` section in the
  * feedback) but ship no sync entry — they have no page location — so the
- * on-page numbers show gaps where globals sit. That is correct: an on-page
- * "Comment 3" must read `## 3.` in the feedback the agent receives, never
- * shift down because a global comment sat between them.
+ * on-page numbers show gaps where globals sit. The entry cap applies AFTER
+ * globals are dropped, so globals never waste sync capacity and a non-global
+ * the export numbers past position 512 still syncs while slots remain.
  */
 export function buildSyncNumbering(
   annotations: readonly Annotation[],
 ): Array<{ id: string; number: number }> {
-  return [...annotations]
-    .sort((a, b) => a.createdA - b.createdA)
-    .slice(0, MAX_SYNC_ANNOTATIONS)
+  return annotations
     .map((ann, index) => ({ ann, number: index + 1 }))
     .filter(({ ann }) => ann.type !== AnnotationType.GLOBAL_COMMENT)
+    .slice(0, MAX_SYNC_ANNOTATIONS)
     .map(({ ann, number }) => ({ id: ann.id, number }));
 }

--- a/packages/ui/components/html-viewer/bridge-script.ts
+++ b/packages/ui/components/html-viewer/bridge-script.ts
@@ -336,6 +336,10 @@ export const BRIDGE_SCRIPT = `(function() {
     var text = capSelectionText(sel.toString().trim());
     if (!text) return false;
 
+    // A draft now owns the surface: kill the click-to-select hover
+    // affordance, including any hit test already scheduled.
+    clearHoverHighlight();
+
     var rect = range.getBoundingClientRect();
     pendingRange = range;
     pendingSelection = {
@@ -575,7 +579,7 @@ export const BRIDGE_SCRIPT = `(function() {
     else if (type === PREFIX + 'set-input-method') {
       currentInputMethod = e.data.method === 'pinpoint' ? 'pinpoint' : 'drag';
       if (currentInputMethod === 'pinpoint') {
-        setHoverHighlight(null); // pinpoint owns clicks; drop the select affordance
+        clearHoverHighlight(); // pinpoint owns clicks; drop the select affordance (and any pending hit test)
         if (document.body) document.body.setAttribute('data-plannotator-pinpoint-cursor', '');
       } else {
         if (document.body) document.body.removeAttribute('data-plannotator-pinpoint-cursor');
@@ -1097,8 +1101,8 @@ export const BRIDGE_SCRIPT = `(function() {
       // pending selection owns the surface.
       if (!pendingPinEl && !pendingSelection && renderedCommittedRects.length) {
         scheduleHoverHitTest(e.clientX, e.clientY);
-      } else if (hoverHighlightId) {
-        setHoverHighlight(null);
+      } else {
+        clearHoverHighlight();
       }
       return;
     }
@@ -1507,8 +1511,12 @@ export const BRIDGE_SCRIPT = `(function() {
   var deadSearchBudget = MAX_DEAD_SEARCHES_PER_PASS;
   var deadSearchSkipped = false;
 
-  function beginDeadSearchPass() {
-    deadSearchBudget = MAX_DEAD_SEARCHES_PER_PASS;
+  // budget: dead searches this pass may run. Per-frame reconcile passes use
+  // the default (they repeat, so skipped targets get follow-up frames);
+  // user-initiated one-shot passes (print, scroll-to) pass Infinity — they
+  // have no follow-up, and the backoff + generation gates still bound them.
+  function beginDeadSearchPass(budget) {
+    deadSearchBudget = typeof budget === 'number' ? budget : MAX_DEAD_SEARCHES_PER_PASS;
     deadSearchSkipped = false;
   }
 
@@ -1984,13 +1992,29 @@ export const BRIDGE_SCRIPT = `(function() {
     hoverHitRaf = requestAnimationFrame(function() {
       hoverHitRaf = 0;
       if (!hoverHitPos) return;
+      // Only drag mode without an open draft may paint the affordance: a
+      // mode switch or draft opening between schedule and frame must not
+      // resurrect a stale hover (flushQueuedHighlights re-applies whatever
+      // hoverHighlightId holds on every render).
+      if (currentInputMethod === 'pinpoint' || pendingPinEl || pendingSelection) return;
       setHoverHighlight(committedHighlightIdAtCached(hoverHitPos.x, hoverHitPos.y));
     });
   }
 
-  document.addEventListener('mouseleave', function() {
+  // Full teardown for every "hover must die" transition (pinpoint switch,
+  // draft open, pointer leave): cancels the pending rAF and clears the
+  // tracked position so a scheduled hit test cannot re-apply the class.
+  function clearHoverHighlight() {
+    if (hoverHitRaf) {
+      cancelAnimationFrame(hoverHitRaf);
+      hoverHitRaf = 0;
+    }
     hoverHitPos = null;
     setHoverHighlight(null);
+  }
+
+  document.addEventListener('mouseleave', function() {
+    clearHoverHighlight();
   });
 
   function makeMarkerButton(annId) {
@@ -2222,7 +2246,7 @@ export const BRIDGE_SCRIPT = `(function() {
   function scrollToAnnotation(id) {
     var record = findAnnRecord(id);
     if (!record) return;
-    beginDeadSearchPass();
+    beginDeadSearchPass(Infinity); // user-initiated one-shot: never budget-starved
     refreshRecordTargets(record);
     var scrollEl = null;
     for (var i = 0; i < record.targets.length && !scrollEl; i++) {
@@ -4153,7 +4177,9 @@ export const BRIDGE_SCRIPT = `(function() {
       layer.style.cssText = 'position:absolute;left:0;top:0;width:0;height:0;overflow:visible;pointer-events:none;';
       var sx = window.scrollX || 0;
       var sy = window.scrollY || 0;
-      beginDeadSearchPass();
+      // User-initiated one-shot: printing has no follow-up pass, so a budget
+      // here would silently print fewer highlights with 3+ dead targets.
+      beginDeadSearchPass(Infinity);
       for (var recordIndex = 0; recordIndex < annRecords.length; recordIndex++) {
         var record = annRecords[recordIndex];
         refreshRecordTargets(record);

--- a/packages/ui/components/html-viewer/bridge-script.ts
+++ b/packages/ui/components/html-viewer/bridge-script.ts
@@ -575,6 +575,7 @@ export const BRIDGE_SCRIPT = `(function() {
     else if (type === PREFIX + 'set-input-method') {
       currentInputMethod = e.data.method === 'pinpoint' ? 'pinpoint' : 'drag';
       if (currentInputMethod === 'pinpoint') {
+        setHoverHighlight(null); // pinpoint owns clicks; drop the select affordance
         if (document.body) document.body.setAttribute('data-plannotator-pinpoint-cursor', '');
       } else {
         if (document.body) document.body.removeAttribute('data-plannotator-pinpoint-cursor');
@@ -1089,7 +1090,18 @@ export const BRIDGE_SCRIPT = `(function() {
   var lastPointer = null;
   document.addEventListener('mousemove', function(e) {
     lastPointer = { x: e.clientX, y: e.clientY };
-    if (currentInputMethod !== 'pinpoint') return;
+    updateDragYield(e);
+    if (currentInputMethod !== 'pinpoint') {
+      // Click-to-select hover affordance (drag mode owns highlight clicks):
+      // cheap cached-rect hit test, rAF-throttled, cleared while a draft or
+      // pending selection owns the surface.
+      if (!pendingPinEl && !pendingSelection && renderedCommittedRects.length) {
+        scheduleHoverHitTest(e.clientX, e.clientY);
+      } else if (hoverHighlightId) {
+        setHoverHighlight(null);
+      }
+      return;
+    }
     if (vimEnabled && vimPhase !== 'inactive') return;
     // Hit-test at the pointer (e.target only backstops engines without
     // elementFromPoint) so the same code path serves the scroll re-hit-test.
@@ -1118,6 +1130,11 @@ export const BRIDGE_SCRIPT = `(function() {
       // the last-position cache must never answer the next probe.
       invalidatePointerHitCache();
       renderAnnotationOverlay();
+      // Scroll under a stationary pointer moves the committed rects: re-run
+      // the cached-rect hover test so the affordance tracks reality.
+      if (currentInputMethod !== 'pinpoint' && lastPointer && !pendingPinEl && !pendingSelection) {
+        setHoverHighlight(committedHighlightIdAtCached(lastPointer.x, lastPointer.y));
+      }
       positionMultiTargetBoxes();
       if (pendingPinEl && pendingPinEl.isConnected) {
         positionPinpointBox(pendingPinEl);
@@ -1157,6 +1174,7 @@ export const BRIDGE_SCRIPT = `(function() {
     '.pn-hl-deletion { background: oklch(from var(--pn-destructive, #c0392b) l c h / 0.28); background-image: linear-gradient(to bottom, transparent calc(50% - 1px), var(--pn-destructive, #c0392b) calc(50% - 1px), var(--pn-destructive, #c0392b) calc(50% + 1px), transparent calc(50% + 1px)); }',
     '.pn-hl-focus { background: oklch(from var(--pn-focus-highlight, #4493f8) l c h / 0.35); box-shadow: 0 0 8px oklch(from var(--pn-focus-highlight, #4493f8) l c h / 0.4); }',
     '.pn-hl-draft { background: oklch(from var(--pn-focus-highlight, #4493f8) l c h / 0.22); }',
+    '.pn-hl-hover { filter: brightness(1.25) saturate(1.1); }',
     '.pn-marker { position: fixed; width: 25px; height: 25px; border: 0; padding: 0; margin: 0; background: transparent; transform: translate(-50%, -50%); pointer-events: auto; cursor: pointer; display: flex; align-items: center; justify-content: center; animation: pn-marker-in 0.2s ease-out both; }',
     '.pn-marker[data-selected="true"] { transform: translate(-50%, -50%) scale(1.08); }',
     '.pn-marker-icon { pointer-events: none; display: block; position: absolute; top: 0; left: 0; width: 100%; height: 100%; filter: drop-shadow(0 1px 3px rgba(0,0,0,.3)); }',
@@ -1223,15 +1241,60 @@ export const BRIDGE_SCRIPT = `(function() {
   // Hit-test yielding: marker buttons accept pointer input, so a bare
   // elementFromPoint over one would resolve overlay chrome instead of the
   // page. Temporarily disable marker hit targets so probes reach beneath.
+  // Restores (never clears) the attribute: the drag-selection yield below
+  // holds the same attribute across events and must survive a probe.
   function withMarkersYielded(fn) {
     if (!overlayHostEl || !overlayHostEl.isConnected) return fn();
+    var alreadyYielded = overlayHostEl.hasAttribute('data-pn-hittest');
     overlayHostEl.setAttribute('data-pn-hittest', '');
     try {
       return fn();
     } finally {
-      overlayHostEl.removeAttribute('data-pn-hittest');
+      if (!alreadyYielded) overlayHostEl.removeAttribute('data-pn-hittest');
     }
   }
+
+  // Drag-selection marker yield: while a text drag is in progress in drag
+  // mode, placed markers drop pointer input (the same data-pn-hittest CSS the
+  // hit-test yield uses) so a 25px bubble sitting over the text cannot
+  // capture the selection mid-drag. Armed only by a >4px move with the
+  // primary button held from a non-overlay mousedown, so marker clicks
+  // (mousedown ON the marker) and plain click-to-select (no drag) are
+  // untouched; disarmed on mouseup or when the button is seen released.
+  var dragYieldStart = null;
+  var dragYieldActive = false;
+  function endDragYield() {
+    dragYieldStart = null;
+    if (dragYieldActive) {
+      dragYieldActive = false;
+      if (overlayHostEl) overlayHostEl.removeAttribute('data-pn-hittest');
+    }
+  }
+  function updateDragYield(e) {
+    if (!dragYieldStart) return;
+    if (typeof e.buttons === 'number' && !(e.buttons & 1)) {
+      endDragYield(); // missed mouseup (released outside the iframe)
+      return;
+    }
+    if (
+      !dragYieldActive
+      && (Math.abs(e.clientX - dragYieldStart.x) > 4 || Math.abs(e.clientY - dragYieldStart.y) > 4)
+    ) {
+      dragYieldActive = true;
+      if (overlayHostEl && overlayHostEl.isConnected) {
+        overlayHostEl.setAttribute('data-pn-hittest', '');
+      }
+    }
+  }
+  document.addEventListener('mousedown', function(e) {
+    if (currentInputMethod === 'pinpoint') return;
+    if (e.button !== 0) return;
+    if (isViewerOverlayNode(e.target)) return;
+    dragYieldStart = { x: e.clientX, y: e.clientY };
+  }, true);
+  document.addEventListener('mouseup', function() {
+    endDragYield();
+  }, true);
 
   // One record per committed annotation. Its targets are live projections;
   // its params are the durable data they re-resolve from after mutations.
@@ -1401,7 +1464,12 @@ export const BRIDGE_SCRIPT = `(function() {
       }
     }
     if (!record.targets.length) removeAnnRecord(id);
-    renderAnnotationOverlay();
+    // rAF-coalesced render (B3): restoring N annotations posts N
+    // find-and-mark messages, and a synchronous render here made a batch
+    // restore O(N^2) full overlay passes. The searches above stay
+    // synchronous (the mark-applied reply depends on them); only the
+    // projection is deferred, and one frame renders the whole batch.
+    schedulePinpointReconcile();
     return found;
   }
 
@@ -1415,30 +1483,86 @@ export const BRIDGE_SCRIPT = `(function() {
   // never unlock a re-search — geometry changes, text doesn't.
   var domGeneration = 1;
 
+  function monotonicNow() {
+    return typeof performance !== 'undefined' && performance.now
+      ? performance.now()
+      : Date.now();
+  }
+
+  // Wall-clock backoff ON TOP of the generation gate: a page that mutates
+  // styles/text once per frame advances domGeneration every frame, so the
+  // generation gate alone would re-run the whole-document text search (or
+  // anchor re-resolution) per frame forever for a permanently unresolvable
+  // target. After each FAILED search a target waits for BOTH a new
+  // generation AND its backoff (300ms, doubling to a 5s cap, reset on any
+  // success) before it may search again.
+  var DEAD_SEARCH_BACKOFF_MS = 300;
+  var DEAD_SEARCH_BACKOFF_MAX_MS = 5000;
+  // Per-reconcile-pass budget: at most this many dead-target searches run in
+  // one pass, so many stale targets can never stack whole-document scans
+  // into a single frame. When eligible targets are skipped for budget, a
+  // follow-up pass is scheduled; each failure's >=300ms backoff then hands
+  // the next pass's budget to different targets (round-robin by backoff).
+  var MAX_DEAD_SEARCHES_PER_PASS = 2;
+  var deadSearchBudget = MAX_DEAD_SEARCHES_PER_PASS;
+  var deadSearchSkipped = false;
+
+  function beginDeadSearchPass() {
+    deadSearchBudget = MAX_DEAD_SEARCHES_PER_PASS;
+    deadSearchSkipped = false;
+  }
+
+  function deadSearchAllowed(target) {
+    if (target.failedGeneration === domGeneration) return false;
+    if (target.searchBackoffUntil && monotonicNow() < target.searchBackoffUntil) return false;
+    if (deadSearchBudget <= 0) {
+      deadSearchSkipped = true;
+      return false;
+    }
+    return true;
+  }
+
+  function noteDeadSearchResult(target, found) {
+    deadSearchBudget -= 1;
+    if (found) {
+      target.failedGeneration = 0;
+      target.searchBackoffMs = 0;
+      target.searchBackoffUntil = 0;
+    } else {
+      target.failedGeneration = domGeneration;
+      target.searchBackoffMs = target.searchBackoffMs
+        ? Math.min(target.searchBackoffMs * 2, DEAD_SEARCH_BACKOFF_MAX_MS)
+        : DEAD_SEARCH_BACKOFF_MS;
+      target.searchBackoffUntil = monotonicNow() + target.searchBackoffMs;
+    }
+  }
+
   // Re-resolve stale live targets from durable data. Element targets
   // re-acquire through their anchor; range targets re-run the text search
   // (anchor-scoped first). Unresolvable targets stay hidden — never guessed
-  // — and cache the generation of their last failed search so they retry
-  // only after the document could actually have changed.
+  // — and each failed search is gated by the generation of its last attempt
+  // PLUS the wall-clock backoff and per-pass budget above, so they retry
+  // only after the document could actually have changed, and never per
+  // frame.
   function refreshRecordTargets(record) {
     for (var i = 0; i < record.targets.length; i++) {
       var target = record.targets[i];
       if (target.kind === 'element') {
         if ((!target.element || !target.element.isConnected) && target.anchor) {
-          if (target.failedGeneration === domGeneration) continue;
+          if (!deadSearchAllowed(target)) continue;
           target.element = resolveAnchorElement(target.anchor);
-          target.failedGeneration = target.element ? 0 : domGeneration;
+          noteDeadSearchResult(target, !!target.element);
         }
       } else if (!rangeAlive(target.range)) {
         target.range = null;
         if (target.text) {
-          if (target.failedGeneration === domGeneration) continue;
+          if (!deadSearchAllowed(target)) continue;
           var scopeEl = record.params && record.params.anchor
             ? resolveAnchorElement(record.params.anchor)
             : null;
           target.range = (scopeEl && findTextRange(target.text, scopeEl))
             || findTextRange(target.text, null);
-          target.failedGeneration = target.range ? 0 : domGeneration;
+          noteDeadSearchResult(target, !!target.range);
         }
       }
     }
@@ -1559,6 +1683,22 @@ export const BRIDGE_SCRIPT = `(function() {
     var bottom = Math.min(rectBottom(rect), bounds.bottom);
     if (right <= left || bottom <= top) return null;
     return { left: left, top: top, right: right, bottom: bottom, width: right - left, height: bottom - top };
+  }
+
+  // Early viewport cull (small margin): a target wholly outside the viewport
+  // paints nothing and places no marker, so the per-frame style/clip reads it
+  // would otherwise cost (getComputedStyle, the clip-chain ancestor walk,
+  // client-rect collection) are skipped outright. Never applies without
+  // layout (headless DOM tests report every rect as 0x0 at the origin).
+  var VIEWPORT_CULL_MARGIN = 64;
+  function rectOutsideViewport(rect) {
+    if (!rect || !layoutActive()) return false;
+    var vw = window.innerWidth;
+    var vh = window.innerHeight;
+    return rectBottom(rect) < -VIEWPORT_CULL_MARGIN
+      || rect.top > vh + VIEWPORT_CULL_MARGIN
+      || rectRight(rect) < -VIEWPORT_CULL_MARGIN
+      || rect.left > vw + VIEWPORT_CULL_MARGIN;
   }
 
   // Intersect a target rect with its clip chain for MARKER projection. May
@@ -1746,29 +1886,112 @@ export const BRIDGE_SCRIPT = `(function() {
 
   var highlightPool = [];
   var highlightUsed = 0;
+  // Read/write batching: the render pass QUEUES highlight rects while it
+  // reads geometry, then flushes every pool write at once. Interleaving a
+  // style write between one record's writes and the next record's
+  // getBoundingClientRect would force a synchronous layout per record.
+  var queuedHighlights = [];
+  // Cached viewport rects of the committed highlights currently painted,
+  // rebuilt on every flush. The hover affordance hit-tests the pointer
+  // against THIS cache — never against live range geometry per mousemove.
+  var renderedCommittedRects = [];
   function takeHighlightRect(className, rect, annId) {
-    var div = highlightPool[highlightUsed];
-    if (!div) {
-      div = document.createElement('div');
-      overlayNodes.add(div);
-      highlightPool.push(div);
-      highlightsLayerEl.appendChild(div);
+    queuedHighlights.push({ className: className, rect: rect, annId: annId || '' });
+  }
+  function flushQueuedHighlights() {
+    highlightUsed = 0;
+    renderedCommittedRects.length = 0;
+    for (var q = 0; q < queuedHighlights.length; q++) {
+      var item = queuedHighlights[q];
+      var div = highlightPool[highlightUsed];
+      if (!div) {
+        div = document.createElement('div');
+        overlayNodes.add(div);
+        highlightPool.push(div);
+        highlightsLayerEl.appendChild(div);
+      }
+      highlightUsed += 1;
+      var hoverClass = item.annId && item.annId === hoverHighlightId ? ' pn-hl-hover' : '';
+      div.className = 'pn-hl ' + item.className + hoverClass;
+      if (item.annId) {
+        div.setAttribute('data-annotation-id', item.annId);
+        renderedCommittedRects.push({
+          id: item.annId,
+          left: item.rect.left,
+          top: item.rect.top,
+          right: rectRight(item.rect),
+          bottom: rectBottom(item.rect)
+        });
+      } else {
+        div.removeAttribute('data-annotation-id');
+      }
+      div.style.display = 'block';
+      div.style.left = item.rect.left + 'px';
+      div.style.top = item.rect.top + 'px';
+      div.style.width = (item.rect.width || 0) + 'px';
+      div.style.height = (item.rect.height || 0) + 'px';
     }
-    highlightUsed += 1;
-    div.className = 'pn-hl ' + className;
-    if (annId) div.setAttribute('data-annotation-id', annId);
-    else div.removeAttribute('data-annotation-id');
-    div.style.display = 'block';
-    div.style.left = rect.left + 'px';
-    div.style.top = rect.top + 'px';
-    div.style.width = (rect.width || 0) + 'px';
-    div.style.height = (rect.height || 0) + 'px';
+    queuedHighlights.length = 0;
+    hideUnusedHighlights();
   }
   function hideUnusedHighlights() {
     for (var i = highlightUsed; i < highlightPool.length; i++) {
       highlightPool[i].style.display = 'none';
     }
   }
+
+  // --- Hover affordance for click-to-select ---
+  // Pre-overlay, inline marks carried cursor:pointer + hover styling; overlay
+  // rects are pointer-transparent, so hovering is detected by hit-testing the
+  // rAF-throttled pointer against the CACHED rendered rects (bounding-box
+  // checks only — no geometry reads) and toggling a class on that
+  // annotation's rect divs inside the shadow root. Shadow-root writes are
+  // unobserved by the page mutation observer, so no reconcile feedback loop,
+  // and the rects stay pointer-events: none throughout.
+  var hoverHighlightId = null;
+  var hoverHitRaf = 0;
+  var hoverHitPos = null;
+
+  function committedHighlightIdAtCached(x, y) {
+    var best = null;
+    for (var i = 0; i < renderedCommittedRects.length; i++) {
+      var r = renderedCommittedRects[i];
+      if (x < r.left || x > r.right || y < r.top || y > r.bottom) continue;
+      var area = (r.right - r.left) * (r.bottom - r.top);
+      if (area <= 0) continue;
+      // Smallest rect wins on overlap, matching the click hit-test.
+      if (!best || area <= best.area) best = { id: r.id, area: area };
+    }
+    return best ? best.id : null;
+  }
+
+  function setHoverHighlight(id) {
+    if (id === hoverHighlightId) return;
+    hoverHighlightId = id;
+    for (var i = 0; i < highlightUsed; i++) {
+      var div = highlightPool[i];
+      if (hoverHighlightId && div.getAttribute('data-annotation-id') === hoverHighlightId) {
+        div.classList.add('pn-hl-hover');
+      } else {
+        div.classList.remove('pn-hl-hover');
+      }
+    }
+  }
+
+  function scheduleHoverHitTest(x, y) {
+    hoverHitPos = { x: x, y: y };
+    if (hoverHitRaf) return;
+    hoverHitRaf = requestAnimationFrame(function() {
+      hoverHitRaf = 0;
+      if (!hoverHitPos) return;
+      setHoverHighlight(committedHighlightIdAtCached(hoverHitPos.x, hoverHitPos.y));
+    });
+  }
+
+  document.addEventListener('mouseleave', function() {
+    hoverHitPos = null;
+    setHoverHighlight(null);
+  });
 
   function makeMarkerButton(annId) {
     var btn = document.createElement('button');
@@ -1849,7 +2072,8 @@ export const BRIDGE_SCRIPT = `(function() {
     var hasDraftRange = !!(pendingSelection && pendingRange);
     if (!annRecords.length && !hasDraftRange && !overlayHostEl) return;
     ensureOverlayHost();
-    highlightUsed = 0;
+    beginDeadSearchPass();
+    queuedHighlights.length = 0;
     var markers = [];
     // Fallback numbering by first-seen registration order — used only until
     // the parent's ordered sync arrives. Numbering NEVER derives from target
@@ -1884,6 +2108,12 @@ export const BRIDGE_SCRIPT = `(function() {
             continue;
           }
           var rect = el.getBoundingClientRect();
+          if (rectOutsideViewport(rect)) {
+            // Entirely off-viewport: the marker would be omitted and any
+            // focus rect invisible — skip the style/clip reads outright.
+            markers.push({ key: markerKey, id: record.id, number: number, hidden: true });
+            continue;
+          }
           var zeroSize = layoutActive() && !(rect.width || 0) && !(rect.height || 0);
           var styleHidden = !zeroSize && targetStyleHidden(el);
           var point = target.point || { x: 0.5, y: 0.5 };
@@ -1907,6 +2137,18 @@ export const BRIDGE_SCRIPT = `(function() {
             markers.push({ key: markerKey, id: record.id, number: number, hidden: true });
           }
         } else {
+          if (rangeAlive(target.range)) {
+            // Cull on the range's bounding rect BEFORE any per-rect work
+            // (client-rect collection, clip-chain walks, computed styles).
+            var rangeCullRect = null;
+            try { rangeCullRect = target.range.getBoundingClientRect(); } catch (exCull) {}
+            if (rangeCullRect && rectOutsideViewport(rangeCullRect)) {
+              if (!target.markerless) {
+                markers.push({ key: markerKey, id: record.id, number: number, hidden: true });
+              }
+              continue;
+            }
+          }
           var geometry = rangeVisualGeometry(target.range);
           for (var rectIndex = 0; rectIndex < geometry.paint.length; rectIndex++) {
             takeHighlightRect(
@@ -1939,13 +2181,24 @@ export const BRIDGE_SCRIPT = `(function() {
     // Clip-tested like committed rects (M1): a draft inside a scrolled inner
     // container must not stripe content outside the container's box.
     if (hasDraftRange) {
-      var draftGeometry = rangeVisualGeometry(pendingRange);
-      for (var draftIndex = 0; draftIndex < draftGeometry.paint.length; draftIndex++) {
-        takeHighlightRect('pn-hl-draft', draftGeometry.paint[draftIndex], '');
+      var draftCullRect = null;
+      try { draftCullRect = pendingRange.getBoundingClientRect(); } catch (exDraftCull) {}
+      if (!draftCullRect || !rectOutsideViewport(draftCullRect)) {
+        var draftGeometry = rangeVisualGeometry(pendingRange);
+        for (var draftIndex = 0; draftIndex < draftGeometry.paint.length; draftIndex++) {
+          takeHighlightRect('pn-hl-draft', draftGeometry.paint[draftIndex], '');
+        }
       }
     }
-    hideUnusedHighlights();
+    // Write phase: every geometry read above is done before the first pool
+    // style write lands (B2), so the pass costs one layout, not one per
+    // record.
+    flushQueuedHighlights();
     placeMarkers(markers);
+    // Eligible dead-target searches skipped for budget get a follow-up pass;
+    // the loop terminates once every eligible target has been attempted at
+    // the current generation (its failedGeneration then blocks it).
+    if (deadSearchSkipped) schedulePinpointReconcile();
   }
 
   function focusAnnotationRecord(id, flash) {
@@ -1969,6 +2222,7 @@ export const BRIDGE_SCRIPT = `(function() {
   function scrollToAnnotation(id) {
     var record = findAnnRecord(id);
     if (!record) return;
+    beginDeadSearchPass();
     refreshRecordTargets(record);
     var scrollEl = null;
     for (var i = 0; i < record.targets.length && !scrollEl; i++) {
@@ -3786,13 +4040,26 @@ export const BRIDGE_SCRIPT = `(function() {
     return true;
   }
 
+  // Zero-work observer gate (B4): with no committed records, no pending
+  // draft, and pinpoint inactive there is nothing for the reconcile pass to
+  // do, so a page mutation should not schedule one. The generation bump
+  // still happens — a record registered later must see the mutations that
+  // occurred while the overlay was idle.
+  function reconcileHasWork() {
+    return annRecords.length > 0
+      || !!pendingSelection
+      || !!pendingPinEl
+      || pendingMultiTargets.length > 0
+      || currentInputMethod === 'pinpoint';
+  }
+
   function watchPageMutations() {
     if (pageMutationObserver || typeof MutationObserver === 'undefined' || !document.documentElement) return;
     pageMutationObserver = new MutationObserver(function(mutations) {
       for (var i = 0; i < mutations.length; i++) {
         if (!isOverlayOnlyMutation(mutations[i])) {
           domGeneration += 1; // page text may have changed: unlock dead-target re-search
-          schedulePinpointReconcile();
+          if (reconcileHasWork()) schedulePinpointReconcile();
           return;
         }
       }
@@ -3886,6 +4153,7 @@ export const BRIDGE_SCRIPT = `(function() {
       layer.style.cssText = 'position:absolute;left:0;top:0;width:0;height:0;overflow:visible;pointer-events:none;';
       var sx = window.scrollX || 0;
       var sy = window.scrollY || 0;
+      beginDeadSearchPass();
       for (var recordIndex = 0; recordIndex < annRecords.length; recordIndex++) {
         var record = annRecords[recordIndex];
         refreshRecordTargets(record);

--- a/packages/ui/components/html-viewer/htmlPinpointProtocol.test.tsx
+++ b/packages/ui/components/html-viewer/htmlPinpointProtocol.test.tsx
@@ -373,7 +373,7 @@ describe.if(hasDom)('ordered saved-annotation sync (placed-marker numbering)', (
     } as Annotation;
   }
 
-  test('on bridge ready, the ordered collection syncs as index+1 numbers (globals excluded)', async () => {
+  test('on bridge ready, the ordered collection syncs export-matching numbers (globals occupy slots)', async () => {
     const { AnnotationType } = await import('../../types');
     const annotations = [
       ann('global-1', 5, AnnotationType.GLOBAL_COMMENT),
@@ -386,10 +386,14 @@ describe.if(hasDom)('ordered saved-annotation sync (placed-marker numbering)', (
       (m) => m.type === 'plannotator-bridge-sync-annotations',
     );
     expect(syncs.length).toBeGreaterThanOrEqual(1);
-    // Ordered by createdA (the panel's order), numbered index+1, no globals.
+    // Numbered against the FULL createdA-sorted list INCLUDING globals — the
+    // same ordering exportAnnotations numbers the feedback with — so on-page
+    // numbers match the `## N.` sections the agent reads. The global (oldest,
+    // number 1) has no page location and ships no entry: the on-page numbers
+    // start at 2, leaving the gap where the global sits.
     expect(syncs.at(-1)!.annotations).toEqual([
-      { id: 'ann-early', number: 1 },
-      { id: 'ann-late', number: 2 },
+      { id: 'ann-early', number: 2 },
+      { id: 'ann-late', number: 3 },
     ]);
   });
 

--- a/packages/ui/components/html-viewer/htmlPinpointProtocol.test.tsx
+++ b/packages/ui/components/html-viewer/htmlPinpointProtocol.test.tsx
@@ -386,14 +386,16 @@ describe.if(hasDom)('ordered saved-annotation sync (placed-marker numbering)', (
       (m) => m.type === 'plannotator-bridge-sync-annotations',
     );
     expect(syncs.length).toBeGreaterThanOrEqual(1);
-    // Numbered against the FULL createdA-sorted list INCLUDING globals — the
-    // same ordering exportAnnotations numbers the feedback with — so on-page
-    // numbers match the `## N.` sections the agent reads. The global (oldest,
-    // number 1) has no page location and ships no entry: the on-page numbers
-    // start at 2, leaving the gap where the global sits.
+    // Numbered by ARRAY position of the full list INCLUDING globals — the
+    // effective ordering exportAnnotations numbers the feedback with (its
+    // sort keys tie for every raw-HTML annotation, so its stable sort keeps
+    // array order; createdA is deliberately ignored because external
+    // annotations interleave server-stamped timestamps). The global (array
+    // position 1) has no page location and ships no entry: the on-page
+    // numbers start at 2, leaving the gap where the global sits.
     expect(syncs.at(-1)!.annotations).toEqual([
-      { id: 'ann-early', number: 2 },
-      { id: 'ann-late', number: 3 },
+      { id: 'ann-late', number: 2 },
+      { id: 'ann-early', number: 3 },
     ]);
   });
 
@@ -404,12 +406,12 @@ describe.if(hasDom)('ordered saved-annotation sync (placed-marker numbering)', (
     ).toBe(false);
   });
 
-  test('the sync feed truncates to 512 entries AFTER the stable sort (m2)', async () => {
-    // The bridge caps its numbering map at 512; without a sender-side slice
-    // the bridge would keep an arbitrary tail whose numbers disagree with
-    // the panel. Slicing after the sort keeps the first 512 numbers equal on
-    // both sides. createdA descends here, so the sort must run before the
-    // slice for bulk-519 (oldest) to survive as number 1.
+  test('the sync feed truncates to 512 entries in export (array) order (m2)', async () => {
+    // The bridge caps its numbering map at 512 entries; the sender ships the
+    // FIRST 512 non-global entries in array order — the same order
+    // exportAnnotations numbers — so both sides keep the same set. createdA
+    // descends here and must NOT reorder anything (external annotations
+    // interleave server-stamped timestamps).
     const annotations = Array.from({ length: 520 }, (_, i) => ann(`bulk-${i}`, 1000 - i));
     const { postReady, postedToIframe } = await mountWithAnnotations(annotations);
     await postReady();
@@ -418,8 +420,8 @@ describe.if(hasDom)('ordered saved-annotation sync (placed-marker numbering)', (
     );
     const list = syncs.at(-1)!.annotations as Array<{ id: string; number: number }>;
     expect(list.length).toBe(512);
-    expect(list[0]).toEqual({ id: 'bulk-519', number: 1 });
-    expect(list[511]).toEqual({ id: 'bulk-8', number: 512 });
+    expect(list[0]).toEqual({ id: 'bulk-0', number: 1 });
+    expect(list[511]).toEqual({ id: 'bulk-511', number: 512 });
   });
 });
 

--- a/packages/ui/components/html-viewer/srcdoc.test.ts
+++ b/packages/ui/components/html-viewer/srcdoc.test.ts
@@ -2908,6 +2908,107 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
+  test("switching to pinpoint before a scheduled hover hit test fires leaves no stale hover (1)", async () => {
+    document.body.innerHTML = "<p>Hover race text</p>";
+    const originalGetClientRects = Range.prototype.getClientRects;
+    await withLayout(async () => {
+      (Range.prototype as unknown as { getClientRects: () => DOMRect[] }).getClientRects = () => [
+        rectOf(100, 100, 200, 20),
+      ];
+      try {
+        postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
+        postBridge({
+          type: "plannotator-bridge-find-and-mark",
+          id: "race-ann",
+          originalText: "Hover race text",
+          annotationType: "comment",
+        });
+        await flushOverlay();
+        const painted = visibleHighlights("pn-hl-comment").filter(
+          (hl) => hl.getAttribute("data-annotation-id") === "race-ann",
+        );
+        expect(painted.length).toBeGreaterThan(0);
+
+        // Schedule a hover hit test, then switch to pinpoint BEFORE the rAF
+        // fires: the pending callback must not re-apply the class, and no
+        // later re-render may resurrect it from stale hover state.
+        document.dispatchEvent(new MouseEvent("mousemove", {
+          bubbles: true,
+          clientX: 150,
+          clientY: 110,
+        }));
+        postBridge({ type: "plannotator-bridge-set-input-method", method: "pinpoint" });
+        await flushOverlay();
+        expect(painted[0]!.classList.contains("pn-hl-hover")).toBe(false);
+        // Pinpoint-mode mousemoves skip the hover-clearing branch, so a
+        // re-render is where stale state would resurface — it must not.
+        postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+        await flushOverlay();
+        expect(painted[0]!.classList.contains("pn-hl-hover")).toBe(false);
+      } finally {
+        (Range.prototype as { getClientRects: typeof originalGetClientRects }).getClientRects =
+          originalGetClientRects;
+      }
+    });
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  test("print passes are never budget-starved: every dead-but-recoverable target re-searches (3)", async () => {
+    document.body.innerHTML = [0, 1, 2]
+      .map((i) => `<p>Print recover text ${i}</p>`)
+      .join("");
+    for (let i = 0; i < 3; i++) {
+      postBridge({
+        type: "plannotator-bridge-find-and-mark",
+        id: `print-recover-${i}`,
+        originalText: `Print recover text ${i}`,
+        annotationType: "comment",
+      });
+    }
+    await flushOverlay();
+
+    // Recreate identical content: every range dies, but the text is still
+    // findable (dead-but-recoverable).
+    document.body.innerHTML = [0, 1, 2]
+      .map((i) => `<p>Print recover text ${i}</p>`)
+      .join("");
+
+    const originalGetClientRects = Range.prototype.getClientRects;
+    const originalCreateTreeWalker = document.createTreeWalker.bind(document);
+    let sweeps = 0;
+    (document as { createTreeWalker: typeof document.createTreeWalker }).createTreeWalker = ((
+      ...args: Parameters<typeof document.createTreeWalker>
+    ) => {
+      sweeps += 1;
+      return originalCreateTreeWalker(...args);
+    }) as typeof document.createTreeWalker;
+    await withLayout(async () => {
+      (Range.prototype as unknown as { getClientRects: () => DOMRect[] }).getClientRects = () => [
+        rectOf(10, 20, 100, 20),
+      ];
+      try {
+        // Printing is a user-initiated one-shot with no follow-up pass: the
+        // 2-search reconcile budget must not apply, or a page with 3+ dead
+        // targets silently prints fewer highlights.
+        window.dispatchEvent(new Event("beforeprint"));
+        expect(sweeps).toBe(3);
+        const layer = document.querySelector<HTMLElement>("[data-plannotator-print-layer]");
+        if (!layer) throw new Error("print layer missing");
+        expect(layer.childNodes.length).toBe(3);
+        window.dispatchEvent(new Event("afterprint"));
+      } finally {
+        (Range.prototype as { getClientRects: typeof originalGetClientRects }).getClientRects =
+          originalGetClientRects;
+        (document as { createTreeWalker: typeof document.createTreeWalker }).createTreeWalker =
+          originalCreateTreeWalker;
+      }
+    });
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
   test("printing re-projects committed highlights into a paginating absolute layer (M4)", async () => {
     document.body.innerHTML = "<p>Printable highlight text</p>";
     const originalGetClientRects = Range.prototype.getClientRects;

--- a/packages/ui/components/html-viewer/srcdoc.test.ts
+++ b/packages/ui/components/html-viewer/srcdoc.test.ts
@@ -186,6 +186,25 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     );
   }
 
+  /** find-and-mark renders through the rAF-coalesced overlay scheduler (a
+   * batch restore renders once instead of once per annotation); happy-dom's
+   * requestAnimationFrame is setImmediate-backed, so yielding one macrotask
+   * turn (the suite's standard flush) settles the pending overlay render. */
+  const flushOverlay = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+  /** Failed dead-target searches also carry a wall-clock backoff (300ms
+   * doubling to a 5s cap) on top of the generation gate. Tests asserting
+   * legitimate recovery after a new generation jump the bridge's monotonic
+   * clock (performance.now) past the cap instead of sleeping. */
+  let monotonicOffsetMs = 0;
+  beforeAll(() => {
+    const realNow = performance.now.bind(performance);
+    performance.now = () => realNow() + monotonicOffsetMs;
+  });
+  function advancePastDeadSearchBackoff() {
+    monotonicOffsetMs += 6000;
+  }
+
   // --- Annotation overlay helpers -------------------------------------------
   // Committed annotation visuals live in a shadow-rooted overlay host on the
   // root element; nothing annotation-related is written into the page's DOM.
@@ -951,6 +970,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       annotationType: "comment",
       anchor,
     });
+    await flushOverlay();
     expect(markersFor("pin-restore").length).toBe(1);
     expect(
       visibleHighlights("pn-hl-comment").some(
@@ -985,6 +1005,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       annotationType: "comment",
       anchor: { selector: "#hero", tagName: "div" },
     });
+    await flushOverlay();
     const driftMarkers = markersFor("pin-badge");
     expect(driftMarkers.length).toBe(1);
     expect(markerNumber(driftMarkers[0]!)).toBe("1");
@@ -1002,6 +1023,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       annotationType: "comment",
       anchor: { selector: anchor.selector, tagName: "p" },
     });
+    await flushOverlay();
     expect(markersFor("pin-no-snapshot").length).toBe(1);
     const fallbackScroll = collectScrollTargets(() => {
       postBridge({ type: "plannotator-bridge-scroll-to", id: "pin-no-snapshot" });
@@ -1020,6 +1042,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       annotationType: "comment",
       anchor: { selector: anchor.selector, tagName: "p", text: "Stale snapshot" },
     });
+    await flushOverlay();
     expect(markersFor("pin-stale").length).toBe(1);
     const staleScroll = collectScrollTargets(() => {
       postBridge({ type: "plannotator-bridge-scroll-to", id: "pin-stale" });
@@ -1082,7 +1105,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
-  test("behavioral-attribute anchors never bypass the text check", () => {
+  test("behavioral-attribute anchors never bypass the text check", async () => {
     // Regenerated page: the button kept its role but its meaning flipped; the
     // annotated text moved into a sibling paragraph. The role anchor must NOT
     // resolve (role names behavior, not content) — the annotation follows the
@@ -1098,6 +1121,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       annotationType: "comment",
       anchor: { selector: 'button[role="button"]', tagName: "button", text: "Save draft" },
     });
+    await flushOverlay();
     expect(markersFor("role-anchor").length).toBe(1);
     const roleScroll = collectScrollTargets(() => {
       postBridge({ type: "plannotator-bridge-scroll-to", id: "role-anchor" });
@@ -1117,6 +1141,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       annotationType: "comment",
       anchor: { selector: 'div[data-testid="stats"]', tagName: "div", text: "Old numbers" },
     });
+    await flushOverlay();
     expect(markersFor("data-anchor").length).toBe(1);
     const dataScroll = collectScrollTargets(() => {
       postBridge({ type: "plannotator-bridge-scroll-to", id: "data-anchor" });
@@ -1126,7 +1151,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
-  test("data-test-id/data-cy/data-qa are author-controlled identity attrs", () => {
+  test("data-test-id/data-cy/data-qa are author-controlled identity attrs", async () => {
     // Same trust class as data-testid: the anchor resolves without a text
     // check even after the element's content drifted completely.
     document.body.innerHTML = '<div data-cy="metrics">Fresh content</div>';
@@ -1137,6 +1162,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       annotationType: "comment",
       anchor: { selector: 'div[data-cy="metrics"]', tagName: "div", text: "Stale content gone from the page" },
     });
+    await flushOverlay();
     expect(markersFor("cy-anchor").length).toBe(1);
     expect(document.querySelector("[data-bind-id]")).toBeNull();
     postBridge({ type: "plannotator-bridge-clear-marks" });
@@ -1382,6 +1408,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       annotationType: "comment",
       anchor,
     });
+    await flushOverlay();
     expect(markersFor("identity-pin").length).toBe(1);
     expect(document.querySelector("[data-bind-id]")).toBeNull();
     postBridge({ type: "plannotator-bridge-clear-marks" });
@@ -1440,6 +1467,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
         annotationType: "comment",
         anchor: { selector, tagName: "span", text: "" },
       });
+      await flushOverlay();
     }
     expect(visibleMarkers().length).toBe(0);
     expect(document.querySelector("[data-bind-id]")).toBeNull();
@@ -1475,6 +1503,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       annotationType: "comment",
       anchor: { selector: "#pin-me", tagName: "p" },
     });
+    await flushOverlay();
     const realMarker = markersFor("badge-owner")[0];
     if (!realMarker) throw new Error("real marker missing");
     const collected: Array<Record<string, unknown>> = [];
@@ -1646,6 +1675,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       annotationType: "comment",
       anchor: { selector: "#hero", tagName: "div" },
     });
+    await flushOverlay();
     const numbers = visibleMarkers().map((b) => markerNumber(b));
     expect(numbers).toContain("2");
     expect(numbers.filter((n) => n === "1").length).toBeGreaterThanOrEqual(2);
@@ -1895,6 +1925,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
         { selector: "p.gamma", tagName: "p", text: "Stale snapshot" },
       ],
     });
+    await flushOverlay();
 
     // Primary restored as an anchored element marker + overlay highlight;
     // beta restored as a marker sharing the SAME number; gamma failed closed
@@ -1961,17 +1992,17 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
   }) as DOMRect;
 
   /** Enable "layout" in happy-dom: give the body a real rect. */
-  function withLayout(run: () => void) {
+  async function withLayout(run: () => void | Promise<void>) {
     const originalBodyRect = document.body.getBoundingClientRect;
     document.body.getBoundingClientRect = () => rectOf(0, 0, 1024, 768);
     try {
-      run();
+      await run();
     } finally {
       document.body.getBoundingClientRect = originalBodyRect;
     }
   }
 
-  test("annotation overlay is layout-neutral: page DOM untouched, host outside body, pointer-transparent", () => {
+  test("annotation overlay is layout-neutral: page DOM untouched, host outside body, pointer-transparent", async () => {
     document.body.innerHTML = [
       '<div id="hero"><p class="intro">Anchor target text</p><p>Second paragraph</p></div>',
     ].join("");
@@ -1984,12 +2015,14 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       annotationType: "comment",
       anchor: { selector: "#hero", tagName: "div" },
     });
+    await flushOverlay();
     postBridge({
       type: "plannotator-bridge-find-and-mark",
       id: "neutral-b",
       originalText: "Second paragraph",
       annotationType: "deletion",
     });
+    await flushOverlay();
     postBridge({
       type: "plannotator-bridge-sync-annotations",
       annotations: [{ id: "neutral-a", number: 1 }, { id: "neutral-b", number: 2 }],
@@ -2019,10 +2052,10 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
-  test("marker reprojects the stored relative point against fresh geometry (no stored pixels)", () => {
+  test("marker reprojects the stored relative point against fresh geometry (no stored pixels)", async () => {
     document.body.innerHTML = '<div id="geo">Geo target</div>';
     const geo = document.querySelector<HTMLElement>("#geo")!;
-    withLayout(() => {
+    await withLayout(async () => {
       geo.getBoundingClientRect = () => rectOf(100, 50, 200, 100);
       postBridge({
         type: "plannotator-bridge-find-and-mark",
@@ -2031,6 +2064,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
         annotationType: "comment",
         anchor: { selector: "#geo", tagName: "div", point: { x: 0.25, y: 0.5 } },
       });
+      await flushOverlay();
       const first = markersFor("geo-ann");
       expect(first.length).toBe(1);
       expect(first[0]!.style.left).toBe("150px");
@@ -2092,7 +2126,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.dispatchEvent(new Event("animationend", { bubbles: true }));
   }
 
-  test("unresolved targets omit their markers instead of guessing", () => {
+  test("unresolved targets omit their markers instead of guessing", async () => {
     document.body.innerHTML = '<div data-testid="vanishing">Now you see me</div>';
     postBridge({
       type: "plannotator-bridge-find-and-mark",
@@ -2101,6 +2135,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       annotationType: "comment",
       anchor: { selector: 'div[data-testid="vanishing"]', tagName: "div" },
     });
+    await flushOverlay();
     expect(markersFor("vanish-ann").length).toBe(1);
 
     // The page rerenders without the element: the anchor no longer resolves,
@@ -2110,8 +2145,10 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
     expect(markersFor("vanish-ann").length).toBe(0);
     // The annotation record survives (it stays reachable via the panel), so
-    // a page that brings the element back re-resolves and re-renders it.
+    // a page that brings the element back re-resolves and re-renders it
+    // (once BOTH a new generation and the failure backoff have passed).
     document.body.innerHTML = '<div data-testid="vanishing">Back again</div>';
+    advancePastDeadSearchBackoff();
     bumpDomGeneration();
     postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
     expect(markersFor("vanish-ann").length).toBe(1);
@@ -2120,10 +2157,10 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
-  test("targets scrolled or clipped out of the viewport omit their markers", () => {
+  test("targets scrolled or clipped out of the viewport omit their markers", async () => {
     document.body.innerHTML = '<div id="offscreen">Off screen</div>';
     const el = document.querySelector<HTMLElement>("#offscreen")!;
-    withLayout(() => {
+    await withLayout(async () => {
       el.getBoundingClientRect = () => rectOf(100, -500, 200, 100); // above viewport
       postBridge({
         type: "plannotator-bridge-find-and-mark",
@@ -2132,6 +2169,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
         annotationType: "comment",
         anchor: { selector: "#offscreen", tagName: "div" },
       });
+      await flushOverlay();
       expect(markersFor("off-ann").length).toBe(0);
 
       el.getBoundingClientRect = () => rectOf(100, 2000, 200, 100); // below viewport
@@ -2146,11 +2184,11 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
-  test("edge clamping keeps the full marker reachable; visually detached clamps are omitted", () => {
+  test("edge clamping keeps the full marker reachable; visually detached clamps are omitted", async () => {
     document.body.innerHTML = '<div id="edge">Edge</div><div id="sliver">S</div>';
     const edge = document.querySelector<HTMLElement>("#edge")!;
     const sliver = document.querySelector<HTMLElement>("#sliver")!;
-    withLayout(() => {
+    await withLayout(async () => {
       // A point at the exact left edge clamps to the 29px inset and stays
       // associated with its (40px-wide) target.
       edge.getBoundingClientRect = () => rectOf(0, 40, 40, 40);
@@ -2161,6 +2199,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
         annotationType: "comment",
         anchor: { selector: "#edge", tagName: "div", point: { x: 0, y: 0.5 } },
       });
+      await flushOverlay();
       const clamped = markersFor("edge-ann");
       expect(clamped.length).toBe(1);
       expect(clamped[0]!.style.left).toBe("29px");
@@ -2180,6 +2219,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
         annotationType: "comment",
         anchor: { selector: "#sliver", tagName: "div" },
       });
+      await flushOverlay();
       const sliverMarkers = markersFor("sliver-ann");
       expect(sliverMarkers.length).toBe(1);
       expect(sliverMarkers[0]!.style.left).toBe("29px");
@@ -2189,14 +2229,14 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
-  test("coincident markers spread horizontally and deterministically", () => {
+  test("coincident markers spread horizontally and deterministically", async () => {
     document.body.innerHTML = [
       '<div data-testid="co-a">A</div>',
       '<div data-testid="co-b">B</div>',
     ].join("");
     const a = document.querySelector<HTMLElement>('div[data-testid="co-a"]')!;
     const b = document.querySelector<HTMLElement>('div[data-testid="co-b"]')!;
-    withLayout(() => {
+    await withLayout(async () => {
       a.getBoundingClientRect = () => rectOf(100, 100, 50, 50);
       b.getBoundingClientRect = () => rectOf(100, 100, 50, 50);
       for (const [id, selector] of [["co-1", 'div[data-testid="co-a"]'], ["co-2", 'div[data-testid="co-b"]']] as const) {
@@ -2207,6 +2247,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
           annotationType: "comment",
           anchor: { selector, tagName: "div" },
         });
+        await flushOverlay();
       }
       // Same rounded point (125,125): the group spreads by 12.5px steps,
       // centered on the shared point, ordered by comment number.
@@ -2227,7 +2268,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
-  test("parent-synced numbering overrides registration order and renumbers markers", () => {
+  test("parent-synced numbering overrides registration order and renumbers markers", async () => {
     document.body.innerHTML = [
       '<div data-testid="n-a">A</div>',
       '<div data-testid="n-b">B</div>',
@@ -2240,6 +2281,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
         annotationType: "comment",
         anchor: { selector, tagName: "div" },
       });
+      await flushOverlay();
     }
     // Pre-sync fallback: registration order.
     expect(markerNumber(markersFor("n-1")[0]!)).toBe("1");
@@ -2259,7 +2301,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
-  test("malformed sync payloads are ignored or skipped at the bridge boundary", () => {
+  test("malformed sync payloads are ignored or skipped at the bridge boundary", async () => {
     document.body.innerHTML = [
       '<div data-testid="m-a">A</div>',
       '<div data-testid="m-b">B</div>',
@@ -2272,6 +2314,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
         annotationType: "comment",
         anchor: { selector, tagName: "div" },
       });
+      await flushOverlay();
     }
     postBridge({
       type: "plannotator-bridge-sync-annotations",
@@ -2306,7 +2349,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
-  test("focus highlight covers EVERY rect of a multi-paragraph selection (partial-blue regression)", () => {
+  test("focus highlight covers EVERY rect of a multi-paragraph selection (partial-blue regression)", async () => {
     document.body.innerHTML = "<p>Alpha beta gamma delta</p>";
     const originalGetClientRects = Range.prototype.getClientRects;
     const originalBodyRect = document.body.getBoundingClientRect;
@@ -2325,6 +2368,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
         originalText: "Alpha beta gamma delta",
         annotationType: "comment",
       });
+      await flushOverlay();
       // Persistent comment highlight paints both rects.
       const commentRects = visibleHighlights("pn-hl-comment").filter(
         (el) => el.getAttribute("data-annotation-id") === "focus-multi",
@@ -2371,7 +2415,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
-  test("hit-testing for new selections yields placed markers to reach the page beneath", () => {
+  test("hit-testing for new selections yields placed markers to reach the page beneath", async () => {
     document.body.innerHTML = '<p id="beneath">Beneath text</p><div data-testid="hit">H</div>';
     postBridge({ type: "plannotator-bridge-set-vim-mode", enabled: false });
     // Materialize the overlay host + a marker.
@@ -2382,6 +2426,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       annotationType: "comment",
       anchor: { selector: 'div[data-testid="hit"]', tagName: "div" },
     });
+    await flushOverlay();
     const host = overlayHost();
     if (!host) throw new Error("overlay host missing");
     const beneath = document.querySelector<HTMLElement>("#beneath")!;
@@ -2419,14 +2464,14 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
   // --- Fix-round regressions: clipping, visibility, search gating, print,
   // --- click-to-select, containment, dedup, numbering, marker anchoring ----
 
-  test("highlight rects are clip-tested against inner scroll containers (M1)", () => {
+  test("highlight rects are clip-tested against inner scroll containers (M1)", async () => {
     document.body.innerHTML =
       '<div id="scroller"><p id="clipped-p">Clipped highlight text</p></div>';
     const scroller = document.querySelector<HTMLElement>("#scroller")!;
     const clippedP = document.querySelector<HTMLElement>("#clipped-p")!;
     scroller.style.overflow = "hidden";
     const originalGetClientRects = Range.prototype.getClientRects;
-    withLayout(() => {
+    await withLayout(async () => {
       scroller.getBoundingClientRect = () => rectOf(0, 0, 200, 100);
       clippedP.getBoundingClientRect = () => rectOf(0, 50, 200, 120);
       (Range.prototype as unknown as { getClientRects: () => DOMRect[] }).getClientRects = () => [
@@ -2441,6 +2486,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
           originalText: "Clipped highlight text",
           annotationType: "comment",
         });
+        await flushOverlay();
         const painted = visibleHighlights("pn-hl-comment")
           .filter((el) => el.getAttribute("data-annotation-id") === "clip-hl")
           .map((el) => ({ top: el.style.top, height: el.style.height }))
@@ -2465,10 +2511,10 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
-  test("style-hidden targets are unresolved-for-display (M2 visibility gate)", () => {
+  test("style-hidden targets are unresolved-for-display (M2 visibility gate)", async () => {
     document.body.innerHTML = '<div id="slide">Slide content</div>';
     const slide = document.querySelector<HTMLElement>("#slide")!;
-    withLayout(() => {
+    await withLayout(async () => {
       slide.getBoundingClientRect = () => rectOf(100, 100, 200, 100);
       postBridge({
         type: "plannotator-bridge-find-and-mark",
@@ -2477,6 +2523,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
         annotationType: "comment",
         anchor: { selector: "#slide", tagName: "div" },
       });
+      await flushOverlay();
       expect(markersFor("vis-ann").length).toBe(1);
 
       // visibility:hidden keeps a full-size rect — the marker must not
@@ -2503,7 +2550,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
-  test("dead-target re-search is generation-gated, never per-render (M3)", () => {
+  test("dead-target re-search is generation-gated, never per-render (M3)", async () => {
     document.body.innerHTML = "<p>Ephemeral searchable text</p>";
     postBridge({
       type: "plannotator-bridge-find-and-mark",
@@ -2511,6 +2558,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       originalText: "Ephemeral searchable text",
       annotationType: "comment",
     });
+    await flushOverlay();
     expect(
       visibleHighlights("pn-hl-comment").some(
         (el) => el.getAttribute("data-annotation-id") === "gen-ann",
@@ -2538,7 +2586,9 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       }
       expect(sweeps).toBe(0);
 
-      // A text-capable invalidation unlocks exactly one more search…
+      // A text-capable invalidation (plus an elapsed failure backoff)
+      // unlocks exactly one more search…
+      advancePastDeadSearchBackoff();
       bumpDomGeneration();
       postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
       expect(sweeps).toBeGreaterThan(0);
@@ -2551,8 +2601,10 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
         originalCreateTreeWalker;
     }
 
-    // The text returning re-resolves after the next invalidation.
+    // The text returning re-resolves after the next invalidation (and an
+    // elapsed backoff).
     document.body.innerHTML = "<p>Ephemeral searchable text</p>";
+    advancePastDeadSearchBackoff();
     bumpDomGeneration();
     postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
     expect(
@@ -2565,10 +2617,301 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
-  test("printing re-projects committed highlights into a paginating absolute layer (M4)", () => {
+  test("mutation-heavy pages: failed re-searches back off on the wall clock and are budgeted per pass (A)", async () => {
+    // A page that mutates every frame advances domGeneration every frame, so
+    // the generation gate alone would re-run the whole-document sweep per
+    // frame forever for permanently unresolvable targets. Failed searches
+    // must (1) run at most 2 per reconcile pass and (2) back off on the
+    // wall clock even across generation bumps.
+    document.body.innerHTML = [0, 1, 2, 3]
+      .map((i) => `<p>Backoff text ${i}</p>`)
+      .join("");
+    for (let i = 0; i < 4; i++) {
+      postBridge({
+        type: "plannotator-bridge-find-and-mark",
+        id: `boff-${i}`,
+        originalText: `Backoff text ${i}`,
+        annotationType: "comment",
+      });
+    }
+    await flushOverlay();
+
+    // Every target's text disappears: all four ranges are dead.
+    document.body.innerHTML = "<p>Rewritten content</p>";
+
+    const originalCreateTreeWalker = document.createTreeWalker.bind(document);
+    let sweeps = 0;
+    (document as { createTreeWalker: typeof document.createTreeWalker }).createTreeWalker = ((
+      ...args: Parameters<typeof document.createTreeWalker>
+    ) => {
+      sweeps += 1;
+      return originalCreateTreeWalker(...args);
+    }) as typeof document.createTreeWalker;
+    try {
+      // Pass 1: only the per-pass budget (2) may search, even though all
+      // four targets are eligible.
+      bumpDomGeneration();
+      postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+      expect(sweeps).toBe(2);
+      // The skipped-but-eligible targets get a scheduled follow-up pass.
+      await flushOverlay();
+      expect(sweeps).toBe(4);
+      // No eligible targets remain: no further passes run searches.
+      await flushOverlay();
+      postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+      expect(sweeps).toBe(4);
+
+      // Mutation-heavy page: generation bumps every "frame". The wall-clock
+      // backoff must keep every failed target locked regardless.
+      for (let i = 0; i < 5; i++) {
+        bumpDomGeneration();
+        postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+        await flushOverlay();
+      }
+      expect(sweeps).toBe(4);
+
+      // Once the backoff elapses AND the generation has advanced, searching
+      // resumes (still budgeted per pass).
+      advancePastDeadSearchBackoff();
+      bumpDomGeneration();
+      postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+      expect(sweeps).toBe(6);
+      await flushOverlay();
+      expect(sweeps).toBe(8);
+    } finally {
+      (document as { createTreeWalker: typeof document.createTreeWalker }).createTreeWalker =
+        originalCreateTreeWalker;
+    }
+
+    // A successful search resets the backoff: the text returning re-resolves
+    // on the next unlocked pass.
+    document.body.innerHTML = [0, 1, 2, 3]
+      .map((i) => `<p>Backoff text ${i}</p>`)
+      .join("");
+    advancePastDeadSearchBackoff();
+    bumpDomGeneration();
+    postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+    await flushOverlay();
+    expect(committedRanges("boff-0").length).toBe(1);
+    expect(committedRanges("boff-3").length).toBe(1);
+
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  test("offscreen targets are culled before style/clip reads (B1)", async () => {
+    document.body.innerHTML = '<div id="cull-el">Cull element</div><p>Cull range text</p>';
+    const el = document.querySelector<HTMLElement>("#cull-el")!;
+    await withLayout(async () => {
+      // Element target far below the viewport (beyond the cull margin).
+      el.getBoundingClientRect = () => rectOf(100, 2000, 200, 100);
+      postBridge({
+        type: "plannotator-bridge-find-and-mark",
+        id: "cull-el-ann",
+        originalText: "Text that exists nowhere on this page",
+        annotationType: "comment",
+        anchor: { selector: "#cull-el", tagName: "div" },
+      });
+      await flushOverlay();
+      expect(markersFor("cull-el-ann").length).toBe(0);
+
+      // A re-render of the culled element does none of the per-target style
+      // work (targetStyleHidden / clipBoundsFor both read computed styles).
+      const realGetComputedStyle = window.getComputedStyle.bind(window);
+      let styleReads = 0;
+      (window as { getComputedStyle: typeof window.getComputedStyle }).getComputedStyle = ((
+        ...args: Parameters<typeof window.getComputedStyle>
+      ) => {
+        styleReads += 1;
+        return realGetComputedStyle(...args);
+      }) as typeof window.getComputedStyle;
+      try {
+        postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+        expect(markersFor("cull-el-ann").length).toBe(0);
+        expect(styleReads).toBe(0);
+      } finally {
+        (window as { getComputedStyle: typeof window.getComputedStyle }).getComputedStyle =
+          realGetComputedStyle;
+      }
+
+      // Scrolled back into view, the marker renders again.
+      el.getBoundingClientRect = () => rectOf(100, 300, 200, 100);
+      postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+      expect(markersFor("cull-el-ann").length).toBe(1);
+      postBridge({ type: "plannotator-bridge-remove-mark", id: "cull-el-ann" });
+
+      // Range targets cull on the range's bounding rect BEFORE collecting
+      // client rects (the per-rect clip/containment work never runs).
+      const originalGetClientRects = Range.prototype.getClientRects;
+      const originalRangeBounds = Range.prototype.getBoundingClientRect;
+      let rectCollections = 0;
+      (Range.prototype as unknown as { getBoundingClientRect: () => DOMRect })
+        .getBoundingClientRect = () => rectOf(10, 2000, 100, 20);
+      (Range.prototype as unknown as { getClientRects: () => DOMRect[] }).getClientRects = (() => {
+        rectCollections += 1;
+        return [rectOf(10, 2000, 100, 20)];
+      }) as unknown as typeof Range.prototype.getClientRects;
+      try {
+        postBridge({
+          type: "plannotator-bridge-find-and-mark",
+          id: "cull-range-ann",
+          originalText: "Cull range text",
+          annotationType: "comment",
+        });
+        await flushOverlay();
+        expect(rectCollections).toBe(0);
+        expect(
+          visibleHighlights("pn-hl-comment").some(
+            (hl) => hl.getAttribute("data-annotation-id") === "cull-range-ann",
+          ),
+        ).toBe(false);
+      } finally {
+        (Range.prototype as { getClientRects: typeof originalGetClientRects }).getClientRects =
+          originalGetClientRects;
+        (Range.prototype as { getBoundingClientRect: typeof originalRangeBounds })
+          .getBoundingClientRect = originalRangeBounds;
+      }
+    });
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  test("batch restore renders the overlay once, not once per annotation (B3)", async () => {
+    document.body.innerHTML =
+      '<div id="b3-0">A</div><div id="b3-1">B</div><div id="b3-2">C</div>';
+    const counts = [0, 0, 0];
+    for (let i = 0; i < 3; i++) {
+      const target = document.querySelector<HTMLElement>(`#b3-${i}`)!;
+      const rect = rectOf(50 + i * 100, 100, 50, 50);
+      target.getBoundingClientRect = () => {
+        counts[i] += 1;
+        return rect;
+      };
+    }
+    await withLayout(async () => {
+      for (let i = 0; i < 3; i++) {
+        postBridge({
+          type: "plannotator-bridge-find-and-mark",
+          id: `b3-ann-${i}`,
+          originalText: "Text that exists nowhere on this page",
+          annotationType: "comment",
+          anchor: { selector: `#b3-${i}`, tagName: "div" },
+        });
+      }
+      // The projection is deferred: no render (no geometry reads) ran yet.
+      expect(counts).toEqual([0, 0, 0]);
+      await flushOverlay();
+      // ONE coalesced pass rendered the whole batch: each target's geometry
+      // was read exactly once (the old synchronous per-restore render read
+      // the first target three times: [3, 2, 1]).
+      expect(counts).toEqual([1, 1, 1]);
+      expect(visibleMarkers().length).toBe(3);
+    });
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  test("page mutations schedule no reconcile when the overlay has zero work (B4)", async () => {
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    postBridge({ type: "plannotator-bridge-cancel-selection" });
+    postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
+    document.body.innerHTML = "<p>B4 idle text</p>";
+    await flushOverlay(); // drain anything pending before counting
+
+    const realRaf = window.requestAnimationFrame.bind(window);
+    let scheduled = 0;
+    (window as { requestAnimationFrame: typeof window.requestAnimationFrame })
+      .requestAnimationFrame = ((cb: FrameRequestCallback) => {
+        scheduled += 1;
+        return realRaf(cb);
+      }) as typeof window.requestAnimationFrame;
+    try {
+      // Zero records, no draft, pinpoint inactive: a page mutation bumps the
+      // generation but must not schedule the reconcile frame.
+      deliverPageMutations([{
+        type: "characterData",
+        target: document.body,
+      } as Partial<MutationRecord>]);
+      expect(scheduled).toBe(0);
+
+      // With a committed record, the same mutation schedules the reconcile.
+      postBridge({
+        type: "plannotator-bridge-find-and-mark",
+        id: "b4-ann",
+        originalText: "B4 idle text",
+        annotationType: "comment",
+      });
+      await flushOverlay();
+      const before = scheduled;
+      deliverPageMutations([{
+        type: "characterData",
+        target: document.body,
+      } as Partial<MutationRecord>]);
+      expect(scheduled).toBeGreaterThan(before);
+      await flushOverlay();
+    } finally {
+      (window as { requestAnimationFrame: typeof window.requestAnimationFrame })
+        .requestAnimationFrame = realRaf;
+    }
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  test("hovering a committed highlight brightens its overlay rects without touching the page (D)", async () => {
+    document.body.innerHTML = "<p>Hover affordance text</p>";
+    const pageSnapshot = document.body.innerHTML;
+    const originalGetClientRects = Range.prototype.getClientRects;
+    await withLayout(async () => {
+      (Range.prototype as unknown as { getClientRects: () => DOMRect[] }).getClientRects = () => [
+        rectOf(100, 100, 200, 20),
+      ];
+      try {
+        postBridge({ type: "plannotator-bridge-set-input-method", method: "drag" });
+        postBridge({
+          type: "plannotator-bridge-find-and-mark",
+          id: "hover-ann",
+          originalText: "Hover affordance text",
+          annotationType: "comment",
+        });
+        await flushOverlay();
+        const painted = visibleHighlights("pn-hl-comment").filter(
+          (hl) => hl.getAttribute("data-annotation-id") === "hover-ann",
+        );
+        expect(painted.length).toBeGreaterThan(0);
+        expect(painted[0]!.classList.contains("pn-hl-hover")).toBe(false);
+
+        // Pointer over the painted rect: the hover class lands on the rect
+        // divs inside the shadow root; the page DOM stays byte-identical.
+        document.dispatchEvent(new MouseEvent("mousemove", {
+          bubbles: true,
+          clientX: 150,
+          clientY: 110,
+        }));
+        await flushOverlay();
+        expect(painted[0]!.classList.contains("pn-hl-hover")).toBe(true);
+        expect(document.body.innerHTML).toBe(pageSnapshot);
+
+        // Pointer off the rect clears the affordance.
+        document.dispatchEvent(new MouseEvent("mousemove", {
+          bubbles: true,
+          clientX: 600,
+          clientY: 500,
+        }));
+        await flushOverlay();
+        expect(painted[0]!.classList.contains("pn-hl-hover")).toBe(false);
+      } finally {
+        (Range.prototype as { getClientRects: typeof originalGetClientRects }).getClientRects =
+          originalGetClientRects;
+      }
+    });
+    postBridge({ type: "plannotator-bridge-clear-marks" });
+    document.body.replaceChildren();
+  });
+
+  test("printing re-projects committed highlights into a paginating absolute layer (M4)", async () => {
     document.body.innerHTML = "<p>Printable highlight text</p>";
     const originalGetClientRects = Range.prototype.getClientRects;
-    withLayout(() => {
+    await withLayout(async () => {
       (Range.prototype as unknown as { getClientRects: () => DOMRect[] }).getClientRects = () => [
         rectOf(10, 20, 100, 20),
       ];
@@ -2579,6 +2922,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
           originalText: "Printable highlight text",
           annotationType: "comment",
         });
+        await flushOverlay();
         window.dispatchEvent(new Event("beforeprint"));
         const layer = document.querySelector<HTMLElement>(
           "[data-plannotator-print-layer]",
@@ -2641,12 +2985,14 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
         originalText: "big highlight target",
         annotationType: "comment",
       });
+      await flushOverlay();
       postBridge({
         type: "plannotator-bridge-find-and-mark",
         id: "click-small",
         originalText: "small nested note",
         annotationType: "comment",
       });
+      await flushOverlay();
 
       // Inside both rects: the smallest highlight wins the overlap.
       const overlapping = await collectMessages(
@@ -2688,14 +3034,14 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
-  test("fixed-position targets ignore static overflow clippers (m3)", () => {
+  test("fixed-position targets ignore static overflow clippers (m3)", async () => {
     document.body.innerHTML =
       '<div id="wrap"><div id="fixed-el">Pinned banner</div></div>';
     const wrap = document.querySelector<HTMLElement>("#wrap")!;
     const fixedEl = document.querySelector<HTMLElement>("#fixed-el")!;
     wrap.style.overflow = "hidden";
     fixedEl.style.position = "fixed";
-    withLayout(() => {
+    await withLayout(async () => {
       wrap.getBoundingClientRect = () => rectOf(0, 0, 100, 50);
       // Fully visible in the viewport but entirely outside the static
       // clipper's box: overflow clipping does not apply to a fixed target
@@ -2708,6 +3054,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
         annotationType: "comment",
         anchor: { selector: "#fixed-el", tagName: "div" },
       });
+      await flushOverlay();
       expect(markersFor("fixed-ann").length).toBe(1);
 
       // Same geometry with static positioning: the clipper applies and the
@@ -2728,13 +3075,13 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
-  test("markers omit when the target scrolls out of its clip container (omission preserved)", () => {
+  test("markers omit when the target scrolls out of its clip container (omission preserved)", async () => {
     document.body.innerHTML =
       '<div id="clipwrap"><div id="clipped-el">Clipped away</div></div>';
     const clipwrap = document.querySelector<HTMLElement>("#clipwrap")!;
     const clippedEl = document.querySelector<HTMLElement>("#clipped-el")!;
     clipwrap.style.overflow = "hidden";
-    withLayout(() => {
+    await withLayout(async () => {
       clipwrap.getBoundingClientRect = () => rectOf(0, 0, 200, 100);
       clippedEl.getBoundingClientRect = () => rectOf(0, 150, 200, 50); // scrolled past the edge
       postBridge({
@@ -2744,6 +3091,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
         annotationType: "comment",
         anchor: { selector: "#clipped-el", tagName: "div" },
       });
+      await flushOverlay();
       expect(markersFor("clip-omit").length).toBe(0);
 
       clippedEl.getBoundingClientRect = () => rectOf(0, 20, 200, 50); // scrolled back in
@@ -2754,10 +3102,10 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
-  test("border boxes that duplicate line rects are dropped (m7 containment filter)", () => {
+  test("border boxes that duplicate line rects are dropped (m7 containment filter)", async () => {
     document.body.innerHTML = "<p>Redline paragraph text</p>";
     const originalGetClientRects = Range.prototype.getClientRects;
-    withLayout(() => {
+    await withLayout(async () => {
       // Range.getClientRects() returns BOTH the contained element's border
       // box AND its line boxes; painting all three double-paints the
       // translucent fill and duplicates the strike line.
@@ -2773,6 +3121,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
           originalText: "Redline paragraph text",
           annotationType: "deletion",
         });
+        await flushOverlay();
         const painted = visibleHighlights("pn-hl-deletion").filter(
           (el) => el.getAttribute("data-annotation-id") === "redline-ann",
         );
@@ -2787,7 +3136,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
-  test("anchors re-resolving to one element render one marker (m10 refresh dedup)", () => {
+  test("anchors re-resolving to one element render one marker (m10 refresh dedup)", async () => {
     document.body.innerHTML =
       '<div id="m10-a">First</div><div data-testid="m10-b">Second</div>';
     postBridge({
@@ -2798,6 +3147,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       anchor: { selector: "#m10-a", tagName: "div" },
       additionalAnchors: [{ selector: 'div[data-testid="m10-b"]', tagName: "div" }],
     });
+    await flushOverlay();
     expect(markersFor("dedup-ann").length).toBe(2);
 
     // The page rerenders so BOTH anchors resolve to the same element: only
@@ -2811,7 +3161,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
-  test("clear-marks clears synced numbering (m11)", () => {
+  test("clear-marks clears synced numbering (m11)", async () => {
     document.body.innerHTML = '<div id="renum">Target</div>';
     postBridge({
       type: "plannotator-bridge-find-and-mark",
@@ -2820,6 +3170,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       annotationType: "comment",
       anchor: { selector: "#renum", tagName: "div" },
     });
+    await flushOverlay();
     postBridge({
       type: "plannotator-bridge-sync-annotations",
       annotations: [{ id: "renum-ann", number: 7 }],
@@ -2836,16 +3187,17 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       annotationType: "comment",
       anchor: { selector: "#renum", tagName: "div" },
     });
+    await flushOverlay();
     expect(markerNumber(markersFor("renum-ann")[0]!)).toBe("1");
 
     postBridge({ type: "plannotator-bridge-clear-marks" });
     document.body.replaceChildren();
   });
 
-  test("marker anchors to the TRUE last client rect past the paint cap (m12)", () => {
+  test("marker anchors to the TRUE last client rect past the paint cap (m12)", async () => {
     document.body.innerHTML = "<p>Long wrapped selection</p>";
     const originalGetClientRects = Range.prototype.getClientRects;
-    withLayout(() => {
+    await withLayout(async () => {
       const rects: DOMRect[] = [];
       for (let i = 0; i < 60; i++) rects.push(rectOf(10, 10 + i * 5, 100, 5));
       (Range.prototype as unknown as { getClientRects: () => DOMRect[] }).getClientRects = () =>
@@ -2857,6 +3209,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
           originalText: "Long wrapped selection",
           annotationType: "comment",
         });
+        await flushOverlay();
         // Painting caps at 48 rects…
         const painted = visibleHighlights("pn-hl-comment").filter(
           (el) => el.getAttribute("data-annotation-id") === "long-ann",
@@ -2877,7 +3230,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
-  test("pinpoint hover over a placed marker advertises the marker, not the element beneath (m6)", () => {
+  test("pinpoint hover over a placed marker advertises the marker, not the element beneath (m6)", async () => {
     document.body.innerHTML = '<p id="under">Beneath paragraph</p><div id="m6-t">Marked</div>';
     postBridge({ type: "plannotator-bridge-set-vim-mode", enabled: false });
     postBridge({
@@ -2887,6 +3240,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       annotationType: "comment",
       anchor: { selector: "#m6-t", tagName: "div" },
     });
+    await flushOverlay();
     postBridge({
       type: "plannotator-bridge-sync-annotations",
       annotations: [{ id: "hover-ann", number: 3 }],
@@ -2929,10 +3283,10 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
-  test("rect collection is capped at 48 with the containment filter, marker at the true tail (perf bound)", () => {
+  test("rect collection is capped at 48 with the containment filter, marker at the true tail (perf bound)", async () => {
     document.body.innerHTML = "<p>Huge wrapped selection</p>";
     const originalGetClientRects = Range.prototype.getClientRects;
-    withLayout(() => {
+    await withLayout(async () => {
       // 60 rects: index 0 is a border box strictly containing lines 1..10;
       // only the first 48 may ever be materialized (a huge selection can
       // yield thousands of rects per reconcile frame), the containment
@@ -2949,6 +3303,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
           originalText: "Huge wrapped selection",
           annotationType: "comment",
         });
+        await flushOverlay();
         const painted = visibleHighlights("pn-hl-comment").filter(
           (el) => el.getAttribute("data-annotation-id") === "huge-ann",
         );
@@ -2969,7 +3324,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
-  test("the page observer watches documentElement; body swaps unlock re-search (M3 scope)", () => {
+  test("the page observer watches documentElement; body swaps unlock re-search (M3 scope)", async () => {
     const observer = capturedObservers[0];
     if (!observer) throw new Error("bridge page observer was not captured");
     // Scope: a body-scoped observer sees NO record when the page swaps the
@@ -2987,6 +3342,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       originalText: "Body swap text",
       annotationType: "comment",
     });
+    await flushOverlay();
     expect(
       visibleHighlights("pn-hl-comment").some(
         (el) => el.getAttribute("data-annotation-id") === "swap-ann",
@@ -3037,8 +3393,10 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     }
 
     // The text returns inside the (new) body — inside the documentElement
-    // observer's subtree — and the next real record unlocks re-search.
+    // observer's subtree — and the next real record (after the failure
+    // backoff) unlocks re-search.
     document.body.innerHTML = "<p>Body swap text</p>";
+    advancePastDeadSearchBackoff();
     deliverPageMutations([{
       type: "childList",
       target: document.documentElement,
@@ -3056,7 +3414,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
-  test("dedup keeps the VISIBLE marker when a hidden sibling target shares the element (5b)", () => {
+  test("dedup keeps the VISIBLE marker when a hidden sibling target shares the element (5b)", async () => {
     document.body.innerHTML =
       '<div id="m10-a">First</div><div data-testid="m10-b">Second</div>';
     postBridge({
@@ -3069,6 +3427,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
         { selector: 'div[data-testid="m10-b"]', tagName: "div", point: { x: 0.75, y: 0.5 } },
       ],
     });
+    await flushOverlay();
     // Both anchors re-resolve to ONE merged element inside a clipper that
     // hides the FIRST target's point but not the second's: dedup must run
     // among PLACED markers, keeping the visible one — not consume the
@@ -3078,7 +3437,7 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     const wrap = document.querySelector<HTMLElement>("#m10-wrap")!;
     const merged = document.querySelector<HTMLElement>("#m10-a")!;
     wrap.style.overflow = "hidden";
-    withLayout(() => {
+    await withLayout(async () => {
       wrap.getBoundingClientRect = () => rectOf(100, 0, 100, 100);
       merged.getBoundingClientRect = () => rectOf(0, 0, 200, 50);
       bumpDomGeneration();

--- a/packages/ui/components/html-viewer/srcdoc.test.ts
+++ b/packages/ui/components/html-viewer/srcdoc.test.ts
@@ -2747,10 +2747,10 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
       let rectCollections = 0;
       (Range.prototype as unknown as { getBoundingClientRect: () => DOMRect })
         .getBoundingClientRect = () => rectOf(10, 2000, 100, 20);
-      (Range.prototype as unknown as { getClientRects: () => DOMRect[] }).getClientRects = (() => {
+      (Range.prototype as unknown as { getClientRects: () => DOMRect[] }).getClientRects = () => {
         rectCollections += 1;
         return [rectOf(10, 2000, 100, 20)];
-      }) as unknown as typeof Range.prototype.getClientRects;
+      };
       try {
         postBridge({
           type: "plannotator-bridge-find-and-mark",


### PR DESCRIPTION
**TLDR:** Hardening round from a 25-item QA gate over everything merged since v0.26.7. Every fix traces directly to code added this release: the raw-HTML overlay (#1257, #1254) and the Qwen system-prompt fix (#1114). No fixes to pre-existing surfaces; the 17 QA items covering old surfaces all passed untouched.

> Label: AI-assisted. Produced by a 28-agent QA workflow (25 reviewers, 3 adversarial verifiers), a hardening pass, an independent verification of that pass, and a polish round for the verifier's findings. All regression tests mutation-verified (fix reverted, test fails, fix restored).

## Fixes

**Overlay perf and lifecycle (bridge-script.ts):**
- Dead-target re-search now backs off per target (300ms doubling to 5s) with a bounded per-frame budget, so a mutation-heavy page can no longer trigger a full-document text scan every frame for a stale annotation. Print and scroll-to passes are user-initiated one-shots and get an unbounded budget so they never silently skip recoverable targets.
- Restored the viewport cull the v0.26.7 badge renderer had: off-screen targets skip computed-style and clip-chain work entirely.
- Layout reads and style writes are now two-phase per reconcile (no forced synchronous layouts mid-pass).
- Batch restore renders once instead of once per annotation.
- Pages with zero annotations and no active pinpoint no longer schedule reconciles on page mutations.
- Committed highlights regained a hover affordance (brightness bump, rendered inside the overlay shadow root; no page-DOM writes), and a mode-switch race that could leave the hover stuck is fixed.
- Markers yield to text-selection drags in drag mode, structurally excluding marker clicks.

**Numbering correctness:**
- On-page marker numbers now match the `## N.` numbers in exported feedback exactly, including with global comments and externally-injected annotations (numbering by array position, the order `exportAnnotations` actually uses). Sync capacity past 512 annotations no longer wasted on globals.

**OpenCode 2 (`server.ts`):**
- The #1114 Qwen3.6 system-prompt consolidation shipped only in the OpenCode 1 entry point; the published V2 adapter still emitted multi-part system injection. The V2 adapter now composes a single system part with identical ordering to V1, plus the regression test for the compose-before-truncate bug class found in #1114's review. Verified against OpenCode v2 source: no first-party prompt-cache regression (system parts are rebuilt per request and cache breakpoints are applied after the hook); only third-party per-part cache hints are flattened, noted in a code comment.

**Docs (AGENTS.md):**
- Annotation types updated (`htmlAdditionalTargets`, `HtmlAnnotationTarget`, `HtmlElementAnchor.point`), the raw-HTML annotate description now reflects the overlay model, and two known limitations are documented (raw-HTML print fidelity; share links intentionally not carrying element anchors).

## Validation

- `bun run typecheck` clean; full `bun test` 3151 pass / 0 fail; CI-shaped DOM suites green (seam-contract set 182, html-viewer 122).
- Build chain green: review, hook, opencode.
- 8 mutation-verified regression tests across the two rounds.
- Bridge template-string constraints verified unchanged (no backticks, no `${` in the emitted script).
