### PR TITLE
fix(comments): expose skill picker semantics

### DIFF
--- a/packages/ui/components/CommentPopover.skillReferences.test.tsx
+++ b/packages/ui/components/CommentPopover.skillReferences.test.tsx
@@ -139,12 +139,14 @@ function activeRow(): Element | null {
   return document.querySelector('[data-skill-item-active]');
 }
 
-function assertOpenCombobox(el: HTMLTextAreaElement): Element {
-  expect(el.getAttribute('role')).toBe('combobox');
+function assertOpenAutocompleteTextbox(el: HTMLTextAreaElement): Element {
+  expect(el.hasAttribute('role')).toBe(false);
   expect(el.getAttribute('aria-autocomplete')).toBe('list');
-  expect(el.getAttribute('aria-expanded')).toBe('true');
+  expect(el.getAttribute('aria-haspopup')).toBe('listbox');
+  expect(el.hasAttribute('aria-expanded')).toBe(false);
   const controls = el.getAttribute('aria-controls');
   expect(controls).not.toBeNull();
+  expect(el.getAttribute('aria-owns')).toBe(controls);
   const listbox = document.getElementById(controls!);
   expect(listbox?.getAttribute('role')).toBe('listbox');
   return listbox!;
@@ -196,13 +198,16 @@ describe('CommentPopover skill references — no-preselection keyboard state mac
     async () => {
       await mountPopover();
       const el = textarea();
-      expect(el.getAttribute('role')).toBe('combobox');
-      expect(el.getAttribute('aria-expanded')).toBe('false');
+      expect(el.hasAttribute('role')).toBe(false);
+      expect(el.getAttribute('aria-autocomplete')).toBe('list');
+      expect(el.getAttribute('aria-haspopup')).toBe('listbox');
+      expect(el.hasAttribute('aria-expanded')).toBe(false);
       expect(el.hasAttribute('aria-controls')).toBe(false);
+      expect(el.hasAttribute('aria-owns')).toBe(false);
       expect(el.hasAttribute('aria-activedescendant')).toBe(false);
 
       await type(el, 'use /anim');
-      const listbox = assertOpenCombobox(el);
+      const listbox = assertOpenAutocompleteTextbox(el);
       const options = listbox.querySelectorAll('[role="option"]');
       expect(options.length).toBe(1);
       for (const option of options) {
@@ -218,8 +223,9 @@ describe('CommentPopover skill references — no-preselection keyboard state mac
       expect(el.getAttribute('aria-activedescendant')).toBe(active?.id);
 
       await press(el, 'Escape');
-      expect(el.getAttribute('aria-expanded')).toBe('false');
+      expect(el.hasAttribute('aria-expanded')).toBe(false);
       expect(el.hasAttribute('aria-controls')).toBe(false);
+      expect(el.hasAttribute('aria-owns')).toBe(false);
       expect(el.hasAttribute('aria-activedescendant')).toBe(false);
     },
   );

--- a/packages/ui/components/CommentPopover.skillReferences.test.tsx
+++ b/packages/ui/components/CommentPopover.skillReferences.test.tsx
@@ -139,6 +139,17 @@ function activeRow(): Element | null {
   return document.querySelector('[data-skill-item-active]');
 }
 
+function assertOpenCombobox(el: HTMLTextAreaElement): Element {
+  expect(el.getAttribute('role')).toBe('combobox');
+  expect(el.getAttribute('aria-autocomplete')).toBe('list');
+  expect(el.getAttribute('aria-expanded')).toBe('true');
+  const controls = el.getAttribute('aria-controls');
+  expect(controls).not.toBeNull();
+  const listbox = document.getElementById(controls!);
+  expect(listbox?.getAttribute('role')).toBe('listbox');
+  return listbox!;
+}
+
 describe('CommentPopover skill references — no-preselection keyboard state machine', () => {
   test.skipIf(!hasDom)(
     'THE regression: bare $ opens the full catalog with NOTHING active; Enter stays a newline',
@@ -177,6 +188,39 @@ describe('CommentPopover skill references — no-preselection keyboard state mac
       const enter = await press(el, 'Enter');
       expect(enter.defaultPrevented).toBe(false);
       expect(el.value).toBe('use /an');
+    },
+  );
+
+  test.skipIf(!hasDom)(
+    'the textarea exposes the open listbox and only identifies an explicitly active option',
+    async () => {
+      await mountPopover();
+      const el = textarea();
+      expect(el.getAttribute('role')).toBe('combobox');
+      expect(el.getAttribute('aria-expanded')).toBe('false');
+      expect(el.hasAttribute('aria-controls')).toBe(false);
+      expect(el.hasAttribute('aria-activedescendant')).toBe(false);
+
+      await type(el, 'use /anim');
+      const listbox = assertOpenCombobox(el);
+      const options = listbox.querySelectorAll('[role="option"]');
+      expect(options.length).toBe(1);
+      for (const option of options) {
+        expect(option.getAttribute('aria-selected')).toBe('false');
+        expect(option.getAttribute('tabindex')).toBe('-1');
+      }
+      expect(el.hasAttribute('aria-activedescendant')).toBe(false);
+
+      await press(el, 'ArrowDown');
+      const active = activeRow();
+      expect(active?.getAttribute('role')).toBe('option');
+      expect(active?.getAttribute('aria-selected')).toBe('true');
+      expect(el.getAttribute('aria-activedescendant')).toBe(active?.id);
+
+      await press(el, 'Escape');
+      expect(el.getAttribute('aria-expanded')).toBe('false');
+      expect(el.hasAttribute('aria-controls')).toBe(false);
+      expect(el.hasAttribute('aria-activedescendant')).toBe(false);
     },
   );
 
@@ -457,6 +501,8 @@ describe('CommentPopover skill references — no-preselection keyboard state mac
       expect(document.querySelector('[data-skill-human-only-notice]')).toBeNull();
       expect(document.querySelector('[data-skill-ref-overlay]')).toBeNull();
       expect(el.classList.contains('pn-ref-input')).toBe(false);
+      expect(el.hasAttribute('role')).toBe(false);
+      expect(el.hasAttribute('aria-expanded')).toBe(false);
       await type(el, 'use $');
       expect(menu()).toBeNull();
       await type(el, 'use $plannotator-rev');

--- a/packages/ui/components/CommentPopover.tsx
+++ b/packages/ui/components/CommentPopover.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useRef, useCallback, useId } from 'react';
 import { createPortal } from 'react-dom';
 import type { ImageAttachment } from '../types';
 import { AttachmentsButton } from './AttachmentsButton';
@@ -483,6 +483,11 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
     textareaRef,
     enabled: skillReferences,
   });
+  const skillListboxId = `skill-reference-listbox-${useId().replace(/:/g, '')}`;
+  const activeSkillOptionId =
+    skillAc.menu?.activeIndex === null || skillAc.menu?.activeIndex === undefined
+      ? undefined
+      : `${skillListboxId}-option-${skillAc.menu.activeIndex}`;
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (skillAc.onKeyDown(e)) return;
@@ -591,6 +596,7 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
           <div className="relative px-4 py-3 min-h-0 flex-1 overflow-y-auto">
             {skillAc.menu && (
               <SkillReferenceMenu
+                id={skillListboxId}
                 items={skillAc.menu.items}
                 activeIndex={skillAc.menu.activeIndex}
                 onSelect={skillAc.select}
@@ -606,6 +612,9 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
               sizeClassName="min-h-32 max-h-full"
               skillReferences={skillReferences}
               tokens={skillAc.referenceTokens}
+              listboxId={skillListboxId}
+              listboxOpen={skillAc.menu !== null}
+              activeOptionId={activeSkillOptionId}
             />
             <HumanOnlySkillNotice skills={skillAc.humanOnlyReferences} />
           </div>
@@ -736,6 +745,7 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
       <div className="relative px-3 py-2">
         {skillAc.menu && (
           <SkillReferenceMenu
+            id={skillListboxId}
             items={skillAc.menu.items}
             activeIndex={skillAc.menu.activeIndex}
             onSelect={skillAc.select}
@@ -751,6 +761,9 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
           sizeClassName="max-h-64 min-h-[4.5rem]"
           skillReferences={skillReferences}
           tokens={skillAc.referenceTokens}
+          listboxId={skillListboxId}
+          listboxOpen={skillAc.menu !== null}
+          activeOptionId={activeSkillOptionId}
         />
         <HumanOnlySkillNotice skills={skillAc.humanOnlyReferences} />
       </div>
@@ -819,6 +832,10 @@ interface ComposerTextareaProps {
   tokens: SkillReferenceToken[];
   /** Off → render the plain pre-feature textarea, byte-for-byte. */
   skillReferences: boolean;
+  /** ARIA relationship to the skill-reference listbox. */
+  listboxId: string;
+  listboxOpen: boolean;
+  activeOptionId?: string;
 }
 
 /**
@@ -843,6 +860,9 @@ const ComposerTextarea: React.FC<ComposerTextareaProps> = ({
   textareaRef,
   tokens,
   skillReferences,
+  listboxId,
+  listboxOpen,
+  activeOptionId,
 }) => {
   const overlayRef = useRef<HTMLDivElement>(null);
   const [composing, setComposing] = useState(false);
@@ -927,6 +947,12 @@ const ComposerTextarea: React.FC<ComposerTextareaProps> = ({
       </div>
       <textarea
         data-pn-mobile-editable="true"
+        role="combobox"
+        aria-label={placeholder}
+        aria-autocomplete="list"
+        aria-expanded={listboxOpen}
+        aria-controls={listboxOpen ? listboxId : undefined}
+        aria-activedescendant={activeOptionId}
         ref={attachRef}
         value={value}
         onChange={onChange}

--- a/packages/ui/components/CommentPopover.tsx
+++ b/packages/ui/components/CommentPopover.tsx
@@ -947,11 +947,11 @@ const ComposerTextarea: React.FC<ComposerTextareaProps> = ({
       </div>
       <textarea
         data-pn-mobile-editable="true"
-        role="combobox"
         aria-label={placeholder}
         aria-autocomplete="list"
-        aria-expanded={listboxOpen}
+        aria-haspopup="listbox"
         aria-controls={listboxOpen ? listboxId : undefined}
+        aria-owns={listboxOpen ? listboxId : undefined}
         aria-activedescendant={activeOptionId}
         ref={attachRef}
         value={value}

--- a/packages/ui/components/SkillReferenceMenu.tsx
+++ b/packages/ui/components/SkillReferenceMenu.tsx
@@ -9,6 +9,8 @@ const ROOT_LABELS: Record<SkillCatalogEntry['root'], string> = {
 };
 
 interface SkillReferenceMenuProps {
+  /** Id referenced by the focused textarea's aria-controls attribute. */
+  id: string;
   items: SkillCatalogEntry[];
   /** Explicitly activated row, or null — the menu opens with nothing active. */
   activeIndex: number | null;
@@ -79,6 +81,7 @@ function computeMenuPlacement(
  * a purely visual affordance; a pointer click inserts directly.
  */
 export const SkillReferenceMenu: React.FC<SkillReferenceMenuProps> = ({
+  id,
   items,
   activeIndex,
   onSelect,
@@ -140,6 +143,8 @@ export const SkillReferenceMenu: React.FC<SkillReferenceMenuProps> = ({
   return (
     <div
       ref={menuRef}
+      id={id}
+      role="listbox"
       data-skill-menu="true"
       data-skill-menu-placement={placement.direction}
       data-popover-layer="true"
@@ -157,6 +162,10 @@ export const SkillReferenceMenu: React.FC<SkillReferenceMenuProps> = ({
           <button
             key={item.name}
             type="button"
+            id={`${id}-option-${index}`}
+            role="option"
+            aria-selected={index === activeIndex}
+            tabIndex={-1}
             data-skill-item={item.name}
             data-skill-item-active={index === activeIndex ? 'true' : undefined}
             // Insert on pointerdown so the textarea never loses focus. A


### PR DESCRIPTION
## Summary

- expose the skill-reference textarea as an editable combobox when skill references are enabled
- connect it to a listbox with uniquely identified, non-tab-stop options
- track the deliberately active keyboard option through `aria-activedescendant` and `aria-selected`
- keep the plain composer unchanged when skill references are disabled

## Validation

- `DOM_TESTS=1 bun test packages/ui` (1,025 passed)
- full TypeScript project checks
- `bun run build:review && bun run build:hook`

Closes #1233