### PR TITLE
security(pi): require Pi 0.79+ and document project trust

### DIFF
--- a/apps/pi-extension/README.md
+++ b/apps/pi-extension/README.md
@@ -23,6 +23,22 @@ pi install ./plannotator/apps/pi-extension
 pi -e npm:@plannotator/pi-extension
 ```
 
+## Pi version and project trust
+
+Plannotator requires **Pi 0.79.1 or newer**. Updating only the Plannotator
+extension does not repair the security behavior of an older Pi host; update Pi
+itself before loading the extension.
+
+Pi 0.79 introduced project trust for repository-local inputs. In interactive
+sessions, Pi asks before loading project settings, instructions, resources, and
+packages, and can save the decision for that working directory. Plannotator
+honors the same decision for `.pi/plannotator.json`.
+
+Noninteractive sessions ignore project-local inputs unless the project already
+has a saved trust decision or Pi is started with `--approve` (`-a`). Use
+`--no-approve` (`-na`) to disable project inputs for a run even when the project
+was previously trusted.
+
 ## Uninstall
 
 Remove a standalone Pi installation with:

--- a/apps/pi-extension/config.test.ts
+++ b/apps/pi-extension/config.test.ts
@@ -30,7 +30,7 @@ describe("plannotator config", () => {
     const cwdDir = makeTempDir("plannotator-config-base-");
     process.env.HOME = makeTempDir("plannotator-config-home-base-");
 
-    const loaded = loadPlannotatorConfig(cwdDir);
+    const loaded = loadPlannotatorConfig(cwdDir, { projectTrusted: true });
     const planning = resolvePhaseProfile(loaded.config, "planning");
 
     expect(loaded.warnings).toEqual([]);
@@ -56,10 +56,28 @@ describe("plannotator config", () => {
     writeFileSync(join(globalConfigDir, "plannotator.json"), JSON.stringify({ executionMode: "external" }), "utf-8");
     writeFileSync(join(projectConfigDir, "plannotator.json"), JSON.stringify({ executionMode: "automatic" }), "utf-8");
 
-    const loaded = loadPlannotatorConfig(cwdDir);
+    const loaded = loadPlannotatorConfig(cwdDir, { projectTrusted: true });
 
     expect(loaded.warnings).toEqual([]);
     expect(resolveExecutionMode(loaded.config)).toBe("automatic");
+  });
+
+  test("ignores project config when Pi denies project trust", () => {
+    const homeDir = makeTempDir("plannotator-config-home-untrusted-");
+    const cwdDir = makeTempDir("plannotator-config-cwd-untrusted-");
+    process.env.HOME = homeDir;
+
+    const globalConfigDir = join(homeDir, ".pi", "agent");
+    const projectConfigDir = join(cwdDir, ".pi");
+    mkdirSync(globalConfigDir, { recursive: true });
+    mkdirSync(projectConfigDir, { recursive: true });
+    writeFileSync(join(globalConfigDir, "plannotator.json"), JSON.stringify({ executionMode: "external" }), "utf-8");
+    writeFileSync(join(projectConfigDir, "plannotator.json"), JSON.stringify({ executionMode: "automatic" }), "utf-8");
+
+    const loaded = loadPlannotatorConfig(cwdDir, { projectTrusted: false });
+
+    expect(loaded.warnings).toEqual([]);
+    expect(resolveExecutionMode(loaded.config)).toBe("external");
   });
 
   test("allows a project config to clear inherited external execution with null", () => {
@@ -74,7 +92,7 @@ describe("plannotator config", () => {
     writeFileSync(join(globalConfigDir, "plannotator.json"), JSON.stringify({ executionMode: "external" }), "utf-8");
     writeFileSync(join(projectConfigDir, "plannotator.json"), JSON.stringify({ executionMode: null }), "utf-8");
 
-    const loaded = loadPlannotatorConfig(cwdDir);
+    const loaded = loadPlannotatorConfig(cwdDir, { projectTrusted: true });
 
     expect(loaded.warnings).toEqual([]);
     expect(resolveExecutionMode(loaded.config)).toBe("automatic");
@@ -89,7 +107,7 @@ describe("plannotator config", () => {
     mkdirSync(projectConfigDir, { recursive: true });
     writeFileSync(join(projectConfigDir, "plannotator.json"), JSON.stringify({ executionMode: "handoff" }), "utf-8");
 
-    const loaded = loadPlannotatorConfig(cwdDir);
+    const loaded = loadPlannotatorConfig(cwdDir, { projectTrusted: true });
 
     expect(loaded.warnings).toHaveLength(1);
     expect(loaded.warnings[0]).toContain('Ignoring unknown executionMode "handoff"');
@@ -121,7 +139,7 @@ describe("plannotator config", () => {
       "utf-8",
     );
 
-    const loaded = loadPlannotatorConfig(cwdDir);
+    const loaded = loadPlannotatorConfig(cwdDir, { projectTrusted: true });
     const planning = resolvePhaseProfile(loaded.config, "planning");
 
     expect(loaded.warnings).toEqual([]);
@@ -158,7 +176,7 @@ describe("plannotator config", () => {
       "utf-8",
     );
 
-    const loaded = loadPlannotatorConfig(cwdDir);
+    const loaded = loadPlannotatorConfig(cwdDir, { projectTrusted: true });
     const planning = resolvePhaseProfile(loaded.config, "planning");
 
     expect(loaded.warnings).toEqual([]);
@@ -229,7 +247,7 @@ describe("plannotator config", () => {
     const cwdDir = makeTempDir("plannotator-config-shipped-instructions-");
     process.env.HOME = makeTempDir("plannotator-config-home-shipped-instructions-");
 
-    const loaded = loadPlannotatorConfig(cwdDir);
+    const loaded = loadPlannotatorConfig(cwdDir, { projectTrusted: true });
     const planning = resolvePhaseProfile(loaded.config, "planning");
     const executing = resolvePhaseProfile(loaded.config, "executing");
 
@@ -262,7 +280,7 @@ describe("plannotator config", () => {
       "utf-8",
     );
 
-    const loaded = loadPlannotatorConfig(cwdDir);
+    const loaded = loadPlannotatorConfig(cwdDir, { projectTrusted: true });
     const executing = resolvePhaseProfile(loaded.config, "executing");
 
     // The obsolete key is ignored: the shipped instructions still apply.

--- a/apps/pi-extension/config.ts
+++ b/apps/pi-extension/config.ts
@@ -44,6 +44,11 @@ export interface LoadedPlannotatorConfig {
   warnings: string[];
 }
 
+export interface LoadPlannotatorConfigOptions {
+  /** Whether Pi approved project-local inputs for this working directory. */
+  projectTrusted: boolean;
+}
+
 export interface ResolvedPhaseProfile {
   model?: PhaseModelRef;
   thinking?: ThinkingLevel;
@@ -232,7 +237,10 @@ function loadConfigSource(path: string): { config: PlannotatorConfig; warnings: 
   return { config, warnings };
 }
 
-export function loadPlannotatorConfig(cwd: string): LoadedPlannotatorConfig {
+export function loadPlannotatorConfig(
+  cwd: string,
+  options: LoadPlannotatorConfigOptions,
+): LoadedPlannotatorConfig {
   const warnings: string[] = [];
 
   // The bundled config carries the planning rules and phase instructions. A
@@ -253,7 +261,9 @@ export function loadPlannotatorConfig(cwd: string): LoadedPlannotatorConfig {
   warnings.push(...globalConfig.warnings);
 
   const projectPath = join(cwd, ".pi", "plannotator.json");
-  const projectConfig = loadConfigSource(projectPath);
+  const projectConfig = options.projectTrusted
+    ? loadConfigSource(projectPath)
+    : { config: {}, warnings: [] };
   warnings.push(...projectConfig.warnings);
 
   const merged = mergeConfig(mergeConfig(internal.config, globalConfig.config), projectConfig.config);

--- a/apps/pi-extension/external-execution.test.ts
+++ b/apps/pi-extension/external-execution.test.ts
@@ -68,6 +68,7 @@ function createHarness(cwd: string) {
 	const ctx = {
 		cwd,
 		hasUI: false,
+		isProjectTrusted: () => true,
 		isIdle: () => true,
 		model: { provider: "test", id: "original-model" },
 		modelRegistry: { find: (provider: string, id: string) => ({ provider, id }) },

--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -1601,7 +1601,9 @@ Mark completed steps with [DONE:n] in your response.`
 	}
 
 	pi.on("session_start", async (_event, ctx) => {
-		const loadedConfig = loadPlannotatorConfig(ctx.cwd);
+		const loadedConfig = loadPlannotatorConfig(ctx.cwd, {
+			projectTrusted: ctx.isProjectTrusted(),
+		});
 		plannotatorConfig = loadedConfig.config;
 		for (const warning of loadedConfig.warnings) {
 			ctx.ui.notify(`Plannotator config: ${warning}`, "warning");

--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -1601,8 +1601,16 @@ Mark completed steps with [DONE:n] in your response.`
 	}
 
 	pi.on("session_start", async (_event, ctx) => {
+		const trustFn = ctx.isProjectTrusted as (() => boolean) | undefined;
+		const projectTrusted = typeof trustFn === "function" ? trustFn.call(ctx) : false;
+		if (typeof trustFn !== "function") {
+			ctx.ui.notify(
+				"Plannotator requires Pi 0.79.1 or newer. Update Pi; project-local config is disabled on this host.",
+				"warning",
+			);
+		}
 		const loadedConfig = loadPlannotatorConfig(ctx.cwd, {
-			projectTrusted: ctx.isProjectTrusted(),
+			projectTrusted,
 		});
 		plannotatorConfig = loadedConfig.config;
 		for (const warning of loadedConfig.warnings) {

--- a/apps/pi-extension/package.json
+++ b/apps/pi-extension/package.json
@@ -60,13 +60,13 @@
     "turndown": "^7.2.4"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": ">=0.74.0"
+    "@earendil-works/pi-coding-agent": ">=0.79.1"
   },
   "devDependencies": {
     "glimpseui": "^0.8.0",
-    "@earendil-works/pi-coding-agent": ">=0.74.0",
-    "@earendil-works/pi-agent-core": ">=0.74.0",
-    "@earendil-works/pi-ai": ">=0.74.0",
-    "@earendil-works/pi-tui": ">=0.74.0"
+    "@earendil-works/pi-coding-agent": ">=0.79.1",
+    "@earendil-works/pi-agent-core": ">=0.79.1",
+    "@earendil-works/pi-ai": ">=0.79.1",
+    "@earendil-works/pi-tui": ">=0.79.1"
   }
 }

--- a/apps/pi-extension/phase-prompts.test.ts
+++ b/apps/pi-extension/phase-prompts.test.ts
@@ -385,6 +385,33 @@ describe("Plannotator phase framing messages", () => {
 		expect(result?.message?.content).not.toContain("untrusted-project-instructions");
 	});
 
+	test("fails closed with an update warning when an older Pi host lacks project trust", async () => {
+		const cwd = makeWorkspace({
+			phases: { planning: { instructions: "untrusted-project-instructions" } },
+		});
+		const globalConfigDir = process.env.PI_CODING_AGENT_DIR!;
+		mkdirSync(globalConfigDir, { recursive: true });
+		writeFileSync(
+			join(globalConfigDir, "plannotator.json"),
+			JSON.stringify({ phases: { planning: { instructions: "trusted-global-instructions" } } }),
+			"utf-8",
+		);
+		const runtime = createRuntime();
+		const context = createContext({ cwd });
+		delete (context as { isProjectTrusted?: () => boolean }).isProjectTrusted;
+
+		await runtime.run("session_start", context);
+		await runtime.commands.get("plannotator-plan-mode")?.handler("", context);
+
+		const result = await startAgent(runtime, context);
+		expect(result?.message?.content).toContain("trusted-global-instructions");
+		expect(result?.message?.content).not.toContain("untrusted-project-instructions");
+		expect(context.notifications).toContainEqual({
+			message: "Plannotator requires Pi 0.79.1 or newer. Update Pi; project-local config is disabled on this host.",
+			level: "warning",
+		});
+	});
+
 	test("persistState records the framing latch on both sides", async () => {
 		const cwd = makeWorkspace();
 		const runtime = createRuntime();

--- a/apps/pi-extension/phase-prompts.test.ts
+++ b/apps/pi-extension/phase-prompts.test.ts
@@ -67,12 +67,13 @@ function makeWorkspace(projectConfig?: unknown): string {
 	return cwd;
 }
 
-function createContext(options: { cwd?: string; entries?: SessionEntry[] } = {}) {
+function createContext(options: { cwd?: string; entries?: SessionEntry[]; projectTrusted?: boolean } = {}) {
 	const entries = options.entries ?? [];
 	const notifications: Array<{ message: string; level: string | undefined }> = [];
 	return {
 		cwd: options.cwd ?? process.cwd(),
 		hasUI: false,
+		isProjectTrusted: () => options.projectTrusted ?? true,
 		isIdle: () => true,
 		model: undefined,
 		modelRegistry: { find: () => undefined },
@@ -368,6 +369,20 @@ describe("Plannotator phase framing messages", () => {
 		const warnings = templateWarnings(context);
 		expect(warnings).toHaveLength(1);
 		expect(warnings[0]?.message).toContain("bogus");
+	});
+
+	test("ignores project Plannotator config when Pi denies project trust", async () => {
+		const cwd = makeWorkspace({
+			phases: { planning: { instructions: "untrusted-project-instructions" } },
+		});
+		const runtime = createRuntime();
+		const context = createContext({ cwd, projectTrusted: false });
+		await runtime.run("session_start", context);
+		await runtime.commands.get("plannotator-plan-mode")?.handler("", context);
+
+		const result = await startAgent(runtime, context);
+		expect(result?.message?.content).toContain("[PLANNOTATOR - PLANNING PHASE]");
+		expect(result?.message?.content).not.toContain("untrusted-project-instructions");
 	});
 
 	test("persistState records the framing latch on both sides", async () => {

--- a/apps/pi-extension/phase-tools-runtime.test.ts
+++ b/apps/pi-extension/phase-tools-runtime.test.ts
@@ -58,6 +58,7 @@ function createContext(options: { cwd?: string; entries?: SessionEntry[] } = {})
 	return {
 		cwd: options.cwd ?? process.cwd(),
 		hasUI: false,
+		isProjectTrusted: () => true,
 		isIdle: () => true,
 		model: undefined,
 		modelRegistry: { find: () => undefined },

--- a/apps/pi-extension/stale-ctx.test.ts
+++ b/apps/pi-extension/stale-ctx.test.ts
@@ -85,6 +85,10 @@ function createHarness(cwd: string) {
 	const ctx = {
 		cwd,
 		hasUI: false,
+		isProjectTrusted: () => {
+			assertActive();
+			return true;
+		},
 		get mode() {
 			assertActive();
 			return "print";

--- a/apps/pi-extension/startup.test.ts
+++ b/apps/pi-extension/startup.test.ts
@@ -74,6 +74,8 @@ describe("Pi extension startup boundary", () => {
 			devDependencies?: Record<string, string>;
 		};
 
+		// Deliberate security/API floor: lowering it re-admits the four Pi
+		// advisories and removes the project-trust context API this extension uses.
 		expect(manifest.peerDependencies?.["@earendil-works/pi-coding-agent"]).toBe(">=0.79.1");
 		for (const packageName of [
 			"@earendil-works/pi-coding-agent",

--- a/apps/pi-extension/startup.test.ts
+++ b/apps/pi-extension/startup.test.ts
@@ -65,4 +65,23 @@ describe("Pi extension startup boundary", () => {
 		expect(manifest.files).toContain("plannotator-browser-runtime.ts");
 		expect(manifest.files).toContain("todo-providers/");
 	});
+
+	test("requires a Pi host that exposes the resolved project-trust decision", () => {
+		const manifest = JSON.parse(
+			readFileSync(join(extensionDirectory, "package.json"), "utf-8"),
+		) as {
+			peerDependencies?: Record<string, string>;
+			devDependencies?: Record<string, string>;
+		};
+
+		expect(manifest.peerDependencies?.["@earendil-works/pi-coding-agent"]).toBe(">=0.79.1");
+		for (const packageName of [
+			"@earendil-works/pi-coding-agent",
+			"@earendil-works/pi-agent-core",
+			"@earendil-works/pi-ai",
+			"@earendil-works/pi-tui",
+		]) {
+			expect(manifest.devDependencies?.[packageName]).toBe(">=0.79.1");
+		}
+	});
 });

--- a/apps/pi-extension/todo-provider-sync.test.ts
+++ b/apps/pi-extension/todo-provider-sync.test.ts
@@ -90,6 +90,7 @@ function createHarness(cwd: string) {
 	const ctx = {
 		cwd,
 		hasUI: false,
+		isProjectTrusted: () => true,
 		isIdle: () => true,
 		model: { provider: "test", id: "original-model" },
 		modelRegistry: { find: (provider: string, id: string) => ({ provider, id }) },

--- a/bun.lock
+++ b/bun.lock
@@ -91,14 +91,14 @@
         "turndown": "^7.2.4",
       },
       "devDependencies": {
-        "@earendil-works/pi-agent-core": ">=0.74.0",
-        "@earendil-works/pi-ai": ">=0.74.0",
-        "@earendil-works/pi-coding-agent": ">=0.74.0",
-        "@earendil-works/pi-tui": ">=0.74.0",
+        "@earendil-works/pi-agent-core": ">=0.79.1",
+        "@earendil-works/pi-ai": ">=0.79.1",
+        "@earendil-works/pi-coding-agent": ">=0.79.1",
+        "@earendil-works/pi-tui": ">=0.79.1",
         "glimpseui": "^0.8.0",
       },
       "peerDependencies": {
-        "@earendil-works/pi-coding-agent": ">=0.74.0",
+        "@earendil-works/pi-coding-agent": ">=0.79.1",
       },
     },
     "apps/portal": {


### PR DESCRIPTION
## Summary

Raise the published Pi host/support floor from `>=0.74.0` to `>=0.79.1`, keep the already-resolved 0.79.1 artifacts unchanged, and make Plannotator honor Pi's resolved project-trust decision before reading `<cwd>/.pi/plannotator.json`. A runtime capability guard gives older hosts an actionable update warning while keeping project configuration fail-closed.

The lockfile was already on the Pi 0.79.1 family, so Plannotator's development and release checks were using patched code. The published peer range was still security-relevant, however: it advertised compatibility with vulnerable Pi hosts installed on user machines. Updating only `@plannotator/pi-extension` cannot repair an older host.

## Threat model and advisory coverage

This sets the support floor above the fixes for all four open Pi Dependabot alerts:

- Alert #9: [GHSA-7v5m-pr3q-6453 / CVE-2026-54326](https://github.com/earendil-works/pi/security/advisories/GHSA-7v5m-pr3q-6453), HTML session-export XSS, patched in 0.78.1.
- Alert #10: [GHSA-r95r-rj6r-c39x / CVE-2026-54327](https://github.com/earendil-works/pi/security/advisories/GHSA-r95r-rj6r-c39x), racing `auth.json` writes that could expose credentials, patched in 0.78.1.
- Alert #11: [GHSA-jfgx-wxx8-mp94 / CVE-2026-54328](https://github.com/earendil-works/pi/security/advisories/GHSA-jfgx-wxx8-mp94), predictable temporary extension install paths on shared Linux hosts, patched in 0.78.1.
- Alert #12: [GHSA-mqxh-6gq7-558m / CVE-2026-54325](https://github.com/earendil-works/pi/security/advisories/GHSA-mqxh-6gq7-558m), project-local extensions loaded without approval, patched in 0.79.0.

Pi 0.79.0 introduced the project-trust lifecycle. This PR requires 0.79.1 specifically because that is the first release exposing `ctx.isProjectTrusted()` to extensions. Plannotator is commonly loaded globally or through the CLI and manually reads `<cwd>/.pi/plannotator.json`; without the new guard, that project file was outside Pi's own project-resource loader and could still influence Plannotator after trust was denied.

## User-visible trust behavior

- Interactive Pi sessions prompt for project trust and can save allow/deny decisions for the working directory.
- Noninteractive sessions ignore project-local inputs by default unless an allow decision was saved or Pi is started with `--approve` / `-a`.
- `--no-approve` / `-na` disables project inputs for that run, including when an allow decision was previously saved.
- Plannotator now applies that same resolved decision to `.pi/plannotator.json`; global and bundled Plannotator configuration remain available.
- Hosts older than 0.79.1 are not repaired by updating only the Plannotator extension. If such a host loads this extension despite the peer floor, Plannotator warns the user to update Pi, disables project-local configuration, and still loads bundled/global configuration.

## Changes

- Set the `@earendil-works/pi-coding-agent` peer floor and the four coherent Pi development floors to `>=0.79.1`.
- Update only Bun workspace metadata; resolved Pi versions remain 0.79.1.
- Gate project-local Plannotator configuration on `ctx.isProjectTrusted()` and fail closed with a clear update warning when an older host lacks that API.
- Add config, runtime, and manifest regression coverage plus test-host mocks for the new Pi context API.
- Document the host requirement and trust behavior in the Pi extension README.

This intentionally does not incorporate the broad dependency churn in #1281.

## Supply-chain audit

The dependency-update audit was completed for `pi-coding-agent`, `pi-agent-core`, `pi-ai`, and `pi-tui` before changing their declared ranges:

- 0.79.0/0.79.1 artifacts are npm registry-signed and SLSA-provenance-attested; an isolated 0.79.1 host graph verified 235 signatures and 45 attestations.
- The added maintainer is an established upstream Pi contributor; the original maintainers remain.
- Tarball/source changes, new runtime dependencies, release notes, package capabilities, install scripts, and suspicious-code patterns were reviewed. No unexplained obfuscation, lifecycle install hook, or anomalous capability was found.
- `pi-tui`'s macOS/Windows native helper hashes match tagged source and the helpers have narrow documented behavior.
- The packages raise their Node floor to 22.19.0, consistent with the Pi 0.79 host requirement.
- The strict audit verdict is **review/accept**, rather than an unconditional "safe" label, because the upgrade span includes a maintainer addition, substantive upstream code, new dependencies, and the Node floor change.
- No dependency was exempted from the age gate. Pi 0.84.1 was six days old at audit time and is deferred to a separate compatibility/supply-chain review after 2026-08-20.

That follow-up should also assess later advisories reported by `npm audit` in the 0.79.1 Pi host graph (`undici`, `brace-expansion`, `protobufjs`, and `ws`); the 0.84.1 host graph audited clean. These are not concealed or folded into this four-alert/floor-only PR, and the open-ended peer range already permits current Pi.

## Validation

- `bun install --frozen-lockfile` — passed; no resolution changes.
- `bun test apps/pi-extension` with isolated Plannotator data — 218 passed, 0 failed.
- Full `bun test` in an isolated home — 3,375 passed, 496 skipped, 0 failed.
- `bun run typecheck` — passed, including Pi vendoring and the Pi extension TypeScript project.
- `bun run build:pi` — passed.
- `bun run check:release-version` — passed for 0.27.1.
- Node-targeted Pi AI runtime smoke build — passed; native Windows execution remains covered by the required CI job.
- `npm pack`/tarball inspection — passed; the packed package declares peer `@earendil-works/pi-coding-agent >=0.79.1` and contains the expected runtime files.
- Isolated installed-package smoke checks — passed with exact minimum host 0.79.1 and current host 0.84.1.
- Actual Pi 0.79.1 trust checks via RPC observer extension confirmed: unsaved noninteractive default=false, `--approve`=true, `--no-approve`=false, saved allow=true, saved deny=false, and command-line flags override saved decisions. The interactive prompt/save path was substantiated against upstream release/source behavior; CI/manual terminal testing may exercise the visible prompt.

## Release and rollback

Merging this PR does **not** publish the remediation. After CI and review, maintainers should issue a patch release containing the updated `@plannotator/pi-extension`, verify the registry metadata/tarball, and confirm Dependabot alerts #9-#12 close against the published compatibility floor.

Do not roll the peer/support floor back below 0.79.1 (and therefore never below 0.79.0). The trust guard depends on the 0.79.1 extension API; a package rollback must preserve that host floor even if other changes are reverted.
