### PR TITLE
ci: harden releases and add security scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+
+# Dependabot owns Bun workspace updates. Renovate owns GitHub Actions.
+updates:
+  - package-ecosystem: bun
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "05:00"
+      timezone: America/Los_Angeles
+    # Delay routine releases long enough for ecosystem problems to surface.
+    # Dependabot security updates do not observe this cooldown.
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    groups:
+      bun-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,64 @@ permissions:
   contents: read
 
 jobs:
+  # Deploy remains automatic, but only after the exact commit has passed the
+  # repository's full Test workflow. The workflows start together on a main
+  # push; this job waits for Test instead of allowing deployment to race it.
+  verify:
+    name: Require successful Test run
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Wait for Test on this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          COMMIT_SHA: ${{ github.sha }}
+        shell: bash
+        run: |
+          deadline=$((SECONDS + 2400))
+          previous_state=""
+
+          while (( SECONDS < deadline )); do
+            run_json="$(gh api --method GET \
+              "repos/${REPOSITORY}/actions/workflows/test.yml/runs" \
+              -f head_sha="$COMMIT_SHA" \
+              -f event=push \
+              -f per_page=1)"
+
+            status="$(jq -r '.workflow_runs[0].status // "missing"' <<<"$run_json")"
+            conclusion="$(jq -r '.workflow_runs[0].conclusion // ""' <<<"$run_json")"
+            run_url="$(jq -r '.workflow_runs[0].html_url // ""' <<<"$run_json")"
+            state="${status}:${conclusion}"
+
+            if [[ "$state" != "$previous_state" ]]; then
+              if [[ -n "$run_url" ]]; then
+                echo "Test workflow for ${COMMIT_SHA}: ${state} (${run_url})"
+              else
+                echo "Test workflow for ${COMMIT_SHA}: ${state}"
+              fi
+              previous_state="$state"
+            fi
+
+            if [[ "$status" == "completed" ]]; then
+              if [[ "$conclusion" == "success" ]]; then
+                exit 0
+              fi
+              echo "Test workflow did not succeed for ${COMMIT_SHA}: ${conclusion} (${run_url})" >&2
+              exit 1
+            fi
+
+            sleep 15
+          done
+
+          echo "Timed out waiting for the Test workflow on ${COMMIT_SHA}." >&2
+          exit 1
+
   detect-changes:
+    needs: verify
     runs-on: ubuntu-latest
     outputs:
       marketing: ${{ steps.changes.outputs.marketing }}
@@ -37,62 +94,69 @@ jobs:
       waitlist: ${{ steps.changes.outputs.waitlist }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Check for changes
         id: changes
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TARGET: ${{ inputs.target }}
+          BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            if [[ "${{ inputs.target }}" == "all" || "${{ inputs.target }}" == "marketing" ]]; then
-              echo "marketing=true" >> $GITHUB_OUTPUT
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            if [[ "$TARGET" == "all" || "$TARGET" == "marketing" ]]; then
+              echo "marketing=true" >> "$GITHUB_OUTPUT"
             else
-              echo "marketing=false" >> $GITHUB_OUTPUT
+              echo "marketing=false" >> "$GITHUB_OUTPUT"
             fi
-            if [[ "${{ inputs.target }}" == "all" || "${{ inputs.target }}" == "portal" ]]; then
-              echo "portal=true" >> $GITHUB_OUTPUT
+            if [[ "$TARGET" == "all" || "$TARGET" == "portal" ]]; then
+              echo "portal=true" >> "$GITHUB_OUTPUT"
             else
-              echo "portal=false" >> $GITHUB_OUTPUT
+              echo "portal=false" >> "$GITHUB_OUTPUT"
             fi
-            if [[ "${{ inputs.target }}" == "all" || "${{ inputs.target }}" == "paste" ]]; then
-              echo "paste=true" >> $GITHUB_OUTPUT
+            if [[ "$TARGET" == "all" || "$TARGET" == "paste" ]]; then
+              echo "paste=true" >> "$GITHUB_OUTPUT"
             else
-              echo "paste=false" >> $GITHUB_OUTPUT
+              echo "paste=false" >> "$GITHUB_OUTPUT"
             fi
-            if [[ "${{ inputs.target }}" == "all" || "${{ inputs.target }}" == "waitlist" ]]; then
-              echo "waitlist=true" >> $GITHUB_OUTPUT
+            if [[ "$TARGET" == "all" || "$TARGET" == "waitlist" ]]; then
+              echo "waitlist=true" >> "$GITHUB_OUTPUT"
             else
-              echo "waitlist=false" >> $GITHUB_OUTPUT
+              echo "waitlist=false" >> "$GITHUB_OUTPUT"
             fi
           else
             # For push events, check what changed
-            git fetch origin ${{ github.event.before }} --depth=1 2>/dev/null || true
+            git fetch origin "$BEFORE_SHA" --depth=1 2>/dev/null || true
 
-            MARKETING_CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} 2>/dev/null | grep -E '^(apps/marketing/|packages/)' || true)
-            PORTAL_CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} 2>/dev/null | grep -E '^(apps/portal/|packages/)' || true)
-            PASTE_CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} 2>/dev/null | grep -E '^apps/paste-service/' || true)
-            WAITLIST_CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} 2>/dev/null | grep -E '^apps/waitlist-service/' || true)
+            MARKETING_CHANGED=$(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA" 2>/dev/null | grep -E '^(apps/marketing/|packages/)' || true)
+            PORTAL_CHANGED=$(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA" 2>/dev/null | grep -E '^(apps/portal/|packages/)' || true)
+            PASTE_CHANGED=$(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA" 2>/dev/null | grep -E '^apps/paste-service/' || true)
+            WAITLIST_CHANGED=$(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA" 2>/dev/null | grep -E '^apps/waitlist-service/' || true)
 
             if [[ -n "$MARKETING_CHANGED" ]]; then
-              echo "marketing=true" >> $GITHUB_OUTPUT
+              echo "marketing=true" >> "$GITHUB_OUTPUT"
             else
-              echo "marketing=false" >> $GITHUB_OUTPUT
+              echo "marketing=false" >> "$GITHUB_OUTPUT"
             fi
 
             if [[ -n "$PORTAL_CHANGED" ]]; then
-              echo "portal=true" >> $GITHUB_OUTPUT
+              echo "portal=true" >> "$GITHUB_OUTPUT"
             else
-              echo "portal=false" >> $GITHUB_OUTPUT
+              echo "portal=false" >> "$GITHUB_OUTPUT"
             fi
 
             if [[ -n "$PASTE_CHANGED" ]]; then
-              echo "paste=true" >> $GITHUB_OUTPUT
+              echo "paste=true" >> "$GITHUB_OUTPUT"
             else
-              echo "paste=false" >> $GITHUB_OUTPUT
+              echo "paste=false" >> "$GITHUB_OUTPUT"
             fi
 
             if [[ -n "$WAITLIST_CHANGED" ]]; then
-              echo "waitlist=true" >> $GITHUB_OUTPUT
+              echo "waitlist=true" >> "$GITHUB_OUTPUT"
             else
-              echo "waitlist=false" >> $GITHUB_OUTPUT
+              echo "waitlist=false" >> "$GITHUB_OUTPUT"
             fi
           fi
 
@@ -106,13 +170,15 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Build marketing
         run: bun run build:marketing
@@ -152,13 +218,15 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Build portal
         run: bun run build:portal
@@ -187,13 +255,15 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Deploy to Cloudflare
         working-directory: apps/paste-service
@@ -211,13 +281,15 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Deploy to Cloudflare
         working-directory: apps/waitlist-service

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,13 +53,26 @@ jobs:
             run_json="$(gh api --method GET \
               "repos/${REPOSITORY}/actions/workflows/test.yml/runs" \
               -f head_sha="$COMMIT_SHA" \
-              -f event=push \
-              -f per_page=1)"
+              -f per_page=100)"
 
-            status="$(jq -r '.workflow_runs[0].status // "missing"' <<<"$run_json")"
-            conclusion="$(jq -r '.workflow_runs[0].conclusion // ""' <<<"$run_json")"
-            run_url="$(jq -r '.workflow_runs[0].html_url // ""' <<<"$run_json")"
-            state="${status}:${conclusion}"
+            # Manual Test runs are an explicit recovery path when the original
+            # push run was skipped or cannot be recovered. Ignore PR runs and
+            # retain the exact-SHA requirement enforced by the API query.
+            run="$(jq -c '
+              [.workflow_runs[]
+                | select(
+                    .head_sha == env.COMMIT_SHA and
+                    (.event == "push" or .event == "workflow_dispatch")
+                  )]
+              | sort_by(.created_at)
+              | last // {}
+            ' <<<"$run_json")"
+
+            trigger="$(jq -r '.event // ""' <<<"$run")"
+            status="$(jq -r '.status // "missing"' <<<"$run")"
+            conclusion="$(jq -r '.conclusion // ""' <<<"$run")"
+            run_url="$(jq -r '.html_url // ""' <<<"$run")"
+            state="${trigger}:${status}:${conclusion}"
 
             if [[ "$state" != "$previous_state" ]]; then
               if [[ -n "$run_url" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1009,11 +1009,11 @@ jobs:
 
       - name: Pack @plannotator/opencode
         working-directory: apps/opencode-plugin
-        run: bun pm pack --filename ../../npm-packages/plannotator-opencode.tgz
+        run: bun pm pack --filename "$GITHUB_WORKSPACE/npm-packages/plannotator-opencode.tgz"
 
       - name: Pack @plannotator/pi-extension
         working-directory: apps/pi-extension
-        run: bun pm pack --filename ../../npm-packages/plannotator-pi-extension.tgz
+        run: bun pm pack --filename "$GITHUB_WORKSPACE/npm-packages/plannotator-pi-extension.tgz"
 
       - name: Upload npm package artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1021,7 +1021,7 @@ jobs:
           name: npm-packages
           path: npm-packages/*.tgz
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 7
 
   # Publish only the tarballs produced by the credential-free job. Automatic
   # tag releases are unchanged; a manual publish must also target a v* tag.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,29 +10,58 @@ on:
   workflow_dispatch:
     inputs:
       dry-run:
-        description: Validate build and npm publish without uploading
+        description: Package only; disable only when dispatching a v* tag to publish
         type: boolean
         default: true
 
 permissions:
   contents: read
 
-env:
-  DRY_RUN: ${{ !(startsWith(github.ref, 'refs/tags/') || inputs.dry-run == 'false') }}
-
 jobs:
+  # A release tag must identify a commit already contained in main. This runs
+  # independently of the build graph so an invalid tag cannot attest, publish,
+  # or create a GitHub release even if the build itself succeeds.
+  release-eligibility:
+    if: startsWith(github.ref, 'refs/tags/v') && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs['dry-run'] == 'false'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Require release commit to be on main
+        shell: bash
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          release_commit="$(git rev-parse "${GITHUB_REF}^{commit}")"
+          if ! git merge-base --is-ancestor "$release_commit" refs/remotes/origin/main; then
+            echo "Release tag ${GITHUB_REF_NAME} points to ${release_commit}, which is not contained in main." >&2
+            exit 1
+          fi
+
+      - name: Require tag to match release manifests
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: node scripts/check-release-version.mjs --tag "$RELEASE_TAG"
+
   test:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
+          no-cache: true
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Generate Pi extension shared copies
         run: bash apps/pi-extension/vendor.sh
@@ -58,13 +87,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
+          no-cache: true
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Build UI
         run: |
@@ -148,6 +180,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Download binaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -158,6 +192,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
+          package-manager-cache: false
 
       - name: Smoke-test binary
         if: runner.os != 'Windows'
@@ -670,17 +705,21 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
+          no-cache: true
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
+          package-manager-cache: false
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Generate Pi extension shared copies
         shell: bash
@@ -706,6 +745,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Download binaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -855,11 +896,12 @@ jobs:
     # publishes the signed bundle to GitHub's attestation store, so the
     # release job downstream doesn't need any new artifact handling.
     needs:
+      - release-eligibility
       - build
       - smoke-binaries
       - pi-extension-ai-runtime-windows
       - install-script-smoke
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/v') && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs['dry-run'] == 'false'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -895,13 +937,15 @@ jobs:
     # users could pull the binary and `gh attestation verify` would
     # race-fail. `needs: attest` implicitly requires `build` too.
     needs: attest
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/v') && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs['dry-run'] == 'false'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -913,6 +957,9 @@ jobs:
         run: ls -la artifacts/
 
       - name: Create GitHub Release
+        # zizmor: ignore[superfluous-actions] The pinned action preserves the
+        # existing release behavior. Owner: maintainers; reassess replacement
+        # with gh by 2027-08-11.
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           files: artifacts/*
@@ -920,7 +967,9 @@ jobs:
           draft: false
           prerelease: ${{ contains(github.ref, '-') }}
 
-  npm-publish:
+  # PRs and manual dry-runs stop here. This job executes repository build code,
+  # so it must never receive an npm token or permission to mint an OIDC token.
+  npm-package:
     needs:
       - build
       - smoke-binaries
@@ -929,21 +978,24 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
+          no-cache: true
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
+          package-manager-cache: false
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Build packages
         run: |
@@ -952,22 +1004,53 @@ jobs:
           bun run build:opencode
           bun run build:pi
 
-      - name: Publish @plannotator/opencode
+      - name: Create package artifact directory
+        run: mkdir -p npm-packages
+
+      - name: Pack @plannotator/opencode
         working-directory: apps/opencode-plugin
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          bun pm pack
-          if [[ "$DRY_RUN" == "false" ]]; then
-            npm publish *.tgz --provenance --access public
-          fi
+        run: bun pm pack --filename ../../npm-packages/plannotator-opencode.tgz
+
+      - name: Pack @plannotator/pi-extension
+        working-directory: apps/pi-extension
+        run: bun pm pack --filename ../../npm-packages/plannotator-pi-extension.tgz
+
+      - name: Upload npm package artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: npm-packages
+          path: npm-packages/*.tgz
+          if-no-files-found: error
+          retention-days: 1
+
+  # Publish only the tarballs produced by the credential-free job. Automatic
+  # tag releases are unchanged; a manual publish must also target a v* tag.
+  npm-publish:
+    needs:
+      - release-eligibility
+      - npm-package
+    if: startsWith(github.ref, 'refs/tags/v') && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs['dry-run'] == 'false'))
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+          registry-url: https://registry.npmjs.org
+
+      - name: Download npm package artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: npm-packages
+          path: npm-packages
+          digest-mismatch: error
+
+      - name: Publish @plannotator/opencode
+        run: npm publish ./npm-packages/plannotator-opencode.tgz --ignore-scripts --provenance --access public
 
       - name: Publish @plannotator/pi-extension
-        working-directory: apps/pi-extension
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          bun pm pack
-          if [[ "$DRY_RUN" == "false" ]]; then
-            npm publish *.tgz --provenance --access public
-          fi
+        run: npm publish ./npm-packages/plannotator-pi-extension.tgz --ignore-scripts --provenance --access public

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,259 @@
+name: Security Scanning
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "23 15 * * 6"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-scanning-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  GITLEAKS_VERSION: 8.30.0
+  GITLEAKS_LINUX_X64_SHA256: 79a3ab579b53f71efd634f3aaf7e04a0fa0cf206b7ed434638d1547a2470a66e
+  ZIZMOR_VERSION: 1.29.0
+  ZIZMOR_LINUX_X64_SHA256: dd96df044a6e8538d5f423790f453bdd03d49e5b2bcc38214acc41a2f1297839
+
+jobs:
+  gitleaks:
+    name: Gitleaks
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      actions: read # Required by upload-sarif to read workflow-run metadata.
+      security-events: write # Required only for the final SARIF upload.
+    steps:
+      - name: Checkout repository history
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fetch all branches and tags
+        run: git fetch --force --prune --tags origin '+refs/heads/*:refs/remotes/origin/*'
+
+      - name: Install verified Gitleaks
+        shell: bash
+        run: |
+          set -euo pipefail
+          archive="$RUNNER_TEMP/gitleaks.tar.gz"
+          install_dir="$RUNNER_TEMP/gitleaks-bin"
+          curl --fail --silent --show-error --location \
+            --proto '=https' --tlsv1.2 \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            --output "$archive"
+          printf '%s  %s\n' "$GITLEAKS_LINUX_X64_SHA256" "$archive" | sha256sum --check --strict
+          mkdir -p "$install_dir"
+          tar -xzf "$archive" -C "$install_dir" gitleaks
+          "$install_dir/gitleaks" version
+          echo "$install_dir" >> "$GITHUB_PATH"
+
+      - name: Verify Gitleaks detector health
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Build the fixture at runtime so the repository never contains a
+          # token-shaped string that GitHub push protection could misclassify.
+          synthetic_prefix='glpat'
+          synthetic_body='abcdefghijklmnopqrst'
+          set +e
+          printf 'token = "%s-%s"\n' "$synthetic_prefix" "$synthetic_body" \
+            | gitleaks stdin --config .gitleaks.toml --no-banner --redact=100 >/dev/null 2>&1
+          detector_exit=$?
+          set -e
+          if [[ "$detector_exit" -ne 1 ]]; then
+            echo "Gitleaks failed its synthetic detection test (exit $detector_exit)." >&2
+            exit 1
+          fi
+
+          # Confirm the exact, reviewed RFC 6455 example is allowlisted without
+          # suppressing the token-shaped fixture above.
+          websocket_example='dGhlIHNhbXBsZSBub25jZQ=='
+          printf 'Sec-WebSocket-Key: %s\n' "$websocket_example" \
+            | gitleaks stdin --config .gitleaks.toml --no-banner --redact=100 >/dev/null
+
+      - name: Scan repository history
+        id: scan
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p security-results
+
+          log_options='--all'
+          scan_scope='all branches and tags'
+
+          if [[ "$EVENT_NAME" == 'pull_request' ]]; then
+            if [[ -z "$PR_BASE_SHA" || -z "$PR_HEAD_SHA" ]]; then
+              echo 'The pull request commit range is missing.' >&2
+              exit 1
+            fi
+            git cat-file -e "${PR_BASE_SHA}^{commit}"
+            git cat-file -e "${PR_HEAD_SHA}^{commit}"
+            log_options="--all ${PR_BASE_SHA}..${PR_HEAD_SHA}"
+            scan_scope='pull request commit range'
+          elif [[ "$EVENT_NAME" == 'push' ]]; then
+            zero_sha='0000000000000000000000000000000000000000'
+            if [[ -n "$PUSH_BEFORE_SHA" && "$PUSH_BEFORE_SHA" != "$zero_sha" ]] \
+              && git cat-file -e "${PUSH_BEFORE_SHA}^{commit}" 2>/dev/null; then
+              git cat-file -e "${CURRENT_SHA}^{commit}"
+              log_options="--all ${PUSH_BEFORE_SHA}..${CURRENT_SHA}"
+              scan_scope='push commit range'
+            else
+              echo 'Push base is unavailable; conservatively scanning all branches and tags.'
+            fi
+          fi
+
+          # Findings are informational during rollout (--exit-code 0), while
+          # an actual scanner/configuration error still fails this step.
+          gitleaks git . \
+            --config .gitleaks.toml \
+            --log-opts="$log_options" \
+            --exit-code 0 \
+            --redact=100 \
+            --report-format sarif \
+            --report-path security-results/gitleaks.sarif \
+            --no-banner
+
+          jq -e '.version == "2.1.0" and (.runs | type == "array")' \
+            security-results/gitleaks.sarif >/dev/null
+          finding_count=$(jq '[.runs[].results[]?] | length' security-results/gitleaks.sarif)
+
+          {
+            echo '### Gitleaks'
+            echo "- Scope: $scan_scope"
+            echo "- Findings: $finding_count"
+            echo '- Enforcement: monitor mode; scanner failures still fail the job'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo 'report-ready=true' >> "$GITHUB_OUTPUT"
+
+      - name: Upload Gitleaks SARIF
+        if: >-
+          always() &&
+          steps.scan.outputs.report-ready == 'true' &&
+          (github.event_name != 'pull_request' ||
+          (github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'dependabot[bot]'))
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          sarif_file: security-results/gitleaks.sarif
+          category: gitleaks
+
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: read # Required by upload-sarif to read workflow-run metadata.
+      security-events: write # Required only for the final SARIF upload.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install verified zizmor
+        shell: bash
+        run: |
+          set -euo pipefail
+          archive="$RUNNER_TEMP/zizmor.tar.gz"
+          install_dir="$RUNNER_TEMP/zizmor-bin"
+          curl --fail --silent --show-error --location \
+            --proto '=https' --tlsv1.2 \
+            "https://github.com/zizmorcore/zizmor/releases/download/v${ZIZMOR_VERSION}/zizmor-x86_64-unknown-linux-gnu.tar.gz" \
+            --output "$archive"
+          printf '%s  %s\n' "$ZIZMOR_LINUX_X64_SHA256" "$archive" | sha256sum --check --strict
+          mkdir -p "$install_dir"
+          tar -xzf "$archive" -C "$install_dir" zizmor
+          "$install_dir/zizmor" --version
+          echo "$install_dir" >> "$GITHUB_PATH"
+
+      - name: Verify zizmor detector health
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Construct an attacker-controlled expression at runtime so this
+          # workflow remains safe while testing that zizmor catches it.
+          unsafe_expression='$'"{{ github.event.issue.title }}"
+          set +e
+          printf '%s\n' \
+            'name: Synthetic unsafe workflow' \
+            'on: issues' \
+            'jobs:' \
+            '  test:' \
+            '    runs-on: ubuntu-latest' \
+            '    steps:' \
+            "      - run: echo \"$unsafe_expression\"" \
+            | zizmor --offline --persona regular --strict-collection \
+                --format=json --no-progress --color=never - \
+                > "$RUNNER_TEMP/zizmor-health.json" 2>/dev/null
+          detector_exit=$?
+          set -e
+
+          if [[ "$detector_exit" -lt 11 || "$detector_exit" -gt 14 ]] \
+            || ! jq -e 'any(.ident == "template-injection")' \
+              "$RUNNER_TEMP/zizmor-health.json" >/dev/null; then
+            echo "zizmor failed its synthetic detection test (exit $detector_exit)." >&2
+            exit 1
+          fi
+
+      - name: Audit GitHub configuration
+        id: scan
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p security-results
+
+          # SARIF mode reports findings without a non-zero exit. Internal,
+          # collection, or configuration failures still fail the step.
+          zizmor --offline \
+            --persona regular \
+            --strict-collection \
+            --format=sarif \
+            --no-progress \
+            --color=never \
+            . > security-results/zizmor.sarif
+
+          jq -e '.version == "2.1.0" and (.runs | type == "array")' \
+            security-results/zizmor.sarif >/dev/null
+          finding_count=$(jq '[.runs[].results[]?] | length' security-results/zizmor.sarif)
+
+          {
+            echo '### zizmor'
+            echo '- Scope: all workflows, local actions, and Dependabot configuration'
+            echo "- Findings: $finding_count"
+            echo '- Network mode: offline'
+            echo '- Enforcement: monitor mode; scanner failures still fail the job'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo 'report-ready=true' >> "$GITHUB_OUTPUT"
+
+      - name: Upload zizmor SARIF
+        if: >-
+          always() &&
+          steps.scan.outputs.report-ready == 'true' &&
+          (github.event_name != 'pull_request' ||
+          (github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'dependabot[bot]'))
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          sarif_file: security-results/zizmor.sarif
+          category: zizmor

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Test
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,19 +8,27 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
+
+      - name: Check release version consistency
+        run: bun run check:release-version
 
       - name: Generate Pi extension shared copies
         run: bash apps/pi-extension/vendor.sh
@@ -126,15 +134,20 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Install OpenCode 2
+        # zizmor: ignore[adhoc-packages] This integration test requires the exact
+        # globally installed CLI. Owner: maintainers; reassess a locked fixture
+        # by 2027-08-11.
         run: npm install --global @opencode-ai/cli@0.0.0-next-16775
 
       - name: Build OpenCode plugin assets
@@ -167,13 +180,15 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Run focused uninstall tests
         run: bun test packages/server/uninstall.test.ts apps/hook/server/cli.test.ts
@@ -187,17 +202,19 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Generate Pi extension shared copies
         shell: bash
@@ -224,6 +241,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Seed fake ~/.gemini/settings.json with pre-existing hook
         shell: pwsh
@@ -259,7 +278,9 @@ jobs:
           '@
           Set-Content -Path "$env:USERPROFILE\.gemini\settings.json" -Value $fixture -NoNewline
 
-      - name: Run install.cmd end-to-end
+      - name: Run install.cmd end-to-end # zizmor: ignore[misfeature]
+        # CMD is the subject of this regression test; replacing the shell would
+        # invalidate it. Owner: maintainers; reassess by 2027-08-11.
         shell: cmd
         # v0.17.1 is pinned intentionally. This test needs a real binary
         # to download so it can exercise install.cmd end-to-end — SHA256
@@ -477,6 +498,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Run install.ps1 end-to-end
         shell: pwsh

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,14 @@
+title = "Plannotator Gitleaks configuration"
+
+[extend]
+useDefault = true
+
+[[allowlists]]
+# Disposition: public, non-secret RFC test vector; reviewed 2026-08-11.
+# Owner: Plannotator maintainers. Re-review by 2027-08-11 or when the fixture is removed.
+description = "RFC 6455 WebSocket handshake example"
+targetRules = ["generic-api-key"]
+regexTarget = "match"
+regexes = [
+  '''Sec-WebSocket-Key:\s*dGhlIHNhbXBsZSBub25jZQ==''',
+]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Supported versions
+
+Plannotator is actively developed. Security fixes are provided for the latest
+released version. Older releases are not supported; users should update before
+reporting a problem that may already be fixed.
+
+| Version | Supported |
+| --- | --- |
+| Latest release | Yes |
+| Older releases | No |
+
+## Reporting a vulnerability
+
+Do not open a public issue for a suspected vulnerability. Use GitHub's
+[private vulnerability reporting form](https://github.com/backnotprop/plannotator/security/advisories/new)
+so the report and any follow-up remain confidential while the issue is assessed.
+
+Include, when available:
+
+- the affected version and component;
+- steps or a minimal example that reproduces the issue;
+- the security impact and required preconditions;
+- any known workarounds or suggested remediation.
+
+Please avoid public disclosure until a fix or coordinated disclosure plan is
+available. Maintainers will use the private advisory to confirm the report,
+coordinate remediation, and credit the reporter when requested.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "dev:vscode": "bun run --cwd apps/vscode-extension watch",
     "build:vscode": "bun run --cwd apps/vscode-extension build",
     "package:vscode": "bun run --cwd apps/vscode-extension package",
+    "check:release-version": "node scripts/check-release-version.mjs",
     "test": "bun test",
     "typecheck": "bash apps/pi-extension/vendor.sh && tsc --noEmit -p packages/core/tsconfig.json && tsc --noEmit -p packages/shared/tsconfig.json && tsc --noEmit -p packages/ai/tsconfig.json && tsc --noEmit -p packages/server/tsconfig.json && tsc --noEmit -p packages/ui/tsconfig.json && tsc --noEmit -p packages/ui/tsconfig.strict-consumer.json && tsc --noEmit -p apps/pi-extension/tsconfig.json",
     "build:ui-css": "bun run --cwd packages/ui build:css"

--- a/scripts/check-release-version.mjs
+++ b/scripts/check-release-version.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const JSON_VERSION_PATHS = [
+  "package.json",
+  "apps/opencode-plugin/package.json",
+  "apps/pi-extension/package.json",
+  "apps/hook/.claude-plugin/plugin.json",
+  "apps/copilot/plugin.json",
+  "packages/server/package.json",
+];
+const OPENPACKAGE_PATH = "openpackage.yml";
+const VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?$/;
+
+function parseArguments(argv) {
+  let root = process.cwd();
+  let tag;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    const value = argv[index + 1];
+
+    if (argument === "--root" && value) {
+      root = resolve(value);
+      index += 1;
+      continue;
+    }
+    if (argument === "--tag" && value) {
+      tag = value;
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown or incomplete argument: ${argument}`);
+  }
+
+  return { root, tag };
+}
+
+function readJsonVersion(root, relativePath) {
+  const parsed = JSON.parse(readFileSync(resolve(root, relativePath), "utf8"));
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`${relativePath} must contain a JSON object`);
+  }
+
+  const version = Object.getOwnPropertyDescriptor(parsed, "version")?.value;
+  if (typeof version !== "string") {
+    throw new Error(`${relativePath} must contain a string version field`);
+  }
+  return version;
+}
+
+function readOpenpackageVersion(root) {
+  const contents = readFileSync(resolve(root, OPENPACKAGE_PATH), "utf8");
+  const matches = [...contents.matchAll(/^version:\s*([^\s#]+)\s*(?:#.*)?$/gm)];
+  if (matches.length !== 1 || !matches[0]?.[1]) {
+    throw new Error(`${OPENPACKAGE_PATH} must contain exactly one top-level version field`);
+  }
+  return matches[0][1];
+}
+
+function checkReleaseVersion({ root, tag }) {
+  const versions = [
+    ...JSON_VERSION_PATHS.map((relativePath) => ({
+      relativePath,
+      version: readJsonVersion(root, relativePath),
+    })),
+    {
+      relativePath: OPENPACKAGE_PATH,
+      version: readOpenpackageVersion(root),
+    },
+  ];
+  const expectedVersion = versions[0].version;
+
+  if (!VERSION_PATTERN.test(expectedVersion)) {
+    throw new Error(`Invalid release version in package.json: ${expectedVersion}`);
+  }
+
+  const mismatches = versions.filter(({ version }) => version !== expectedVersion);
+  if (mismatches.length > 0) {
+    const details = versions
+      .map(({ relativePath, version }) => `  ${relativePath}: ${version}`)
+      .join("\n");
+    throw new Error(`Release-coupled versions do not match:\n${details}`);
+  }
+
+  if (tag !== undefined && tag !== `v${expectedVersion}`) {
+    throw new Error(`Release tag ${tag} does not match manifest version v${expectedVersion}`);
+  }
+
+  return expectedVersion;
+}
+
+try {
+  const version = checkReleaseVersion(parseArguments(process.argv.slice(2)));
+  console.log(`Release version is consistent: v${version}`);
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exitCode = 1;
+}

--- a/scripts/check-release-version.test.ts
+++ b/scripts/check-release-version.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+const scriptPath = resolve(import.meta.dir, "check-release-version.mjs");
+const temporaryRoots: string[] = [];
+const jsonVersionPaths = [
+  "package.json",
+  "apps/opencode-plugin/package.json",
+  "apps/pi-extension/package.json",
+  "apps/hook/.claude-plugin/plugin.json",
+  "apps/copilot/plugin.json",
+  "packages/server/package.json",
+] as const;
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function createFixture(version = "1.2.3"): string {
+  const root = mkdtempSync(join(tmpdir(), "plannotator-release-version-"));
+  temporaryRoots.push(root);
+
+  for (const relativePath of jsonVersionPaths) {
+    const absolutePath = join(root, relativePath);
+    mkdirSync(dirname(absolutePath), { recursive: true });
+    writeFileSync(absolutePath, `${JSON.stringify({ version }, null, 2)}\n`);
+  }
+  writeFileSync(join(root, "openpackage.yml"), `name: plannotator\nversion: ${version}\n`);
+  return root;
+}
+
+function runCheck(root: string, tag?: string) {
+  const argumentsList = [process.execPath, scriptPath, "--root", root];
+  if (tag !== undefined) argumentsList.push("--tag", tag);
+  return Bun.spawnSync(argumentsList, { stdout: "pipe", stderr: "pipe" });
+}
+
+describe("release version consistency check", () => {
+  test("accepts matching manifests and tag", () => {
+    const result = runCheck(createFixture(), "v1.2.3");
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString()).toContain("Release version is consistent: v1.2.3");
+  });
+
+  test("rejects a mismatched release-coupled manifest", () => {
+    const root = createFixture();
+    writeFileSync(join(root, "apps/pi-extension/package.json"), '{"version":"1.2.4"}\n');
+
+    const result = runCheck(root);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain("Release-coupled versions do not match");
+    expect(result.stderr.toString()).toContain("apps/pi-extension/package.json: 1.2.4");
+  });
+
+  test("rejects a tag that does not match the manifests", () => {
+    const result = runCheck(createFixture(), "v1.2.4");
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain(
+      "Release tag v1.2.4 does not match manifest version v1.2.3",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

This PR implements the first three phases of the Plannotator security rollout:

- hardens release and production deployment boundaries without requiring pull requests for owner changes to `main`;
- enables repository-native dependency ownership and security reporting;
- adds credential-isolated Gitleaks and zizmor monitoring with SARIF output.

## Pipeline changes

### Test and deployment

- Pins Bun 1.3.14 and uses frozen-lockfile installs in test, release, and deployment jobs.
- Disables checkout credential persistence where Git credentials are not required.
- Adds a release-version consistency test across all release-coupled manifests.
- Keeps continuous deployment from `main`, but deployment now waits for the exact commit SHA to pass the full `Test` workflow before any production job runs.
- Production jobs continue using the existing `production` GitHub environment and existing AWS/Cloudflare deployment paths.

### Release and npm publishing

- Requires every publishing `v*` tag to point to a commit contained in `main` and match all release manifest versions.
- Separates credential-free package construction from the privileged npm publication job.
- PRs and ordinary manual dry runs build and pack npm artifacts but receive neither npm credentials nor OIDC permission.
- Real npm publication remains automatic for valid `v*` tags and is isolated behind the `npm-publish` environment using npm trusted publishing/OIDC.
- Removes `NPM_TOKEN` from the workflow. The existing token should be revoked only after the first successful OIDC-only release.
- Preserves the existing GitHub release and artifact-attestation behavior.
- Disables Bun and Node package-manager caching in release jobs to prevent untrusted cache state from influencing published artifacts. The tradeoff is a small increase in release download/setup time.

### Security scanning

- Adds Gitleaks 8.30.0 and zizmor 1.29.0, installed from checksum-verified release archives.
- Runs on pull requests to `main`, pushes to `main`, a weekly schedule, and manual dispatch.
- Gitleaks scans PR/push commit ranges and performs full-history scans weekly/manually.
- zizmor runs offline with strict collection against all workflows, local actions, and Dependabot configuration.
- Both scanners include runtime-generated detector-health fixtures and fail when the scanner/configuration is broken.
- Findings start in monitor mode and upload as separate SARIF categories; findings do not yet block the PR.
- Fork and Dependabot PRs run without repository secrets and intentionally skip SARIF upload because their GitHub tokens are read-only.
- Local baselines are clean: zero active Gitleaks findings and zero active zizmor findings.

### Dependencies and reporting

- Adds weekly Bun Dependabot updates, grouped minor/patch PRs, and a seven-day cooldown for routine releases. Security updates bypass the cooldown; it does not increase CI duration.
- Keeps Renovate as the sole owner of GitHub Actions updates.
- Adds a latest-release-only security support policy and private vulnerability reporting instructions.

## Live prerequisites already configured

The following repository/service settings were configured before this PR and are not introduced by the YAML itself:

- GitHub dependency graph, Dependabot alerts/security updates, secret scanning, push protection, and private vulnerability reporting;
- `production` environment restricted to `main`;
- `npm-publish` environment restricted to `v*` tags;
- npm trusted publishers for both published packages;
- protected `v*` tag ruleset;
- AWS trust restricted to the GitHub `production` environment and S3 versioning enabled.

`main` remains directly writable by the owner. The controls gate deployment and publishing rather than changing that operating practice.

## Validation performed

- `bun run check:release-version`
- `bun test scripts/check-release-version.test.ts`
- actionlint 1.7.12 across all workflow files
- zizmor 1.29.0, offline regular persona with strict collection: zero active findings
- Gitleaks 8.30.0 working-tree and full-history audits: zero unresolved findings
- synthetic positive and reviewed-allowlist scanner health checks
- `git diff --check`

## Follow-up after merge

- Verify the first live SARIF uploads and fork behavior.
- Verify the next normal tag release through npm trusted publishing, then delete the repository `NPM_TOKEN` and revoke the superseded npm token.
- Validate the first Dependabot Bun PR and security notification delivery.
- Introduce blocking for new findings only after the monitor-mode GitHub run is confirmed.
- Implement Semgrep/Trivy, SBOM/Grype, isolated ZAP, and governance in separate follow-up PRs.