### PR TITLE
docs(marketing): link OSS security page from footer

### DIFF
--- a/apps/marketing/src/components/Footer.astro
+++ b/apps/marketing/src/components/Footer.astro
@@ -22,6 +22,7 @@ const { authors, community } = await getContributors();
       <h4 class="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">Resources</h4>
       <ul class="space-y-1.5">
         <li><a href="https://docs.plannotator.ai/open-source/start/quickstart" class="text-muted-foreground hover:text-foreground transition-colors">Quickstart</a></li>
+        <li><a href="https://docs.plannotator.ai/open-source/security" class="text-muted-foreground hover:text-foreground transition-colors">Security</a></li>
         <li><a href="https://docs.plannotator.ai/open-source/agents/claude-code" class="text-muted-foreground hover:text-foreground transition-colors">Claude Code</a></li>
         <li><a href="https://docs.plannotator.ai/open-source/agents/opencode" class="text-muted-foreground hover:text-foreground transition-colors">OpenCode</a></li>
         <li><a href="https://docs.plannotator.ai/learn/" class="text-muted-foreground hover:text-foreground transition-colors">Learn</a></li>


### PR DESCRIPTION
## Summary

Adds Security to the Resources section of the shared plannotator.ai footer. The link points directly to https://docs.plannotator.ai/open-source/security.

## Merge order

Keep this PR blocked until plannotator/docs#40 is merged and the public docs URL is verified. The plannotator.ai/security redirect is a separate engineering change and is intentionally not included here.

## Validation

- bun install --frozen-lockfile
- bun run build:marketing
- Astro built all 40 routes successfully
- the generated footer link is present on all 39 HTML pages that render the shared footer
- git diff --check