### PR TITLE
feat(editor): focus-mode shortcut to toggle both sidebars

### DIFF
--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -111,10 +111,12 @@ import { observeActionsLabelMode } from './actionsLabelMode';
 // same env var on the server side so V2/V3 stay paired.
 import { DEMO_PLAN_CONTENT as DEFAULT_DEMO_PLAN_CONTENT } from './demoPlan';
 import { DIFF_DEMO_PLAN_CONTENT } from './demoPlanDiffDemo';
-import { canUseAnnotateWideMode, resolveWideModeExitLayout, type WideModeLayoutSnapshot, type WideModeType } from '@plannotator/ui/utils/wideMode';
+import { canUseAnnotateWideMode, resolveFocusShortcutAction, resolveWideModeExitLayout, type WideModeLayoutSnapshot, type WideModeType } from '@plannotator/ui/utils/wideMode';
+import { modKey } from '@plannotator/ui/utils/platform';
 import {
   annotateSidebarShortcuts,
   useAnnotateSidebarShortcuts,
+  useDocumentViewShortcuts,
   useDoubleTapShortcuts,
 } from '@plannotator/ui/shortcuts';
 const USE_DIFF_DEMO =
@@ -984,8 +986,11 @@ const App: React.FC = () => {
     [projectRoot, uiPrefs]
   );
 
-  const canHandleAnnotateSidebarShortcut = useCallback((event: KeyboardEvent) => {
-    if (!annotateMode || archive.archiveMode || goalSetupMode) return false;
+  // Shared gate for the chrome-level keyboard commands (sidebars, focus mode):
+  // never while a dialog, an overlay, a submission, or a text field owns the
+  // keystroke. Annotate-only commands layer their own conditions on top.
+  const canHandleDocumentChromeShortcut = useCallback((event: KeyboardEvent) => {
+    if (archive.archiveMode || goalSetupMode) return false;
     if (event.defaultPrevented) return false;
     if (document.querySelector('[data-plannotator-confirm-dialog="true"]')) return false;
     if (showExport || showImport || showFeedbackPrompt || showClaudeCodeWarning ||
@@ -997,7 +1002,6 @@ const App: React.FC = () => {
     const tag = target?.tagName;
     return tag !== 'INPUT' && tag !== 'TEXTAREA' && !target?.isContentEditable;
   }, [
-    annotateMode,
     archive.archiveMode,
     goalSetupMode,
     showExport,
@@ -1015,6 +1019,36 @@ const App: React.FC = () => {
     isExiting,
     isEditingMarkdown,
   ]);
+
+  const canHandleAnnotateSidebarShortcut = useCallback(
+    (event: KeyboardEvent) => annotateMode && canHandleDocumentChromeShortcut(event),
+    [annotateMode, canHandleDocumentChromeShortcut],
+  );
+
+  // Focus mode from the keyboard. Mirrors the document card's `Focus` control —
+  // including its availability — so the shortcut can never park the layout in a
+  // state with no visible way back. HTML surfaces are excluded because they own
+  // their own persisted chrome and never render that control.
+  const handleToggleFocusMode = useCallback(() => {
+    const action = resolveFocusShortcutAction({
+      canUseWideMode: canUseWideMode && !isHtmlSurface,
+      wideModeType,
+    });
+    if (action === 'enter-focus') enterViewMode('focus');
+    else if (action === 'exit') exitWideMode();
+  }, [canUseWideMode, enterViewMode, exitWideMode, isHtmlSurface, wideModeType]);
+
+  useDocumentViewShortcuts({
+    handlers: {
+      toggleFocusMode: {
+        when: (event) =>
+          canHandleDocumentChromeShortcut(event)
+          && !isHtmlSurface
+          && (canUseWideMode || wideModeType !== null),
+        handle: handleToggleFocusMode,
+      },
+    },
+  });
 
   useAnnotateSidebarShortcuts({
     handlers: {
@@ -4627,7 +4661,7 @@ const App: React.FC = () => {
                           <Tooltip
                             side="top"
                             align="end"
-                            content={type === 'wide' ? 'Hide panels and expand document width' : 'Hide panels, keep document width'}
+                            content={type === 'wide' ? 'Hide panels and expand document width' : `Hide panels, keep document width (${modKey}+.)`}
                           >
                             <button
                               type="button"

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -1027,8 +1027,10 @@ const App: React.FC = () => {
 
   // Focus mode from the keyboard. Mirrors the document card's `Focus` control —
   // including its availability — so the shortcut can never park the layout in a
-  // state with no visible way back. HTML surfaces are excluded because they own
-  // their own persisted chrome and never render that control.
+  // state with no visible way back. HTML surfaces cannot ENTER focus mode (they
+  // own their own persisted chrome and never render that control), but exit stays
+  // available everywhere: a linked-doc navigation can flip the surface to HTML
+  // while focus mode is active, and without the exit path that layout is stuck.
   const handleToggleFocusMode = useCallback(() => {
     const action = resolveFocusShortcutAction({
       canUseWideMode: canUseWideMode && !isHtmlSurface,
@@ -1043,8 +1045,7 @@ const App: React.FC = () => {
       toggleFocusMode: {
         when: (event) =>
           canHandleDocumentChromeShortcut(event)
-          && !isHtmlSurface
-          && (canUseWideMode || wideModeType !== null),
+          && ((canUseWideMode && !isHtmlSurface) || wideModeType !== null),
         handle: handleToggleFocusMode,
       },
     },

--- a/packages/editor/shortcuts.ts
+++ b/packages/editor/shortcuts.ts
@@ -6,6 +6,7 @@ import {
   createShortcutRegistry,
   createShortcutScopeHook,
   defineShortcutScope,
+  documentViewShortcuts,
   goalSetupShortcuts,
   imageAnnotatorShortcuts,
   inputMethodShortcuts,
@@ -79,6 +80,7 @@ const annotateEditorSettingsShortcuts = defineShortcutScope({
 });
 
 const sharedPlanSurfaceShortcuts = [
+  documentViewShortcuts,
   inputMethodShortcuts,
   annotationToolbarShortcuts,
   viewerShortcuts,

--- a/packages/ui/components/KeyboardShortcuts.tsx
+++ b/packages/ui/components/KeyboardShortcuts.tsx
@@ -84,6 +84,13 @@ const inputMethodShortcuts: ShortcutSection = {
   ],
 };
 
+const documentViewShortcuts: ShortcutSection = {
+  title: 'View',
+  shortcuts: [
+    { keys: [modKey, '.'], desc: 'Toggle focus mode', hint: 'Collapses the Contents sidebar and the right-hand panel together; press again to restore whatever was open before.' },
+  ],
+};
+
 const annotationShortcuts: ShortcutSection = {
   title: 'Annotations',
   shortcuts: [
@@ -108,6 +115,7 @@ const imageAnnotatorShortcuts: ShortcutSection = {
 };
 
 const sharedPlanEditorShortcuts: ShortcutSection[] = [
+  documentViewShortcuts,
   inputMethodShortcuts,
   annotationShortcuts,
   imageAnnotatorShortcuts,

--- a/packages/ui/components/KeyboardShortcuts.tsx
+++ b/packages/ui/components/KeyboardShortcuts.tsx
@@ -87,7 +87,7 @@ const inputMethodShortcuts: ShortcutSection = {
 const documentViewShortcuts: ShortcutSection = {
   title: 'View',
   shortcuts: [
-    { keys: [modKey, '.'], desc: 'Toggle focus mode', hint: 'Collapses the Contents sidebar and the right-hand panel together; press again to restore whatever was open before.' },
+    { keys: [modKey, '.'], desc: 'Toggle focus mode', hint: 'Collapses the Contents sidebar and the right-hand panel together; press again to restore whatever was open before. Markdown documents only; HTML pages keep their own layout.' },
   ],
 };
 

--- a/packages/ui/shortcuts.test.ts
+++ b/packages/ui/shortcuts.test.ts
@@ -8,6 +8,7 @@ import {
   formatShortcutBindingText,
   formatShortcutBindingTokens,
   getShortcut,
+  listRegistryShortcuts,
   listRegistryShortcutSections,
   matchesKeyName,
   matchesShortcutBinding,
@@ -73,6 +74,7 @@ describe('shortcuts', () => {
 
     expect(planReviewSections.map(section => section.title)).toEqual([
       'Actions',
+      'View',
       'Input Method',
       'Annotations',
       'Vim Document Navigation',
@@ -84,6 +86,7 @@ describe('shortcuts', () => {
     expect(annotateSections.map(section => section.title)).toEqual([
       'Actions',
       'Sidebar',
+      'View',
       'Input Method',
       'Annotations',
       'Vim Document Navigation',
@@ -111,6 +114,21 @@ describe('shortcuts', () => {
       'PR Comments',
       'Tour',
     ]);
+  });
+
+  // The focus-mode toggle collapses both side panels at once. It has to exist
+  // on BOTH plan surfaces (they render the same panels), and its binding has to
+  // stay the only claim on `Mod+.` there — a second claimant would double-fire,
+  // since the dispatcher has no cross-scope arbitration.
+  it('binds focus mode once on every plan surface', () => {
+    for (const registry of [planReviewSettingsShortcutRegistry, annotateSettingsShortcutRegistry]) {
+      expect(getShortcut(registry, 'document-view', 'toggleFocusMode')?.bindings).toEqual(['Mod+.']);
+
+      const claimants = listRegistryShortcuts(registry)
+        .filter(entry => entry.bindings.includes('Mod+.'))
+        .map(entry => `${entry.scopeId}.${entry.actionId}`);
+      expect(claimants).toEqual(['document-view.toggleFocusMode']);
+    }
   });
 
   it('matches normalized runtime bindings', () => {

--- a/packages/ui/shortcuts/index.ts
+++ b/packages/ui/shortcuts/index.ts
@@ -8,6 +8,7 @@ export { commentPopoverShortcuts } from './plan-review/commentPopover.shortcuts'
 export { imageAnnotatorShortcuts, useImageAnnotatorShortcuts } from './plan-review/imageAnnotator.shortcuts';
 export { inputMethodShortcuts } from './plan-review/inputMethod.shortcuts';
 export { viewerShortcuts, useViewerShortcuts } from './plan-review/viewer.shortcuts';
+export { documentViewShortcuts, useDocumentViewShortcuts } from './plan-review/documentView.shortcuts';
 export {
   describeVimSelectionAction,
   isVimSelectionActionId,

--- a/packages/ui/shortcuts/plan-review/documentView.shortcuts.ts
+++ b/packages/ui/shortcuts/plan-review/documentView.shortcuts.ts
@@ -1,0 +1,26 @@
+import { defineShortcutScope } from '../core';
+import { createShortcutScopeHook } from '../runtime';
+
+/**
+ * Document-chrome view commands shared by plan review and annotate mode.
+ *
+ * Focus mode is the keyboard entry point to the same view state the document
+ * card's `Focus` control drives: both side panels collapse in one press and the
+ * previous arrangement comes back on the next one.
+ */
+export const documentViewShortcuts = defineShortcutScope({
+  id: 'document-view',
+  title: 'Document View',
+  shortcuts: {
+    toggleFocusMode: {
+      description: 'Toggle focus mode',
+      bindings: ['Mod+.'],
+      section: 'View',
+      hint: 'Collapses the Contents sidebar and the right-hand panel together; press again to restore whatever was open before.',
+      displayOrder: 10,
+      preventDefault: true,
+    },
+  },
+});
+
+export const useDocumentViewShortcuts = createShortcutScopeHook(documentViewShortcuts);

--- a/packages/ui/utils/wideMode.test.ts
+++ b/packages/ui/utils/wideMode.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import {
   canUseAnnotateWideMode,
+  resolveFocusShortcutAction,
   resolveWideModeExitLayout,
   type WideModeLayoutSnapshot,
 } from './wideMode';
@@ -32,6 +33,47 @@ describe('canUseAnnotateWideMode', () => {
       archiveMode: true,
       isPlanDiffActive: true,
     })).toBe(false);
+  });
+});
+
+describe('resolveFocusShortcutAction', () => {
+  test('enters focus mode from the ordinary layout', () => {
+    expect(resolveFocusShortcutAction({
+      canUseWideMode: true,
+      wideModeType: null,
+    })).toBe('enter-focus');
+  });
+
+  test('restores the remembered layout on the second press', () => {
+    expect(resolveFocusShortcutAction({
+      canUseWideMode: true,
+      wideModeType: 'focus',
+    })).toBe('exit');
+  });
+
+  // A press while `wide` is active must restore, not swap wide -> focus: the
+  // panels are already hidden, so re-hiding them would read as a dead key.
+  test('restores from wide mode instead of switching to focus', () => {
+    expect(resolveFocusShortcutAction({
+      canUseWideMode: true,
+      wideModeType: 'wide',
+    })).toBe('exit');
+  });
+
+  test('does nothing where the view modes are unavailable', () => {
+    expect(resolveFocusShortcutAction({
+      canUseWideMode: false,
+      wideModeType: null,
+    })).toBe('none');
+  });
+
+  // Availability can drop while a view mode is still active (opening the plan
+  // diff); the shortcut must still be able to give the panels back.
+  test('still restores when availability drops mid-focus', () => {
+    expect(resolveFocusShortcutAction({
+      canUseWideMode: false,
+      wideModeType: 'focus',
+    })).toBe('exit');
   });
 });
 

--- a/packages/ui/utils/wideMode.ts
+++ b/packages/ui/utils/wideMode.ts
@@ -1,4 +1,5 @@
 import type { SidebarTab } from '@plannotator/ui/hooks/useSidebar';
+import type { WideModeType } from '@plannotator/ui/types';
 export type { WideModeType } from '@plannotator/ui/types';
 
 export type WideModeLayoutSnapshot = {
@@ -24,6 +25,25 @@ export function canUseAnnotateWideMode(options: {
   isPlanDiffActive: boolean;
 }): boolean {
   return !options.archiveMode && !options.isPlanDiffActive;
+}
+
+/** What the focus-mode keyboard shortcut should do on this press. */
+export type FocusShortcutAction = 'enter-focus' | 'exit' | 'none';
+
+/**
+ * Decide the next step for the focus-mode keyboard shortcut.
+ *
+ * The shortcut is a single "hide the chrome / give it back" toggle, so ANY
+ * active panel-hiding view mode restores the remembered layout — including
+ * `wide`, which the toolbar control would instead swap for `focus`. A press
+ * that could only re-hide already-hidden panels would look like a dead key.
+ */
+export function resolveFocusShortcutAction(state: {
+  canUseWideMode: boolean;
+  wideModeType: WideModeType | null;
+}): FocusShortcutAction {
+  if (state.wideModeType !== null) return 'exit';
+  return state.canUseWideMode ? 'enter-focus' : 'none';
 }
 
 export function resolveWideModeExitLayout(


### PR DESCRIPTION
**TLDR:** Closes #1276. One shortcut, Mod+., toggles focus mode in plan review and annotate: first press closes both the left sidebar and the annotation panel, second press restores the exact prior arrangement. Verified end to end in headless Chrome via CDP, including the typing guard and asymmetric open states.

## Why Mod+.

A full audit of every binding across both plan surfaces (registry scopes plus ad-hoc handlers, all states) found Mod+. unclaimed everywhere on these surfaces. Mod+B is already the annotate Contents toggle and means bold inside editable fields; Mod+\ requires AltGr on German and Nordic layouts, so it silently fails there. Mod+. is unshifted on every layout, unclaimed by browsers and OSes, and matches this codebase's existing idiom: code review already uses Mod+. to collapse its sidebar. A registry test now asserts the binding has exactly one claimant per surface.

## What changed

- New `document-view` scope with a `toggleFocusMode` action, composed into both `planReviewSurface` and `annotateSurface`; the marketing shortcuts docs page picks it up automatically.
- The handler drives the existing focus view-mode machinery (snapshot and restore already existed behind the document card's Focus button); the keyboard entry point was the only missing piece. A press while wide mode is active restores instead of swapping, since re-hiding already-hidden panels reads as a dead key. Pure decision logic extracted to `resolveFocusShortcutAction` with unit tests.
- Focus button tooltip now shows the binding; the shortcuts help modal gains a View section.
- Raw-HTML annotate surfaces are deliberately excluded: they persist their own chrome state and do not render the Focus control.

## Verification

- `bun run typecheck` clean; `bun test packages/ui packages/editor` 674 pass, 0 fail.
- Headless Chrome via raw CDP against real sandboxed servers: screencast video plus before/during/after screenshots for annotate and plan review, the typing guard (press inside a comment editor does nothing), and the help modal entry.

*AI-assisted: implemented and verified by Claude under maintainer direction.*
