### PR TITLE
fix(annotate): strip document-authored CSP meta tags that block the annotation bridge

### DIFF
--- a/packages/ui/components/html-viewer/srcdoc.test.ts
+++ b/packages/ui/components/html-viewer/srcdoc.test.ts
@@ -3562,4 +3562,29 @@ describe("injectIntoHead", () => {
     );
     expect(injectIntoHead("<p>no head</p>", "[X]")).toBe("[X]<p>no head</p>");
   });
+
+  test("removes document-authored CSP meta tags so the bridge can execute", () => {
+    // The exact tag Plannotator's own portable guided-review exports embed;
+    // with it present the inline bridge script is blocked and annotation dies.
+    const csp =
+      '<meta http-equiv="Content-Security-Policy" content="default-src \'none\'; style-src \'unsafe-inline\'; img-src data:; font-src \'none\'; connect-src \'none\'; media-src \'none\'; object-src \'none\'; base-uri \'none\'; form-action \'none\'; frame-src \'none\'">';
+    const out = injectIntoHead(`<html><head>${csp}<title>t</title></head><body/></html>`, "[X]");
+    expect(out).not.toMatch(/content-security-policy/i);
+    expect(out).toContain("[X]</head>");
+    expect(out).toContain("<title>t</title>");
+
+    // Attribute-order, quoting, casing, and self-closing variants.
+    const variants = [
+      "<meta content=\"default-src 'none'\" http-equiv=content-security-policy>",
+      "<META HTTP-EQUIV='Content-Security-Policy' CONTENT=\"script-src 'none'\" />",
+      "<meta http-equiv = \" content-security-policy \" content=\"default-src 'self'\">",
+    ];
+    for (const tag of variants) {
+      expect(injectIntoHead(`<head>${tag}</head>`, "[X]")).not.toMatch(/http-equiv/i);
+    }
+
+    // Other meta tags survive untouched.
+    const keep = '<meta http-equiv="refresh" content="0"><meta charset="utf-8">';
+    expect(injectIntoHead(`<head>${keep}</head>`, "[X]")).toContain(keep);
+  });
 });

--- a/packages/ui/components/html-viewer/srcdoc.ts
+++ b/packages/ui/components/html-viewer/srcdoc.ts
@@ -120,11 +120,26 @@ export function buildSrcdocInjection({
   return `<style>${themeCSS}${ANNOTATION_HIGHLIGHT_CSS}${diffCSS}</style><script>${BRIDGE_SCRIPT}</script>`;
 }
 
+/**
+ * A document-authored CSP `<meta>` tag (e.g. `default-src 'none'` in
+ * Plannotator's own portable guided-review exports) blocks the inline bridge
+ * script and disables annotation entirely. The iframe `sandbox` attribute is
+ * the security boundary for the annotate surface; the page's CSP was written
+ * for its standalone context, so it is removed before injection.
+ */
+const META_CSP_RE =
+  /<meta\s[^>]*http-equiv\s*=\s*["']?\s*content-security-policy\s*["']?[^>]*\/?>/gi;
+
+export function neutralizeMetaCsp(rawHtml: string): string {
+  return rawHtml.replace(META_CSP_RE, "<!-- plannotator: meta CSP removed for annotation -->");
+}
+
 /** Splice the injection just before `</head>`, or prepend when there is none. */
 export function injectIntoHead(rawHtml: string, injection: string): string {
-  const headClose = rawHtml.indexOf("</head>");
+  const html = neutralizeMetaCsp(rawHtml);
+  const headClose = html.indexOf("</head>");
   if (headClose !== -1) {
-    return rawHtml.slice(0, headClose) + injection + rawHtml.slice(headClose);
+    return html.slice(0, headClose) + injection + html.slice(headClose);
   }
-  return injection + rawHtml;
+  return injection + html;
 }


### PR DESCRIPTION
**TLDR:** A document that ships its own CSP meta tag (including Plannotator's own portable guided-review HTML exports, which embed `default-src 'none'`) blocked the injected inline annotation bridge, so annotating such a file did nothing at all: no pinpoint, no selection. `injectIntoHead` now strips document-authored CSP meta tags before splicing the bridge. Pre-existing bug, found in v0.26.8 manual QA when annotating one of our own exports.

> Label: AI-assisted.

The iframe `sandbox` attribute is the annotate surface's actual security boundary; the page's CSP was authored for its standalone context, so removing it inside the viewer does not weaken anything. The removal is tolerant of attribute order, quoting, casing, and self-closing forms; other `http-equiv` metas and the rest of the head are untouched. A replacement comment marks the removal in the assembled srcdoc.

**Validation:** new regression test covering the exact exported tag plus variants, mutation-verified (neutralization disabled makes it fail); srcdoc suite 74 pass; typecheck clean.
