### PR TITLE
Mobile Phase 2B: Plan shell and navigation

### DIFF
--- a/adr/research/synthesis-mobile-feedback-triage-20260812.md
+++ b/adr/research/synthesis-mobile-feedback-triage-20260812.md
@@ -71,6 +71,15 @@ No Phase 3 multi-block or multi-line selection semantics are claimed by this
 cleanup. Pinpoint one-block targeting and native drag selection remain the
 known input foundations for the 2B.2 physical gate.
 
+The next iPhone folder pass exposed one state-transition defect inside 2B.1:
+file selection closed the navigator, then asynchronous linked-document
+activation replayed the desktop “open Files sidebar” behavior and resurrected
+the compact navigator. That close/reopen sequence caused the visible flashing
+and forced the reviewer to use X before seeing the selected document. Compact
+activation now suppresses that desktop-only side effect; the selected filename
+and document render with the navigator remaining closed, while fine-pointer
+desktop keeps its incumbent sidebar activation.
+
 ## Triage matrix
 
 `Now` means the next implementation checkpoint. `Next` is the first structural

--- a/adr/research/synthesis-mobile-feedback-triage-20260812.md
+++ b/adr/research/synthesis-mobile-feedback-triage-20260812.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-12
 Status: Phase 2A implementation accepted as the working mobile baseline;
-filename micro-gate pending in parallel, Phase 2B.1 ready for physical review
+filename micro-gate pending in parallel, Phase 2B.2 ready for physical review
 Source dossier: [`SPIKE-mobile-web-compatibility-20260812.md`](./SPIKE-mobile-web-compatibility-20260812.md)
 Foundation spec: [`mobile-platform-foundation-phase1-20260812.md`](../specs/mobile-platform-foundation-phase1-20260812.md)
 Phase 2B spec: [`mobile-plan-shell-phase2b-20260813.md`](../specs/mobile-plan-shell-phase2b-20260813.md)
@@ -44,6 +44,32 @@ and prevents a phone workaround from mutating desktop preferences.
 | Guided Review intro | Preserve | The reviewer found the initial Guide explanation useful. Guide is a strong candidate for mobile comprehension, not noise to remove. |
 | Edit Code to Suggest | Preserve | The tested dialog was acceptable; suggestion editing is not pulled into the next layout phase. |
 | All Files | Preserve and learn from | It was the cleanest Code Review presentation observed on the phone. |
+
+## Phase 2B physical feedback incorporated
+
+The first 2B.1 phone pass clarified that restoring folder navigation was not
+enough: once a file was selected, the Plan still exposed its entire desktop
+annotation matrix plus Wide / Focus / Edit micro-links. The reviewer also asked
+for Plan completion decisions to follow the Code Review pattern and move into
+Options.
+
+This feedback is assigned to 2B.2 and implemented as one compact document-
+chrome contract:
+
+- arrival shows one `Annotate · <method>` entry instead of Select / Pinpoint
+  beside Markup / Comment / Redline / Label;
+- compact targeting is always presented through Markup semantics, with Select
+  text and Pinpoint as the only up-front acquisition choices;
+- compact method choices remain session-only, protecting desktop preferences;
+- Wide and Focus are removed from compact touch entirely;
+- Edit moves into Options and gains a normal-flow Save / Done / Cancel row while
+  active; and
+- terminal decisions move into Options while calling the exact incumbent
+  handlers and warning paths.
+
+No Phase 3 multi-block or multi-line selection semantics are claimed by this
+cleanup. Pinpoint one-block targeting and native drag selection remain the
+known input foundations for the 2B.2 physical gate.
 
 ## Triage matrix
 

--- a/adr/research/synthesis-mobile-feedback-triage-20260812.md
+++ b/adr/research/synthesis-mobile-feedback-triage-20260812.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-12
 Status: Phase 2A implementation accepted as the working mobile baseline;
-filename micro-gate pending, Phase 2B specified
+filename micro-gate pending in parallel, Phase 2B.1 ready for physical review
 Source dossier: [`SPIKE-mobile-web-compatibility-20260812.md`](./SPIKE-mobile-web-compatibility-20260812.md)
 Foundation spec: [`mobile-platform-foundation-phase1-20260812.md`](../specs/mobile-platform-foundation-phase1-20260812.md)
 Phase 2B spec: [`mobile-plan-shell-phase2b-20260813.md`](../specs/mobile-plan-shell-phase2b-20260813.md)
@@ -310,6 +310,60 @@ The physical iPhone iteration established a stable baseline:
 Do not reopen the rejected scroll architecture during Phase 2B. A future
 document-native Pierre Virtualizer experiment, if pursued, must remain isolated
 and earn promotion through complete interaction parity plus physical testing.
+
+## Phase 2B.1 implementation checkpoint
+
+Checkpoint 2B.1 is implemented on `codex/mobile-phase-2b-plan-shell`. It keeps
+the Phase 1 document-scroll owner and introduces a session-only compact
+foreground state instead of reusing desktop rail booleans.
+
+- Compact touch arrives on the artifact even when the remembered desktop right
+  panel is open. Annotation and AI buttons/panels remain out of the compact
+  arrival composition; their dedicated foreground states belong to 2B.3.
+- A leading **Plan** disclosure opens one full-stage navigator. It is bounded
+  by the observed visual viewport and safe areas, contains focus/Escape,
+  restores the trigger on explicit close, and gives its tabs and destination
+  rows 44 px touch targets.
+- The navigator reuses `SidebarContainer`, `TableOfContents`, `FileBrowser`,
+  `VersionBrowser`, `MessagesBrowser`, and `ArchiveBrowser`. Desktop keeps the
+  incumbent sticky/resizable presentation; there is no second browser model.
+- Contents, file, message, archive, and linked-document destinations return to
+  the artifact. Tab changes remain inside the navigator. File loading listens
+  to the compact Files state without writing `sidebar.activeTab`, so opening
+  Files on a phone does not alter the desktop sidebar state.
+- Folder annotation no longer instructs a phone user to find a hidden sidebar.
+  Its empty state has a touch-safe **Choose a file** action that opens Files.
+- The Plan header remains in normal page flow on compact touch. No fixed or
+  sticky mobile edge bar, Safari scroll proxy, selection semantic, server,
+  Tailscale, or Pierre code changed.
+
+Focused proof covers the foreground reducer, compact-arrival desktop-panel
+gate, header disclosure, shared navigator desktop/overlay presentations,
+visible-viewport and touch CSS, focus and tab behavior, and the folder empty
+state. Shared typecheck, production UI CSS, and the production Hook build pass.
+A 1440×900 fine-pointer browser control retained the 48 px sticky header,
+240 px sticky Contents rail, 288 px right panel, and zero root/main horizontal
+overflow. Responsive Chromium does not expose a coarse pointer in this run, so
+it deliberately retained desktop presentation at phone width; physical Safari
+remains the authoritative compact checkpoint.
+
+### Phase 2B.1 physical review script
+
+1. Open the folder checkpoint on iPhone. Arrival should show the empty artifact
+   and **Choose a file**, not a sidebar or Ask AI.
+2. Tap **Choose a file**, select any fixture, and confirm the navigator closes
+   to the selected document. Tap **Plan**, return to Files, and choose a second
+   file; the same close-to-artifact behavior should repeat.
+3. Open **Plan** → Contents and choose a heading. Confirm it returns to the same
+   document at that heading without changing Safari's accepted page scrolling.
+4. Close the navigator with its close button, reopen it, and rotate once. No
+   right rail, AI panel, or stale navigator should squeeze the artifact.
+5. Open the ordinary document checkpoint separately. The document—not Ask AI,
+   annotations, or navigation—must be the first surface.
+
+This gate judges navigation and arrival only. Persistent annotation chrome,
+direct-edit controls, auxiliary surfaces, completion, and multi-block selection
+remain checkpoints 2B.2, 2B.3, and Phase 3 respectively.
 
 ## Why selection is not bundled into layout
 

--- a/adr/specs/mobile-plan-shell-phase2b-20260813.md
+++ b/adr/specs/mobile-plan-shell-phase2b-20260813.md
@@ -258,6 +258,18 @@ Physical correction:
 - A full-App coarse-pointer test loads a real file tree through the shared
   backend, selects a file, waits for `/api/doc`, and proves that the selected
   document and filename render while the navigator remains closed.
+- A later physical cold-load review exposed a second transition defect: the
+  navigator closed before the first `/api/doc` request completed, briefly
+  revealing the folder landing page and its `Choose a file` action. Warm file
+  switches were fast enough to hide the same ordering bug.
+- Compact file selection now keeps Files visible, marks the selected
+  destination as `Opening…`, and prevents competing selections until document
+  activation succeeds. It then closes the initiating navigator; a failed load
+  leaves Files open for retry. Desktop retains its incumbent asynchronous
+  sidebar behavior.
+- The full-App test now holds `/api/doc` behind a deliberate gate and proves
+  that the navigator remains visible and the selected file is busy/disabled
+  throughout the delay before closing on successful activation.
 
 ### 2B.2 — Compact document chrome and direct edit
 

--- a/adr/specs/mobile-plan-shell-phase2b-20260813.md
+++ b/adr/specs/mobile-plan-shell-phase2b-20260813.md
@@ -243,6 +243,22 @@ Physical gate:
    is the first surface.
 5. Rotate and confirm no desktop rail appears.
 
+Physical correction:
+
+- iPhone review found that selecting a folder file visibly changed the
+  document behind the navigator but left the navigator open. The transition
+  flashed because it briefly closed and then returned.
+- The selection handler was closing the compact foreground state correctly;
+  asynchronous document activation later invoked `useLinkedDoc`'s incumbent
+  desktop instruction to open the Files sidebar. On compact touch, that desktop
+  side effect reopened the navigator after the destination loaded.
+- Compact document activation now leaves foreground navigation to the compact
+  state owner. A file tap closes the navigator and the later activation cannot
+  resurrect it; desktop still opens its incumbent sidebar tab.
+- A full-App coarse-pointer test loads a real file tree through the shared
+  backend, selects a file, waits for `/api/doc`, and proves that the selected
+  document and filename render while the navigator remains closed.
+
 ### 2B.2 — Compact document chrome and direct edit
 
 Implement the three-region header, idle annotation entry/contextual tools,

--- a/adr/specs/mobile-plan-shell-phase2b-20260813.md
+++ b/adr/specs/mobile-plan-shell-phase2b-20260813.md
@@ -1,7 +1,7 @@
 # Spec: Mobile Plan Shell and Navigation — Phase 2B
 
 Date: 2026-08-13
-Status: In progress; checkpoint 2B.2 implementation ready for physical iPhone/iPad review while the Phase 2A filename micro-gate continues in parallel
+Status: In progress; checkpoint 2B.3 implementation ready for physical iPhone/iPad review while the Phase 2A filename micro-gate continues in parallel
 Depends on: Phase 1 mobile platform foundation and Phase 2A mobile Code Review shell
 Research: [`SPIKE-mobile-web-compatibility-20260812.md`](../research/SPIKE-mobile-web-compatibility-20260812.md)
 Sequence: [`synthesis-mobile-feedback-triage-20260812.md`](../research/synthesis-mobile-feedback-triage-20260812.md)
@@ -320,6 +320,36 @@ Physical gate:
 4. Background/restore the phone and rotate once with unsent feedback.
 5. Reload at desktop width and confirm the saved sidebar/right-panel layout,
    sticky actions, header actions, and edit controls are unchanged.
+
+Implementation checkpoint:
+
+- Annotations and Ask AI now open as mutually exclusive, visible-viewport
+  compact stages. They replace the artifact while active, keep one internal
+  scroll owner, and return focus to the opening control when closed.
+- The shared annotation timeline gained an embedded presentation seam; its
+  incumbent desktop panel geometry, backdrop, header, and persisted open state
+  remain unchanged.
+- A normal-flow completion block follows eligible Plan and document artifacts.
+  It summarizes the current feedback state and opens the same Review surface
+  exposed from Options; edit, diff, goal, HTML, and unselected-folder states do
+  not render it.
+- Review reuses the incumbent decision callbacks and policy rather than adding
+  another submission state machine. Feedback-bearing sessions prioritize Send
+  Feedback, approval-capable clean sessions prioritize Approve, and close-only
+  sessions retain their established exit behavior.
+- Compact stages use the Phase 1 visible-viewport and safe-area contract, 44 px
+  touch targets, immediate interaction feedback, focus containment, and a
+  16 px Ask AI input. No fixed or sticky Safari-edge control was introduced.
+- Full-App coarse-pointer tests cover mutual exclusion, close behavior, the
+  end-of-document entry, decision submission, edit exclusion, and the absence
+  of desktop-only terminal actions in compact Options. Shared component tests
+  cover focus containment, embedded annotation presentation, review ordering,
+  and terminal action semantics.
+- The editor/UI DOM suite passes 111 tests with 412 expectations. Shared
+  typecheck, production UI CSS, Hook, and OpenCode builds pass, together with
+  `git diff --check`. Fine-pointer rendered preflight retained the incumbent
+  desktop sidebar/right-panel composition with no compact completion block or
+  full-stage overlay.
 
 Phase 2B passes only when all three checkpoints pass on physical iPhone and the
 relevant iPad matrix. Browser preflight cannot close the phase.

--- a/adr/specs/mobile-plan-shell-phase2b-20260813.md
+++ b/adr/specs/mobile-plan-shell-phase2b-20260813.md
@@ -1,7 +1,7 @@
 # Spec: Mobile Plan Shell and Navigation — Phase 2B
 
 Date: 2026-08-13
-Status: Proposed; implementation begins after the Phase 2A filename micro-gate
+Status: In progress; checkpoint 2B.1 ready for physical iPhone/iPad review while the Phase 2A filename micro-gate continues in parallel
 Depends on: Phase 1 mobile platform foundation and Phase 2A mobile Code Review shell
 Research: [`SPIKE-mobile-web-compatibility-20260812.md`](../research/SPIKE-mobile-web-compatibility-20260812.md)
 Sequence: [`synthesis-mobile-feedback-triage-20260812.md`](../research/synthesis-mobile-feedback-triage-20260812.md)

--- a/adr/specs/mobile-plan-shell-phase2b-20260813.md
+++ b/adr/specs/mobile-plan-shell-phase2b-20260813.md
@@ -1,7 +1,7 @@
 # Spec: Mobile Plan Shell and Navigation — Phase 2B
 
 Date: 2026-08-13
-Status: In progress; checkpoint 2B.1 ready for physical iPhone/iPad review while the Phase 2A filename micro-gate continues in parallel
+Status: In progress; checkpoint 2B.2 implementation ready for physical iPhone/iPad review while the Phase 2A filename micro-gate continues in parallel
 Depends on: Phase 1 mobile platform foundation and Phase 2A mobile Code Review shell
 Research: [`SPIKE-mobile-web-compatibility-20260812.md`](../research/SPIKE-mobile-web-compatibility-20260812.md)
 Sequence: [`synthesis-mobile-feedback-triage-20260812.md`](../research/synthesis-mobile-feedback-triage-20260812.md)
@@ -108,8 +108,9 @@ It contains three geometrically stable regions:
    tab).
 2. **Document identity** — current basename or plan identity, with the full path
    available to accessibility and leading-ellipsis treatment when constrained.
-3. **Options** — opens a compact action menu containing Review, Annotations,
-   Ask AI when available, view/edit commands, and secondary application actions.
+3. **Options** — opens a compact action menu containing the incumbent terminal
+   decisions, Edit when available, and secondary application actions. Annotations
+   and Ask AI join this menu in checkpoint 2B.3.
 
 The header does not show simultaneous Send Feedback, Approve, Annotations, AI,
 and Options controls. It does not show desktop keyboard shortcuts. Branding is
@@ -150,10 +151,14 @@ Compact touch arrives in `artifact` with the document first. The existing
 input method and annotation semantics are preserved, but their full matrix is
 not persistently expanded.
 
-- Idle state shows one explicit `Annotate` entry with the current method named.
-- Opening it reveals the incumbent input-method choices and makes `Pinpoint`
-  clearly identifiable as the tap-oriented method. Phase 2B does not silently
-  overwrite the user's persisted method.
+- Compact touch always presents the incumbent Markup semantics: selecting a
+  target reveals the contextual Copy / Delete / Comment / Label actions instead
+  of requiring a permanent action-mode row. This is a compact presentation
+  decision and never overwrites the saved desktop action mode.
+- Idle state shows one explicit `Annotate · <method>` entry.
+- Opening it reveals only `Select text` and `Pinpoint`. Pinpoint is named as the
+  one-block tap method; Select text is named as the drag-over-text method.
+  Choices are session-local and never overwrite the saved desktop input method.
 - Markup / Comment / Redline / Label actions appear contextually after a valid
   target exists, not as a permanent second toolbar on arrival.
 - Compact controls use the shared 44 px touch contract and immediate press
@@ -169,8 +174,10 @@ unresolved semantics with CSS.
 
 ### Document card and direct editing
 
-Wide and Focus are secondary mobile presentation choices. They move into
-Options rather than occupying absolute micro-links above the document card.
+Wide and Focus are desktop workspace presentation choices. They are not shown
+on compact touch—not above the card and not in Options—because the phone already
+gives the artifact its available width and exposes no simultaneous panels to
+focus away.
 
 Direct Edit remains supported:
 
@@ -250,6 +257,38 @@ Physical gate:
 3. Enter direct edit, type with the software keyboard, Save, rotate, and Done.
 4. Confirm every edit control is fully visible and at least 44 px tall.
 5. Confirm no persistent duplicate toolbar or shortcut glyph dominates arrival.
+
+Implementation checkpoint:
+
+- The compact header is now a stable 52 px grid containing a 44 px navigation
+  target, centered current-document basename, and a 44 px Options target. It
+  remains normal-flow so the accepted Safari document-scroll behavior is
+  unchanged.
+- Close / Send Feedback / Approve, callback decisions, archive decisions, and
+  goal-setup decisions move into Options only on compact touch. Every item calls
+  the incumbent handler and therefore retains the established confirmation,
+  unsaved-file, transport, and agent-validation behavior.
+- Persistent Select / Pinpoint and Markup / Comment / Redline / Label groups are
+  replaced with one `Annotate · <method>` disclosure. The revealed choices are
+  only Select text and Pinpoint; contextual feedback actions still come from the
+  existing target toolbar.
+- Compact annotation always uses Markup semantics without writing the saved
+  desktop action mode. Compact input-method changes are session-only as well.
+- Wide and Focus are absent on compact touch. Desktop keeps their existing
+  absolute micro-controls and behavior unchanged.
+- Edit moves into Options. Once editing starts, a normal-flow row above the
+  editor identifies the document and exposes source-file Save plus Done/Cancel/
+  two-step Discard through the existing edit state machine.
+- Desktop rendered preflight retained the incumbent 48 px flex header, full
+  toolstrip, Wide / Focus / Edit controls, and exact page width with no overflow.
+  A narrow fine-pointer control also retained desktop composition. Compact
+  coarse-pointer rendering remains a physical-device gate.
+- A full-App coarse-pointer integration test now proves the real compact route:
+  current filename in the three-region header, one annotation disclosure, no
+  persistent desktop tool matrix, session-only input-method changes, review
+  decisions and Edit in Options, and the in-flow edit row. Eighteen focused DOM
+  tests and 72 editor tests pass, along with shared typecheck, production UI CSS,
+  Hook, and OpenCode builds plus `git diff --check`.
 
 ### 2B.3 — Auxiliary and completion surfaces
 

--- a/packages/editor/App.archiveReadOnly.test.tsx
+++ b/packages/editor/App.archiveReadOnly.test.tsx
@@ -12,6 +12,7 @@ if (hasDom) {
 }
 
 const storageModule = hasDom ? await import("@plannotator/ui/utils/storage") : null;
+const fileTreeModule = hasDom ? await import("@plannotator/ui/hooks/useFileBrowser") : null;
 const appModule = hasDom ? await import("./App") : null;
 const App = appModule?.default as typeof import("./App")["default"];
 const originalFetch = globalThis.fetch;
@@ -21,10 +22,11 @@ const originalMatchMedia = hasDom ? window.matchMedia : undefined;
 interface PlanResponse {
   readonly plan: string;
   readonly origin: "codex";
-  readonly mode: "archive" | "annotate";
+  readonly mode: "archive" | "annotate" | "annotate-folder";
   readonly filePath?: string;
   readonly sourceSave?: SourceSaveCapability;
   readonly gate?: boolean;
+  readonly projectRoot?: string;
   readonly archivePlans?: readonly [{
     readonly filename: string;
     readonly status: "approved";
@@ -94,6 +96,16 @@ function useCompactTouchMedia(): void {
   })) as typeof window.matchMedia;
 }
 
+function useSingleFileTree(): void {
+  fileTreeModule?.setFileTreeBackend({
+    loadTree: async () => Response.json({
+      tree: [{ name: "alpha.md", path: "alpha.md", type: "file" }],
+    }),
+    loadVaultTree: async () => Response.json({ error: "Unavailable" }, { status: 404 }),
+    watchTrees: () => undefined,
+  });
+}
+
 function findButton(label: string): HTMLButtonElement | undefined {
   return Array.from(document.querySelectorAll("button"))
     .find((button) => button.textContent?.trim() === label);
@@ -132,6 +144,14 @@ function responseFor(planResponse: PlanResponse): typeof fetch {
     }
     if (url.pathname === "/api/draft") {
       return Response.json({ error: "Not found" }, { status: 404 });
+    }
+    if (url.pathname === "/api/doc") {
+      const filepath = url.searchParams.get("path");
+      return Response.json({
+        markdown: "# Selected file\n\nLoaded from the compact navigator.",
+        filepath,
+        renderAs: "markdown",
+      });
     }
     if (url.pathname === "/api/save-notes") {
       return Response.json({
@@ -177,6 +197,7 @@ afterEach(async () => {
   if (hasDom && originalMatchMedia) window.matchMedia = originalMatchMedia;
   noteSettings.clear();
   storageModule?.resetStorageBackend();
+  fileTreeModule?.resetFileTreeBackend();
   if (hasDom) document.body.replaceChildren();
 });
 
@@ -347,5 +368,43 @@ describe.if(hasDom)("App document permissions", () => {
     expect(editControls?.textContent).toContain("Editing mobile.md");
     expect(findButton("Saved")).not.toBeUndefined();
     expect(findButton("Done")).not.toBeUndefined();
+  });
+
+  test("compact folder selection closes the navigator after the async document activation", async () => {
+    configureNotesApps();
+    useCompactTouchMedia();
+    useSingleFileTree();
+    await mountApp({
+      plan: "",
+      origin: "codex",
+      mode: "annotate-folder",
+      filePath: "/repo",
+      projectRoot: "/repo",
+      sharingEnabled: false,
+      serverConfig: {},
+    });
+
+    for (let attempt = 0; attempt < 20 && !findButton("Choose a file"); attempt += 1) {
+      await act(async () => new Promise((resolve) => setTimeout(resolve, 0)));
+    }
+    const chooseFile = findButton("Choose a file");
+    if (!chooseFile) throw new Error("Folder arrival did not expose Choose a file");
+    await act(async () => chooseFile.click());
+
+    for (let attempt = 0; attempt < 20 && !findButtonContaining("alpha"); attempt += 1) {
+      await act(async () => new Promise((resolve) => setTimeout(resolve, 0)));
+    }
+    const alphaFile = findButtonContaining("alpha");
+    if (!alphaFile) throw new Error("Folder tree did not load alpha.md");
+    expect(document.querySelector("[data-pn-plan-navigator]")).not.toBeNull();
+
+    await act(async () => {
+      alphaFile.click();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(document.querySelector("[data-pn-plan-navigator]")).toBeNull();
+    expect(document.body.textContent).toContain("Selected file");
+    expect(document.querySelector("[data-pn-compact-document-title]")?.textContent).toBe("alpha.md");
   });
 });

--- a/packages/editor/App.archiveReadOnly.test.tsx
+++ b/packages/editor/App.archiveReadOnly.test.tsx
@@ -65,6 +65,7 @@ class SilentEventSource {
 let root: Root | null = null;
 let host: HTMLElement | null = null;
 let requestedRoutes: string[] = [];
+let aiCapabilitiesAvailable = false;
 
 const noteSettings = new Map<string, string>();
 
@@ -134,7 +135,13 @@ function responseFor(planResponse: PlanResponse): typeof fetch {
       return Response.json({ markdown: planResponse.plan, filepath: "saved.md" });
     }
     if (url.pathname === "/api/ai/capabilities") {
-      return Response.json({ available: false, providers: [] });
+      return Response.json(aiCapabilitiesAvailable
+        ? {
+            available: true,
+            defaultProvider: "codex",
+            providers: [{ id: "codex", name: "Codex", models: [] }],
+          }
+        : { available: false, providers: [] });
     }
     if (url.pathname === "/api/open-in/apps") {
       return Response.json({
@@ -196,6 +203,7 @@ afterEach(async () => {
   globalThis.EventSource = originalEventSource;
   if (hasDom && originalMatchMedia) window.matchMedia = originalMatchMedia;
   noteSettings.clear();
+  aiCapabilitiesAvailable = false;
   storageModule?.resetStorageBackend();
   fileTreeModule?.resetFileTreeBackend();
   if (hasDom) document.body.replaceChildren();
@@ -293,6 +301,7 @@ describe.if(hasDom)("App document permissions", () => {
     });
 
     expect(document.body.textContent).toContain("Writable document");
+    expect(document.querySelector("[data-pn-compact-plan-completion]")).toBeNull();
     expect(document.querySelector('button[title="Add global comment"]')).not.toBeNull();
     expect(document.querySelector('button[title="Attachments"]')).not.toBeNull();
 
@@ -317,6 +326,7 @@ describe.if(hasDom)("App document permissions", () => {
   test("compact touch presents a reading-first file surface without mutating desktop preferences", async () => {
     configureNotesApps();
     noteSettings.set("plannotator-input-method", "pinpoint");
+    aiCapabilitiesAvailable = true;
     useCompactTouchMedia();
     await mountApp({
       plan: "# Mobile document\n\nA paragraph to annotate and edit.",
@@ -359,15 +369,77 @@ describe.if(hasDom)("App document permissions", () => {
     const optionsButton = document.querySelector<HTMLButtonElement>('button[aria-label="Options"]');
     if (!optionsButton) throw new Error("Options menu trigger did not render");
     await act(async () => optionsButton.click());
-    expect(findButton("Close session")).not.toBeUndefined();
-    expect(findButton("Approve")).not.toBeUndefined();
+    for (let attempt = 0; attempt < 20 && !findButtonContaining("Ask AI"); attempt += 1) {
+      await act(async () => new Promise((resolve) => setTimeout(resolve, 0)));
+    }
+    expect(findButtonContaining("Annotations")).not.toBeUndefined();
+    expect(findButtonContaining("Ask AI")).not.toBeUndefined();
+    expect(findButtonContaining("Review and finish")).not.toBeUndefined();
+    expect(findButton("Close session")).toBeUndefined();
+    expect(findButton("Approve")).toBeUndefined();
     expect(findButtonContaining("Edit document")).not.toBeUndefined();
 
+    await act(async () => findButtonContaining("Annotations")?.click());
+    expect(document.querySelector('[data-pn-compact-plan-stage="true"]')?.getAttribute("aria-label")).toBe("Annotations");
+    expect(document.body.textContent).toContain("No annotations yet");
+    const closeAnnotations = document.querySelector<HTMLButtonElement>('button[aria-label="Close Annotations"]');
+    if (!closeAnnotations) throw new Error("Compact Annotations close control did not render");
+    await act(async () => closeAnnotations.click());
+    expect(document.querySelector('[data-pn-compact-plan-stage="true"]')).toBeNull();
+
+    await act(async () => optionsButton.click());
+    await act(async () => findButtonContaining("Ask AI")?.click());
+    expect(document.querySelector('[data-pn-compact-plan-stage="true"]')?.getAttribute("aria-label")).toBe("Ask AI");
+    expect(document.querySelector('textarea[placeholder="Ask about this document..."]')?.getAttribute("data-pn-mobile-editable")).toBe("true");
+    const closeAI = document.querySelector<HTMLButtonElement>('button[aria-label="Close Ask AI"]');
+    if (!closeAI) throw new Error("Compact Ask AI close control did not render");
+    await act(async () => closeAI.click());
+
+    const completion = document.querySelector("[data-pn-compact-plan-completion]");
+    expect(completion?.textContent).toContain("Ready to finish?");
+    const reviewTrigger = document.querySelector<HTMLButtonElement>("#pn-compact-plan-review-trigger");
+    if (!reviewTrigger) throw new Error("End-of-document review trigger did not render");
+    await act(async () => reviewTrigger.click());
+    expect(document.querySelector('[data-pn-compact-plan-stage="true"]')?.getAttribute("aria-label")).toBe("Review");
+    expect(findButton("Close session")).not.toBeUndefined();
+    expect(findButton("Approve")).not.toBeUndefined();
+    const closeReview = document.querySelector<HTMLButtonElement>('button[aria-label="Close Review"]');
+    if (!closeReview) throw new Error("Compact Review close control did not render");
+    await act(async () => closeReview.click());
+
+    await act(async () => optionsButton.click());
     await act(async () => findButtonContaining("Edit document")?.click());
     const editControls = document.querySelector("[data-pn-compact-edit-controls]");
     expect(editControls?.textContent).toContain("Editing mobile.md");
     expect(findButton("Saved")).not.toBeUndefined();
     expect(findButton("Done")).not.toBeUndefined();
+    expect(document.querySelector("[data-pn-compact-plan-completion]")).toBeNull();
+  });
+
+  test("compact review sends the incumbent approval request", async () => {
+    configureNotesApps();
+    useCompactTouchMedia();
+    await mountApp({
+      plan: "# Mobile decision\n\nReview this plan.",
+      origin: "codex",
+      mode: "annotate",
+      filePath: "/repo/docs/decision.md",
+      gate: true,
+      sharingEnabled: false,
+      serverConfig: {},
+    });
+
+    const reviewTrigger = document.querySelector<HTMLButtonElement>("#pn-compact-plan-review-trigger");
+    if (!reviewTrigger) throw new Error("Compact review trigger did not render");
+    await act(async () => reviewTrigger.click());
+    const approve = findButton("Approve");
+    if (!approve) throw new Error("Compact review did not expose Approve");
+    requestedRoutes = [];
+    await act(async () => {
+      approve.click();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(requestedRoutes).toContain("POST /api/approve");
   });
 
   test("compact folder selection closes the navigator after the async document activation", async () => {

--- a/packages/editor/App.archiveReadOnly.test.tsx
+++ b/packages/editor/App.archiveReadOnly.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
+import type { SourceSaveCapability } from "@plannotator/core/source-save";
 
 const hasDom = typeof document !== "undefined";
 
@@ -15,12 +16,15 @@ const appModule = hasDom ? await import("./App") : null;
 const App = appModule?.default as typeof import("./App")["default"];
 const originalFetch = globalThis.fetch;
 const originalEventSource = globalThis.EventSource;
+const originalMatchMedia = hasDom ? window.matchMedia : undefined;
 
 interface PlanResponse {
   readonly plan: string;
   readonly origin: "codex";
   readonly mode: "archive" | "annotate";
   readonly filePath?: string;
+  readonly sourceSave?: SourceSaveCapability;
+  readonly gate?: boolean;
   readonly archivePlans?: readonly [{
     readonly filename: string;
     readonly status: "approved";
@@ -76,9 +80,28 @@ function configureNotesApps(): void {
   noteSettings.set("plannotator-default-notes-app", "obsidian");
 }
 
+function useCompactTouchMedia(): void {
+  if (!hasDom) return;
+  window.matchMedia = ((query: string): MediaQueryList => ({
+    matches: query.includes("max-width") || query.includes("pointer: coarse"),
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => true,
+  })) as typeof window.matchMedia;
+}
+
 function findButton(label: string): HTMLButtonElement | undefined {
   return Array.from(document.querySelectorAll("button"))
     .find((button) => button.textContent?.trim() === label);
+}
+
+function findButtonContaining(label: string): HTMLButtonElement | undefined {
+  return Array.from(document.querySelectorAll("button"))
+    .find((button) => button.textContent?.includes(label));
 }
 
 function responseFor(planResponse: PlanResponse): typeof fetch {
@@ -151,6 +174,7 @@ afterEach(async () => {
   host = null;
   globalThis.fetch = originalFetch;
   globalThis.EventSource = originalEventSource;
+  if (hasDom && originalMatchMedia) window.matchMedia = originalMatchMedia;
   noteSettings.clear();
   storageModule?.resetStorageBackend();
   if (hasDom) document.body.replaceChildren();
@@ -267,5 +291,61 @@ describe.if(hasDom)("App document permissions", () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
     expect(requestedRoutes).toContain("POST /api/save-notes");
+  });
+
+  test("compact touch presents a reading-first file surface without mutating desktop preferences", async () => {
+    configureNotesApps();
+    noteSettings.set("plannotator-input-method", "pinpoint");
+    useCompactTouchMedia();
+    await mountApp({
+      plan: "# Mobile document\n\nA paragraph to annotate and edit.",
+      origin: "codex",
+      mode: "annotate",
+      filePath: "/repo/docs/mobile.md",
+      sourceSave: {
+        enabled: true,
+        kind: "local-text-file",
+        scope: "single-file",
+        path: "/repo/docs/mobile.md",
+        basename: "mobile.md",
+        language: "markdown",
+        hash: "sha256:mobile",
+        mtimeMs: 1_000,
+        size: 52,
+        eol: "lf",
+      },
+      gate: true,
+      sharingEnabled: false,
+      serverConfig: {},
+    });
+
+    expect(document.querySelector("[data-pn-compact-document-title]")?.textContent).toBe("mobile.md");
+    expect(document.querySelector("[data-pn-compact-annotate-entry]")?.textContent).toContain("Pinpoint");
+    for (const label of ["Wide", "Focus", "Edit", "Markup", "Comment", "Redline", "Label"]) {
+      expect(findButton(label)).toBeUndefined();
+    }
+
+    const annotateEntry = document.querySelector<HTMLButtonElement>("[data-pn-compact-annotate-entry]");
+    if (!annotateEntry) throw new Error("Compact annotation entry did not render");
+    await act(async () => annotateEntry.click());
+    expect(findButtonContaining("Select text")).not.toBeUndefined();
+    expect(findButtonContaining("Pinpoint")).not.toBeUndefined();
+
+    await act(async () => findButtonContaining("Select text")?.click());
+    expect(document.querySelector("[data-pn-compact-annotate-entry]")?.textContent).toContain("Select text");
+    expect(noteSettings.get("plannotator-input-method")).toBe("pinpoint");
+
+    const optionsButton = document.querySelector<HTMLButtonElement>('button[aria-label="Options"]');
+    if (!optionsButton) throw new Error("Options menu trigger did not render");
+    await act(async () => optionsButton.click());
+    expect(findButton("Close session")).not.toBeUndefined();
+    expect(findButton("Approve")).not.toBeUndefined();
+    expect(findButtonContaining("Edit document")).not.toBeUndefined();
+
+    await act(async () => findButtonContaining("Edit document")?.click());
+    const editControls = document.querySelector("[data-pn-compact-edit-controls]");
+    expect(editControls?.textContent).toContain("Editing mobile.md");
+    expect(findButton("Saved")).not.toBeUndefined();
+    expect(findButton("Done")).not.toBeUndefined();
   });
 });

--- a/packages/editor/App.archiveReadOnly.test.tsx
+++ b/packages/editor/App.archiveReadOnly.test.tsx
@@ -66,6 +66,7 @@ let root: Root | null = null;
 let host: HTMLElement | null = null;
 let requestedRoutes: string[] = [];
 let aiCapabilitiesAvailable = false;
+let documentLoadGate: Promise<void> | null = null;
 
 const noteSettings = new Map<string, string>();
 
@@ -153,6 +154,7 @@ function responseFor(planResponse: PlanResponse): typeof fetch {
       return Response.json({ error: "Not found" }, { status: 404 });
     }
     if (url.pathname === "/api/doc") {
+      await documentLoadGate;
       const filepath = url.searchParams.get("path");
       return Response.json({
         markdown: "# Selected file\n\nLoaded from the compact navigator.",
@@ -204,6 +206,7 @@ afterEach(async () => {
   if (hasDom && originalMatchMedia) window.matchMedia = originalMatchMedia;
   noteSettings.clear();
   aiCapabilitiesAvailable = false;
+  documentLoadGate = null;
   storageModule?.resetStorageBackend();
   fileTreeModule?.resetFileTreeBackend();
   if (hasDom) document.body.replaceChildren();
@@ -470,8 +473,23 @@ describe.if(hasDom)("App document permissions", () => {
     if (!alphaFile) throw new Error("Folder tree did not load alpha.md");
     expect(document.querySelector("[data-pn-plan-navigator]")).not.toBeNull();
 
+    let releaseDocumentLoad: (() => void) | undefined;
+    documentLoadGate = new Promise<void>((resolve) => {
+      releaseDocumentLoad = resolve;
+    });
     await act(async () => {
       alphaFile.click();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    const pendingNavigator = document.querySelector<HTMLElement>("[data-pn-plan-navigator]");
+    expect(pendingNavigator).not.toBeNull();
+    expect(pendingNavigator?.textContent).toContain("Opening alpha.md…");
+    expect(alphaFile.disabled).toBe(true);
+    expect(alphaFile.getAttribute("aria-busy")).toBe("true");
+
+    await act(async () => {
+      releaseDocumentLoad?.();
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
 

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -817,9 +817,16 @@ const App: React.FC = () => {
 
   const linkedDocSidebar = useMemo(() => ({
     ...sidebar,
-    open: openSidebarTab,
+    // useLinkedDoc opens the relevant desktop rail after activating a file.
+    // Compact navigation is a foreground task instead: selecting a destination
+    // closes it, and the later async document activation must not resurrect it.
+    open: (tab?: SidebarTab) => {
+      if (isCompactTouchLayout) return;
+      openSidebarTab(tab ?? 'toc');
+    },
     toggleTab: toggleSidebarTab,
   }), [
+    isCompactTouchLayout,
     openSidebarTab,
     sidebar.activeTab,
     sidebar.close,

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -128,7 +128,10 @@ const DEMO_PLAN_CONTENT = USE_DIFF_DEMO
 import { useCheckboxOverrides } from './hooks/useCheckboxOverrides';
 import { usePlanDiffViewAutoExit } from './hooks/usePlanDiffViewAutoExit';
 import { AppHeader } from './components/AppHeader';
+import type { CompactPlanAction } from '@plannotator/ui/components/PlanHeaderMenu';
 import { FolderAnnotationEmptyState } from './components/FolderAnnotationEmptyState';
+import { CompactAnnotationControls } from './components/CompactAnnotationControls';
+import { CompactEditControls } from './components/CompactEditControls';
 import {
   COMPACT_PLAN_ARTIFACT,
   openCompactPlanNavigator,
@@ -341,6 +344,7 @@ const App: React.FC = () => {
   const [mobileSettingsOpen, setMobileSettingsOpen] = useState(false);
   const [editorMode, setEditorMode] = useState<EditorMode>(getEditorMode);
   const [inputMethod, setInputMethod] = useState<InputMethod>(getInputMethod);
+  const [compactInputMethod, setCompactInputMethod] = useState<InputMethod>(getInputMethod);
   const [taterMode, setTaterMode] = useState(() => {
     const stored = storage.getItem('plannotator-tater-mode');
     return stored === 'true';
@@ -530,6 +534,8 @@ const App: React.FC = () => {
   const isMobile = useIsMobile();
   const isCompactTouchLayout = useCompactTouchLayout();
   const usesDocumentScroll = isCompactTouchLayout;
+  const effectiveEditorMode: EditorMode = isCompactTouchLayout ? 'selection' : editorMode;
+  const effectiveInputMethod = isCompactTouchLayout ? compactInputMethod : inputMethod;
   const [compactPlanSurface, setCompactPlanSurface] = useState<CompactPlanSurface>(COMPACT_PLAN_ARTIFACT);
   const [compactNavigatorTab, setCompactNavigatorTab] = useState<SidebarTab>('toc');
   const isCompactNavigatorOpen = isCompactTouchLayout && compactPlanSurface.type === 'navigator';
@@ -543,8 +549,12 @@ const App: React.FC = () => {
   // state. Crossing back to a fine-pointer workspace simply removes the
   // transient foreground surface and reveals the incumbent desktop layout.
   useEffect(() => {
-    if (!isCompactTouchLayout) setCompactPlanSurface(COMPACT_PLAN_ARTIFACT);
-  }, [isCompactTouchLayout]);
+    if (isCompactTouchLayout) return;
+    setCompactPlanSurface(COMPACT_PLAN_ARTIFACT);
+    // Keep the session-only compact method ready to inherit the latest
+    // explicit desktop choice without letting compact changes write it back.
+    setCompactInputMethod(inputMethod);
+  }, [inputMethod, isCompactTouchLayout]);
 
   const viewerRef = useRef<ViewerHandle>(null);
   // Desktop uses the main document element as its native scroll viewport.
@@ -2551,6 +2561,10 @@ const App: React.FC = () => {
   };
 
   const handleInputMethodChange = (method: InputMethod) => {
+    if (isCompactTouchLayout) {
+      setCompactInputMethod(method);
+      return;
+    }
     setInputMethod(method);
     // Surface-scoped persistence: an explicit choice made on the HTML surface
     // sticks for HTML sessions only; markdown keeps its own preference.
@@ -2565,11 +2579,13 @@ const App: React.FC = () => {
   useEffect(() => {
     if (prevSurfaceRef.current === isHtmlSurface) return;
     prevSurfaceRef.current = isHtmlSurface;
-    setInputMethod(getInputMethod(isHtmlSurface ? 'html' : 'markdown'));
+    const method = getInputMethod(isHtmlSurface ? 'html' : 'markdown');
+    setInputMethod(method);
+    setCompactInputMethod(method);
   }, [isHtmlSurface]);
 
   // Alt/Option key: hold to temporarily switch, double-tap to toggle
-  useInputMethodSwitch(inputMethod, handleInputMethodChange);
+  useInputMethodSwitch(effectiveInputMethod, handleInputMethodChange);
 
   // Check if we're in API mode (served from Bun hook server)
   // Skip if we loaded from a shared URL
@@ -4256,6 +4272,118 @@ const App: React.FC = () => {
   const handleSaveToOctarine = useCallback(() => headerHandlersRef.current.handleQuickSaveToNotes('octarine'), []);
   const handleSaveToBear = useCallback(() => headerHandlersRef.current.handleQuickSaveToNotes('bear'), []);
 
+  const compactDocumentTitle = useMemo(() => {
+    const path = linkedDocHook.filepath ?? sourceFilePath ?? fileBrowser.activeFile;
+    if (path) return path.replace(/\\/g, '/').split('/').pop() || path;
+    if (archive.currentInfo?.title) return archive.currentInfo.title;
+    if (annotateSource === 'message') return 'Message';
+    if (annotateSource === 'folder') return 'Choose a file';
+    return 'Plan';
+  }, [annotateSource, archive.currentInfo?.title, fileBrowser.activeFile, linkedDocHook.filepath, sourceFilePath]);
+
+  const callbackShareUrlReady = callbackConfig
+    ? Boolean(shareUrl || shortShareUrl || (renderAs === 'html' && (shareHtml || rawHtml)))
+    : true;
+  const compactActionBusy = isSubmitting || isExiting || goalSetupAction.isSubmitting;
+  const compactSessionActions: CompactPlanAction[] = !isCompactTouchLayout
+    ? []
+    : callbackConfig && !isApiMode && isSharedSession
+      ? [
+          {
+            id: 'feedback',
+            label: 'Send feedback to bot',
+            onSelect: handleCallbackFeedback,
+            disabled: compactActionBusy || !callbackShareUrlReady,
+          },
+          {
+            id: 'approve',
+            label: 'Approve design',
+            onSelect: handleCallbackApprove,
+            disabled: compactActionBusy || !callbackShareUrlReady,
+          },
+        ]
+      : isApiMode && !linkedDocHook.isActive && archive.archiveMode
+        ? [
+            { id: 'copy', label: 'Copy plan', onSelect: archive.copy },
+            { id: 'done', label: 'Done', onSelect: archive.done },
+          ]
+        : isApiMode && !linkedDocHook.isActive && goalSetupMode
+          ? [
+              {
+                id: 'exit',
+                label: 'Close goal setup',
+                onSelect: handleGoalSetupExit,
+                disabled: compactActionBusy,
+              },
+              {
+                id: 'approve',
+                label: goalSetupAction.submitLabel,
+                onSelect: handleGoalSetupSubmit,
+                disabled: !goalSetupAction.canSubmit || compactActionBusy,
+              },
+            ]
+          : isApiMode && (!linkedDocHook.isActive || annotateMode) && !archive.archiveMode && !goalSetupMode
+            ? [
+                ...(annotateMode
+                  ? [
+                      {
+                        id: 'exit' as const,
+                        label: 'Close session',
+                        onSelect: handleHeaderAnnotateExit,
+                        disabled: compactActionBusy,
+                      },
+                      ...(hasFeedbackContent
+                        ? [{
+                            id: 'feedback' as const,
+                            label: 'Send feedback',
+                            subtitle: feedbackAnnotationCount > 0
+                              ? `${feedbackAnnotationCount} annotation${feedbackAnnotationCount === 1 ? '' : 's'}`
+                              : 'Edited document',
+                            onSelect: handleHeaderAnnotateFeedback,
+                            disabled: compactActionBusy,
+                          }]
+                        : []),
+                    ]
+                  : [{
+                      id: 'feedback' as const,
+                      label: 'Send feedback',
+                      subtitle: hasFeedbackToSend
+                        ? `${feedbackAnnotationCount} annotation${feedbackAnnotationCount === 1 ? '' : 's'}`
+                        : 'Add general feedback',
+                      onSelect: handleHeaderFeedback,
+                      disabled: compactActionBusy,
+                    }]),
+                ...((!annotateMode || gate)
+                  ? [{
+                      id: 'approve' as const,
+                      label: annotateMode ? annotateApprovalPolicy.label : 'Approve',
+                      subtitle: !annotateMode && hasFeedbackToSend ? 'Feedback remains unsent' : undefined,
+                      onSelect: handleHeaderApprove,
+                      disabled: compactActionBusy,
+                    }]
+                  : []),
+              ]
+            : [];
+  const compactDocumentActions: CompactPlanAction[] = !isCompactTouchLayout
+    ? []
+    : [
+        ...(isHtmlSurface
+          ? [{
+              id: 'tools' as const,
+              label: htmlToolsHidden ? 'Show annotation tools' : 'Hide annotation tools',
+              onSelect: () => setHtmlToolsHidden((hidden) => !hidden),
+            }]
+          : []),
+        ...(canEditMarkdown && !isEditingMarkdown && !isPlanDiffActive && !archive.archiveMode && !isHtmlSurface
+          ? [{
+              id: 'edit' as const,
+              label: 'Edit document',
+              subtitle: activeSourceSave ? `Edit ${activeSourceSave.basename}` : 'Edit the plan text directly',
+              onSelect: handleEditExitClick,
+            }]
+          : []),
+      ];
+
   const planMaxWidth = useMemo(() => {
     const widths: Record<PlanWidth, number> = { compact: 832, default: 1040, wide: 1280 };
     return widths[uiPrefs.planWidth] ?? 832;
@@ -4435,6 +4563,9 @@ const App: React.FC = () => {
           compactNavigatorAvailable={compactNavigatorAvailable}
           compactNavigatorOpen={isCompactNavigatorOpen}
           onCompactNavigatorToggle={() => toggleSidebarTab(effectiveCompactNavigatorTab)}
+          compactDocumentTitle={compactDocumentTitle}
+          compactSessionActions={compactSessionActions}
+          compactDocumentActions={compactDocumentActions}
           isApiMode={isApiMode}
           annotateMode={annotateMode}
           archiveMode={archive.archiveMode}
@@ -4454,7 +4585,7 @@ const App: React.FC = () => {
           hasAnyAnnotations={hasAnyAnnotations || hasDirectEdits || hasSavedFileChanges}
           annotationCount={feedbackAnnotationCount}
           linkedDocIsActive={linkedDocHook.isActive}
-          callbackShareUrlReady={callbackConfig ? Boolean(shareUrl || shortShareUrl || (renderAs === 'html' && (shareHtml || rawHtml))) : true}
+          callbackShareUrlReady={callbackShareUrlReady}
           canShareCurrentSession={canShareCurrentSession}
           agentName={agentName}
           availableAgents={availableAgents}
@@ -4675,7 +4806,8 @@ const App: React.FC = () => {
                   comment/markup mode). Hidden during plan diff, and on HTML surfaces
                   when the header's "Hide tools" toggle is on (leaving the rendered HTML
                   free of overlay controls). On HTML it floats top-left over the doc. */}
-              {!goalSetupMode && !isPlanDiffActive && !archive.archiveMode && !isEditingMarkdown && !htmlChromeHidden && (
+              {!goalSetupMode && !isPlanDiffActive && !archive.archiveMode && !isEditingMarkdown && !htmlChromeHidden &&
+                (!isCompactTouchLayout || !(annotateSource === 'folder' && !markdown && !linkedDocHook.isActive)) && (
                 <div
                   data-print-hide
                   className={isHtmlSurface
@@ -4683,14 +4815,21 @@ const App: React.FC = () => {
                     : "w-full mb-3 md:mb-4 flex items-center justify-start"}
                   style={isHtmlSurface || annotateReaderMaxWidth == null ? undefined : { maxWidth: annotateReaderMaxWidth }}
                 >
-                  <AnnotationToolstrip
-                    inputMethod={inputMethod}
-                    onInputMethodChange={handleInputMethodChange}
-                    mode={editorMode}
-                    onModeChange={handleEditorModeChange}
-                    taterMode={taterMode}
-                    showHelpLink={!isHtmlSurface}
-                  />
+                  {isCompactTouchLayout && !isHtmlSurface ? (
+                    <CompactAnnotationControls
+                      inputMethod={effectiveInputMethod}
+                      onInputMethodChange={handleInputMethodChange}
+                    />
+                  ) : (
+                    <AnnotationToolstrip
+                      inputMethod={inputMethod}
+                      onInputMethodChange={handleInputMethodChange}
+                      mode={editorMode}
+                      onModeChange={handleEditorModeChange}
+                      taterMode={taterMode}
+                      showHelpLink={!isHtmlSurface}
+                    />
+                  )}
                 </div>
               )}
 
@@ -4723,7 +4862,7 @@ const App: React.FC = () => {
                     onAddAnnotation={handleAddAnnotation}
                     onSelectAnnotation={handleSelectAnnotation}
                     selectedAnnotationId={selectedAnnotationId}
-                    mode={editorMode}
+                    mode={effectiveEditorMode}
                   />
                 </div>
               )}
@@ -4735,8 +4874,8 @@ const App: React.FC = () => {
                 />
               )}
               {/* Normal Plan View — always mounted, hidden during diff mode */}
-              <div className={`w-full relative ${isHtmlSurface ? 'flex-1 flex flex-col' : `flex justify-center${isEditingMarkdown ? ' flex-1 min-h-0' : ''}`}`} style={{ display: goalSetupMode || (isPlanDiffActive && planDiff.diffBlocks) || (annotateSource === 'folder' && !markdown && !linkedDocHook.isActive) ? 'none' : undefined }}>
-                {(canUseWideMode || canEditMarkdown) && !isPlanDiffActive && !archive.archiveMode && !isHtmlSurface && (
+              <div className={`w-full relative ${isHtmlSurface ? 'flex-1 flex flex-col' : `${isCompactTouchLayout && isEditingMarkdown ? 'flex flex-col items-center' : 'flex justify-center'}${isEditingMarkdown ? ' flex-1 min-h-0' : ''}`}`} style={{ display: goalSetupMode || (isPlanDiffActive && planDiff.diffBlocks) || (annotateSource === 'folder' && !markdown && !linkedDocHook.isActive) ? 'none' : undefined }}>
+                {!isCompactTouchLayout && (canUseWideMode || canEditMarkdown) && !isPlanDiffActive && !archive.archiveMode && !isHtmlSurface && (
                   <div
                     data-print-hide
                     className="absolute -top-5 left-0 right-0 mx-auto w-full flex justify-end pointer-events-none"
@@ -4850,6 +4989,17 @@ const App: React.FC = () => {
                     </div>
                   </div>
                 )}
+                {isCompactTouchLayout && isEditingMarkdown && !isHtmlSurface && (
+                  <CompactEditControls
+                    documentTitle={compactDocumentTitle}
+                    sourceBacked={!!activeSourceSave}
+                    saveStatus={activeSaveStatus}
+                    cancelMode={cancelMode}
+                    confirmDiscard={confirmCancelEdits}
+                    onSave={() => { void handleSaveEditedSourceFile(); }}
+                    onExit={handleEditExitClick}
+                  />
+                )}
                 {renderAs === 'html' ? (
                   <HtmlViewer
                     key={(linkedDocHook.isActive ? `doc:${linkedDocHook.filepath}` : 'plan') + (isPlanDiffActive && htmlDiffHtml ? ':diff' : '')}
@@ -4859,8 +5009,8 @@ const App: React.FC = () => {
                     onAddAnnotation={handleAddAnnotation}
                     onSelectAnnotation={handleSelectAnnotation}
                     selectedAnnotationId={selectedAnnotationId}
-                    mode={editorMode}
-                    inputMethod={inputMethod}
+                    mode={effectiveEditorMode}
+                    inputMethod={effectiveInputMethod}
                     vimModeEnabled={vimModeEnabled}
                     vimHudEnabled={vimModeEnabled && vimHudEnabled}
                     vimHudKeyPanelEnabled={vimHudKeyPanelEnabled}
@@ -4897,8 +5047,8 @@ const App: React.FC = () => {
                     onAddAnnotation={handleAddAnnotation}
                     onSelectAnnotation={handleSelectAnnotation}
                     selectedAnnotationId={selectedAnnotationId}
-                    mode={editorMode}
-                    inputMethod={inputMethod}
+                    mode={effectiveEditorMode}
+                    inputMethod={effectiveInputMethod}
                     vimModeEnabled={vimModeEnabled}
                     vimHudEnabled={vimModeEnabled && vimHudEnabled}
                     vimHudKeyPanelEnabled={vimHudKeyPanelEnabled}

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -128,6 +128,14 @@ const DEMO_PLAN_CONTENT = USE_DIFF_DEMO
 import { useCheckboxOverrides } from './hooks/useCheckboxOverrides';
 import { usePlanDiffViewAutoExit } from './hooks/usePlanDiffViewAutoExit';
 import { AppHeader } from './components/AppHeader';
+import { FolderAnnotationEmptyState } from './components/FolderAnnotationEmptyState';
+import {
+  COMPACT_PLAN_ARTIFACT,
+  openCompactPlanNavigator,
+  shouldPresentDesktopPlanPanel,
+  toggleCompactPlanNavigator,
+  type CompactPlanSurface,
+} from './compactPlanSurface';
 import {
   AnnotateAgentTerminalPanel,
   type AnnotateAgentTerminalPanelHandle,
@@ -520,7 +528,23 @@ const App: React.FC = () => {
   });
   const [showLookAndFeelAnnouncement, setShowLookAndFeelAnnouncement] = useState(needsLookAndFeelAnnouncement);
   const isMobile = useIsMobile();
-  const usesDocumentScroll = useCompactTouchLayout();
+  const isCompactTouchLayout = useCompactTouchLayout();
+  const usesDocumentScroll = isCompactTouchLayout;
+  const [compactPlanSurface, setCompactPlanSurface] = useState<CompactPlanSurface>(COMPACT_PLAN_ARTIFACT);
+  const [compactNavigatorTab, setCompactNavigatorTab] = useState<SidebarTab>('toc');
+  const isCompactNavigatorOpen = isCompactTouchLayout && compactPlanSurface.type === 'navigator';
+  const isCompactFilesSurfaceOpen =
+    isCompactNavigatorOpen && compactPlanSurface.type === 'navigator' && compactPlanSurface.tab === 'files';
+  const isCompactContentsSurfaceOpen =
+    isCompactNavigatorOpen && compactPlanSurface.type === 'navigator' && compactPlanSurface.tab === 'toc';
+  const effectivePanelOpen = shouldPresentDesktopPlanPanel(isCompactTouchLayout, isPanelOpen);
+
+  // Compact interactions never write into the remembered desktop rail/panel
+  // state. Crossing back to a fine-pointer workspace simply removes the
+  // transient foreground surface and reveals the incumbent desktop layout.
+  useEffect(() => {
+    if (!isCompactTouchLayout) setCompactPlanSurface(COMPACT_PLAN_ARTIFACT);
+  }, [isCompactTouchLayout]);
 
   const viewerRef = useRef<ViewerHandle>(null);
   // Desktop uses the main document element as its native scroll viewport.
@@ -622,20 +646,40 @@ const App: React.FC = () => {
   }, [wideModeType, sidebar.close, sidebar.open]);
 
   const openSidebarTab = useCallback((tab: SidebarTab) => {
+    if (isCompactTouchLayout) {
+      setCompactNavigatorTab(tab);
+      setCompactPlanSurface(openCompactPlanNavigator(tab));
+      return;
+    }
     if (wideModeType !== null) {
       exitWideMode({ restore: false, sidebarTab: tab, panelOpen: false });
       return;
     }
     sidebar.open(tab);
-  }, [exitWideMode, wideModeType, sidebar.open]);
+  }, [exitWideMode, isCompactTouchLayout, wideModeType, sidebar.open]);
 
   const toggleSidebarTab = useCallback((tab: SidebarTab) => {
+    if (isCompactTouchLayout) {
+      setCompactNavigatorTab(tab);
+      setCompactPlanSurface((surface) => toggleCompactPlanNavigator(surface, tab));
+      return;
+    }
     if (wideModeType !== null) {
       exitWideMode({ restore: false, sidebarTab: tab, panelOpen: false });
       return;
     }
     sidebar.toggleTab(tab);
-  }, [exitWideMode, wideModeType, sidebar.toggleTab]);
+  }, [exitWideMode, isCompactTouchLayout, wideModeType, sidebar.toggleTab]);
+
+  const closeCompactNavigator = useCallback((restoreFocus = true) => {
+    setCompactPlanSurface(COMPACT_PLAN_ARTIFACT);
+    if (!restoreFocus) return;
+    window.setTimeout(() => {
+      document
+        .getElementById('pn-compact-plan-navigator-trigger')
+        ?.focus({ preventScroll: true });
+    }, 0);
+  }, []);
 
   const handleAnnotationPanelToggle = useCallback(() => {
     if (wideModeType !== null) {
@@ -744,10 +788,10 @@ const App: React.FC = () => {
 
   // Clear diff view when switching away from versions tab
   useEffect(() => {
-    if (sidebar.activeTab === 'toc' && isPlanDiffActive) {
+    if ((sidebar.activeTab === 'toc' || isCompactContentsSurfaceOpen) && isPlanDiffActive) {
       setIsPlanDiffActive(false);
     }
-  }, [sidebar.activeTab]);
+  }, [isCompactContentsSurfaceOpen, isPlanDiffActive, sidebar.activeTab]);
 
   // Clear diff view on Escape key
   useEffect(() => {
@@ -1100,7 +1144,7 @@ const App: React.FC = () => {
   }, [vaultPath]);
 
   useEffect(() => {
-    if (sidebar.activeTab === 'files' && showFilesTab) {
+    if ((sidebar.activeTab === 'files' || isCompactFilesSurfaceOpen) && showFilesTab) {
       // Load regular dirs
       if (fileBrowserDirs.length > 0) {
         const regularLoaded = fileBrowser.dirs.filter(d => !d.isVault).map(d => d.path);
@@ -1114,7 +1158,7 @@ const App: React.FC = () => {
         fileBrowser.addVaultDir(vaultPath);
       }
     }
-  }, [sidebar.activeTab, showFilesTab, fileBrowserDirs, vaultPath]);
+  }, [fileBrowserDirs, isCompactFilesSurfaceOpen, showFilesTab, sidebar.activeTab, vaultPath]);
 
   const buildCurrentMessageState = React.useCallback((): MessageAnnotationState | null => {
     if (annotateSource !== 'message' || !selectedMessageId) return null;
@@ -1368,7 +1412,9 @@ const App: React.FC = () => {
     const filePaths = new Set(allAnnotationCounts.keys());
     if (filePaths.size === 0) return;
     // Open sidebar to the files tab so the flash is visible
-    if (!sidebar.isOpen || sidebar.activeTab !== 'files') {
+    if (isCompactTouchLayout
+      ? !isCompactFilesSurfaceOpen
+      : (!sidebar.isOpen || sidebar.activeTab !== 'files')) {
       openSidebarTab('files');
     }
     // Cancel any pending clear from a previous flash
@@ -1379,7 +1425,7 @@ const App: React.FC = () => {
       setHighlightedFiles(filePaths);
       flashTimerRef.current = setTimeout(() => setHighlightedFiles(undefined), 1200);
     });
-  }, [allAnnotationCounts, openSidebarTab, sidebar, hasFileAnnotations]);
+  }, [allAnnotationCounts, isCompactFilesSurfaceOpen, isCompactTouchLayout, openSidebarTab, sidebar]);
 
   // Context-aware back label for linked doc navigation
   const backLabel = annotateSource === 'folder' ? 'file list'
@@ -3659,7 +3705,7 @@ const App: React.FC = () => {
 
   // Opening the Ask AI surface with a provider selected is the other explicit
   // gesture that should surface the provider's real model list.
-  const aiSurfaceOpen = isPanelOpen && rightSidebarTab === 'ai';
+  const aiSurfaceOpen = effectivePanelOpen && rightSidebarTab === 'ai';
   useEffect(() => {
     if (!aiAvailable || !aiSurfaceOpen) return;
     activateAIProvider(aiConfig.providerId);
@@ -4233,6 +4279,131 @@ const App: React.FC = () => {
     !isSharedSession &&
     !goalSetupMode &&
     !showPermissionModeSetup;
+  const compactNavigatorTabs: SidebarTab[] = [
+    ...(hasTocEntries ? ['toc' as const] : []),
+    ...(!isHtmlSurface && activeDiffVersionInfo !== null && activeDiffVersionInfo.totalVersions > 1
+      ? ['versions' as const]
+      : []),
+    ...(annotateSource === 'message' && recentMessages.length > 1 ? ['messages' as const] : []),
+    ...(showFilesTab && !archive.archiveMode ? ['files' as const] : []),
+    ...(isApiMode && !annotateMode && !goalSetupMode ? ['archive' as const] : []),
+  ];
+  const compactNavigatorAvailable = !goalSetupMode && compactNavigatorTabs.length > 0;
+  const effectiveCompactNavigatorTab = compactNavigatorTabs.includes(compactNavigatorTab)
+    ? compactNavigatorTab
+    : (compactNavigatorTabs[0] ?? 'toc');
+
+  useEffect(() => {
+    if (isCompactNavigatorOpen && !compactNavigatorAvailable) {
+      closeCompactNavigator(false);
+    }
+  }, [closeCompactNavigator, compactNavigatorAvailable, isCompactNavigatorOpen]);
+
+  const handleNavigatorTabChange = (tab: SidebarTab) => {
+    if (isCompactTouchLayout) openSidebarTab(tab);
+    else toggleSidebarTab(tab);
+    if (tab === 'archive' && !archive.archiveMode) archive.fetchPlans();
+  };
+
+  const handleNavigatorFileSelect = (...args: Parameters<typeof handleFileBrowserSelect>) => {
+    // Plan/review linked-doc browsing still swaps the root document under the
+    // editor. Folder mode snapshots the active file first.
+    if (isEditingMarkdown && annotateSource !== 'folder') {
+      toast('Finish editing first', { description: 'Use "Done editing" before opening files.' });
+      return;
+    }
+    // Wider annotatable types are view-only. Switching to one mid-edit would
+    // silently downgrade "Done editing" to feedback-only edits.
+    if (isEditingMarkdown && !isSourceSaveFilePath(args[0])) {
+      toast('Finish editing first', { description: 'Use "Done editing" before opening non-editable files.' });
+      return;
+    }
+    handleFileBrowserSelect(...args);
+    if (isCompactTouchLayout) closeCompactNavigator();
+  };
+
+  const handleNavigatorArchiveSelect = (...args: Parameters<typeof archive.select>) => {
+    if (isEditingMarkdown) {
+      toast('Finish editing first', { description: 'Use "Done editing" before browsing archived plans.' });
+      return;
+    }
+    archive.select(...args);
+    if (isCompactTouchLayout) closeCompactNavigator();
+  };
+
+  const handleNavigatorMessageSelect = (messageId: string) => {
+    handleSelectMessage(messageId);
+    if (isCompactTouchLayout) closeCompactNavigator();
+  };
+
+  const handleNavigatorDiffActivate = () => {
+    handleActivatePlanDiff();
+    if (isCompactTouchLayout && !isEditingMarkdown) closeCompactNavigator();
+  };
+
+  const renderPlanSidebar = (presentation: 'desktop' | 'overlay') => {
+    const compact = presentation === 'overlay';
+    return (
+      <SidebarContainer
+        presentation={presentation}
+        activeTab={compact ? effectiveCompactNavigatorTab : sidebar.activeTab}
+        onTabChange={handleNavigatorTabChange}
+        onClose={compact ? closeCompactNavigator : sidebar.close}
+        width={compact ? '100%' : `var(--toc-w, ${tocResize.width}px)`}
+        showAgentTerminalButton={!compact && showAgentTerminalControls}
+        isAgentTerminalOpen={isAgentTerminalOpen}
+        isAgentTerminalRunning={isAgentTerminalRunning}
+        onToggleAgentTerminal={toggleAgentTerminal}
+        showContentsTab={!compact || hasTocEntries}
+        blocks={blocks}
+        annotations={annotations}
+        activeSection={activeSection}
+        onTocNavigate={(blockId) => {
+          handleTocNavigate(blockId);
+          if (compact) closeCompactNavigator();
+        }}
+        linkedDocFilepath={linkedDocHook.filepath}
+        onLinkedDocBack={linkedDocHook.isActive
+          ? () => {
+              handleLinkedDocBack();
+              if (compact) closeCompactNavigator();
+            }
+          : undefined}
+        backLabel={backLabel}
+        showFilesTab={showFilesTab && !archive.archiveMode}
+        fileAnnotationCounts={fileAnnotationCounts}
+        highlightedFiles={highlightedFiles}
+        fileEditStatuses={editableDocuments.fileEditStatuses}
+        fileBrowser={fileBrowser}
+        onFilesSelectFile={handleNavigatorFileSelect}
+        onFilesFetchAll={() => fileBrowser.fetchAll(fileBrowserDirs)}
+        onFilesRetryVaultDir={(vaultPath) => fileBrowser.addVaultDir(vaultPath)}
+        hasFileAnnotations={hasFileAnnotations}
+        showVersionsTab={!isHtmlSurface && activeDiffVersionInfo !== null && activeDiffVersionInfo.totalVersions > 1}
+        versionInfo={activeDiffVersionInfo}
+        versions={planDiff.versions}
+        selectedBaseVersion={planDiff.diffBaseVersion}
+        onSelectBaseVersion={handleSelectBaseVersion}
+        isPlanDiffActive={isPlanDiffActive}
+        hasPreviousVersion={planDiff.hasPreviousVersion}
+        onActivatePlanDiff={handleNavigatorDiffActivate}
+        isLoadingVersions={planDiff.isLoadingVersions}
+        isSelectingVersion={planDiff.isSelectingVersion}
+        fetchingVersion={planDiff.fetchingVersion}
+        onFetchVersions={planDiff.fetchVersions}
+        showArchiveTab={isApiMode && !annotateMode && !goalSetupMode}
+        archivePlans={archive.plans}
+        selectedArchiveFile={archive.selectedFile}
+        onArchiveSelect={handleNavigatorArchiveSelect}
+        isLoadingArchive={archive.isLoading}
+        showMessagesTab={annotateSource === 'message' && recentMessages.length > 1}
+        messages={recentMessages}
+        selectedMessageId={selectedMessageId}
+        onSelectMessage={handleNavigatorMessageSelect}
+        messageAnnotationCounts={activeMessageAnnotationCounts}
+      />
+    );
+  };
   // Mobile Safari paints the browser-controls backdrop from the document/app
   // canvas, not from the nested document scroller. Keep that canvas continuous
   // with the active surface so a card-backed plan does not end in a dark band.
@@ -4260,6 +4431,10 @@ const App: React.FC = () => {
           htmlSurface={isHtmlSurface}
           htmlToolsHidden={htmlToolsHidden}
           onToggleHtmlTools={() => setHtmlToolsHidden((v) => !v)}
+          compactTouchLayout={isCompactTouchLayout}
+          compactNavigatorAvailable={compactNavigatorAvailable}
+          compactNavigatorOpen={isCompactNavigatorOpen}
+          onCompactNavigatorToggle={() => toggleSidebarTab(effectiveCompactNavigatorTab)}
           isApiMode={isApiMode}
           annotateMode={annotateMode}
           archiveMode={archive.archiveMode}
@@ -4272,9 +4447,9 @@ const App: React.FC = () => {
           origin={origin}
           isSubmitting={isSubmitting}
           isExiting={isExiting}
-          isPanelOpen={isPanelOpen && rightSidebarTab === 'annotations'}
+          isPanelOpen={effectivePanelOpen && rightSidebarTab === 'annotations'}
           aiAvailable={canUseAskAI}
-          isAIChatOpen={isPanelOpen && rightSidebarTab === 'ai'}
+          isAIChatOpen={effectivePanelOpen && rightSidebarTab === 'ai'}
           aiHasMessages={visibleAIMessages.length > 0}
           hasAnyAnnotations={hasAnyAnnotations || hasDirectEdits || hasSavedFileChanges}
           annotationCount={feedbackAnnotationCount}
@@ -4325,6 +4500,8 @@ const App: React.FC = () => {
           bearConfigured={getBearSettings().enabled}
           octarineConfigured={isOctarineConfigured()}
         />
+
+        {isCompactNavigatorOpen && compactNavigatorAvailable && renderPlanSidebar('overlay')}
 
         {/* Linked document error banner */}
         {linkedDocHook.error && (
@@ -4421,7 +4598,7 @@ const App: React.FC = () => {
             </div>
           )}
           {/* Left Sidebar: collapsed tab flags (when sidebar is closed) */}
-          {wideModeType === null && !sidebar.isOpen && !goalSetupMode && !isAgentTerminalOpen && !htmlChromeHidden && (
+          {!isCompactTouchLayout && wideModeType === null && !sidebar.isOpen && !goalSetupMode && !isAgentTerminalOpen && !htmlChromeHidden && (
             <SidebarTabs
               activeTab={sidebar.activeTab}
               onToggleTab={toggleSidebarTab}
@@ -4440,83 +4617,9 @@ const App: React.FC = () => {
           )}
 
           {/* Left Sidebar: open state (TOC or Version Browser) */}
-          {sidebar.isOpen && !goalSetupMode && (
+          {!isCompactTouchLayout && sidebar.isOpen && !goalSetupMode && (
             <div className="contents group/sidebar">
-              <SidebarContainer
-                activeTab={sidebar.activeTab}
-                onTabChange={(tab) => {
-                  toggleSidebarTab(tab);
-                  if (tab === 'archive' && !archive.archiveMode) archive.fetchPlans();
-                }}
-                onClose={sidebar.close}
-                width={`var(--toc-w, ${tocResize.width}px)`}
-                showAgentTerminalButton={showAgentTerminalControls}
-                isAgentTerminalOpen={isAgentTerminalOpen}
-                isAgentTerminalRunning={isAgentTerminalRunning}
-                onToggleAgentTerminal={toggleAgentTerminal}
-                blocks={blocks}
-                annotations={annotations}
-                activeSection={activeSection}
-                onTocNavigate={handleTocNavigate}
-                linkedDocFilepath={linkedDocHook.filepath}
-                onLinkedDocBack={linkedDocHook.isActive ? handleLinkedDocBack : undefined}
-                backLabel={backLabel}
-                showFilesTab={showFilesTab && !archive.archiveMode}
-                fileAnnotationCounts={fileAnnotationCounts}
-                highlightedFiles={highlightedFiles}
-                fileEditStatuses={editableDocuments.fileEditStatuses}
-                fileBrowser={fileBrowser}
-                onFilesSelectFile={(...args: Parameters<typeof handleFileBrowserSelect>) => {
-                  // Plan/review linked-doc browsing still swaps the root document
-                  // under the editor. Folder mode snapshots the active file first.
-                  if (isEditingMarkdown && annotateSource !== 'folder') {
-                    toast('Finish editing first', { description: 'Use "Done editing" before opening files.' });
-                    return;
-                  }
-                  // Mid-edit, only files that can themselves be edited (source-save
-                  // capable: .md/.mdx/.txt) may be opened. Wider annotatable types
-                  // (.yaml/.json/…) are view-only — switching to one mid-edit would
-                  // silently downgrade "Done editing" to feedback-only edits.
-                  if (isEditingMarkdown && !isSourceSaveFilePath(args[0])) {
-                    toast('Finish editing first', { description: 'Use "Done editing" before opening non-editable files.' });
-                    return;
-                  }
-                  handleFileBrowserSelect(...args);
-                }}
-                onFilesFetchAll={() => fileBrowser.fetchAll(fileBrowserDirs)}
-                onFilesRetryVaultDir={(vaultPath) => fileBrowser.addVaultDir(vaultPath)}
-                hasFileAnnotations={hasFileAnnotations}
-                showVersionsTab={!isHtmlSurface && activeDiffVersionInfo !== null && activeDiffVersionInfo.totalVersions > 1}
-                versionInfo={activeDiffVersionInfo}
-                versions={planDiff.versions}
-                selectedBaseVersion={planDiff.diffBaseVersion}
-                onSelectBaseVersion={handleSelectBaseVersion}
-                isPlanDiffActive={isPlanDiffActive}
-                hasPreviousVersion={planDiff.hasPreviousVersion}
-                onActivatePlanDiff={handleActivatePlanDiff}
-                isLoadingVersions={planDiff.isLoadingVersions}
-                isSelectingVersion={planDiff.isSelectingVersion}
-                fetchingVersion={planDiff.fetchingVersion}
-                onFetchVersions={planDiff.fetchVersions}
-                showArchiveTab={isApiMode && !annotateMode && !goalSetupMode}
-                archivePlans={archive.plans}
-                selectedArchiveFile={archive.selectedFile}
-                onArchiveSelect={(...args: Parameters<typeof archive.select>) => {
-                  // Archive selection swaps the markdown state under the open
-                  // editor — block it rather than corrupt the edit session.
-                  if (isEditingMarkdown) {
-                    toast('Finish editing first', { description: 'Use "Done editing" before browsing archived plans.' });
-                    return;
-                  }
-                  archive.select(...args);
-                }}
-                isLoadingArchive={archive.isLoading}
-                showMessagesTab={annotateSource === 'message' && recentMessages.length > 1}
-                messages={recentMessages}
-                selectedMessageId={selectedMessageId}
-                onSelectMessage={handleSelectMessage}
-                messageAnnotationCounts={activeMessageAnnotationCounts}
-              />
+              {renderPlanSidebar('desktop')}
               <ResizeHandle {...tocResize.handleProps} className="hidden lg:block z-[55]" side="left" hideHoverTrack tooltip={RESIZE_HANDLE_TOOLTIP} onCollapse={sidebar.close} />
             </div>
           )}
@@ -4626,12 +4729,10 @@ const App: React.FC = () => {
               )}
               {/* Folder annotation empty state — shown before user picks a file */}
               {annotateSource === 'folder' && !markdown && !linkedDocHook.isActive && !goalSetupMode && (
-                <div className="w-full flex justify-center">
-                  <div className="w-full max-w-3xl p-12 text-center text-muted-foreground">
-                    <p className="text-lg font-medium mb-2">Select a file to annotate</p>
-                    <p className="text-sm">Pick a markdown or HTML file from the sidebar to begin.</p>
-                  </div>
-                </div>
+                <FolderAnnotationEmptyState
+                  compactTouchLayout={isCompactTouchLayout}
+                  onChooseFile={() => openSidebarTab('files')}
+                />
               )}
               {/* Normal Plan View — always mounted, hidden during diff mode */}
               <div className={`w-full relative ${isHtmlSurface ? 'flex-1 flex flex-col' : `flex justify-center${isEditingMarkdown ? ' flex-1 min-h-0' : ''}`}`} style={{ display: goalSetupMode || (isPlanDiffActive && planDiff.diffBlocks) || (annotateSource === 'folder' && !markdown && !linkedDocHook.isActive) ? 'none' : undefined }}>
@@ -4847,7 +4948,7 @@ const App: React.FC = () => {
                             // only changed via handleSelectMessage), so findIndex is >= 0.
                             current: recentMessages.findIndex((m) => m.messageId === selectedMessageId) + 1,
                             total: recentMessages.length,
-                            onOpen: () => sidebar.open('messages'),
+                            onOpen: () => openSidebarTab('messages'),
                           }
                         : undefined
                     }
@@ -4868,11 +4969,11 @@ const App: React.FC = () => {
               ancestor (`contents` = no layout box). */}
           <div className="contents group/sidebar">
           {/* Resize Handle */}
-          {isPanelOpen && wideModeType === null && !goalSetupMode && (rightSidebarTab === 'annotations' || canUseAskAI) && <ResizeHandle {...panelResize.handleProps} className="hidden md:block z-[55]" side="right" hideHoverTrack tooltip={RESIZE_HANDLE_TOOLTIP} onCollapse={() => setIsPanelOpen(false)} />}
+          {effectivePanelOpen && wideModeType === null && !goalSetupMode && (rightSidebarTab === 'annotations' || canUseAskAI) && <ResizeHandle {...panelResize.handleProps} className="hidden md:block z-[55]" side="right" hideHoverTrack tooltip={RESIZE_HANDLE_TOOLTIP} onCollapse={() => setIsPanelOpen(false)} />}
 
           {/* Annotation Panel */}
           <AnnotationPanel
-            isOpen={isPanelOpen && rightSidebarTab === 'annotations' && wideModeType === null && !goalSetupMode}
+            isOpen={effectivePanelOpen && rightSidebarTab === 'annotations' && wideModeType === null && !goalSetupMode}
             blocks={blocks}
             annotations={allAnnotations}
             selectedId={selectedAnnotationId ?? selectedCodeAnnotationId}
@@ -4901,7 +5002,7 @@ const App: React.FC = () => {
             onOtherFileAnnotationsClick={handleFlashAnnotatedFiles}
             readOnly={documentReadOnly}
           />
-          {isPanelOpen && rightSidebarTab === 'ai' && wideModeType === null && !goalSetupMode && canUseAskAI && (
+          {effectivePanelOpen && rightSidebarTab === 'ai' && wideModeType === null && !goalSetupMode && canUseAskAI && (
             <aside
               data-annotation-panel="true"
               className={`border-l border-border/50 bg-card flex flex-col flex-shrink-0 ${

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -549,6 +549,8 @@ const App: React.FC = () => {
   const [compactPlanSurface, setCompactPlanSurface] = useState<CompactPlanSurface>(COMPACT_PLAN_ARTIFACT);
   const compactPlanSurfaceTriggerRef = useRef<HTMLElement | null>(null);
   const [compactNavigatorTab, setCompactNavigatorTab] = useState<SidebarTab>('toc');
+  const [compactPendingFilePath, setCompactPendingFilePath] = useState<string | null>(null);
+  const compactPendingFileRef = useRef<string | null>(null);
   const isCompactNavigatorOpen = isCompactTouchLayout && compactPlanSurface.type === 'navigator';
   const isCompactFilesSurfaceOpen =
     isCompactNavigatorOpen && compactPlanSurface.type === 'navigator' && compactPlanSurface.tab === 'files';
@@ -566,6 +568,8 @@ const App: React.FC = () => {
     if (isCompactTouchLayout) return;
     setCompactPlanSurface(COMPACT_PLAN_ARTIFACT);
     compactPlanSurfaceTriggerRef.current = null;
+    compactPendingFileRef.current = null;
+    setCompactPendingFilePath(null);
     // Keep the session-only compact method ready to inherit the latest
     // explicit desktop choice without letting compact changes write it back.
     setCompactInputMethod(inputMethod);
@@ -928,6 +932,15 @@ const App: React.FC = () => {
     return currentText;
   }, [activeEditableDocument, annotateSource, editableDocuments, isEditingMarkdown]);
 
+  const handleLinkedDocumentActivated = useCallback(() => {
+    if (!compactPendingFileRef.current) return;
+    compactPendingFileRef.current = null;
+    setCompactPendingFilePath(null);
+    setCompactPlanSurface((surface) =>
+      surface.type === 'navigator' ? COMPACT_PLAN_ARTIFACT : surface,
+    );
+  }, []);
+
   // Linked document navigation
   const linkedDocHook = useLinkedDoc({
     markdown, annotations, selectedAnnotationId, globalAttachments,
@@ -936,6 +949,7 @@ const App: React.FC = () => {
     viewerRef, sidebar: linkedDocSidebar, sourceFilePath, sourceConverted,
     onBeforeNavigate: snapshotActiveEditableDocument,
     onDocumentLoaded: handleLinkedDocumentLoaded,
+    onDocumentActivated: handleLinkedDocumentActivated,
     getDocumentMarkdown: getLinkedDocumentMarkdown,
     onAfterBack: restoreLinkedDocumentEditableKey,
   });
@@ -1336,7 +1350,7 @@ const App: React.FC = () => {
     linkedDocHook.restoreSession,
   ]);
 
-  const handleFileBrowserSelect = React.useCallback((absolutePath: string, dirPath: string) => {
+  const handleFileBrowserSelect = React.useCallback(async (absolutePath: string, dirPath: string): Promise<void> => {
     const normalizedAbsolutePath = normalizeBrowserPath(absolutePath);
     const dirState = fileBrowser.dirs.find(d => d.path === dirPath);
     const normalizedDirPath = normalizeBrowserPath(dirPath);
@@ -1384,8 +1398,8 @@ const App: React.FC = () => {
       // rendering — without it, extensions that overlap the code-file set
       // (.yaml, .json, .toml, …) would come back as code-file popout payloads.
       : (path: string) => `/api/doc?path=${encodeURIComponent(path)}&base=${encodeURIComponent(dirPath)}&doc=1${convertHtml ? '&convert=1' : ''}`;
-    linkedDocHook.open(absolutePath, buildUrl, 'files');
     fileBrowser.setActiveFile(absolutePath);
+    await linkedDocHook.open(absolutePath, buildUrl, 'files');
   }, [editableDocuments, linkedDocHook, fileBrowser, convertHtml, isEditingMarkdown]);
 
   // Route linked doc opens through the correct endpoint based on current context
@@ -4550,7 +4564,7 @@ const App: React.FC = () => {
     if (tab === 'archive' && !archive.archiveMode) archive.fetchPlans();
   };
 
-  const handleNavigatorFileSelect = (...args: Parameters<typeof handleFileBrowserSelect>) => {
+  const handleNavigatorFileSelect = async (...args: Parameters<typeof handleFileBrowserSelect>) => {
     // Plan/review linked-doc browsing still swaps the root document under the
     // editor. Folder mode snapshots the active file first.
     if (isEditingMarkdown && annotateSource !== 'folder') {
@@ -4563,8 +4577,26 @@ const App: React.FC = () => {
       toast('Finish editing first', { description: 'Use "Done editing" before opening non-editable files.' });
       return;
     }
-    handleFileBrowserSelect(...args);
-    if (isCompactTouchLayout) closeCompactNavigator();
+    if (!isCompactTouchLayout) {
+      void handleFileBrowserSelect(...args);
+      return;
+    }
+    if (compactPendingFileRef.current) return;
+
+    const destination = args[0];
+    compactPendingFileRef.current = destination;
+    setCompactPendingFilePath(destination);
+    try {
+      await handleFileBrowserSelect(...args);
+    } catch {
+      // The shared fetch path reports expected failures through its error
+      // state. Treat an unexpected exception as the same retryable outcome.
+    }
+    if (compactPendingFileRef.current === destination) {
+      compactPendingFileRef.current = null;
+      setCompactPendingFilePath(null);
+      toast('Couldn’t open file', { description: 'The file navigator is still open so you can try again.' });
+    }
   };
 
   const handleNavigatorArchiveSelect = (...args: Parameters<typeof archive.select>) => {
@@ -4623,6 +4655,9 @@ const App: React.FC = () => {
         onFilesSelectFile={handleNavigatorFileSelect}
         onFilesFetchAll={() => fileBrowser.fetchAll(fileBrowserDirs)}
         onFilesRetryVaultDir={(vaultPath) => fileBrowser.addVaultDir(vaultPath)}
+        pendingFileLabel={compact && compactPendingFilePath
+          ? compactPendingFilePath.replace(/\\/g, '/').split('/').pop() || compactPendingFilePath
+          : null}
         hasFileAnnotations={hasFileAnnotations}
         showVersionsTab={!isHtmlSurface && activeDiffVersionInfo !== null && activeDiffVersionInfo.totalVersions > 1}
         versionInfo={activeDiffVersionInfo}

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -126,7 +126,10 @@ const DEMO_PLAN_CONTENT = USE_DIFF_DEMO
   ? DIFF_DEMO_PLAN_CONTENT
   : DEFAULT_DEMO_PLAN_CONTENT;
 import { useCheckboxOverrides } from './hooks/useCheckboxOverrides';
-import { usePlanDiffViewAutoExit } from './hooks/usePlanDiffViewAutoExit';
+import {
+  usePlanDiffNavigationAutoExit,
+  usePlanDiffViewAutoExit,
+} from './hooks/usePlanDiffViewAutoExit';
 import { AppHeader } from './components/AppHeader';
 import type { CompactPlanAction } from '@plannotator/ui/components/PlanHeaderMenu';
 import { FolderAnnotationEmptyState } from './components/FolderAnnotationEmptyState';
@@ -845,13 +848,6 @@ const App: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [blocks, hasTocEntries]);
 
-  // Clear diff view when switching away from versions tab
-  useEffect(() => {
-    if ((sidebar.activeTab === 'toc' || isCompactContentsSurfaceOpen) && isPlanDiffActive) {
-      setIsPlanDiffActive(false);
-    }
-  }, [isCompactContentsSurfaceOpen, isPlanDiffActive, sidebar.activeTab]);
-
   // Clear diff view on Escape key
   useEffect(() => {
     if (!isPlanDiffActive) return;
@@ -1008,6 +1004,10 @@ const App: React.FC = () => {
   usePlanDiffViewAutoExit(
     isPlanDiffActive && !isHtmlSurface,
     planDiff.hasPreviousVersion,
+    exitPlanDiffView,
+  );
+  usePlanDiffNavigationAutoExit(
+    sidebar.activeTab === 'toc' || isCompactContentsSurfaceOpen,
     exitPlanDiffView,
   );
   const warnFinishEditingFirst = useCallback((target: 'versions' | 'diff') => {

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -132,6 +132,12 @@ import type { CompactPlanAction } from '@plannotator/ui/components/PlanHeaderMen
 import { FolderAnnotationEmptyState } from './components/FolderAnnotationEmptyState';
 import { CompactAnnotationControls } from './components/CompactAnnotationControls';
 import { CompactEditControls } from './components/CompactEditControls';
+import { CompactPlanStage } from './components/CompactPlanStage';
+import {
+  CompactPlanCompletion,
+  CompactPlanReview,
+  type CompactPlanReviewAction,
+} from './components/CompactPlanReview';
 import {
   COMPACT_PLAN_ARTIFACT,
   openCompactPlanNavigator,
@@ -286,6 +292,10 @@ const feedbackLossDescription = (annotationCount: number, hasDirectEdits: boolea
 };
 
 type SourceFileEditWarningAction = 'send-feedback' | 'approve' | 'close';
+type CompactPlanTransientSurface = Extract<
+  CompactPlanSurface,
+  { readonly type: 'annotations' | 'ai' | 'review' }
+>['type'];
 
 /** Hint shown following the cursor while hovering a sidebar/panel resize handle. */
 const RESIZE_HANDLE_TOOLTIP = 'Click to close · Drag to resize';
@@ -537,12 +547,16 @@ const App: React.FC = () => {
   const effectiveEditorMode: EditorMode = isCompactTouchLayout ? 'selection' : editorMode;
   const effectiveInputMethod = isCompactTouchLayout ? compactInputMethod : inputMethod;
   const [compactPlanSurface, setCompactPlanSurface] = useState<CompactPlanSurface>(COMPACT_PLAN_ARTIFACT);
+  const compactPlanSurfaceTriggerRef = useRef<HTMLElement | null>(null);
   const [compactNavigatorTab, setCompactNavigatorTab] = useState<SidebarTab>('toc');
   const isCompactNavigatorOpen = isCompactTouchLayout && compactPlanSurface.type === 'navigator';
   const isCompactFilesSurfaceOpen =
     isCompactNavigatorOpen && compactPlanSurface.type === 'navigator' && compactPlanSurface.tab === 'files';
   const isCompactContentsSurfaceOpen =
     isCompactNavigatorOpen && compactPlanSurface.type === 'navigator' && compactPlanSurface.tab === 'toc';
+  const isCompactAnnotationsOpen = isCompactTouchLayout && compactPlanSurface.type === 'annotations';
+  const isCompactAIOpen = isCompactTouchLayout && compactPlanSurface.type === 'ai';
+  const isCompactReviewOpen = isCompactTouchLayout && compactPlanSurface.type === 'review';
   const effectivePanelOpen = shouldPresentDesktopPlanPanel(isCompactTouchLayout, isPanelOpen);
 
   // Compact interactions never write into the remembered desktop rail/panel
@@ -551,6 +565,7 @@ const App: React.FC = () => {
   useEffect(() => {
     if (isCompactTouchLayout) return;
     setCompactPlanSurface(COMPACT_PLAN_ARTIFACT);
+    compactPlanSurfaceTriggerRef.current = null;
     // Keep the session-only compact method ready to inherit the latest
     // explicit desktop choice without letting compact changes write it back.
     setCompactInputMethod(inputMethod);
@@ -691,7 +706,33 @@ const App: React.FC = () => {
     }, 0);
   }, []);
 
+  const openCompactPlanSurface = useCallback((type: CompactPlanTransientSurface) => {
+    const activeElement = document.activeElement;
+    compactPlanSurfaceTriggerRef.current = activeElement instanceof HTMLElement ? activeElement : null;
+    setCompactPlanSurface({ type });
+  }, []);
+
+  const switchCompactPlanSurface = useCallback((type: CompactPlanTransientSurface) => {
+    setCompactPlanSurface({ type });
+  }, []);
+
+  const closeCompactPlanSurface = useCallback((restoreFocus = true) => {
+    const trigger = compactPlanSurfaceTriggerRef.current;
+    compactPlanSurfaceTriggerRef.current = null;
+    setCompactPlanSurface(COMPACT_PLAN_ARTIFACT);
+    if (!restoreFocus) return;
+    window.setTimeout(() => {
+      const fallback = document.getElementById('pn-compact-plan-options-trigger');
+      const focusTarget = trigger?.isConnected ? trigger : fallback;
+      focusTarget?.focus({ preventScroll: true });
+    }, 0);
+  }, []);
+
   const handleAnnotationPanelToggle = useCallback(() => {
+    if (isCompactTouchLayout) {
+      openCompactPlanSurface('annotations');
+      return;
+    }
     if (wideModeType !== null) {
       exitWideMode({ restore: false, panelOpen: true });
       setRightSidebarTab('annotations');
@@ -699,7 +740,7 @@ const App: React.FC = () => {
     }
     setRightSidebarTab('annotations');
     setIsPanelOpen(prev => rightSidebarTab === 'annotations' ? !prev : true);
-  }, [exitWideMode, rightSidebarTab, wideModeType]);
+  }, [exitWideMode, isCompactTouchLayout, openCompactPlanSurface, rightSidebarTab, wideModeType]);
 
   const dismissLookAndFeelAnnouncement = useCallback(() => {
     // Persist even when the user accepts the displayed default without first
@@ -710,6 +751,10 @@ const App: React.FC = () => {
   }, [gridEnabled]);
 
   const handleAIChatToggle = useCallback(() => {
+    if (isCompactTouchLayout) {
+      openCompactPlanSurface('ai');
+      return;
+    }
     if (wideModeType !== null) {
       exitWideMode({ restore: false, panelOpen: true });
       setRightSidebarTab('ai');
@@ -717,7 +762,7 @@ const App: React.FC = () => {
     }
     setRightSidebarTab('ai');
     setIsPanelOpen(prev => rightSidebarTab === 'ai' ? !prev : true);
-  }, [exitWideMode, rightSidebarTab, wideModeType]);
+  }, [exitWideMode, isCompactTouchLayout, openCompactPlanSurface, rightSidebarTab, wideModeType]);
 
   const hideAgentTerminal = useCallback(() => {
     setIsAgentTerminalOpen(false);
@@ -3449,8 +3494,8 @@ const App: React.FC = () => {
   const handleSelectAnnotation = React.useCallback((id: string | null) => {
     setSelectedAnnotationId(id);
     if (id) setSelectedCodeAnnotationId(null);
-    if (id && isMobile && wideModeType === null) setIsPanelOpen(true);
-  }, [isMobile, wideModeType]);
+    if (id && isMobile && !isCompactTouchLayout && wideModeType === null) setIsPanelOpen(true);
+  }, [isCompactTouchLayout, isMobile, wideModeType]);
 
   const handleAddCodeAnnotation = React.useCallback((input: CodeFileAnnotationInput) => {
     if (documentReadOnly) return;
@@ -3482,8 +3527,8 @@ const App: React.FC = () => {
     setSelectedAnnotationId(null);
     setSelectedCodeAnnotationId(id);
     codeFilePopout.open(annotation.filePath);
-    if (isMobile && wideModeType === null) setIsPanelOpen(true);
-  }, [codeAnnotations, codeFilePopout.open, isMobile, wideModeType]);
+    if (isMobile && !isCompactTouchLayout && wideModeType === null) setIsPanelOpen(true);
+  }, [codeAnnotations, codeFilePopout.open, isCompactTouchLayout, isMobile, wideModeType]);
 
   const handleDeleteCodeAnnotation = React.useCallback((id: string) => {
     if (documentReadOnly) return;
@@ -3728,19 +3773,25 @@ const App: React.FC = () => {
 
   // Opening the Ask AI surface with a provider selected is the other explicit
   // gesture that should surface the provider's real model list.
-  const aiSurfaceOpen = effectivePanelOpen && rightSidebarTab === 'ai';
+  const aiSurfaceOpen = isCompactTouchLayout
+    ? compactPlanSurface.type === 'ai'
+    : effectivePanelOpen && rightSidebarTab === 'ai';
   useEffect(() => {
     if (!aiAvailable || !aiSurfaceOpen) return;
     activateAIProvider(aiConfig.providerId);
   }, [aiAvailable, aiSurfaceOpen, aiConfig.providerId, activateAIProvider]);
 
   const openAIChat = useCallback(() => {
+    if (isCompactTouchLayout) {
+      openCompactPlanSurface('ai');
+      return;
+    }
     if (wideModeType !== null) {
       exitWideMode({ restore: false, panelOpen: true });
     }
     setRightSidebarTab('ai');
     setIsPanelOpen(true);
-  }, [exitWideMode, wideModeType]);
+  }, [exitWideMode, isCompactTouchLayout, openCompactPlanSurface, wideModeType]);
 
   const handleAskAI = useCallback((question: string, context?: CommentAskAIContext): boolean => {
     if (isAgentTerminalReady) {
@@ -4292,7 +4343,7 @@ const App: React.FC = () => {
     ? Boolean(shareUrl || shortShareUrl || (renderAs === 'html' && (shareHtml || rawHtml)))
     : true;
   const compactActionBusy = isSubmitting || isExiting || goalSetupAction.isSubmitting;
-  const compactSessionActions: CompactPlanAction[] = !isCompactTouchLayout
+  const compactReviewActions: CompactPlanReviewAction[] = !isCompactTouchLayout
     ? []
     : callbackConfig && !isApiMode && isSharedSession
       ? [
@@ -4309,68 +4360,127 @@ const App: React.FC = () => {
             disabled: compactActionBusy || !callbackShareUrlReady,
           },
         ]
-      : isApiMode && !linkedDocHook.isActive && archive.archiveMode
+      : isApiMode && (!linkedDocHook.isActive || annotateMode) && !archive.archiveMode && !goalSetupMode
         ? [
-            { id: 'copy', label: 'Copy plan', onSelect: archive.copy },
-            { id: 'done', label: 'Done', onSelect: archive.done },
-          ]
-        : isApiMode && !linkedDocHook.isActive && goalSetupMode
-          ? [
-              {
-                id: 'exit',
-                label: 'Close goal setup',
-                onSelect: handleGoalSetupExit,
-                disabled: compactActionBusy,
-              },
-              {
-                id: 'approve',
-                label: goalSetupAction.submitLabel,
-                onSelect: handleGoalSetupSubmit,
-                disabled: !goalSetupAction.canSubmit || compactActionBusy,
-              },
-            ]
-          : isApiMode && (!linkedDocHook.isActive || annotateMode) && !archive.archiveMode && !goalSetupMode
-            ? [
-                ...(annotateMode
-                  ? [
-                      {
-                        id: 'exit' as const,
-                        label: 'Close session',
-                        onSelect: handleHeaderAnnotateExit,
+            ...(annotateMode
+              ? [
+                  {
+                    id: 'exit' as const,
+                    label: 'Close session',
+                    onSelect: handleHeaderAnnotateExit,
+                    disabled: compactActionBusy,
+                  },
+                  ...(hasFeedbackContent
+                    ? [{
+                        id: 'feedback' as const,
+                        label: 'Send feedback',
+                        subtitle: feedbackAnnotationCount > 0
+                          ? `${feedbackAnnotationCount} annotation${feedbackAnnotationCount === 1 ? '' : 's'}`
+                          : 'Edited document',
+                        onSelect: handleHeaderAnnotateFeedback,
                         disabled: compactActionBusy,
-                      },
-                      ...(hasFeedbackContent
-                        ? [{
-                            id: 'feedback' as const,
-                            label: 'Send feedback',
-                            subtitle: feedbackAnnotationCount > 0
-                              ? `${feedbackAnnotationCount} annotation${feedbackAnnotationCount === 1 ? '' : 's'}`
-                              : 'Edited document',
-                            onSelect: handleHeaderAnnotateFeedback,
-                            disabled: compactActionBusy,
-                          }]
-                        : []),
-                    ]
-                  : [{
-                      id: 'feedback' as const,
-                      label: 'Send feedback',
-                      subtitle: hasFeedbackToSend
-                        ? `${feedbackAnnotationCount} annotation${feedbackAnnotationCount === 1 ? '' : 's'}`
-                        : 'Add general feedback',
-                      onSelect: handleHeaderFeedback,
-                      disabled: compactActionBusy,
-                    }]),
-                ...((!annotateMode || gate)
-                  ? [{
-                      id: 'approve' as const,
-                      label: annotateMode ? annotateApprovalPolicy.label : 'Approve',
-                      subtitle: !annotateMode && hasFeedbackToSend ? 'Feedback remains unsent' : undefined,
-                      onSelect: handleHeaderApprove,
-                      disabled: compactActionBusy,
-                    }]
-                  : []),
-              ]
-            : [];
+                      }]
+                    : []),
+                ]
+              : [{
+                  id: 'feedback' as const,
+                  label: 'Send feedback',
+                  subtitle: hasFeedbackToSend
+                    ? `${feedbackAnnotationCount} annotation${feedbackAnnotationCount === 1 ? '' : 's'}`
+                    : 'Add general feedback',
+                  onSelect: handleHeaderFeedback,
+                  disabled: compactActionBusy,
+                }]),
+            ...((!annotateMode || gate)
+              ? [{
+                  id: 'approve' as const,
+                  label: annotateMode ? annotateApprovalPolicy.label : 'Approve',
+                  subtitle: !annotateMode && hasFeedbackToSend ? 'Feedback remains unsent' : undefined,
+                  onSelect: handleHeaderApprove,
+                  disabled: compactActionBusy,
+                }]
+              : []),
+          ]
+        : [];
+  const compactModeActions: CompactPlanAction[] = !isCompactTouchLayout
+    ? []
+    : isApiMode && !linkedDocHook.isActive && archive.archiveMode
+      ? [
+          { id: 'copy', label: 'Copy plan', onSelect: archive.copy },
+          { id: 'done', label: 'Done', onSelect: archive.done },
+        ]
+      : isApiMode && !linkedDocHook.isActive && goalSetupMode
+        ? [
+            {
+              id: 'exit',
+              label: 'Close goal setup',
+              onSelect: handleGoalSetupExit,
+              disabled: compactActionBusy,
+            },
+            {
+              id: 'approve',
+              label: goalSetupAction.submitLabel,
+              onSelect: handleGoalSetupSubmit,
+              disabled: !goalSetupAction.canSubmit || compactActionBusy,
+            },
+          ]
+        : [];
+  const hasReviewDocumentChanges = hasDirectEdits || hasSavedFileChanges;
+  const compactCanApprove = compactReviewActions.some((action) => action.id === 'approve');
+  const compactFeedbackSummary = showAgentTerminalDeliveryStatus
+    ? 'Feedback was sent to the agent. You can keep reviewing or close the session.'
+    : feedbackAnnotationCount > 0 && hasReviewDocumentChanges
+      ? `${feedbackAnnotationCount} annotation${feedbackAnnotationCount === 1 ? '' : 's'} and document edits are ready.`
+      : feedbackAnnotationCount > 0
+        ? `${feedbackAnnotationCount} annotation${feedbackAnnotationCount === 1 ? '' : 's'} ${feedbackAnnotationCount === 1 ? 'is' : 'are'} ready.`
+        : hasReviewDocumentChanges
+          ? 'Document edits are ready to send with your review.'
+          : compactCanApprove
+            ? 'No feedback added. You can approve or keep reviewing.'
+            : 'No feedback added. You can keep reviewing or close the session.';
+  const compactPrimaryReviewActionId: CompactPlanReviewAction['id'] | undefined =
+    compactReviewActions.some((action) => action.id === 'feedback') &&
+    (hasFeedbackToSend || !compactCanApprove)
+      ? 'feedback'
+      : compactReviewActions.find((action) => action.id === 'approve')?.id
+        ?? compactReviewActions.find((action) => action.id !== 'exit')?.id
+        ?? compactReviewActions[0]?.id;
+  const compactSessionActions: CompactPlanAction[] = !isCompactTouchLayout
+    ? []
+    : [
+        ...(!goalSetupMode
+          ? [{
+              id: 'annotations' as const,
+              label: 'Annotations',
+              subtitle: feedbackAnnotationCount > 0
+                ? `${feedbackAnnotationCount} item${feedbackAnnotationCount === 1 ? '' : 's'}`
+                : undefined,
+              onSelect: () => openCompactPlanSurface('annotations'),
+            }]
+          : []),
+        ...(!goalSetupMode && canUseAskAI
+          ? [{
+              id: 'ai' as const,
+              label: 'Ask AI',
+              subtitle: visibleAIMessages.length > 0
+                ? `${visibleAIMessages.length} message${visibleAIMessages.length === 1 ? '' : 's'}`
+                : undefined,
+              onSelect: () => openCompactPlanSurface('ai'),
+            }]
+          : []),
+        ...(compactReviewActions.length > 0
+          ? [{
+              id: 'review' as const,
+              label: 'Review and finish',
+              subtitle: hasFeedbackToSend
+                ? 'Feedback ready'
+                : compactCanApprove
+                  ? 'Approve or send feedback'
+                  : 'Close when finished',
+              onSelect: () => openCompactPlanSurface('review'),
+            }]
+          : compactModeActions),
+      ];
   const compactDocumentActions: CompactPlanAction[] = !isCompactTouchLayout
     ? []
     : [
@@ -4539,6 +4649,70 @@ const App: React.FC = () => {
       />
     );
   };
+
+  const renderAnnotationPanel = (presentation: 'panel' | 'embedded', isOpen = true) => (
+    <AnnotationPanel
+      isOpen={isOpen}
+      presentation={presentation}
+      blocks={blocks}
+      annotations={allAnnotations}
+      selectedId={selectedAnnotationId ?? selectedCodeAnnotationId}
+      onSelect={handleSelectAnnotation}
+      onDelete={handleDeleteAnnotation}
+      onEdit={handleEditAnnotation}
+      codeAnnotations={codeAnnotations}
+      onSelectCodeAnnotation={handleSelectCodeAnnotation}
+      onDeleteCodeAnnotation={handleDeleteCodeAnnotation}
+      onEditCodeAnnotation={handleEditCodeAnnotation}
+      sharingEnabled={canShareCurrentSession}
+      width={presentation === 'panel' ? `var(--rpanel-w, ${panelResize.width}px)` : undefined}
+      editorAnnotations={editorAnnotations}
+      onDeleteEditorAnnotation={deleteEditorAnnotation}
+      onClose={presentation === 'panel' ? () => setIsPanelOpen(false) : closeCompactPlanSurface}
+      onQuickCopy={async () => {
+        const output = getCurrentFeedbackPayload();
+        return copyTextToClipboard(wrapCopiedFeedback(output));
+      }}
+      onShare={canShareCurrentSession ? () => {
+        if (presentation === 'panel') setIsPanelOpen(false);
+        else closeCompactPlanSurface(false);
+        setInitialExportTab('share');
+        setShowExport(true);
+      } : undefined}
+      otherFileAnnotations={otherFileAnnotations}
+      directEdits={directEditsPanelInfo?.map((item) => ({
+        ...item,
+        onDiscard: item.id === 'plan' ? () => handleDiscardEdits() : undefined,
+      })) ?? null}
+      onOtherFileAnnotationsClick={handleFlashAnnotatedFiles}
+      readOnly={documentReadOnly}
+    />
+  );
+
+  const renderDocumentAIChat = () => (
+    <DocumentAIChatPanel
+      messages={visibleAIMessages}
+      isCreatingSession={isAgentTerminalReady ? false : aiIsCreatingSession}
+      isStreaming={isAgentTerminalReady ? false : aiIsStreaming}
+      onAskGeneral={handleAskGeneralAI}
+      onStop={isAgentTerminalReady ? undefined : abortAI}
+      permissionRequests={isAgentTerminalReady ? [] : aiPermissionRequests}
+      onRespondToPermission={isAgentTerminalReady ? undefined : respondToAIPermission}
+      aiProviders={visibleAIProviders}
+      aiConfig={visibleAIConfig}
+      onAIConfigChange={isAgentTerminalReady ? undefined : handleAIConfigChange}
+    />
+  );
+
+  const showCompactPlanCompletion =
+    isCompactTouchLayout &&
+    compactPlanSurface.type === 'artifact' &&
+    compactReviewActions.length > 0 &&
+    !isEditingMarkdown &&
+    !isPlanDiffActive &&
+    !goalSetupMode &&
+    !isHtmlSurface &&
+    !(annotateSource === 'folder' && !markdown && !linkedDocHook.isActive);
   // Mobile Safari paints the browser-controls backdrop from the document/app
   // canvas, not from the nested document scroller. Keep that canvas continuous
   // with the active surface so a card-backed plan does not end in a dark band.
@@ -4640,6 +4814,51 @@ const App: React.FC = () => {
         />
 
         {isCompactNavigatorOpen && compactNavigatorAvailable && renderPlanSidebar('overlay')}
+
+        {isCompactAnnotationsOpen && (
+          <CompactPlanStage
+            id="pn-compact-plan-annotations"
+            title="Annotations"
+            subtitle={compactDocumentTitle}
+            count={feedbackAnnotationCount}
+            onClose={closeCompactPlanSurface}
+          >
+            <div className="mx-auto flex min-h-0 w-full max-w-3xl flex-1">
+              {renderAnnotationPanel('embedded')}
+            </div>
+          </CompactPlanStage>
+        )}
+
+        {isCompactAIOpen && canUseAskAI && (
+          <CompactPlanStage
+            id="pn-compact-plan-ai"
+            title="Ask AI"
+            subtitle={compactDocumentTitle}
+            count={visibleAIMessages.length}
+            onClose={closeCompactPlanSurface}
+          >
+            <div className="mx-auto flex min-h-0 w-full max-w-3xl flex-1">
+              {renderDocumentAIChat()}
+            </div>
+          </CompactPlanStage>
+        )}
+
+        {isCompactReviewOpen && compactReviewActions.length > 0 && (
+          <CompactPlanStage
+            id="pn-compact-plan-review"
+            title="Review"
+            subtitle={compactDocumentTitle}
+            onClose={closeCompactPlanSurface}
+          >
+            <CompactPlanReview
+              feedbackSummary={compactFeedbackSummary}
+              actions={compactReviewActions}
+              primaryActionId={compactPrimaryReviewActionId}
+              onOpenAnnotations={() => switchCompactPlanSurface('annotations')}
+              onOpenAI={canUseAskAI ? () => switchCompactPlanSurface('ai') : undefined}
+            />
+          </CompactPlanStage>
+        )}
 
         {/* Linked document error banner */}
         {linkedDocHook.error && (
@@ -5117,6 +5336,13 @@ const App: React.FC = () => {
                   />
                 )}
               </div>
+              {showCompactPlanCompletion && (
+                <CompactPlanCompletion
+                  feedbackSummary={compactFeedbackSummary}
+                  maxWidth={planMaxWidth}
+                  onOpenReview={() => openCompactPlanSurface('review')}
+                />
+              )}
             </div>
           </OverlayScrollArea>
 
@@ -5129,36 +5355,10 @@ const App: React.FC = () => {
           {effectivePanelOpen && wideModeType === null && !goalSetupMode && (rightSidebarTab === 'annotations' || canUseAskAI) && <ResizeHandle {...panelResize.handleProps} className="hidden md:block z-[55]" side="right" hideHoverTrack tooltip={RESIZE_HANDLE_TOOLTIP} onCollapse={() => setIsPanelOpen(false)} />}
 
           {/* Annotation Panel */}
-          <AnnotationPanel
-            isOpen={effectivePanelOpen && rightSidebarTab === 'annotations' && wideModeType === null && !goalSetupMode}
-            blocks={blocks}
-            annotations={allAnnotations}
-            selectedId={selectedAnnotationId ?? selectedCodeAnnotationId}
-            onSelect={handleSelectAnnotation}
-            onDelete={handleDeleteAnnotation}
-            onEdit={handleEditAnnotation}
-            codeAnnotations={codeAnnotations}
-            onSelectCodeAnnotation={handleSelectCodeAnnotation}
-            onDeleteCodeAnnotation={handleDeleteCodeAnnotation}
-            onEditCodeAnnotation={handleEditCodeAnnotation}
-            sharingEnabled={canShareCurrentSession}
-            width={`var(--rpanel-w, ${panelResize.width}px)`}
-            editorAnnotations={editorAnnotations}
-            onDeleteEditorAnnotation={deleteEditorAnnotation}
-            onClose={() => setIsPanelOpen(false)}
-            onQuickCopy={async () => {
-              const output = getCurrentFeedbackPayload();
-              return copyTextToClipboard(wrapCopiedFeedback(output));
-            }}
-            onShare={canShareCurrentSession ? () => { setIsPanelOpen(false); setInitialExportTab('share'); setShowExport(true); } : undefined}
-            otherFileAnnotations={otherFileAnnotations}
-            directEdits={directEditsPanelInfo?.map((item) => ({
-              ...item,
-              onDiscard: item.id === 'plan' ? () => handleDiscardEdits() : undefined,
-            })) ?? null}
-            onOtherFileAnnotationsClick={handleFlashAnnotatedFiles}
-            readOnly={documentReadOnly}
-          />
+          {renderAnnotationPanel(
+            'panel',
+            effectivePanelOpen && rightSidebarTab === 'annotations' && wideModeType === null && !goalSetupMode,
+          )}
           {effectivePanelOpen && rightSidebarTab === 'ai' && wideModeType === null && !goalSetupMode && canUseAskAI && (
             <aside
               data-annotation-panel="true"
@@ -5194,18 +5394,7 @@ const App: React.FC = () => {
                   )}
                 </div>
               </div>
-              <DocumentAIChatPanel
-                messages={visibleAIMessages}
-                isCreatingSession={isAgentTerminalReady ? false : aiIsCreatingSession}
-                isStreaming={isAgentTerminalReady ? false : aiIsStreaming}
-                onAskGeneral={handleAskGeneralAI}
-                onStop={isAgentTerminalReady ? undefined : abortAI}
-                permissionRequests={isAgentTerminalReady ? [] : aiPermissionRequests}
-                onRespondToPermission={isAgentTerminalReady ? undefined : respondToAIPermission}
-                aiProviders={visibleAIProviders}
-                aiConfig={visibleAIConfig}
-                onAIConfigChange={isAgentTerminalReady ? undefined : handleAIConfigChange}
-              />
+              {renderDocumentAIChat()}
             </aside>
           )}
           </div>

--- a/packages/editor/compactPlanSurface.test.ts
+++ b/packages/editor/compactPlanSurface.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  COMPACT_PLAN_ARTIFACT,
+  openCompactPlanNavigator,
+  shouldPresentDesktopPlanPanel,
+  toggleCompactPlanNavigator,
+} from './compactPlanSurface';
+
+describe('compact Plan foreground state', () => {
+  test('opens the requested navigator tab from the reading surface', () => {
+    expect(openCompactPlanNavigator('files')).toEqual({ type: 'navigator', tab: 'files' });
+    expect(toggleCompactPlanNavigator(COMPACT_PLAN_ARTIFACT, 'toc')).toEqual({
+      type: 'navigator',
+      tab: 'toc',
+    });
+  });
+
+  test('keeps tab changes inside the navigator', () => {
+    expect(toggleCompactPlanNavigator({ type: 'navigator', tab: 'toc' }, 'files')).toEqual({
+      type: 'navigator',
+      tab: 'files',
+    });
+  });
+
+  test('returns to the artifact when the header toggles the active tab', () => {
+    expect(toggleCompactPlanNavigator({ type: 'navigator', tab: 'versions' }, 'versions'))
+      .toBe(COMPACT_PLAN_ARTIFACT);
+  });
+
+  test('keeps the remembered desktop panel out of compact arrival', () => {
+    expect(shouldPresentDesktopPlanPanel(true, true)).toBe(false);
+    expect(shouldPresentDesktopPlanPanel(false, true)).toBe(true);
+    expect(shouldPresentDesktopPlanPanel(false, false)).toBe(false);
+  });
+});

--- a/packages/editor/compactPlanSurface.ts
+++ b/packages/editor/compactPlanSurface.ts
@@ -1,9 +1,9 @@
 import type { SidebarTab } from '@plannotator/ui/hooks/useSidebar';
 
 /**
- * The compact Plan shell presents one foreground task at a time. Phase 2B.1
- * implements the document and navigator states; the remaining states reserve
- * the same explicit model for later annotation, AI, and completion surfaces.
+ * The compact Plan shell presents one foreground task at a time. Navigator,
+ * annotations, AI, and review all replace the artifact instead of competing
+ * with it for horizontal space.
  */
 export type CompactPlanSurface =
   | { readonly type: 'artifact' }

--- a/packages/editor/compactPlanSurface.ts
+++ b/packages/editor/compactPlanSurface.ts
@@ -1,0 +1,43 @@
+import type { SidebarTab } from '@plannotator/ui/hooks/useSidebar';
+
+/**
+ * The compact Plan shell presents one foreground task at a time. Phase 2B.1
+ * implements the document and navigator states; the remaining states reserve
+ * the same explicit model for later annotation, AI, and completion surfaces.
+ */
+export type CompactPlanSurface =
+  | { readonly type: 'artifact' }
+  | { readonly type: 'navigator'; readonly tab: SidebarTab }
+  | { readonly type: 'annotations' }
+  | { readonly type: 'ai' }
+  | { readonly type: 'review' };
+
+export const COMPACT_PLAN_ARTIFACT: CompactPlanSurface = { type: 'artifact' };
+
+export function openCompactPlanNavigator(tab: SidebarTab): CompactPlanSurface {
+  return { type: 'navigator', tab };
+}
+
+/**
+ * The header trigger behaves like a disclosure: it returns to the document
+ * when the currently visible navigator is invoked again, and otherwise opens
+ * the requested tab. Tabs inside the navigator use openCompactPlanNavigator
+ * directly so tapping the active tab never dismisses the surface.
+ */
+export function toggleCompactPlanNavigator(
+  surface: CompactPlanSurface,
+  tab: SidebarTab,
+): CompactPlanSurface {
+  if (surface.type === 'navigator' && surface.tab === tab) {
+    return COMPACT_PLAN_ARTIFACT;
+  }
+  return openCompactPlanNavigator(tab);
+}
+
+/** Compact foreground surfaces never borrow the desktop panel presentation. */
+export function shouldPresentDesktopPlanPanel(
+  compactTouchLayout: boolean,
+  desktopPanelOpen: boolean,
+): boolean {
+  return !compactTouchLayout && desktopPanelOpen;
+}

--- a/packages/editor/components/AppHeader.mobile.test.tsx
+++ b/packages/editor/components/AppHeader.mobile.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { CompactPlanNavigatorTrigger } from './AppHeader';
+
+describe('compact Plan navigator trigger', () => {
+  test('is a touch-safe disclosure with a stable focus-restoration target', () => {
+    const html = renderToStaticMarkup(
+      <CompactPlanNavigatorTrigger open={false} onToggle={() => {}} />,
+    );
+
+    expect(html).toContain('id="pn-compact-plan-navigator-trigger"');
+    expect(html).toContain('data-pn-touch-target="true"');
+    expect(html).toContain('aria-expanded="false"');
+    expect(html).toContain('aria-controls="pn-compact-plan-navigator"');
+    expect(html).toContain('Open plan navigator');
+    expect(html).toContain('>Plan<');
+  });
+
+  test('announces the open state without changing the control footprint', () => {
+    const closed = renderToStaticMarkup(
+      <CompactPlanNavigatorTrigger open={false} onToggle={() => {}} />,
+    );
+    const open = renderToStaticMarkup(
+      <CompactPlanNavigatorTrigger open onToggle={() => {}} />,
+    );
+
+    expect(open).toContain('aria-expanded="true"');
+    expect(open).toContain('Close plan navigator');
+    expect(open).toContain('h-11 min-w-11');
+    expect(closed).toContain('h-11 min-w-11');
+  });
+});

--- a/packages/editor/components/AppHeader.mobile.test.tsx
+++ b/packages/editor/components/AppHeader.mobile.test.tsx
@@ -1,7 +1,78 @@
 import { describe, expect, test } from 'bun:test';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { CompactPlanNavigatorTrigger } from './AppHeader';
+import { ThemeProvider } from '@plannotator/ui/components/ThemeProvider';
+import { AppHeader, CompactPlanNavigatorTrigger } from './AppHeader';
+
+const hasDom = typeof document !== 'undefined' && typeof window !== 'undefined';
+const domClient = hasDom ? await import('react-dom/client') : null;
+const act = hasDom ? (await import('react')).act : null;
+
+const noop = () => {};
+const headerProps: React.ComponentProps<typeof AppHeader> = {
+  isApiMode: true,
+  annotateMode: false,
+  archiveMode: false,
+  goalSetupMode: false,
+  goalSetupCanSubmit: false,
+  goalSetupIsSubmitting: false,
+  goalSetupSubmitLabel: 'Submit',
+  gate: false,
+  isSharedSession: false,
+  origin: 'claude-code',
+  isSubmitting: false,
+  isExiting: false,
+  isPanelOpen: false,
+  aiAvailable: true,
+  isAIChatOpen: false,
+  aiHasMessages: false,
+  hasAnyAnnotations: false,
+  annotationCount: 0,
+  linkedDocIsActive: false,
+  callbackShareUrlReady: true,
+  canShareCurrentSession: false,
+  agentName: 'Claude',
+  availableAgents: [],
+  showAnnotationsWarning: false,
+  annotateApproveLabel: 'Approve',
+  annotateApproveTitle: 'Approve',
+  callbackConfig: null,
+  taterMode: false,
+  mobileSettingsOpen: false,
+  gitUser: undefined,
+  onCallbackFeedback: noop,
+  onCallbackApprove: noop,
+  onAnnotateExit: noop,
+  onGoalSetupExit: noop,
+  onGoalSetupSubmit: noop,
+  onAnnotateFeedback: noop,
+  onAnnotateApprove: noop,
+  onFeedback: noop,
+  onApprove: noop,
+  onAnnotationPanelToggle: noop,
+  onAIChatToggle: noop,
+  onArchiveCopy: noop,
+  onArchiveDone: noop,
+  onTaterModeChange: noop,
+  onIdentityChange: noop,
+  onUIPreferencesChange: noop,
+  onOpenSettings: noop,
+  onCloseSettings: noop,
+  onOpenExport: noop,
+  onCopyAgentInstructions: noop,
+  onDownloadAnnotations: noop,
+  onPrint: noop,
+  onCopyShareLink: noop,
+  onOpenImport: noop,
+  onSaveToObsidian: noop,
+  onSaveToBear: noop,
+  onSaveToOctarine: noop,
+  appVersion: '0.0.0',
+  agentInstructionsEnabled: true,
+  obsidianConfigured: false,
+  bearConfigured: false,
+  octarineConfigured: false,
+};
 
 describe('compact Plan navigator trigger', () => {
   test('is a touch-safe disclosure with a stable focus-restoration target', () => {
@@ -14,7 +85,7 @@ describe('compact Plan navigator trigger', () => {
     expect(html).toContain('aria-expanded="false"');
     expect(html).toContain('aria-controls="pn-compact-plan-navigator"');
     expect(html).toContain('Open plan navigator');
-    expect(html).toContain('>Plan<');
+    expect(html).toContain('Plan navigation');
   });
 
   test('announces the open state without changing the control footprint', () => {
@@ -27,7 +98,42 @@ describe('compact Plan navigator trigger', () => {
 
     expect(open).toContain('aria-expanded="true"');
     expect(open).toContain('Close plan navigator');
-    expect(open).toContain('h-11 min-w-11');
-    expect(closed).toContain('h-11 min-w-11');
+    expect(open).toContain('h-11 w-11');
+    expect(closed).toContain('h-11 w-11');
+  });
+
+  test.skipIf(!hasDom)('uses stable navigate, document identity, and Options regions on compact touch', async () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = domClient!.createRoot(host);
+    await act!(async () => {
+      root.render(
+        <ThemeProvider defaultTheme="dark">
+          <AppHeader
+            {...headerProps}
+            sticky={false}
+            compactTouchLayout
+            compactNavigatorAvailable
+            compactNavigatorOpen={false}
+            onCompactNavigatorToggle={noop}
+            compactDocumentTitle="mobile-plan.md"
+            compactSessionActions={[
+              { id: 'feedback', label: 'Send feedback', onSelect: noop },
+              { id: 'approve', label: 'Approve', onSelect: noop },
+            ]}
+          />
+        </ThemeProvider>,
+      );
+    });
+
+    const header = host.querySelector<HTMLElement>('[data-app-header="true"]')!;
+    expect(header.className).toContain('grid-cols-[44px_minmax(0,1fr)_44px]');
+    expect(host.querySelector('[data-pn-compact-document-title]')?.textContent).toBe('mobile-plan.md');
+    expect(host.querySelector('button[aria-label="Options"]')).not.toBeNull();
+    expect(host.textContent).not.toContain('Send Feedback');
+    expect(host.textContent).not.toContain('Approve');
+    expect(host.textContent).not.toContain('Plannotator');
+    await act!(async () => root.unmount());
+    host.remove();
   });
 });

--- a/packages/editor/components/AppHeader.tsx
+++ b/packages/editor/components/AppHeader.tsx
@@ -19,6 +19,12 @@ interface AppHeaderProps {
   htmlSurface?: boolean;
   htmlToolsHidden?: boolean;
   onToggleHtmlTools?: () => void;
+  /** Compact touch layouts replace the brand mark with a task-focused entry
+   * into the full-stage document navigator. Desktop never receives it. */
+  compactTouchLayout?: boolean;
+  compactNavigatorAvailable?: boolean;
+  compactNavigatorOpen?: boolean;
+  onCompactNavigatorToggle?: () => void;
   // Mode flags (stable after mount)
   isApiMode: boolean;
   annotateMode: boolean;
@@ -101,6 +107,10 @@ export const AppHeader = React.memo<AppHeaderProps>(({
   htmlSurface,
   htmlToolsHidden,
   onToggleHtmlTools,
+  compactTouchLayout = false,
+  compactNavigatorAvailable = false,
+  compactNavigatorOpen = false,
+  onCompactNavigatorToggle,
   isApiMode,
   annotateMode,
   archiveMode,
@@ -172,7 +182,14 @@ export const AppHeader = React.memo<AppHeaderProps>(({
       className={`h-12 flex items-center justify-between px-2 md:px-4 border-b border-border/50 bg-card/50 backdrop-blur-xl z-[50] ${sticky ? 'sticky top-0' : 'relative'}`}
     >
       <div className="flex items-center gap-2">
-        <AppHeaderLogo />
+        {compactTouchLayout && compactNavigatorAvailable && onCompactNavigatorToggle ? (
+          <CompactPlanNavigatorTrigger
+            open={compactNavigatorOpen}
+            onToggle={onCompactNavigatorToggle}
+          />
+        ) : (
+          <AppHeaderLogo />
+        )}
         {htmlSurface && onToggleHtmlTools && (
           <button
             type="button"
@@ -312,7 +329,7 @@ export const AppHeader = React.memo<AppHeaderProps>(({
         )}
 
         {/* Annotations panel toggle */}
-        {!goalSetupMode && (
+        {!compactTouchLayout && !goalSetupMode && (
           <button
             onClick={onAnnotationPanelToggle}
             className={`relative p-1.5 rounded-md text-xs font-medium transition-all ${
@@ -332,7 +349,7 @@ export const AppHeader = React.memo<AppHeaderProps>(({
             )}
           </button>
         )}
-        {!goalSetupMode && aiAvailable && (
+        {!compactTouchLayout && !goalSetupMode && aiAvailable && (
           <button
             onClick={onAIChatToggle}
             className={`relative p-1.5 rounded-md text-xs font-medium transition-all ${
@@ -391,6 +408,37 @@ export const AppHeader = React.memo<AppHeaderProps>(({
     </header>
   );
 });
+
+export const CompactPlanNavigatorTrigger = ({
+  open,
+  onToggle,
+}: {
+  open: boolean;
+  onToggle: () => void;
+}) => (
+  <button
+    id="pn-compact-plan-navigator-trigger"
+    type="button"
+    onClick={onToggle}
+    data-pn-touch-target="true"
+    data-pn-touch-target-icon="true"
+    data-pn-compact-navigator-trigger="true"
+    className={`-ml-1 flex h-11 min-w-11 items-center gap-2 rounded-lg px-2 text-sm font-semibold tracking-tight outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring/60 ${
+      open
+        ? 'bg-primary/15 text-primary'
+        : 'text-foreground hover:bg-muted'
+    }`}
+    aria-label={open ? 'Close plan navigator' : 'Open plan navigator'}
+    aria-expanded={open}
+    aria-controls="pn-compact-plan-navigator"
+    title={open ? 'Close navigator' : 'Navigate plan'}
+  >
+    <svg className="h-[18px] w-[18px] flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M5 6h14M5 12h14M5 18h9" />
+    </svg>
+    <span>Plan</span>
+  </button>
+);
 
 const AppHeaderLogo = () => (
   <div className="flex items-center gap-2 md:gap-3">

--- a/packages/editor/components/AppHeader.tsx
+++ b/packages/editor/components/AppHeader.tsx
@@ -9,6 +9,7 @@ import { PlanHeaderMenu } from '@plannotator/ui/components/PlanHeaderMenu';
 import type { CallbackConfig } from '@plannotator/ui/utils/callback';
 import type { UIPreferences } from '@plannotator/ui/utils/uiPreferences';
 import { SparklesIcon } from '@plannotator/ui/components/SparklesIcon';
+import type { CompactPlanAction } from '@plannotator/ui/components/PlanHeaderMenu';
 
 interface AppHeaderProps {
   /** Mobile document-scroll surfaces let Safari own the top edge and scroll
@@ -25,6 +26,9 @@ interface AppHeaderProps {
   compactNavigatorAvailable?: boolean;
   compactNavigatorOpen?: boolean;
   onCompactNavigatorToggle?: () => void;
+  compactDocumentTitle?: string;
+  compactSessionActions?: CompactPlanAction[];
+  compactDocumentActions?: CompactPlanAction[];
   // Mode flags (stable after mount)
   isApiMode: boolean;
   annotateMode: boolean;
@@ -111,6 +115,9 @@ export const AppHeader = React.memo<AppHeaderProps>(({
   compactNavigatorAvailable = false,
   compactNavigatorOpen = false,
   onCompactNavigatorToggle,
+  compactDocumentTitle,
+  compactSessionActions,
+  compactDocumentActions,
   isApiMode,
   annotateMode,
   archiveMode,
@@ -179,18 +186,22 @@ export const AppHeader = React.memo<AppHeaderProps>(({
   return (
     <header
       data-app-header="true"
-      className={`h-12 flex items-center justify-between px-2 md:px-4 border-b border-border/50 bg-card/50 backdrop-blur-xl z-[50] ${sticky ? 'sticky top-0' : 'relative'}`}
+      className={`${compactTouchLayout ? 'h-[52px] grid grid-cols-[44px_minmax(0,1fr)_44px] items-center px-1' : 'h-12 flex items-center justify-between px-2 md:px-4'} border-b border-border/50 bg-card/50 backdrop-blur-xl z-[50] ${sticky ? 'sticky top-0' : 'relative'}`}
     >
-      <div className="flex items-center gap-2">
-        {compactTouchLayout && compactNavigatorAvailable && onCompactNavigatorToggle ? (
-          <CompactPlanNavigatorTrigger
-            open={compactNavigatorOpen}
-            onToggle={onCompactNavigatorToggle}
-          />
+      <div className={compactTouchLayout ? 'flex items-center justify-start' : 'flex items-center gap-2'}>
+        {compactTouchLayout ? (
+          compactNavigatorAvailable && onCompactNavigatorToggle ? (
+            <CompactPlanNavigatorTrigger
+              open={compactNavigatorOpen}
+              onToggle={onCompactNavigatorToggle}
+            />
+          ) : (
+            <span className="block h-11 w-11" aria-hidden="true" />
+          )
         ) : (
           <AppHeaderLogo />
         )}
-        {htmlSurface && onToggleHtmlTools && (
+        {!compactTouchLayout && htmlSurface && onToggleHtmlTools && (
           <button
             type="button"
             onClick={onToggleHtmlTools}
@@ -202,9 +213,19 @@ export const AppHeader = React.memo<AppHeaderProps>(({
         )}
       </div>
 
-      <div className="flex items-center gap-1 md:gap-2">
+      {compactTouchLayout && (
+        <div
+          data-pn-compact-document-title="true"
+          className="min-w-0 px-2 text-center text-sm font-medium tracking-tight text-foreground"
+          title={compactDocumentTitle}
+        >
+          <span className="block truncate">{compactDocumentTitle || 'Plan'}</span>
+        </div>
+      )}
+
+      <div className={`flex items-center gap-1 md:gap-2 ${compactTouchLayout ? 'justify-end' : ''}`}>
         {/* Bot callback buttons — only shown when ?cb=&ct= params are present */}
-        {callbackConfig && !isApiMode && isSharedSession && (
+        {!compactTouchLayout && callbackConfig && !isApiMode && isSharedSession && (
           <>
             <div className="w-px h-5 bg-border/50 mx-1 hidden md:block" />
             <FeedbackButton
@@ -222,7 +243,7 @@ export const AppHeader = React.memo<AppHeaderProps>(({
           </>
         )}
 
-        {isApiMode && !linkedDocIsActive && archiveMode && (
+        {!compactTouchLayout && isApiMode && !linkedDocIsActive && archiveMode && (
           <>
             <button
               onClick={onArchiveCopy}
@@ -244,7 +265,7 @@ export const AppHeader = React.memo<AppHeaderProps>(({
           </>
         )}
 
-        {isApiMode && !linkedDocIsActive && goalSetupMode && (
+        {!compactTouchLayout && isApiMode && !linkedDocIsActive && goalSetupMode && (
           <>
             <ExitButton
               onClick={onGoalSetupExit}
@@ -265,7 +286,7 @@ export const AppHeader = React.memo<AppHeaderProps>(({
           </>
         )}
 
-        {isApiMode && (!linkedDocIsActive || annotateMode) && !archiveMode && !goalSetupMode && (
+        {!compactTouchLayout && isApiMode && (!linkedDocIsActive || annotateMode) && !archiveMode && !goalSetupMode && (
           <>
             {annotateMode ? (
               <>
@@ -403,6 +424,9 @@ export const AppHeader = React.memo<AppHeaderProps>(({
           obsidianConfigured={!archiveMode && !goalSetupMode && obsidianConfigured}
           bearConfigured={!archiveMode && !goalSetupMode && bearConfigured}
           octarineConfigured={!archiveMode && !goalSetupMode && octarineConfigured}
+          compactTouchLayout={compactTouchLayout}
+          compactSessionActions={compactSessionActions}
+          compactDocumentActions={compactDocumentActions}
         />
       </div>
     </header>
@@ -423,7 +447,7 @@ export const CompactPlanNavigatorTrigger = ({
     data-pn-touch-target="true"
     data-pn-touch-target-icon="true"
     data-pn-compact-navigator-trigger="true"
-    className={`-ml-1 flex h-11 min-w-11 items-center gap-2 rounded-lg px-2 text-sm font-semibold tracking-tight outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring/60 ${
+    className={`flex h-11 w-11 items-center justify-center rounded-lg text-sm font-semibold tracking-tight outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring/60 ${
       open
         ? 'bg-primary/15 text-primary'
         : 'text-foreground hover:bg-muted'
@@ -436,7 +460,7 @@ export const CompactPlanNavigatorTrigger = ({
     <svg className="h-[18px] w-[18px] flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
       <path strokeLinecap="round" strokeLinejoin="round" d="M5 6h14M5 12h14M5 18h9" />
     </svg>
-    <span>Plan</span>
+    <span className="sr-only">Plan navigation</span>
   </button>
 );
 

--- a/packages/editor/components/CompactAnnotationControls.test.tsx
+++ b/packages/editor/components/CompactAnnotationControls.test.tsx
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+const hasDom = typeof document !== 'undefined' && typeof window !== 'undefined';
+const domClient = hasDom ? await import('react-dom/client') : null;
+const act = hasDom ? (await import('react')).act : null;
+const component = await import('./CompactAnnotationControls');
+const CompactAnnotationControls = component.CompactAnnotationControls;
+
+afterEach(() => {
+  if (hasDom) document.body.innerHTML = '';
+});
+
+describe('CompactAnnotationControls', () => {
+  test('keeps the idle compact surface to one current-method entry', () => {
+    const html = renderToStaticMarkup(
+      <CompactAnnotationControls inputMethod="pinpoint" onInputMethodChange={() => {}} />,
+    );
+
+    expect(html).toContain('data-pn-compact-annotate-entry="true"');
+    expect(html).toContain('Annotate');
+    expect(html).toContain('Pinpoint');
+    expect(html).not.toContain('Select text</span>');
+    expect(html).not.toContain('Comment');
+    expect(html).not.toContain('Redline');
+    expect(html).not.toContain('Label');
+  });
+
+  test.skipIf(!hasDom)('reveals only target acquisition choices and collapses after selection', async () => {
+    const choices: string[] = [];
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = domClient!.createRoot(host);
+
+    await act!(async () => {
+      root.render(
+        <CompactAnnotationControls
+          inputMethod="pinpoint"
+          onInputMethodChange={(method) => choices.push(method)}
+        />,
+      );
+    });
+    await act!(async () => {
+      host.querySelector<HTMLButtonElement>('[data-pn-compact-annotate-entry]')!.click();
+    });
+
+    expect(host.querySelector('[data-pn-compact-annotate-choices]')).not.toBeNull();
+    const selectText = Array.from(host.querySelectorAll<HTMLButtonElement>('button'))
+      .find((button) => button.textContent?.includes('Select text'))!;
+    expect(selectText.getAttribute('data-pn-touch-target')).not.toBeNull();
+
+    await act!(async () => selectText.click());
+    expect(choices).toEqual(['drag']);
+    expect(host.querySelector('[data-pn-compact-annotate-choices]')).toBeNull();
+    await act!(async () => root.unmount());
+  });
+});

--- a/packages/editor/components/CompactAnnotationControls.tsx
+++ b/packages/editor/components/CompactAnnotationControls.tsx
@@ -1,0 +1,132 @@
+import React, { useState } from 'react';
+import type { InputMethod } from '@plannotator/ui/types';
+
+interface CompactAnnotationControlsProps {
+  inputMethod: InputMethod;
+  onInputMethodChange: (method: InputMethod) => void;
+}
+
+/**
+ * Reading-first entry into the existing Plan annotation engine. Compact touch
+ * always uses Markup semantics; this control only chooses how a target is
+ * acquired. Compact method changes remain session-only, so the persisted
+ * desktop action and input-method preferences stay untouched.
+ */
+export const CompactAnnotationControls: React.FC<CompactAnnotationControlsProps> = ({
+  inputMethod,
+  onInputMethodChange,
+}) => {
+  const [expanded, setExpanded] = useState(false);
+
+  if (!expanded) {
+    return (
+      <button
+        type="button"
+        data-pn-touch-target
+        data-pn-compact-annotate-entry="true"
+        onClick={() => setExpanded(true)}
+        aria-expanded="false"
+        className="inline-flex min-w-0 items-center gap-2 rounded-lg border border-border/50 bg-muted/45 px-3 text-sm font-medium text-foreground outline-none transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/60"
+      >
+        <MarkupIcon />
+        <span>Annotate</span>
+        <span className="text-muted-foreground">·</span>
+        <span className="truncate text-muted-foreground">
+          {inputMethod === 'pinpoint' ? 'Pinpoint' : 'Select text'}
+        </span>
+        <ChevronIcon />
+      </button>
+    );
+  }
+
+  const choose = (method: InputMethod) => {
+    onInputMethodChange(method);
+    setExpanded(false);
+  };
+
+  return (
+    <div
+      data-pn-compact-annotate-choices="true"
+      className="grid w-full grid-cols-2 gap-1 rounded-xl border border-border/50 bg-muted/45 p-1"
+      role="group"
+      aria-label="Choose how to annotate"
+    >
+      <MethodButton
+        selected={inputMethod === 'drag'}
+        label="Select text"
+        description="Drag over text"
+        icon={<SelectIcon />}
+        onClick={() => choose('drag')}
+      />
+      <MethodButton
+        selected={inputMethod === 'pinpoint'}
+        label="Pinpoint"
+        description="Tap one block"
+        icon={<PinpointIcon />}
+        onClick={() => choose('pinpoint')}
+      />
+    </div>
+  );
+};
+
+const MethodButton = ({
+  selected,
+  label,
+  description,
+  icon,
+  onClick,
+}: {
+  selected: boolean;
+  label: string;
+  description: string;
+  icon: React.ReactNode;
+  onClick: () => void;
+}) => (
+  <button
+    type="button"
+    data-pn-touch-target
+    aria-pressed={selected}
+    onClick={onClick}
+    className={`flex min-w-0 items-center gap-2 rounded-lg px-2.5 py-1.5 text-left outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring/60 ${
+      selected
+        ? 'bg-background text-foreground shadow-sm'
+        : 'text-muted-foreground hover:bg-background/60 hover:text-foreground'
+    }`}
+  >
+    <span className="shrink-0">{icon}</span>
+    <span className="min-w-0">
+      <span className="block text-sm font-medium leading-4">{label}</span>
+      <span className="block truncate text-[11px] leading-4 text-muted-foreground">{description}</span>
+    </span>
+  </button>
+);
+
+const MarkupIcon = () => (
+  <svg className="h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+    <path strokeLinecap="round" strokeLinejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+  </svg>
+);
+
+const SelectIcon = () => (
+  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d="M12 20h-1a2 2 0 0 1-2-2 2 2 0 0 1-2 2H6" />
+    <path d="M13 8h7a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2h-7" />
+    <path d="M5 16H4a2 2 0 0 1-2-2v-4a2 2 0 0 1 2-2h1" />
+    <path d="M6 4h1a2 2 0 0 1 2 2 2 2 0 0 1 2-2h1" />
+    <path d="M9 6v12" />
+  </svg>
+);
+
+const PinpointIcon = () => (
+  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="9" />
+    <circle cx="12" cy="12" r="3" />
+    <path d="M12 3v3M12 18v3M3 12h3M18 12h3" />
+  </svg>
+);
+
+const ChevronIcon = () => (
+  <svg className="ml-auto h-3.5 w-3.5 shrink-0 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+    <path strokeLinecap="round" strokeLinejoin="round" d="m6 9 6 6 6-6" />
+  </svg>
+);

--- a/packages/editor/components/CompactEditControls.test.tsx
+++ b/packages/editor/components/CompactEditControls.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { CompactEditControls } from './CompactEditControls';
+
+describe('CompactEditControls', () => {
+  test('keeps source-file Save and Cancel in a normal-flow touch row', () => {
+    const html = renderToStaticMarkup(
+      <CompactEditControls
+        documentTitle="notes.md"
+        sourceBacked
+        saveStatus="dirty"
+        cancelMode
+        confirmDiscard={false}
+        onSave={() => {}}
+        onExit={() => {}}
+      />,
+    );
+
+    expect(html).toContain('data-pn-compact-edit-controls="true"');
+    expect(html).toContain('Editing notes.md');
+    expect(html).toContain('>Save<');
+    expect(html).toContain('>Cancel<');
+    expect(html.match(/data-pn-touch-target/g)).toHaveLength(2);
+    expect(html).not.toContain('fixed');
+    expect(html).not.toContain('sticky');
+  });
+
+  test('uses Done for plan edits and a clear second-step discard label', () => {
+    const plan = renderToStaticMarkup(
+      <CompactEditControls
+        documentTitle="Plan"
+        sourceBacked={false}
+        saveStatus={undefined}
+        cancelMode={false}
+        confirmDiscard={false}
+        onSave={() => {}}
+        onExit={() => {}}
+      />,
+    );
+    const discard = renderToStaticMarkup(
+      <CompactEditControls
+        documentTitle="notes.md"
+        sourceBacked
+        saveStatus="dirty"
+        cancelMode
+        confirmDiscard
+        onSave={() => {}}
+        onExit={() => {}}
+      />,
+    );
+
+    expect(plan).toContain('>Done<');
+    expect(plan).not.toContain('>Save<');
+    expect(discard).toContain('>Discard changes<');
+  });
+});

--- a/packages/editor/components/CompactEditControls.tsx
+++ b/packages/editor/components/CompactEditControls.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import type { EditableDocumentSaveStatus } from '../editableDocuments';
+
+interface CompactEditControlsProps {
+  documentTitle: string;
+  sourceBacked: boolean;
+  saveStatus: EditableDocumentSaveStatus | undefined;
+  cancelMode: boolean;
+  confirmDiscard: boolean;
+  onSave: () => void;
+  onExit: () => void;
+}
+
+/** Normal-flow mobile editing chrome. It deliberately avoids sticky/fixed
+ * placement so the Plan keeps the page-scrolling Safari behavior. */
+export const CompactEditControls: React.FC<CompactEditControlsProps> = ({
+  documentTitle,
+  sourceBacked,
+  saveStatus,
+  cancelMode,
+  confirmDiscard,
+  onSave,
+  onExit,
+}) => {
+  const saving = saveStatus === 'saving';
+  const saveFailed = saveStatus === 'conflict' || saveStatus === 'error';
+  const canSave = sourceBacked && saveStatus !== 'clean' && saveStatus !== 'saved';
+  const saveLabel = saving
+    ? 'Saving…'
+    : saveFailed
+      ? 'Retry save'
+      : saveStatus === 'missing'
+        ? 'Recreate file'
+        : canSave
+          ? 'Save'
+          : 'Saved';
+  const exitLabel = cancelMode
+    ? (confirmDiscard ? 'Discard changes' : 'Cancel')
+    : 'Done';
+
+  return (
+    <div
+      data-pn-compact-edit-controls="true"
+      className="mb-3 flex w-full items-center gap-2 rounded-xl border border-border/60 bg-card/95 p-1.5 shadow-sm"
+    >
+      <div className="min-w-0 flex-1 px-2">
+        <span className="block truncate text-sm font-medium text-foreground">Editing {documentTitle}</span>
+        <span className="block text-[11px] leading-4 text-muted-foreground">
+          {sourceBacked ? 'Save writes to the source file' : 'Done adds this edit to your feedback'}
+        </span>
+      </div>
+      {sourceBacked && (
+        <button
+          type="button"
+          data-pn-touch-target
+          onClick={onSave}
+          disabled={saving || !canSave}
+          className={`shrink-0 rounded-lg px-3 text-sm font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring/60 disabled:cursor-not-allowed disabled:opacity-50 ${
+            saveFailed
+              ? 'bg-destructive/10 text-destructive'
+              : canSave
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-muted text-muted-foreground'
+          }`}
+        >
+          {saveLabel}
+        </button>
+      )}
+      <button
+        type="button"
+        data-pn-touch-target
+        onClick={onExit}
+        className={`shrink-0 rounded-lg px-3 text-sm font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring/60 ${
+          confirmDiscard
+            ? 'bg-destructive text-destructive-foreground'
+            : cancelMode
+              ? 'bg-muted text-foreground'
+              : 'bg-success text-success-foreground'
+        }`}
+      >
+        {exitLabel}
+      </button>
+    </div>
+  );
+};

--- a/packages/editor/components/CompactPlanReview.test.tsx
+++ b/packages/editor/components/CompactPlanReview.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { CompactPlanCompletion, CompactPlanReview } from './CompactPlanReview';
+
+describe('compact Plan completion', () => {
+  test('keeps the handoff in document flow with one explicit review action', () => {
+    const html = renderToStaticMarkup(
+      <CompactPlanCompletion
+        feedbackSummary="Two annotations are ready."
+        maxWidth={832}
+        onOpenReview={() => {}}
+      />,
+    );
+
+    expect(html).toContain('data-pn-compact-plan-completion="true"');
+    expect(html).toContain('Ready to finish?');
+    expect(html).toContain('Review and finish');
+    expect(html).toContain('pn-compact-plan-review-trigger');
+    expect(html).toContain('--pn-safe-bottom');
+  });
+
+  test('promotes one incumbent decision without duplicating decision logic', () => {
+    const html = renderToStaticMarkup(
+      <CompactPlanReview
+        feedbackSummary="One annotation is ready."
+        actions={[
+          { id: 'exit', label: 'Close session', onSelect: () => {} },
+          { id: 'feedback', label: 'Send feedback', onSelect: () => {} },
+          { id: 'approve', label: 'Approve', onSelect: () => {} },
+        ]}
+        primaryActionId="feedback"
+        onOpenAnnotations={() => {}}
+      />,
+    );
+
+    expect(html).toContain('Review annotations');
+    expect(html).toContain('data-pn-compact-review-action="feedback"');
+    expect(html).toContain('bg-primary text-primary-foreground');
+    expect(html.indexOf('Send feedback')).toBeLessThan(html.indexOf('Approve'));
+    expect(html.indexOf('Approve')).toBeLessThan(html.indexOf('Close session'));
+  });
+});

--- a/packages/editor/components/CompactPlanReview.tsx
+++ b/packages/editor/components/CompactPlanReview.tsx
@@ -1,0 +1,180 @@
+import React from 'react';
+import type { CompactPlanAction } from '@plannotator/ui/components/PlanHeaderMenu';
+
+type CompactPlanDecisionActionId = Extract<
+  CompactPlanAction['id'],
+  'exit' | 'feedback' | 'approve' | 'copy' | 'done'
+>;
+
+/** An incumbent session decision that may be presented by compact Review. */
+export type CompactPlanReviewAction = Omit<CompactPlanAction, 'id'> & {
+  id: CompactPlanDecisionActionId;
+};
+
+interface CompactPlanCompletionProps {
+  feedbackSummary: string;
+  onOpenReview: () => void;
+  maxWidth: number;
+}
+
+/** End-of-document handoff into the compact review decision surface. */
+export const CompactPlanCompletion: React.FC<CompactPlanCompletionProps> = ({
+  feedbackSummary,
+  onOpenReview,
+  maxWidth,
+}) => (
+  <section
+    data-pn-compact-plan-completion="true"
+    className="mt-10 w-full px-2 pt-2"
+    style={{ maxWidth, paddingBottom: 'calc(1.25rem + var(--pn-safe-bottom))' }}
+    aria-labelledby="pn-compact-plan-completion-title"
+  >
+    <div className="flex flex-col gap-4 border-t border-border/60 pt-6">
+      <div>
+        <h2 id="pn-compact-plan-completion-title" className="text-base font-semibold tracking-tight text-foreground">
+          Ready to finish?
+        </h2>
+        <p className="mt-1 text-sm leading-relaxed text-muted-foreground">{feedbackSummary}</p>
+      </div>
+      <button
+        id="pn-compact-plan-review-trigger"
+        type="button"
+        data-pn-touch-target="true"
+        onClick={onOpenReview}
+        className="flex min-h-11 w-full items-center justify-between gap-3 rounded-xl bg-primary px-4 py-3 text-left text-sm font-semibold text-primary-foreground outline-none transition-opacity active:opacity-90 focus-visible:ring-2 focus-visible:ring-ring/70 focus-visible:ring-offset-2 focus-visible:ring-offset-card"
+      >
+        <span>Review and finish</span>
+        <svg className="h-4 w-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+        </svg>
+      </button>
+    </div>
+  </section>
+);
+
+interface CompactPlanReviewProps {
+  feedbackSummary: string;
+  actions: CompactPlanReviewAction[];
+  primaryActionId?: CompactPlanReviewAction['id'];
+  onOpenAnnotations: () => void;
+  onOpenAI?: () => void;
+}
+
+/** Compact review summary and the incumbent session decision actions. */
+export const CompactPlanReview: React.FC<CompactPlanReviewProps> = ({
+  feedbackSummary,
+  actions,
+  primaryActionId,
+  onOpenAnnotations,
+  onOpenAI,
+}) => {
+  const orderedActions = [...actions].sort((left, right) => {
+    if (left.id === primaryActionId) return -1;
+    if (right.id === primaryActionId) return 1;
+    if (left.id === 'exit') return 1;
+    if (right.id === 'exit') return -1;
+    return 0;
+  });
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 py-5">
+      <div className="mx-auto flex w-full max-w-xl flex-col gap-6">
+        <section aria-labelledby="pn-compact-review-summary-title">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">Feedback</p>
+          <h2 id="pn-compact-review-summary-title" className="mt-2 text-xl font-semibold tracking-tight text-foreground">
+            {feedbackSummary}
+          </h2>
+          <div className="mt-4 grid grid-cols-1 gap-2 min-[460px]:grid-cols-2">
+            <button
+              type="button"
+              data-pn-touch-target="true"
+              onClick={onOpenAnnotations}
+              className="flex min-h-11 items-center justify-between gap-3 rounded-xl border border-border bg-background/40 px-4 py-3 text-left text-sm font-medium text-foreground outline-none transition-colors active:bg-muted focus-visible:ring-2 focus-visible:ring-ring/60"
+            >
+              <span>Review annotations</span>
+              <CommentIcon />
+            </button>
+            {onOpenAI && (
+              <button
+                type="button"
+                data-pn-touch-target="true"
+                onClick={onOpenAI}
+                className="flex min-h-11 items-center justify-between gap-3 rounded-xl border border-border bg-background/40 px-4 py-3 text-left text-sm font-medium text-foreground outline-none transition-colors active:bg-muted focus-visible:ring-2 focus-visible:ring-ring/60"
+              >
+                <span>Ask AI</span>
+                <SparklesIcon />
+              </button>
+            )}
+          </div>
+        </section>
+
+        <section aria-labelledby="pn-compact-review-decision-title">
+          <h2 id="pn-compact-review-decision-title" className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+            Decision
+          </h2>
+          <div className="mt-2 flex flex-col gap-2">
+            {orderedActions.map((action) => {
+              const primary = action.id === primaryActionId;
+              const quiet = action.id === 'exit';
+              return (
+                <button
+                  key={action.id}
+                  type="button"
+                  data-pn-touch-target="true"
+                  data-pn-compact-review-action={action.id}
+                  onClick={action.onSelect}
+                  disabled={action.disabled}
+                  className={`flex min-h-11 w-full items-center justify-between gap-4 rounded-xl px-4 py-3 text-left outline-none transition-opacity active:opacity-90 disabled:cursor-not-allowed disabled:opacity-45 focus-visible:ring-2 focus-visible:ring-ring/60 ${
+                    primary
+                      ? 'bg-primary text-primary-foreground'
+                      : quiet
+                        ? 'border border-transparent text-muted-foreground'
+                        : 'border border-border bg-background/40 text-foreground'
+                  }`}
+                >
+                  <span className="min-w-0">
+                    <span className="block text-sm font-semibold">{action.label}</span>
+                    {action.subtitle && (
+                      <span className={`mt-0.5 block text-xs leading-snug ${primary ? 'text-primary-foreground/75' : 'text-muted-foreground'}`}>
+                        {action.subtitle}
+                      </span>
+                    )}
+                  </span>
+                  <ActionIcon kind={action.id} />
+                </button>
+              );
+            })}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+const CommentIcon = () => (
+  <svg className="h-4 w-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+    <path strokeLinecap="round" strokeLinejoin="round" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
+  </svg>
+);
+
+const SparklesIcon = () => (
+  <svg className="h-4 w-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8} aria-hidden="true">
+    <path strokeLinecap="round" strokeLinejoin="round" d="M12 3l1.2 3.8L17 8l-3.8 1.2L12 13l-1.2-3.8L7 8l3.8-1.2L12 3zM18.5 13l.8 2.7L22 16.5l-2.7.8-.8 2.7-.8-2.7-2.7-.8 2.7-.8.8-2.7zM5 13l.7 2.3L8 16l-2.3.7L5 19l-.7-2.3L2 16l2.3-.7L5 13z" />
+  </svg>
+);
+
+const ActionIcon = ({ kind }: { kind: CompactPlanReviewAction['id'] }) => {
+  if (kind === 'approve' || kind === 'done') {
+    return (
+      <svg className="h-4 w-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+      </svg>
+    );
+  }
+  if (kind === 'feedback') return <CommentIcon />;
+  return (
+    <svg className="h-4 w-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+    </svg>
+  );
+};

--- a/packages/editor/components/CompactPlanStage.test.tsx
+++ b/packages/editor/components/CompactPlanStage.test.tsx
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import React from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { act } from 'react';
+
+import { CompactPlanStage } from './CompactPlanStage';
+
+const hasDom = typeof document !== 'undefined';
+let root: Root | null = null;
+let host: HTMLElement | null = null;
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  root = null;
+  host?.remove();
+  host = null;
+  if (hasDom) document.body.replaceChildren();
+});
+
+describe.if(hasDom)('CompactPlanStage', () => {
+  test('owns visible-viewport geometry, initial focus, Escape, and tab containment', async () => {
+    let closeCount = 0;
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    await act(async () => {
+      root?.render(
+        <CompactPlanStage
+          id="test-stage"
+          title="Annotations"
+          subtitle="plan.md"
+          onClose={() => { closeCount += 1; }}
+        >
+          <button type="button">First action</button>
+          <button type="button">Last action</button>
+        </CompactPlanStage>,
+      );
+    });
+
+    const stage = document.querySelector<HTMLElement>('[data-pn-compact-plan-stage="true"]');
+    const close = document.querySelector<HTMLButtonElement>('button[aria-label="Close Annotations"]');
+    const buttons = Array.from(stage?.querySelectorAll<HTMLButtonElement>('button') ?? []);
+    if (!stage || !close) throw new Error('Compact stage did not render');
+
+    expect(stage.className).toContain('pn-visible-viewport-stage');
+    expect(stage.getAttribute('role')).toBe('dialog');
+    expect(stage.getAttribute('aria-modal')).toBe('true');
+    expect(document.activeElement).toBe(close);
+
+    const last = buttons[buttons.length - 1];
+    if (!last) throw new Error('Compact stage did not render its last action');
+    last.focus();
+    await act(async () => {
+      last.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    });
+    expect(document.activeElement).toBe(close);
+
+    await act(async () => {
+      stage.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+    expect(closeCount).toBe(1);
+  });
+
+  test('lets an editing child consume Escape without dismissing the stage', async () => {
+    let closeCount = 0;
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    await act(async () => {
+      root?.render(
+        <CompactPlanStage id="editing-stage" title="Annotations" onClose={() => { closeCount += 1; }}>
+          <textarea
+            aria-label="Edit annotation"
+            onKeyDown={(event) => {
+              if (event.key === 'Escape') event.preventDefault();
+            }}
+          />
+        </CompactPlanStage>,
+      );
+    });
+
+    const textarea = document.querySelector<HTMLTextAreaElement>('textarea');
+    if (!textarea) throw new Error('Editing control did not render');
+    await act(async () => {
+      textarea.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+    expect(closeCount).toBe(0);
+  });
+});

--- a/packages/editor/components/CompactPlanStage.tsx
+++ b/packages/editor/components/CompactPlanStage.tsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useRef } from 'react';
+
+interface CompactPlanStageProps {
+  id: string;
+  title: string;
+  subtitle?: string;
+  count?: number;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+/**
+ * Full-visible-viewport shell for one transient compact Plan task.
+ *
+ * The shell intentionally has no entrance animation: these are frequent
+ * review surfaces, and immediate replacement makes the foreground-state
+ * change easier to understand on a small screen.
+ */
+export const CompactPlanStage: React.FC<CompactPlanStageProps> = ({
+  id,
+  title,
+  subtitle,
+  count,
+  onClose,
+  children,
+}) => {
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    closeButtonRef.current?.focus({ preventScroll: true });
+  }, []);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    if (event.defaultPrevented) return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      event.stopPropagation();
+      onClose();
+      return;
+    }
+    if (event.key !== 'Tab') return;
+
+    const focusable = Array.from(
+      event.currentTarget.querySelectorAll<HTMLElement>(
+        'button:not(:disabled), input:not(:disabled), textarea:not(:disabled), select:not(:disabled), [href], [tabindex]:not([tabindex="-1"])',
+      ),
+    );
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (!first || !last) return;
+
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  return (
+    <section
+      id={id}
+      data-pn-compact-plan-stage="true"
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+      onKeyDown={handleKeyDown}
+      className="pn-visible-viewport-stage z-[90] flex flex-col overflow-hidden bg-card text-foreground"
+    >
+      <header className="flex min-h-[52px] flex-shrink-0 items-center justify-between gap-3 border-b border-border/50 px-3">
+        <div className="min-w-0 py-2">
+          <div className="flex min-w-0 items-center gap-2">
+            <h1 className="truncate text-sm font-semibold tracking-tight">{title}</h1>
+            {typeof count === 'number' && count > 0 && (
+              <span className="flex h-[18px] min-w-[18px] flex-shrink-0 items-center justify-center rounded-full bg-primary/10 px-1 font-mono text-[10px] font-medium tabular-nums text-primary">
+                {count > 99 ? '99+' : count}
+              </span>
+            )}
+          </div>
+          {subtitle && <p className="truncate text-[11px] text-muted-foreground">{subtitle}</p>}
+        </div>
+        <button
+          ref={closeButtonRef}
+          type="button"
+          onClick={onClose}
+          data-pn-touch-target="true"
+          data-pn-touch-target-icon="true"
+          className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-lg text-muted-foreground outline-none transition-colors [@media(hover:hover)_and_(pointer:fine)]:hover:bg-muted [@media(hover:hover)_and_(pointer:fine)]:hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/60"
+          aria-label={`Close ${title}`}
+          title={`Close ${title}`}
+        >
+          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </header>
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">{children}</div>
+    </section>
+  );
+};

--- a/packages/editor/components/FolderAnnotationEmptyState.test.tsx
+++ b/packages/editor/components/FolderAnnotationEmptyState.test.tsx
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { FolderAnnotationEmptyState } from './FolderAnnotationEmptyState';
+
+const hasDom = typeof document !== 'undefined';
+let root: Root | null = null;
+let host: HTMLElement | null = null;
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  root = null;
+  host?.remove();
+  host = null;
+  if (hasDom) document.body.replaceChildren();
+});
+
+describe('folder annotation empty state', () => {
+  test('preserves the incumbent desktop sidebar instruction', () => {
+    const html = renderToStaticMarkup(
+      <FolderAnnotationEmptyState compactTouchLayout={false} onChooseFile={() => {}} />,
+    );
+
+    expect(html).toContain('Pick a markdown or HTML file from the sidebar to begin.');
+    expect(html).not.toContain('Choose a file</button>');
+  });
+
+  test.skipIf(!hasDom)('makes the hidden mobile file journey directly actionable', async () => {
+    const onChooseFile = mock(() => {});
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    await act(async () => {
+      root?.render(
+        <FolderAnnotationEmptyState compactTouchLayout onChooseFile={onChooseFile} />,
+      );
+    });
+
+    const choose = Array.from(document.querySelectorAll<HTMLButtonElement>('button'))
+      .find((button) => button.textContent?.trim() === 'Choose a file');
+    expect(choose?.getAttribute('data-pn-touch-target')).toBe('true');
+    await act(async () => choose?.click());
+    expect(onChooseFile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/editor/components/FolderAnnotationEmptyState.tsx
+++ b/packages/editor/components/FolderAnnotationEmptyState.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Button } from '@plannotator/ui/components/ui/button';
+
+export function FolderAnnotationEmptyState({
+  compactTouchLayout,
+  onChooseFile,
+}: {
+  compactTouchLayout: boolean;
+  onChooseFile: () => void;
+}) {
+  return (
+    <div className="w-full flex justify-center">
+      <div className="w-full max-w-3xl p-12 text-center text-muted-foreground">
+        <p className="text-lg font-medium mb-2">Select a file to annotate</p>
+        <p className="text-sm">
+          {compactTouchLayout
+            ? 'Choose a markdown, text, or HTML file to begin.'
+            : 'Pick a markdown or HTML file from the sidebar to begin.'}
+        </p>
+        {compactTouchLayout && (
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="mt-4"
+            onClick={onChooseFile}
+          >
+            Choose a file
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/editor/hooks/usePlanDiffViewAutoExit.ts
+++ b/packages/editor/hooks/usePlanDiffViewAutoExit.ts
@@ -28,3 +28,19 @@ export function usePlanDiffViewAutoExit(
     }
   }, [active, hasPreviousVersion, exitPlanDiff]);
 }
+
+/**
+ * Exits the diff only when navigation moves into the document-contents view.
+ *
+ * `diffActive` is intentionally not an input. A desktop sidebar may already
+ * remember the Contents tab while closed; activating the diff must not cause
+ * that unchanged navigation state to close it in the same commit phase.
+ */
+export function usePlanDiffNavigationAutoExit(
+  contentsVisible: boolean,
+  exitPlanDiff: () => void,
+): void {
+  useEffect(() => {
+    if (contentsVisible) exitPlanDiff();
+  }, [contentsVisible, exitPlanDiff]);
+}

--- a/packages/editor/planDiffAutoExit.test.tsx
+++ b/packages/editor/planDiffAutoExit.test.tsx
@@ -11,10 +11,13 @@
  */
 
 import { afterEach, describe, expect, test } from 'bun:test';
-import React, { act, useState } from 'react';
+import React, { act, useCallback, useState } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { usePlanDiff, type VersionInfo } from '@plannotator/ui/hooks/usePlanDiff';
-import { usePlanDiffViewAutoExit } from './hooks/usePlanDiffViewAutoExit';
+import {
+  usePlanDiffNavigationAutoExit,
+  usePlanDiffViewAutoExit,
+} from './hooks/usePlanDiffViewAutoExit';
 
 const hasDom = typeof document !== 'undefined';
 
@@ -30,6 +33,12 @@ interface HarnessApi {
   hasPreviousVersion: boolean;
   activate: () => void;
   switchDoc: (doc: DocState) => void;
+}
+
+interface NavigationHarnessApi {
+  isPlanDiffActive: boolean;
+  activate: () => void;
+  setContentsVisible: (visible: boolean) => void;
 }
 
 const DOC_WITH_BASELINE: DocState = {
@@ -89,6 +98,25 @@ function Harness({
   return null;
 }
 
+function NavigationHarness({
+  apiRef,
+}: {
+  apiRef: { current: NavigationHarnessApi | null };
+}) {
+  const [isPlanDiffActive, setIsPlanDiffActive] = useState(false);
+  const [contentsVisible, setContentsVisible] = useState(true);
+  const exitPlanDiff = useCallback(() => setIsPlanDiffActive(false), []);
+
+  usePlanDiffNavigationAutoExit(contentsVisible, exitPlanDiff);
+
+  apiRef.current = {
+    isPlanDiffActive,
+    activate: () => setIsPlanDiffActive(true),
+    setContentsVisible,
+  };
+  return null;
+}
+
 async function mountHarness(htmlSurface = false): Promise<{ current: () => HarnessApi }> {
   const container = document.createElement('div');
   document.body.appendChild(container);
@@ -107,6 +135,22 @@ async function mountHarness(htmlSurface = false): Promise<{ current: () => Harne
   };
 }
 
+async function mountNavigationHarness(): Promise<{ current: () => NavigationHarnessApi }> {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  containers.push(container);
+  const root = createRoot(container);
+  roots.push(root);
+  const apiRef: { current: NavigationHarnessApi | null } = { current: null };
+  await act(async () => root.render(<NavigationHarness apiRef={apiRef} />));
+  return {
+    current: () => {
+      if (!apiRef.current) throw new Error('Navigation harness not mounted');
+      return apiRef.current;
+    },
+  };
+}
+
 afterEach(async () => {
   for (const root of roots) await act(async () => root.unmount());
   roots = [];
@@ -115,6 +159,17 @@ afterEach(async () => {
 });
 
 describe('usePlanDiffViewAutoExit', () => {
+  test.skipIf(!hasDom)('does not close a newly activated diff for an unchanged remembered Contents tab', async () => {
+    const harness = await mountNavigationHarness();
+
+    await act(async () => harness.current().activate());
+    expect(harness.current().isPlanDiffActive).toBe(true);
+
+    await act(async () => harness.current().setContentsVisible(false));
+    await act(async () => harness.current().setContentsVisible(true));
+    expect(harness.current().isPlanDiffActive).toBe(false);
+  });
+
   test.skipIf(!hasDom)('exits diff view when the active document switches to one with no baseline', async () => {
     const harness = await mountHarness();
 

--- a/packages/ui/components/AnnotationPanel.props.test.tsx
+++ b/packages/ui/components/AnnotationPanel.props.test.tsx
@@ -3,7 +3,8 @@
  *   - readOnly hides every mutation affordance (delete/edit on all card kinds)
  *   - renderCardFooter renders a per-card slot whose interactions do NOT
  *     select the card
- * Both default to today's behavior (mutable, no footer).
+ *   - embedded presentation leaves stage geometry and chrome to its host
+ * All default to today's behavior (mutable panel, no footer).
  */
 import { afterEach, describe, expect, test } from 'bun:test';
 import React from 'react';
@@ -133,5 +134,14 @@ describe('AnnotationPanel consumer props', () => {
   test.skipIf(!hasDom)('no footer prop → no slot rendered', async () => {
     await mount(<AnnotationPanel {...baseProps} />);
     expect(document.querySelector('[data-annotation-card-footer="true"]')).toBeNull();
+  });
+
+  test.skipIf(!hasDom)('embedded presentation keeps the timeline and omits panel chrome', async () => {
+    await mount(<AnnotationPanel {...baseProps} presentation="embedded" />);
+    const panel = document.querySelector<HTMLElement>('[data-annotation-panel="true"]');
+    expect(panel?.className).toContain('h-full min-h-0 w-full flex-1');
+    expect(document.body.textContent).not.toContain('Annotations');
+    expect(document.querySelector('[data-annotation-id="a1"]')).not.toBeNull();
+    expect(document.querySelector('.fixed.inset-0')).toBeNull();
   });
 });

--- a/packages/ui/components/AnnotationPanel.tsx
+++ b/packages/ui/components/AnnotationPanel.tsx
@@ -86,6 +86,9 @@ interface PanelProps {
     *  gates what belongs in it. Selection and scrolling still work.
     *  Default false — today's behavior. */
   readOnly?: boolean;
+  /** Embed only the timeline body in a host-owned stage. The host owns the
+    *  title, close control, visible-viewport geometry, and focus boundary. */
+  presentation?: 'panel' | 'embedded';
 }
 
 export const AnnotationPanel: React.FC<PanelProps> = ({
@@ -111,8 +114,11 @@ export const AnnotationPanel: React.FC<PanelProps> = ({
   directEdits = null,
   renderCardFooter,
   readOnly = false,
+  presentation = 'panel',
 }) => {
   const isMobile = useIsMobile();
+  const embedded = presentation === 'embedded';
+  const mobilePanel = isMobile && !embedded;
   const [copiedText, setCopiedText] = useState(false);
   const listRef = useRef<HTMLDivElement>(null);
   const sortedAnnotations = [...annotations].sort((a, b) => a.createdA - b.createdA);
@@ -138,47 +144,61 @@ export const AnnotationPanel: React.FC<PanelProps> = ({
     <aside
       data-annotation-panel="true"
       data-plan-sidebar="right"
-      className={`border-l border-border/50 bg-card flex flex-col flex-shrink-0 ${
-        isMobile ? 'fixed top-12 bottom-0 right-0 z-[60] w-full max-w-sm shadow-2xl bg-card' : ''
+      className={`bg-card flex flex-col ${embedded ? 'h-full min-h-0 w-full flex-1' : 'flex-shrink-0 border-l border-border/50'} ${
+        mobilePanel ? 'fixed top-12 bottom-0 right-0 z-[60] w-full max-w-sm shadow-2xl bg-card' : ''
       }`}
-      style={isMobile ? undefined : { width: width ?? 288 }}
+      style={embedded || mobilePanel ? undefined : { width: width ?? 288 }}
     >
       {/* Header */}
-      <div className="border-b border-border/50">
-        <div className="flex h-10 items-center justify-between px-3">
-          <div className="flex items-center gap-2">
-            <h2 className="text-xs font-medium text-foreground">
-              Annotations
-            </h2>
-            {totalCount > 0 && (
-              <span className="flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-primary/10 px-1 font-mono text-[10px] font-medium tabular-nums text-primary">
-                {totalCount}
-              </span>
+      {!embedded && (
+        <div className="border-b border-border/50">
+          <div className="flex h-10 items-center justify-between px-3">
+            <div className="flex items-center gap-2">
+              <h2 className="text-xs font-medium text-foreground">
+                Annotations
+              </h2>
+              {totalCount > 0 && (
+                <span className="flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-primary/10 px-1 font-mono text-[10px] font-medium tabular-nums text-primary">
+                  {totalCount}
+                </span>
+              )}
+            </div>
+            {mobilePanel && onClose && (
+              <button
+                onClick={onClose}
+                className="relative rounded-md p-1.5 text-muted-foreground transition-colors before:absolute before:-inset-1.5 before:content-[''] hover:text-foreground md:hidden"
+                title="Close panel"
+                aria-label="Close panel"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
             )}
           </div>
-          {isMobile && onClose && (
+          {otherFileAnnotations && otherFileAnnotations.count > 0 && (
             <button
-              onClick={onClose}
-              className="relative rounded-md p-1.5 text-muted-foreground transition-colors before:absolute before:-inset-1.5 before:content-[''] hover:text-foreground md:hidden"
-              title="Close panel"
-              aria-label="Close panel"
+              onClick={onOtherFileAnnotationsClick}
+              className="px-3 pb-2 text-[10px] text-primary/70 hover:text-primary transition-colors cursor-pointer"
+              title="Show annotated files in sidebar"
             >
-              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-              </svg>
+              +{otherFileAnnotations.count} in {otherFileAnnotations.files} other file{otherFileAnnotations.files === 1 ? '' : 's'}
             </button>
           )}
         </div>
-        {otherFileAnnotations && otherFileAnnotations.count > 0 && (
-          <button
-            onClick={onOtherFileAnnotationsClick}
-            className="px-3 pb-2 text-[10px] text-primary/70 hover:text-primary transition-colors cursor-pointer"
-            title="Show annotated files in sidebar"
-          >
-            +{otherFileAnnotations.count} in {otherFileAnnotations.files} other file{otherFileAnnotations.files === 1 ? '' : 's'}
-          </button>
-        )}
-      </div>
+      )}
+
+      {embedded && otherFileAnnotations && otherFileAnnotations.count > 0 && (
+        <button
+          type="button"
+          data-pn-touch-target="true"
+          onClick={onOtherFileAnnotationsClick}
+          className="min-h-11 flex-shrink-0 border-b border-border/50 px-3 text-left text-xs text-primary/80 active:bg-muted"
+          title="Show annotated files in navigator"
+        >
+          {otherFileAnnotations.count} more in {otherFileAnnotations.files} other file{otherFileAnnotations.files === 1 ? '' : 's'}
+        </button>
+      )}
 
       {/* List */}
       <OverlayScrollArea className="flex-1 min-h-0">
@@ -297,7 +317,7 @@ export const AnnotationPanel: React.FC<PanelProps> = ({
     </aside>
   );
 
-  if (isMobile) {
+  if (mobilePanel) {
     return (
       <>
         <div

--- a/packages/ui/components/PlanHeaderMenu.mobile.test.tsx
+++ b/packages/ui/components/PlanHeaderMenu.mobile.test.tsx
@@ -34,7 +34,7 @@ const baseProps = {
 };
 
 describe.if(hasDom)('PlanHeaderMenu compact actions', () => {
-  test('moves session and edit decisions into the compact Options menu', async () => {
+  test('moves compact review surfaces and edit entry into Options', async () => {
     const selected: string[] = [];
     const host = document.createElement('div');
     document.body.appendChild(host);
@@ -47,8 +47,9 @@ describe.if(hasDom)('PlanHeaderMenu compact actions', () => {
             {...baseProps}
             compactTouchLayout
             compactSessionActions={[
-              { id: 'feedback', label: 'Send feedback', onSelect: () => selected.push('feedback') },
-              { id: 'approve', label: 'Approve', onSelect: () => selected.push('approve') },
+              { id: 'annotations', label: 'Annotations', onSelect: () => selected.push('annotations') },
+              { id: 'ai', label: 'Ask AI', onSelect: () => selected.push('ai') },
+              { id: 'review', label: 'Review and finish', onSelect: () => selected.push('review') },
             ]}
             compactDocumentActions={[
               { id: 'edit', label: 'Edit document', onSelect: () => selected.push('edit') },
@@ -60,11 +61,13 @@ describe.if(hasDom)('PlanHeaderMenu compact actions', () => {
 
     const trigger = host.querySelector<HTMLButtonElement>('button[aria-label="Options"]')!;
     expect(trigger.getAttribute('data-pn-touch-target')).not.toBeNull();
+    expect(trigger.id).toBe('pn-compact-plan-options-trigger');
     await act!(async () => trigger.click());
 
     expect(host.textContent).toContain('Review');
-    expect(host.textContent).toContain('Send feedback');
-    expect(host.textContent).toContain('Approve');
+    expect(host.textContent).toContain('Annotations');
+    expect(host.textContent).toContain('Ask AI');
+    expect(host.textContent).toContain('Review and finish');
     expect(host.textContent).toContain('Document');
     expect(host.textContent).toContain('Edit document');
 

--- a/packages/ui/components/PlanHeaderMenu.mobile.test.tsx
+++ b/packages/ui/components/PlanHeaderMenu.mobile.test.tsx
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import React from 'react';
+
+const hasDom = typeof document !== 'undefined' && typeof window !== 'undefined';
+const domClient = hasDom ? await import('react-dom/client') : null;
+const act = hasDom ? (await import('react')).act : null;
+const menuModule = await import('./PlanHeaderMenu');
+const themeModule = await import('./ThemeProvider');
+const PlanHeaderMenu = menuModule.PlanHeaderMenu;
+const ThemeProvider = themeModule.ThemeProvider;
+
+afterEach(() => {
+  if (hasDom) document.body.innerHTML = '';
+});
+
+const baseProps = {
+  appVersion: '0.0.0',
+  onOpenSettings: () => {},
+  onOpenExport: () => {},
+  onCopyAgentInstructions: () => {},
+  onDownloadAnnotations: () => {},
+  onPrint: () => {},
+  onCopyShareLink: () => {},
+  onOpenImport: () => {},
+  onSaveToObsidian: () => {},
+  onSaveToBear: () => {},
+  onSaveToOctarine: () => {},
+  sharingEnabled: false,
+  isApiMode: true,
+  agentInstructionsEnabled: false,
+  obsidianConfigured: false,
+  bearConfigured: false,
+  octarineConfigured: false,
+};
+
+describe.if(hasDom)('PlanHeaderMenu compact actions', () => {
+  test('moves session and edit decisions into the compact Options menu', async () => {
+    const selected: string[] = [];
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = domClient!.createRoot(host);
+
+    await act!(async () => {
+      root.render(
+        <ThemeProvider defaultTheme="dark">
+          <PlanHeaderMenu
+            {...baseProps}
+            compactTouchLayout
+            compactSessionActions={[
+              { id: 'feedback', label: 'Send feedback', onSelect: () => selected.push('feedback') },
+              { id: 'approve', label: 'Approve', onSelect: () => selected.push('approve') },
+            ]}
+            compactDocumentActions={[
+              { id: 'edit', label: 'Edit document', onSelect: () => selected.push('edit') },
+            ]}
+          />
+        </ThemeProvider>,
+      );
+    });
+
+    const trigger = host.querySelector<HTMLButtonElement>('button[aria-label="Options"]')!;
+    expect(trigger.getAttribute('data-pn-touch-target')).not.toBeNull();
+    await act!(async () => trigger.click());
+
+    expect(host.textContent).toContain('Review');
+    expect(host.textContent).toContain('Send feedback');
+    expect(host.textContent).toContain('Approve');
+    expect(host.textContent).toContain('Document');
+    expect(host.textContent).toContain('Edit document');
+
+    const edit = Array.from(host.querySelectorAll<HTMLButtonElement>('button'))
+      .find((button) => button.textContent?.includes('Edit document'))!;
+    await act!(async () => edit.click());
+    expect(selected).toEqual(['edit']);
+    expect(host.textContent).not.toContain('Edit document');
+    await act!(async () => root.unmount());
+  });
+
+  test('keeps compact-only decisions out of the desktop menu', async () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = domClient!.createRoot(host);
+
+    await act!(async () => {
+      root.render(
+        <ThemeProvider defaultTheme="dark">
+          <PlanHeaderMenu
+            {...baseProps}
+            compactSessionActions={[
+              { id: 'approve', label: 'Approve', onSelect: () => {} },
+            ]}
+          />
+        </ThemeProvider>,
+      );
+    });
+    await act!(async () => host.querySelector<HTMLButtonElement>('button[aria-label="Options"]')!.click());
+
+    expect(host.textContent).not.toContain('Approve');
+    expect(host.textContent).toContain('Settings');
+    await act!(async () => root.unmount());
+  });
+});

--- a/packages/ui/components/PlanHeaderMenu.tsx
+++ b/packages/ui/components/PlanHeaderMenu.tsx
@@ -34,6 +34,17 @@ interface PlanHeaderMenuProps {
   obsidianConfigured: boolean;
   bearConfigured: boolean;
   octarineConfigured: boolean;
+  compactTouchLayout?: boolean;
+  compactSessionActions?: CompactPlanAction[];
+  compactDocumentActions?: CompactPlanAction[];
+}
+
+export interface CompactPlanAction {
+  id: 'exit' | 'feedback' | 'approve' | 'copy' | 'done' | 'edit' | 'tools';
+  label: string;
+  subtitle?: string;
+  onSelect: () => void;
+  disabled?: boolean;
 }
 
 export const PlanHeaderMenu: React.FC<PlanHeaderMenuProps> = ({
@@ -57,6 +68,9 @@ export const PlanHeaderMenu: React.FC<PlanHeaderMenuProps> = ({
   obsidianConfigured,
   bearConfigured,
   octarineConfigured,
+  compactTouchLayout = false,
+  compactSessionActions = [],
+  compactDocumentActions = [],
 }) => {
   const { theme, setTheme } = useTheme();
 
@@ -68,13 +82,19 @@ export const PlanHeaderMenu: React.FC<PlanHeaderMenuProps> = ({
   return (
     <ActionMenu
       panelWidth="wide"
+      panelClassName={compactTouchLayout
+        ? 'absolute top-full right-0 mt-1 w-[min(18rem,calc(100vw-1rem))] max-h-[calc(var(--pn-viewport-height,100dvh)-4.5rem-var(--pn-safe-top)-var(--pn-safe-bottom))] overflow-y-auto rounded-lg border border-border bg-popover py-1 shadow-xl z-[70]'
+        : undefined
+      }
       renderTrigger={({ isOpen, toggleMenu }) => (
         <button
+          data-pn-touch-target={compactTouchLayout || undefined}
+          data-pn-touch-target-icon={compactTouchLayout || undefined}
           onClick={() => {
             if (!isOpen && showUpdateDot) updateInfo?.dismiss();
             toggleMenu();
           }}
-          className={`relative flex items-center gap-1.5 p-1.5 md:px-2.5 md:py-1 rounded-md text-xs font-medium transition-colors ${
+          className={`relative flex items-center justify-center gap-1.5 rounded-md text-xs font-medium transition-colors ${compactTouchLayout ? 'h-11 w-11 p-0' : 'p-1.5 md:px-2.5 md:py-1'} ${
             isOpen
               ? 'bg-muted text-foreground'
               : 'text-muted-foreground hover:text-foreground hover:bg-muted'
@@ -99,11 +119,34 @@ export const PlanHeaderMenu: React.FC<PlanHeaderMenuProps> = ({
     >
       {({ closeMenu }) => (
         <>
+          {compactTouchLayout && compactSessionActions.length > 0 && (
+            <>
+              <CompactActionSection
+                label="Review"
+                actions={compactSessionActions}
+                closeMenu={closeMenu}
+              />
+              <ActionMenuDivider />
+            </>
+          )}
+
+          {compactTouchLayout && compactDocumentActions.length > 0 && (
+            <>
+              <CompactActionSection
+                label="Document"
+                actions={compactDocumentActions}
+                closeMenu={closeMenu}
+              />
+              <ActionMenuDivider />
+            </>
+          )}
+
           <div className="px-3 py-2 space-y-1.5">
             <ActionMenuSectionLabel>Theme</ActionMenuSectionLabel>
             <div className="flex items-center gap-1 rounded-lg bg-muted/50 p-0.5">
               {THEME_MODES.map(({ id, label, Icon }) => (
                 <button
+                  data-pn-touch-target={compactTouchLayout || undefined}
                   key={id}
                   onClick={() => {
                     closeMenu();
@@ -240,6 +283,71 @@ export const PlanHeaderMenu: React.FC<PlanHeaderMenuProps> = ({
         </>
       )}
     </ActionMenu>
+  );
+};
+
+const CompactActionSection = ({
+  label,
+  actions,
+  closeMenu,
+}: {
+  label: string;
+  actions: CompactPlanAction[];
+  closeMenu: () => void;
+}) => (
+  <div className="py-1">
+    <div className="px-3 py-1">
+      <ActionMenuSectionLabel>{label}</ActionMenuSectionLabel>
+    </div>
+    {actions.map((action) => (
+      <ActionMenuItem
+        key={action.id}
+        onClick={() => {
+          closeMenu();
+          action.onSelect();
+        }}
+        disabled={action.disabled}
+        icon={<CompactPlanActionIcon kind={action.id} />}
+        label={action.label}
+        subtitle={action.subtitle}
+      />
+    ))}
+  </div>
+);
+
+const CompactPlanActionIcon = ({ kind }: { kind: CompactPlanAction['id'] }) => {
+  if (kind === 'approve' || kind === 'done') {
+    return (
+      <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+      </svg>
+    );
+  }
+  if (kind === 'feedback') {
+    return (
+      <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
+      </svg>
+    );
+  }
+  if (kind === 'copy') {
+    return (
+      <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+      </svg>
+    );
+  }
+  if (kind === 'edit' || kind === 'tools') {
+    return (
+      <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+      </svg>
+    );
+  }
+  return (
+    <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+    </svg>
   );
 };
 

--- a/packages/ui/components/PlanHeaderMenu.tsx
+++ b/packages/ui/components/PlanHeaderMenu.tsx
@@ -40,7 +40,7 @@ interface PlanHeaderMenuProps {
 }
 
 export interface CompactPlanAction {
-  id: 'exit' | 'feedback' | 'approve' | 'copy' | 'done' | 'edit' | 'tools';
+  id: 'exit' | 'feedback' | 'approve' | 'copy' | 'done' | 'edit' | 'tools' | 'annotations' | 'ai' | 'review';
   label: string;
   subtitle?: string;
   onSelect: () => void;
@@ -88,6 +88,7 @@ export const PlanHeaderMenu: React.FC<PlanHeaderMenuProps> = ({
       }
       renderTrigger={({ isOpen, toggleMenu }) => (
         <button
+          id={compactTouchLayout ? 'pn-compact-plan-options-trigger' : undefined}
           data-pn-touch-target={compactTouchLayout || undefined}
           data-pn-touch-target-icon={compactTouchLayout || undefined}
           onClick={() => {
@@ -316,6 +317,27 @@ const CompactActionSection = ({
 );
 
 const CompactPlanActionIcon = ({ kind }: { kind: CompactPlanAction['id'] }) => {
+  if (kind === 'review') {
+    return (
+      <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 11l2 2 4-4m6 3a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    );
+  }
+  if (kind === 'annotations') {
+    return (
+      <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
+      </svg>
+    );
+  }
+  if (kind === 'ai') {
+    return (
+      <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 3l1.2 3.8L17 8l-3.8 1.2L12 13l-1.2-3.8L7 8l3.8-1.2L12 3zM18.5 13l.8 2.7L22 16.5l-2.7.8-.8 2.7-.8-2.7-2.7-.8 2.7-.8.8-2.7zM5 13l.7 2.3L8 16l-2.3.7L5 19l-.7-2.3L2 16l2.3-.7L5 13z" />
+      </svg>
+    );
+  }
   if (kind === 'approve' || kind === 'done') {
     return (
       <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>

--- a/packages/ui/components/PlanHeaderMenu.tsx
+++ b/packages/ui/components/PlanHeaderMenu.tsx
@@ -83,7 +83,7 @@ export const PlanHeaderMenu: React.FC<PlanHeaderMenuProps> = ({
     <ActionMenu
       panelWidth="wide"
       panelClassName={compactTouchLayout
-        ? 'absolute top-full right-0 mt-1 w-[min(18rem,calc(100vw-1rem))] max-h-[calc(var(--pn-viewport-height,100dvh)-4.5rem-var(--pn-safe-top)-var(--pn-safe-bottom))] overflow-y-auto rounded-lg border border-border bg-popover py-1 shadow-xl z-[70]'
+        ? 'absolute top-full right-0 mt-1 w-[min(18rem,calc(100vw-1rem))] max-h-[calc(var(--pn-viewport-height,100vh)-4.5rem-var(--pn-safe-top)-var(--pn-safe-bottom))] overflow-y-auto rounded-lg border border-border bg-popover py-1 shadow-xl z-[70]'
         : undefined
       }
       renderTrigger={({ isOpen, toggleMenu }) => (

--- a/packages/ui/components/ai/DocumentAIChatPanel.tsx
+++ b/packages/ui/components/ai/DocumentAIChatPanel.tsx
@@ -268,6 +268,7 @@ const GeneralInput: React.FC<{
     <div className="border-t border-border/50 p-2">
       <div className="flex items-end gap-1.5">
         <textarea
+          data-pn-mobile-editable="true"
           ref={textareaRef}
           value={value}
           onChange={(event) => onChange(event.target.value)}

--- a/packages/ui/components/sidebar/FileBrowser.tsx
+++ b/packages/ui/components/sidebar/FileBrowser.tsx
@@ -27,6 +27,8 @@ interface FileBrowserProps {
   annotationCounts?: Map<string, number>;
   highlightedFiles?: Set<string>;
   editStatuses?: Map<string, FileEditStatus>;
+  /** Prevent competing destination changes while a document is activating. */
+  selectionPending?: boolean;
 }
 
 export interface FileEditStatus {
@@ -246,7 +248,8 @@ const TreeNode: React.FC<{
   editStatuses?: Map<string, FileEditStatus>;
   workspaceStatus?: WorkspaceStatusPayload;
   forceExpandFolders?: boolean;
-}> = ({ node, depth, dirPath, expandedFolders, onToggleFolder, onSelectFile, activeFile, annotationCounts, highlightedFiles, editStatuses, workspaceStatus, forceExpandFolders = false }) => {
+  selectionPending?: boolean;
+}> = ({ node, depth, dirPath, expandedFolders, onToggleFolder, onSelectFile, activeFile, annotationCounts, highlightedFiles, editStatuses, workspaceStatus, forceExpandFolders = false, selectionPending = false }) => {
   const folderKey = `${dirPath}:${node.path}`;
   const absolutePath = `${dirPath}/${node.path}`;
   const isExpanded = forceExpandFolders || expandedFolders.has(folderKey);
@@ -305,6 +308,7 @@ const TreeNode: React.FC<{
             editStatuses={editStatuses}
             workspaceStatus={workspaceStatus}
             forceExpandFolders={forceExpandFolders}
+            selectionPending={selectionPending}
           />
         ))}
       </>
@@ -347,7 +351,8 @@ const TreeNode: React.FC<{
       onClick={() => {
         if (!isSelectionDisabled) onSelectFile(absolutePath, dirPath);
       }}
-      disabled={isSelectionDisabled}
+      disabled={isSelectionDisabled || selectionPending}
+      aria-busy={isActive && selectionPending ? true : undefined}
       className={`file-tree-item w-full text-left group ${isActive ? "active" : ""} ${fileCount > 0 ? "has-annotations" : ""} ${isHighlighted ? 'file-annotation-flash' : ''} ${isSelectionDisabled ? 'opacity-70 cursor-default' : ''}`}
       style={{ paddingLeft: paddingLeft + 15 }}
       title={isDeleted ? `${node.path} (${editStatus?.status === "missing" ? "missing on disk" : "deleted on disk"})` : node.path}
@@ -357,6 +362,9 @@ const TreeNode: React.FC<{
       </svg>
       <span className={`truncate flex-1 min-w-0 ${isDeleted ? "line-through" : ""}`}>{displayName}</span>
       <div className="ml-auto flex flex-shrink-0 items-center gap-1.5 text-[10px]">
+        {isActive && selectionPending && (
+          <span className="text-primary">Opening…</span>
+        )}
         {editMarker && (
           <span
             className={`inline-flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[9px] font-semibold leading-none ${editMarker.className}`}
@@ -393,7 +401,8 @@ const DirSection: React.FC<{
   highlightedFiles?: Set<string>;
   editStatuses?: Map<string, FileEditStatus>;
   forceExpandFolders?: boolean;
-}> = ({ dir, expandedFolders, onToggleFolder, onSelectFile, activeFile, onRetry, annotationCounts, highlightedFiles, editStatuses, forceExpandFolders = false }) => {
+  selectionPending?: boolean;
+}> = ({ dir, expandedFolders, onToggleFolder, onSelectFile, activeFile, onRetry, annotationCounts, highlightedFiles, editStatuses, forceExpandFolders = false, selectionPending = false }) => {
   const workspaceStatus = React.useMemo(() => normalizeWorkspaceStatus(dir.workspaceStatus), [dir.workspaceStatus]);
 
   if (dir.isLoading) {
@@ -443,6 +452,7 @@ const DirSection: React.FC<{
           editStatuses={editStatuses}
           workspaceStatus={workspaceStatus}
           forceExpandFolders={forceExpandFolders}
+          selectionPending={selectionPending}
         />
       ))}
     </div>
@@ -462,6 +472,7 @@ export const FileBrowser: React.FC<FileBrowserProps> = ({
   annotationCounts,
   highlightedFiles,
   editStatuses,
+  selectionPending = false,
 }) => {
   const [isFilterOpen, setIsFilterOpen] = React.useState(false);
   const [filterQuery, setFilterQuery] = React.useState("");
@@ -617,6 +628,7 @@ export const FileBrowser: React.FC<FileBrowserProps> = ({
                 highlightedFiles={highlightedFiles}
                 editStatuses={editStatuses}
                 forceExpandFolders={isFiltering}
+                selectionPending={selectionPending}
               />
             )}
           </div>

--- a/packages/ui/components/sidebar/FileBrowser.tsx
+++ b/packages/ui/components/sidebar/FileBrowser.tsx
@@ -528,7 +528,7 @@ export const FileBrowser: React.FC<FileBrowserProps> = ({
         {showFilterInput ? (
           <div
             onBlur={handleFilterBlur}
-            className="flex h-6 items-center gap-1.5 rounded-sm bg-muted/25 px-1.5 text-muted-foreground focus-within:bg-muted/40"
+            className="file-browser-filter-field flex h-6 items-center gap-1.5 rounded-sm bg-muted/25 px-1.5 text-muted-foreground focus-within:bg-muted/40"
           >
             <Search size={12} className="shrink-0 text-muted-foreground/55" aria-hidden="true" />
             <input
@@ -556,7 +556,7 @@ export const FileBrowser: React.FC<FileBrowserProps> = ({
                   setFilterQuery("");
                   inputRef.current?.focus();
                 }}
-                className="flex h-5 w-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground/55 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:bg-muted"
+                className="file-browser-filter-clear flex h-5 w-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground/55 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:bg-muted"
                 aria-label="Clear file filter"
                 title="Clear file filter"
               >

--- a/packages/ui/components/sidebar/SidebarContainer.mobile.test.tsx
+++ b/packages/ui/components/sidebar/SidebarContainer.mobile.test.tsx
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { SidebarContainer } from './SidebarContainer';
+
+const hasDom = typeof document !== 'undefined';
+
+let root: Root | null = null;
+let host: HTMLElement | null = null;
+
+const baseProps: React.ComponentProps<typeof SidebarContainer> = {
+  activeTab: 'toc',
+  onTabChange: () => {},
+  onClose: () => {},
+  width: 'var(--toc-w, 240px)',
+  blocks: [],
+  annotations: [],
+  activeSection: null,
+  onTocNavigate: () => {},
+  versionInfo: null,
+  versions: [],
+  selectedBaseVersion: null,
+  onSelectBaseVersion: () => {},
+  isPlanDiffActive: false,
+  hasPreviousVersion: false,
+  onActivatePlanDiff: () => {},
+  isLoadingVersions: false,
+  isSelectingVersion: false,
+  fetchingVersion: null,
+  onFetchVersions: () => {},
+  archivePlans: [],
+  selectedArchiveFile: null,
+  onArchiveSelect: () => {},
+  isLoadingArchive: false,
+};
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  root = null;
+  host?.remove();
+  host = null;
+  if (hasDom) document.body.replaceChildren();
+});
+
+describe('SidebarContainer compact presentation', () => {
+  test('preserves the incumbent desktop rail geometry by default', () => {
+    const html = renderToStaticMarkup(<SidebarContainer {...baseProps} />);
+
+    expect(html).toContain('hidden lg:flex flex-col sticky top-12 h-[calc(100vh-3rem)]');
+    expect(html).toContain('style="width:var(--toc-w, 240px)"');
+    expect(html).not.toContain('data-pn-plan-navigator');
+    expect(html).not.toContain('Close navigator');
+  });
+
+  test('renders a full visible-viewport stage with touch-safe navigation', () => {
+    const html = renderToStaticMarkup(
+      <SidebarContainer
+        {...baseProps}
+        presentation="overlay"
+        showContentsTab={false}
+        activeTab="archive"
+        showArchiveTab
+      />,
+    );
+
+    expect(html).toContain('id="pn-compact-plan-navigator"');
+    expect(html).toContain('data-pn-plan-navigator="true"');
+    expect(html).toContain('role="dialog"');
+    expect(html).toContain('aria-modal="true"');
+    expect(html).toContain('pn-visible-viewport-stage');
+    expect(html).toContain('aria-label="Close navigator"');
+    expect(html).toContain('data-pn-touch-target="true"');
+    expect(html).not.toContain('sticky top-12');
+    expect(html).not.toContain('>Contents<');
+    expect(html).toContain('>Archive<');
+
+    const theme = readFileSync(resolve(import.meta.dir, '../../theme.css'), 'utf8');
+    expect(theme).toContain('.pn-visible-viewport-stage');
+    expect(theme).toContain('top: var(--pn-viewport-offset-top, 0px)');
+    expect(theme).toContain('height: var(--pn-viewport-height, 100dvh)');
+    expect(theme).toContain('[data-pn-plan-navigator="true"] button');
+    expect(theme).toContain('min-block-size: var(--pn-touch-target)');
+  });
+
+  test('keeps every contextual browser in the single shared navigator', () => {
+    const html = renderToStaticMarkup(
+      <SidebarContainer
+        {...baseProps}
+        presentation="overlay"
+        showVersionsTab
+        showMessagesTab
+        messages={[]}
+        showFilesTab
+        showArchiveTab
+      />,
+    );
+
+    for (const label of ['Contents', 'Versions', 'Messages', 'Files', 'Archive']) {
+      expect(html).toContain(`>${label}<`);
+    }
+    expect(html.match(/data-pn-touch-target="true"/g)?.length).toBe(6);
+  });
+
+  test.skipIf(!hasDom)('moves focus inside and exposes explicit close/tab actions', async () => {
+    const onClose = mock(() => {});
+    const onTabChange = mock(() => {});
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+
+    await act(async () => {
+      root?.render(
+        <SidebarContainer
+          {...baseProps}
+          presentation="overlay"
+          showFilesTab
+          onClose={onClose}
+          onTabChange={onTabChange}
+        />,
+      );
+    });
+
+    const close = document.querySelector<HTMLButtonElement>('[aria-label="Close navigator"]');
+    const files = Array.from(document.querySelectorAll<HTMLButtonElement>('button'))
+      .find((button) => button.textContent?.trim() === 'Files');
+
+    expect(document.activeElement).toBe(close);
+    await act(async () => files?.click());
+    expect(onTabChange).toHaveBeenCalledWith('files');
+
+    const reverseTab = new KeyboardEvent('keydown', {
+      key: 'Tab',
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    await act(async () => close?.dispatchEvent(reverseTab));
+    expect(reverseTab.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(files);
+
+    const escape = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+    });
+    await act(async () => files?.dispatchEvent(escape));
+    expect(escape.defaultPrevented).toBe(true);
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    await act(async () => close?.click());
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/ui/components/sidebar/SidebarContainer.mobile.test.tsx
+++ b/packages/ui/components/sidebar/SidebarContainer.mobile.test.tsx
@@ -82,7 +82,7 @@ describe('SidebarContainer compact presentation', () => {
     const theme = readFileSync(resolve(import.meta.dir, '../../theme.css'), 'utf8');
     expect(theme).toContain('.pn-visible-viewport-stage');
     expect(theme).toContain('top: var(--pn-viewport-offset-top, 0px)');
-    expect(theme).toContain('height: var(--pn-viewport-height, 100dvh)');
+    expect(theme).toContain('height: var(--pn-viewport-height, 100vh)');
     expect(theme).toContain('[data-pn-plan-navigator="true"] button');
     expect(theme).toContain('min-block-size: var(--pn-touch-target)');
   });

--- a/packages/ui/components/sidebar/SidebarContainer.mobile.test.tsx
+++ b/packages/ui/components/sidebar/SidebarContainer.mobile.test.tsx
@@ -63,6 +63,7 @@ describe('SidebarContainer compact presentation', () => {
         showContentsTab={false}
         activeTab="archive"
         showArchiveTab
+        pendingFileLabel="alpha.md"
       />,
     );
 
@@ -70,6 +71,7 @@ describe('SidebarContainer compact presentation', () => {
     expect(html).toContain('data-pn-plan-navigator="true"');
     expect(html).toContain('role="dialog"');
     expect(html).toContain('aria-modal="true"');
+    expect(html).toContain('Opening alpha.md…');
     expect(html).toContain('pn-visible-viewport-stage');
     expect(html).toContain('aria-label="Close navigator"');
     expect(html).toContain('data-pn-touch-target="true"');

--- a/packages/ui/components/sidebar/SidebarContainer.tsx
+++ b/packages/ui/components/sidebar/SidebarContainer.tsx
@@ -20,6 +20,9 @@ import { OverlayScrollArea } from "../OverlayScrollArea";
 import { ReviewAgentsIcon } from "../ReviewAgentsIcon";
 
 interface SidebarContainerProps {
+  /** Desktop preserves the incumbent sticky rail. Compact Plan uses the same
+   * content as a safe, visible-viewport-bounded foreground surface. */
+  presentation?: "desktop" | "overlay";
   activeTab: SidebarTab;
   onTabChange: (tab: SidebarTab) => void;
   onClose: () => void;
@@ -29,6 +32,7 @@ interface SidebarContainerProps {
   isAgentTerminalRunning?: boolean;
   onToggleAgentTerminal?: () => void;
   // TOC props
+  showContentsTab?: boolean;
   blocks: Block[];
   annotations: Annotation[];
   activeSection: string | null;
@@ -74,6 +78,7 @@ interface SidebarContainerProps {
 }
 
 export const SidebarContainer: React.FC<SidebarContainerProps> = ({
+  presentation = "desktop",
   activeTab,
   onTabChange,
   onClose,
@@ -82,6 +87,7 @@ export const SidebarContainer: React.FC<SidebarContainerProps> = ({
   isAgentTerminalOpen,
   isAgentTerminalRunning,
   onToggleAgentTerminal,
+  showContentsTab = true,
   blocks,
   annotations,
   activeSection,
@@ -121,14 +127,81 @@ export const SidebarContainer: React.FC<SidebarContainerProps> = ({
   onSelectMessage,
   messageAnnotationCounts,
 }) => {
+  const compact = presentation === "overlay";
+  const closeButtonRef = React.useRef<HTMLButtonElement>(null);
+
+  React.useEffect(() => {
+    if (compact) closeButtonRef.current?.focus({ preventScroll: true });
+  }, [compact]);
+
+  const handleCompactKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    if (!compact) return;
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      onClose();
+      return;
+    }
+    if (event.key !== "Tab") return;
+    const focusable = Array.from(
+      event.currentTarget.querySelectorAll<HTMLElement>(
+        'button:not(:disabled), input:not(:disabled), [href], [tabindex]:not([tabindex="-1"])',
+      ),
+    );
+    if (focusable.length === 0) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last?.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first?.focus();
+    }
+  };
+
   return (
     <aside
-      className="hidden lg:flex flex-col sticky top-12 h-[calc(100vh-3rem)] flex-shrink-0 bg-card border-r border-border"
-      style={{ width }}
+      id={compact ? "pn-compact-plan-navigator" : undefined}
+      data-pn-plan-navigator={compact ? "true" : undefined}
+      role={compact ? "dialog" : undefined}
+      aria-modal={compact ? true : undefined}
+      aria-label={compact ? "Plan navigator" : undefined}
+      onKeyDown={compact ? handleCompactKeyDown : undefined}
+      className={compact
+        ? "pn-visible-viewport-stage z-[90] flex flex-col overflow-hidden bg-card text-foreground"
+        : "hidden lg:flex flex-col sticky top-12 h-[calc(100vh-3rem)] flex-shrink-0 bg-card border-r border-border"}
+      style={{ width: compact ? undefined : width }}
     >
+      {compact && (
+        <div className="flex h-[52px] flex-shrink-0 items-center justify-between border-b border-border/50 px-3">
+          <div className="min-w-0">
+            <p className="text-sm font-semibold tracking-tight">Navigate</p>
+            <p className="text-[11px] text-muted-foreground">Choose what to review</p>
+          </div>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            onClick={onClose}
+            data-pn-touch-target="true"
+            data-pn-touch-target-icon="true"
+            className="flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground outline-none transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/60"
+            aria-label="Close navigator"
+            title="Close navigator"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      )}
+
       {/* Tab bar */}
-      <div className="flex h-10 items-center border-b border-border/50 px-2 gap-0.5 flex-shrink-0 overflow-hidden min-w-0">
-        {showAgentTerminalButton && onToggleAgentTerminal && (
+      <div className={compact
+        ? "flex min-h-11 items-center gap-1 overflow-x-auto border-b border-border/50 px-2 py-1"
+        : "flex h-10 items-center border-b border-border/50 px-2 gap-0.5 flex-shrink-0 overflow-hidden min-w-0"}
+      >
+        {!compact && showAgentTerminalButton && onToggleAgentTerminal && (
           <ActionButton
             active={!!isAgentTerminalOpen}
             running={!!isAgentTerminalRunning}
@@ -137,26 +210,29 @@ export const SidebarContainer: React.FC<SidebarContainerProps> = ({
             label="Agent"
           />
         )}
-        <TabButton
-          active={activeTab === "toc"}
-          onClick={() => onTabChange("toc")}
-          icon={
-            <svg
-              className="w-3 h-3"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M4 6h16M4 10h16M4 14h10M4 18h10"
-              />
-            </svg>
-          }
-          label="Contents"
-        />
+        {showContentsTab && (
+          <TabButton
+            active={activeTab === "toc"}
+            onClick={() => onTabChange("toc")}
+            icon={
+              <svg
+                className="w-3 h-3"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M4 6h16M4 10h16M4 14h10M4 18h10"
+                />
+              </svg>
+            }
+            label="Contents"
+            touch={compact}
+          />
+        )}
         {showVersionsTab && (
           <TabButton
             active={activeTab === "versions"}
@@ -177,6 +253,7 @@ export const SidebarContainer: React.FC<SidebarContainerProps> = ({
               </svg>
             }
             label="Versions"
+            touch={compact}
           />
         )}
         {showMessagesTab && (
@@ -186,6 +263,7 @@ export const SidebarContainer: React.FC<SidebarContainerProps> = ({
             icon={<MessagesIcon className="w-3 h-3" />}
             label="Messages"
             badge={messageAnnotationCounts !== undefined && messageAnnotationCounts.size > 0}
+            touch={compact}
           />
         )}
         {showFilesTab && (
@@ -209,6 +287,7 @@ export const SidebarContainer: React.FC<SidebarContainerProps> = ({
             }
             label="Files"
             badge={hasFileAnnotations}
+            touch={compact}
           />
         )}
         {showArchiveTab && (
@@ -231,6 +310,7 @@ export const SidebarContainer: React.FC<SidebarContainerProps> = ({
               </svg>
             }
             label="Archive"
+            touch={compact}
           />
         )}
         {/* No header close button — the sidebar collapses via the resize-handle
@@ -238,8 +318,11 @@ export const SidebarContainer: React.FC<SidebarContainerProps> = ({
       </div>
 
       {/* Content area */}
-      <OverlayScrollArea className="flex-1 min-h-0">
-        {activeTab === "toc" && (
+      <OverlayScrollArea className={compact
+        ? "flex-1 min-h-0 overscroll-contain [-webkit-overflow-scrolling:touch]"
+        : "flex-1 min-h-0"}
+      >
+        {activeTab === "toc" && showContentsTab && (
           <TableOfContents
             blocks={blocks}
             annotations={annotations}
@@ -309,10 +392,13 @@ const TabButton: React.FC<{
   icon: React.ReactNode;
   label: string;
   badge?: boolean;
-}> = ({ active, onClick, icon, label, badge }) => (
+  touch?: boolean;
+}> = ({ active, onClick, icon, label, badge, touch = false }) => (
   <button
+    type="button"
     onClick={onClick}
-    className={`relative flex items-center gap-1 px-2 py-1 rounded text-xs font-medium transition-colors min-w-0 shrink-0 ${
+    data-pn-touch-target={touch ? "true" : undefined}
+    className={`relative flex items-center gap-1 px-2 py-1 rounded text-xs font-medium transition-colors min-w-0 shrink-0${touch ? " h-9" : ""} ${
       active
         ? "bg-primary/10 text-primary"
         : "text-muted-foreground hover:text-foreground hover:bg-muted/50"

--- a/packages/ui/components/sidebar/SidebarContainer.tsx
+++ b/packages/ui/components/sidebar/SidebarContainer.tsx
@@ -49,6 +49,8 @@ interface SidebarContainerProps {
   onFilesSelectFile?: (absolutePath: string, dirPath: string) => void;
   onFilesFetchAll?: () => void;
   onFilesRetryVaultDir?: (vaultPath: string) => void;
+  /** Compact-only file activation feedback; desktop does not pass this. */
+  pendingFileLabel?: string | null;
   // Version Browser props
   showVersionsTab?: boolean;
   versionInfo: VersionInfo | null;
@@ -103,6 +105,7 @@ export const SidebarContainer: React.FC<SidebarContainerProps> = ({
   onFilesSelectFile,
   onFilesFetchAll,
   onFilesRetryVaultDir,
+  pendingFileLabel,
   showVersionsTab,
   versionInfo,
   versions,
@@ -177,7 +180,9 @@ export const SidebarContainer: React.FC<SidebarContainerProps> = ({
         <div className="flex h-[52px] flex-shrink-0 items-center justify-between border-b border-border/50 px-3">
           <div className="min-w-0">
             <p className="text-sm font-semibold tracking-tight">Navigate</p>
-            <p className="text-[11px] text-muted-foreground">Choose what to review</p>
+            <p className="truncate text-[11px] text-muted-foreground" aria-live="polite">
+              {pendingFileLabel ? `Opening ${pendingFileLabel}…` : 'Choose what to review'}
+            </p>
           </div>
           <button
             ref={closeButtonRef}
@@ -363,6 +368,7 @@ export const SidebarContainer: React.FC<SidebarContainerProps> = ({
             annotationCounts={fileAnnotationCounts}
             highlightedFiles={highlightedFiles}
             editStatuses={fileEditStatuses}
+            selectionPending={compact && !!pendingFileLabel}
           />
         )}
         {activeTab === "archive" && showArchiveTab && (

--- a/packages/ui/hooks/useLinkedDoc.ts
+++ b/packages/ui/hooks/useLinkedDoc.ts
@@ -90,6 +90,9 @@ export interface UseLinkedDocOptions {
   /** Let the host initialize/restore editable document state and optionally
    *  override the markdown displayed for this file. */
   onDocumentLoaded?: (doc: LinkedDocLoadData) => string | undefined;
+  /** Notify the host after any fetched or already-loaded destination has been
+   *  activated, including HTML documents and backlinks to the source. */
+  onDocumentActivated?: (doc: LinkedDocLoadData & { filepath: string }) => void;
   /** Read current host-owned text when caching a linked doc. */
   getDocumentMarkdown?: (filepath: string, fallback?: string) => string | undefined;
   /** Let the host restore any state that was suspended while a linked doc was active. */
@@ -185,6 +188,7 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
     sourceConverted,
     onBeforeNavigate,
     onDocumentLoaded,
+    onDocumentActivated,
     getDocumentMarkdown,
     onAfterBack,
   } = options;
@@ -292,6 +296,7 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
     // annotations intact.
     if (sourceFilePath && data.filepath === sourceFilePath && savedPlanState.current) {
       back();
+      onDocumentActivated?.(data);
       return;
     }
 
@@ -364,6 +369,7 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
     });
     setError(null);
     sidebar.open(targetTab ?? "toc");
+    onDocumentActivated?.(data);
 
     // Re-apply cached annotations after DOM settles
     if (cached?.annotations.length) {
@@ -393,6 +399,7 @@ export function useLinkedDoc(options: UseLinkedDocOptions): UseLinkedDocReturn {
     sourceFilePath,
     onBeforeNavigate,
     onDocumentLoaded,
+    onDocumentActivated,
     getDocumentMarkdown,
     back,
   ]);

--- a/packages/ui/theme.css
+++ b/packages/ui/theme.css
@@ -799,6 +799,44 @@ body:has([data-pn-document-scroll="true"]) > #root {
   padding-left: max(1rem, var(--pn-safe-left));
 }
 
+/* Full-stage compact surfaces (for example the Plan navigator) use the same
+ * observed visual viewport as portaled dialogs without inheriting their 1rem
+ * ornamental margin. The stage owns its safe areas and contains scroll-chain
+ * gestures so the document beneath it does not move at a list boundary. */
+.pn-visible-viewport-stage {
+  position: fixed;
+  top: var(--pn-viewport-offset-top, 0px);
+  left: var(--pn-viewport-offset-left, 0px);
+  box-sizing: border-box;
+  width: var(--pn-viewport-width, 100vw);
+  height: var(--pn-viewport-height, 100dvh);
+  padding-top: var(--pn-safe-top);
+  padding-right: var(--pn-safe-right);
+  padding-bottom: var(--pn-safe-bottom);
+  padding-left: var(--pn-safe-left);
+  overscroll-behavior: contain;
+}
+
+/* The navigator reuses information-dense desktop browser content, but its
+ * interactive rows become physical controls on touch. Scope both the 44px
+ * target and the TOC's legible type lift to the compact stage only. */
+[data-pn-plan-navigator="true"] button {
+  min-block-size: var(--pn-touch-target);
+  touch-action: manipulation;
+}
+
+[data-pn-plan-navigator="true"] nav button {
+  font-size: 0.8125rem;
+}
+
+[data-pn-plan-navigator="true"] .file-browser-filter-field {
+  height: var(--pn-touch-target);
+}
+
+[data-pn-plan-navigator="true"] .file-browser-filter-clear {
+  min-inline-size: var(--pn-touch-target);
+}
+
 /* Existing expanded composers keep their 85dvh desktop proportion. Compact
  * and touch layouts use the full safe visible stage so the keyboard cannot
  * strand the footer below an ornamental desktop margin. */

--- a/packages/ui/theme.css
+++ b/packages/ui/theme.css
@@ -837,6 +837,14 @@ body:has([data-pn-document-scroll="true"]) > #root {
   min-inline-size: var(--pn-touch-target);
 }
 
+/* Compact Plan auxiliary stages reuse dense desktop panel contents, but every
+ * nested action remains a physical touch control. This selector is stage-only,
+ * so the incumbent desktop panel geometry stays pixel-identical. */
+[data-pn-compact-plan-stage="true"] button {
+  min-block-size: var(--pn-touch-target);
+  touch-action: manipulation;
+}
+
 /* Existing expanded composers keep their 85dvh desktop proportion. Compact
  * and touch layouts use the full safe visible stage so the keyboard cannot
  * strand the footer below an ornamental desktop margin. */

--- a/packages/ui/theme.css
+++ b/packages/ui/theme.css
@@ -809,7 +809,7 @@ body:has([data-pn-document-scroll="true"]) > #root {
   left: var(--pn-viewport-offset-left, 0px);
   box-sizing: border-box;
   width: var(--pn-viewport-width, 100vw);
-  height: var(--pn-viewport-height, 100dvh);
+  height: var(--pn-viewport-height, 100vh);
   padding-top: var(--pn-safe-top);
   padding-right: var(--pn-safe-right);
   padding-bottom: var(--pn-safe-bottom);


### PR DESCRIPTION
## Summary

- add a capability-gated compact Plan foreground state without mutating desktop rail, panel, action-mode, or input-method preferences
- reuse the shared sidebar browsers as a safe-area-bounded, touch-first mobile navigator and make folder annotation directly actionable
- keep file destinations closed after asynchronous linked-document activation instead of replaying the desktop sidebar-open behavior
- keep the compact navigator visible with an explicit Opening state through a cold first-file load, then close only after successful activation
- replace the noisy phone tool matrix with one Annotate disclosure, incumbent Markup semantics, and only Select text / Pinpoint choices
- use a stable Navigate / filename / Options header; move compact terminal decisions and Edit into Options while removing Wide / Focus on phones
- keep direct editing usable with a normal-flow filename, Save state, and Done / Cancel / Discard row
- present Annotations and Ask AI as mutually exclusive full-stage mobile tasks instead of rails that squeeze the artifact
- add one normal-flow completion entry and one Review surface that reuse the incumbent Send Feedback / Approve / Close policy and callbacks
- preserve desktop panel geometry and preferences; document the complete Phase 2B methodology, implementation evidence, and physical gates

## Checkpoint

Phase 2B.1, 2B.2, and 2B.3 are implemented. The full phase is now at its physical iPhone/iPad gate. Touch range accumulation and multi-block selection remain Phase 3.

## Verification

- 116 editor/sidebar tests pass with 443 expectations, including delayed first-file activation, full-App coarse-pointer navigation, auxiliary-surface mutual exclusion, completion policy, and decision submission
- shared typecheck passes
- production UI CSS, Hook, and OpenCode builds pass
- git diff whitespace checks pass
- rendered fine-pointer desktop preflight retains the incumbent sidebar/right-panel composition and renders no compact stage or completion block
- exact production build is live on two tailnet-only physical review sessions
