### PR TITLE
ci(release): add SBOM attestation and Grype policy

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -189,9 +189,18 @@ If anything is missing, fix it before proceeding to Phase 4. Common fixes:
    - Runs tests
    - Cross-compiles binaries for 6 platforms (macOS ARM64/x64, Linux x64/ARM64, Windows x64/ARM64)
    - Compiles paste service binaries (same 6 platforms)
+   - Packs the two npm packages in a credential-free job
+   - Downloads pinned, checksum-verified Syft and Grype binaries; generates and schema-validates the release-wide CycloneDX SBOM after all shipped subjects exist
+   - Forces the repository-owned, suppression-free Grype configuration, retries the official database update up to three times, requires a valid/active schema-v6 database no more than 120 hours old with no pending update, and preserves the machine-readable scan/database/policy evidence as a workflow artifact
+   - Rejects every scanner-side ignored match, then blocks before any attestation or publication on CISA KEV or fixable Critical findings classified as shipped/runtime or unknown-applicability. High, development-only, and no-fix Critical findings are report-only but remain in the evidence
    - Generates SLSA build provenance attestations for all 12 binaries via `actions/attest-build-provenance` (signed through Sigstore, recorded in Rekor)
-   - Creates the GitHub Release with all binaries attached
+   - Uses the separate official `actions/attest` SBOM path to bind the CycloneDX predicate to all 12 binaries and both npm tarballs through the same GitHub OIDC/Sigstore service. This is an inventory attestation, not a replacement for SLSA or npm provenance
+   - Creates the GitHub Release with all binaries, SHA256 sidecars, the versioned CycloneDX SBOM, and its SHA256 sidecar attached
    - Publishes `@plannotator/opencode` and `@plannotator/pi-extension` to npm with provenance
+
+   **SBOM scope:** the public document is a release-wide Syft inventory of the monorepo's locked build inputs and dependencies. It is deliberately not described as exact binary runtime contents. Coverage testing found that Bun standalone executables hide bundled JavaScript dependency metadata from Syft. The OpenCode tarball is similarly opaque; the Pi tarball exposes only a partial view through nested package-lock files. The scope and limitations are also embedded in the CycloneDX metadata.
+
+   **Exceptions:** there is no active production exception file. If a future release baseline needs one, do not add a loose ignore. Add a repository-reviewed OpenVEX document and explicitly wire it through `PLANNOTATOR_RELEASE_VEX`; each statement must match one exact package URL and vulnerability ID and carry `not_affected` status, an OpenVEX justification, impact statement, HTTPS evidence, owner, created date, and expiration date. The policy tests reject expired, malformed, broad, and nonmatching records.
 
    **Note on immutable releases:** The repo has GitHub Immutable Releases enabled, so once the `v*` tag is pushed and the release is created, the tag→commit and tag→asset bindings are permanent. You cannot delete and re-create a tag to "fix" a bad release — you must ship a new version. Release notes remain editable (see step 5), but everything else is locked.
 
@@ -202,9 +211,36 @@ If anything is missing, fix it before proceeding to Phase 4. Common fixes:
    gh run view <run-id> --log
    ```
    Verify:
-   - All jobs pass (test, build, release, npm-publish)
-   - The GitHub Release was created with all binary artifacts
+   - All jobs pass, including `release-security`, `attest`, `release`, and `npm-publish`
+   - `release-security-evidence` records the Syft/Grype versions, active database schema/build/checksum/update status, all Grype matches, and an `ACCEPT` policy decision
+   - The GitHub Release was created with all binary artifacts, SHA256 sidecars, the versioned `plannotator-X.Y.Z-release-sbom.cdx.json`, and its `.sha256` sidecar
    - npm packages published successfully (check with `npm view @plannotator/opencode version` and `npm view @plannotator/pi-extension version`)
+
+   A pull request proves generation, schema/sentinel validation, database policy, Grype evaluation, least-privilege job wiring, and all report artifacts. GitHub OIDC issuance, publication to the artifact-attestation service, and final release-asset publication only run for a real eligible `v*` tag. For the first release after this control lands, complete this bounded tag-only verification before calling the rollout complete:
+
+   Before tagging that first release, update the canonical Mintlify page at `https://docs.plannotator.ai/open-source/start/installation#pin-or-verify-a-release` with the SBOM scope/limitations, Grype policy, download/checksum commands, and both predicate-verification commands from the README. The legacy Astro files under `apps/marketing/src/content/docs/` are redirect-only/deprecated copies and are not the public documentation source. Confirm the live Mintlify page contains the material; do not let its publication lag the shipped control.
+
+   ```bash
+   tag=vX.Y.Z
+   version="${tag#v}"
+   gh release download "$tag" --pattern 'plannotator-linux-x64*' --pattern "plannotator-${version}-release-sbom.cdx.json*" --dir /tmp/plannotator-release-verify
+   (cd /tmp/plannotator-release-verify && sha256sum --check plannotator-linux-x64.sha256)
+   (cd /tmp/plannotator-release-verify && sha256sum --check "plannotator-${version}-release-sbom.cdx.json.sha256")
+
+   gh attestation verify /tmp/plannotator-release-verify/plannotator-linux-x64 \
+     --repo backnotprop/plannotator \
+     --source-ref "refs/tags/$tag" \
+     --signer-workflow backnotprop/plannotator/.github/workflows/release.yml \
+     --predicate-type https://slsa.dev/provenance/v1
+
+   gh attestation verify /tmp/plannotator-release-verify/plannotator-linux-x64 \
+     --repo backnotprop/plannotator \
+     --source-ref "refs/tags/$tag" \
+     --signer-workflow backnotprop/plannotator/.github/workflows/release.yml \
+     --predicate-type https://cyclonedx.org/bom
+   ```
+
+   Also extract the attested CycloneDX predicate with `gh attestation verify --format json --jq '.[0].verificationResult.statement.predicate'`, canonicalize both it and the downloaded release SBOM with `jq -S`, and `cmp` them. Verify one npm tarball subject the same way if you download the exact published tarball. Record any tag-only discrepancy as a release blocker and ship a new version rather than mutating an immutable release.
 
    If anything fails, investigate the logs and report to the user before retrying.
 
@@ -228,9 +264,16 @@ Before tagging, verify:
 - [ ] Version bump committed
 - [ ] Pi parity gate passed (imports, vendor.sh, dry-run pack)
 - [ ] No stale build artifacts (clean builds, no cache issues — run `bun install` first if dependencies changed)
+- [ ] The PR-safe `release-security` job generated a schema-valid, sentinel-complete SBOM and accepted the Grype policy with a fresh database
+- [ ] No scanner binary, database, generated SBOM/report, credential, or `DO_NOT_COMMIT` content is staged
+- [ ] For the first SBOM-enabled release, the canonical Mintlify install/verification page contains the README's SBOM scope, policy, checksum, SLSA, and CycloneDX commands (do not edit the deprecated Astro docs instead)
 
 After tagging, verify:
-- [ ] Release workflow completed (all 4 jobs green)
-- [ ] GitHub Release created with all binaries
+- [ ] Release workflow completed with `release-security`, `attest`, `release`, and `npm-publish` green
+- [ ] GitHub Release created with all binaries, sidecars, SBOM, and SBOM sidecar
+- [ ] One native binary passes both the explicit SLSA and CycloneDX predicate checks pinned to the tag and signer workflow
+- [ ] Downloaded SBOM checksum passes and canonical JSON matches the attested predicate
+- [ ] `release-security-evidence` shows a fresh/active database and an accepted policy decision
 - [ ] npm packages published at correct version
+- [ ] npm trusted-publishing provenance remains visible for both packages
 - [ ] Release notes replaced via `gh release edit`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -892,15 +892,16 @@ jobs:
     # never get id-token: write granted, closing the trusted-contributor
     # compromise window where a malicious build step could mint a
     # repo-identity OIDC token. The attestation is produced against the
-    # same binaries the build job uploaded; attest-build-provenance
-    # publishes the signed bundle to GitHub's attestation store, so the
-    # release job downstream doesn't need any new artifact handling.
+    # same binaries the build job uploaded. It rechecks the security gate's
+    # subject digests, preserves attest-build-provenance for native binaries,
+    # and adds the release-wide CycloneDX predicate for every shipped subject.
     needs:
       - release-eligibility
       - build
       - smoke-binaries
       - pi-extension-ai-runtime-windows
       - install-script-smoke
+      - release-security
     if: startsWith(github.ref, 'refs/tags/v') && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs['dry-run'] == 'false'))
     runs-on: ubuntu-latest
     permissions:
@@ -913,6 +914,31 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: binaries
+          digest-mismatch: error
+
+      - name: Download npm package subjects
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: npm-packages
+          path: npm-packages
+          digest-mismatch: error
+
+      - name: Download validated subject evidence
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-security-subjects
+          path: release-security-subjects
+          digest-mismatch: error
+
+      - name: Download public release SBOM
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-sbom
+          path: release-sbom
+          digest-mismatch: error
+
+      - name: Revalidate gated release subjects
+        run: sha256sum --check --strict release-security-subjects/subject-checksums.sha256
 
       - name: Generate SLSA build provenance attestation
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
@@ -931,8 +957,32 @@ jobs:
             plannotator-paste-win32-x64.exe
             plannotator-paste-win32-arm64.exe
 
+      # actions/attest is the current official general attestation action.
+      # Its sbom-path mode supersedes the deprecated actions/attest-sbom
+      # wrapper and binds the CycloneDX predicate to the shipped subjects,
+      # not to the SBOM file itself.
+      - name: Generate release SBOM attestation
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: |
+            plannotator-darwin-arm64
+            plannotator-darwin-x64
+            plannotator-linux-x64
+            plannotator-linux-arm64
+            plannotator-win32-x64.exe
+            plannotator-win32-arm64.exe
+            plannotator-paste-darwin-arm64
+            plannotator-paste-darwin-x64
+            plannotator-paste-linux-x64
+            plannotator-paste-linux-arm64
+            plannotator-paste-win32-x64.exe
+            plannotator-paste-win32-arm64.exe
+            npm-packages/plannotator-opencode.tgz
+            npm-packages/plannotator-pi-extension.tgz
+          sbom-path: release-sbom/${{ needs.release-security.outputs.sbom-name }}
+
   release:
-    # Depends on `attest` so the signed provenance exists before the
+    # Depends on `attest` so the signed provenance and SBOM attestation exist before the
     # GitHub Release is published — otherwise there'd be a window where
     # users could pull the binary and `gh attestation verify` would
     # race-fail. `needs: attest` implicitly requires `build` too.
@@ -952,6 +1002,13 @@ jobs:
         with:
           name: binaries
           path: artifacts
+
+      - name: Download release SBOM
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-sbom
+          path: artifacts
+          digest-mismatch: error
 
       - name: List artifacts
         run: ls -la artifacts/
@@ -1023,12 +1080,90 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  # Credential-free release inventory and vulnerability gate. This job runs on
+  # PRs and dry-runs against the exact binaries and npm tarballs produced above,
+  # but it cannot attest, publish, deploy, or mint an OIDC token.
+  release-security:
+    needs:
+      - build
+      - npm-package
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.release-metadata.outputs.version }}
+      sbom-name: ${{ steps.release-metadata.outputs.sbom-name }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+          no-cache: true
+
+      - name: Download binary subjects
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: binaries
+          path: release-subjects
+          digest-mismatch: error
+
+      - name: Download npm package subjects
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: npm-packages
+          path: release-subjects/npm-packages
+          digest-mismatch: error
+
+      - name: Define release evidence names
+        id: release-metadata
+        run: |
+          version="$(jq -r .version package.json)"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "sbom-name=plannotator-${version}-release-sbom.cdx.json" >> "$GITHUB_OUTPUT"
+
+      - name: Generate SBOM and enforce Grype policy
+        env:
+          PLANNOTATOR_RELEASE_SUBJECTS_DIR: ${{ github.workspace }}/release-subjects
+          PLANNOTATOR_RELEASE_SECURITY_DIR: ${{ runner.temp }}/plannotator-release-security
+        run: scripts/release-security/run-release-security.sh
+
+      - name: Upload public release SBOM
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-sbom
+          path: ${{ runner.temp }}/plannotator-release-security/public/*
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload validated subject evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-security-subjects
+          path: |
+            ${{ runner.temp }}/plannotator-release-security/evidence/release-subjects.json
+            ${{ runner.temp }}/plannotator-release-security/evidence/subject-checksums.sha256
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Preserve private scanner evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-security-evidence
+          path: ${{ runner.temp }}/plannotator-release-security/evidence
+          if-no-files-found: warn
+          retention-days: 14
+
   # Publish only the tarballs produced by the credential-free job. Automatic
   # tag releases are unchanged; a manual publish must also target a v* tag.
   npm-publish:
     needs:
       - release-eligibility
       - npm-package
+      - release-security
     if: startsWith(github.ref, 'refs/tags/v') && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs['dry-run'] == 'false'))
     runs-on: ubuntu-latest
     environment: npm-publish

--- a/README.md
+++ b/README.md
@@ -385,7 +385,38 @@ Host your-server
 
 ## Security
 
-Every released binary ships with a SHA256 sidecar. [SLSA provenance](https://slsa.dev/) attestations are available from v0.17.2.
+Every released binary ships with a SHA256 sidecar. [SLSA provenance](https://slsa.dev/) attestations are available from v0.17.2. The current release workflow also attaches a CycloneDX JSON SBOM, evaluates it with a fresh Grype database before anything is attested or published, and creates a GitHub/Sigstore SBOM attestation for the shipped binaries and npm tarballs.
+
+The SBOM is intentionally labeled as a release-wide Syft inventory of the monorepo's locked build inputs and dependencies. It is not an exact per-binary runtime inventory: Bun standalone executables do not expose their bundled JavaScript package metadata to Syft. The canonical [installation and verification docs](https://docs.plannotator.ai/open-source/start/installation#pin-or-verify-a-release) cover the existing installer path; the exact new SBOM commands are included below and must be copied to that Mintlify page before the first SBOM-enabled release.
+
+The release gate rejects scanner-side ignored matches and treats unknown applicability conservatively as runtime when evaluating CISA KEV and fixable Critical findings. Its explicit Grype configuration, complete JSON results, database status, and repository policy decision remain available as workflow evidence.
+
+To verify a released Linux x64 binary, its existing provenance, and the new SBOM evidence directly:
+
+```bash
+tag=vX.Y.Z
+version="${tag#v}"
+mkdir -p /tmp/plannotator-release-verify
+gh release download "$tag" --repo backnotprop/plannotator \
+  --pattern 'plannotator-linux-x64*' \
+  --pattern "plannotator-${version}-release-sbom.cdx.json*" \
+  --dir /tmp/plannotator-release-verify
+
+(cd /tmp/plannotator-release-verify && sha256sum --check plannotator-linux-x64.sha256)
+(cd /tmp/plannotator-release-verify && sha256sum --check "plannotator-${version}-release-sbom.cdx.json.sha256")
+
+gh attestation verify /tmp/plannotator-release-verify/plannotator-linux-x64 \
+  --repo backnotprop/plannotator --source-ref "refs/tags/$tag" \
+  --signer-workflow backnotprop/plannotator/.github/workflows/release.yml \
+  --predicate-type https://slsa.dev/provenance/v1
+
+gh attestation verify /tmp/plannotator-release-verify/plannotator-linux-x64 \
+  --repo backnotprop/plannotator --source-ref "refs/tags/$tag" \
+  --signer-workflow backnotprop/plannotator/.github/workflows/release.yml \
+  --predicate-type https://cyclonedx.org/bom
+```
+
+These are separate claims over the same artifact digest: provenance identifies its builder/source/workflow, while the CycloneDX predicate describes the release-wide inventory. The release runbook also canonicalizes the downloaded SBOM and attested predicate with `jq -S` and compares them.
 
 To verify on install:
 
@@ -399,7 +430,7 @@ Requires the `gh` CLI, but no login: the installer fetches the attestation bundl
 { "verifyAttestation": true }
 ```
 
-See the [verification docs](https://docs.plannotator.ai/open-source/start/installation#pin-or-verify-a-release) for details.
+Installer verification remains opt-in and verifies SLSA build provenance; normal installation does not require `gh`. See the [canonical installation docs](https://docs.plannotator.ai/open-source/start/installation#pin-or-verify-a-release) for details.
 
 ---
 

--- a/scripts/release-security/grype-policy.mjs
+++ b/scripts/release-security/grype-policy.mjs
@@ -1,0 +1,382 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+export const MAX_DATABASE_AGE_HOURS = 120;
+export const SUPPORTED_DATABASE_SCHEMA = 6;
+export const OPENVEX_CONTEXT = "https://openvex.dev/ns/v0.2.0";
+
+const VALID_JUSTIFICATIONS = new Set([
+  "component_not_present",
+  "vulnerable_code_not_present",
+  "vulnerable_code_not_in_execute_path",
+  "vulnerable_code_cannot_be_controlled_by_adversary",
+  "inline_mitigations_already_exist",
+]);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function requireObject(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) fail(`${label} must be an object`);
+  return value;
+}
+
+function requireString(value, label) {
+  if (typeof value !== "string" || value.trim() === "") fail(`${label} must be a non-empty string`);
+  return value;
+}
+
+function parseTimestamp(value, label) {
+  requireString(value, label);
+  const milliseconds = Date.parse(value);
+  if (!Number.isFinite(milliseconds)) fail(`${label} must be an ISO-8601 timestamp`);
+  return milliseconds;
+}
+
+function parseDate(value, label) {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    fail(`${label} must be an ISO date (YYYY-MM-DD)`);
+  }
+  const milliseconds = Date.parse(`${value}T00:00:00Z`);
+  if (!Number.isFinite(milliseconds)) fail(`${label} is not a valid date`);
+  return milliseconds;
+}
+
+function databaseChecksumFromUrl(value) {
+  const url = new URL(requireString(value, "database status.from"));
+  if (url.protocol !== "https:" || url.hostname !== "grype.anchore.io" || !url.pathname.startsWith("/databases/v6/")) {
+    fail("database status.from must use the official Grype v6 HTTPS endpoint");
+  }
+  const checksum = url.searchParams.get("checksum");
+  if (!/^sha256:[0-9a-f]{64}$/.test(checksum ?? "")) {
+    fail("database status.from must contain a SHA256 checksum");
+  }
+  return checksum;
+}
+
+export function validateDatabaseEvidence({ status, listing, check, now = new Date() }) {
+  requireObject(status, "database status");
+  if (status.valid !== true) fail("Grype database status is not valid");
+  const schema = requireString(status.schemaVersion, "database schemaVersion");
+  if (!new RegExp(`^v${SUPPORTED_DATABASE_SCHEMA}\\.`).test(schema)) {
+    fail(`Grype database schema ${schema} is incompatible; expected v${SUPPORTED_DATABASE_SCHEMA}.x`);
+  }
+
+  const builtMilliseconds = parseTimestamp(status.built, "database built time");
+  const nowMilliseconds = now.getTime();
+  const ageHours = (nowMilliseconds - builtMilliseconds) / 3_600_000;
+  if (ageHours < -1) fail("Grype database build time is unreasonably far in the future");
+  if (ageHours > MAX_DATABASE_AGE_HOURS) {
+    fail(`Grype database is stale (${ageHours.toFixed(1)}h old; maximum ${MAX_DATABASE_AGE_HOURS}h)`);
+  }
+
+  if (!Array.isArray(listing) || listing.length === 0) fail("Grype database listing is missing or empty");
+  const active = listing.filter((entry) => entry?.status === "active");
+  if (active.length !== 1) fail(`Expected exactly one active Grype database listing, found ${active.length}`);
+  const activeEntry = requireObject(active[0], "active database listing");
+  if (activeEntry.schemaVersion !== schema || activeEntry.built !== status.built) {
+    fail("Grype database status and active listing disagree on schema or build time");
+  }
+
+  const sourceChecksum = databaseChecksumFromUrl(status.from);
+  if (activeEntry.checksum !== sourceChecksum) fail("Grype database source and listing checksums do not match");
+
+  requireObject(check, "database update check");
+  const current = requireObject(check.currentDB, "database update check currentDB");
+  if (current.schemaVersion !== schema || current.built !== status.built) {
+    fail("Grype database status and update check disagree on the current database");
+  }
+  if (check.candidateDB !== null || check.updateAvailable !== false) {
+    fail("A newer Grype database is available or database update status is ambiguous");
+  }
+
+  return {
+    schemaVersion: schema,
+    built: status.built,
+    ageHours: Number(ageHours.toFixed(2)),
+    source: status.from,
+    checksum: sourceChecksum,
+    valid: true,
+    updateAvailable: false,
+  };
+}
+
+function validateApplicability(value) {
+  const applicability = requireObject(value, "applicability evidence");
+  if (applicability.schemaVersion !== 1) fail("Unsupported applicability evidence schemaVersion");
+  for (const field of ["runtimePackageNames", "developmentOnlyPackageNames"]) {
+    if (!Array.isArray(applicability[field]) || applicability[field].some((item) => typeof item !== "string")) {
+      fail(`Applicability evidence ${field} must be a string array`);
+    }
+  }
+  const runtime = new Set(applicability.runtimePackageNames);
+  const development = new Set(applicability.developmentOnlyPackageNames);
+  for (const name of runtime) {
+    if (development.has(name)) fail(`Package is both runtime and development-only: ${name}`);
+  }
+  return { applicability, runtime, development };
+}
+
+function findingIdentity(match) {
+  const artifact = requireObject(match.artifact, "Grype match artifact");
+  const vulnerability = requireObject(match.vulnerability, "Grype match vulnerability");
+  const id = requireString(vulnerability.id, "vulnerability id");
+  const name = requireString(artifact.name, `artifact name for ${id}`);
+  const version = requireString(artifact.version, `artifact version for ${id}`);
+  const purl = requireString(artifact.purl, `artifact purl for ${id}`);
+  const severity = requireString(vulnerability.severity, `severity for ${id}`);
+  if (!Array.isArray(vulnerability.fix?.versions)) fail(`fix versions for ${id} must be an array`);
+  if (!Array.isArray(vulnerability.knownExploited ?? [])) fail(`knownExploited for ${id} must be an array`);
+  if (!Array.isArray(match.relatedVulnerabilities ?? [])) fail(`relatedVulnerabilities for ${id} must be an array`);
+  return { artifact, vulnerability, id, name, version, purl, severity };
+}
+
+function validateOpenVex(document, now) {
+  if (document === null || document === undefined) return [];
+  const vex = requireObject(document, "OpenVEX document");
+  if (vex["@context"] !== OPENVEX_CONTEXT) fail(`OpenVEX @context must be ${OPENVEX_CONTEXT}`);
+  requireString(vex["@id"], "OpenVEX @id");
+  requireString(vex.author, "OpenVEX author");
+  parseTimestamp(vex.timestamp, "OpenVEX timestamp");
+  if (!Number.isInteger(vex.version) || vex.version < 1) fail("OpenVEX version must be a positive integer");
+  if (!Array.isArray(vex.statements) || vex.statements.length === 0) {
+    fail("An OpenVEX exception document must contain at least one statement");
+  }
+
+  return vex.statements.map((value, index) => {
+    const label = `OpenVEX statement ${index + 1}`;
+    const statement = requireObject(value, label);
+    const vulnerability = requireObject(statement.vulnerability, `${label} vulnerability`);
+    const vulnerabilityId = requireString(vulnerability.name, `${label} vulnerability name`);
+    if (vulnerability["@id"] !== undefined) requireString(vulnerability["@id"], `${label} vulnerability @id`);
+    if (!Array.isArray(statement.products) || statement.products.length !== 1) {
+      fail(`${label} must name exactly one product; broad exceptions are forbidden`);
+    }
+    const product = requireObject(statement.products[0], `${label} product`);
+    const productId = requireString(product["@id"], `${label} product @id`);
+    if (!productId.startsWith("pkg:")) fail(`${label} product must be an exact package URL`);
+    if (statement.status !== "not_affected") fail(`${label} status must be not_affected`);
+    if (!VALID_JUSTIFICATIONS.has(statement.justification)) {
+      fail(`${label} justification is missing or is not an OpenVEX not_affected justification`);
+    }
+    requireString(statement.impact_statement, `${label} impact_statement`);
+    const created = parseTimestamp(statement.timestamp, `${label} timestamp`);
+    const statusNotes = requireString(statement.status_notes, `${label} status_notes`);
+    const metadata = new Map();
+    for (const line of statusNotes.split("\n")) {
+      const match = line.match(/^plannotator-(owner|evidence|expires): (.+)$/);
+      if (!match || metadata.has(match[1])) {
+        fail(`${label} status_notes must contain exactly one owner, evidence, and expires line`);
+      }
+      metadata.set(match[1], match[2]);
+    }
+    if (metadata.size !== 3) fail(`${label} status_notes is missing owner, evidence, or expires metadata`);
+    const owner = requireString(metadata.get("owner"), `${label} owner`);
+    const evidence = requireString(metadata.get("evidence"), `${label} evidence`);
+    const evidenceUrl = new URL(evidence);
+    if (evidenceUrl.protocol !== "https:") fail(`${label} evidence must be an HTTPS URL`);
+    const expiresText = metadata.get("expires");
+    const expires = parseDate(expiresText, `${label} expires`);
+    if (created > now.getTime()) fail(`${label} created date is in the future`);
+    if (expires < now.getTime()) fail(`${label} expired on ${expiresText}`);
+    if (expires <= created) fail(`${label} expires must be after created`);
+
+    return { vulnerabilityId, productId, owner, evidence, created: statement.timestamp, expires: expiresText };
+  });
+}
+
+function aliasesFor(match) {
+  const aliases = new Set([match.vulnerability.id]);
+  for (const related of match.relatedVulnerabilities ?? []) {
+    if (typeof related?.id === "string") aliases.add(related.id);
+  }
+  for (const exploited of match.vulnerability.knownExploited ?? []) {
+    if (typeof exploited?.cve === "string") aliases.add(exploited.cve);
+  }
+  return aliases;
+}
+
+function isKev(match) {
+  if ((match.vulnerability.knownExploited ?? []).length > 0) return true;
+  return (match.relatedVulnerabilities ?? []).some((related) => (related?.knownExploited ?? []).length > 0);
+}
+
+function exceptionFor(match, exceptions) {
+  const aliases = aliasesFor(match);
+  return exceptions.find(
+    (exception) => aliases.has(exception.vulnerabilityId) && exception.productId === match.artifact.purl,
+  );
+}
+
+export function evaluatePolicy({ scan, status, listing, check, applicability, vex = null, now = new Date(), grypeVersion }) {
+  const database = validateDatabaseEvidence({ status, listing, check, now });
+  const { runtime, development } = validateApplicability(applicability);
+  const document = requireObject(scan, "Grype scan evidence");
+  if (
+    !Array.isArray(document.matches) ||
+    (document.ignoredMatches !== undefined && !Array.isArray(document.ignoredMatches))
+  ) {
+    fail("Grype scan evidence must contain matches and, when present, an ignoredMatches array");
+  }
+  if ((document.ignoredMatches ?? []).length > 0) {
+    fail(`Grype scan suppressed ${document.ignoredMatches.length} match(es); scanner-side ignores are forbidden`);
+  }
+  const descriptor = requireObject(document.descriptor, "Grype scan descriptor");
+  if (descriptor.name !== "grype" || descriptor.version !== grypeVersion) {
+    fail(`Grype scan descriptor must identify grype ${grypeVersion}`);
+  }
+  const scanDatabase = requireObject(descriptor.db?.status, "Grype scan database status");
+  if (
+    scanDatabase.valid !== true ||
+    scanDatabase.schemaVersion !== database.schemaVersion ||
+    scanDatabase.built !== database.built ||
+    scanDatabase.from !== database.source
+  ) {
+    fail("Grype scan did not use the separately validated database evidence");
+  }
+
+  const exceptions = validateOpenVex(vex, now);
+  const matchedExceptions = new Set();
+  const findings = document.matches.map((match) => {
+    const identity = findingIdentity(match);
+    const applicabilityClass = runtime.has(identity.name)
+      ? "runtime"
+      : development.has(identity.name)
+        ? "development-only"
+        : "unknown";
+    const confidence = applicabilityClass === "unknown" ? "unknown" : "conservative-name-match";
+    const kev = isKev(match);
+    const fixable = identity.vulnerability.fix.state === "fixed" && identity.vulnerability.fix.versions.length > 0;
+    const exception = exceptionFor(match, exceptions);
+    if (exception) matchedExceptions.add(exception);
+
+    const blockReasons = [];
+    const conservativelyApplicable = applicabilityClass !== "development-only";
+    if (conservativelyApplicable && kev) blockReasons.push("applicable-cisa-kev");
+    if (conservativelyApplicable && identity.severity === "Critical" && fixable) {
+      blockReasons.push("applicable-fixable-critical");
+    }
+
+    return {
+      vulnerability: identity.id,
+      aliases: [...aliasesFor(match)].sort(),
+      severity: identity.severity,
+      package: { name: identity.name, version: identity.version, purl: identity.purl },
+      applicability: applicabilityClass,
+      confidence,
+      fix: { state: identity.vulnerability.fix.state, versions: identity.vulnerability.fix.versions },
+      cisaKev: kev,
+      decision: blockReasons.length > 0 && !exception ? "block" : exception ? "suppressed" : "report",
+      blockReasons,
+      exception: exception
+        ? { owner: exception.owner, evidence: exception.evidence, created: exception.created, expires: exception.expires }
+        : null,
+    };
+  });
+
+  for (const exception of exceptions) {
+    if (!matchedExceptions.has(exception)) {
+      fail(`OpenVEX exception does not match any finding: ${exception.vulnerabilityId} / ${exception.productId}`);
+    }
+  }
+
+  const counts = {
+    total: findings.length,
+    blocked: findings.filter((finding) => finding.decision === "block").length,
+    suppressed: findings.filter((finding) => finding.decision === "suppressed").length,
+    reportOnly: findings.filter((finding) => finding.decision === "report").length,
+    runtime: findings.filter((finding) => finding.applicability === "runtime").length,
+    developmentOnly: findings.filter((finding) => finding.applicability === "development-only").length,
+    unknown: findings.filter((finding) => finding.applicability === "unknown").length,
+    critical: findings.filter((finding) => finding.severity === "Critical").length,
+    high: findings.filter((finding) => finding.severity === "High").length,
+    cisaKev: findings.filter((finding) => finding.cisaKev).length,
+  };
+
+  return {
+    schemaVersion: 1,
+    decision: counts.blocked === 0 ? "accept" : "reject",
+    policy: {
+      block: ["runtime-or-unknown CISA KEV", "runtime-or-unknown fixable Critical"],
+      report: ["High", "development-only", "no-fix Critical"],
+      maximumDatabaseAgeHours: MAX_DATABASE_AGE_HOURS,
+    },
+    scanner: { name: "grype", version: grypeVersion },
+    database,
+    counts,
+    findings,
+    ignoredMatches: document.ignoredMatches ?? [],
+  };
+}
+
+export function formatSummary(result) {
+  const lines = [
+    "## Release vulnerability policy",
+    "",
+    `**Decision:** ${result.decision === "accept" ? "ACCEPT" : "REJECT"}`,
+    "",
+    `Grype ${result.scanner.version}; database ${result.database.schemaVersion}, built ${result.database.built} (${result.database.ageHours}h old).`,
+    "",
+    `Findings: ${result.counts.total} total; ${result.counts.blocked} blocked; ${result.counts.suppressed} suppressed; ${result.counts.high} High; ${result.counts.critical} Critical; ${result.counts.cisaKev} CISA KEV.`,
+    "",
+    `Applicability: ${result.counts.runtime} runtime; ${result.counts.developmentOnly} development-only; ${result.counts.unknown} unknown.`,
+    "",
+    "The gate blocks runtime or unknown-applicability CISA KEV and fixable Critical findings. High, development-only, and no-fix Critical findings remain visible but report-only.",
+  ];
+  if (result.counts.blocked > 0) {
+    lines.push("", "### Blocking findings", "");
+    for (const finding of result.findings.filter((item) => item.decision === "block")) {
+      lines.push(
+        `- ${finding.vulnerability}: ${finding.package.name}@${finding.package.version} (${finding.blockReasons.join(", ")})`,
+      );
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function parseArgs(argv) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith("--") || !value) fail(`Expected --name value arguments, received: ${argv.join(" ")}`);
+    values.set(key.slice(2), value);
+  }
+  return values;
+}
+
+async function readJson(filePath, label) {
+  if (!filePath) fail(`Missing ${label} path`);
+  try {
+    return JSON.parse(await readFile(filePath, "utf8"));
+  } catch (error) {
+    fail(`${label} is missing or malformed: ${error.message}`);
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const vexPath = args.get("vex");
+  const result = evaluatePolicy({
+    scan: await readJson(args.get("scan"), "Grype scan evidence"),
+    status: await readJson(args.get("db-status"), "database status evidence"),
+    listing: await readJson(args.get("db-list"), "database listing evidence"),
+    check: await readJson(args.get("db-check"), "database update evidence"),
+    applicability: await readJson(args.get("applicability"), "applicability evidence"),
+    vex: vexPath ? await readJson(vexPath, "OpenVEX exceptions") : null,
+    grypeVersion: args.get("grype-version"),
+  });
+  if (!args.get("output") || !args.get("summary")) fail("Missing --output or --summary path");
+  await writeFile(args.get("output"), `${JSON.stringify(result, null, 2)}\n`);
+  const summary = formatSummary(result);
+  await writeFile(args.get("summary"), summary);
+  console.log(summary);
+  if (result.decision !== "accept") process.exitCode = 1;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(`Grype policy evidence error: ${error.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/release-security/grype-policy.test.mjs
+++ b/scripts/release-security/grype-policy.test.mjs
@@ -1,0 +1,287 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { evaluatePolicy, OPENVEX_CONTEXT } from "./grype-policy.mjs";
+
+const NOW = new Date("2026-08-13T00:00:00Z");
+const CHECKSUM = "a".repeat(64);
+
+function databaseEvidence(overrides = {}) {
+  const status = {
+    schemaVersion: "v6.1.9",
+    from: `https://grype.anchore.io/databases/v6/example.tar.zst?checksum=sha256%3A${CHECKSUM}`,
+    built: "2026-08-12T12:00:00Z",
+    path: "/tmp/grype/6/vulnerability.db",
+    valid: true,
+    ...overrides,
+  };
+  return {
+    status,
+    listing: [
+      {
+        status: "active",
+        schemaVersion: status.schemaVersion,
+        built: status.built,
+        path: "example.tar.zst",
+        checksum: `sha256:${CHECKSUM}`,
+      },
+    ],
+    check: {
+      currentDB: { schemaVersion: status.schemaVersion, built: status.built },
+      candidateDB: null,
+      updateAvailable: false,
+    },
+  };
+}
+
+function vulnerabilityMatch({
+  id = "GHSA-critical",
+  severity = "Critical",
+  name = "runtime-package",
+  version = "1.0.0",
+  fixState = "fixed",
+  fixVersions = ["1.0.1"],
+  knownExploited = [],
+} = {}) {
+  return {
+    vulnerability: {
+      id,
+      dataSource: `https://example.test/${id}`,
+      severity,
+      urls: [],
+      cvss: [],
+      knownExploited,
+      fix: { state: fixState, versions: fixVersions },
+    },
+    relatedVulnerabilities: [],
+    matchDetails: [],
+    artifact: {
+      id: `${name}-${version}`,
+      name,
+      version,
+      type: "npm",
+      locations: [{ path: "/bun.lock" }],
+      language: "javascript",
+      licenses: [],
+      purl: `pkg:npm/${name}@${version}`,
+    },
+  };
+}
+
+function scan(matches = []) {
+  const { status } = databaseEvidence();
+  return {
+    matches,
+    ignoredMatches: [],
+    source: { type: "directory", target: "release-sbom-input" },
+    descriptor: {
+      name: "grype",
+      version: "0.117.0",
+      db: { status },
+    },
+  };
+}
+
+function applicability() {
+  return {
+    schemaVersion: 1,
+    runtimePackageNames: ["runtime-package"],
+    developmentOnlyPackageNames: ["dev-package"],
+  };
+}
+
+function evaluate(overrides = {}) {
+  const database = databaseEvidence();
+  return evaluatePolicy({
+    scan: scan(),
+    ...database,
+    applicability: applicability(),
+    vex: null,
+    now: NOW,
+    grypeVersion: "0.117.0",
+    ...overrides,
+  });
+}
+
+function vexStatement(overrides = {}) {
+  return {
+    vulnerability: {
+      "@id": "https://github.com/advisories/GHSA-critical",
+      name: "GHSA-critical",
+    },
+    products: [{ "@id": "pkg:npm/runtime-package@1.0.0" }],
+    status: "not_affected",
+    justification: "vulnerable_code_not_in_execute_path",
+    impact_statement: "The vulnerable entry point is not included in the shipped bundle.",
+    timestamp: "2026-08-01T00:00:00Z",
+    status_notes: [
+      "plannotator-owner: security-maintainers",
+      "plannotator-evidence: https://github.com/backnotprop/plannotator/issues/1234",
+      "plannotator-expires: 2026-09-01",
+    ].join("\n"),
+    ...overrides,
+  };
+}
+
+function vex(statements = [vexStatement()]) {
+  return {
+    "@context": OPENVEX_CONTEXT,
+    "@id": "https://github.com/backnotprop/plannotator/security/vex/test",
+    author: "Plannotator maintainers",
+    timestamp: "2026-08-01T00:00:00Z",
+    version: 1,
+    statements,
+  };
+}
+
+test("accepts clean, fresh, schema-compatible evidence", () => {
+  const result = evaluate();
+  assert.equal(result.decision, "accept");
+  assert.equal(result.counts.total, 0);
+  assert.equal(result.database.schemaVersion, "v6.1.9");
+});
+
+test("rejects an applicable fixable Critical finding", () => {
+  const result = evaluate({ scan: scan([vulnerabilityMatch()]) });
+  assert.equal(result.decision, "reject");
+  assert.deepEqual(result.findings[0].blockReasons, ["applicable-fixable-critical"]);
+});
+
+test("rejects an applicable CISA KEV finding at any severity", () => {
+  const result = evaluate({
+    scan: scan([
+      vulnerabilityMatch({
+        id: "CVE-2026-1234",
+        severity: "Medium",
+        fixState: "not-fixed",
+        fixVersions: [],
+        knownExploited: [{ cve: "CVE-2026-1234", dateAdded: "2026-08-01" }],
+      }),
+    ]),
+  });
+  assert.equal(result.decision, "reject");
+  assert.deepEqual(result.findings[0].blockReasons, ["applicable-cisa-kev"]);
+});
+
+test("reports High, development-only, unknown non-gated, and no-fix Critical findings", () => {
+  const matches = [
+    vulnerabilityMatch({ id: "GHSA-high", severity: "High" }),
+    vulnerabilityMatch({ id: "GHSA-dev", name: "dev-package" }),
+    vulnerabilityMatch({ id: "GHSA-unknown", name: "unclassified-package", severity: "High" }),
+    vulnerabilityMatch({ id: "GHSA-nofix", fixState: "not-fixed", fixVersions: [] }),
+  ];
+  const result = evaluate({ scan: scan(matches) });
+  assert.equal(result.decision, "accept");
+  assert.ok(result.findings.every((finding) => finding.decision === "report"));
+  assert.equal(result.counts.developmentOnly, 1);
+  assert.equal(result.counts.unknown, 1);
+});
+
+test("treats unknown applicability as runtime for KEV and fixable Critical findings", () => {
+  const unknownCritical = evaluate({
+    scan: scan([vulnerabilityMatch({ name: "unclassified-package" })]),
+  });
+  assert.equal(unknownCritical.decision, "reject");
+  assert.equal(unknownCritical.findings[0].applicability, "unknown");
+  assert.deepEqual(unknownCritical.findings[0].blockReasons, ["applicable-fixable-critical"]);
+
+  const unknownKev = evaluate({
+    scan: scan([
+      vulnerabilityMatch({
+        id: "CVE-2026-5678",
+        name: "unclassified-package",
+        severity: "Medium",
+        fixState: "not-fixed",
+        fixVersions: [],
+        knownExploited: [{ cve: "CVE-2026-5678", dateAdded: "2026-08-01" }],
+      }),
+    ]),
+  });
+  assert.equal(unknownKev.decision, "reject");
+  assert.deepEqual(unknownKev.findings[0].blockReasons, ["applicable-cisa-kev"]);
+});
+
+test("rejects stale, missing, incompatible, and unavailable database evidence", () => {
+  const stale = databaseEvidence({ built: "2026-08-01T00:00:00Z" });
+  assert.throws(() => evaluate({ ...stale }), /stale/);
+  assert.throws(() => evaluate({ status: null }), /must be an object/);
+
+  const incompatible = databaseEvidence({ schemaVersion: "v5.0.0" });
+  assert.throws(() => evaluate({ ...incompatible }), /incompatible/);
+
+  const invalid = databaseEvidence({ valid: false });
+  assert.throws(() => evaluate({ ...invalid }), /not valid/);
+});
+
+test("rejects malformed scan evidence", () => {
+  assert.throws(() => evaluate({ scan: { descriptor: {} } }), /must contain matches/);
+  assert.throws(() => evaluate({ scan: { ...scan(), ignoredMatches: null } }), /ignoredMatches array/);
+  assert.throws(
+    () => evaluate({ scan: { ...scan(), descriptor: { name: "grype", version: "unexpected" } } }),
+    /must identify grype/,
+  );
+});
+
+test("rejects every scanner-side ignored match", () => {
+  assert.throws(
+    () =>
+      evaluate({
+        scan: {
+          ...scan(),
+          ignoredMatches: [{ match: vulnerabilityMatch(), appliedIgnoreRules: [{ vulnerability: "*" }] }],
+        },
+      }),
+    /scanner-side ignores are forbidden/,
+  );
+});
+
+test("accepts a valid exact OpenVEX exception and preserves the finding", () => {
+  const result = evaluate({ scan: scan([vulnerabilityMatch()]), vex: vex() });
+  assert.equal(result.decision, "accept");
+  assert.equal(result.counts.suppressed, 1);
+  assert.equal(result.findings[0].decision, "suppressed");
+  assert.deepEqual(result.findings[0].blockReasons, ["applicable-fixable-critical"]);
+});
+
+test("rejects expired, malformed, broad, and nonmatching OpenVEX exceptions", () => {
+  const criticalScan = scan([vulnerabilityMatch()]);
+  assert.throws(
+    () =>
+      evaluate({
+        scan: criticalScan,
+        vex: vex([
+          vexStatement({
+            status_notes: vexStatement().status_notes.replace("2026-09-01", "2026-08-12"),
+          }),
+        ]),
+      }),
+    /expired/,
+  );
+  assert.throws(
+    () => evaluate({ scan: criticalScan, vex: vex([vexStatement({ status_notes: "missing metadata" })]) }),
+    /status_notes must contain exactly one/,
+  );
+  assert.throws(
+    () =>
+      evaluate({
+        scan: criticalScan,
+        vex: vex([
+          vexStatement({
+            products: [
+              { "@id": "pkg:npm/runtime-package@1.0.0" },
+              { "@id": "pkg:npm/other@1.0.0" },
+            ],
+          }),
+        ]),
+      }),
+    /exactly one product/,
+  );
+  assert.throws(
+    () =>
+      evaluate({
+        scan: criticalScan,
+        vex: vex([vexStatement({ products: [{ "@id": "pkg:npm/other@1.0.0" }] })]),
+      }),
+    /does not match any finding/,
+  );
+});

--- a/scripts/release-security/grype.yaml
+++ b/scripts/release-security/grype.yaml
@@ -1,0 +1,21 @@
+# Release scanning always selects this file explicitly. Keep suppression empty;
+# the repository policy also rejects any ignoredMatches emitted by Grype.
+check-for-app-update: false
+only-fixed: false
+only-notfixed: false
+ignore-states: ""
+ignore: []
+vex-documents: []
+vex-add: []
+match-upstream-kernel-headers: true
+
+db:
+  update-url: https://grype.anchore.io/databases
+  auto-update: false
+  validate-by-hash-on-start: true
+  validate-age: true
+  max-allowed-built-age: 120h
+  require-update-check: true
+  update-available-timeout: 30s
+  update-download-timeout: 300s
+  max-update-check-frequency: 0s

--- a/scripts/release-security/release-evidence.mjs
+++ b/scripts/release-security/release-evidence.mjs
@@ -1,0 +1,412 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export const NATIVE_SUBJECTS = [
+  "plannotator-darwin-arm64",
+  "plannotator-darwin-x64",
+  "plannotator-linux-x64",
+  "plannotator-linux-arm64",
+  "plannotator-win32-x64.exe",
+  "plannotator-win32-arm64.exe",
+  "plannotator-paste-darwin-arm64",
+  "plannotator-paste-darwin-x64",
+  "plannotator-paste-linux-x64",
+  "plannotator-paste-linux-arm64",
+  "plannotator-paste-win32-x64.exe",
+  "plannotator-paste-win32-arm64.exe",
+];
+
+export const NPM_SUBJECTS = [
+  "npm-packages/plannotator-opencode.tgz",
+  "npm-packages/plannotator-pi-extension.tgz",
+];
+
+export const RELEASE_WORKSPACES = [
+  "",
+  "apps/hook",
+  "apps/opencode-plugin",
+  "apps/paste-service",
+  "apps/pi-extension",
+  "apps/review",
+  "packages/ai",
+  "packages/core",
+  "packages/editor",
+  "packages/review-editor",
+  "packages/server",
+  "packages/shared",
+  "packages/ui",
+];
+
+export const SBOM_SENTINELS = [
+  "@anthropic-ai/claude-agent-sdk",
+  "@joplin/turndown-plugin-gfm",
+  "@opencode-ai/sdk",
+  "@pierre/diffs",
+  "@plannotator/webtui",
+  "marked",
+];
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function parseArgs(argv) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith("--") || !value) {
+      fail(`Expected --name value arguments, received: ${argv.join(" ")}`);
+    }
+    values.set(key.slice(2), value);
+  }
+  return values;
+}
+
+function requireArg(args, name) {
+  const value = args.get(name);
+  if (!value) fail(`Missing required --${name} argument`);
+  return value;
+}
+
+function packageNameFromIdentity(identity) {
+  if (typeof identity !== "string") return null;
+  const separator = identity.lastIndexOf("@");
+  if (separator <= 0) return null;
+  return identity.slice(0, separator);
+}
+
+function packageEntriesByName(lock) {
+  const entries = new Map();
+  for (const value of Object.values(lock.packages ?? {})) {
+    if (!Array.isArray(value)) continue;
+    const name = packageNameFromIdentity(value[0]);
+    if (!name) continue;
+    const existing = entries.get(name) ?? [];
+    existing.push(value);
+    entries.set(name, existing);
+  }
+  return entries;
+}
+
+export function buildApplicability(lock) {
+  if (!lock || typeof lock !== "object" || !lock.workspaces || !lock.packages) {
+    fail("bun.lock evidence is missing workspaces or packages");
+  }
+
+  const workspaceByName = new Map();
+  for (const [workspacePath, workspace] of Object.entries(lock.workspaces)) {
+    if (workspace?.name) workspaceByName.set(workspace.name, { path: workspacePath, workspace });
+  }
+
+  for (const workspacePath of RELEASE_WORKSPACES) {
+    if (!lock.workspaces[workspacePath]) {
+      fail(`Release workspace is absent from bun.lock: ${workspacePath || "<root>"}`);
+    }
+  }
+
+  const entriesByName = packageEntriesByName(lock);
+  const runtimeNames = new Set();
+  const visitedWorkspaces = new Set();
+  const pending = [];
+
+  const enqueueDependencies = (manifest) => {
+    for (const field of ["dependencies", "optionalDependencies"]) {
+      for (const name of Object.keys(manifest?.[field] ?? {})) pending.push(name);
+    }
+  };
+
+  for (const workspacePath of RELEASE_WORKSPACES) {
+    const workspace = lock.workspaces[workspacePath];
+    visitedWorkspaces.add(workspace.name);
+    enqueueDependencies(workspace);
+  }
+
+  while (pending.length > 0) {
+    const name = pending.pop();
+    if (!name) continue;
+
+    const internal = workspaceByName.get(name);
+    if (internal) {
+      if (!visitedWorkspaces.has(name)) {
+        visitedWorkspaces.add(name);
+        enqueueDependencies(internal.workspace);
+      }
+      continue;
+    }
+
+    if (runtimeNames.has(name)) continue;
+    runtimeNames.add(name);
+
+    // Bun can lock several versions under dependent-prefixed keys. Treat every
+    // locked instance of a runtime package name as runtime and walk every one
+    // of their dependency sets. This is intentionally conservative: it may
+    // gate a dev-only duplicate, but it will not silently label a shipped
+    // instance as development-only because version resolution was ambiguous.
+    for (const entry of entriesByName.get(name) ?? []) {
+      enqueueDependencies(entry[2]);
+    }
+  }
+
+  const allNames = new Set(entriesByName.keys());
+  const developmentOnlyNames = [...allNames].filter((name) => !runtimeNames.has(name)).sort();
+
+  return {
+    schemaVersion: 1,
+    classificationMethod: "conservative package-name closure over production and optional dependencies",
+    confidence: "conservative-name-match",
+    releaseWorkspaces: RELEASE_WORKSPACES,
+    runtimePackageNames: [...runtimeNames].sort(),
+    developmentOnlyPackageNames: developmentOnlyNames,
+    counts: {
+      runtimePackageNames: runtimeNames.size,
+      developmentOnlyPackageNames: developmentOnlyNames.length,
+      lockedPackageNames: allNames.size,
+    },
+  };
+}
+
+async function sha256(filePath) {
+  const data = await readFile(filePath);
+  return createHash("sha256").update(data).digest("hex");
+}
+
+async function validateSubject(subjectsRoot, relativePath) {
+  const filePath = path.join(subjectsRoot, relativePath);
+  const details = await stat(filePath).catch(() => null);
+  if (!details?.isFile() || details.size === 0) fail(`Release subject is missing or empty: ${relativePath}`);
+
+  const digest = await sha256(filePath);
+  if (NATIVE_SUBJECTS.includes(relativePath)) {
+    const sidecarPath = `${filePath}.sha256`;
+    const sidecar = await readFile(sidecarPath, "utf8").catch(() => "");
+    const match = sidecar.trim().match(/^([0-9a-f]{64})\s+\*?(.+)$/i);
+    if (!match || match[1].toLowerCase() !== digest || path.basename(match[2]) !== relativePath) {
+      fail(`SHA256 sidecar does not match ${relativePath}`);
+    }
+  }
+
+  return { path: relativePath, sha256: digest, size: details.size };
+}
+
+export async function prepareReleaseEvidence(options) {
+  const repositoryRoot = path.resolve(options.repositoryRoot);
+  const subjectsRoot = path.resolve(options.subjectsRoot);
+  const sbomInput = path.resolve(options.sbomInput);
+  const evidenceDirectory = path.resolve(options.evidenceDirectory);
+  const packageJson = JSON.parse(await readFile(path.join(repositoryRoot, "package.json"), "utf8"));
+  if (packageJson.version !== options.version) {
+    fail(`Release version ${options.version} does not match package.json ${packageJson.version}`);
+  }
+  if (!/^[0-9a-f]{40}$/.test(options.commit)) fail("Commit must be a full 40-character SHA");
+  if (!/^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(options.repository)) {
+    fail(`Repository must be a canonical GitHub HTTPS URL: ${options.repository}`);
+  }
+
+  const subjects = [];
+  for (const relativePath of [...NATIVE_SUBJECTS, ...NPM_SUBJECTS]) {
+    subjects.push(await validateSubject(subjectsRoot, relativePath));
+  }
+
+  await mkdir(sbomInput, { recursive: true });
+  await mkdir(evidenceDirectory, { recursive: true });
+  const lockText = await readFile(path.join(repositoryRoot, "bun.lock"), "utf8");
+  const lock = globalThis.Bun?.JSONC?.parse(lockText);
+  if (!lock) fail("This command must run with Bun so bun.lock JSONC can be parsed safely");
+
+  await writeFile(path.join(sbomInput, "package.json"), `${JSON.stringify(packageJson, null, 2)}\n`);
+  await writeFile(path.join(sbomInput, "bun.lock"), lockText);
+
+  const applicability = buildApplicability(lock);
+  await writeFile(
+    path.join(evidenceDirectory, "release-applicability.json"),
+    `${JSON.stringify(applicability, null, 2)}\n`,
+  );
+
+  const subjectEvidence = {
+    schemaVersion: 1,
+    repository: options.repository,
+    commit: options.commit,
+    version: options.version,
+    subjects,
+  };
+  await writeFile(
+    path.join(evidenceDirectory, "release-subjects.json"),
+    `${JSON.stringify(subjectEvidence, null, 2)}\n`,
+  );
+  await writeFile(
+    path.join(evidenceDirectory, "subject-checksums.sha256"),
+    `${subjects.map((subject) => `${subject.sha256}  ${subject.path}`).join("\n")}\n`,
+  );
+
+  return { applicability, subjectEvidence };
+}
+
+export async function verifyReleaseSubjects(options) {
+  const evidence = requireObject(JSON.parse(await readFile(options.subjectsPath, "utf8")), "subject evidence");
+  if (
+    evidence.version !== options.version ||
+    evidence.repository !== options.repository ||
+    evidence.commit !== options.commit
+  ) {
+    fail("Validated subject evidence does not match this release invocation");
+  }
+  const expectedPaths = [...NATIVE_SUBJECTS, ...NPM_SUBJECTS];
+  if (!Array.isArray(evidence.subjects) || evidence.subjects.length !== expectedPaths.length) {
+    fail(`Subject evidence must contain exactly ${expectedPaths.length} release subjects`);
+  }
+  const byPath = new Map(evidence.subjects.map((subject) => [subject?.path, subject]));
+  if (byPath.size !== expectedPaths.length) fail("Subject evidence contains duplicate paths");
+  for (const relativePath of expectedPaths) {
+    const expected = byPath.get(relativePath);
+    if (!expected) fail(`Subject evidence is missing ${relativePath}`);
+    const actual = await validateSubject(path.resolve(options.subjectsRoot), relativePath);
+    if (actual.sha256 !== expected.sha256 || actual.size !== expected.size) {
+      fail(`Release subject changed after the security gate: ${relativePath}`);
+    }
+  }
+  return evidence.subjects.length;
+}
+
+function requireObject(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) fail(`${label} must be an object`);
+  return value;
+}
+
+export async function finalizeSbom(options) {
+  const cyclonedxFile = await stat(options.cyclonedxPath).catch(() => null);
+  if (!cyclonedxFile?.isFile() || cyclonedxFile.size === 0) fail("CycloneDX SBOM is missing or empty");
+  if (cyclonedxFile.size > 16 * 1024 * 1024) {
+    fail("CycloneDX SBOM exceeds the 16 MiB GitHub attestation predicate limit");
+  }
+  const cyclonedx = requireObject(JSON.parse(await readFile(options.cyclonedxPath, "utf8")), "CycloneDX SBOM");
+  const syft = requireObject(JSON.parse(await readFile(options.syftPath, "utf8")), "Syft SBOM");
+  const subjects = requireObject(JSON.parse(await readFile(options.subjectsPath, "utf8")), "subject evidence");
+
+  if (cyclonedx.bomFormat !== "CycloneDX" || cyclonedx.specVersion !== "1.6" || cyclonedx.version !== 1) {
+    fail("Public SBOM must be CycloneDX JSON 1.6 with document version 1");
+  }
+  if (!/^urn:uuid:[0-9a-f-]{36}$/i.test(cyclonedx.serialNumber ?? "")) fail("CycloneDX serialNumber is invalid");
+  if (!Array.isArray(cyclonedx.components) || cyclonedx.components.length === 0) {
+    fail("CycloneDX SBOM contains zero components");
+  }
+  if (!Array.isArray(syft.artifacts) || syft.artifacts.length === 0) fail("Syft scan contains zero packages");
+  if (subjects.version !== options.version || subjects.repository !== options.repository || subjects.commit !== options.commit) {
+    fail("SBOM metadata does not match the validated release subjects");
+  }
+
+  const componentNames = new Set(cyclonedx.components.map((component) => component?.name));
+  const syftNames = new Set(syft.artifacts.map((artifact) => artifact?.name));
+  for (const sentinel of SBOM_SENTINELS) {
+    if (!componentNames.has(sentinel) || !syftNames.has(sentinel)) {
+      fail(`SBOM is missing release dependency sentinel: ${sentinel}`);
+    }
+  }
+
+  const metadata = requireObject(cyclonedx.metadata, "CycloneDX metadata");
+  if (Number.isNaN(Date.parse(metadata.timestamp ?? ""))) fail("CycloneDX generation timestamp is invalid");
+  const tools = metadata.tools?.components;
+  const syftTool = Array.isArray(tools) ? tools.find((tool) => tool?.name === "syft") : null;
+  if (!syftTool?.version || syftTool.version !== options.syftVersion) {
+    fail(`CycloneDX metadata must identify Syft ${options.syftVersion}`);
+  }
+
+  metadata.component = {
+    "bom-ref": `pkg:generic/plannotator-release@${options.version}`,
+    type: "application",
+    group: "backnotprop",
+    name: "plannotator-release",
+    version: options.version,
+    externalReferences: [{ type: "vcs", url: options.repository }],
+    properties: [
+      { name: "plannotator:source:commit", value: options.commit },
+      { name: "plannotator:source:repository", value: options.repository },
+      {
+        name: "plannotator:sbom:scope",
+        value: "release-wide Syft-detected monorepo locked build-input and dependency inventory",
+      },
+      {
+        name: "plannotator:sbom:limitations",
+        value:
+          "Not an exact per-binary runtime inventory: Bun standalone executables hide JavaScript package metadata from Syft; host-provided peers and dependencies Syft cannot parse may be absent.",
+      },
+      { name: "plannotator:sbom:subject-count", value: String(subjects.subjects?.length ?? 0) },
+    ],
+  };
+
+  // Syft models the lockfile itself as a component and records its source
+  // directory in that component name. Keep the evidence while removing the
+  // runner-specific prefix from the public document.
+  for (const component of cyclonedx.components) {
+    if (component?.type === "file" && path.basename(component.name ?? "") === "bun.lock") {
+      component.name = "/bun.lock";
+    }
+  }
+
+  const serialized = `${JSON.stringify(cyclonedx, null, 2)}\n`;
+  for (const forbidden of ["DO_NOT_COMMIT", "/Users/", "/home/runner/", "/private/var/"]) {
+    if (serialized.includes(forbidden)) fail(`Public SBOM contains forbidden runner or private path marker: ${forbidden}`);
+  }
+  await writeFile(options.cyclonedxPath, serialized);
+
+  return {
+    components: cyclonedx.components.length,
+    packages: syft.artifacts.length,
+    sentinels: SBOM_SENTINELS,
+  };
+}
+
+async function main() {
+  const [command, ...argv] = process.argv.slice(2);
+  const args = parseArgs(argv);
+  if (command === "prepare") {
+    const result = await prepareReleaseEvidence({
+      repositoryRoot: requireArg(args, "repository-root"),
+      subjectsRoot: requireArg(args, "subjects-root"),
+      sbomInput: requireArg(args, "sbom-input"),
+      evidenceDirectory: requireArg(args, "evidence-directory"),
+      version: requireArg(args, "version"),
+      repository: requireArg(args, "repository"),
+      commit: requireArg(args, "commit"),
+    });
+    console.log(
+      `Validated ${result.subjectEvidence.subjects.length} release subjects; classified ${result.applicability.counts.runtimePackageNames} runtime package names.`,
+    );
+    return;
+  }
+  if (command === "finalize-sbom") {
+    const result = await finalizeSbom({
+      cyclonedxPath: requireArg(args, "cyclonedx"),
+      syftPath: requireArg(args, "syft"),
+      subjectsPath: requireArg(args, "subjects"),
+      version: requireArg(args, "version"),
+      repository: requireArg(args, "repository"),
+      commit: requireArg(args, "commit"),
+      syftVersion: requireArg(args, "syft-version"),
+    });
+    console.log(
+      `Validated CycloneDX 1.6 SBOM with ${result.components} components and sentinels: ${result.sentinels.join(", ")}`,
+    );
+    return;
+  }
+  if (command === "verify-subjects") {
+    const count = await verifyReleaseSubjects({
+      subjectsRoot: requireArg(args, "subjects-root"),
+      subjectsPath: requireArg(args, "subjects"),
+      version: requireArg(args, "version"),
+      repository: requireArg(args, "repository"),
+      commit: requireArg(args, "commit"),
+    });
+    console.log(`Revalidated ${count} release subjects against the security gate evidence.`);
+    return;
+  }
+  fail(`Unknown command: ${command ?? "<missing>"}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(`release evidence error: ${error.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/release-security/release-evidence.test.mjs
+++ b/scripts/release-security/release-evidence.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { buildApplicability, finalizeSbom, RELEASE_WORKSPACES, SBOM_SENTINELS } from "./release-evidence.mjs";
+
+function workspaceLock() {
+  const workspaces = Object.fromEntries(
+    RELEASE_WORKSPACES.map((workspacePath, index) => [
+      workspacePath,
+      { name: index === 0 ? "plannotator" : `workspace-${index}`, dependencies: {} },
+    ]),
+  );
+  workspaces[""].dependencies = { runtime: "1.0.0", "workspace-1": "workspace:*" };
+  workspaces[""].devDependencies = { development: "1.0.0" };
+  workspaces[RELEASE_WORKSPACES[1]].dependencies = { nested: "1.0.0" };
+  return {
+    workspaces,
+    packages: {
+      runtime: ["runtime@1.0.0", "", { dependencies: { transitive: "1.0.0" } }],
+      nested: ["nested@1.0.0", "", {}],
+      transitive: ["transitive@1.0.0", "", {}],
+      development: ["development@1.0.0", "", {}],
+    },
+  };
+}
+
+test("classifies release production dependency closure conservatively", () => {
+  const result = buildApplicability(workspaceLock());
+  assert.deepEqual(result.runtimePackageNames, ["nested", "runtime", "transitive"]);
+  assert.deepEqual(result.developmentOnlyPackageNames, ["development"]);
+});
+
+test("rejects a lock missing a release workspace", () => {
+  const lock = workspaceLock();
+  delete lock.workspaces[RELEASE_WORKSPACES.at(-1)];
+  assert.throws(() => buildApplicability(lock), /Release workspace is absent/);
+});
+
+async function sbomFixture() {
+  const directory = await mkdtemp(path.join(tmpdir(), "plannotator-sbom-test-"));
+  const cyclonedxPath = path.join(directory, "release.cdx.json");
+  const syftPath = path.join(directory, "release.syft.json");
+  const subjectsPath = path.join(directory, "subjects.json");
+  const components = SBOM_SENTINELS.map((name) => ({ type: "library", name, version: "1.0.0" }));
+  await writeFile(
+    cyclonedxPath,
+    JSON.stringify({
+      bomFormat: "CycloneDX",
+      specVersion: "1.6",
+      serialNumber: "urn:uuid:11111111-1111-4111-8111-111111111111",
+      version: 1,
+      metadata: {
+        timestamp: "2026-08-13T00:00:00Z",
+        tools: { components: [{ name: "syft", version: "1.51.0" }] },
+      },
+      components,
+    }),
+  );
+  await writeFile(syftPath, JSON.stringify({ artifacts: components }));
+  await writeFile(
+    subjectsPath,
+    JSON.stringify({
+      version: "0.27.1",
+      repository: "https://github.com/backnotprop/plannotator",
+      commit: "a".repeat(40),
+      subjects: [{ path: "plannotator-linux-x64" }],
+    }),
+  );
+  return { directory, cyclonedxPath, syftPath, subjectsPath };
+}
+
+test("finalizes required release metadata and sentinel assertions", async () => {
+  const fixture = await sbomFixture();
+  const result = await finalizeSbom({
+    ...fixture,
+    version: "0.27.1",
+    repository: "https://github.com/backnotprop/plannotator",
+    commit: "a".repeat(40),
+    syftVersion: "1.51.0",
+  });
+  assert.equal(result.components, SBOM_SENTINELS.length);
+  const output = JSON.parse(await readFile(fixture.cyclonedxPath, "utf8"));
+  assert.equal(output.metadata.component.name, "plannotator-release");
+  assert.equal(
+    output.metadata.component.properties.find((property) => property.name === "plannotator:source:commit").value,
+    "a".repeat(40),
+  );
+});
+
+test("rejects empty and sentinel-incomplete SBOMs", async () => {
+  const empty = await sbomFixture();
+  const emptyDocument = JSON.parse(await readFile(empty.cyclonedxPath, "utf8"));
+  emptyDocument.components = [];
+  await writeFile(empty.cyclonedxPath, JSON.stringify(emptyDocument));
+  await assert.rejects(
+    finalizeSbom({
+      ...empty,
+      version: "0.27.1",
+      repository: "https://github.com/backnotprop/plannotator",
+      commit: "a".repeat(40),
+      syftVersion: "1.51.0",
+    }),
+    /zero components/,
+  );
+
+  const incomplete = await sbomFixture();
+  const incompleteDocument = JSON.parse(await readFile(incomplete.cyclonedxPath, "utf8"));
+  incompleteDocument.components.pop();
+  await writeFile(incomplete.cyclonedxPath, JSON.stringify(incompleteDocument));
+  await assert.rejects(
+    finalizeSbom({
+      ...incomplete,
+      version: "0.27.1",
+      repository: "https://github.com/backnotprop/plannotator",
+      commit: "a".repeat(40),
+      syftVersion: "1.51.0",
+    }),
+    /missing release dependency sentinel/,
+  );
+});

--- a/scripts/release-security/run-release-security.sh
+++ b/scripts/release-security/run-release-security.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workspace="${GITHUB_WORKSPACE:-$(pwd)}"
+subjects_dir="${PLANNOTATOR_RELEASE_SUBJECTS_DIR:?Set PLANNOTATOR_RELEASE_SUBJECTS_DIR to the downloaded release subjects}"
+output_dir="${PLANNOTATOR_RELEASE_SECURITY_DIR:?Set PLANNOTATOR_RELEASE_SECURITY_DIR to an empty output directory}"
+repository="https://github.com/${GITHUB_REPOSITORY:-backnotprop/plannotator}"
+commit="${GITHUB_SHA:-$(git -C "$workspace" rev-parse HEAD)}"
+version="$(jq -r .version "$workspace/package.json")"
+
+syft_version="1.51.0"
+syft_commit="2293641e3bd628a01bb37639318d62c0ebe89b39"
+syft_manifest_sha256="3d85f1d0e1266cae4346514124665f10b7cefd9cce815be13921d199917e5581"
+syft_archive_sha256="2a2e837a2c8d59ec9af5472ee22d3b04ee463c4e44476ecf993fd1e5ab6ebc7f"
+
+grype_version="0.117.0"
+grype_commit="b5fa92bbcbef655497e3be840a2f718380e2cdd3"
+grype_manifest_sha256="960a8acecdd2fa4b20520cb04d7e11ab40df58fc22769b513a25b8257d18dcfe"
+grype_archive_sha256="38525dab1e06f162ebaa02f94d82d1f807076b011a44180cf2777edf1a7b9c26"
+
+cyclonedx_version="0.33.1"
+cyclonedx_commit="b3cfa4b0edc356dad07e0b6e7ab6da0a94af0246"
+cyclonedx_sha256="bfc8b2538da86fe239bc53658bbb63c1c8c510a293c1e6891aa5bea5d3c58746"
+
+if [[ "$(uname -s)" != "Linux" || "$(uname -m)" != "x86_64" ]]; then
+  echo "run-release-security.sh supports the release workflow's Linux x64 runner only" >&2
+  exit 1
+fi
+if [[ ! "$commit" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "Release commit must be a full 40-character SHA: $commit" >&2
+  exit 1
+fi
+
+tools_dir="$output_dir/tools"
+downloads_dir="$output_dir/downloads"
+sbom_input="$output_dir/sbom-input"
+evidence_dir="$output_dir/evidence"
+public_dir="$output_dir/public"
+db_dir="$output_dir/grype-db"
+grype_config="$workspace/scripts/release-security/grype.yaml"
+mkdir -p "$tools_dir" "$downloads_dir" "$sbom_input" "$evidence_dir" "$public_dir" "$db_dir"
+
+if [[ ! -f "$grype_config" ]]; then
+  echo "Pinned Grype configuration is missing: $grype_config" >&2
+  exit 1
+fi
+
+download() {
+  local url="$1"
+  local destination="$2"
+  curl --fail --location --retry 3 --proto '=https' --tlsv1.2 --output "$destination" "$url"
+}
+
+verify_sha256() {
+  local expected="$1"
+  local file="$2"
+  printf '%s  %s\n' "$expected" "$file" | sha256sum --check --strict -
+}
+
+syft_archive="$downloads_dir/syft_${syft_version}_linux_amd64.tar.gz"
+syft_manifest="$downloads_dir/syft_${syft_version}_checksums.txt"
+download "https://github.com/anchore/syft/releases/download/v${syft_version}/syft_${syft_version}_linux_amd64.tar.gz" "$syft_archive"
+download "https://github.com/anchore/syft/releases/download/v${syft_version}/syft_${syft_version}_checksums.txt" "$syft_manifest"
+verify_sha256 "$syft_manifest_sha256" "$syft_manifest"
+verify_sha256 "$syft_archive_sha256" "$syft_archive"
+(
+  cd "$downloads_dir"
+  grep "  $(basename "$syft_archive")$" "$(basename "$syft_manifest")" | sha256sum --check --strict -
+)
+tar -xzf "$syft_archive" -C "$tools_dir" syft
+
+grype_archive="$downloads_dir/grype_${grype_version}_linux_amd64.tar.gz"
+grype_manifest="$downloads_dir/grype_${grype_version}_checksums.txt"
+download "https://github.com/anchore/grype/releases/download/v${grype_version}/grype_${grype_version}_linux_amd64.tar.gz" "$grype_archive"
+download "https://github.com/anchore/grype/releases/download/v${grype_version}/grype_${grype_version}_checksums.txt" "$grype_manifest"
+verify_sha256 "$grype_manifest_sha256" "$grype_manifest"
+verify_sha256 "$grype_archive_sha256" "$grype_archive"
+(
+  cd "$downloads_dir"
+  grep "  $(basename "$grype_archive")$" "$(basename "$grype_manifest")" | sha256sum --check --strict -
+)
+tar -xzf "$grype_archive" -C "$tools_dir" grype
+
+cyclonedx_binary="$tools_dir/cyclonedx"
+download "https://github.com/CycloneDX/cyclonedx-cli/releases/download/v${cyclonedx_version}/cyclonedx-linux-x64" "$cyclonedx_binary"
+verify_sha256 "$cyclonedx_sha256" "$cyclonedx_binary"
+chmod +x "$tools_dir/syft" "$tools_dir/grype" "$cyclonedx_binary"
+
+# Schema validation does not require locale-sensitive behavior. Keep the
+# self-contained .NET CycloneDX binary independent of the runner's ICU image.
+export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+
+"$tools_dir/syft" version -o json | tee "$evidence_dir/syft-version.json"
+"$tools_dir/grype" --config "$grype_config" version -o json | tee "$evidence_dir/grype-version.json"
+"$cyclonedx_binary" --version | tee "$evidence_dir/cyclonedx-cli-version.txt"
+
+jq -e --arg version "$syft_version" --arg commit "$syft_commit" \
+  '.application == "syft" and .version == $version and .gitCommit == $commit' \
+  "$evidence_dir/syft-version.json" >/dev/null
+jq -e --arg version "$grype_version" --arg commit "$grype_commit" \
+  --argjson schema 6 \
+  '.application == "grype" and .version == $version and .gitCommit == $commit and .supportedDbSchema == $schema' \
+  "$evidence_dir/grype-version.json" >/dev/null
+grep -Fx "${cyclonedx_version}+${cyclonedx_commit}" "$evidence_dir/cyclonedx-cli-version.txt" >/dev/null
+
+bun "$workspace/scripts/release-security/release-evidence.mjs" prepare \
+  --repository-root "$workspace" \
+  --subjects-root "$subjects_dir" \
+  --sbom-input "$sbom_input" \
+  --evidence-directory "$evidence_dir" \
+  --version "$version" \
+  --repository "$repository" \
+  --commit "$commit"
+
+sbom_name="plannotator-${version}-release-sbom.cdx.json"
+public_sbom="$public_dir/$sbom_name"
+private_sbom="$evidence_dir/plannotator-${version}-release.sbom.syft.json"
+"$tools_dir/syft" scan "dir:$sbom_input" \
+  --source-name plannotator-release \
+  --source-version "$version" \
+  -o "syft-json=$private_sbom" \
+  -o "cyclonedx-json@1.6=$public_sbom"
+
+bun "$workspace/scripts/release-security/release-evidence.mjs" finalize-sbom \
+  --cyclonedx "$public_sbom" \
+  --syft "$private_sbom" \
+  --subjects "$evidence_dir/release-subjects.json" \
+  --version "$version" \
+  --repository "$repository" \
+  --commit "$commit" \
+  --syft-version "$syft_version"
+
+"$cyclonedx_binary" validate --input-file "$public_sbom" --input-format json --input-version v1_6
+"$tools_dir/syft" convert "$public_sbom" -o "syft-json=$evidence_dir/cyclonedx-roundtrip.syft.json"
+jq -e '.artifacts | length > 0' "$evidence_dir/cyclonedx-roundtrip.syft.json" >/dev/null
+(
+  cd "$public_dir"
+  sha256sum "$sbom_name" > "${sbom_name}.sha256"
+)
+
+export GRYPE_DB_CACHE_DIR="$db_dir"
+export GRYPE_DB_AUTO_UPDATE=false
+export GRYPE_DB_VALIDATE_BY_HASH_ON_START=true
+export GRYPE_DB_VALIDATE_AGE=true
+export GRYPE_DB_MAX_ALLOWED_BUILT_AGE=120h
+export GRYPE_CHECK_FOR_APP_UPDATE=false
+
+update_grype_database() {
+  local attempt
+  for attempt in 1 2 3; do
+    echo "Grype database update attempt ${attempt}/3"
+    if "$tools_dir/grype" --config "$grype_config" db update; then
+      return 0
+    fi
+    if [[ "$attempt" -eq 3 ]]; then
+      echo "Grype database update failed after 3 attempts" >&2
+      return 1
+    fi
+    sleep "$((attempt * 5))"
+  done
+}
+
+update_grype_database
+"$tools_dir/grype" --config "$grype_config" db status -o json > "$evidence_dir/grype-db-status.json"
+"$tools_dir/grype" --config "$grype_config" db list -o json > "$evidence_dir/grype-db-list.json"
+"$tools_dir/grype" --config "$grype_config" db check -o json > "$evidence_dir/grype-db-check.json"
+"$tools_dir/grype" --config "$grype_config" "sbom:$private_sbom" -o json > "$evidence_dir/grype-results.json"
+
+policy_arguments=(
+  --scan "$evidence_dir/grype-results.json"
+  --db-status "$evidence_dir/grype-db-status.json"
+  --db-list "$evidence_dir/grype-db-list.json"
+  --db-check "$evidence_dir/grype-db-check.json"
+  --applicability "$evidence_dir/release-applicability.json"
+  --grype-version "$grype_version"
+  --output "$evidence_dir/grype-policy-result.json"
+  --summary "$evidence_dir/grype-policy-summary.md"
+)
+if [[ -n "${PLANNOTATOR_RELEASE_VEX:-}" ]]; then
+  policy_arguments+=(--vex "$PLANNOTATOR_RELEASE_VEX")
+fi
+policy_status=0
+bun "$workspace/scripts/release-security/grype-policy.mjs" "${policy_arguments[@]}" || policy_status=$?
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" && -f "$evidence_dir/grype-policy-summary.md" ]]; then
+  cat "$evidence_dir/grype-policy-summary.md" >> "$GITHUB_STEP_SUMMARY"
+fi
+if [[ "$policy_status" -ne 0 ]]; then
+  exit "$policy_status"
+fi
+
+echo "Release security evidence is ready:"
+echo "  public SBOM: $public_sbom"
+echo "  private evidence: $evidence_dir"


### PR DESCRIPTION
## Summary

Adds the missing inventory/evaluation layer to the existing release trust chain without replacing SLSA build provenance or npm trusted publishing:

- generates a public, schema-validated CycloneDX 1.6 release SBOM with pinned Syft 1.51.0 after all 12 native binaries and both npm tarballs exist
- evaluates the SBOM with pinned Grype 0.117.0 and a freshly updated, checksum-recorded schema-v6 database
- enforces a small repository-owned, unit-tested release policy before any attestation or publication
- attaches the SBOM and its SHA256 sidecar to GitHub Releases
- binds the SBOM predicate to all 14 shipped subjects through GitHub's existing OIDC artifact-attestation service
- preserves the existing `actions/attest-build-provenance` native provenance and `npm publish --provenance` paths unchanged

## Official attestation and scanner choices

This uses the current general-purpose [`actions/attest`](https://github.com/actions/attest) action in `sbom-path` mode, pinned to `1e69f48acb82d1966a394da916b4c1698aa569d6` (`v4.2.2`). GitHub has deprecated the older `actions/attest-sbom` wrapper in favor of this mode. `subject-path` names the 12 binaries and two npm tarballs, so the attestation binds the CycloneDX predicate to shipped artifact digests; the SBOM file is not incorrectly used as the subject.

Syft, Grype, and CycloneDX CLI are standalone upstream release binaries. Every version, upstream commit, release checksum manifest, archive checksum, and executable-reported version is pinned/verified. There is no moving `latest` URL, remote install script, project runtime dependency, Anchore account, separate Sigstore account, or cosign/key-management path.

## Workflow behavior

### Pull requests and manual dry-runs

The credential-free `release-security` job downloads the exact `binaries` and `npm-packages` workflow artifacts, generates/validates the SBOM, updates and validates the Grype database, scans, applies policy, and uploads evidence. It has only `contents: read`; it has no OIDC, attestation, release-write, npm, or deployment permission. Grype is always invoked with the repository-owned suppression-free config (never an ambient `.grype.yaml`), scanner-side ignored matches are rejected, and the large database update gets three bounded attempts before failing closed.

PRs therefore prove the generation, schema/sentinel validation, scan, policy, and evidence path without publishing or attesting anything.

### Eligible `v*` tags

`release-security` must succeed before:

- the isolated tag-only `attest` job can mint OIDC or write attestations
- `npm-publish` can enter its existing environment-scoped trusted-publishing path
- `release` can publish GitHub assets (it remains downstream of `attest`)

The attestation job checks out no repository code and rechecks the gate's subject digests before producing existing SLSA provenance plus the new CycloneDX attestation. A rejected release cannot reach SLSA/SBOM attestation, npm publication, or GitHub release publication.

## SBOM scope and coverage

The public asset is stably named `plannotator-X.Y.Z-release-sbom.cdx.json`, with its own `.sha256` sidecar. Its metadata records the version, source repository, commit SHA, Syft version, generation timestamp, and an explicit scope/limitations statement.

The truthful scope is a **release-wide Syft inventory of the monorepo's locked build inputs and dependencies**, not an exact per-binary runtime inventory. Coverage spike results:

| Input | Syft packages |
|---|---:|
| Controlled clean `bun.lock` dependency graph | 862 |
| Representative Bun-compiled Plannotator binary | 0 |
| Representative Bun-compiled paste-service binary | 0 |
| Packed OpenCode npm tarball | 0 |
| Packed Pi npm tarball | 122 (nested lock metadata) |
| Output-only release staging directory | 0 |
| Finalized public release SBOM | 865 components |

Bun standalone executables hide bundled JavaScript package metadata from Syft, so neither the workflow nor the docs claim otherwise. The gate asserts justified sentinels (`@anthropic-ai/claude-agent-sdk`, `@joplin/turndown-plugin-gfm`, `@opencode-ai/sdk`, `@pierre/diffs`, `@plannotator/webtui`, and `marked`) and rejects missing, empty, malformed, zero-package, oversized, unsanitized, or sentinel-incomplete output. `DO_NOT_COMMIT`, caches, scanner tools/databases, temp paths, and host dependencies are outside the inventory and release asset.

## Grype policy and current baseline

The current post-rebase baseline used Grype database schema 6, version 6.1.9, built `2026-08-12T06:38:08Z`, with source checksum `sha256:334cbc9b87d518b06f3d12fca7f65d654ba685c2de262d2a840e771336935f7e`. Grype reported 38 findings: 13 High, 0 Critical, and 0 CISA KEV; applicability classified 26 runtime and 12 development-only. The policy accepted the baseline without an exception.

The gate fails closed on:

- missing or malformed scan/database evidence
- unavailable, inactive, incompatible, update-pending, or older-than-120-hours databases
- any scanner-side ignored match, including one introduced through ambient configuration or CLI suppression
- malformed or expired exception records
- CISA KEV findings classified as shipped/runtime or unknown-applicability
- fixable Critical findings classified as shipped/runtime or unknown-applicability

High, development-only, and no-fix Critical findings are initially report-only and remain in machine-readable evidence. Unknown applicability is surfaced and treated conservatively as runtime for the KEV/fixable-Critical gates rather than silently treated as safe. This narrow threshold blocks the strongest actionable release risks without making release availability depend on noisy or unfixable matches.

There is no active production exception. The evaluator supports an optional, explicitly wired OpenVEX-compatible document only if a future baseline genuinely requires one. Statements must match one exact vulnerability and package URL and include a standard status/justification, evidence URL, owner, created timestamp, and expiration; tests reject expired, malformed, broad, and nonmatching records.

The machine-readable Grype report, full match set (including repository-policy-suppressed VEX findings), database status, tool versions, and policy decision remain short-lived workflow evidence rather than becoming a noisy durable release asset. Scheduled post-release rescanning remains a separate follow-up.

## Consumer verification

Existing installer verification remains opt-in and unchanged; normal installation still does not require `gh`.

```bash
tag=vX.Y.Z
version="${tag#v}"
mkdir -p /tmp/plannotator-release-verify
gh release download "$tag" \
  --repo backnotprop/plannotator \
  --pattern 'plannotator-linux-x64*' \
  --pattern "plannotator-${version}-release-sbom.cdx.json*" \
  --dir /tmp/plannotator-release-verify

(cd /tmp/plannotator-release-verify && sha256sum --check plannotator-linux-x64.sha256)
(cd /tmp/plannotator-release-verify && sha256sum --check "plannotator-${version}-release-sbom.cdx.json.sha256")

gh attestation verify /tmp/plannotator-release-verify/plannotator-linux-x64 \
  --repo backnotprop/plannotator \
  --source-ref "refs/tags/$tag" \
  --signer-workflow backnotprop/plannotator/.github/workflows/release.yml \
  --predicate-type https://slsa.dev/provenance/v1

gh attestation verify /tmp/plannotator-release-verify/plannotator-linux-x64 \
  --repo backnotprop/plannotator \
  --source-ref "refs/tags/$tag" \
  --signer-workflow backnotprop/plannotator/.github/workflows/release.yml \
  --predicate-type https://cyclonedx.org/bom
```

The release operator runbook also extracts the attested predicate, canonicalizes it and the release asset with `jq -S`, compares them byte-for-byte, and repeats subject verification for one npm tarball.

## Validation completed

- exact release checksums and reported versions verified for Syft 1.51.0, Grype 0.117.0, and CycloneDX CLI 0.33.1
- `bun install --frozen-lockfile`
- release UI/hook/OpenCode/Pi builds, representative native/paste binaries, and both npm packs
- actual end-to-end SBOM generation, CycloneDX 1.6 formal validation, Syft round-trip validation, sentinel assertions, current Grype scan, database policy, and ACCEPT decision
- `bun test scripts/release-security` — 14/14 pass, including runtime and unknown-applicability Critical/KEV, scanner-side ignored matches, stale/missing/incompatible DB, malformed evidence, and VEX cases
- `bun run typecheck`
- `bun run build:marketing` (Astro 7, 40 pages)
- actionlint 1.7.12 and zizmor 1.29.0 on the changed workflow
- workflow event/condition/needs/environment/permission audit and immutable-action-pin audit
- clean tracked-file audit: no generated SBOM/report, scanner binary/database, credential, cache, or `DO_NOT_COMMIT` content

The full local `bun test` suite is environment-sensitive: the normal run passed 3,370 tests and skipped 496, with 14 semantic-diff tests affected by the maintainer workstation's persisted `semanticDiff=false` setting; those 14 passed with isolated Plannotator data. A clean Linux container passed 3,367 and skipped 503, with 10 existing platform/container-specific process/runtime/permission cases. This PR's clean GitHub checks are the authoritative complete-suite result and will be monitored to completion.

Performance impact is one additional serialized Ubuntu job plus pinned tool/database downloads. The scan itself completed in seconds locally; downloads and the fresh database update dominate. The final hardened hosted `release-security` run completed in 1m24s, with the database update succeeding on attempt 1 of the bounded 3-attempt retry loop.

## Real-tag validation gap and first-release checklist

A pull request cannot prove GitHub OIDC issuance, publication to GitHub's artifact-attestation service, or final immutable release-asset publication because those paths correctly run only for an eligible real `v*` tag. For the first release after merge, the release operator must:

1. verify `release-security` accepted with the expected tool/DB versions and inspect its retained evidence
2. verify the SBOM asset and sidecar checksums
3. verify both SLSA and CycloneDX predicates with the pinned repository/ref/workflow identity
4. canonicalize and compare the attested CycloneDX predicate with the downloaded public SBOM
5. verify the SBOM attestation for one exact npm tarball subject
6. treat any discrepancy as a release blocker and ship a new version rather than mutating the immutable release

The exact commands are now in `.agents/skills/release/SKILL.md` and the public verification documentation.

The repository's legacy Astro documentation is redirect-only and deprecated, so this PR keeps the exact public commands in README and adds an explicit first-release checklist item to copy the scope, policy, and commands to the canonical Mintlify installation/verification page and confirm the live page before tagging.
