### PR TITLE
feat(ui): onUnanchoredChange report + readOnly keeps the host footer slot (0.30.0)

### DIFF
--- a/packages/ui/HANDOFF.md
+++ b/packages/ui/HANDOFF.md
@@ -328,7 +328,7 @@ Re-verify your seam contract against `0.23.0` before adopting; the list above is
 
 Six items accumulated through Workspaces' first three integration slices. All are additive; every default reproduces 0.23.0 behavior.
 
-1. **`AnnotationPanel` host props.** `renderCardFooter?: (annotation) => ReactNode` — a per-card slot at each plan-annotation card's foot (plug reply/resolve UI in; clicks inside the slot don't select the card). `readOnly?: boolean` — hides every mutation affordance (delete/edit on all card kinds); selection and scrolling still work.
+1. **`AnnotationPanel` host props.** `renderCardFooter?: (annotation) => ReactNode` — a per-card slot at each plan-annotation card's foot (plug reply/resolve UI in; clicks inside the slot don't select the card). `readOnly?: boolean` — hides the built-in mutation affordances (delete/edit on all card kinds); selection and scrolling still work, and as of 0.30.0 the host footer slot still renders (see "Unanchored-annotation reporting + readOnly footer fix (0.30.0)").
 2. **Six more supported imports** (already in the table above, tagged *Blessed in 0.24.0*): `TableOfContents`, `ResizeHandle` + `useResizablePanel`, `useActiveSection`, `useScrollViewport`, `utils/annotationHelpers`. All verified under the strict-consumer gate.
 3. **`Viewer`/`CommentPopover` `allowImages?: boolean`.** Pass `false` when you have no `uploadTransport` — the attach-image affordance disappears instead of dead-ending. (CommentPopover already had the prop; Viewer now exposes and threads it.)
 4. **`Viewer` `readOnly?: boolean`.** View-only users: suppresses every composer entry point (selection toolbar, comment popovers, quick labels, pinpoint, global comment, attachments, checkbox toggles) while existing annotations still render and select.
@@ -444,9 +444,30 @@ Additive only, but required: `@plannotator/ui` 0.29.0 imports the new `@plannota
 
 ---
 
+## Unanchored-annotation reporting + readOnly footer fix (0.30.0)
+
+Two consumer-driven changes: the `onUnanchoredChange` callback (the accepted ask from the 0.29.0 adoption) and a behavior fix to `AnnotationPanel`'s readOnly mode.
+
+### `HtmlViewer` `onUnanchoredChange?: (ids: string[]) => void`
+
+Fail-closed anchors hide markers rather than guess, which previously meant an annotation whose content vanished from the page disappeared silently. The viewer now reports it:
+
+1. **The callback receives the complete current set** of annotation ids with no live representation on the page — every target dead (element disconnected AND text unfindable), or the restore never resolved anything. It fires only when the set changes, including back to `[]` on recovery. An id being merely offscreen, clipped, or style-hidden is NOT unanchored: its content exists, so no report.
+2. **It fires in readOnly mode too** — view-only surfaces are exactly where silently missing markers go unnoticed.
+3. **Bounded like every bridge message:** at most 512 ids of at most 256 chars; an out-of-contract report is rejected whole at the parent trust boundary.
+4. **Timing:** reports ride the overlay reconcile (rAF-coalesced), so expect them shortly after load, after page mutations, and after your own `annotations` prop changes — not synchronously with them.
+
+Pinned by "unanchored ids are reported on change" in `components/html-viewer/srcdoc.test.ts` (bridge behavior) and the "unanchored report" suite in `components/html-viewer/htmlPinpointProtocol.test.tsx` (trust boundary + readOnly delivery).
+
+### `AnnotationPanel` readOnly no longer suppresses the host footer slot
+
+**Behavior change.** Through 0.29.1, `readOnly` dropped the `renderCardFooter` slot entirely, which threw away host READ affordances (a replies list, a copy link) along with mutations — view-only panels lost their replies. As of 0.30.0 the footer slot always renders; `readOnly` hides only the built-in mutation affordances (delete/edit, direct-edit discard). **The host gates its own footer contents:** if you render mutation UI in the footer, gate it on your own view-only state. A host that relied on the automatic suppression must add that gate when upgrading.
+
+---
+
 ## Publishing & versioning
 
-- `@plannotator/ui` is now `0.29.0`; `@plannotator/core` is `0.23.0`. **Publish `core` first** — ui 0.29.0 imports `@plannotator/core/annotatable`, which does not exist in core 0.22.0. The ui→core dependency resolves exactly at pack time.
+- `@plannotator/ui` is now `0.30.0`; `@plannotator/core` is `0.23.0`. **Publish `core` first** — ui 0.29.0 imports `@plannotator/core/annotatable`, which does not exist in core 0.22.0. The ui→core dependency resolves exactly at pack time.
 - They depend on each other via `workspace:*`. At publish time that must resolve to the **exact** version in the tarball, so publish with a tool that does that resolution (the repo's existing flow uses `bun pm pack` to build the tarball, then `npm publish *.tgz --access public`). Publish **`core` first, then `ui`**.
 - **`--provenance` only works from a supported CI environment (GitHub Actions OIDC)** — a local publish fails with `Automatic provenance generation not supported for provider: null`. Until a CI publish job exists for these two packages, local publishes drop the flag. Publishing under `--tag next` first lets the consumer preflight before `npm dist-tag add <pkg>@<version> latest` promotes it.
 - `styles.css` is built by the `prepack` script (`bun run build:css`) so the published tarball always carries fresh precompiled CSS.

--- a/packages/ui/components/AnnotationPanel.props.test.tsx
+++ b/packages/ui/components/AnnotationPanel.props.test.tsx
@@ -77,7 +77,11 @@ describe('AnnotationPanel consumer props', () => {
     expect(document.querySelector('button[title="Edit annotation"]')).toBeNull();
   });
 
-  test.skipIf(!hasDom)('readOnly hides direct-edit discard and host mutation slots', async () => {
+  test.skipIf(!hasDom)('readOnly hides direct-edit discard but keeps the host footer slot', async () => {
+    // The footer's contents are host-owned and may be pure read affordances
+    // (a replies list, a copy link) — view-only panels losing them was the
+    // Workspaces regression behind the 0.30.0 change. Built-in mutation
+    // affordances stay hidden; the host gates its own footer contents.
     await mount(
       <AnnotationPanel
         {...baseProps}
@@ -93,7 +97,8 @@ describe('AnnotationPanel consumer props', () => {
       />,
     );
     expect(document.body.textContent).not.toContain('Discard');
-    expect(document.body.textContent).not.toContain('Reply');
+    expect(document.querySelector('[data-annotation-card-footer="true"]')).not.toBeNull();
+    expect(document.body.textContent).toContain('Reply');
   });
 
   test.skipIf(!hasDom)('renderCardFooter renders per-card and does not select the card', async () => {

--- a/packages/ui/components/AnnotationPanel.tsx
+++ b/packages/ui/components/AnnotationPanel.tsx
@@ -80,8 +80,11 @@ interface PanelProps {
     *  resolve UI). The panel stays presentation-only; clicks inside the slot
     *  do not select the card. Default: nothing rendered. */
   renderCardFooter?: (annotation: Annotation) => React.ReactNode;
-  /** Hide every mutation affordance (delete/edit, direct-edit discard, and host card footers).
-    *  Selection and scrolling still work. Default false — today's behavior. */
+  /** Hide every built-in mutation affordance (delete/edit, direct-edit
+    *  discard). The host footer slot still renders: its contents are
+    *  host-owned and may be read affordances (replies, links), so the host
+    *  gates what belongs in it. Selection and scrolling still work.
+    *  Default false — today's behavior. */
   readOnly?: boolean;
 }
 
@@ -207,7 +210,7 @@ export const AnnotationPanel: React.FC<PanelProps> = ({
                   onDelete={() => onDelete(entry.annotation.id)}
                   onEdit={onEdit ? (updates: Partial<Annotation>) => onEdit(entry.annotation.id, updates) : undefined}
                   readOnly={readOnly}
-                  footer={readOnly ? undefined : renderCardFooter?.(entry.annotation)}
+                  footer={renderCardFooter?.(entry.annotation)}
                 />
               ) : (
                 <CodeAnnotationCard

--- a/packages/ui/components/html-viewer/HtmlViewer.tsx
+++ b/packages/ui/components/html-viewer/HtmlViewer.tsx
@@ -172,6 +172,11 @@ export interface HtmlViewerProps {
   onAskAI?: CommentAskAIHandler;
   /** Disable every annotation mutation entry point while preserving reading and navigation. */
   readOnly?: boolean;
+  /** Reports the full set of annotation ids with no live representation on
+   *  the page (fail-closed anchors hide markers rather than guess). Called
+   *  with the complete current set whenever it changes, including back to
+   *  empty on recovery. Fires in readOnly mode too. */
+  onUnanchoredChange?: (ids: string[]) => void;
   /** Accessible iframe title. */
   title?: string;
 }
@@ -205,6 +210,7 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
       onToggleDiff,
       onAskAI,
       readOnly = false,
+      onUnanchoredChange,
       title = "HTML Plan Viewer",
     },
     ref,
@@ -294,6 +300,7 @@ export const HtmlViewer = forwardRef<ViewerHandle, HtmlViewerProps>(
       mode,
       onResize: handleResize,
       onBridgePointer: handleBridgePointer,
+      onUnanchoredChange,
     });
 
     const multiSelectActive = !readOnly && !!hook.commentPopover && hook.draftTargets.length > 0;

--- a/packages/ui/components/html-viewer/bridge-script.ts
+++ b/packages/ui/components/html-viewer/bridge-script.ts
@@ -499,6 +499,7 @@ export const BRIDGE_SCRIPT = `(function() {
       annRecords = [];
       annNumbers = null; // stale synced numbers must not leak onto future records
       focusedAnnotationId = null;
+      restoreFailedIds.clear();
       renderAnnotationOverlay();
     }
 
@@ -1327,7 +1328,41 @@ export const BRIDGE_SCRIPT = `(function() {
     for (var i = annRecords.length - 1; i >= 0; i--) {
       if (annRecords[i].id === id) annRecords.splice(i, 1);
     }
+    restoreFailedIds['delete'](id);
     if (focusedAnnotationId === id) focusedAnnotationId = null;
+  }
+
+  // Fail-closed transparency (host ask): markers for dead targets are
+  // omitted, never guessed — this names WHICH annotations currently have no
+  // live representation on the page (every target dead, or the restore never
+  // resolved anything) so the host can tell the user instead of letting them
+  // silently vanish. Emitted only when the set changes, and only from
+  // complete overlay passes — budget-starved passes reschedule themselves
+  // and would flap the set. restoreFailedIds carries total restore failures,
+  // whose records are removed and therefore invisible to the per-pass scan.
+  var lastUnanchoredKey = '[]';
+  var restoreFailedIds = new Set();
+  function emitUnanchored(deadRecordIds) {
+    var seen = new Set();
+    var combined = [];
+    for (var deadIndex = 0; deadIndex < deadRecordIds.length; deadIndex++) {
+      if (!seen.has(deadRecordIds[deadIndex])) {
+        seen.add(deadRecordIds[deadIndex]);
+        combined.push(deadRecordIds[deadIndex]);
+      }
+    }
+    restoreFailedIds.forEach(function(failedId) {
+      if (!seen.has(failedId)) {
+        seen.add(failedId);
+        combined.push(failedId);
+      }
+    });
+    combined.sort();
+    if (combined.length > 512) combined = combined.slice(0, 512);
+    var key = JSON.stringify(combined);
+    if (key === lastUnanchoredKey) return;
+    lastUnanchoredKey = key;
+    parent.postMessage({ type: PREFIX + 'unanchored', ids: combined }, '*');
   }
 
   function validNormalizedPoint(p) {
@@ -1467,7 +1502,12 @@ export const BRIDGE_SCRIPT = `(function() {
         }
       }
     }
-    if (!record.targets.length) removeAnnRecord(id);
+    if (!record.targets.length) {
+      // The record is removed (nothing to retry), so the per-pass dead scan
+      // cannot see this id: track it separately for the unanchored report.
+      removeAnnRecord(id);
+      restoreFailedIds.add(id);
+    }
     // rAF-coalesced render (B3): restoring N annotations posts N
     // find-and-mark messages, and a synchronous render here made a batch
     // restore O(N^2) full overlay passes. The searches above stay
@@ -2094,10 +2134,17 @@ export const BRIDGE_SCRIPT = `(function() {
 
   function renderAnnotationOverlay() {
     var hasDraftRange = !!(pendingSelection && pendingRange);
-    if (!annRecords.length && !hasDraftRange && !overlayHostEl) return;
+    if (!annRecords.length && !hasDraftRange && !overlayHostEl) {
+      // Nothing to project, but total restore failures must still report:
+      // a session whose only annotations failed to restore never builds the
+      // overlay host, and silence here would hide exactly that case.
+      emitUnanchored([]);
+      return;
+    }
     ensureOverlayHost();
     beginDeadSearchPass();
     queuedHighlights.length = 0;
+    var unanchoredThisPass = [];
     var markers = [];
     // Fallback numbering by first-seen registration order — used only until
     // the parent's ordered sync arrives. Numbering NEVER derives from target
@@ -2111,6 +2158,20 @@ export const BRIDGE_SCRIPT = `(function() {
     for (var recordIndex = 0; recordIndex < annRecords.length; recordIndex++) {
       var record = annRecords[recordIndex];
       refreshRecordTargets(record);
+      // Live means connected/findable — clipped, offscreen, or style-hidden
+      // targets are still anchored (their content exists; it just isn't
+      // currently visible) and must not report as unanchored.
+      var recordAnchored = false;
+      for (var liveIndex = 0; liveIndex < record.targets.length; liveIndex++) {
+        var liveTarget = record.targets[liveIndex];
+        if (liveTarget.kind === 'element'
+          ? (liveTarget.element && liveTarget.element.isConnected)
+          : rangeAlive(liveTarget.range)) {
+          recordAnchored = true;
+          break;
+        }
+      }
+      if (!recordAnchored) unanchoredThisPass.push(record.id);
       var number = annNumbers && annNumbers.has(record.id)
         ? annNumbers.get(record.id)
         : fallbackNumbers.get(record.id);
@@ -2219,6 +2280,9 @@ export const BRIDGE_SCRIPT = `(function() {
     // record.
     flushQueuedHighlights();
     placeMarkers(markers);
+    // Budget-starved passes reschedule below and may still revive targets,
+    // so only a complete pass may update the unanchored report.
+    if (!deadSearchSkipped) emitUnanchored(unanchoredThisPass);
     // Eligible dead-target searches skipped for budget get a follow-up pass;
     // the loop terminates once every eligible target has been attempted at
     // the current generation (its failedGeneration then blocks it).

--- a/packages/ui/components/html-viewer/htmlPinpointProtocol.test.tsx
+++ b/packages/ui/components/html-viewer/htmlPinpointProtocol.test.tsx
@@ -982,3 +982,62 @@ describe.if(hasDom)('readOnly view-only contract', () => {
     expect(document.querySelector('[data-annotation-toolbar]')).toBeNull();
   });
 });
+
+describe.if(hasDom)('unanchored report (trust boundary + delivery)', () => {
+  const MSG = 'plannotator-bridge-unanchored';
+
+  test('accepts a bounded report, including the empty recovery set', () => {
+    expect(hookModule!.parseBridgeMessage({ type: MSG, ids: ['a-1', 'b-2'] }))
+      .toEqual({ type: MSG, ids: ['a-1', 'b-2'] });
+    expect(hookModule!.parseBridgeMessage({ type: MSG, ids: [] }))
+      .toEqual({ type: MSG, ids: [] });
+  });
+
+  test('out-of-contract reports are rejected whole (forged-message posture)', () => {
+    // The real bridge caps at 512 ids of <=256 chars; anything past that is a
+    // hostile page forging the message, so nothing salvageable is delivered.
+    expect(hookModule!.parseBridgeMessage({ type: MSG, ids: 'a' })).toBeNull();
+    expect(hookModule!.parseBridgeMessage({ type: MSG })).toBeNull();
+    expect(hookModule!.parseBridgeMessage({ type: MSG, ids: [42] })).toBeNull();
+    expect(hookModule!.parseBridgeMessage({ type: MSG, ids: ['ok', 'x'.repeat(257)] })).toBeNull();
+    expect(
+      hookModule!.parseBridgeMessage({ type: MSG, ids: Array.from({ length: 513 }, () => 'a') }),
+    ).toBeNull();
+  });
+
+  test('delivery reaches onUnanchoredChange even in readOnly mode', async () => {
+    // View-only surfaces are exactly where silently missing markers would go
+    // unnoticed, so the report must bypass the enabled gate like mark-click.
+    if (!htmlViewerModule) throw new Error('DOM test environment is not registered');
+    const HtmlViewer = htmlViewerModule.HtmlViewer;
+    const received: string[][] = [];
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    mountedRoots.push(root);
+    await act(async () => {
+      root.render(
+        <HtmlViewer
+          rawHtml="<html><body><p>Page</p></body></html>"
+          annotations={[]}
+          onAddAnnotation={() => {}}
+          onSelectAnnotation={() => {}}
+          selectedAnnotationId={null}
+          mode="selection"
+          inputMethod="pinpoint"
+          readOnly
+          onUnanchoredChange={(ids) => received.push(ids)}
+        />,
+      );
+    });
+    const iframe = host.querySelector<HTMLIFrameElement>('iframe');
+    if (!iframe?.contentWindow) throw new Error('HTML iframe missing');
+    await act(async () => {
+      window.dispatchEvent(new MessageEvent('message', {
+        source: iframe.contentWindow,
+        data: { type: MSG, ids: ['lost-1'] },
+      }));
+    });
+    expect(received).toEqual([['lost-1']]);
+  });
+});

--- a/packages/ui/components/html-viewer/srcdoc.test.ts
+++ b/packages/ui/components/html-viewer/srcdoc.test.ts
@@ -2617,6 +2617,83 @@ describe.if(hasDom)("bridge theme handler (DOM)", () => {
     document.body.replaceChildren();
   });
 
+  test("unanchored ids are reported on change: restore failures, late deaths, recovery, and clear", async () => {
+    // The fail-closed transparency contract (onUnanchoredChange): the bridge
+    // names WHICH annotations currently have no live representation — total
+    // restore failures (whose records are removed) and records whose every
+    // target died — re-reporting the full set only when it changes.
+    const reports: string[][] = [];
+    const listener = (e: MessageEvent) => {
+      const d = bridgeMessageData(e);
+      if (d && d.type === "plannotator-bridge-unanchored") reports.push(d.ids as string[]);
+    };
+    window.addEventListener("message", listener);
+    try {
+      document.body.innerHTML = "<p>Anchored copy</p>";
+      postBridge({
+        type: "plannotator-bridge-find-and-mark",
+        id: "live-ann",
+        originalText: "Anchored copy",
+        annotationType: "comment",
+      });
+      postBridge({
+        type: "plannotator-bridge-find-and-mark",
+        id: "ghost-ann",
+        originalText: "Text this page never contained",
+        annotationType: "comment",
+      });
+      await flushOverlay();
+      // Only the total restore failure reports; the resolved one does not.
+      expect(reports.at(-1)).toEqual(["ghost-ann"]);
+
+      // Change-only: an idle re-render must not repeat the report. (Bridge
+      // emissions deliver async like all postMessage traffic, so the flush
+      // guarantees any duplicate would have arrived before the count check.)
+      const countAfterRestore = reports.length;
+      postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+      await flushOverlay();
+      expect(reports.length).toBe(countAfterRestore);
+
+      // A re-restore that now resolves clears the failed id.
+      document.body.innerHTML =
+        "<p>Anchored copy</p><p>Text this page never contained</p>";
+      postBridge({
+        type: "plannotator-bridge-find-and-mark",
+        id: "ghost-ann",
+        originalText: "Text this page never contained",
+        annotationType: "comment",
+      });
+      await flushOverlay();
+      expect(reports.at(-1)).toEqual([]);
+
+      // Late death: both texts vanish, both records go dead after the
+      // generation-gated re-search fails.
+      document.body.innerHTML = "<p>Unrelated content</p>";
+      advancePastDeadSearchBackoff();
+      bumpDomGeneration();
+      postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+      await flushOverlay();
+      expect(reports.at(-1)).toEqual(["ghost-ann", "live-ann"]);
+
+      // Partial recovery: one text returns, the other stays dead.
+      document.body.innerHTML = "<p>Anchored copy</p>";
+      advancePastDeadSearchBackoff();
+      bumpDomGeneration();
+      postBridge({ type: "plannotator-bridge-sync-annotations", annotations: [] });
+      await flushOverlay();
+      expect(reports.at(-1)).toEqual(["ghost-ann"]);
+
+      // clear-marks empties the report along with the records.
+      postBridge({ type: "plannotator-bridge-clear-marks" });
+      await flushOverlay();
+      expect(reports.at(-1)).toEqual([]);
+    } finally {
+      window.removeEventListener("message", listener);
+      postBridge({ type: "plannotator-bridge-clear-marks" });
+      document.body.replaceChildren();
+    }
+  });
+
   test("mutation-heavy pages: failed re-searches back off on the wall clock and are budgeted per pass (A)", async () => {
     // A page that mutates every frame advances domGeneration every frame, so
     // the generation gate alone would re-run the whole-document sweep per

--- a/packages/ui/components/html-viewer/useHtmlAnnotation.ts
+++ b/packages/ui/components/html-viewer/useHtmlAnnotation.ts
@@ -65,6 +65,7 @@ type BridgeMessage =
   | { type: `${typeof PREFIX}selection-rect`; rect: BridgeRect }
   | { type: `${typeof PREFIX}keytype`; key: string }
   | { type: `${typeof PREFIX}mark-click`; id: string }
+  | { type: `${typeof PREFIX}unanchored`; ids: string[] }
   | { type: `${typeof PREFIX}resize`; height: number };
 
 /** Dependencies and callbacks for the sandboxed HTML annotation bridge. */
@@ -84,6 +85,13 @@ export interface UseHtmlAnnotationOptions {
    *  held while the pointer lives in the sandbox). Drives the composer-yield
    *  fade in the host component. */
   onBridgePointer?: (x: number, y: number, shift: boolean) => void;
+  /** Reports the full set of annotation ids that currently have NO live
+   *  representation on the page — every target dead, or the restore never
+   *  resolved (fail-closed anchors hide markers rather than guess). Called
+   *  with the complete current set whenever it changes, including back to
+   *  empty on recovery. Delivered in readOnly mode too: view-only surfaces
+   *  are exactly where silently missing markers would go unnoticed. */
+  onUnanchoredChange?: (ids: string[]) => void;
 }
 
 function postToIframe(iframe: HTMLIFrameElement | null, msg: Record<string, unknown>) {
@@ -258,6 +266,18 @@ export function parseBridgeMessage(value: unknown): BridgeMessage | null {
       return typeof value.id === "string" && value.id.length <= 256
         ? { type: value.type, id: value.id }
         : null;
+    case `${PREFIX}unanchored`: {
+      // Bounded like the bridge's own emission (512 ids, 256 chars each); any
+      // out-of-contract entry rejects the whole report — the real bridge
+      // never sends one, so a violation means a forged message.
+      if (!Array.isArray(value.ids) || value.ids.length > 512) return null;
+      const unanchoredIds: string[] = [];
+      for (const entry of value.ids) {
+        if (typeof entry !== "string" || entry.length > 256) return null;
+        unanchoredIds.push(entry);
+      }
+      return { type: value.type, ids: unanchoredIds };
+    }
     case `${PREFIX}resize`:
       return typeof value.height === "number" && Number.isFinite(value.height)
         ? { type: value.type, height: value.height }
@@ -282,6 +302,7 @@ export function useHtmlAnnotation({
   mode,
   onResize,
   onBridgePointer,
+  onUnanchoredChange,
 }: UseHtmlAnnotationOptions): Omit<
   UseAnnotationHighlighterReturn,
   "highlighterRef" | "highlightRange" | "highlightMathElement"
@@ -328,6 +349,8 @@ export function useHtmlAnnotation({
   onAddRef.current = onAddAnnotation;
   const onSelectRef = useRef(onSelectAnnotation);
   onSelectRef.current = onSelectAnnotation;
+  const onUnanchoredChangeRef = useRef(onUnanchoredChange);
+  onUnanchoredChangeRef.current = onUnanchoredChange;
 
   const anchorRef = useRef<HTMLDivElement | null>(null);
 
@@ -411,7 +434,12 @@ export function useHtmlAnnotation({
 
       const type = message.type;
 
-      if (!enabledRef.current && type !== `${PREFIX}mark-click` && type !== `${PREFIX}resize`) {
+      if (
+        !enabledRef.current
+        && type !== `${PREFIX}mark-click`
+        && type !== `${PREFIX}unanchored`
+        && type !== `${PREFIX}resize`
+      ) {
         return;
       }
 
@@ -562,6 +590,10 @@ export function useHtmlAnnotation({
 
       if (type === `${PREFIX}mark-click`) {
         onSelectRef.current?.(message.id);
+      }
+
+      if (type === `${PREFIX}unanchored`) {
+        onUnanchoredChangeRef.current?.(message.ids);
       }
 
       if (type === `${PREFIX}resize`) {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plannotator/ui",
-  "version": "0.29.1",
+  "version": "0.30.0",
   "type": "module",
   "exports": {
     "./components/*": "./components/*.tsx",


### PR DESCRIPTION
**TLDR:** Ships both remaining consumer asks from the 0.29.x adoption as @plannotator/ui 0.30.0: the accepted onUnanchoredChange callback (fail-closed anchors no longer hide markers silently) and the readOnly footer fix (view-only panels keep host read affordances like replies). No behavior change for Plannotator itself, which passes neither prop.

## onUnanchoredChange (new)

Fail-closed anchoring omits a marker rather than guessing, which meant an annotation whose content vanished from the page disappeared with no signal. The bridge now tracks two states the host could never see:

- **Total restore failures**: a find-and-mark that resolves nothing removes its record, so a separate failed-id set carries it (bridge-script.ts).
- **Late deaths**: records whose every target is dead after the generation-gated re-search (element disconnected AND text unfindable). Offscreen, clipped, or style-hidden targets are NOT unanchored; their content exists.

The union is emitted as a new `unanchored` bridge message only when the set changes (including back to empty on recovery) and only from complete overlay passes, since budget-starved passes reschedule and would flap the set. The parent validates it at the trust boundary (512 ids max, 256 chars each, out-of-contract reports rejected whole) and delivers it through the new `HtmlViewer` `onUnanchoredChange` prop. It bypasses the enabled gate like mark-click: readOnly surfaces are exactly where silently missing markers go unnoticed.

## readOnly footer fix (behavior change for hosts)

Through 0.29.1, `AnnotationPanel` readOnly dropped the `renderCardFooter` slot entirely, discarding host READ affordances (replies list, copy link) along with mutations; the consumer's view-only panels lost their replies. The slot now always renders and readOnly hides only the built-in mutation affordances (delete/edit, direct-edit discard). Hosts that render mutation UI in the footer gate it themselves; documented as a behavior change in the HANDOFF.

## Verification

- New bridge behavior test (restore failure, change-only emission, re-restore recovery, late death, partial recovery, clear-marks) in srcdoc.test.ts; new trust-boundary + readOnly-delivery suite in htmlPinpointProtocol.test.tsx; the pinned AnnotationPanel test updated from asserting the old suppression to asserting the new contract.
- Mutation-verified: removing the failed-id tracking fails the bridge test; removing the enabled-gate bypass fails the readOnly delivery test.
- Full sweep: `DOM_TESTS=1 bun test packages/editor/ packages/ui/` — 1048 pass, 0 fail.
- Bridge string-constant constraints held: no backticks, no interpolation, no backslashes in the added code.

## After merge

Manual publish (core unchanged at 0.23.0, no republish): `bun pm pack` in packages/ui, then `npm publish *.tgz --access public`. The consumer preflights nothing this time beyond their normal bump; they asked for this callback and left their host-side seam ready.

AI-assisted.