### PR TITLE
Fix folder-mode cold-start refs scan

### DIFF
--- a/apps/pi-extension/server/file-browser-watch.ts
+++ b/apps/pi-extension/server/file-browser-watch.ts
@@ -168,6 +168,9 @@ function ensureWatcher(target: WatchTarget): WatchEntry {
 		entry.gitWatcher = chokidar.watch(gitWatchPaths, {
 			ignoreInitial: true,
 			persistent: true,
+			// These are exact metadata files. Keep this non-recursive so a future
+			// target cannot make startup walk the repository's entire refs tree.
+			depth: 0,
 			awaitWriteFinish: {
 				stabilityThreshold: 80,
 				pollInterval: 30,

--- a/packages/server/reference-watch.ts
+++ b/packages/server/reference-watch.ts
@@ -166,6 +166,9 @@ function ensureWatcher(target: WatchTarget): WatchEntry {
 		entry.gitWatcher = chokidar.watch(gitWatchPaths, {
 			ignoreInitial: true,
 			persistent: true,
+			// These are exact metadata files. Keep this non-recursive so a future
+			// target cannot make startup walk the repository's entire refs tree.
+			depth: 0,
 			awaitWriteFinish: {
 				stabilityThreshold: 80,
 				pollInterval: 30,

--- a/packages/shared/workspace-status.test.ts
+++ b/packages/shared/workspace-status.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -205,18 +205,44 @@ describe("workspace status", () => {
 		expect(status.totals.deletions).toBe(1);
 	});
 
-	test("resolves git metadata paths when watching a repository subdirectory", () => {
+	test("uses only bounded exact git metadata targets even when refs is large", () => {
 		const repo = tempRepo();
 		const subdir = join(repo, "docs", "sub");
 		mkdirSync(subdir, { recursive: true });
 		writeFileSync(join(subdir, "plan.md"), "# Plan\n");
 		git(repo, "add", "-A");
 		git(repo, "commit", "-m", "init");
+		for (let i = 0; i < 64; i++) {
+			const refDir = join(repo, ".git", "refs", "remotes", `remote-${i}`);
+			mkdirSync(refDir, { recursive: true });
+			writeFileSync(join(refDir, "topic"), `${"0".repeat(40)}\n`);
+		}
 
 		const paths = getGitMetadataWatchPaths(subdir);
 		const realRepo = realpathSync(repo);
+		const gitDir = join(realRepo, ".git");
 
-		expect(paths).toContain(join(realRepo, ".git", "refs"));
+		expect(new Set(paths)).toEqual(new Set([
+			join(gitDir, "HEAD"),
+			join(gitDir, "index"),
+			join(gitDir, "logs", "HEAD"),
+			join(gitDir, "packed-refs"),
+			join(gitDir, "refs", "heads", "main"),
+		]));
+		expect(paths).not.toContain(join(gitDir, "refs"));
+		expect(paths.every((path) => !existsSync(path) || statSync(path).isFile())).toBe(true);
+	});
+
+	test("keeps the exact current branch target when its ref is packed", () => {
+		const repo = tempRepo();
+		writeFileSync(join(repo, "plan.md"), "# Plan\n");
+		git(repo, "add", "-A");
+		git(repo, "commit", "-m", "init");
+		git(repo, "pack-refs", "--all", "--prune");
+
+		const currentRef = join(realpathSync(repo), ".git", "refs", "heads", "main");
+		expect(existsSync(currentRef)).toBe(false);
+		expect(getGitMetadataWatchPaths(repo)).toContain(currentRef);
 	});
 
 	test("counts staged and unstaged changes when the net diff against HEAD is empty", async () => {

--- a/packages/shared/workspace-status.ts
+++ b/packages/shared/workspace-status.ts
@@ -1,5 +1,5 @@
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync, realpathSync } from "node:fs";
+import { readFileSync, realpathSync, statSync } from "node:fs";
 import { readFile, realpath, stat } from "node:fs/promises";
 import { isAbsolute, relative, resolve } from "node:path";
 
@@ -445,15 +445,30 @@ export function filterWorkspaceStatusForDirectory(
 export function getGitMetadataWatchPaths(cwd: string): string[] {
 	const repo = getGitRepositoryInfo(cwd);
 	if (!repo) return [];
+	let currentRefPath: string | null = null;
+	try {
+		const head = readFileSync(resolve(repo.gitDir, "HEAD"), "utf8").trim();
+		if (head.startsWith("ref: ")) {
+			const refsRoot = resolve(repo.gitCommonDir, "refs");
+			const candidate = resolve(repo.gitCommonDir, head.slice("ref: ".length).trim());
+			if (candidate !== refsRoot && isWithinPath(candidate, refsRoot)) currentRefPath = candidate;
+		}
+	} catch {
+		// A detached, missing, or concurrently replaced HEAD has no symbolic ref target.
+	}
 	const candidates = [
 		resolve(repo.gitDir, "HEAD"),
 		resolve(repo.gitDir, "index"),
-		resolve(repo.gitDir, "MERGE_HEAD"),
-		resolve(repo.gitDir, "rebase-merge"),
-		resolve(repo.gitDir, "rebase-apply"),
-		resolve(repo.gitCommonDir, "HEAD"),
+		resolve(repo.gitDir, "logs", "HEAD"),
 		resolve(repo.gitCommonDir, "packed-refs"),
-		resolve(repo.gitCommonDir, "refs"),
+		currentRefPath,
 	];
-	return [...new Set(candidates)].filter((path) => existsSync(path));
+	return [...new Set(candidates)].filter((path): path is string => {
+		if (path === null) return false;
+		try {
+			return !statSync(path).isDirectory();
+		} catch {
+			return true;
+		}
+	});
 }


### PR DESCRIPTION
## Summary

- replace the recursive `.git/refs` watcher with five bounded exact Git metadata targets
- preserve worktree content watching and Git-status refreshes through `HEAD`, `index`, `logs/HEAD`, `packed-refs`, and the current symbolic ref
- enforce non-recursive Git metadata watching in both Bun and Pi runtimes
- add deterministic regression coverage for large refs trees and packed current refs

## Root cause

The live folder watcher added in #931 initialized chokidar against the entire Git common `refs` directory after the first file-tree snapshot. #935 delayed watcher setup, but first-file selection could still overlap that recursive initialization. On this checkout, `.git/refs` contains 1,714 files across 161 directories.

## Measurement

A standalone chokidar-ready timer on the same checkout measured 23,102 ms and 25,631 ms before this change. With the five exact targets, the final measurement is 29.7 ms. The regression tests assert the target set directly and do not use timing thresholds.

## Behavior tradeoff

Changes to unrelated branches and tags no longer trigger redundant file-tree status refreshes. Current worktree content, staging, commits, resets, branch movement, and packed-ref updates remain covered by exact targets.

## Verification

- `bun test packages/shared/workspace-status.test.ts packages/server/reference-watch.test.ts apps/pi-extension/server/file-browser-watch.test.ts` (31 pass)
- `bun run typecheck`
- `bun run build:pi`
- `bun build apps/hook/server/index.ts --target=bun --outfile <temp>/plannotator.js`