### PR TITLE
chore(ui): prep @plannotator/ui 0.29.0 + @plannotator/core 0.23.0 publish

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -63,7 +63,7 @@
     },
     "apps/opencode-plugin": {
       "name": "@plannotator/opencode",
-      "version": "0.26.7",
+      "version": "0.26.8",
       "devDependencies": {
         "@opencode-ai/plugin": "0.0.0-next-16775",
         "@plannotator/server": "workspace:*",
@@ -80,7 +80,7 @@
     },
     "apps/pi-extension": {
       "name": "@plannotator/pi-extension",
-      "version": "0.26.7",
+      "version": "0.26.8",
       "dependencies": {
         "@joplin/turndown-plugin-gfm": "^1.0.64",
         "@pierre/diffs": "1.3.2",
@@ -169,7 +169,7 @@
     },
     "packages/core": {
       "name": "@plannotator/core",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "devDependencies": {
         "typescript": "~5.8.2",
       },
@@ -218,7 +218,7 @@
     },
     "packages/server": {
       "name": "@plannotator/server",
-      "version": "0.26.7",
+      "version": "0.26.8",
       "dependencies": {
         "@pierre/diffs": "1.3.2",
         "@plannotator/ai": "workspace:*",
@@ -246,7 +246,7 @@
     },
     "packages/ui": {
       "name": "@plannotator/ui",
-      "version": "0.28.0",
+      "version": "0.29.0",
       "dependencies": {
         "@base-ui/react": "^1.6.0",
         "@codemirror/autocomplete": "^6.20.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plannotator/core",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "type": "module",
   "exports": {
     "./agents": "./agents.ts",

--- a/packages/ui/HANDOFF.md
+++ b/packages/ui/HANDOFF.md
@@ -204,6 +204,8 @@ We deliberately did **not** restructure the exports map in this PR (move-don't-r
 | `hooks/useActiveSection` | Scroll-spy over rendered headings; no backend. *(Blessed in 0.24.0.)* |
 | `hooks/useScrollViewport` | Resolves the scrolling element for viewport-aware UI; no backend. *(Blessed in 0.24.0.)* |
 | `utils/annotationHelpers` | Pure annotation utilities (`getAnnotationCountBySection`, `buildTocHierarchy` + `TocItem`). *(Blessed in 0.24.0.)* |
+| `components/html-viewer` (`HtmlViewer`) | The raw-HTML annotation viewer: overlay-projected placed markers, pinpoint anchors, multi-target comments. Props + validated bridge protocol; no backend of its own. See "Raw-HTML annotation viewer + syntax-highlighting migration (0.29.0)". *(Blessed in 0.29.0.)* |
+| `utils/codeHighlight` / `utils/codeBlockMark` / `utils/syntaxTheme` | The Shiki-based fence highlighter, swap-surviving annotation marks, and palette→Shiki theme mapping. Replaces all `.hljs` styling. *(Blessed in 0.29.0.)* |
 
 **AI is fully avoidable** — with one precision worth knowing. No AI *UI* is reachable from the supported components: `useAIChat` is imported only by `components/ai/DocumentAIChatPanel` and `useAIProviderConfig`, neither of which any supported component imports, and `CommentPopover`'s Ask-AI affordance exists only behind the optional `onAskAI` prop. `configure.ts` does statically import the `useAIChat` module (it needs `setAITransport`), but if you never use AI the hook is dead code and bundlers eliminate it — verified empirically: a standalone consumer's production bundle importing the full supported surface contains zero `/api/ai` strings. Don't import `components/ai/*` and don't pass `aiTransport`, and you ship no AI code.
 
@@ -411,9 +413,38 @@ Seam pinned end-to-end by `components/MarkdownDiff.reexport.test.tsx` (public su
 
 ---
 
+## Raw-HTML annotation viewer + syntax-highlighting migration (0.29.0)
+
+0.29.0 blesses the rebuilt raw-HTML annotation viewer as supported host surface and carries one **breaking** migration inherited from the diff-pane highlighter unification. Read both parts before upgrading from 0.28.0.
+
+### BREAKING: `.hljs` is gone — style code via `pn-code`
+
+highlight.js was removed from the package; the single highlighter is now Shiki via `@pierre/diffs` (new dependency, pinned `1.3.2`). Consumer impact:
+
+1. **Any host CSS targeting `.hljs` or `.hljs-*` token classes is inert.** Fenced code blocks now carry `pn-code font-mono language-{lang}` — import `CODE_BLOCK_CLASS` from `utils/codeHighlight` instead of hardcoding class strings.
+2. **Per-theme token CSS is the wrong layer now.** Fences resolve a real Shiki theme from the active palette (`utils/syntaxTheme`, `hooks/useFenceTheme`); to change code colors, map the palette to a different Shiki theme — don't write token-class CSS.
+3. **New supported utils:** `utils/codeHighlight` (`applyHighlight`, `highlightToHtml`, `codeBlockClassName`, `onCodeHighlightSwap`), `utils/codeBlockMark` (annotation marks that survive highlight swaps), `utils/syntaxTheme`. All pure/browser-safe.
+4. **Language-less fences render as plain text — there is no auto-detection anywhere.** Don't reintroduce it host-side; it breaks the byte-identity contract the annotation layer depends on.
+
+### Blessed: `components/html-viewer` (`HtmlViewer`)
+
+The overlay-projection annotation viewer for raw HTML (placed comment markers, pinpoint element anchors, shift-click multi-target, drag selection) is now on the supported allowlist, same standing as `components/Viewer`. The full architecture handoff (anchor model, reconcile loop, message protocol, test map) is a separate document — ask the maintainer for `HANDOFF_HTML_ANNOTATION_v0.26.8.md`. The contract summary:
+
+1. **The contract is props + the validated message protocol — not `configurePlannotatorUI`.** `HtmlViewer` is driven by its props (`rawHtml`, `annotations`, `onAddAnnotation`, `onSelectAnnotation`, `selectedAnnotationId`, `mode`, `inputMethod`, `readOnly`, …) and adapts the sandboxed iframe's validated bridge messages to the same annotation controls the markdown `Viewer` uses. The `configure()` seams still govern what surrounds it (storage, drafts, images, AI), but nothing about the viewer itself routes through `configure()`. Integrate on props; that is the path we maintain.
+2. **Numbering derives from the `annotations` prop — drive the prop.** Marker numbers are computed from the prop's array order (matching `exportAnnotations` numbering, globals occupying slots) and synced to the iframe on every prop change. Mounting with an empty prop and driving the viewer imperatively is NOT supported and will leave bubbles unnumbered; the imperative handle (`applySharedAnnotations`, `removeHighlight`, `clearAllHighlights`) exists for repaint scenarios on top of a prop-driven mount, not as a substitute for it. If your host architecture truly cannot supply the prop, ask for a numbering seam rather than working around it.
+3. **`readOnly` is view-only, not blank.** With `readOnly`, committed annotations still restore, markers still paint with correct numbers, and clicking a marker still fires `onSelectAnnotation`; every authoring entry point (composer, toolbar, quick label, vim) is disabled. Pinned by the "readOnly view-only contract" tests in `components/html-viewer/htmlPinpointProtocol.test.tsx`.
+4. **Security envelope: opaque-origin `srcdoc` sandbox only.** The iframe is `sandbox="allow-scripts"` (no `allow-same-origin`) and both sides authenticate messages by source identity with `targetOrigin: "*"`. That pattern is safe **only** because a `srcdoc` sandbox has an opaque origin. If a host serves annotated content from a real origin (a proxy, a hosted iframe), it must add strict `targetOrigin` and origin checks — do not reuse the `"*"` pattern there.
+5. **Multi-target cap is 16 on our side.** `htmlAdditionalTargets` accepts up to 16 additional anchors per comment; a host enforcing a smaller product cap (e.g. 7) should cap at composer level before submit — the stored schema is unchanged either way. As with every anchor field, persist `htmlAnchor`/`htmlAdditionalTargets` as opaque JSON and round-trip them unchanged (see "The annotation anchor schema").
+
+### `@plannotator/core` 0.23.0
+
+Additive only, but required: `@plannotator/ui` 0.29.0 imports the new `@plannotator/core/annotatable` subpath (absent from published core 0.22.0), so core 0.23.0 must be installed/published first. Also picks up additive exports in `agent-jobs`, `config-types`, `favicon`, `feedback-templates`, and an external-annotation PATCH-merge fix (tool-submitted `source` markers are no longer clearable via PATCH).
+
+---
+
 ## Publishing & versioning
 
-- `@plannotator/core` and `@plannotator/ui` are versioned **in lockstep with the repo** (`@plannotator/ui` is now `0.28.0`; `@plannotator/core` remains `0.22.0` until its next change — the ui→core dependency still resolves exactly at pack time).
+- `@plannotator/ui` is now `0.29.0`; `@plannotator/core` is `0.23.0`. **Publish `core` first** — ui 0.29.0 imports `@plannotator/core/annotatable`, which does not exist in core 0.22.0. The ui→core dependency resolves exactly at pack time.
 - They depend on each other via `workspace:*`. At publish time that must resolve to the **exact** version in the tarball, so publish with a tool that does that resolution (the repo's existing flow uses `bun pm pack` to build the tarball, then `npm publish *.tgz --provenance --access public`). Publish **`core` first, then `ui`**.
 - `styles.css` is built by the `prepack` script (`bun run build:css`) so the published tarball always carries fresh precompiled CSS.
 - There is **no CI publish job for these two packages yet** — first publish is manual from `main` after merge. (Wiring a CI publish job is a follow-up.)

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -80,6 +80,10 @@ Requires `@plannotator/markdown-editor ^0.3.2` and `@plannotator/atomic-editor ^
 
 Requires `@plannotator/markdown-editor ^0.4.0` and `@plannotator/atomic-editor ^0.8.0` (which adds a `@codemirror/merge` peer — declared by this package). See HANDOFF.md § "Frozen markdown diff (0.28.0)".
 
+### Raw-HTML annotation viewer (`HtmlViewer`)
+
+`components/html-viewer` is supported host surface as of 0.29.0: the overlay-projection annotation viewer for raw HTML (placed comment markers, pinpoint element anchors, shift-click multi-target comments). Its contract is **props plus the validated iframe message protocol** — not `configurePlannotatorUI()`, which only governs the backend surfaces around it. Drive the `annotations` prop (marker numbering derives from its array order); `readOnly` keeps markers painted and clickable while disabling all authoring. **0.29.0 also carries a breaking migration:** highlight.js is gone and `.hljs` selectors are inert — style code via the exported `pn-code` class (`CODE_BLOCK_CLASS` in `utils/codeHighlight`). See HANDOFF.md § "Raw-HTML annotation viewer + syntax-highlighting migration (0.29.0)" before upgrading from 0.28.0.
+
 ## Consuming it (e.g. from Workspaces)
 
 ```bash

--- a/packages/ui/components/html-viewer/htmlPinpointProtocol.test.tsx
+++ b/packages/ui/components/html-viewer/htmlPinpointProtocol.test.tsx
@@ -877,3 +877,108 @@ describe.if(hasDom)('multi-target composer flow (chips, promotion, submit)', () 
     expect(popover.className).not.toContain('pn-composer-yield-near');
   });
 });
+
+describe.if(hasDom)('readOnly view-only contract', () => {
+  // The promise made to hosts (HANDOFF.md 0.29.0): readOnly disables every
+  // authoring entry point but is NOT blank — committed annotations restore,
+  // markers paint with export-matching numbers, and marker clicks still
+  // navigate. View-only review contexts depend on all three.
+  async function mountReadOnly(
+    annotations: Annotation[],
+    onSelect: (id: string | null) => void = () => {},
+  ) {
+    if (!htmlViewerModule) throw new Error('DOM test environment is not registered');
+    const HtmlViewer = htmlViewerModule.HtmlViewer;
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    mountedRoots.push(root);
+    await act(async () => {
+      root.render(
+        <HtmlViewer
+          rawHtml="<html><body><p>Read-only target</p></body></html>"
+          annotations={annotations}
+          onAddAnnotation={() => {}}
+          onSelectAnnotation={onSelect}
+          selectedAnnotationId={null}
+          mode="selection"
+          inputMethod="pinpoint"
+          readOnly
+        />,
+      );
+    });
+    const iframe = host.querySelector<HTMLIFrameElement>('iframe');
+    if (!iframe?.contentWindow) throw new Error('HTML iframe missing');
+    const postedToIframe: Array<Record<string, unknown>> = [];
+    const realPost = iframe.contentWindow.postMessage.bind(iframe.contentWindow);
+    (iframe.contentWindow as unknown as { postMessage: (data: unknown) => void }).postMessage =
+      ((data: unknown, ...rest: unknown[]) => {
+        if (data && typeof data === 'object') postedToIframe.push(data as Record<string, unknown>);
+        return (realPost as (...args: unknown[]) => unknown)(data, ...rest);
+      }) as typeof iframe.contentWindow.postMessage;
+    const post = async (data: Record<string, unknown>) => {
+      await act(async () => {
+        window.dispatchEvent(new MessageEvent('message', {
+          source: iframe.contentWindow,
+          data,
+        }));
+      });
+    };
+    return { post, postedToIframe };
+  }
+
+  function committed(id: string): Annotation {
+    return {
+      id,
+      blockId: '',
+      startOffset: 0,
+      endOffset: 0,
+      type: 'COMMENT',
+      text: 'noted',
+      originalText: 'Read-only target',
+      createdA: 1,
+      htmlAnchor: { selector: 'p', tagName: 'p', text: 'Read-only target' },
+    } as Annotation;
+  }
+
+  test('readOnly still restores markers and syncs export-matching numbers on ready', async () => {
+    const { post, postedToIframe } = await mountReadOnly([committed('ro-1'), committed('ro-2')]);
+    await post({ type: 'plannotator-bridge-ready' });
+
+    const restores = postedToIframe.filter((m) => m.type === 'plannotator-bridge-find-and-mark');
+    expect(restores.map((m) => m.id)).toEqual(['ro-1', 'ro-2']);
+    // Anchor-first restore must survive readOnly: the anchor is forwarded so
+    // the bridge can pin the marker at the element, not just text-search.
+    expect((restores[0]!.anchor as { selector: string }).selector).toBe('p');
+
+    const syncs = postedToIframe.filter((m) => m.type === 'plannotator-bridge-sync-annotations');
+    expect(syncs.at(-1)!.annotations).toEqual([
+      { id: 'ro-1', number: 1 },
+      { id: 'ro-2', number: 2 },
+    ]);
+  });
+
+  test('readOnly marker clicks still navigate via onSelectAnnotation', async () => {
+    const selected: Array<string | null> = [];
+    const { post } = await mountReadOnly([committed('ro-1')], (id) => selected.push(id));
+    await post({ type: 'plannotator-bridge-ready' });
+    await post({ type: 'plannotator-bridge-mark-click', id: 'ro-1' });
+    expect(selected).toEqual(['ro-1']);
+  });
+
+  test('readOnly ignores selection messages: no toolbar, no composer', async () => {
+    const { post } = await mountReadOnly([committed('ro-1')]);
+    await post({ type: 'plannotator-bridge-ready' });
+    await post({
+      type: 'plannotator-bridge-selection',
+      text: 'Read-only target',
+      rect: { top: 10, left: 10, width: 120, height: 24 },
+      pinpoint: true,
+      targetKey: 'ht-ro',
+      targetLabel: 'Paragraph',
+      anchor: { selector: 'p', tagName: 'p', text: 'Read-only target' },
+    });
+    expect(document.querySelector('[data-comment-popover]')).toBeNull();
+    expect(document.querySelector('[data-annotation-toolbar]')).toBeNull();
+  });
+});

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plannotator/ui",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "type": "module",
   "exports": {
     "./components/*": "./components/*.tsx",


### PR DESCRIPTION
**TLDR:** Pre-publish prep so the Workspaces team can adopt the v0.26.8 HTML annotation rebuild from npm. Bumps ui to 0.29.0 and core to 0.23.0, blesses components/html-viewer as supported host surface, documents the .hljs to pn-code migration, and pins the readOnly view-only contract with tests. Closes #1222. No runtime code changes; the only source change is additive tests.

## Why now

The commercial consumer is adopting the overlay-projection HTML annotation viewer and adopts by version bump only. The registry's latest @plannotator/ui (0.28.0, published July 10) predates the rebuild, and the repo content has since drifted breaking-ly from that publish (#1222: highlight.js removed, .hljs renamed to pn-code). This PR does everything #1222 required before the next publish, plus the consumer-facing contract work their adoption asked for.

## Changes

- **packages/ui/package.json**: 0.28.0 to 0.29.0.
- **packages/core/package.json**: 0.22.0 to 0.23.0. Required, not optional: ui imports `@plannotator/core/annotatable`, which does not exist in published core 0.22.0, so core must publish first.
- **packages/ui/HANDOFF.md**: new section "Raw-HTML annotation viewer + syntax-highlighting migration (0.29.0)" covering the .hljs to pn-code breaking migration, the html-viewer contract (props + validated bridge protocol, not configurePlannotatorUI), the numbering contract (drive the annotations prop; imperative handle is repaint-only), the readOnly promise, the srcdoc-sandbox-only security envelope, and the core 0.23.0 dependency note. Allowlist gains `components/html-viewer` and the `codeHighlight`/`codeBlockMark`/`syntaxTheme` utils. Publishing section updated with the core-first ordering.
- **packages/ui/README.md**: short HtmlViewer section pointing at the HANDOFF entry.
- **packages/ui/components/html-viewer/htmlPinpointProtocol.test.tsx**: new "readOnly view-only contract" suite (3 tests): readOnly still restores markers with anchors and syncs export-matching numbers on bridge ready; marker clicks still route to onSelectAnnotation; selection messages are ignored (no toolbar, no composer). Mutation-verified: gating the restore effect on readOnly fails the suite.

## Verification

- `DOM_TESTS=1 bun test packages/ui/components/html-viewer/ packages/ui/utils/htmlChrome.test.ts packages/ui/utils/inputMethod.test.ts`: 147 pass, 0 fail.
- Mutation check on the new suite: adding `if (readOnly) return` to the restore effect produces 1 failure; reverted.
- Core drift audited against the published 0.22.0 tarball: additive exports plus the external-annotation PATCH-merge fix, one new module (annotatable) with a new export subpath, hence minor bump.

## After merge (manual, maintainer)

Publish is manual (the release pipeline deliberately does not publish these packages): `bun pm pack` then `npm publish *.tgz --provenance --access public`, **core first, then ui**, under the `next` dist-tag for consumer preflight before promoting to `latest`.

AI-assisted.