### PR TITLE
ci(security): add isolated ZAP DAST monitoring

### DIFF
--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -1,0 +1,328 @@
+name: ZAP DAST
+
+on:
+  schedule:
+    - cron: "47 16 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: zap-dast-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  BUN_VERSION: 1.3.11
+  TARGET_IMAGE: oven/bun:1.3.11-slim@sha256:478281fdd196871c7e51ba6a820b7803a8ae97042ec86cdbc2e1c6b6626442d9
+  ZAP_VERSION: 2.17.0
+  ZAP_IMAGE: ghcr.io/zaproxy/zaproxy:stable@sha256:781a2bdaea47324e7bab583e2263f21d257b0aee61ed51521a5be45f5f5081ef
+  DAST_NETWORK: plannotator-dast-${{ github.run_id }}-${{ github.run_attempt }}
+  DAST_TARGET: plannotator-dast-target-${{ github.run_id }}-${{ github.run_attempt }}
+
+jobs:
+  passive-baseline:
+    name: Passive baseline
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Test DAST evidence validator
+        run: bun test scripts/dast/report.test.ts
+
+      - name: Build disposable target UI
+        run: bun run build:review && bun run build:hook
+
+      - name: Pull and verify pinned runtime images
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          pull_image() {
+            local image=$1
+            for attempt in 1 2 3; do
+              if docker pull "$image"; then
+                return 0
+              fi
+              if (( attempt == 3 )); then
+                echo "Failed to pull $image after three attempts." >&2
+                return 1
+              fi
+              sleep $((attempt * 5))
+            done
+          }
+
+          pull_image "$TARGET_IMAGE"
+          pull_image "$ZAP_IMAGE"
+
+          target_digest=$(docker image inspect --format '{{index .RepoDigests 0}}' "$TARGET_IMAGE")
+          zap_digest=$(docker image inspect --format '{{index .RepoDigests 0}}' "$ZAP_IMAGE")
+          [[ "$target_digest" == *@"${TARGET_IMAGE##*@}" ]]
+          [[ "$zap_digest" == *@"${ZAP_IMAGE##*@}" ]]
+
+          actual_bun=$(docker run --rm --network none "$TARGET_IMAGE" bun --version)
+          [[ "$actual_bun" == "$BUN_VERSION" ]]
+          [[ "$(docker run --rm --network none "$TARGET_IMAGE" id -u bun)" == "1000" ]]
+          [[ "$(docker image inspect --format '{{.Config.User}}' "$ZAP_IMAGE")" == "zap" ]]
+
+          actual_zap=$(
+            docker run --rm --network none --hostname zap "$ZAP_IMAGE" zap.sh -version 2>&1 \
+              | tail -n 1
+          )
+          [[ "$actual_zap" == "$ZAP_VERSION" ]]
+
+          {
+            echo "### Pinned DAST runtimes"
+            echo "- Bun target image: $target_digest (Bun $actual_bun)"
+            echo "- ZAP image: $zap_digest (ZAP $actual_zap)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Start isolated disposable targets
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p security-results/zap
+          chmod 777 security-results/zap
+
+          # ZAP's stock database template allows only 32 MiB of cached response
+          # data. Plannotator's single-file UI is over 20 MiB, so derive the
+          # exact template from the pinned image and change only that limit.
+          docker run --rm \
+            --network none \
+            --entrypoint cat \
+            "$ZAP_IMAGE" \
+            /zap/db/zapdb.script > security-results/zap/zapdb.script
+          [[ "$(grep -c '^SET FILES CACHE SIZE 32000$' security-results/zap/zapdb.script)" == "1" ]]
+          sed -i 's/^SET FILES CACHE SIZE 32000$/SET FILES CACHE SIZE 131072/' \
+            security-results/zap/zapdb.script
+          grep -qx 'SET FILES CACHE SIZE 131072' security-results/zap/zapdb.script
+          chmod 444 security-results/zap/zapdb.script
+
+          docker network create \
+            --internal \
+            --label plannotator.security-scan=dast \
+            "$DAST_NETWORK"
+          [[ "$(docker network inspect --format '{{.Internal}}' "$DAST_NETWORK")" == "true" ]]
+          docker run --rm \
+            --network "$DAST_NETWORK" \
+            --user 1000:1000 \
+            --read-only \
+            --cap-drop ALL \
+            --security-opt no-new-privileges \
+            "$TARGET_IMAGE" \
+            bun -e '
+              const escaped = await fetch("http://192.0.2.1", {
+                signal: AbortSignal.timeout(2000),
+              }).then(
+                () => true,
+                () => false,
+              );
+              if (escaped) throw new Error("Internal DAST network permits outbound traffic.");
+            '
+
+          docker run --detach \
+            --name "$DAST_TARGET" \
+            --label plannotator.security-scan=dast \
+            --user 1000:1000 \
+            --network "$DAST_NETWORK" \
+            --network-alias plannotator-dast-target \
+            --read-only \
+            --cap-drop ALL \
+            --security-opt no-new-privileges \
+            --pids-limit 128 \
+            --memory 1g \
+            --cpus 2 \
+            --tmpfs /tmp:rw,nosuid,nodev,size=128m \
+            --env HOME=/tmp/home \
+            --env PLANNOTATOR_DATA_DIR=/tmp/plannotator \
+            --env PLANNOTATOR_DAST_ISOLATED=1 \
+            --volume "$GITHUB_WORKSPACE:/workspace:ro" \
+            --workdir /workspace \
+            "$TARGET_IMAGE" \
+            bun run scripts/dast/target.ts
+
+          for _ in {1..60}; do
+            if docker run --rm \
+              --network "$DAST_NETWORK" \
+              --user 1000:1000 \
+              --read-only \
+              --cap-drop ALL \
+              --security-opt no-new-privileges \
+              "$TARGET_IMAGE" \
+              bun -e '
+                const base = "http://plannotator-dast-target";
+                const checks = [
+                  [19432, "/", 200],
+                  [19432, "/api/plan", 200],
+                  [19432, "/api/ai/capabilities", 200],
+                  [19432, "/api/definitely-missing", 404],
+                  [19432, "/robots.txt", 404],
+                  [19433, "/", 200],
+                ];
+                for (const [port, path, expected] of checks) {
+                  const response = await fetch(`${base}:${port}${path}`);
+                  if (response.status !== expected) {
+                    throw new Error(`${path}: expected ${expected}, got ${response.status}`);
+                  }
+                }
+                const blocked = await fetch(`${base}:19432/api/approve`, { method: "POST" });
+                if (blocked.status !== 405) {
+                  throw new Error(`POST guard: expected 405, got ${blocked.status}`);
+                }
+                const upstreamExposed = await fetch(`${base}:19434/`).then(
+                  () => true,
+                  () => false,
+                );
+                if (upstreamExposed) throw new Error("Unprotected upstream port is network-accessible.");
+              ' >/dev/null 2>&1; then
+              exit 0
+            fi
+            if ! docker inspect --format '{{.State.Running}}' "$DAST_TARGET" | grep -qx true; then
+              docker logs "$DAST_TARGET" >&2
+              exit 1
+            fi
+            sleep 1
+          done
+
+          docker logs "$DAST_TARGET" >&2
+          echo 'Disposable DAST targets did not become healthy.' >&2
+          exit 1
+
+      - name: Verify ZAP detector health
+        shell: bash
+        run: |
+          set -euo pipefail
+          set +e
+          docker run --rm \
+            --network "$DAST_NETWORK" \
+            --read-only \
+            --cap-drop ALL \
+            --security-opt no-new-privileges \
+            --pids-limit 512 \
+            --memory 2g \
+            --tmpfs /tmp:rw,nosuid,nodev,size=256m,mode=1777 \
+            --tmpfs /home/zap/.ZAP:rw,nosuid,nodev,size=256m,uid=1000,gid=1000,mode=0700 \
+            --tmpfs /home/zap/.cache:rw,nosuid,nodev,size=128m,uid=1000,gid=1000,mode=0700 \
+            --tmpfs /home/zap/.config:rw,nosuid,nodev,size=64m,uid=1000,gid=1000,mode=0700 \
+            --tmpfs /home/zap/.mozilla:rw,nosuid,nodev,size=128m,uid=1000,gid=1000,mode=0700 \
+            --volume "$GITHUB_WORKSPACE/security-results/zap:/zap/wrk:rw" \
+            --volume "$GITHUB_WORKSPACE/security-results/zap/zapdb.script:/zap/db/zapdb.script:ro" \
+            --volume "$GITHUB_WORKSPACE/scripts/dast/zap-hooks.py:/zap/hooks.py:ro" \
+            --workdir /zap/wrk \
+            "$ZAP_IMAGE" \
+            zap-baseline.py \
+              --autooff \
+              -t http://plannotator-dast-target:19433 \
+              -m 0 \
+              -T 5 \
+              -I \
+              -z "-Xmx1024m -silent -config database.response.bodysize=33554432" \
+              --hook /zap/hooks.py \
+              -J sentinel.json \
+              -r sentinel.html \
+              -w sentinel.md \
+              -l WARN \
+              2>&1 | tee security-results/zap/sentinel.log
+          scan_status=${PIPESTATUS[0]}
+          set -e
+          if [[ "$scan_status" -eq 3 || "$scan_status" -gt 3 ]]; then
+            echo "ZAP detector-health scan failed with exit $scan_status." >&2
+            exit "$scan_status"
+          fi
+          mv security-results/zap/zap.out security-results/zap/sentinel-zap.log
+
+      - name: Scan disposable Plannotator session
+        shell: bash
+        run: |
+          set -euo pipefail
+          set +e
+          docker run --rm \
+            --network "$DAST_NETWORK" \
+            --read-only \
+            --cap-drop ALL \
+            --security-opt no-new-privileges \
+            --pids-limit 512 \
+            --memory 3g \
+            --tmpfs /tmp:rw,nosuid,nodev,size=512m,mode=1777 \
+            --tmpfs /home/zap/.ZAP:rw,nosuid,nodev,size=1g,uid=1000,gid=1000,mode=0700 \
+            --tmpfs /home/zap/.cache:rw,nosuid,nodev,size=256m,uid=1000,gid=1000,mode=0700 \
+            --tmpfs /home/zap/.config:rw,nosuid,nodev,size=128m,uid=1000,gid=1000,mode=0700 \
+            --tmpfs /home/zap/.mozilla:rw,nosuid,nodev,size=256m,uid=1000,gid=1000,mode=0700 \
+            --volume "$GITHUB_WORKSPACE/security-results/zap:/zap/wrk:rw" \
+            --volume "$GITHUB_WORKSPACE/security-results/zap/zapdb.script:/zap/db/zapdb.script:ro" \
+            --volume "$GITHUB_WORKSPACE/scripts/dast/zap-hooks.py:/zap/hooks.py:ro" \
+            --workdir /zap/wrk \
+            "$ZAP_IMAGE" \
+            zap-baseline.py \
+              --autooff \
+              -t http://plannotator-dast-target:19432 \
+              -m 1 \
+              -T 10 \
+              -I \
+              -z "-Xmx2048m -silent -config database.response.bodysize=33554432" \
+              --hook /zap/hooks.py \
+              -J plannotator.json \
+              -r plannotator.html \
+              -w plannotator.md \
+              -l WARN \
+              2>&1 | tee security-results/zap/plannotator.log
+          scan_status=${PIPESTATUS[0]}
+          set -e
+          if [[ "$scan_status" -eq 3 || "$scan_status" -gt 3 ]]; then
+            echo "ZAP application scan failed with exit $scan_status." >&2
+            exit "$scan_status"
+          fi
+          mv security-results/zap/zap.out security-results/zap/plannotator-zap.log
+
+      - name: Validate and summarize DAST evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+          bun run scripts/dast/report.ts \
+            --report security-results/zap/plannotator.json \
+            --sentinel-report security-results/zap/sentinel.json \
+            --scan-log security-results/zap/plannotator.log \
+            --zap-log security-results/zap/plannotator-zap.log \
+            --sentinel-zap-log security-results/zap/sentinel-zap.log \
+            --minimum-urls 8 \
+            --expected-host plannotator-dast-target \
+            --sentinel-rule 10020 \
+            --summary security-results/zap/summary.md \
+            --evidence security-results/zap/evidence.json
+          cat security-results/zap/summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Capture target diagnostics and tear down
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          mkdir -p security-results/zap
+          if docker inspect "$DAST_TARGET" >/dev/null 2>&1; then
+            docker logs "$DAST_TARGET" > security-results/zap/target.log 2>&1
+            docker rm --force "$DAST_TARGET"
+          fi
+          docker network rm "$DAST_NETWORK"
+          exit 0
+
+      - name: Upload DAST evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: zap-dast-${{ github.run_id }}-${{ github.run_attempt }}
+          path: security-results/zap/
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/dast/README.md
+++ b/scripts/dast/README.md
@@ -1,0 +1,50 @@
+# Isolated OWASP ZAP DAST
+
+The `ZAP DAST` workflow runs a passive baseline scan against a disposable
+Plannotator annotate session. Both the application and ZAP run on a Docker
+network created with `--internal`, so neither can reach production or any
+external service. No repository, cloud, npm, model-provider, or user
+credentials are passed to either container.
+
+The workflow is intentionally scheduled/manual rather than part of every PR:
+
+```bash
+gh workflow run dast.yml --repo backnotprop/plannotator
+```
+
+Each run retains the human-readable HTML report, machine-readable JSON report,
+Markdown report, target/scanner logs, and a small evidence manifest for 30
+days. Findings are initially monitor-only. Missing targets, empty coverage,
+malformed reports, scanner failures, and failure to detect the controlled
+passive-scan fixture fail the workflow.
+
+The scan hook seeds `/`, `/api/plan`, the disabled-AI capabilities response,
+and an unknown-API 404 through ZAP. The traditional spider is confined to that
+small API 404 because parsing the single-file bundle as static HTML creates
+false link candidates. A read-only route guard forwards those approved GET
+routes to the real annotate server and returns small 404 responses for crawler
+metadata or any other path. It also rejects every state-changing HTTP method.
+Browser/AJAX crawling was evaluated and deferred: ZAP's pinned image does not
+carry a WebDriver and an internal network correctly prevents downloading one
+at runtime. This keeps the scan deterministic and offline while still
+passively inspecting real Plannotator UI and API responses.
+
+ZAP passive rule `10003` (Vulnerable JS Library) is disabled deliberately.
+Trivy owns repository dependency detection and Grype owns release dependency
+decisions. On Plannotator's 20+ MiB single-file bundle, rule `10003` also tries
+to store the complete bundle as alert evidence and exceeds ZAP's alert-column
+limit. Informational rule `10109` (Modern App Detection) is disabled for the
+same evidence-size reason; it is not a vulnerability decision. All other
+passive web rules still receive the full response.
+
+The same large response exceeds the 32 MiB cache in ZAP's stock HSQLDB
+template once scan metadata is included. At run time, the workflow extracts
+that template from the digest-pinned image, verifies the expected setting,
+changes only the cache limit to 128 MiB, and mounts the derived template
+read-only. The validator fails closed if ZAP reports cache exhaustion, disk
+exhaustion, or a response-size truncation.
+
+The target entry point refuses to start unless
+`PLANNOTATOR_DAST_ISOLATED=1`. Do not set that acknowledgement outside an
+isolated disposable environment. The workflow is the supported execution
+path; the target is not a production server.

--- a/scripts/dast/report.test.ts
+++ b/scripts/dast/report.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import {
+  assertAlert,
+  assertExpectedHost,
+  assertHealthyZapLog,
+  assertMinimumCoverage,
+  extractCrawledUrlCount,
+  parseZapReport,
+  summarizeAlerts,
+} from "./report";
+
+const report = parseZapReport(
+  JSON.stringify({
+    site: [
+      {
+        "@name": "http://plannotator-dast-target:19432",
+        "@host": "plannotator-dast-target",
+        alerts: [
+          { pluginid: "10020", riskdesc: "Low (Medium)", instances: [{}] },
+          { alertRef: "10038", riskdesc: "Medium (High)", instances: [{}] },
+          { pluginid: "90000", riskdesc: "Informational (Low)", instances: [] },
+        ],
+      },
+    ],
+  }),
+  "fixture",
+);
+
+describe("DAST report validation", () => {
+  test("validates the target host and controlled rule", () => {
+    expect(() =>
+      assertExpectedHost(report, "plannotator-dast-target"),
+    ).not.toThrow();
+    expect(() => assertAlert(report, "10020")).not.toThrow();
+  });
+
+  test("rejects an absent target or detector-health rule", () => {
+    expect(() =>
+      assertExpectedHost(report, "production.example.com"),
+    ).toThrow();
+    expect(() => assertAlert(report, "missing-rule")).toThrow();
+  });
+
+  test("rejects any report host outside the explicit allowlist", () => {
+    const mixedHostReport = parseZapReport(
+      JSON.stringify({
+        site: [
+          { "@host": "plannotator-dast-target", alerts: [] },
+          { "@host": "production.example.com", alerts: [] },
+        ],
+      }),
+      "mixed-host fixture",
+    );
+    expect(() =>
+      assertExpectedHost(mixedHostReport, "plannotator-dast-target"),
+    ).toThrow("outside the allowlist");
+  });
+
+  test("requires evidence that at least one URL was crawled", () => {
+    expect(extractCrawledUrlCount("Total of 1 URL\nTotal of 4 URLs")).toBe(4);
+    expect(() => extractCrawledUrlCount("scan completed")).toThrow();
+    expect(() => extractCrawledUrlCount("Total of 0 URLs")).toThrow();
+    expect(() => assertMinimumCoverage(9, 8)).not.toThrow();
+    expect(() => assertMinimumCoverage(7, 8)).toThrow();
+  });
+
+  test("rejects scanner-engine errors even when reports exist", () => {
+    expect(() => assertHealthyZapLog("INFO scan complete")).not.toThrow();
+    expect(() => assertHealthyZapLog("ERROR database write failed")).toThrow();
+    expect(() =>
+      assertHealthyZapLog(
+        "The actual Response Body length 20000000 is greater than the configured response body length 16777216",
+      ),
+    ).toThrow();
+    expect(() =>
+      assertHealthyZapLog(
+        "WARN ClientSpiderTask - Task 1 failed Unable to obtain driver",
+      ),
+    ).toThrow();
+    expect(() =>
+      assertHealthyZapLog("WARN Data cache size limit is reached: 32000"),
+    ).toThrow();
+    expect(() =>
+      assertHealthyZapLog("java.io.IOException: No space left on device"),
+    ).toThrow();
+  });
+
+  test("summarizes alert rules by risk", () => {
+    expect(summarizeAlerts(report)).toEqual({
+      total: 3,
+      high: 0,
+      medium: 1,
+      low: 1,
+      informational: 1,
+      unknown: 0,
+    });
+  });
+
+  test("rejects malformed or empty reports", () => {
+    expect(() => parseZapReport("not-json", "bad report")).toThrow();
+    expect(() => parseZapReport("{}", "empty report")).toThrow();
+    expect(() => parseZapReport('{"site":[{}]}', "bad site")).toThrow();
+  });
+});

--- a/scripts/dast/report.ts
+++ b/scripts/dast/report.ts
@@ -1,0 +1,329 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+type ZapAlert = {
+  pluginid?: string;
+  alertRef?: string;
+  alert?: string;
+  riskdesc?: string;
+  instances?: unknown[];
+};
+
+type ZapSite = {
+  "@name"?: string;
+  "@host"?: string;
+  alerts?: ZapAlert[];
+};
+
+type ZapReport = {
+  site?: ZapSite[];
+};
+
+export type AlertSummary = {
+  total: number;
+  high: number;
+  medium: number;
+  low: number;
+  informational: number;
+  unknown: number;
+};
+
+function assertRecord(
+  value: unknown,
+  label: string,
+): asserts value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be a JSON object.`);
+  }
+}
+
+export function parseZapReport(raw: string, label: string): ZapReport {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`${label} is not valid JSON: ${String(error)}`);
+  }
+  assertRecord(parsed, label);
+  if (!Array.isArray(parsed.site)) {
+    throw new Error(`${label} does not contain a site array.`);
+  }
+  for (const [index, site] of parsed.site.entries()) {
+    assertRecord(site, `${label} site ${index}`);
+    if (!Array.isArray(site.alerts)) {
+      throw new Error(
+        `${label} site ${index} does not contain an alerts array.`,
+      );
+    }
+  }
+  return parsed as ZapReport;
+}
+
+export function flattenAlerts(report: ZapReport): ZapAlert[] {
+  return (report.site ?? []).flatMap((site) => site.alerts ?? []);
+}
+
+export function assertExpectedHost(
+  report: ZapReport,
+  expectedHost: string,
+): void {
+  const hosts = (report.site ?? []).map((site, index) => {
+    if (site["@host"]) return site["@host"];
+    if (!site["@name"]) {
+      throw new Error(`ZAP report site ${index} does not identify its host.`);
+    }
+    try {
+      return new URL(site["@name"]).hostname;
+    } catch {
+      throw new Error(`ZAP report site ${index} has an invalid URL.`);
+    }
+  });
+  if (!hosts.includes(expectedHost)) {
+    throw new Error(
+      `ZAP report does not contain expected host ${expectedHost}.`,
+    );
+  }
+  const unexpectedHosts = [
+    ...new Set(hosts.filter((host) => host !== expectedHost)),
+  ];
+  if (unexpectedHosts.length > 0) {
+    throw new Error(
+      `ZAP report contains hosts outside the allowlist: ${unexpectedHosts.join(", ")}.`,
+    );
+  }
+}
+
+export function assertAlert(report: ZapReport, ruleId: string): void {
+  const found = flattenAlerts(report).some(
+    (alert) => alert.pluginid === ruleId || alert.alertRef === ruleId,
+  );
+  if (!found) {
+    throw new Error(`Controlled ZAP fixture did not trigger rule ${ruleId}.`);
+  }
+}
+
+export function extractCrawledUrlCount(log: string): number {
+  const matches = [...log.matchAll(/Total of\s+(\d+)\s+URLs?/gi)];
+  if (matches.length === 0) {
+    throw new Error("ZAP log does not report how many URLs were crawled.");
+  }
+  const count = Math.max(...matches.map((match) => Number(match[1])));
+  if (!Number.isSafeInteger(count) || count < 1) {
+    throw new Error(
+      `ZAP reported an invalid crawled URL count: ${String(count)}.`,
+    );
+  }
+  return count;
+}
+
+export function assertMinimumCoverage(count: number, minimum: number): void {
+  if (!Number.isSafeInteger(minimum) || minimum < 1) {
+    throw new Error(
+      `Minimum URL coverage must be a positive integer; got ${minimum}.`,
+    );
+  }
+  if (count < minimum) {
+    throw new Error(`ZAP reached ${count} URLs; expected at least ${minimum}.`);
+  }
+}
+
+export function assertHealthyZapLog(log: string): void {
+  const unhealthyPatterns = [
+    /\bERROR\b/,
+    /OutOfMemoryError/,
+    /greater than the configured response body length/i,
+    /failed to start zap/i,
+    /no urls found/i,
+    /ClientSpiderTask - Task .*failed/i,
+    /Data cache size limit is reached/i,
+    /No space left on device/i,
+  ];
+  const matched = unhealthyPatterns.find((pattern) => pattern.test(log));
+  if (matched) {
+    throw new Error(
+      `ZAP engine log contains an unhealthy condition (${matched}).`,
+    );
+  }
+}
+
+export function summarizeAlerts(report: ZapReport): AlertSummary {
+  const summary: AlertSummary = {
+    total: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+    informational: 0,
+    unknown: 0,
+  };
+  for (const alert of flattenAlerts(report)) {
+    summary.total += 1;
+    const risk = (alert.riskdesc ?? "").split(" ", 1)[0].toLowerCase();
+    if (risk === "high") summary.high += 1;
+    else if (risk === "medium") summary.medium += 1;
+    else if (risk === "low") summary.low += 1;
+    else if (risk === "informational" || risk === "info")
+      summary.informational += 1;
+    else summary.unknown += 1;
+  }
+  return summary;
+}
+
+type CliOptions = {
+  report: string;
+  sentinelReport: string;
+  scanLog: string;
+  zapLog: string;
+  sentinelZapLog: string;
+  minimumUrls: number;
+  expectedHost: string;
+  sentinelRule: string;
+  summary: string;
+  evidence: string;
+};
+
+function parseArgs(args: string[]): CliOptions {
+  const values = new Map<string, string>();
+  for (let index = 0; index < args.length; index += 2) {
+    const name = args[index];
+    const value = args[index + 1];
+    if (!name?.startsWith("--") || !value) {
+      throw new Error(
+        `Expected --name value arguments; received ${args.join(" ")}.`,
+      );
+    }
+    values.set(name.slice(2), value);
+  }
+  const required = [
+    "report",
+    "sentinel-report",
+    "scan-log",
+    "zap-log",
+    "sentinel-zap-log",
+    "minimum-urls",
+    "expected-host",
+    "sentinel-rule",
+    "summary",
+    "evidence",
+  ];
+  for (const key of required) {
+    if (!values.get(key))
+      throw new Error(`Missing required argument --${key}.`);
+  }
+  const minimumUrls = Number(values.get("minimum-urls"));
+  if (!Number.isSafeInteger(minimumUrls) || minimumUrls < 1) {
+    throw new Error("--minimum-urls must be a positive integer.");
+  }
+  return {
+    report: values.get("report")!,
+    sentinelReport: values.get("sentinel-report")!,
+    scanLog: values.get("scan-log")!,
+    zapLog: values.get("zap-log")!,
+    sentinelZapLog: values.get("sentinel-zap-log")!,
+    minimumUrls,
+    expectedHost: values.get("expected-host")!,
+    sentinelRule: values.get("sentinel-rule")!,
+    summary: values.get("summary")!,
+    evidence: values.get("evidence")!,
+  };
+}
+
+function markdownSummary(summary: AlertSummary, crawledUrls: number): string {
+  return [
+    "### OWASP ZAP passive DAST",
+    `- URLs crawled: ${crawledUrls}`,
+    `- Alert rules: ${summary.total}`,
+    `- High: ${summary.high}`,
+    `- Medium: ${summary.medium}`,
+    `- Low: ${summary.low}`,
+    `- Informational: ${summary.informational}`,
+    `- Unclassified: ${summary.unknown}`,
+    "- Enforcement: monitor mode; scanner, target, coverage, and detector-health failures block the job",
+    "- Target: disposable annotate session on an internal Docker network; no production services or credentials",
+    "",
+  ].join("\n");
+}
+
+function main(args: string[]): void {
+  const options = parseArgs(args);
+  const report = parseZapReport(
+    readFileSync(options.report, "utf8"),
+    "application report",
+  );
+  const sentinel = parseZapReport(
+    readFileSync(options.sentinelReport, "utf8"),
+    "detector-health report",
+  );
+  assertExpectedHost(report, options.expectedHost);
+  assertExpectedHost(sentinel, options.expectedHost);
+  assertAlert(sentinel, options.sentinelRule);
+  const scanLog = readFileSync(options.scanLog, "utf8");
+  const crawledUrls = extractCrawledUrlCount(scanLog);
+  assertMinimumCoverage(crawledUrls, options.minimumUrls);
+  assertHealthyZapLog(scanLog);
+  assertHealthyZapLog(readFileSync(options.zapLog, "utf8"));
+  assertHealthyZapLog(readFileSync(options.sentinelZapLog, "utf8"));
+  const alertSummary = summarizeAlerts(report);
+  writeFileSync(options.summary, markdownSummary(alertSummary, crawledUrls));
+  writeFileSync(
+    options.evidence,
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        commit: process.env.GITHUB_SHA ?? "local",
+        workflowRun: process.env.GITHUB_RUN_ID ?? "local",
+        generatedAt: new Date().toISOString(),
+        scanMode: "passive-baseline",
+        target: {
+          kind: "disposable-annotate-session",
+          host: options.expectedHost,
+          outboundNetwork: "blocked-by-internal-docker-network",
+          ai: "disabled",
+          sharing: "disabled",
+          persistence: "disabled",
+        },
+        scanner: {
+          name: "OWASP ZAP",
+          version: process.env.ZAP_VERSION ?? "unknown",
+          image: process.env.ZAP_IMAGE ?? "unknown",
+          responseBodyLimitBytes: 33_554_432,
+          databaseCacheKiB: 131_072,
+        },
+        coverage: {
+          crawledUrls,
+          minimumRequired: options.minimumUrls,
+          seededRoutes: [
+            "/",
+            "/api/plan",
+            "/api/ai/capabilities",
+            "/api/definitely-missing",
+          ],
+        },
+        detectorHealth: { rule: options.sentinelRule, status: "detected" },
+        disabledRules: [
+          {
+            id: "10003",
+            reason:
+              "Dependency CVEs are owned by Trivy/Grype; this rule cannot store evidence for the 20+ MiB single-file bundle.",
+          },
+          {
+            id: "10109",
+            reason:
+              "Informational modern-app detection stores the entire single-file bundle as evidence and exceeds ZAP's alert-column limit.",
+          },
+        ],
+        findings: alertSummary,
+        enforcement: "monitor-findings-fail-closed-health",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+if (import.meta.main) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/dast/target.ts
+++ b/scripts/dast/target.ts
@@ -1,0 +1,147 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { startAnnotateServer } from "../../packages/server/annotate";
+
+const SCAN_PORT = 19432;
+const SENTINEL_PORT = 19433;
+const APP_PORT = 19434;
+
+if (process.env.PLANNOTATOR_DAST_ISOLATED !== "1") {
+  throw new Error(
+    "Refusing to start the DAST target without PLANNOTATOR_DAST_ISOLATED=1. " +
+      "Run it only inside the workflow's internal Docker network.",
+  );
+}
+
+// These are defense-in-depth defaults for the test target. The Docker network
+// is the primary outbound boundary; the application is also configured so an
+// accidentally reached feature cannot invoke agents, share content, persist
+// review data, open a browser, or install optional runtimes.
+Object.assign(process.env, {
+  PLANNOTATOR_REMOTE: "0",
+  PLANNOTATOR_PORT: String(APP_PORT),
+  PLANNOTATOR_AI: "disabled",
+  PLANNOTATOR_SHARE: "disabled",
+  PLANNOTATOR_JINA: "0",
+  PLANNOTATOR_ANNOTATE_HISTORY: "0",
+  PLANNOTATOR_GUIDE_HISTORY: "0",
+  PLANNOTATOR_TODO_PROVIDER: "off",
+  PLANNOTATOR_GLIMPSE: "0",
+  PLANNOTATOR_SKIP_BROWSER_OPEN: "1",
+  PLANNOTATOR_SKIP_AGENT_TERMINAL_INSTALL: "1",
+  PLANNOTATOR_SKIP_SEM_INSTALL: "1",
+  PLANNOTATOR_FILE_BROWSER_MAX_FILES: "64",
+  BROWSER: "true",
+});
+
+const htmlPath = resolve("apps/hook/dist/index.html");
+const htmlContent = readFileSync(htmlPath, "utf8");
+
+const application = await startAnnotateServer({
+  markdown: [
+    "# Disposable DAST fixture",
+    "",
+    "This document exists only inside an isolated GitHub Actions runner.",
+    "",
+    "- It contains no credentials or user data.",
+    "- Submitting feedback is outside the passive scan scope.",
+  ].join("\n"),
+  filePath: "dast-fixture.md",
+  htmlContent,
+  mode: "annotate-last",
+  origin: "claude-code",
+  sharingEnabled: false,
+  gate: false,
+  project: "dast-fixture",
+});
+
+const forwardedPaths = new Set([
+  "/",
+  "/api/plan",
+  "/api/ai/capabilities",
+  "/api/definitely-missing",
+]);
+const readOnlyMethods = new Set(["GET", "HEAD"]);
+
+// Place a read-only route guard in front of the real annotate server. ZAP's
+// baseline spider requests crawler metadata such as /robots.txt and
+// /sitemap.xml; the application's browser fallback correctly serves the SPA
+// for those paths, but feeding the 20+ MiB bundle back to a static spider is
+// both wasteful and misleading. The guard also makes it impossible for this
+// passive workflow to reach state-changing application endpoints.
+const scanTarget = Bun.serve({
+  hostname: "0.0.0.0",
+  port: SCAN_PORT,
+  async fetch(request) {
+    const sourceUrl = new URL(request.url);
+    if (
+      !readOnlyMethods.has(request.method) ||
+      !forwardedPaths.has(sourceUrl.pathname)
+    ) {
+      return new Response("Not found", {
+        status:
+          request.method === "GET" || request.method === "HEAD" ? 404 : 405,
+        headers: {
+          "Content-Type": "text/plain; charset=utf-8",
+          "X-Plannotator-DAST-Guard": "blocked",
+        },
+      });
+    }
+
+    const upstreamUrl = new URL(request.url);
+    upstreamUrl.hostname = "127.0.0.1";
+    upstreamUrl.port = String(APP_PORT);
+    const response = await fetch(upstreamUrl, {
+      method: request.method,
+      headers: request.headers,
+      redirect: "manual",
+    });
+    const headers = new Headers(response.headers);
+    headers.set("X-Plannotator-DAST-Guard", "forwarded");
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  },
+});
+
+// A harmless detector-health target. Its deliberately absent defensive
+// headers should trigger ZAP rule 10020 (anti-clickjacking header missing).
+// It is separate from the application report and never enters a product build.
+const sentinel = Bun.serve({
+  hostname: "0.0.0.0",
+  port: SENTINEL_PORT,
+  fetch(request) {
+    const { pathname } = new URL(request.url);
+    if (pathname === "/healthz") {
+      return new Response("ok", {
+        headers: { "Content-Type": "text/plain; charset=utf-8" },
+      });
+    }
+    return new Response(
+      "<!doctype html><html><head><title>ZAP detector health</title></head>" +
+        "<body><h1>Controlled passive-scan fixture</h1></body></html>",
+      { headers: { "Content-Type": "text/html; charset=utf-8" } },
+    );
+  },
+});
+
+console.log(
+  JSON.stringify({
+    event: "dast-target-ready",
+    applicationPort: application.port,
+    scanPort: scanTarget.port,
+    sentinelPort: sentinel.port,
+  }),
+);
+
+await new Promise<void>((resolveShutdown) => {
+  const shutdown = () => resolveShutdown();
+  process.once("SIGINT", shutdown);
+  process.once("SIGTERM", shutdown);
+});
+
+sentinel.stop(true);
+scanTarget.stop(true);
+application.stop();

--- a/scripts/dast/zap-hooks.py
+++ b/scripts/dast/zap-hooks.py
@@ -1,0 +1,42 @@
+"""Deterministic hooks for Plannotator's packaged ZAP baseline scan."""
+
+
+def zap_access_target(zap, target):
+    # Seed the real read-only application routes through ZAP so passive rules
+    # inspect the SPA plus its JSON/error responses without invoking any
+    # state-changing endpoint.
+    for path in (
+        "",
+        "/api/plan",
+        "/api/ai/capabilities",
+        "/api/definitely-missing",
+    ):
+        response = zap.urlopen(target.rstrip("/") + path)
+        if response.startswith("ZAP Error"):
+            raise RuntimeError(f"ZAP failed to seed {path or '/'}: {response}")
+    return zap, target
+
+
+def zap_tuned(zap):
+    # Dependency CVEs are owned by Trivy (repository) and Grype (release).
+    # ZAP rule 10003 also tries to store the entire 20+ MiB single-file bundle
+    # as alert evidence, exceeding ZAP's 16 MiB alert-column limit and turning
+    # a redundant check into an engine error. Disable only that rule; the
+    # remaining passive web rules continue to inspect the full response.
+    # 10109 (Modern App Detection) similarly captures the full HTML response
+    # as evidence; its informational classification is not a vulnerability
+    # decision and exceeds the same alert-column limit for this bundle.
+    zap.pscan.disable_scanners("10003,10109")
+
+
+def zap_spider(zap, target):
+    # The traditional spider treats strings inside Plannotator's 20+ MiB
+    # single-file JavaScript bundle as links. Send that spider to a small,
+    # read-only API 404 instead. (The favicon path is handled by the SPA
+    # fallback and therefore returns the full bundle.) zap_access_target above
+    # seeds the real UI/API responses through the passive scanner. Keeping the
+    # spider on the application origin also keeps detector-fixture findings out
+    # of the application report.
+    if target.rstrip("/").endswith(":19432"):
+        return zap, target.rstrip("/") + "/api/definitely-missing"
+    return zap, target


### PR DESCRIPTION
## Summary

- add a weekly/manual OWASP ZAP 2.17.0 passive baseline against a real disposable Plannotator annotate session
- confine the target and scanner to an internal-only Docker network with no secrets, read-only filesystems, dropped capabilities, non-root execution, resource limits, and an explicit outbound-network canary
- put a read-only method/path guard in front of the loopback-only application so ZAP can observe approved UI/API responses but cannot reach state-changing endpoints
- verify scanner health with a controlled missing-header fixture, enforce an exclusive target-host allowlist and minimum URL coverage, and fail closed on malformed reports or engine/cache/memory errors
- retain HTML, JSON, Markdown, logs, a target diagnostic, and a machine-readable evidence manifest for 30 days

Findings start in monitor mode. Scanner/target/report/coverage/detector failures block the workflow; the application findings themselves do not block yet.

## Local baseline

The digest-pinned end-to-end run completed against the isolated target:

- URLs: 9
- High: 0
- Medium: 2 — CSP and anti-clickjacking headers
- Low: 2 — `X-Content-Type-Options` and timestamp disclosure
- Informational: 1 — suspicious comments

Rules 10003 and 10109 are explicitly disabled with rationale: both try to retain the entire 20+ MiB single-file UI as alert evidence and exceed ZAP's alert-column limit; dependency CVEs remain owned by Trivy/Grype, while 10109 is only modern-app classification.

## Verification

- exact containerized ZAP detector-health and application scans
- `bun test scripts/dast/report.test.ts` — 7 passed
- `bun run typecheck`
- `bun run build:review && bun run build:hook`
- actionlint 1.7.7 — clean
- zizmor 1.29.0 offline/regular/strict — zero findings
- affected Pi server tests with isolated config — 29 passed

The ordinary full-suite run on this workstation inherits the user's persisted `reviewAnalysis.semanticDiff: false` and therefore changes seven unrelated Pi expectations; rerunning that affected file with isolated config is clean. GitHub's fresh runner remains the authoritative full-suite result.

## Rollout

This workflow intentionally has only `schedule` and `workflow_dispatch` triggers. After merge, run it once manually with:

```bash
gh workflow run dast.yml --repo backnotprop/plannotator
```

Then review the retained baseline evidence and observe two weekly runs before promoting any stable rule to blocking or expanding to additional disposable targets/active scanning.
