### PR TITLE
fix(review): detach open-in-editor launches and bound the wait

### DIFF
--- a/apps/pi-extension/open-in-launch.test.ts
+++ b/apps/pi-extension/open-in-launch.test.ts
@@ -1,0 +1,177 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { openFileInApp } from "./server/open-in-apps.ts";
+
+// Launch semantics for the Pi mirror of POST /api/open-in: the launcher must
+// be a concurrent side concern of the review session, mirroring the Bun
+// runtime (packages/server/open-in.test.ts). Each test shims the per-platform
+// launcher command (mac: `open`, linux: the catalog's `code` bin) onto PATH
+// and drives the real openFileInApp. Skipped on Windows (no sh shims).
+
+const tempDirs: string[] = [];
+function makeDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), "pi-open-in-launch-"));
+	tempDirs.push(dir);
+	return dir;
+}
+afterAll(() => {
+	for (const dir of tempDirs) {
+		try {
+			rmSync(dir, { recursive: true, force: true });
+		} catch {
+			/* best effort cleanup */
+		}
+	}
+});
+
+const launcherShimName = process.platform === "darwin" ? "open" : "code";
+const launchTest = process.platform === "win32" ? test.skip : test;
+
+/** Write the executable launcher shim into `dir`. */
+function writeShim(dir: string, script: string): void {
+	const shim = join(dir, launcherShimName);
+	writeFileSync(shim, script);
+	chmodSync(shim, 0o755);
+}
+
+function pgidOf(pid: number): number {
+	const out = spawnSync("ps", ["-o", "pgid=", "-p", String(pid)], {
+		encoding: "utf-8",
+	});
+	return Number.parseInt(out.stdout.trim(), 10);
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForPidFile(path: string, timeoutMs = 5000): Promise<number> {
+	const start = Date.now();
+	while (Date.now() - start < timeoutMs) {
+		try {
+			const text = readFileSync(path, "utf-8").trim();
+			if (text) return Number.parseInt(text, 10);
+		} catch {
+			/* not written yet */
+		}
+		await sleep(25);
+	}
+	throw new Error(`timed out waiting for ${path}`);
+}
+
+describe("openFileInApp launch semantics (Pi mirror)", () => {
+	launchTest(
+		"a lingering launcher returns ok within the grace and runs detached from the server's process group",
+		async () => {
+			const shimDir = makeDir();
+			const pidFile = join(shimDir, "child.pid");
+			writeShim(shimDir, `#!/bin/sh\necho $$ > "${pidFile}"\nexec sleep 30\n`);
+			const target = join(makeDir(), "file.txt");
+			writeFileSync(target, "x");
+
+			const oldPath = process.env.PATH;
+			process.env.PATH = `${shimDir}${delimiter}${oldPath ?? ""}`;
+			let childPid: number | null = null;
+			try {
+				const started = Date.now();
+				const result = await openFileInApp(target, "vscode");
+				const elapsed = Date.now() - started;
+
+				// Regression guard: the request must not be held until the launcher
+				// exits (30s here). It resolves ok at the grace deadline instead.
+				expect(result.ok).toBe(true);
+				expect(elapsed).toBeLessThan(8000);
+
+				childPid = await waitForPidFile(pidFile);
+				// The launcher is still running after we answered ok...
+				expect(() => process.kill(childPid!, 0)).not.toThrow();
+				// ...and in its OWN process group, so a signal aimed at this
+				// process's group cannot take a cold-started editor down with it.
+				expect(pgidOf(childPid)).not.toBe(pgidOf(process.pid));
+			} finally {
+				process.env.PATH = oldPath;
+				if (childPid != null) {
+					try {
+						process.kill(childPid, "SIGKILL");
+					} catch {
+						/* already gone */
+					}
+				}
+			}
+		},
+		15000,
+	);
+
+	launchTest(
+		"an instantly failing launcher still reports the friendly exit + stderr error",
+		async () => {
+			const shimDir = makeDir();
+			writeShim(
+				shimDir,
+				`#!/bin/sh\necho "Unable to find application named 'ShimTarget'" >&2\nexit 1\n`,
+			);
+			const target = join(makeDir(), "file.txt");
+			writeFileSync(target, "x");
+
+			const oldPath = process.env.PATH;
+			process.env.PATH = `${shimDir}${delimiter}${oldPath ?? ""}`;
+			try {
+				const result = await openFileInApp(target, "vscode");
+				expect(result.ok).toBe(false);
+				if (result.ok === false) {
+					// Same failure shape as the Bun runtime: exit code + stderr.
+					expect(result.error).toContain("Failed to open");
+					expect(result.error).toContain("exit 1");
+					expect(result.error).toContain(
+						"Unable to find application named 'ShimTarget'",
+					);
+				}
+			} finally {
+				process.env.PATH = oldPath;
+			}
+		},
+		15000,
+	);
+
+	launchTest(
+		"a chatty launcher (>128KB stderr, then lingers) cannot deadlock the request",
+		async () => {
+			const shimDir = makeDir();
+			const pidFile = join(shimDir, "child.pid");
+			// Writes far more stderr than a pipe buffer holds, THEN records its pid
+			// and lingers. Without a concurrent drain the shim blocks on the full
+			// pipe and never reaches sleep, and the request never returns.
+			writeShim(
+				shimDir,
+				`#!/bin/sh\nhead -c 200000 /dev/zero | tr '\\0' e >&2\necho $$ > "${pidFile}"\nexec sleep 30\n`,
+			);
+			const target = join(makeDir(), "file.txt");
+			writeFileSync(target, "x");
+
+			const oldPath = process.env.PATH;
+			process.env.PATH = `${shimDir}${delimiter}${oldPath ?? ""}`;
+			let childPid: number | null = null;
+			try {
+				const started = Date.now();
+				const result = await openFileInApp(target, "vscode");
+				const elapsed = Date.now() - started;
+				expect(result.ok).toBe(true);
+				expect(elapsed).toBeLessThan(8000);
+				childPid = await waitForPidFile(pidFile);
+			} finally {
+				process.env.PATH = oldPath;
+				if (childPid != null) {
+					try {
+						process.kill(childPid, "SIGKILL");
+					} catch {
+						/* already gone */
+					}
+				}
+			}
+		},
+		15000,
+	);
+});

--- a/apps/pi-extension/server/open-in-apps.ts
+++ b/apps/pi-extension/server/open-in-apps.ts
@@ -8,7 +8,7 @@
  * (packages/shared/open-in-apps.ts, vendored into generated/).
  */
 
-import { execFile, execFileSync, spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import os from "node:os";
@@ -103,7 +103,26 @@ export function getAvailableOpenInApps(): Array<{
 	});
 }
 
-/** Run execFile and surface ENOENT (app not found) as a friendly error. */
+/**
+ * How long a launch may take to fail before we call it launched (ms). Mirrors
+ * the Bun runtime (packages/server/open-in.ts).
+ */
+const LAUNCH_GRACE_MS = 2000;
+
+/** Cap on captured stderr; the stream keeps draining beyond it. */
+const LAUNCH_STDERR_CAP_BYTES = 8192;
+
+/**
+ * Run an argv launcher and surface ENOENT (app not found) as a friendly error.
+ *
+ * Mirrors the Bun runtime's runArgv semantics exactly: the child is spawned
+ * DETACHED (its own process group) so an editor cold-started by a launcher CLI
+ * can never be taken down by a signal aimed at this server's group, the wait
+ * is BOUNDED so a launcher CLI that stays attached to the app it started
+ * cannot hold the HTTP request hostage, and stderr is drained from spawn time
+ * so a chatty child can never fill the pipe and deadlock inside the grace
+ * window.
+ */
 function run(
 	cmd: string,
 	args: string[],
@@ -111,20 +130,85 @@ function run(
 	opts?: { cwd?: string },
 ): Promise<{ ok: true } | { ok: false; error: string }> {
 	return new Promise((resolve) => {
-		const proc = execFile(cmd, args, opts?.cwd ? { cwd: opts.cwd } : {}, (err) => {
-			if (!err) {
-				resolve({ ok: true });
+		const failure = (msg: string): { ok: false; error: string } =>
+			/ENOENT|not found/i.test(msg)
+				? { ok: false, error: `${notFoundLabel} was not found on this system.` }
+				: { ok: false, error: msg };
+
+		let child: ReturnType<typeof spawn>;
+		try {
+			child = spawn(cmd, args, {
+				detached: true,
+				stdio: ["ignore", "ignore", "pipe"],
+				...(opts?.cwd ? { cwd: opts.cwd } : {}),
+			});
+		} catch (err) {
+			resolve(failure(err instanceof Error ? err.message : String(err)));
+			return;
+		}
+
+		let stderr = "";
+		child.stderr?.on("data", (chunk: Buffer) => {
+			if (stderr.length < LAUNCH_STDERR_CAP_BYTES) stderr += chunk.toString();
+		});
+
+		let settled = false;
+		let exitInfo: { code: number | null; signal: NodeJS.Signals | null } | null =
+			null;
+		const finish = (result: { ok: true } | { ok: false; error: string }) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(deadline);
+			resolve(result);
+		};
+
+		const concludeExit = () => {
+			if (!exitInfo) return;
+			if (/not found|ENOENT/i.test(stderr)) {
+				finish({ ok: false, error: `${notFoundLabel} was not found on this system.` });
 				return;
 			}
-			const code = (err as NodeJS.ErrnoException).code;
-			if (code === "ENOENT" || /ENOENT|not found/i.test(err.message)) {
-				resolve({ ok: false, error: `${notFoundLabel} was not found on this system.` });
-			} else {
-				resolve({ ok: false, error: err.message });
-			}
+			const status = exitInfo.code ?? exitInfo.signal ?? "unknown";
+			finish({
+				ok: false,
+				error: `Failed to open ${notFoundLabel} (exit ${status})${stderr ? `: ${stderr.trim()}` : ""}`,
+			});
+		};
+
+		// Still running at the deadline: it launched. A failure observed just
+		// before the deadline still reports as a failure.
+		const deadline = setTimeout(() => {
+			if (exitInfo) concludeExit();
+			else finish({ ok: true });
+		}, LAUNCH_GRACE_MS);
+
+		child.once("error", (err) => {
+			finish(failure(err instanceof Error ? err.message : String(err)));
 		});
-		// Detach: we don't care about the child's lifetime once launched.
-		proc.unref?.();
+
+		child.once("exit", (code, signal) => {
+			if (code === 0) {
+				finish({ ok: true });
+				return;
+			}
+			exitInfo = { code, signal };
+			// Give the stderr pipe a beat to flush before reporting; "close" (all
+			// stdio ended) concludes immediately when it arrives first. close alone
+			// is not enough: a grandchild inheriting the pipe can hold it open.
+			setTimeout(concludeExit, 50);
+		});
+
+		child.once("close", (code, signal) => {
+			if (code === 0) {
+				finish({ ok: true });
+				return;
+			}
+			exitInfo = { code, signal };
+			concludeExit();
+		});
+
+		// The launcher runs on its own; never keep this process alive for it.
+		child.unref();
 	});
 }
 

--- a/packages/server/open-in.test.ts
+++ b/packages/server/open-in.test.ts
@@ -1,8 +1,17 @@
 import { afterAll, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { resolveOpenInTarget } from "@plannotator/shared/html-assets-node";
+import { openFileInApp } from "./open-in";
 
 // resolveOpenInTarget is the security boundary for POST /api/open-in: it decides
 // which absolute file a launch is allowed to touch. Real temp dirs/files are
@@ -93,4 +102,157 @@ describe("resolveOpenInTarget — /api/open-in containment", () => {
     // A traversal can't escape one root by landing inside another.
     expect(resolveOpenInTarget("../x.md", null, () => [a, b])).toBeNull();
   });
+});
+
+// Launch semantics for POST /api/open-in: the launcher must be a concurrent
+// side concern of the review session. Each test shims the per-platform
+// launcher command (mac: `open`, linux: the catalog's `code` bin) onto PATH
+// and drives the real openFileInApp. Skipped on Windows (no sh shims).
+const launcherShimName = process.platform === "darwin" ? "open" : "code";
+const launchTest = process.platform === "win32" ? test.skip : test;
+
+/** Write the executable launcher shim into `dir`. */
+function writeShim(dir: string, script: string): void {
+  const shim = join(dir, launcherShimName);
+  writeFileSync(shim, script);
+  chmodSync(shim, 0o755);
+}
+
+function pgidOf(pid: number): number {
+  const out = spawnSync("ps", ["-o", "pgid=", "-p", String(pid)], {
+    encoding: "utf-8",
+  });
+  return Number.parseInt(out.stdout.trim(), 10);
+}
+
+async function waitForPidFile(path: string, timeoutMs = 5000): Promise<number> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const text = readFileSync(path, "utf-8").trim();
+      if (text) return Number.parseInt(text, 10);
+    } catch {
+      /* not written yet */
+    }
+    await Bun.sleep(25);
+  }
+  throw new Error(`timed out waiting for ${path}`);
+}
+
+describe("openFileInApp launch semantics", () => {
+  launchTest(
+    "a lingering launcher returns ok within the grace and runs detached from the server's process group",
+    async () => {
+      const shimDir = makeDir();
+      const pidFile = join(shimDir, "child.pid");
+      writeShim(
+        shimDir,
+        `#!/bin/sh\necho $$ > "${pidFile}"\nexec sleep 30\n`,
+      );
+      const target = join(makeDir(), "file.txt");
+      writeFileSync(target, "x");
+
+      const oldPath = process.env.PATH;
+      process.env.PATH = `${shimDir}${delimiter}${oldPath ?? ""}`;
+      let childPid: number | null = null;
+      try {
+        const started = Date.now();
+        const result = await openFileInApp(target, "vscode");
+        const elapsed = Date.now() - started;
+
+        // Regression guard: the request must not be held until the launcher
+        // exits (30s here). It resolves ok at the grace deadline instead.
+        expect(result.ok).toBe(true);
+        expect(elapsed).toBeLessThan(8000);
+
+        childPid = await waitForPidFile(pidFile);
+        // The launcher is still running after we answered ok...
+        expect(() => process.kill(childPid!, 0)).not.toThrow();
+        // ...and in its OWN process group, so a signal aimed at this
+        // process's group (agent cancelling the session, terminal close)
+        // cannot take a cold-started editor down with it.
+        expect(pgidOf(childPid)).not.toBe(pgidOf(process.pid));
+      } finally {
+        process.env.PATH = oldPath;
+        if (childPid != null) {
+          try {
+            process.kill(childPid, "SIGKILL");
+          } catch {
+            /* already gone */
+          }
+        }
+      }
+    },
+    15000,
+  );
+
+  launchTest(
+    "an instantly failing launcher still reports the friendly exit + stderr error",
+    async () => {
+      const shimDir = makeDir();
+      writeShim(
+        shimDir,
+        `#!/bin/sh\necho "Unable to find application named 'ShimTarget'" >&2\nexit 1\n`,
+      );
+      const target = join(makeDir(), "file.txt");
+      writeFileSync(target, "x");
+
+      const oldPath = process.env.PATH;
+      process.env.PATH = `${shimDir}${delimiter}${oldPath ?? ""}`;
+      try {
+        const result = await openFileInApp(target, "vscode");
+        expect(result.ok).toBe(false);
+        if (result.ok === false) {
+          // Same failure shape as before the detach: exit code + stderr.
+          expect(result.error).toContain("Failed to open");
+          expect(result.error).toContain("exit 1");
+          expect(result.error).toContain(
+            "Unable to find application named 'ShimTarget'",
+          );
+        }
+      } finally {
+        process.env.PATH = oldPath;
+      }
+    },
+    15000,
+  );
+
+  launchTest(
+    "a chatty launcher (>128KB stderr, then lingers) cannot deadlock the request",
+    async () => {
+      const shimDir = makeDir();
+      const pidFile = join(shimDir, "child.pid");
+      // Writes far more stderr than a pipe buffer holds, THEN records its pid
+      // and lingers. Without a concurrent drain the shim blocks on the full
+      // pipe and never reaches sleep, and the request never returns.
+      writeShim(
+        shimDir,
+        `#!/bin/sh\nhead -c 200000 /dev/zero | tr '\\0' e >&2\necho $$ > "${pidFile}"\nexec sleep 30\n`,
+      );
+      const target = join(makeDir(), "file.txt");
+      writeFileSync(target, "x");
+
+      const oldPath = process.env.PATH;
+      process.env.PATH = `${shimDir}${delimiter}${oldPath ?? ""}`;
+      let childPid: number | null = null;
+      try {
+        const started = Date.now();
+        const result = await openFileInApp(target, "vscode");
+        const elapsed = Date.now() - started;
+        expect(result.ok).toBe(true);
+        expect(elapsed).toBeLessThan(8000);
+        childPid = await waitForPidFile(pidFile);
+      } finally {
+        process.env.PATH = oldPath;
+        if (childPid != null) {
+          try {
+            process.kill(childPid, "SIGKILL");
+          } catch {
+            /* already gone */
+          }
+        }
+      }
+    },
+    15000,
+  );
 });

--- a/packages/server/open-in.ts
+++ b/packages/server/open-in.ts
@@ -3,8 +3,12 @@
  *
  * Cross-platform "open this file in <app>" helper, modeled on
  * `packages/server/browser.ts` (openBrowser) and `packages/server/ide.ts`
- * (openEditorDiff). Uses argv arrays via `Bun.spawn` — never shell string
- * interpolation — to avoid command injection.
+ * (openEditorDiff). Uses argv arrays, never shell string interpolation, to
+ * avoid command injection.
+ *
+ * Launches are a side concern of the review session, never part of it: each
+ * launcher is spawned detached (its own process group) and the request only
+ * waits a short grace for instant failures. See runArgv.
  *
  * The app catalog is the single source of truth at
  * `@plannotator/shared/open-in-apps`. `kind` drives launch semantics:
@@ -16,6 +20,7 @@
 import path from "node:path";
 import fs from "node:fs";
 import os from "node:os";
+import { spawn } from "node:child_process";
 import {
   OPEN_IN_APPS,
   getOpenInApp,
@@ -42,40 +47,116 @@ function currentPlatform(): OpenInPlatform {
 }
 
 /**
+ * How long a launch may take to fail before we call it launched (ms). Instant
+ * failures (missing binary, "Unable to find application") land well inside
+ * this window; anything still running after it is a successful launch that we
+ * stop waiting on.
+ */
+const LAUNCH_GRACE_MS = 2000;
+
+/** Cap on captured stderr; the stream keeps draining beyond it. */
+const LAUNCH_STDERR_CAP_BYTES = 8192;
+
+/**
  * Run an argv command without a shell. Resolves to a launch result, surfacing
  * ENOENT (app/binary not found) as a friendly error.
+ *
+ * The child is spawned DETACHED (its own process group) so an editor
+ * cold-started by a launcher CLI can never be taken down by a signal aimed at
+ * this server's group (agent runtimes cancelling the session, terminal close).
+ * The wait is BOUNDED: a launcher CLI that stays attached to the app it
+ * started must not hold the HTTP request (and the UI button) hostage until
+ * the app quits. stderr is drained from spawn time so a chatty child can
+ * never fill the pipe and deadlock inside the grace window.
  */
-async function runArgv(
+function runArgv(
   cmd: string,
   args: string[],
   friendlyName: string,
   opts?: { cwd?: string },
 ): Promise<OpenInLaunchResult> {
-  try {
-    const proc = Bun.spawn([cmd, ...args], {
-      stdout: "ignore",
-      stderr: "pipe",
-      ...(opts?.cwd && { cwd: opts.cwd }),
+  return new Promise((resolve) => {
+    const failure = (msg: string): OpenInLaunchResult =>
+      /ENOENT|not found/i.test(msg)
+        ? { ok: false, error: `${friendlyName} not found` }
+        : { ok: false, error: msg };
+
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(cmd, args, {
+        detached: true,
+        stdio: ["ignore", "ignore", "pipe"],
+        ...(opts?.cwd && { cwd: opts.cwd }),
+      });
+    } catch (err) {
+      resolve(failure(err instanceof Error ? err.message : String(err)));
+      return;
+    }
+
+    let stderr = "";
+    child.stderr?.on("data", (chunk: Buffer) => {
+      if (stderr.length < LAUNCH_STDERR_CAP_BYTES) stderr += chunk.toString();
     });
-    const exitCode = await proc.exited;
-    if (exitCode !== 0) {
-      const stderr = await new Response(proc.stderr).text();
+
+    let settled = false;
+    let exitInfo: { code: number | null; signal: NodeJS.Signals | null } | null =
+      null;
+    const finish = (result: OpenInLaunchResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(deadline);
+      resolve(result);
+    };
+
+    // Same failure shape as before: friendly not-found, else exit + stderr.
+    const concludeExit = () => {
+      if (!exitInfo) return;
       if (/not found|ENOENT/i.test(stderr)) {
-        return { ok: false, error: `${friendlyName} not found` };
+        finish({ ok: false, error: `${friendlyName} not found` });
+        return;
       }
-      return {
+      const status = exitInfo.code ?? exitInfo.signal ?? "unknown";
+      finish({
         ok: false,
-        error: `Failed to open ${friendlyName} (exit ${exitCode})${stderr ? `: ${stderr.trim()}` : ""}`,
-      };
-    }
-    return { ok: true };
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (/ENOENT|not found/i.test(msg)) {
-      return { ok: false, error: `${friendlyName} not found` };
-    }
-    return { ok: false, error: msg };
-  }
+        error: `Failed to open ${friendlyName} (exit ${status})${stderr ? `: ${stderr.trim()}` : ""}`,
+      });
+    };
+
+    // Still running at the deadline: it launched. A failure observed just
+    // before the deadline still reports as a failure.
+    const deadline = setTimeout(() => {
+      if (exitInfo) concludeExit();
+      else finish({ ok: true });
+    }, LAUNCH_GRACE_MS);
+
+    child.once("error", (err) => {
+      finish(failure(err instanceof Error ? err.message : String(err)));
+    });
+
+    child.once("exit", (code, signal) => {
+      if (code === 0) {
+        finish({ ok: true });
+        return;
+      }
+      exitInfo = { code, signal };
+      // Give the stderr pipe a beat to flush before reporting; "close" (all
+      // stdio ended) concludes immediately when it arrives first. close alone
+      // is not enough: a grandchild inheriting the pipe can hold it open.
+      setTimeout(concludeExit, 50);
+    });
+
+    child.once("close", (code, signal) => {
+      if (code === 0) {
+        finish({ ok: true });
+        return;
+      }
+      exitInfo = { code, signal };
+      concludeExit();
+    });
+
+    // The launcher runs on its own; never keep this process alive for it.
+    child.unref();
+  });
 }
 
 /**


### PR DESCRIPTION
**TLDR:** The code-review "Open in editor" launch is now a concurrent side concern of the review session: launchers spawn detached in their own process group, the request waits at most a 2s grace for instant failures, and stderr is drained from spawn time. The CLI's agent-session interjection flow is untouched.

## The two demonstrated defects

Community report: "plannotator review -> open file in editor, make some changes -> add comments -> send feedback. Repeat the same process but now the open file in editor stops working. Breaks after I launch a few times." Investigating it turned up two concrete defects in the launch path (`runArgv` in `packages/server/open-in.ts`, `run` in the Pi mirror):

1. **Unbounded wait with an undrained stderr pipe.** The handler awaited the launcher's exit before answering `POST /api/open-in`, and only read stderr after exit. A launcher CLI that stays attached to the editor it cold-started held the HTTP request open indefinitely (verified: a lingering shim launcher made the endpoint never respond), which leaves the UI button stuck on its busy spinner for the rest of the tab. A child writing more stderr than a pipe buffer holds could also deadlock against the never-read pipe.
2. **The launcher inherited the session's process group.** Verified: the spawned launcher shared the review server's pgid. On Linux and Windows the editor is started by its CLI, so an editor cold-started from the review UI became a descendant in the session's group. Any signal aimed at that group (agent runtime cancelling the tool call, terminal close) killed the editor along with the session. An uncleanly killed Cursor or Zed instance can strand editor singleton state (Electron `SingletonLock`, Zed's IPC socket), after which later `cursor <file>` or `zed <file>` handoffs exit 0 without opening anything: launches silently no-op from then on, which matches the reported "works, then permanently stops after a few launches."

## Honest uncertainty

The reporter's OS is unknown. macOS launches go through `open -a`, which detaches via LaunchServices and is immune to defect 2, and sequential sandboxed review cycles (curl and full-UI with a persistent browser profile) showed no Plannotator-side state that degrades across sessions. So this PR does not claim to certainly fix that specific report; it removes both demonstrated defects on every platform, which is the only Plannotator-side mechanism found that produces that failure signature.

## What changed

- `packages/server/open-in.ts`: `runArgv` (the single launch path behind `openWithApp`, `openSystemDefault`, and `revealFile`) now spawns via `node:child_process` `spawn(cmd, args, { detached: true, stdio: ["ignore", "ignore", "pipe"] })` plus `unref()`, drains stderr concurrently (capped capture, stream keeps draining), and bounds the wait at `LAUNCH_GRACE_MS` (2s). Exit 0 still resolves ok immediately, so the normal fast path is unchanged. Instant failures keep the existing friendly shapes: `<App> not found` and `Failed to open <App> (exit N): <stderr>`.
- `apps/pi-extension/server/open-in-apps.ts`: `run` mirrors the same semantics (two-runtime law). Its not-found copy (`... was not found on this system.`) is preserved; nonzero exits now report the same exit-plus-stderr shape as the Bun runtime instead of raw `execFile` messages.

## What deliberately did NOT change

- App catalog, path containment and resolution (`resolveOpenInTarget`, `resolveOpenInRoot`), endpoint shapes, UI, cookies.
- The CLI's decision flow and how it interjects with agent sessions: nothing new blocks or delays the review lifecycle; launches are fire-and-observe within the grace, then fully independent.
- `spawnDetached` (Windows `explorer` reveal) was already fire-and-forget and stays as is.

## Tests

Behavior tests using shimmed launcher executables on PATH (mac shims `open`, linux shims the catalog's `code` bin; skipped on Windows), same trio in `packages/server/open-in.test.ts` and the Pi mirror `apps/pi-extension/open-in-launch.test.ts`:

- Lingering launcher (30s sleep): responds ok within the grace, launcher still running afterwards, and the launcher's pgid differs from the server's (the core regression guard for defect 2). Probe evidence: server pid 41159 pgid 41156; launcher pid 41163 pgid 41163, alive after the ok response at 2003ms.
- Instantly failing launcher (exit 1 with stderr): friendly error containing `Failed to open`, `exit 1`, and the stderr text.
- Chatty launcher (200KB stderr, then lingers): no deadlock, ok within the grace.

`bun run typecheck` exit 0. `bun test packages/server packages/shared apps/pi-extension`: 1702 pass, 14 fail; the same 14 fail on pristine origin/main in this environment (semantic-diff sidecar and GitButler CLI dependent suites), zero new failures from this change.

*AI-assisted: implemented and tested by Claude under maintainer direction.*