### PR TITLE
guides.show: GitHub link in the landing header

### DIFF
--- a/apps/guides-show/site/index.html
+++ b/apps/guides-show/site/index.html
@@ -49,6 +49,8 @@
 
   header{display:flex;align-items:center;gap:.6rem;font-family:var(--mono);font-size:.85rem}
   header .name{color:var(--heading)}
+  header .gh{margin-left:auto;display:inline-flex;align-items:center;gap:.4rem;color:var(--text);text-decoration:none;border:1px solid var(--border-strong);border-radius:6px;padding:.25rem .6rem;font-size:.78rem}
+  header .gh:hover{color:var(--heading);border-color:var(--muted)}
   .add{color:var(--add)}.del{color:var(--del)}
 
   /* A guide, the way the viewer lays one out: chapters, an overview each, the files under it. */
@@ -87,6 +89,10 @@
 <main>
   <header>
     <span class="name">guides.show</span>
+    <a class="gh" href="https://github.com/plannotator/guides" title="plannotator/guides on GitHub">
+      <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+      GitHub
+    </a>
   </header>
 
   <img class="banner" src="/banner.webp" alt="guides.show, by Plannotator" width="1774" height="887" decoding="async" fetchpriority="high">


### PR DESCRIPTION
Adds an outlined GitHub button (right-aligned in the header) linking to plannotator/guides, the skill repo that is the distribution path for guides.show users. Landing page only; no Worker or viewer change. Deployed manually to guides.show ahead of the next release tag.