### PR TITLE
fix: v0.27.2 pre-release QA batch (mobile TOC, dialog bounds, seed guard)

### DIFF
--- a/apps/portal/index.html
+++ b/apps/portal/index.html
@@ -2,13 +2,13 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Plannotator</title>
     <link rel="icon" type="image/png" sizes="64x64" href="/favicon.png">
 
   </head>
-  <body class="min-h-screen antialiased">
-    <div id="root" class="h-full"></div>
+  <body class="overflow-hidden overscroll-none antialiased">
+    <div id="root" class="h-full overflow-hidden"></div>
     <script type="module" src="/index.tsx"></script>
   </body>
 </html>

--- a/packages/editor/App.compactToc.mobile.test.tsx
+++ b/packages/editor/App.compactToc.mobile.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * Compact navigator "jump to heading" (DOM_TESTS=1)
+ *
+ * The compact navigator renders the SAME TableOfContents as the desktop rail,
+ * and that component resolves its scroll target from ScrollViewportContext.
+ * When the overlay rendered outside App's ScrollViewportProvider the context
+ * was null, so every heading tap silently did nothing. This mounts the real
+ * app in the compact touch shell and pins that a TOC activation still scrolls
+ * the viewport.
+ */
+
+import { afterAll, afterEach, describe, expect, test } from "bun:test";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  resetStorageBackend,
+  setStorageBackend,
+  type StorageBackend,
+} from "@plannotator/ui/utils/storage";
+
+const hasDom = typeof document !== "undefined";
+
+const appModule = hasDom ? await import("./App") : null;
+const App = appModule?.default as typeof import("./App")["default"];
+
+const originalFetch = globalThis.fetch;
+const originalEventSource = globalThis.EventSource;
+const originalMatchMedia = hasDom ? window.matchMedia : undefined;
+const originalScrollTo = hasDom ? window.scrollTo : undefined;
+
+const PLAN = "# Alpha section\n\nFirst body paragraph.\n\n## Beta section\n\nSecond body paragraph.\n";
+
+const memory = new Map<string, string>();
+const memoryBackend: StorageBackend = {
+  getItem: (key) => memory.get(key) ?? null,
+  setItem: (key, value) => void memory.set(key, value),
+  removeItem: (key) => void memory.delete(key),
+};
+
+function seedAnnouncementsSeen(): void {
+  memory.set("plannotator-look-feel-announcement-seen", "2");
+  memory.set("plannotator-vim-mode-announcement-seen", "2");
+  memory.set("plannotator-plan-ai-announcement-seen", "1");
+}
+
+// SAFETY: implements the MediaQueryList surface the shell hooks consume.
+// Coarse-pointer matches put the app in its compact touch layout.
+function coarseMatchMedia(query: string): MediaQueryList {
+  return {
+    matches: query.includes("pointer: coarse"),
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => true,
+  } as unknown as MediaQueryList;
+}
+
+class SilentEventSource {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
+
+  readonly CONNECTING = 0;
+  readonly OPEN = 1;
+  readonly CLOSED = 2;
+  readonly readyState = SilentEventSource.OPEN;
+  readonly url: string;
+  readonly withCredentials = false;
+  onerror: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onopen: ((event: Event) => void) | null = null;
+
+  constructor(url: string | URL) {
+    this.url = String(url);
+  }
+
+  addEventListener(): void {}
+  close(): void {}
+  dispatchEvent(): boolean { return true; }
+  removeEventListener(): void {}
+}
+
+const planFetch: typeof fetch = async (input) => {
+  const rawUrl = input instanceof Request ? input.url : String(input);
+  if (rawUrl.startsWith("https://api.github.com/")) return new Response(null, { status: 404 });
+  const url = new URL(rawUrl, "http://localhost");
+  if (url.pathname === "/api/plan") {
+    return Response.json({ plan: PLAN, origin: "codex", sharingEnabled: false, serverConfig: {} });
+  }
+  if (url.pathname === "/api/ai/capabilities") return Response.json({ available: false, providers: [] });
+  if (url.pathname === "/api/draft") return Response.json({ error: "Not found" }, { status: 404 });
+  return Response.json({});
+};
+
+let root: Root | null = null;
+let host: HTMLElement | null = null;
+
+async function settle(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  root = null;
+  host?.remove();
+  host = null;
+  globalThis.fetch = originalFetch;
+  globalThis.EventSource = originalEventSource;
+  if (hasDom) {
+    if (originalMatchMedia) window.matchMedia = originalMatchMedia;
+    if (originalScrollTo) window.scrollTo = originalScrollTo;
+    document.body.replaceChildren();
+  }
+  memory.clear();
+  resetStorageBackend();
+});
+
+afterAll(() => {
+  resetStorageBackend();
+});
+
+describe.if(hasDom)("compact navigator table of contents", () => {
+  test("a heading activation scrolls the document viewport", async () => {
+    setStorageBackend(memoryBackend);
+    seedAnnouncementsSeen();
+    window.matchMedia = coarseMatchMedia as typeof window.matchMedia;
+    globalThis.fetch = planFetch;
+    // SAFETY: the App only uses EventSource's constructor, handlers, and close.
+    globalThis.EventSource = SilentEventSource as unknown as typeof EventSource;
+
+    host = document.createElement("div");
+    document.body.appendChild(host);
+    root = createRoot(host);
+    await act(async () => { root?.render(<App />); });
+
+    let trigger: HTMLElement | null = null;
+    for (let attempt = 0; attempt < 20 && !trigger; attempt += 1) {
+      await settle();
+      trigger = document.getElementById("pn-compact-plan-navigator-trigger");
+    }
+    if (!trigger) throw new Error("compact navigator trigger never rendered");
+
+    await act(async () => trigger?.click());
+    await settle();
+
+    const tocButton = Array.from(
+      document.querySelectorAll<HTMLButtonElement>('nav[aria-label="Table of contents"] button'),
+    ).find((button) => button.textContent?.includes("Beta section"));
+    if (!tocButton) throw new Error("compact navigator did not render the plan's headings");
+
+    // The heading has to exist in the document under the overlay, otherwise the
+    // no-op being guarded against would be indistinguishable from a miss.
+    expect(document.querySelector("[data-block-id]")).not.toBeNull();
+
+    const scrollCalls: unknown[] = [];
+    window.scrollTo = ((...args: unknown[]) => { scrollCalls.push(args); }) as typeof window.scrollTo;
+
+    await act(async () => tocButton.click());
+
+    expect(scrollCalls.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/editor/App.permissionModeSetup.test.tsx
+++ b/packages/editor/App.permissionModeSetup.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * Permission-mode first-run scope (DOM_TESTS=1)
+ *
+ * The permission mode decides what happens to Claude Code's permissions after
+ * a plan is APPROVED, so the one-time chooser belongs to plan review only. It
+ * used to fire in every non-goal-setup Claude Code session, which put an
+ * unrelated blocking dialog in front of annotate and archive reviewers.
+ */
+
+import { afterAll, afterEach, describe, expect, test } from "bun:test";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  resetStorageBackend,
+  setStorageBackend,
+  type StorageBackend,
+} from "@plannotator/ui/utils/storage";
+
+const hasDom = typeof document !== "undefined";
+
+const appModule = hasDom ? await import("./App") : null;
+const App = appModule?.default as typeof import("./App")["default"];
+
+const originalFetch = globalThis.fetch;
+const originalEventSource = globalThis.EventSource;
+
+// Deliberate copy pin: the dialog's own heading is how this test identifies it.
+const DIALOG_HEADING = "New: Permission Mode Preservation";
+
+const memory = new Map<string, string>();
+const memoryBackend: StorageBackend = {
+  getItem: (key) => memory.get(key) ?? null,
+  setItem: (key, value) => void memory.set(key, value),
+  removeItem: (key) => void memory.delete(key),
+};
+
+function seedAnnouncementsSeen(): void {
+  memory.set("plannotator-look-feel-announcement-seen", "2");
+  memory.set("plannotator-vim-mode-announcement-seen", "2");
+  memory.set("plannotator-plan-ai-announcement-seen", "1");
+}
+
+class SilentEventSource {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
+
+  readonly CONNECTING = 0;
+  readonly OPEN = 1;
+  readonly CLOSED = 2;
+  readonly readyState = SilentEventSource.OPEN;
+  readonly url: string;
+  readonly withCredentials = false;
+  onerror: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onopen: ((event: Event) => void) | null = null;
+
+  constructor(url: string | URL) {
+    this.url = String(url);
+  }
+
+  addEventListener(): void {}
+  close(): void {}
+  dispatchEvent(): boolean { return true; }
+  removeEventListener(): void {}
+}
+
+function fetchForPlan(plan: Record<string, unknown>): typeof fetch {
+  return async (input) => {
+    const rawUrl = input instanceof Request ? input.url : String(input);
+    if (rawUrl.startsWith("https://api.github.com/")) return new Response(null, { status: 404 });
+    const url = new URL(rawUrl, "http://localhost");
+    if (url.pathname === "/api/plan") return Response.json(plan);
+    if (url.pathname === "/api/archive/plans") return Response.json({ plans: [] });
+    if (url.pathname === "/api/ai/capabilities") return Response.json({ available: false, providers: [] });
+    if (url.pathname === "/api/draft") return Response.json({ error: "Not found" }, { status: 404 });
+    return Response.json({});
+  };
+}
+
+let root: Root | null = null;
+let host: HTMLElement | null = null;
+
+async function settle(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function mount(plan: Record<string, unknown>): Promise<void> {
+  setStorageBackend(memoryBackend);
+  seedAnnouncementsSeen();
+  globalThis.fetch = fetchForPlan(plan);
+  // SAFETY: the App only uses EventSource's constructor, handlers, and close.
+  globalThis.EventSource = SilentEventSource as unknown as typeof EventSource;
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  root = createRoot(host);
+  await act(async () => { root?.render(<App />); });
+  for (let attempt = 0; attempt < 10; attempt += 1) await settle();
+}
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  root = null;
+  host?.remove();
+  host = null;
+  globalThis.fetch = originalFetch;
+  globalThis.EventSource = originalEventSource;
+  if (hasDom) document.body.replaceChildren();
+  memory.clear();
+  resetStorageBackend();
+});
+
+afterAll(() => {
+  resetStorageBackend();
+});
+
+describe.if(hasDom)("permission mode first-run chooser", () => {
+  test("an unconfigured Claude Code plan review still offers it", async () => {
+    await mount({ plan: "# Plan\n\nBody.\n", origin: "claude-code", sharingEnabled: false, serverConfig: {} });
+
+    expect(document.body.textContent).toContain(DIALOG_HEADING);
+  });
+
+  test("an annotate session never offers it", async () => {
+    await mount({
+      plan: "# Notes\n\nBody.\n",
+      origin: "claude-code",
+      mode: "annotate",
+      filePath: "/tmp/notes.md",
+      sharingEnabled: false,
+      serverConfig: {},
+    });
+
+    expect(document.body.textContent).not.toContain(DIALOG_HEADING);
+  });
+
+  test("an archive session never offers it", async () => {
+    await mount({
+      plan: "",
+      origin: "claude-code",
+      mode: "archive",
+      archivePlans: [],
+      sharingEnabled: false,
+      serverConfig: {},
+    });
+
+    expect(document.body.textContent).not.toContain(DIALOG_HEADING);
+  });
+});

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -4853,6 +4853,13 @@ const App: React.FC = () => {
           octarineConfigured={isOctarineConfigured()}
         />
 
+        {/* The provider is render-transparent (context only, no DOM), so it can
+            open here without changing the shell's element structure or order.
+            It has to: the compact navigator renders the SAME TableOfContents as
+            the desktop rail, and a TOC outside this provider resolves a null
+            viewport, which makes every "jump to heading" tap a silent no-op. */}
+        <ScrollViewportProvider viewport={scrollViewport}>
+
         {isCompactNavigatorOpen && compactNavigatorAvailable && renderPlanSidebar('overlay')}
 
         {isCompactAnnotationsOpen && (
@@ -4960,7 +4967,6 @@ const App: React.FC = () => {
         )}
 
         {/* Main Content */}
-        <ScrollViewportProvider viewport={scrollViewport}>
         <div data-print-region="content" className={`flex-1 flex ${usesDocumentScroll ? 'overflow-visible' : 'overflow-hidden'} relative z-0 ${isResizing ? 'select-none' : ''}`}>
           {/* Tater sprites — inside content wrapper so z-0 stacking context applies */}
           {taterMode && <TaterSpriteRunning />}

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -2767,8 +2767,13 @@ const App: React.FC = () => {
         }
         if (data.origin) {
           setOrigin(data.origin);
-          // For Claude Code, check if user needs to configure permission mode
-          if (data.origin === 'claude-code' && data.mode !== 'goal-setup' && needsPermissionModeSetup()) {
+          // For Claude Code, check if user needs to configure permission mode.
+          // Plan review only: the setting decides what happens after a plan is
+          // APPROVED, which is meaningless in annotate / annotate-last /
+          // annotate-folder / archive / goal-setup sessions. Plan review is the
+          // absence of a mode field (the plan server sends `mode` only for
+          // archive; annotate and goal-setup always name themselves).
+          if (data.origin === 'claude-code' && data.mode === undefined && needsPermissionModeSetup()) {
             setShowPermissionModeSetup(true);
           }
           // Load saved permission mode preference

--- a/packages/editor/components/CompactPlanStage.test.tsx
+++ b/packages/editor/components/CompactPlanStage.test.tsx
@@ -43,6 +43,9 @@ describe.if(hasDom)('CompactPlanStage', () => {
     if (!stage || !close) throw new Error('Compact stage did not render');
 
     expect(stage.className).toContain('pn-visible-viewport-stage');
+    // A transient task surface must not print over the document (print.css
+    // hides [data-print-hide]).
+    expect(stage.hasAttribute('data-print-hide')).toBe(true);
     expect(stage.getAttribute('role')).toBe('dialog');
     expect(stage.getAttribute('aria-modal')).toBe('true');
     expect(document.activeElement).toBe(close);

--- a/packages/editor/components/CompactPlanStage.tsx
+++ b/packages/editor/components/CompactPlanStage.tsx
@@ -62,6 +62,11 @@ export const CompactPlanStage: React.FC<CompactPlanStageProps> = ({
     <section
       id={id}
       data-pn-compact-plan-stage="true"
+      // A transient task surface is never part of the printed document. Without
+      // this, printing with Settings / Versions / Archive open on a touch device
+      // puts the full-viewport overlay over the plan (print.css hides
+      // [data-print-hide]).
+      data-print-hide
       role="dialog"
       aria-modal="true"
       aria-label={title}

--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -4503,6 +4503,10 @@ const ReviewApp: React.FC = () => {
               !!gitContext && gitContext.vcsType === 'git' && !prMetadata &&
               reviewMode !== 'workspace' && !sectionsCapable
             }
+            // The compact shell renders a session-only unified diff, so the
+            // Display tab hides the Split/Unified control rather than writing
+            // the desktop preference from a phone.
+            isCompactTouchLayout={isCompactTouchLayout}
           />
         </div>
 

--- a/packages/review-editor/utils/reviewSetup.test.ts
+++ b/packages/review-editor/utils/reviewSetup.test.ts
@@ -47,6 +47,38 @@ describe('initializeReviewSetup', () => {
     expect(store.get('defaultDiffType')).toBe('uncommitted');
   });
 
+  test('an explicit persisted view survives a session that never tripped the seen gate', () => {
+    // Non-git / workspace / PR / no-since-base sessions never reach the
+    // initializer, so a reviewer can persist a view from Settings while
+    // "seen" stays unset. The next plain git session must not seed over it.
+    installMemoryBackend({
+      'plannotator-review-panel-view': 'sections',
+      'plannotator-default-diff-type': 'since-base',
+    });
+    const store = makeStore();
+
+    expect(initializeReviewSetup(store)).toBe(false);
+    expect(store.get('reviewPanelView')).toBe('sections');
+    expect(store.get('defaultDiffType')).toBe('since-base');
+    // The one-time setup is consumed, so this cannot be re-evaluated later.
+    expect(needsReviewSetup()).toBe(false);
+  });
+
+  test('a persisted Tree view is left alone rather than re-written', () => {
+    installMemoryBackend({
+      'plannotator-review-panel-view': 'tree',
+      'plannotator-review-panel-view-last-used': 'sections',
+    });
+    const store = makeStore();
+
+    expect(initializeReviewSetup(store)).toBe(false);
+    expect(store.get('reviewPanelView')).toBe('tree');
+    // The seeding path would have stamped 'tree' here; the memo is the
+    // reviewer's, so a skipped seed must not touch it.
+    expect(store.get('reviewPanelViewLastUsed')).toBe('sections');
+    expect(needsReviewSetup()).toBe(false);
+  });
+
   test('a returning reviewer keeps both the persisted view and last-used memo', () => {
     installMemoryBackend({
       'plannotator-review-setup-seen': 'true',

--- a/packages/review-editor/utils/reviewSetup.ts
+++ b/packages/review-editor/utils/reviewSetup.ts
@@ -1,5 +1,5 @@
 import { storage } from '@plannotator/ui/utils/storage';
-import { configStore, setReviewPanelView } from '@plannotator/ui/config';
+import { configStore, getPersistedReviewPanelView, setReviewPanelView } from '@plannotator/ui/config';
 
 /**
  * First-run gate for the code-review setup dialog (panel-view default + the
@@ -25,6 +25,16 @@ export function markReviewSetupSeen(): void {
  */
 export function initializeReviewSetup(store: typeof configStore = configStore): boolean {
   if (!needsReviewSetup()) return false;
+
+  // The seen cookie is not the only evidence of a returning reviewer. Sessions
+  // that never reach this gate (non-git, workspace, PR, or no since-base) still
+  // let Settings persist a panel view, so a reviewer can hold an explicit
+  // choice while "seen" stays unset. Seeding Tree there would overwrite it.
+  // A persisted view IS the decision: consume the one-time setup and leave it.
+  if (getPersistedReviewPanelView() !== undefined) {
+    markReviewSetupSeen();
+    return false;
+  }
 
   // Selecting Tree preserves whichever defaultDiffType the store resolved.
   // The shared setter also records Tree as last-used, so accepting the dialog

--- a/packages/ui/components/AnnotationToolbar.touchTargets.test.tsx
+++ b/packages/ui/components/AnnotationToolbar.touchTargets.test.tsx
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { AnnotationToolbar } from './AnnotationToolbar';
+import { AnnotationType } from '../types';
+
+/**
+ * The selection toolbar is the primary annotate control on a phone, but its
+ * buttons never got the touch-target markers the rest of the stack uses, so
+ * they stayed 28x28 inside the compact scope. theme.css sizes marked controls
+ * to var(--pn-touch-target) there and the markers are inert everywhere else,
+ * so this pins the markup contract the stylesheet depends on.
+ */
+
+const hasDom = typeof document !== 'undefined';
+let root: Root | null = null;
+let host: HTMLElement | null = null;
+let anchor: HTMLElement | null = null;
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  root = null;
+  host?.remove();
+  host = null;
+  anchor?.remove();
+  anchor = null;
+  if (hasDom) document.body.replaceChildren();
+});
+
+describe.if(hasDom)('AnnotationToolbar touch targets', () => {
+  test('every action carries the icon touch-target markers', async () => {
+    anchor = document.createElement('p');
+    anchor.textContent = 'annotated paragraph';
+    document.body.appendChild(anchor);
+
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    await act(async () => {
+      root?.render(
+        <AnnotationToolbar
+          element={anchor!}
+          positionMode="center-above"
+          onAnnotate={() => {}}
+          onClose={() => {}}
+          onRequestComment={() => {}}
+          onQuickLabel={() => {}}
+        />,
+      );
+    });
+
+    const toolbar = document.querySelector<HTMLElement>('.annotation-toolbar');
+    if (!toolbar) throw new Error('annotation toolbar did not render');
+
+    const buttons = Array.from(toolbar.querySelectorAll<HTMLButtonElement>('button'));
+    expect(buttons.length).toBeGreaterThan(0);
+    for (const button of buttons) {
+      expect(button.getAttribute('data-pn-touch-target')).toBe('true');
+      expect(button.getAttribute('data-pn-touch-target-icon')).toBe('true');
+    }
+
+    // The row the compact-scoped gap rule keys on.
+    expect(toolbar.querySelector('[data-pn-annotation-toolbar-row]')).not.toBeNull();
+  });
+
+  test('the actions still fire', async () => {
+    anchor = document.createElement('p');
+    anchor.textContent = 'annotated paragraph';
+    document.body.appendChild(anchor);
+
+    const annotated: AnnotationType[] = [];
+    let closes = 0;
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    await act(async () => {
+      root?.render(
+        <AnnotationToolbar
+          element={anchor!}
+          positionMode="center-above"
+          onAnnotate={(type) => { annotated.push(type); }}
+          onClose={() => { closes += 1; }}
+        />,
+      );
+    });
+
+    const find = (label: string) =>
+      document.querySelector<HTMLButtonElement>(`.annotation-toolbar button[title="${label}"]`);
+
+    await act(async () => find('Delete')?.click());
+    await act(async () => find('Cancel')?.click());
+    expect(annotated).toEqual([AnnotationType.DELETION]);
+    expect(closes).toBe(1);
+  });
+});

--- a/packages/ui/components/AnnotationToolbar.tsx
+++ b/packages/ui/components/AnnotationToolbar.tsx
@@ -197,7 +197,7 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
           to { opacity: 0; transform: translateY(8px)${translateX}; }
         }
       `}</style>
-      <div className="flex items-center p-1 gap-0.5">
+      <div data-pn-annotation-toolbar-row="true" className="flex items-center p-1 gap-0.5">
         {!hideCopyButton && (
           <>
             <ToolbarButton
@@ -306,6 +306,11 @@ const ToolbarButton = React.forwardRef<HTMLButtonElement, {
 }>(({ onClick, icon, label, className }, ref) => (
   <button
     ref={ref}
+    // Icon-only controls: the markers are inert outside the compact touch
+    // scope, where theme.css grows them to var(--pn-touch-target). Desktop
+    // geometry is unchanged.
+    data-pn-touch-target="true"
+    data-pn-touch-target-icon="true"
     onClick={onClick}
     title={label}
     className={`p-1.5 rounded-md transition-colors ${className}`}

--- a/packages/ui/components/CommentPopover.forcedDialog.test.tsx
+++ b/packages/ui/components/CommentPopover.forcedDialog.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * Geometry-forced expanded composer (DOM_TESTS=1)
+ *
+ * On a fine-pointer viewport the composer normally opens as a popover and the
+ * expanded dialog is a user choice, so Escape and the Collapse button take it
+ * back. When the anchor has no room, the position tracker FORCES the dialog —
+ * and collapsing recomputes the same geometry and immediately re-expands. That
+ * made Escape a no-op and left the composer with no keyboard exit.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { CommentPopover } from './CommentPopover';
+
+const hasDom = typeof document !== 'undefined';
+
+// Fine pointer, and a viewport short enough that a mid-document anchor has
+// under 280px of room on either side (the popover's minimum).
+const VIEWPORT_WIDTH = 900;
+const VIEWPORT_HEIGHT = 560;
+const CRAMPED_ANCHOR = { top: 280, bottom: 300, left: 400, right: 460, width: 60 };
+const ROOMY_ANCHOR = { top: 40, bottom: 60, left: 400, right: 460, width: 60 };
+
+let root: Root | null = null;
+let host: HTMLElement | null = null;
+let originalMatchMedia: typeof window.matchMedia | undefined;
+let originalWidth = 0;
+let originalHeight = 0;
+
+// SAFETY: implements the MediaQueryList surface the composer consumes; nothing
+// matches, which is a fine-pointer desktop.
+function fineMatchMedia(query: string): MediaQueryList {
+  return {
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => true,
+  } as unknown as MediaQueryList;
+}
+
+function setViewport(width: number, height: number): void {
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: width });
+  Object.defineProperty(window, 'innerHeight', { configurable: true, value: height });
+}
+
+async function mount(ui: React.ReactElement): Promise<void> {
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  root = createRoot(host);
+  await act(async () => root?.render(ui));
+  await act(async () => new Promise(resolve => setTimeout(resolve, 0)));
+}
+
+function dialog(): HTMLElement | null {
+  return document.querySelector<HTMLElement>('[role="dialog"]');
+}
+
+function collapseButton(): HTMLButtonElement | null {
+  return document.querySelector<HTMLButtonElement>('button[title="Collapse"]');
+}
+
+async function pressEscapeInComposer(): Promise<void> {
+  const textarea = document.querySelector<HTMLTextAreaElement>('textarea');
+  if (!textarea) throw new Error('composer textarea did not render');
+  await act(async () => {
+    textarea.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+    }));
+  });
+}
+
+beforeEach(() => {
+  if (!hasDom) return;
+  originalMatchMedia = window.matchMedia;
+  originalWidth = window.innerWidth;
+  originalHeight = window.innerHeight;
+  window.matchMedia = fineMatchMedia as typeof window.matchMedia;
+  setViewport(VIEWPORT_WIDTH, VIEWPORT_HEIGHT);
+});
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  root = null;
+  host?.remove();
+  host = null;
+  if (hasDom) {
+    document.body.replaceChildren();
+    if (originalMatchMedia) window.matchMedia = originalMatchMedia;
+    setViewport(originalWidth, originalHeight);
+  }
+});
+
+describe.if(hasDom)('CommentPopover forced expansion', () => {
+  test('a cramped anchor opens the dialog with no Collapse control', async () => {
+    await mount(
+      <CommentPopover
+        anchorRect={CRAMPED_ANCHOR as DOMRect}
+        contextText="selected text"
+        isGlobal={false}
+        onSubmit={() => {}}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(dialog()).not.toBeNull();
+    expect(collapseButton()).toBeNull();
+  });
+
+  test('Escape closes a forced dialog instead of bouncing off the re-expand', async () => {
+    let closes = 0;
+    await mount(
+      <CommentPopover
+        anchorRect={CRAMPED_ANCHOR as DOMRect}
+        contextText="selected text"
+        isGlobal={false}
+        onSubmit={() => {}}
+        onClose={() => { closes += 1; }}
+      />,
+    );
+    expect(dialog()).not.toBeNull();
+
+    await pressEscapeInComposer();
+    expect(closes).toBe(1);
+  });
+
+  test('a user-expanded dialog still collapses on Escape and keeps its Collapse control', async () => {
+    let closes = 0;
+    await mount(
+      <CommentPopover
+        anchorRect={ROOMY_ANCHOR as DOMRect}
+        contextText="selected text"
+        isGlobal={false}
+        onSubmit={() => {}}
+        onClose={() => { closes += 1; }}
+      />,
+    );
+    // Roomy anchor: opens as a popover.
+    expect(dialog()).toBeNull();
+
+    const expand = document.querySelector<HTMLButtonElement>('button[title="Expand"]');
+    if (!expand) throw new Error('popover did not render its Expand control');
+    await act(async () => expand.click());
+    expect(dialog()).not.toBeNull();
+    expect(collapseButton()).not.toBeNull();
+
+    await pressEscapeInComposer();
+    expect(closes).toBe(0);
+    expect(dialog()).toBeNull();
+  });
+});

--- a/packages/ui/components/CommentPopover.forcedDialog.test.tsx
+++ b/packages/ui/components/CommentPopover.forcedDialog.test.tsx
@@ -3,7 +3,7 @@
  *
  * On a fine-pointer viewport the composer normally opens as a popover and the
  * expanded dialog is a user choice, so Escape and the Collapse button take it
- * back. When the anchor has no room, the position tracker FORCES the dialog —
+ * back. When the anchor has no room, the position tracker FORCES the dialog,
  * and collapsing recomputes the same geometry and immediately re-expands. That
  * made Escape a no-op and left the composer with no keyboard exit.
  */

--- a/packages/ui/components/CommentPopover.tsx
+++ b/packages/ui/components/CommentPopover.tsx
@@ -173,6 +173,14 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
   const [mode, setMode] = useState<'popover' | 'dialog'>(() =>
     prefersExpandedComposer ? 'dialog' : 'popover'
   );
+  // Dialog mode has two very different origins. Either the viewport PREFERS an
+  // expanded composer (phones, small windows), or the anchor simply has no room
+  // for a popover and the geometry FORCED it. Only the forced kind can bounce:
+  // collapsing recomputes the same geometry and immediately re-expands, which
+  // ate Escape and made the Collapse button a no-op. Track which one we are in.
+  const [dialogIsForced, setDialogIsForced] = useState(false);
+  // A preference-driven dialog is never the forced kind.
+  const forcedDialog = dialogIsForced && !prefersExpandedComposer;
   const initialDraft = draftKey ? draftStore.get(draftKey) : undefined;
   const [text, setText] = useState(initialDraft?.text ?? initialText);
   const [images, setImages] = useState<ImageAttachment[]>(allowImages ? initialDraft?.images ?? [] : []);
@@ -224,6 +232,7 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
       if (!rect) return;
       const nextPosition = computeCommentPopoverPosition(rect, visibleBounds);
       if (nextPosition.requiresExpanded) {
+        setDialogIsForced(true);
         setMode('dialog');
         return;
       }
@@ -480,7 +489,10 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
     if (e.key === 'Escape') {
       e.stopPropagation();
       if (mode === 'dialog') {
-        if (prefersExpandedComposer) handleClose();
+        // Collapsing a forced dialog is geometrically impossible, so Escape
+        // closes it (draft-preserving) instead of being swallowed by the
+        // re-expand.
+        if (prefersExpandedComposer || forcedDialog) handleClose();
         else setMode('popover');
       } else {
         handleClose();
@@ -554,9 +566,9 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
               {headerLabel}
             </span>
             <div className="flex items-center gap-1">
-              {!prefersExpandedComposer && (
+              {!prefersExpandedComposer && !forcedDialog && (
                 <button
-                  onClick={() => setMode('popover')}
+                  onClick={() => { setDialogIsForced(false); setMode('popover'); }}
                   className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
                   title="Collapse"
                 >
@@ -702,7 +714,7 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
         </span>
         <div className="flex items-center gap-1">
           <button
-            onClick={() => setMode('dialog')}
+            onClick={() => { setDialogIsForced(false); setMode('dialog'); }}
             className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
             title="Expand"
           >

--- a/packages/ui/components/PermissionModeSetup.mobile.test.tsx
+++ b/packages/ui/components/PermissionModeSetup.mobile.test.tsx
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { PermissionModeSetup } from './PermissionModeSetup';
+
+/**
+ * The chooser is modal and has no dismiss control, so a card taller than the
+ * viewport is a trap: on a short landscape phone its options and its Continue
+ * button both sat off-screen with nothing scrollable. Pin the bounded shell.
+ */
+
+const hasDom = typeof document !== 'undefined';
+let root: Root | null = null;
+let host: HTMLElement | null = null;
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  root = null;
+  host?.remove();
+  host = null;
+  if (hasDom) document.body.replaceChildren();
+});
+
+describe.if(hasDom)('PermissionModeSetup shell', () => {
+  test('caps the card to the visible viewport and scrolls its options', async () => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    await act(async () => {
+      root?.render(<PermissionModeSetup isOpen onComplete={() => {}} />);
+    });
+
+    const card = document.querySelector<HTMLElement>('.bg-card.max-w-lg');
+    if (!card) throw new Error('permission mode card did not render');
+    expect(card.style.maxHeight).toContain('--pn-viewport-height');
+    expect(card.className).toContain('flex-col');
+
+    const scroller = Array.from(card.children).find(
+      (child) => child instanceof HTMLElement && child.className.includes('overflow-y-auto'),
+    );
+    expect(scroller).not.toBeUndefined();
+
+    // The confirm control stays inside the card, below the scrolling region,
+    // so it can never be pushed past the viewport edge.
+    const confirm = Array.from(card.querySelectorAll('button'))
+      .find((button) => button.textContent?.trim() === 'Continue');
+    expect(confirm).not.toBeUndefined();
+  });
+});

--- a/packages/ui/components/PermissionModeSetup.tsx
+++ b/packages/ui/components/PermissionModeSetup.tsx
@@ -25,10 +25,29 @@ export const PermissionModeSetup: React.FC<PermissionModeSetupProps> = ({
   };
 
   return createPortal(
-    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-background/90 backdrop-blur-sm p-4">
-      <div className="bg-card border border-border rounded-xl w-full max-w-lg shadow-2xl">
+    // Same bounded shell as the sibling one-time dialogs (see
+    // LookAndFeelAnnouncementDialog): safe-area padding, a card capped to the
+    // visible viewport, and the option list as the only scrolling region. The
+    // hand-rolled unbounded card used to overflow both edges of a short
+    // landscape phone with nothing left to tap.
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center overflow-y-auto bg-background/90 backdrop-blur-sm"
+      style={{
+        paddingTop: 'max(1rem, var(--pn-safe-top, 0px))',
+        paddingRight: 'max(1rem, var(--pn-safe-right, 0px))',
+        paddingBottom: 'max(1rem, var(--pn-safe-bottom, 0px))',
+        paddingLeft: 'max(1rem, var(--pn-safe-left, 0px))',
+      }}
+    >
+      <div
+        className="bg-card border border-border rounded-xl w-full max-w-lg shadow-2xl flex flex-col overflow-hidden"
+        style={{
+          maxHeight:
+            'calc(var(--pn-viewport-height, 100vh) - max(1rem, var(--pn-safe-top, 0px)) - max(1rem, var(--pn-safe-bottom, 0px)))',
+        }}
+      >
         {/* Header */}
-        <div className="p-5 border-b border-border">
+        <div className="p-5 border-b border-border flex-shrink-0">
           <div className="flex items-center gap-2 mb-2">
             <div className="p-1.5 rounded-lg bg-primary/15">
               <svg className="w-5 h-5 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
@@ -47,7 +66,7 @@ export const PermissionModeSetup: React.FC<PermissionModeSetupProps> = ({
         </div>
 
         {/* Options */}
-        <div className="p-4 space-y-2">
+        <div className="min-h-0 flex-1 overflow-y-auto p-4 space-y-2">
           {PERMISSION_MODE_OPTIONS.map((option) => (
             <label
               key={option.value}
@@ -74,7 +93,7 @@ export const PermissionModeSetup: React.FC<PermissionModeSetupProps> = ({
         </div>
 
         {/* Footer */}
-        <div className="p-4 border-t border-border flex justify-between items-center">
+        <div className="p-4 border-t border-border flex flex-shrink-0 flex-wrap gap-2 justify-between items-center">
           <p className="text-xs text-muted-foreground">
             You can change this later in Settings.
           </p>

--- a/packages/ui/components/Settings.compactDisplay.test.tsx
+++ b/packages/ui/components/Settings.compactDisplay.test.tsx
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { Settings } from './Settings';
+
+/**
+ * The compact review shell renders a session-only unified diff, so the
+ * Display tab's Split/Unified control had no effect there while still writing
+ * the persisted DESKTOP preference. Hide it on compact and say what the phone
+ * is doing; leave the desktop control exactly as it was.
+ */
+
+const hasDom = typeof document !== 'undefined';
+let host: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+async function openDisplayTab(isCompactTouchLayout: boolean): Promise<void> {
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  root = createRoot(host);
+  await act(async () => {
+    root!.render(
+      <Settings
+        taterMode={false}
+        onTaterModeChange={() => {}}
+        mode="review"
+        externalOpen
+        isCompactTouchLayout={isCompactTouchLayout}
+      />,
+    );
+  });
+
+  const displayTab = Array.from(document.querySelectorAll<HTMLButtonElement>('button'))
+    .find((button) => button.textContent?.trim() === 'Editor');
+  if (!displayTab) throw new Error('review display tab did not render');
+  await act(async () => displayTab.click());
+}
+
+function styleControlButtons(): HTMLButtonElement[] {
+  return Array.from(document.querySelectorAll<HTMLButtonElement>('button'))
+    .filter((button) => button.textContent?.trim() === 'Split' || button.textContent?.trim() === 'Unified');
+}
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  root = null;
+  host?.remove();
+  host = null;
+  if (hasDom) document.body.replaceChildren();
+});
+
+describe.if(hasDom)('review Display tab diff style', () => {
+  test('desktop keeps the Split/Unified control', async () => {
+    await openDisplayTab(false);
+
+    const options = styleControlButtons();
+    expect(options.map((button) => button.textContent?.trim()).sort()).toEqual(['Split', 'Unified']);
+    expect(document.body.textContent).not.toContain('unified diffs for the session');
+  });
+
+  test('compact hides the control and explains the session behavior', async () => {
+    await openDisplayTab(true);
+
+    expect(styleControlButtons()).toHaveLength(0);
+    expect(document.body.textContent).toContain('unified diffs for the session');
+    // The rest of the tab is unaffected.
+    expect(document.body.textContent).toContain('Diff Style');
+  });
+});

--- a/packages/ui/components/Settings.tsx
+++ b/packages/ui/components/Settings.tsx
@@ -95,6 +95,10 @@ interface SettingsProps {
    *  (base ref unresolvable) — the Git tab shows a note that the Git-status
    *  preference can't take effect in THIS repo. */
   sinceBaseUnavailable?: boolean;
+  /** The host is rendering its compact touch shell (review only). Display
+   *  settings that the compact shell overrides for the session are hidden
+   *  there instead of silently editing the desktop preference. */
+  isCompactTouchLayout?: boolean;
   /** Override Obsidian vault detection (default = GET /api/obsidian/vaults). */
   onDetectObsidianVaults?: () => Promise<string[]>;
 }
@@ -421,7 +425,7 @@ const GitTab: React.FC<{ sinceBaseUnavailable?: boolean }> = ({ sinceBaseUnavail
   );
 };
 
-const ReviewDisplayTab: React.FC = () => {
+const ReviewDisplayTab: React.FC<{ isCompactTouchLayout?: boolean }> = ({ isCompactTouchLayout = false }) => {
   const diffStyle = useConfigValue('diffStyle');
   const diffOverflow = useConfigValue('diffOverflow');
   const diffIndicators = useConfigValue('diffIndicators');
@@ -519,13 +523,23 @@ const ReviewDisplayTab: React.FC = () => {
 
       <div className="border-t border-border" />
 
-      {/* Diff Style */}
+      {/* Diff Style. The compact touch shell renders a session-only unified
+          diff, so the control there would look dead while quietly rewriting
+          the DESKTOP preference. Say what the phone is doing instead. */}
       <div className="space-y-2">
         <div>
           <div className="text-sm font-medium">Diff Style</div>
           <div className="text-xs text-muted-foreground">Side-by-side or inline diff view</div>
+          {isCompactTouchLayout && (
+            <div className="text-xs text-muted-foreground mt-1">
+              This layout shows unified diffs for the session; your desktop
+              preference is unchanged.
+            </div>
+          )}
         </div>
-        <SegmentedControl options={DIFF_STYLE_OPTIONS} value={diffStyle} onChange={(v) => configStore.set('diffStyle', v)} />
+        {!isCompactTouchLayout && (
+          <SegmentedControl options={DIFF_STYLE_OPTIONS} value={diffStyle} onChange={(v) => configStore.set('diffStyle', v)} />
+        )}
       </div>
 
       <div className="border-t border-border" />
@@ -822,7 +836,7 @@ const CommentsTab: React.FC = () => {
   );
 };
 
-export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange, onIdentityChange, origin, mode = 'plan', onUIPreferencesChange, externalOpen, onExternalClose, aiProviders = [], gitUser, sinceBaseUnavailable, onDetectObsidianVaults }) => {
+export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange, onIdentityChange, origin, mode = 'plan', onUIPreferencesChange, externalOpen, onExternalClose, aiProviders = [], gitUser, sinceBaseUnavailable, isCompactTouchLayout = false, onDetectObsidianVaults }) => {
   const [showDialog, setShowDialog] = useState(false);
   const settingsWasOpenRef = useRef(false);
   const [themePreview, setThemePreview] = useState(false);
@@ -1407,7 +1421,7 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
 
                 {/* === DISPLAY TAB === */}
                 {activeTab === 'display' && mode === 'review' && (
-                  <ReviewDisplayTab />
+                  <ReviewDisplayTab isCompactTouchLayout={isCompactTouchLayout} />
                 )}
 
                 {activeTab === 'analysis' && mode === 'review' && (

--- a/packages/ui/components/sidebar/SidebarContainer.tsx
+++ b/packages/ui/components/sidebar/SidebarContainer.tsx
@@ -167,6 +167,10 @@ export const SidebarContainer: React.FC<SidebarContainerProps> = ({
     <aside
       id={compact ? "pn-compact-plan-navigator" : undefined}
       data-pn-plan-navigator={compact ? "true" : undefined}
+      // The compact navigator (Contents / Versions / Archive) is the same kind
+      // of full-viewport transient surface as CompactPlanStage, so it must not
+      // print over the document either. Desktop rail printing is unchanged.
+      data-print-hide={compact ? true : undefined}
       role={compact ? "dialog" : undefined}
       aria-modal={compact ? true : undefined}
       aria-label={compact ? "Plan navigator" : undefined}

--- a/packages/ui/config/index.ts
+++ b/packages/ui/config/index.ts
@@ -1,4 +1,9 @@
 export { configStore } from './configStore';
 export type { ServerSyncFn } from './configStore';
 export { useConfigValue } from './useConfig';
-export { setReviewPanelView, setReviewDefaultDiffType, type ReviewDefaultDiffType } from './reviewView';
+export {
+  setReviewPanelView,
+  setReviewDefaultDiffType,
+  getPersistedReviewPanelView,
+  type ReviewDefaultDiffType,
+} from './reviewView';

--- a/packages/ui/config/reviewView.ts
+++ b/packages/ui/config/reviewView.ts
@@ -46,8 +46,8 @@ export function setReviewPanelView(
 /**
  * The panel view the reviewer has actually persisted, or `undefined` when they
  * never chose one. Distinct from `configStore.get('reviewPanelView')`, which
- * cannot tell a stored choice apart from the built-in default — the difference
- * first-run seeding has to respect before it writes over anything.
+ * cannot tell a stored choice apart from the built-in default, which is the
+ * difference first-run seeding has to respect before it writes over anything.
  */
 export function getPersistedReviewPanelView(): 'sections' | 'tree' | undefined {
   return SETTINGS.reviewPanelView.fromCookie();

--- a/packages/ui/config/reviewView.ts
+++ b/packages/ui/config/reviewView.ts
@@ -1,4 +1,5 @@
 import { configStore } from './configStore';
+import { SETTINGS } from './settings';
 
 /**
  * The ONLY writers for the coupled setting pair (reviewPanelView,
@@ -40,6 +41,16 @@ export function setReviewPanelView(
   if (view === 'sections' && store.get('defaultDiffType') !== 'since-base') {
     store.set('defaultDiffType', 'since-base');
   }
+}
+
+/**
+ * The panel view the reviewer has actually persisted, or `undefined` when they
+ * never chose one. Distinct from `configStore.get('reviewPanelView')`, which
+ * cannot tell a stored choice apart from the built-in default — the difference
+ * first-run seeding has to respect before it writes over anything.
+ */
+export function getPersistedReviewPanelView(): 'sections' | 'tree' | undefined {
+  return SETTINGS.reviewPanelView.fromCookie();
 }
 
 export type ReviewDefaultDiffType =

--- a/packages/ui/theme.css
+++ b/packages/ui/theme.css
@@ -904,6 +904,14 @@ html:has([data-pn-compact-touch-layout='true'])
   touch-action: manipulation;
 }
 
+/* The selection toolbar packs its controls at desktop density (2px gaps), so
+ * 44px targets alone would still leave adjacent destructive and comment
+ * actions a mis-tap apart. Space them only inside the compact scope. */
+html:has([data-pn-compact-touch-layout='true'])
+  [data-pn-annotation-toolbar-row] {
+  gap: 0.5rem;
+}
+
 html:has([data-pn-compact-touch-layout='true'])
   [data-pn-touch-target]:not(:disabled):not([aria-disabled='true']):active {
   filter: brightness(0.92);

--- a/tests/entry-assets.test.ts
+++ b/tests/entry-assets.test.ts
@@ -15,7 +15,10 @@ describe('review entry assets', () => {
     },
   );
 
-  test.each(['apps/hook/index.html', 'apps/review/index.html'])(
+  // The portal mounts the same @plannotator/editor App as the hook, so it needs
+  // the identical shell: without it the mobile layout's safe-area tokens are
+  // inert and the document scrolls behind the app's own scroll ownership.
+  test.each(['apps/hook/index.html', 'apps/review/index.html', 'apps/portal/index.html'])(
     '%s leaves scrolling to the visible-viewport application shell',
     (path) => {
       const html = read(path);


### PR DESCRIPTION
TLDR: Eight small pre-release fixes from the v0.27.2 QA sweep (structured 19-item workflow + 3 creative browser sweeps). Two breaks-user mobile bugs, six hardening/UX items. Every fix carries a regression test verified to fail on the unfixed code. AI-assisted.

## Fixes

1. Mobile TOC jump was dead: the compact navigator rendered outside ScrollViewportProvider, so heading taps silently no-oped. Provider hoisted; desktop DOM unchanged.
2. Permission Mode chooser: scoped to plan-review sessions only (was leaking into annotate/archive), and migrated to the bounded safe-dialog shell so phone-landscape users are not trapped with the Continue button off-screen.
3. Tree first-run seed no longer overwrites a persisted panel view for users whose sessions never tripped the setup gate.
4. The geometry-forced expanded comment composer now closes on Escape and hides its impossible Collapse button (previously Escape was eaten by a re-force loop).
5. Compact review Settings no longer shows a Split/Unified control that silently edited the desktop preference; a caption explains the session uses Unified.
6. The share portal got the mobile app shell (viewport-fit=cover, overflow containment) so shared plans opened on phones use safe areas correctly; entry-assets test extended to pin it.
7. Compact stage and navigator overlays are print-hidden so printing cannot clip the document behind them.
8. The selection annotation toolbar buttons carry touch-target markers (44px under the compact scope) with compact-scoped gaps; desktop geometry untouched.

## Validation

- typecheck clean
- DOM_TESTS=1 across packages/ui, packages/editor, packages/review-editor: 1509 pass, 0 fail (+12 new tests)
- tests/entry-assets.test.ts extended and green
- review, hook, and portal builds green
- Each behavioral fix demonstrated failing pre-fix
