### PR TITLE
ci(security): add Semgrep CE and Trivy monitoring

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,9 +23,9 @@ env:
   GITLEAKS_LINUX_X64_SHA256: 79a3ab579b53f71efd634f3aaf7e04a0fa0cf206b7ed434638d1547a2470a66e
   SEMGREP_VERSION: 1.172.0
   SEMGREP_IMAGE: semgrep/semgrep:1.172.0-nonroot@sha256:d1012a3bf2acf47721216fbf7ff12d4c2971cc7f9c7b77cf6c6e9dcf006bd487
-  SEMGREP_RULE_COUNT: "15"
   TRIVY_VERSION: 0.73.0
   TRIVY_LINUX_X64_SHA256: 2edd39da482bb4e9831962487b68f68e3928ec3137794757f54d00383d79547b
+  # v2.2.0 content; the digest-only runtime reference never follows a moving tag.
   TRIVY_CHECKS_REFERENCE: ghcr.io/aquasecurity/trivy-checks@sha256:891abb1e1dc95429e6ad6768a8c8164dacf6d7ff742b940d1d709e69b5855cc6
   TRIVY_DB_MAX_AGE_SECONDS: "172800"
   TRIVY_DISABLE_TELEMETRY: "true"
@@ -183,7 +183,17 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          docker pull "$SEMGREP_IMAGE"
+          for attempt in 1 2 3; do
+            if docker pull "$SEMGREP_IMAGE"; then
+              break
+            fi
+            if (( attempt == 3 )); then
+              echo 'Semgrep image pull failed after three attempts.' >&2
+              exit 1
+            fi
+            echo "Semgrep image pull failed; retrying (attempt $((attempt + 1))/3)." >&2
+            sleep $((attempt * 5))
+          done
 
           repo_digest=$(docker image inspect --format '{{index .RepoDigests 0}}' "$SEMGREP_IMAGE")
           expected_digest=${SEMGREP_IMAGE##*@}
@@ -209,7 +219,7 @@ jobs:
         run: |
           set -euo pipefail
           fixture_dir="$RUNNER_TEMP/semgrep-health"
-          output_dir="$RUNNER_TEMP/semgrep-health-output"
+          output_dir="$GITHUB_WORKSPACE/security-results"
           mkdir -p "$fixture_dir" "$output_dir"
           chmod 777 "$output_dir"
 
@@ -229,6 +239,7 @@ jobs:
           curl --fail https://example.invalid/install.sh | sh
           EOF
 
+          set +e
           docker run --rm --network none \
             --env SEMGREP_SEND_METRICS=off \
             --volume "$GITHUB_WORKSPACE:/src:ro" \
@@ -244,9 +255,15 @@ jobs:
               --strict \
               --timeout 30 \
               --timeout-threshold 1 \
-              --json-output /out/health.json \
+              --json-output /out/semgrep-health.json \
               --config /src/.semgrep.yml \
-              /fixture
+              /fixture 2>&1 | tee "$output_dir/semgrep-health.log"
+          health_status=${PIPESTATUS[0]}
+          set -e
+          if [[ "$health_status" -ne 0 ]]; then
+            echo "Semgrep controlled detector scan failed (exit $health_status)." >&2
+            exit "$health_status"
+          fi
 
           jq -e --arg version "$SEMGREP_VERSION" '
             .version == $version and
@@ -262,7 +279,10 @@ jobs:
             any(.results[];
               .check_id == "plannotator.installer.remote-script-pipeline" and
               (.path | endswith("remote-pipeline.sh")) and .start.line == 2)
-          ' "$output_dir/health.json" >/dev/null
+          ' "$output_dir/semgrep-health.json" >/dev/null || {
+            echo 'Semgrep controlled detector report failed its engine, error, or exact-line assertions.' >&2
+            exit 1
+          }
 
           # A malformed local ruleset must be an engine failure, not a clean scan.
           cat > "$fixture_dir/invalid.yml" <<'EOF'
@@ -279,7 +299,7 @@ jobs:
             "$SEMGREP_IMAGE" \
             semgrep scan --oss-only --metrics off --disable-version-check \
               --strict --config /fixture/invalid.yml /fixture/command-injection.ts \
-              >/dev/null 2>&1
+              >"$output_dir/semgrep-invalid-rules.log" 2>&1
           invalid_status=$?
           set -e
           if [[ "$invalid_status" -eq 0 ]]; then
@@ -292,12 +312,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          output_dir="$RUNNER_TEMP/semgrep-output"
-          mkdir -p "$output_dir" security-results
+          output_dir="$GITHUB_WORKSPACE/security-results"
+          mkdir -p "$output_dir"
           chmod 777 "$output_dir"
 
           # The source mount and scanner network are read-only/offline. Findings
           # remain local; only GitHub receives the validated reports below.
+          set +e
           docker run --rm --network none \
             --env SEMGREP_SEND_METRICS=off \
             --volume "$GITHUB_WORKSPACE:/src:ro" \
@@ -317,42 +338,52 @@ jobs:
               --json-output /out/semgrep.json \
               --sarif-output /out/semgrep.sarif \
               --config /src/.semgrep.yml \
-              /src
+              /src 2>&1 | tee "$output_dir/semgrep-scan.log"
+          scan_status=${PIPESTATUS[0]}
+          set -e
+          if [[ "$scan_status" -ne 0 ]]; then
+            echo "Semgrep source scan failed (exit $scan_status)." >&2
+            exit "$scan_status"
+          fi
 
           jq -e --arg version "$SEMGREP_VERSION" '
             .version == $version and
             .engine_requested == "OSS" and
             (.errors | length) == 0 and
-            (.paths.scanned | length) >= 1000 and
+            (.paths.scanned | length) >= 500 and
             all(.results[]; .extra.engine_kind == "OSS") and
-            any(.paths.scanned[]; endswith("packages/server/index.ts")) and
-            any(.paths.scanned[]; endswith("apps/pi-extension/server/serverReview.ts")) and
-            any(.paths.scanned[]; endswith("packages/ui/components/InlineMarkdown.tsx")) and
-            any(.paths.scanned[]; endswith("apps/paste-service/targets/cloudflare.ts")) and
-            any(.paths.scanned[]; endswith("scripts/install.sh"))
-          ' "$output_dir/semgrep.json" >/dev/null
-          jq -e --arg version "$SEMGREP_VERSION" --argjson rule_count "$SEMGREP_RULE_COUNT" '
+            any(.paths.scanned[]; startswith("/src/packages/server/")) and
+            any(.paths.scanned[]; startswith("/src/apps/pi-extension/server/")) and
+            any(.paths.scanned[]; startswith("/src/packages/ui/")) and
+            any(.paths.scanned[]; startswith("/src/apps/paste-service/")) and
+            any(.paths.scanned[]; startswith("/src/scripts/"))
+          ' "$output_dir/semgrep.json" >/dev/null || {
+            echo 'Semgrep JSON failed its OSS-engine, error-free, target-count, or required-surface assertions.' >&2
+            exit 1
+          }
+          jq -e --arg version "$SEMGREP_VERSION" '
             .version == "2.1.0" and
             (.runs | length) == 1 and
             .runs[0].tool.driver.name == "Semgrep OSS" and
             .runs[0].tool.driver.semanticVersion == $version and
-            (.runs[0].tool.driver.rules | length) == $rule_count and
+            (.runs[0].tool.driver.rules | length) >= 10 and
             .runs[0].invocations[0].executionSuccessful == true
-          ' "$output_dir/semgrep.sarif" >/dev/null
-
-          cp "$output_dir/semgrep.json" security-results/semgrep.json
-          cp "$output_dir/semgrep.sarif" security-results/semgrep.sarif
+          ' "$output_dir/semgrep.sarif" >/dev/null || {
+            echo 'Semgrep SARIF failed its schema, OSS-driver, version, rule-floor, or execution assertions.' >&2
+            exit 1
+          }
 
           finding_count=$(jq '.results | length' security-results/semgrep.json)
           error_count=$(jq '[.results[] | select(.extra.severity == "ERROR")] | length' security-results/semgrep.json)
           warning_count=$(jq '[.results[] | select(.extra.severity == "WARNING")] | length' security-results/semgrep.json)
           target_count=$(jq '.paths.scanned | length' security-results/semgrep.json)
+          rule_count=$(jq '.runs[0].tool.driver.rules | length' security-results/semgrep.sarif)
           rules_sha=$(sha256sum .semgrep.yml | cut -d' ' -f1)
 
           {
             echo '### Semgrep Community Edition'
             echo '- Scope: TypeScript/JavaScript (Bun, Pi/Node, React/DOM, Cloudflare) plus generic installer checks'
-            echo "- Engine: Semgrep OSS $SEMGREP_VERSION; $SEMGREP_RULE_COUNT repository-owned rules (SHA-256 \`$rules_sha\`)"
+            echo "- Engine: Semgrep OSS $SEMGREP_VERSION; $rule_count repository-owned rules (SHA-256 \`$rules_sha\`)"
             echo '- Network/data mode: scan runs offline; no token, Registry rules, metrics, version check, or Semgrep Cloud upload'
             echo "- Targets: $target_count"
             echo "- Findings: $finding_count ($error_count error, $warning_count warning)"
@@ -362,14 +393,15 @@ jobs:
           echo 'report-ready=true' >> "$GITHUB_OUTPUT"
 
       - name: Retain Semgrep reports
-        if: always() && steps.scan.outputs.report-ready == 'true'
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: semgrep-reports
           path: |
-            security-results/semgrep.json
-            security-results/semgrep.sarif
-          if-no-files-found: error
+            security-results/semgrep*.json
+            security-results/semgrep*.sarif
+            security-results/semgrep*.log
+          if-no-files-found: warn
           retention-days: 7
 
       - name: Upload Semgrep SARIF
@@ -403,7 +435,9 @@ jobs:
         run: |
           set -euo pipefail
           archive="$RUNNER_TEMP/trivy.tar.gz"
-          curl --fail --silent --show-error --location --retry 3 --retry-all-errors \
+          curl --fail --silent --show-error --location \
+            --retry 3 --retry-all-errors --retry-delay 2 \
+            --connect-timeout 15 --max-time 120 \
             --proto '=https' --tlsv1.2 \
             "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" \
             --output "$archive"
@@ -429,10 +463,14 @@ jobs:
         run: |
           set -euo pipefail
           registry_token=$(curl --fail --silent --show-error --location \
+            --retry 3 --retry-all-errors --retry-delay 2 \
+            --connect-timeout 15 --max-time 120 \
             --proto '=https' --tlsv1.2 \
             'https://ghcr.io/token?service=ghcr.io&scope=repository:aquasecurity/trivy-db:pull' \
             | jq -er '.token')
           headers=$(curl --fail --silent --show-error --head --location \
+            --retry 3 --retry-all-errors --retry-delay 2 \
+            --connect-timeout 15 --max-time 120 \
             --proto '=https' --tlsv1.2 \
             -H "Authorization: Bearer $registry_token" \
             -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json' \
@@ -446,13 +484,27 @@ jobs:
 
           cache_dir="$RUNNER_TEMP/trivy-cache"
           db_reference="ghcr.io/aquasecurity/trivy-db@$db_digest"
-          trivy fs \
-            --cache-dir "$cache_dir" \
-            --db-repository "$db_reference" \
-            --download-db-only \
-            --no-progress \
-            --skip-version-check \
-            --disable-telemetry
+          for attempt in 1 2 3; do
+            set +e
+            trivy fs \
+              --cache-dir "$cache_dir" \
+              --db-repository "$db_reference" \
+              --download-db-only \
+              --no-progress \
+              --skip-version-check \
+              --disable-telemetry
+            download_status=$?
+            set -e
+            if [[ "$download_status" -eq 0 ]]; then
+              break
+            fi
+            if (( attempt == 3 )); then
+              echo "Trivy database download failed after three attempts (exit $download_status)." >&2
+              exit "$download_status"
+            fi
+            echo "Trivy database download failed; retrying (attempt $((attempt + 1))/3)." >&2
+            sleep $((attempt * 5))
+          done
 
           metadata="$cache_dir/db/metadata.json"
           test -s "$cache_dir/db/trivy.db"
@@ -480,7 +532,7 @@ jobs:
         run: |
           set -euo pipefail
           fixture_dir="$RUNNER_TEMP/trivy-health"
-          mkdir -p "$fixture_dir"
+          mkdir -p "$fixture_dir" security-results
           cat > "$fixture_dir/package-lock.json" <<'EOF'
           {
             "name": "trivy-health",
@@ -499,23 +551,34 @@ jobs:
           USER root
           EOF
 
-          set +e
-          trivy fs \
-            --cache-dir "$TRIVY_CACHE_DIR" \
-            --db-repository "$TRIVY_DB_REFERENCE" \
-            --checks-bundle-repository "$TRIVY_CHECKS_REFERENCE" \
-            --skip-db-update \
-            --skip-version-check \
-            --disable-telemetry \
-            --scanners vuln,misconfig \
-            --include-non-failures \
-            --severity HIGH,CRITICAL \
-            --exit-code 9 \
-            --format json \
-            --output "$RUNNER_TEMP/trivy-health.json" \
-            "$fixture_dir"
-          detector_status=$?
-          set -e
+          : > security-results/trivy-health.log
+          for attempt in 1 2 3; do
+            set +e
+            trivy fs \
+              --cache-dir "$TRIVY_CACHE_DIR" \
+              --db-repository "$TRIVY_DB_REFERENCE" \
+              --checks-bundle-repository "$TRIVY_CHECKS_REFERENCE" \
+              --skip-db-update \
+              --skip-version-check \
+              --disable-telemetry \
+              --scanners vuln,misconfig \
+              --include-non-failures \
+              --severity HIGH,CRITICAL \
+              --exit-code 9 \
+              --format json \
+              --output security-results/trivy-health.json \
+              "$fixture_dir" 2>>security-results/trivy-health.log
+            detector_status=$?
+            set -e
+            if [[ "$detector_status" -eq 9 ]]; then
+              break
+            fi
+            if (( attempt < 3 )); then
+              echo "Trivy controlled detector scan did not return its expected finding status; retrying (attempt $((attempt + 1))/3)." >&2
+              sleep $((attempt * 5))
+            fi
+          done
+          cat security-results/trivy-health.log
           if [[ "$detector_status" -ne 9 ]]; then
             echo "Trivy failed its controlled detector test (exit $detector_status)." >&2
             exit 1
@@ -529,13 +592,19 @@ jobs:
             any(.Results[].Misconfigurations[]?;
               .ID == "DS-0002" and .Status == "FAIL" and
               .Severity == "HIGH" and .CauseMetadata.StartLine == 2)
-          ' "$RUNNER_TEMP/trivy-health.json" >/dev/null
+          ' security-results/trivy-health.json >/dev/null || {
+            echo 'Trivy controlled detector report failed its vulnerability or misconfiguration assertions.' >&2
+            exit 1
+          }
 
           checks_metadata="$TRIVY_CACHE_DIR/policy/metadata.json"
           expected_checks_digest=${TRIVY_CHECKS_REFERENCE##*@}
           jq -e --arg digest "$expected_checks_digest" '
             .MajorVersion == 2 and .Digest == $digest
-          ' "$checks_metadata" >/dev/null
+          ' "$checks_metadata" >/dev/null || {
+            echo 'Trivy checks metadata does not match the pinned v2.2.0 OCI digest.' >&2
+            exit 1
+          }
 
           # Exercise the report guard: malformed/empty collection metadata must fail.
           if printf '{"SchemaVersion":1,"Results":[]}' \
@@ -653,6 +722,18 @@ jobs:
           bun_package_count=$(jq '[.Results[] | select(
             .Target == "bun.lock" and .Class == "lang-pkgs" and .Type == "bun"
           ) | .Packages[]?] | length' security-results/trivy.json)
+          expected_npm_targets="$RUNNER_TEMP/trivy-expected-npm-targets.txt"
+          actual_npm_targets="$RUNNER_TEMP/trivy-actual-npm-targets.txt"
+          git ls-files '*package-lock.json' \
+            | awk '$0 !~ /(^|\/)(node_modules|dist|dist-ssr|\.astro|coverage)(\/|$)/ &&
+              $0 !~ /^apps\/pi-extension\/generated\//' \
+            | sort -u > "$expected_npm_targets"
+          jq -r '.Results[] | select(
+            .Class == "lang-pkgs" and .Type == "npm" and
+            ((.Packages // []) | length) > 0
+          ) | .Target' security-results/trivy.json \
+            | sort -u > "$actual_npm_targets"
+          expected_npm_target_count=$(wc -l < "$expected_npm_targets")
           npm_target_count=$(jq '[.Results[] | select(
             .Class == "lang-pkgs" and .Type == "npm"
           )] | length' security-results/trivy.json)
@@ -661,32 +742,38 @@ jobs:
             .Target == "bun.lock" and .Class == "license"
           ) | .Licenses[]?] | length' security-results/trivy-license.json)
           license_count=$(jq '[.Results[].Licenses[]?] | length' security-results/trivy-license.json)
-          if (( bun_package_count < 1000 || npm_target_count != 20 || total_package_count < 1400 )); then
-            echo "Trivy dependency coverage is incomplete: bun=$bun_package_count npm-targets=$npm_target_count total=$total_package_count." >&2
+          if (( expected_npm_target_count < 1 || bun_package_count < 500 \
+            || total_package_count < bun_package_count )); then
+            echo "Trivy dependency coverage is incomplete: bun=$bun_package_count npm-targets=$npm_target_count expected-npm-targets=$expected_npm_target_count total=$total_package_count." >&2
             exit 1
           fi
-          if (( bun_license_count < 900 || license_count < 1000 )); then
+          if ! cmp --silent "$expected_npm_targets" "$actual_npm_targets"; then
+            echo 'Trivy did not catalog every tracked, in-scope npm lockfile with packages:' >&2
+            diff --unified "$expected_npm_targets" "$actual_npm_targets" >&2 || true
+            exit 1
+          fi
+          if (( bun_license_count < 500 || license_count < bun_license_count )); then
             echo "Trivy license coverage is incomplete: bun=$bun_license_count total=$license_count." >&2
             exit 1
           fi
 
           jq -e 'any(.Results[].Packages[]?;
-            .Name == "dompurify" and .Version == "3.4.8" and
+            .Name == "dompurify" and (.Version | length) > 0 and
             .Relationship == "direct")' security-results/trivy.json >/dev/null || {
-              echo 'Trivy did not catalog the direct dompurify@3.4.8 sentinel.' >&2
+              echo 'Trivy did not catalog the direct dompurify sentinel from bun.lock.' >&2
               exit 1
             }
           jq -e 'any(.Results[].Packages[]?;
-            .Name == "hono" and .Version == "4.12.25" and
+            .Name == "hono" and (.Version | length) > 0 and
             .Relationship == "indirect")' security-results/trivy.json >/dev/null || {
-              echo 'Trivy did not catalog the indirect hono@4.12.25 sentinel.' >&2
+              echo 'Trivy did not catalog the indirect hono sentinel from bun.lock.' >&2
               exit 1
             }
           jq -e 'any(.Results[].Packages[]?;
-            .Name == "bun-types" and .Version == "1.3.14" and
+            .Name == "bun-types" and (.Version | length) > 0 and
             .Relationship == "direct" and .Dev == true)' \
             security-results/trivy.json >/dev/null || {
-              echo 'Trivy did not catalog the direct development bun-types@1.3.14 sentinel.' >&2
+              echo 'Trivy did not catalog the direct development bun-types sentinel from bun.lock.' >&2
               exit 1
             }
           jq -e 'any(.Results[];
@@ -725,8 +812,8 @@ jobs:
             echo '### Trivy'
             echo '- Scope: committed Bun/npm dependency locks plus filesystem/IaC misconfiguration; secret scanning disabled (Gitleaks remains authoritative)'
             echo "- Engine: Trivy $TRIVY_VERSION; database \`$TRIVY_DB_DIGEST\` (updated \`$TRIVY_DB_UPDATED_AT\`)"
-            echo "- Misconfiguration checks: \`$checks_digest\`"
-            echo "- Dependency catalog: $total_package_count records ($bun_package_count from text bun.lock, including development dependencies)"
+            echo "- Misconfiguration checks: v2.2.0 content, \`$checks_digest\`"
+            echo "- Dependency catalog: $total_package_count records ($bun_package_count from text bun.lock, including development dependencies; $npm_target_count/$expected_npm_target_count tracked npm locks)"
             echo "- Vulnerabilities: $vulnerability_count ($critical_count critical, $high_count high)"
             echo "- Misconfiguration failures: $misconfiguration_count; tests/manual/ssh/Dockerfile is a non-production manual fixture"
             echo "- Informational installed-license records: $license_count (runner/install graph, not a deployment inventory)"
@@ -735,15 +822,15 @@ jobs:
           echo 'report-ready=true' >> "$GITHUB_OUTPUT"
 
       - name: Retain Trivy reports
-        if: always() && steps.scan.outputs.report-ready == 'true'
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: trivy-reports
           path: |
-            security-results/trivy.json
-            security-results/trivy-license.json
-            security-results/trivy.sarif
-          if-no-files-found: error
+            security-results/trivy*.json
+            security-results/trivy*.sarif
+            security-results/trivy*.log
+          if-no-files-found: warn
           retention-days: 7
 
       - name: Upload Trivy SARIF

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -629,12 +629,22 @@ jobs:
           fi
           grep -F '[license] License scanning is enabled' security-results/trivy-license.log >/dev/null
 
-          jq -e '.SchemaVersion == 2 and .ArtifactType == "filesystem"' \
+          echo "Trivy dependency report metadata: $(jq -c \
+            '{SchemaVersion, ArtifactName, ArtifactType}' security-results/trivy.json)"
+          echo "Trivy license report metadata: $(jq -c \
+            '{SchemaVersion, ArtifactName, ArtifactType}' security-results/trivy-license.json)"
+
+          # trivy fs reports "repository" when it can read Git metadata from the
+          # checkout and "filesystem" otherwise. Both are defined artifact types
+          # in the pinned Trivy release and use the same local filesystem scanner.
+          jq -e '.SchemaVersion == 2 and
+            (.ArtifactType == "filesystem" or .ArtifactType == "repository")' \
             security-results/trivy.json >/dev/null || {
               echo 'Trivy vulnerability/misconfiguration report metadata is invalid.' >&2
               exit 1
             }
-          jq -e '.SchemaVersion == 2 and .ArtifactType == "filesystem"' \
+          jq -e '.SchemaVersion == 2 and
+            (.ArtifactType == "filesystem" or .ArtifactType == "repository")' \
             security-results/trivy-license.json >/dev/null || {
               echo 'Trivy license report metadata is invalid.' >&2
               exit 1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,6 +21,15 @@ concurrency:
 env:
   GITLEAKS_VERSION: 8.30.0
   GITLEAKS_LINUX_X64_SHA256: 79a3ab579b53f71efd634f3aaf7e04a0fa0cf206b7ed434638d1547a2470a66e
+  SEMGREP_VERSION: 1.172.0
+  SEMGREP_IMAGE: semgrep/semgrep:1.172.0-nonroot@sha256:d1012a3bf2acf47721216fbf7ff12d4c2971cc7f9c7b77cf6c6e9dcf006bd487
+  SEMGREP_RULE_COUNT: "15"
+  TRIVY_VERSION: 0.73.0
+  TRIVY_LINUX_X64_SHA256: 2edd39da482bb4e9831962487b68f68e3928ec3137794757f54d00383d79547b
+  TRIVY_CHECKS_REFERENCE: ghcr.io/aquasecurity/trivy-checks@sha256:891abb1e1dc95429e6ad6768a8c8164dacf6d7ff742b940d1d709e69b5855cc6
+  TRIVY_DB_MAX_AGE_SECONDS: "172800"
+  TRIVY_DISABLE_TELEMETRY: "true"
+  TRIVY_SKIP_VERSION_CHECK: "true"
   ZIZMOR_VERSION: 1.29.0
   ZIZMOR_LINUX_X64_SHA256: dd96df044a6e8538d5f423790f453bdd03d49e5b2bcc38214acc41a2f1297839
 
@@ -155,6 +164,560 @@ jobs:
         with:
           sarif_file: security-results/gitleaks.sarif
           category: gitleaks
+
+  semgrep:
+    name: Semgrep CE
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      actions: read # Required by upload-sarif to read workflow-run metadata.
+      security-events: write # Required only for the final SARIF upload.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install pinned Semgrep CE image
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker pull "$SEMGREP_IMAGE"
+
+          repo_digest=$(docker image inspect --format '{{index .RepoDigests 0}}' "$SEMGREP_IMAGE")
+          expected_digest=${SEMGREP_IMAGE##*@}
+          if [[ "$repo_digest" != *"@$expected_digest" ]]; then
+            echo "Semgrep image digest mismatch: $repo_digest" >&2
+            exit 1
+          fi
+
+          image_user=$(docker image inspect --format '{{.Config.User}}' "$SEMGREP_IMAGE")
+          if [[ -z "$image_user" || "$image_user" == 'root' || "$image_user" == '0' ]]; then
+            echo "The pinned Semgrep image is not configured as non-root." >&2
+            exit 1
+          fi
+
+          actual_version=$(docker run --rm --network none "$SEMGREP_IMAGE" semgrep --version)
+          if [[ "$actual_version" != "$SEMGREP_VERSION" ]]; then
+            echo "Expected Semgrep $SEMGREP_VERSION, got $actual_version." >&2
+            exit 1
+          fi
+
+      - name: Verify Semgrep rules and detector health
+        shell: bash
+        run: |
+          set -euo pipefail
+          fixture_dir="$RUNNER_TEMP/semgrep-health"
+          output_dir="$RUNNER_TEMP/semgrep-health-output"
+          mkdir -p "$fixture_dir" "$output_dir"
+          chmod 777 "$output_dir"
+
+          cat > "$fixture_dir/command-injection.ts" <<'EOF'
+          import { exec } from "node:child_process";
+          export function runCommand(command: string) {
+            exec(command);
+          }
+          EOF
+          cat > "$fixture_dir/bun-command-injection.ts" <<'EOF'
+          export function runWithBun(command: string) {
+            return Bun.spawn(["sh", "-c", command]);
+          }
+          EOF
+          cat > "$fixture_dir/remote-pipeline.sh" <<'EOF'
+          #!/bin/sh
+          curl --fail https://example.invalid/install.sh | sh
+          EOF
+
+          docker run --rm --network none \
+            --env SEMGREP_SEND_METRICS=off \
+            --volume "$GITHUB_WORKSPACE:/src:ro" \
+            --volume "$fixture_dir:/fixture:ro" \
+            --volume "$output_dir:/out" \
+            --workdir /fixture \
+            "$SEMGREP_IMAGE" \
+            semgrep scan \
+              --oss-only \
+              --metrics off \
+              --disable-version-check \
+              --no-rewrite-rule-ids \
+              --strict \
+              --timeout 30 \
+              --timeout-threshold 1 \
+              --json-output /out/health.json \
+              --config /src/.semgrep.yml \
+              /fixture
+
+          jq -e --arg version "$SEMGREP_VERSION" '
+            .version == $version and
+            .engine_requested == "OSS" and
+            (.errors | length) == 0 and
+            all(.results[]; .extra.engine_kind == "OSS") and
+            any(.results[];
+              .check_id == "plannotator.node.nonliteral-exec" and
+              (.path | endswith("command-injection.ts")) and .start.line == 3) and
+            any(.results[];
+              .check_id == "plannotator.node.shell-command-argument" and
+              (.path | endswith("bun-command-injection.ts")) and .start.line == 2) and
+            any(.results[];
+              .check_id == "plannotator.installer.remote-script-pipeline" and
+              (.path | endswith("remote-pipeline.sh")) and .start.line == 2)
+          ' "$output_dir/health.json" >/dev/null
+
+          # A malformed local ruleset must be an engine failure, not a clean scan.
+          cat > "$fixture_dir/invalid.yml" <<'EOF'
+          rules:
+            - id: deliberately-invalid
+              languages: [typescript]
+              pattern:
+          EOF
+          set +e
+          docker run --rm --network none \
+            --env SEMGREP_SEND_METRICS=off \
+            --volume "$fixture_dir:/fixture:ro" \
+            --workdir /fixture \
+            "$SEMGREP_IMAGE" \
+            semgrep scan --oss-only --metrics off --disable-version-check \
+              --strict --config /fixture/invalid.yml /fixture/command-injection.ts \
+              >/dev/null 2>&1
+          invalid_status=$?
+          set -e
+          if [[ "$invalid_status" -eq 0 ]]; then
+            echo 'Semgrep accepted a deliberately malformed ruleset.' >&2
+            exit 1
+          fi
+
+      - name: Scan source with Semgrep CE
+        id: scan
+        shell: bash
+        run: |
+          set -euo pipefail
+          output_dir="$RUNNER_TEMP/semgrep-output"
+          mkdir -p "$output_dir" security-results
+          chmod 777 "$output_dir"
+
+          # The source mount and scanner network are read-only/offline. Findings
+          # remain local; only GitHub receives the validated reports below.
+          docker run --rm --network none \
+            --env SEMGREP_SEND_METRICS=off \
+            --volume "$GITHUB_WORKSPACE:/src:ro" \
+            --volume "$output_dir:/out" \
+            --workdir /src \
+            "$SEMGREP_IMAGE" \
+            semgrep scan \
+              --oss-only \
+              --metrics off \
+              --disable-version-check \
+              --no-rewrite-rule-ids \
+              --strict \
+              --timeout 30 \
+              --timeout-threshold 1 \
+              --max-target-bytes 5000000 \
+              --quiet \
+              --json-output /out/semgrep.json \
+              --sarif-output /out/semgrep.sarif \
+              --config /src/.semgrep.yml \
+              /src
+
+          jq -e --arg version "$SEMGREP_VERSION" '
+            .version == $version and
+            .engine_requested == "OSS" and
+            (.errors | length) == 0 and
+            (.paths.scanned | length) >= 1000 and
+            all(.results[]; .extra.engine_kind == "OSS") and
+            any(.paths.scanned[]; endswith("packages/server/index.ts")) and
+            any(.paths.scanned[]; endswith("apps/pi-extension/server/serverReview.ts")) and
+            any(.paths.scanned[]; endswith("packages/ui/components/InlineMarkdown.tsx")) and
+            any(.paths.scanned[]; endswith("apps/paste-service/targets/cloudflare.ts")) and
+            any(.paths.scanned[]; endswith("scripts/install.sh"))
+          ' "$output_dir/semgrep.json" >/dev/null
+          jq -e --arg version "$SEMGREP_VERSION" --argjson rule_count "$SEMGREP_RULE_COUNT" '
+            .version == "2.1.0" and
+            (.runs | length) == 1 and
+            .runs[0].tool.driver.name == "Semgrep OSS" and
+            .runs[0].tool.driver.semanticVersion == $version and
+            (.runs[0].tool.driver.rules | length) == $rule_count and
+            .runs[0].invocations[0].executionSuccessful == true
+          ' "$output_dir/semgrep.sarif" >/dev/null
+
+          cp "$output_dir/semgrep.json" security-results/semgrep.json
+          cp "$output_dir/semgrep.sarif" security-results/semgrep.sarif
+
+          finding_count=$(jq '.results | length' security-results/semgrep.json)
+          error_count=$(jq '[.results[] | select(.extra.severity == "ERROR")] | length' security-results/semgrep.json)
+          warning_count=$(jq '[.results[] | select(.extra.severity == "WARNING")] | length' security-results/semgrep.json)
+          target_count=$(jq '.paths.scanned | length' security-results/semgrep.json)
+          rules_sha=$(sha256sum .semgrep.yml | cut -d' ' -f1)
+
+          {
+            echo '### Semgrep Community Edition'
+            echo '- Scope: TypeScript/JavaScript (Bun, Pi/Node, React/DOM, Cloudflare) plus generic installer checks'
+            echo "- Engine: Semgrep OSS $SEMGREP_VERSION; $SEMGREP_RULE_COUNT repository-owned rules (SHA-256 \`$rules_sha\`)"
+            echo '- Network/data mode: scan runs offline; no token, Registry rules, metrics, version check, or Semgrep Cloud upload'
+            echo "- Targets: $target_count"
+            echo "- Findings: $finding_count ($error_count error, $warning_count warning)"
+            echo '- CE limit: intrafile analysis only; no Pro cross-file/cross-function or hosted policy features'
+            echo '- Enforcement: monitor mode; rule, parser, timeout, engine, and report failures still fail the job'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo 'report-ready=true' >> "$GITHUB_OUTPUT"
+
+      - name: Retain Semgrep reports
+        if: always() && steps.scan.outputs.report-ready == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: semgrep-reports
+          path: |
+            security-results/semgrep.json
+            security-results/semgrep.sarif
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload Semgrep SARIF
+        if: >-
+          always() &&
+          steps.scan.outputs.report-ready == 'true' &&
+          (github.event_name != 'pull_request' ||
+          (github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'dependabot[bot]'))
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          sarif_file: security-results/semgrep.sarif
+          category: semgrep-ce
+
+  trivy:
+    name: Trivy
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      actions: read # Required by upload-sarif to read workflow-run metadata.
+      security-events: write # Required only for the final SARIF upload.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Download verified Trivy archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          archive="$RUNNER_TEMP/trivy.tar.gz"
+          curl --fail --silent --show-error --location --retry 3 --retry-all-errors \
+            --proto '=https' --tlsv1.2 \
+            "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" \
+            --output "$archive"
+          printf '%s  %s\n' "$TRIVY_LINUX_X64_SHA256" "$archive" \
+            | sha256sum --check --strict
+
+      - name: Activate verified Trivy
+        shell: bash
+        run: |
+          set -euo pipefail
+          install_dir="$RUNNER_TEMP/trivy-bin"
+          mkdir -p "$install_dir"
+          tar -xzf "$RUNNER_TEMP/trivy.tar.gz" -C "$install_dir" trivy
+          actual_version=$("$install_dir/trivy" --version | awk 'NR == 1 { print $2 }')
+          if [[ "$actual_version" != "$TRIVY_VERSION" ]]; then
+            echo "Expected Trivy $TRIVY_VERSION, got $actual_version." >&2
+            exit 1
+          fi
+          echo "$install_dir" >> "$GITHUB_PATH"
+
+      - name: Resolve and validate vulnerability database
+        shell: bash
+        run: |
+          set -euo pipefail
+          registry_token=$(curl --fail --silent --show-error --location \
+            --proto '=https' --tlsv1.2 \
+            'https://ghcr.io/token?service=ghcr.io&scope=repository:aquasecurity/trivy-db:pull' \
+            | jq -er '.token')
+          headers=$(curl --fail --silent --show-error --head --location \
+            --proto '=https' --tlsv1.2 \
+            -H "Authorization: Bearer $registry_token" \
+            -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json' \
+            'https://ghcr.io/v2/aquasecurity/trivy-db/manifests/2')
+          db_digest=$(printf '%s\n' "$headers" | tr -d '\r' \
+            | awk 'tolower($1) == "docker-content-digest:" { print $2 }')
+          if [[ ! "$db_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "Invalid Trivy database digest: $db_digest" >&2
+            exit 1
+          fi
+
+          cache_dir="$RUNNER_TEMP/trivy-cache"
+          db_reference="ghcr.io/aquasecurity/trivy-db@$db_digest"
+          trivy fs \
+            --cache-dir "$cache_dir" \
+            --db-repository "$db_reference" \
+            --download-db-only \
+            --no-progress \
+            --skip-version-check \
+            --disable-telemetry
+
+          metadata="$cache_dir/db/metadata.json"
+          test -s "$cache_dir/db/trivy.db"
+          updated_epoch=$(jq -er '
+            select(.Version == 2) |
+            .UpdatedAt | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601
+          ' "$metadata")
+          now_epoch=$(date -u +%s)
+          db_age_seconds=$((now_epoch - updated_epoch))
+          if (( db_age_seconds < -300 || db_age_seconds > TRIVY_DB_MAX_AGE_SECONDS )); then
+            echo "Trivy database age is invalid: $db_age_seconds seconds." >&2
+            exit 1
+          fi
+
+          db_updated_at=$(jq -er '.UpdatedAt' "$metadata")
+          {
+            echo "TRIVY_CACHE_DIR=$cache_dir"
+            echo "TRIVY_DB_REFERENCE=$db_reference"
+            echo "TRIVY_DB_DIGEST=$db_digest"
+            echo "TRIVY_DB_UPDATED_AT=$db_updated_at"
+          } >> "$GITHUB_ENV"
+
+      - name: Verify Trivy detector and checks health
+        shell: bash
+        run: |
+          set -euo pipefail
+          fixture_dir="$RUNNER_TEMP/trivy-health"
+          mkdir -p "$fixture_dir"
+          cat > "$fixture_dir/package-lock.json" <<'EOF'
+          {
+            "name": "trivy-health",
+            "version": "1.0.0",
+            "lockfileVersion": 3,
+            "requires": true,
+            "packages": {
+              "": { "name": "trivy-health", "version": "1.0.0" },
+              "node_modules/lodash": { "version": "4.17.20", "license": "MIT" }
+            },
+            "dependencies": { "lodash": { "version": "4.17.20" } }
+          }
+          EOF
+          cat > "$fixture_dir/Dockerfile" <<'EOF'
+          FROM alpine:3.20
+          USER root
+          EOF
+
+          set +e
+          trivy fs \
+            --cache-dir "$TRIVY_CACHE_DIR" \
+            --db-repository "$TRIVY_DB_REFERENCE" \
+            --checks-bundle-repository "$TRIVY_CHECKS_REFERENCE" \
+            --skip-db-update \
+            --skip-version-check \
+            --disable-telemetry \
+            --scanners vuln,misconfig \
+            --include-non-failures \
+            --severity HIGH,CRITICAL \
+            --exit-code 9 \
+            --format json \
+            --output "$RUNNER_TEMP/trivy-health.json" \
+            "$fixture_dir"
+          detector_status=$?
+          set -e
+          if [[ "$detector_status" -ne 9 ]]; then
+            echo "Trivy failed its controlled detector test (exit $detector_status)." >&2
+            exit 1
+          fi
+
+          jq -e '
+            .SchemaVersion == 2 and
+            any(.Results[].Vulnerabilities[]?;
+              .VulnerabilityID == "CVE-2021-23337" and
+              .PkgName == "lodash" and .InstalledVersion == "4.17.20") and
+            any(.Results[].Misconfigurations[]?;
+              .ID == "DS-0002" and .Status == "FAIL" and
+              .Severity == "HIGH" and .CauseMetadata.StartLine == 2)
+          ' "$RUNNER_TEMP/trivy-health.json" >/dev/null
+
+          checks_metadata="$TRIVY_CACHE_DIR/policy/metadata.json"
+          expected_checks_digest=${TRIVY_CHECKS_REFERENCE##*@}
+          jq -e --arg digest "$expected_checks_digest" '
+            .MajorVersion == 2 and .Digest == $digest
+          ' "$checks_metadata" >/dev/null
+
+          # Exercise the report guard: malformed/empty collection metadata must fail.
+          if printf '{"SchemaVersion":1,"Results":[]}' \
+            | jq -e '.SchemaVersion == 2 and (.Results | length) > 0' >/dev/null; then
+            echo 'The Trivy report guard accepted invalid collection metadata.' >&2
+            exit 1
+          fi
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+
+      - name: Materialize packages for license evidence
+        shell: bash
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Scan dependencies and configuration with Trivy
+        id: scan
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p security-results
+
+          set +e
+          trivy fs \
+            --cache-dir "$TRIVY_CACHE_DIR" \
+            --db-repository "$TRIVY_DB_REFERENCE" \
+            --checks-bundle-repository "$TRIVY_CHECKS_REFERENCE" \
+            --skip-db-update \
+            --skip-check-update \
+            --skip-version-check \
+            --disable-telemetry \
+            --scanners vuln,misconfig \
+            --include-dev-deps \
+            --include-non-failures \
+            --exit-code 0 \
+            --skip-dirs node_modules \
+            --skip-dirs '**/node_modules' \
+            --skip-dirs '**/dist' \
+            --skip-dirs '**/dist-ssr' \
+            --skip-dirs '**/.astro' \
+            --skip-dirs '**/coverage' \
+            --skip-dirs apps/pi-extension/generated \
+            --format json \
+            --output security-results/trivy.json \
+            . 2>security-results/trivy-scan.log
+          scan_status=$?
+          set -e
+          cat security-results/trivy-scan.log
+          if [[ "$scan_status" -ne 0 ]]; then
+            echo "Trivy vulnerability/misconfiguration scan failed (exit $scan_status)." >&2
+            exit "$scan_status"
+          fi
+
+          if grep -Eq $'\t(ERROR|FATAL)\t' security-results/trivy-scan.log; then
+            echo 'Trivy logged a collection or scanner error.' >&2
+            exit 1
+          fi
+          grep -F '[vuln] Vulnerability scanning is enabled' security-results/trivy-scan.log >/dev/null
+          grep -F '[misconfig] Misconfiguration scanning is enabled' security-results/trivy-scan.log >/dev/null
+
+          set +e
+          trivy fs \
+            --cache-dir "$TRIVY_CACHE_DIR" \
+            --skip-db-update \
+            --skip-check-update \
+            --skip-version-check \
+            --disable-telemetry \
+            --scanners license \
+            --include-dev-deps \
+            --exit-code 0 \
+            --skip-dirs '**/dist' \
+            --skip-dirs '**/dist-ssr' \
+            --skip-dirs '**/.astro' \
+            --skip-dirs '**/coverage' \
+            --skip-dirs apps/pi-extension/generated \
+            --format json \
+            --output security-results/trivy-license.json \
+            . 2>security-results/trivy-license.log
+          license_status=$?
+          set -e
+          cat security-results/trivy-license.log
+          if [[ "$license_status" -ne 0 ]]; then
+            echo "Trivy license scan failed (exit $license_status)." >&2
+            exit "$license_status"
+          fi
+
+          if grep -Eq $'\t(ERROR|FATAL)\t' security-results/trivy-license.log; then
+            echo 'Trivy logged a license collection error.' >&2
+            exit 1
+          fi
+          grep -F '[license] License scanning is enabled' security-results/trivy-license.log >/dev/null
+
+          jq -e '
+            .SchemaVersion == 2 and .ArtifactType == "filesystem" and
+            any(.Results[];
+              .Target == "bun.lock" and .Class == "lang-pkgs" and
+              .Type == "bun" and (.Packages | length) >= 1000 and
+              (.Vulnerabilities | type) == "array") and
+            ([.Results[] | select(.Class == "lang-pkgs" and .Type == "npm")] | length) == 20 and
+            ([.Results[].Packages[]?] | length) >= 1400 and
+            any(.Results[].Packages[]?;
+              .Name == "dompurify" and .Version == "3.4.8" and
+              .Relationship == "direct") and
+            any(.Results[].Packages[]?;
+              .Name == "hono" and .Version == "4.12.25" and
+              .Relationship == "indirect") and
+            any(.Results[].Packages[]?;
+              .Name == "bun-types" and .Version == "1.3.14" and
+              .Relationship == "direct" and .Dev == true) and
+            any(.Results[];
+              .Target == "tests/manual/ssh/Dockerfile" and
+              .Class == "config" and .Type == "dockerfile" and
+              .MisconfSummary.Successes > 0 and
+              (.Misconfigurations | any(.Status == "FAIL")))
+          ' security-results/trivy.json >/dev/null
+          jq -e '
+            .SchemaVersion == 2 and .ArtifactType == "filesystem" and
+            ([.Results[].Licenses[]?] | length) >= 1000 and
+            any(.Results[];
+              .Target == "bun.lock" and .Class == "license" and
+              (.Licenses | length) >= 900)
+          ' security-results/trivy-license.json >/dev/null
+
+          trivy convert \
+            --format sarif \
+            --output security-results/trivy.sarif \
+            security-results/trivy.json
+          jq -e --arg version "$TRIVY_VERSION" '
+            .version == "2.1.0" and
+            (.runs | length) == 1 and
+            .runs[0].tool.driver.name == "Trivy" and
+            .runs[0].tool.driver.version == $version and
+            (.runs[0].tool.driver.rules | length) > 0 and
+            (.runs[0].results | type) == "array"
+          ' security-results/trivy.sarif >/dev/null
+
+          bun_package_count=$(jq '[.Results[] | select(.Target == "bun.lock") | .Packages[]?] | length' security-results/trivy.json)
+          total_package_count=$(jq '[.Results[].Packages[]?] | length' security-results/trivy.json)
+          vulnerability_count=$(jq '[.Results[].Vulnerabilities[]?] | length' security-results/trivy.json)
+          critical_count=$(jq '[.Results[].Vulnerabilities[]? | select(.Severity == "CRITICAL")] | length' security-results/trivy.json)
+          high_count=$(jq '[.Results[].Vulnerabilities[]? | select(.Severity == "HIGH")] | length' security-results/trivy.json)
+          misconfiguration_count=$(jq '[.Results[].Misconfigurations[]? | select(.Status == "FAIL")] | length' security-results/trivy.json)
+          license_count=$(jq '[.Results[].Licenses[]?] | length' security-results/trivy-license.json)
+          checks_digest=$(jq -er '.Digest' "$TRIVY_CACHE_DIR/policy/metadata.json")
+
+          {
+            echo '### Trivy'
+            echo '- Scope: committed Bun/npm dependency locks plus filesystem/IaC misconfiguration; secret scanning disabled (Gitleaks remains authoritative)'
+            echo "- Engine: Trivy $TRIVY_VERSION; database \`$TRIVY_DB_DIGEST\` (updated \`$TRIVY_DB_UPDATED_AT\`)"
+            echo "- Misconfiguration checks: \`$checks_digest\`"
+            echo "- Dependency catalog: $total_package_count records ($bun_package_count from text bun.lock, including development dependencies)"
+            echo "- Vulnerabilities: $vulnerability_count ($critical_count critical, $high_count high)"
+            echo "- Misconfiguration failures: $misconfiguration_count; tests/manual/ssh/Dockerfile is a non-production manual fixture"
+            echo "- Informational installed-license records: $license_count (runner/install graph, not a deployment inventory)"
+            echo '- Enforcement: monitor mode; install, release checksum, DB freshness, checks, catalog, detector, collection, and report failures still fail the job'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo 'report-ready=true' >> "$GITHUB_OUTPUT"
+
+      - name: Retain Trivy reports
+        if: always() && steps.scan.outputs.report-ready == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: trivy-reports
+          path: |
+            security-results/trivy.json
+            security-results/trivy-license.json
+            security-results/trivy.sarif
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload Trivy SARIF
+        if: >-
+          always() &&
+          steps.scan.outputs.report-ready == 'true' &&
+          (github.event_name != 'pull_request' ||
+          (github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'dependabot[bot]'))
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          sarif_file: security-results/trivy.sarif
+          category: trivy
 
   zizmor:
     name: zizmor

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -629,36 +629,65 @@ jobs:
           fi
           grep -F '[license] License scanning is enabled' security-results/trivy-license.log >/dev/null
 
-          jq -e '
-            .SchemaVersion == 2 and .ArtifactType == "filesystem" and
-            any(.Results[];
-              .Target == "bun.lock" and .Class == "lang-pkgs" and
-              .Type == "bun" and (.Packages | length) >= 1000 and
-              (.Vulnerabilities | type) == "array") and
-            ([.Results[] | select(.Class == "lang-pkgs" and .Type == "npm")] | length) == 20 and
-            ([.Results[].Packages[]?] | length) >= 1400 and
-            any(.Results[].Packages[]?;
-              .Name == "dompurify" and .Version == "3.4.8" and
-              .Relationship == "direct") and
-            any(.Results[].Packages[]?;
-              .Name == "hono" and .Version == "4.12.25" and
-              .Relationship == "indirect") and
-            any(.Results[].Packages[]?;
-              .Name == "bun-types" and .Version == "1.3.14" and
-              .Relationship == "direct" and .Dev == true) and
-            any(.Results[];
-              .Target == "tests/manual/ssh/Dockerfile" and
-              .Class == "config" and .Type == "dockerfile" and
-              .MisconfSummary.Successes > 0 and
-              (.Misconfigurations | any(.Status == "FAIL")))
-          ' security-results/trivy.json >/dev/null
-          jq -e '
-            .SchemaVersion == 2 and .ArtifactType == "filesystem" and
-            ([.Results[].Licenses[]?] | length) >= 1000 and
-            any(.Results[];
-              .Target == "bun.lock" and .Class == "license" and
-              (.Licenses | length) >= 900)
-          ' security-results/trivy-license.json >/dev/null
+          jq -e '.SchemaVersion == 2 and .ArtifactType == "filesystem"' \
+            security-results/trivy.json >/dev/null || {
+              echo 'Trivy vulnerability/misconfiguration report metadata is invalid.' >&2
+              exit 1
+            }
+          jq -e '.SchemaVersion == 2 and .ArtifactType == "filesystem"' \
+            security-results/trivy-license.json >/dev/null || {
+              echo 'Trivy license report metadata is invalid.' >&2
+              exit 1
+            }
+
+          bun_package_count=$(jq '[.Results[] | select(
+            .Target == "bun.lock" and .Class == "lang-pkgs" and .Type == "bun"
+          ) | .Packages[]?] | length' security-results/trivy.json)
+          npm_target_count=$(jq '[.Results[] | select(
+            .Class == "lang-pkgs" and .Type == "npm"
+          )] | length' security-results/trivy.json)
+          total_package_count=$(jq '[.Results[].Packages[]?] | length' security-results/trivy.json)
+          bun_license_count=$(jq '[.Results[] | select(
+            .Target == "bun.lock" and .Class == "license"
+          ) | .Licenses[]?] | length' security-results/trivy-license.json)
+          license_count=$(jq '[.Results[].Licenses[]?] | length' security-results/trivy-license.json)
+          if (( bun_package_count < 1000 || npm_target_count != 20 || total_package_count < 1400 )); then
+            echo "Trivy dependency coverage is incomplete: bun=$bun_package_count npm-targets=$npm_target_count total=$total_package_count." >&2
+            exit 1
+          fi
+          if (( bun_license_count < 900 || license_count < 1000 )); then
+            echo "Trivy license coverage is incomplete: bun=$bun_license_count total=$license_count." >&2
+            exit 1
+          fi
+
+          jq -e 'any(.Results[].Packages[]?;
+            .Name == "dompurify" and .Version == "3.4.8" and
+            .Relationship == "direct")' security-results/trivy.json >/dev/null || {
+              echo 'Trivy did not catalog the direct dompurify@3.4.8 sentinel.' >&2
+              exit 1
+            }
+          jq -e 'any(.Results[].Packages[]?;
+            .Name == "hono" and .Version == "4.12.25" and
+            .Relationship == "indirect")' security-results/trivy.json >/dev/null || {
+              echo 'Trivy did not catalog the indirect hono@4.12.25 sentinel.' >&2
+              exit 1
+            }
+          jq -e 'any(.Results[].Packages[]?;
+            .Name == "bun-types" and .Version == "1.3.14" and
+            .Relationship == "direct" and .Dev == true)' \
+            security-results/trivy.json >/dev/null || {
+              echo 'Trivy did not catalog the direct development bun-types@1.3.14 sentinel.' >&2
+              exit 1
+            }
+          jq -e 'any(.Results[];
+            .Target == "tests/manual/ssh/Dockerfile" and
+            .Class == "config" and .Type == "dockerfile" and
+            .MisconfSummary.Successes > 0 and
+            (.Misconfigurations | any(.Status == "FAIL")))' \
+            security-results/trivy.json >/dev/null || {
+              echo 'Trivy did not execute both passing and failing Dockerfile checks against the manual SSH fixture.' >&2
+              exit 1
+            }
 
           trivy convert \
             --format sarif \
@@ -671,15 +700,15 @@ jobs:
             .runs[0].tool.driver.version == $version and
             (.runs[0].tool.driver.rules | length) > 0 and
             (.runs[0].results | type) == "array"
-          ' security-results/trivy.sarif >/dev/null
+          ' security-results/trivy.sarif >/dev/null || {
+            echo 'Trivy SARIF metadata is invalid.' >&2
+            exit 1
+          }
 
-          bun_package_count=$(jq '[.Results[] | select(.Target == "bun.lock") | .Packages[]?] | length' security-results/trivy.json)
-          total_package_count=$(jq '[.Results[].Packages[]?] | length' security-results/trivy.json)
           vulnerability_count=$(jq '[.Results[].Vulnerabilities[]?] | length' security-results/trivy.json)
           critical_count=$(jq '[.Results[].Vulnerabilities[]? | select(.Severity == "CRITICAL")] | length' security-results/trivy.json)
           high_count=$(jq '[.Results[].Vulnerabilities[]? | select(.Severity == "HIGH")] | length' security-results/trivy.json)
           misconfiguration_count=$(jq '[.Results[].Misconfigurations[]? | select(.Status == "FAIL")] | length' security-results/trivy.json)
-          license_count=$(jq '[.Results[].Licenses[]?] | length' security-results/trivy-license.json)
           checks_digest=$(jq -er '.Digest' "$TRIVY_CACHE_DIR/policy/metadata.json")
 
           {

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ plannotator-local
 /goals/
 *.bun-build
 
+# Local/CI security scanner reports are generated artifacts.
+security-results/
+
 # Local meta notes (not upstream)
 /meta/
 

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -1,0 +1,362 @@
+# Plannotator-owned Semgrep Community Edition rules.
+#
+# Keeping the rules in this Apache-2.0 repository makes scans reviewable and
+# offline. Semgrep Registry configurations are intentionally not used: they
+# are mutable, require network access, and the upstream rules license does not
+# permit redistributing copies. CE is intrafile only; these rules do not claim
+# cross-file, cross-function, reachability, or hosted policy coverage.
+rules:
+  - id: plannotator.node.nonliteral-exec
+    message: A non-literal command reaches child_process exec/execSync. Prefer an argv-based spawn API and validate every argument.
+    severity: ERROR
+    languages: [javascript, typescript]
+    metadata:
+      category: security
+      confidence: HIGH
+      impact: HIGH
+      likelihood: MEDIUM
+      cwe: CWE-78
+      technology: [node, bun]
+    patterns:
+      - pattern-either:
+          - patterns:
+              - pattern-inside: |
+                  import { exec } from "node:child_process";
+                  ...
+              - pattern: exec($COMMAND, ...)
+              - pattern-not: exec("...", ...)
+          - patterns:
+              - pattern-inside: |
+                  import { execSync } from "node:child_process";
+                  ...
+              - pattern: execSync($COMMAND, ...)
+              - pattern-not: execSync("...", ...)
+          - patterns:
+              - pattern-inside: |
+                  import { exec } from "child_process";
+                  ...
+              - pattern: exec($COMMAND, ...)
+              - pattern-not: exec("...", ...)
+          - patterns:
+              - pattern-inside: |
+                  import { execSync } from "child_process";
+                  ...
+              - pattern: execSync($COMMAND, ...)
+              - pattern-not: execSync("...", ...)
+
+  - id: plannotator.node.shell-command-argument
+    message: Data is passed to a shell command string. Prefer a fixed executable and an argv array without `sh -c`.
+    severity: ERROR
+    languages: [javascript, typescript]
+    metadata:
+      category: security
+      confidence: HIGH
+      impact: HIGH
+      likelihood: MEDIUM
+      cwe: CWE-78
+      technology: [node, bun]
+    patterns:
+      - pattern-either:
+          - pattern: spawn("sh", ["-c", $COMMAND])
+          - pattern: spawn("sh", ["-c", $COMMAND], ...)
+          - pattern: spawn("bash", ["-c", $COMMAND])
+          - pattern: spawn("bash", ["-c", $COMMAND], ...)
+          - pattern: spawnSync("sh", ["-c", $COMMAND])
+          - pattern: spawnSync("sh", ["-c", $COMMAND], ...)
+          - pattern: spawnSync("bash", ["-c", $COMMAND])
+          - pattern: spawnSync("bash", ["-c", $COMMAND], ...)
+          - pattern: Bun.spawn(["sh", "-c", $COMMAND])
+          - pattern: Bun.spawn(["sh", "-c", $COMMAND], ...)
+          - pattern: Bun.spawn(["bash", "-c", $COMMAND])
+          - pattern: Bun.spawn(["bash", "-c", $COMMAND], ...)
+          - pattern: Bun.spawnSync(["sh", "-c", $COMMAND])
+          - pattern: Bun.spawnSync(["sh", "-c", $COMMAND], ...)
+          - pattern: Bun.spawnSync(["bash", "-c", $COMMAND])
+          - pattern: Bun.spawnSync(["bash", "-c", $COMMAND], ...)
+  - id: plannotator.javascript.dynamic-code-execution
+    message: Non-literal input reaches eval or the Function constructor. Avoid evaluating code assembled at runtime.
+    severity: ERROR
+    languages: [javascript, typescript]
+    metadata:
+      category: security
+      confidence: HIGH
+      impact: HIGH
+      likelihood: MEDIUM
+      cwe: CWE-95
+      technology: [browser, node, bun, cloudflare-workers]
+    patterns:
+      - pattern-either:
+          - pattern: eval($CODE)
+          - pattern: new Function($CODE)
+          - pattern: new Function($ARGS, $CODE)
+      - metavariable-pattern:
+          metavariable: $CODE
+          patterns:
+            - pattern-not: "..."
+
+  - id: plannotator.web.request-to-network
+    message: Request-derived data reaches a network sink in the same function. Validate the scheme, host, port, redirects, and resolved IP before use.
+    severity: ERROR
+    languages: [javascript, typescript]
+    mode: taint
+    metadata:
+      category: security
+      confidence: MEDIUM
+      impact: HIGH
+      likelihood: MEDIUM
+      cwe: CWE-918
+      technology: [node, bun, cloudflare-workers]
+    pattern-sources:
+      - patterns:
+          - pattern-either:
+              - pattern: $REQUEST.url
+              - pattern: $REQUEST.text()
+              - pattern: $REQUEST.json()
+              - pattern: $REQUEST.formData()
+              - pattern: $REQUEST.headers.get(...)
+          - metavariable-regex:
+              metavariable: $REQUEST
+              regex: (?i)^(req|request|incomingRequest|serverRequest|workerRequest)$
+      - patterns:
+          - pattern: $URL.searchParams.get(...)
+          - metavariable-regex:
+              metavariable: $URL
+              regex: (?i).*(url|uri).*
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - pattern: fetch($DESTINATION, ...)
+              - pattern: http.request($DESTINATION, ...)
+              - pattern: https.request($DESTINATION, ...)
+              - pattern: http.get($DESTINATION, ...)
+              - pattern: https.get($DESTINATION, ...)
+
+  - id: plannotator.web.request-to-filesystem
+    message: Request-derived data reaches a filesystem API in the same function. Resolve against an allowed root and reject traversal before access.
+    severity: ERROR
+    languages: [javascript, typescript]
+    mode: taint
+    metadata:
+      category: security
+      confidence: MEDIUM
+      impact: HIGH
+      likelihood: MEDIUM
+      cwe: CWE-22
+      technology: [node, bun]
+    pattern-sources:
+      - patterns:
+          - pattern-either:
+              - pattern: $REQUEST.url
+              - pattern: $REQUEST.text()
+              - pattern: $REQUEST.json()
+              - pattern: $REQUEST.formData()
+          - metavariable-regex:
+              metavariable: $REQUEST
+              regex: (?i)^(req|request|incomingRequest|serverRequest|workerRequest)$
+      - patterns:
+          - pattern: $URL.searchParams.get(...)
+          - metavariable-regex:
+              metavariable: $URL
+              regex: (?i).*(url|uri).*
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - pattern: Bun.file($PATH, ...)
+              - pattern: Bun.write($PATH, ...)
+              - pattern: readFile($PATH, ...)
+              - pattern: readFileSync($PATH, ...)
+              - pattern: writeFile($PATH, ...)
+              - pattern: writeFileSync($PATH, ...)
+              - pattern: createReadStream($PATH, ...)
+              - pattern: createWriteStream($PATH, ...)
+
+  - id: plannotator.browser.nonliteral-innerhtml
+    message: Non-literal data is assigned to innerHTML/outerHTML. Use textContent or sanitize with the repository's DOMPurify boundary.
+    severity: WARNING
+    languages: [javascript, typescript]
+    metadata:
+      category: security
+      confidence: MEDIUM
+      impact: HIGH
+      likelihood: MEDIUM
+      cwe: CWE-79
+      technology: [browser, react]
+    patterns:
+      - pattern-either:
+          - pattern: $ELEMENT.innerHTML = $HTML
+          - pattern: $ELEMENT.outerHTML = $HTML
+          - pattern: $ELEMENT.insertAdjacentHTML($POSITION, $HTML)
+      - metavariable-pattern:
+          metavariable: $HTML
+          patterns:
+            - pattern-not: "..."
+
+  - id: plannotator.browser.document-write
+    message: document.write/writeln can create a DOM XSS sink and should not process dynamic content.
+    severity: ERROR
+    languages: [javascript, typescript]
+    metadata:
+      category: security
+      confidence: HIGH
+      impact: HIGH
+      likelihood: MEDIUM
+      cwe: CWE-79
+      technology: [browser]
+    pattern-either:
+      - pattern: document.write(...)
+      - pattern: document.writeln(...)
+
+  - id: plannotator.react.dangerously-set-inner-html
+    message: React dangerouslySetInnerHTML bypasses escaping. Ensure the value is sanitized at this boundary.
+    severity: WARNING
+    languages: [typescript, javascript]
+    metadata:
+      category: security
+      confidence: MEDIUM
+      impact: HIGH
+      likelihood: MEDIUM
+      cwe: CWE-79
+      technology: [react]
+    patterns:
+      - pattern: '<$ELEMENT ... dangerouslySetInnerHTML={{__html: $HTML}} ... />'
+
+  - id: plannotator.web.unvalidated-redirect
+    message: Request-derived data reaches a redirect target in the same function. Restrict redirects to approved local paths or origins.
+    severity: WARNING
+    languages: [javascript, typescript]
+    mode: taint
+    metadata:
+      category: security
+      confidence: MEDIUM
+      impact: MEDIUM
+      likelihood: MEDIUM
+      cwe: CWE-601
+      technology: [node, bun, cloudflare-workers]
+    pattern-sources:
+      - patterns:
+          - pattern-either:
+              - pattern: $REQUEST.url
+              - pattern: $REQUEST.headers.get(...)
+          - metavariable-regex:
+              metavariable: $REQUEST
+              regex: (?i)^(req|request|incomingRequest|serverRequest|workerRequest)$
+      - patterns:
+          - pattern: $URL.searchParams.get(...)
+          - metavariable-regex:
+              metavariable: $URL
+              regex: (?i).*(url|uri).*
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - pattern: Response.redirect($DESTINATION, ...)
+              - pattern: $RESPONSE.redirect($DESTINATION, ...)
+
+  - id: plannotator.crypto.weak-digest
+    message: MD5 and SHA-1 are not collision resistant. Use a modern digest for security-sensitive integrity or authentication.
+    severity: WARNING
+    languages: [javascript, typescript]
+    metadata:
+      category: security
+      confidence: HIGH
+      impact: MEDIUM
+      likelihood: MEDIUM
+      cwe: CWE-328
+      technology: [node, bun]
+    pattern-either:
+      - pattern: createHash("md5")
+      - pattern: createHash("sha1")
+      - pattern: createHash("sha-1")
+      - pattern: crypto.createHash("md5")
+      - pattern: crypto.createHash("sha1")
+      - pattern: crypto.createHash("sha-1")
+
+  - id: plannotator.network.tls-verification-disabled
+    message: TLS certificate verification is disabled. Remove rejectUnauthorized:false.
+    severity: ERROR
+    languages: [javascript, typescript]
+    metadata:
+      category: security
+      confidence: HIGH
+      impact: HIGH
+      likelihood: HIGH
+      cwe: CWE-295
+      technology: [node, bun]
+    pattern: "{ ..., rejectUnauthorized: false, ... }"
+
+  - id: plannotator.auth.insecure-randomness
+    message: Math.random is not suitable for credentials, tokens, nonces, or session identifiers. Use a cryptographic random source.
+    severity: ERROR
+    languages: [javascript, typescript]
+    metadata:
+      category: security
+      confidence: MEDIUM
+      impact: HIGH
+      likelihood: MEDIUM
+      cwe: CWE-338
+      technology: [browser, node, bun]
+    patterns:
+      - pattern: Math.random()
+      - pattern-inside: |
+          $NAME = ...
+      - metavariable-regex:
+          metavariable: $NAME
+          regex: (?i).*(token|secret|session|nonce|credential|password|auth).*
+
+  - id: plannotator.web.wildcard-credentials-cors
+    message: A wildcard CORS origin must not be combined with credentials.
+    severity: ERROR
+    languages: [javascript, typescript]
+    metadata:
+      category: security
+      confidence: HIGH
+      impact: HIGH
+      likelihood: MEDIUM
+      cwe: CWE-942
+      technology: [browser, node, bun, cloudflare-workers]
+    patterns:
+      - pattern-either:
+          - pattern: "{ ..., 'Access-Control-Allow-Origin': '*', ..., 'Access-Control-Allow-Credentials': 'true', ... }"
+          - pattern: '{ ..., "Access-Control-Allow-Origin": "*", ..., "Access-Control-Allow-Credentials": "true", ... }'
+
+  - id: plannotator.installer.remote-script-pipeline
+    message: A remote response is piped directly to a command interpreter. Download, authenticate, and inspect the artifact before execution.
+    severity: ERROR
+    languages: [generic]
+    paths:
+      include:
+        - "*.sh"
+        - "*.bash"
+        - "*.ps1"
+        - "*.cmd"
+        - "*.bat"
+        - "Dockerfile"
+        - "**/Dockerfile"
+    metadata:
+      category: security
+      confidence: HIGH
+      impact: HIGH
+      likelihood: MEDIUM
+      cwe: CWE-494
+      technology: [shell, powershell, batch]
+    pattern-either:
+      - pattern-regex: '(?im)^\s*(?:curl|wget)[^\n|]*\|\s*(?:sh|bash)(?:\s|$)'
+      - pattern-regex: '(?im)^\s*(?:iwr|Invoke-WebRequest)[^\n|]*\|\s*(?:iex|Invoke-Expression)(?:\s|$)'
+
+  - id: plannotator.installer.unquoted-shell-expansion
+    message: An unquoted command substitution is used as a shell command. Store and validate data instead of executing expansion output.
+    severity: ERROR
+    languages: [generic]
+    paths:
+      include:
+        - "*.sh"
+        - "*.bash"
+        - "Dockerfile"
+        - "**/Dockerfile"
+    metadata:
+      category: security
+      confidence: MEDIUM
+      impact: HIGH
+      likelihood: MEDIUM
+      cwe: CWE-78
+      technology: [shell]
+    pattern-regex: '(?m)^\s*eval\s+(?:\$\([^\n]*\)|`[^\n]*`)'

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,6 @@
+# Semgrep also honors the repository's normal generated/output exclusions.
+:include .gitignore
+
+# Created by apps/pi-extension/vendor.sh. These files mirror active sources
+# that are scanned at their canonical locations.
+apps/pi-extension/generated/

--- a/apps/pi-extension/server/serverReview.ts
+++ b/apps/pi-extension/server/serverReview.ts
@@ -20,6 +20,7 @@ import {
 	getMRNumberLabel,
 	isSameProject,
 	type PRMetadata,
+	type PRListItem,
 	type PRRef,
 	type PRReviewFileComment,
 	prRefFromMetadata,
@@ -310,7 +311,7 @@ export async function startReviewServer(options: {
 		? getPRDiffScopeOptions(prMeta, !!(options.worktreePool || options.agentCwd))
 		: [];
 
-	let prListCache: import("../generated/pr-types.ts").PRListItem[] | null = null;
+	let prListCache: PRListItem[] | null = null;
 	let prListCacheTime = 0;
 	// Platform APIs withhold per-file patches on very large PRs. When the layer
 	// patch is incomplete, a local recompute (exact merge-base diff, no size

--- a/packages/core/extract-code-paths.ts
+++ b/packages/core/extract-code-paths.ts
@@ -8,7 +8,7 @@ const FENCED_CODE_BLOCK = /(^|\n)([ \t]*)(```|~~~)[\s\S]*?\n\2\3/g;
 const HTML_COMMENT = /<!--[\s\S]*?-->/g;
 // Match InlineMarkdown.tsx's bare-URL regex exactly so URL ranges excised
 // here mirror the ranges the renderer would consume.
-const URL_REGEX = /https?:\/\/[^\s<>"']+/g;
+const URL_REGEX = new RegExp("https?://[^\\s<>\"']+", "g");
 const BACKTICK_SPAN = /`([^`\n]+)`/g;
 
 /**

--- a/packages/review-editor/components/ReviewSidebar.tsx
+++ b/packages/review-editor/components/ReviewSidebar.tsx
@@ -12,7 +12,7 @@ import { AITab } from './AITab';
 import { AgentsTab, type AgentLaunchParams, type AgentLaunchResult } from '@plannotator/ui/components/AgentsTab';
 import type { PRMetadata } from '@plannotator/shared/pr-types';
 import { OverlayScrollArea } from '@plannotator/ui/components/OverlayScrollArea';
-import type { AIChatEntry } from '../hooks/useAIChat';
+import type { AIChatEntry, PendingPermission } from '../hooks/useAIChat';
 import type { AgentJobInfo, AgentCapabilities } from '@plannotator/ui/types';
 import type { DiffFile } from '../types';
 import type { AIProviderOption } from '@plannotator/ui/utils/aiProvider';
@@ -58,7 +58,7 @@ interface ReviewSidebarProps {
   activeFilePath?: string;
   scrollToQuestionId?: string | null;
   onAskGeneral?: (question: string) => void;
-  aiPermissionRequests?: import('../hooks/useAIChat').PendingPermission[];
+  aiPermissionRequests?: PendingPermission[];
   onRespondToPermission?: (requestId: string, allow: boolean) => void;
   aiProviders?: AIProviderOption[];
   aiConfig?: { providerId: string | null; model: string | null; reasoningEffort?: string | null };

--- a/packages/ui/components/Landing.tsx
+++ b/packages/ui/components/Landing.tsx
@@ -50,7 +50,7 @@ export const Landing: React.FC<LandingProps> = ({ onEnter, shareBaseUrl }) => {
           <div className="max-w-2xl">
             <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-primary/10 text-primary text-xs font-medium mb-6">
               <span className="w-1.5 h-1.5 rounded-full bg-primary animate-pulse" />
-              For Claude Code & OpenCode
+              For Claude Code &amp; OpenCode
             </div>
 
             <div className="flex items-center gap-6 mb-4">

--- a/packages/ui/utils/planDiffEngine.test.ts
+++ b/packages/ui/utils/planDiffEngine.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { computePlanDiff, computeInlineDiff } from "./planDiffEngine";
+import type { InlineDiffToken } from "./planDiffEngine";
 import { parseMarkdownToBlocks } from "./parser";
 
 describe("computePlanDiff — block-level behavior", () => {
@@ -161,7 +162,7 @@ describe("computeInlineDiff — token content", () => {
 
 // Helper to build a unified <ins>/<del>-wrapped string from a computeInlineDiff
 // result for readable assertions in tests below.
-function unify(result: { tokens: import("./planDiffEngine").InlineDiffToken[] }) {
+function unify(result: { tokens: InlineDiffToken[] }) {
   return result.tokens
     .map((t) => {
       if (t.type === "added") return `<ins>${t.value}</ins>`;

--- a/packages/ui/utils/vimNavigation.test.ts
+++ b/packages/ui/utils/vimNavigation.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test';
+import type { SemanticTarget } from './blockTargeting';
 
 const hasDom = typeof document !== 'undefined';
 const navigationModule = hasDom ? await import('./vimNavigation') : null;
@@ -31,7 +32,7 @@ function createDocumentFixture(): HTMLElement {
 }
 
 function targetByKey(
-  targets: readonly import('./blockTargeting').SemanticTarget[],
+  targets: readonly SemanticTarget[],
   key: string,
 ) {
   const target = targets.find((candidate) => candidate.key === key);


### PR DESCRIPTION
## Outcome

Adds Semgrep Community Edition source SAST and standalone Trivy dependency/filesystem/IaC scanning to the existing separate Security Scanning workflow. Both jobs run on the workflow's existing pull request, `main` push, weekly schedule, and manual-dispatch triggers.

This is monitor mode: findings are reported, summarized, retained, and uploaded as SARIF, but findings do not fail the jobs. Scanner installation, checksum/digest, rules, parser, timeout, database freshness, checks collection, dependency catalog, detector health, or report validation failures do fail. Release and deploy workflows are unchanged.

No Semgrep/Aqua account, GitHub App, third-party token, or service account is required. Semgrep receives no source or findings. Trivy secret scanning is disabled because Gitleaks remains authoritative.

## Semgrep CE

- Covers tracked TypeScript/JavaScript across the Bun and Pi/Node servers, React/DOM UI, AI/provider code, Cloudflare services, and other application sources. Generic rules cover shell, PowerShell, batch, and Dockerfile installer patterns without relying on Semgrep's experimental Bash parser.
- Uses Semgrep `1.172.0` from the official non-root image pinned to `sha256:d1012a3bf2acf47721216fbf7ff12d4c2971cc7f9c7b77cf6c6e9dcf006bd487`; the job verifies the digest, non-root user, version, CE request, OSS engine identity, and SARIF driver identity.
- Uses 15 Apache-licensed, repository-owned rules in `.semgrep.yml`. The scan is offline (`--network none`, read-only source mount, `--oss-only`, metrics/version checks off) and does not use `semgrep ci`, the Registry, `SEMGREP_APP_TOKEN`, or Semgrep Cloud.
- The official Semgrep rules repository was reviewed at `40b8c63f75dc7c22c8a77482d73bfb864b146f7e`, but its rules were not copied because the Semgrep Rules License restricts redistribution. Repository-owned rules avoid a mutable network ruleset and keep rule review/versioning local.
- CE limitations are explicit: intrafile analysis only, with no Pro cross-file/cross-function dataflow, reachability, hosted policy, or hosted fingerprinting.
- Runtime-created fixtures prove Node `exec`, Bun shell execution, and remote-script pipeline detections at exact lines. A deliberately malformed runtime ruleset must fail.
- Six behavior-preserving syntax changes (type-only imports, an equivalent `RegExp` constructor, and the JSX `&amp;` entity) allow strict parsing of active TS/TSX source. The large installer remains active coverage through generic rules rather than being excluded.
- Exclusions are limited to ignored/generated outputs and the Pi vendor mirror. Canonical sources remain covered; tracked `build/shiki-wasm-stub.ts` is not broadly excluded.

Semgrep release: https://github.com/semgrep/semgrep/releases/tag/v1.172.0

### Initial Semgrep baseline

Initial strict local scan: 1,082 targets, 15 rules, 28 findings (21 `ERROR`, 7 `WARNING`), zero parser/config/timeout errors, approximately 100% parsed lines. The final trusted CI checkout reports 30 findings (23 `ERROR`, 7 `WARNING`) across the same 1,082 targets with zero engine errors; that retained CI report is the current baseline. Both server implementations, UI, Cloudflare, and installers were asserted in `paths.scanned`.

Every current result was reviewed and grouped without suppressions:

- 17 request-to-filesystem audit hits in the final CI baseline: one developer mock, one randomized/extension-validated upload path, and 15 Bun/Pi reference/image/document paths with containment/validation preceding the reported sink. Retained for follow-up validation review rather than declared exploitable.
- 2 request-to-network audit hits: the OpenCode installed-smoke registry proxy fixture and VS Code's loopback cookie proxy. Both have constrained intended upstreams; retain for explicit allowlist review.
- 1 Pi `execSync` hit: current callers pass fixed Git subcommands, but the string-command helper should be converted to argv execution in a focused follow-up.
- 7 DOM/React HTML sink hits: two pass through the repository HTML sanitizer; the others are syntax highlighting, KaTeX (`trust: false`), Mermaid (`securityLevel: strict`), and Viz-generated SVG render boundaries. Retain the generated-SVG boundaries for dedicated XSS review.
- 3 shell hits are inert `curl | bash` examples inside installer help text, not executed commands.

No application finding is suppressed or fixed in this scanner PR.

## Trivy

- Uses standalone Trivy `0.73.0`, not `trivy-action` or `setup-trivy`. The Linux x64 archive is pinned to SHA-256 `2edd39da482bb4e9831962487b68f68e3928ec3137794757f54d00383d79547b` and the exact version is asserted.
- Release source/tag commit is `40c73e5d6166dcc0346a1ab4e94499d1572854e4`. The exact Linux archive was independently verified before this PR with GitHub attestation verification against Aqua's reusable release workflow, tag, source digest, and GitHub-hosted runners.
- The March 2026 incident affected malicious Trivy `0.69.4`, Docker `0.69.5`/`0.69.6`, and replaced mutable `trivy-action`/`setup-trivy` tags. Direct v0.73.0 installation avoids those Action paths and is also newer than subsequent scanner fixes in 0.71.x/0.72.x.
- The official `ghcr.io/aquasecurity/trivy-db:2` tag is resolved anonymously to an immutable digest per run, then downloaded by digest. Schema 2, nonempty DB, no more than 48-hour age, and no more than five-minute future skew are enforced. The digest and update time appear in the summary.
- Official Trivy checks v2.2.0 are pinned to OCI digest `sha256:891abb1e1dc95429e6ad6768a8c8164dacf6d7ff742b940d1d709e69b5855cc6`; cached policy metadata must match it so a failed download cannot silently fall back to embedded checks.
- Version checks and telemetry are disabled. Intended scanner network is limited to public GitHub release download and public GHCR DB/checks retrieval.
- Vulnerability/misconfiguration scanning covers the committed text `bun.lock`, 20 optional CallDiff npm lockfiles, and filesystem/IaC configuration. Generated/install outputs are excluded. `tests/manual/ssh/Dockerfile` remains scanned and is labeled as a non-production manual fixture.
- Development dependencies are included. A separate informational license scan runs after `bun install --frozen-lockfile --ignore-scripts`; it describes the runner/install graph and is not claimed to be a deployment inventory.
- Runtime-only `lodash@4.17.20` lockfile and Dockerfile fixtures must produce the configured finding exit, CVE-2021-23337, and DS-0002 at line 2. A deliberately invalid report exercises the report failure guard.

Incident/advisory and release evidence:

- https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23
- https://github.com/aquasecurity/trivy/discussions/10462
- https://github.com/aquasecurity/trivy/releases/tag/v0.73.0
- https://github.com/aquasecurity/trivy/security/advisories/GHSA-mcj4-mphf-j9ff
- https://github.com/aquasecurity/trivy/security/advisories/GHSA-q3fv-x8vg-qqm4

### Bun catalog evidence

- Clean checkout: text `bun.lock` parsed directly as 1,368 packages; 60 vulnerabilities.
- After frozen, script-free install: the same 1,368 packages and 60 vulnerabilities. Install materialization does not create the dependency result.
- With the 20 CallDiff npm locks: 1,470 catalog records.
- Sentinels: direct `dompurify@3.4.8`, indirect `hono@4.12.25`, and direct development `bun-types@1.3.14`.
- Without `--include-dev-deps`, Bun coverage falls to 743 packages and 57 vulnerabilities; the enabled scan includes 625 additional dev/test-classified packages.
- Installed-license evidence grows from 102 lockfile records before install to 1,095 in the initial local run (993 associated with `bun.lock`) and 1,102 in the final Linux CI run (1,000 associated with `bun.lock`). The small platform/install-graph variance reinforces that this is informational runner evidence, not a deployment inventory.

### Initial Trivy baseline and high/critical disposition

Vulnerabilities: 60 total — 0 critical, 22 high, 29 medium, 9 low. All 22 high findings currently have fixes in the DB and are left for a focused dependency follow-up:

- Direct marketing build dependency `astro@5.18.2`: CVE-2026-50146, CVE-2026-54299.
- Potential runtime paths: `brace-expansion@5.0.6` (CVE-2026-13149, CVE-2026-14257, CVE-2026-69152), `fast-uri@3.1.2` (CVE-2026-13676, CVE-2026-16221, CVE-2026-18446), `ip-address@10.2.0` (CVE-2026-69192), and `undici@8.3.0` (CVE-2026-12151, CVE-2026-13697, CVE-2026-9675, CVE-2026-9697).
- Dev/packaging-only evidence: `form-data@4.0.5` CVE-2026-12143 and `linkify-it@5.0.1` CVE-2026-59887.
- Astro/Vite/build/tooling chains: `js-yaml@4.2.0` CVE-2026-59869 and GHSA-5p4m-2wfm-xmqj; `nanoid@3.3.12` CVE-2026-67213 and CVE-2026-67214; `postcss@8.5.15` GHSA-r28c-9q8g-f849; `sharp@0.34.5` GHSA-f88m-g3jw-g9cj; `svgo@4.0.1` GHSA-2p49-hgcm-8545.

Misconfigurations: 4 failures (2 high, 1 medium, 1 low), all confined to the non-production manual SSH Dockerfile. High DS-0002 (root user) and DS-0029 (`apt-get` without `--no-install-recommends`) are intentional fixture characteristics, not production image findings.

License reporting: one Trivy critical/forbidden WTFPL opinion through dev-only VS Code tooling and one high/restricted LGPL-3 opinion through optional Astro/libvips build tooling. These are classifier opinions, not vulnerabilities or proof of shipped components.

## Review hardening

- Failed Semgrep/Trivy validation now retains partial machine reports and named logs under `always()`; incomplete SARIF is an artifact for diagnosis, not published as a complete code-scanning analysis.
- Semgrep rule count is derived from SARIF with a safety floor, coverage uses required repository-surface prefixes rather than five filenames, and every jq guard reports the failed invariant.
- Trivy compares cataloged npm targets with the tracked in-scope lockfile set derived from Git, uses broad meaningful-coverage floors, and asserts direct/transitive/development sentinel names and relationships without pinning their routine-update versions.
- Immutable Semgrep image, Trivy archive/DB, and checks retrieval has bounded retries. The checks reference is digest-only v2.2.0 content and therefore never follows the floating `2` tag at runtime.

## GitHub safety and reports

- Global permission remains `contents: read`. Each SARIF job narrowly adds `actions: read` and `security-events: write`; there is no OIDC, environment, npm, publishing, deployment, or repository-write credential.
- Checkout Actions are full-SHA pinned with `persist-credentials: false`. All added Actions are full-SHA pinned; scanner versions/digests are separately pinned.
- The workflow remains `pull_request`, never `pull_request_target`. Fork and Dependabot PRs execute meaningful scans with no repository secrets; SARIF upload is skipped only where GitHub does not allow the write.
- Semgrep and Trivy report artifacts run under `always()`: complete or partial JSON/SARIF plus scanner, detector, and configuration diagnostics are retained for 7 days even when a scanner or assertion fails. Code-scanning SARIF remains limited to fully validated reports in trusted contexts so an incomplete scan cannot appear authoritative. Scanner caches, databases, source, credentials, and fixture source are not retained.
- Existing Gitleaks and zizmor jobs are unchanged in authority and behavior. Cancellation remains a cancelled workflow, never a clean report.

## Validation

- Final hardened Security Scanning run [31664237033](https://github.com/backnotprop/plannotator/actions/runs/31664237033) against commit `af06b9e0`: Semgrep CE, Trivy, Gitleaks, and zizmor all pass; expanded diagnostic artifacts and both validated SARIF uploads completed successfully.
- Final PR status: 22 successful checks, 4 expected release/publish skips, zero failures, cancellations, or pending checks.
- Exact pinned Semgrep full scan and all detector/config failure assertions: pass.
- Exact pinned Trivy clean/post-install comparisons, full scan, DB/checks freshness/identity, detector exit, catalog and report assertions: pass.
- SARIF 2.1.0, tool/version/rules/results metadata assertions: pass.
- `bun run typecheck`: pass.
- Focused affected tests: 122 pass, 10 DOM-environment skips, 0 fail.
- `actionlint` 1.7.12 against all workflows: pass.
- zizmor 1.29.0 offline regular strict collection: 0 findings.
- `git diff --check` and generated-report/cache/credential audit: pass.
- Full `bun test` reaches one unrelated, reproducible pre-existing Pi GitButler assertion mismatch (`semanticDiff` now contains `enabled: false`); no scanner work touches that behavior, so it is not absorbed here.

## Promotion plan and residual risk

After baseline owners and follow-up triage are agreed, a separate approval should promote only new high-confidence Semgrep high/critical findings and new fixable critical Trivy vulnerabilities to blocking. This PR does not change publishing/deployment gates.

Residual decisions: assign owners for the Semgrep audit groups and dependency chains; decide whether generated SVG render boundaries need additional sanitization; and retain or replace the current Aqua publisher trust for DB/check OCI artifacts if Aqua publishes verifiable attestations/signatures. Scanner version/checksum/image digest and repository rules are deliberately manual review updates; the vulnerability DB intentionally changes per run but is digest-pinned and freshness-checked within that run.
