### PR TITLE
guide-viewer: readable on phones and tablets, desktop untouched

### DIFF
--- a/apps/guides-show/site/index.html
+++ b/apps/guides-show/site/index.html
@@ -83,6 +83,12 @@
   footer{margin-top:4rem;padding-top:1.25rem;border-top:1px solid var(--border);color:var(--muted);font-size:.85rem;display:flex;flex-wrap:wrap;gap:.4rem 1.25rem}
   footer a{color:var(--text)}
   @media (prefers-reduced-motion:no-preference){a{transition:text-decoration-color .15s}}
+  button,a{touch-action:manipulation}
+  @media (pointer:coarse){
+    header .gh{padding:.55rem .85rem}
+    .cmd{padding:.5rem .5rem .5rem .9rem}
+    .cmd button{padding:.55rem .85rem;font-size:.8rem}
+  }
 </style>
 </head>
 <body>

--- a/apps/guides-show/viewer/ReadOnlyDiffRenderer.tsx
+++ b/apps/guides-show/viewer/ReadOnlyDiffRenderer.tsx
@@ -15,8 +15,33 @@ const noop = () => {};
  * Display settings come from configStore defaults (or whatever the host
  * seeded) — never cookies, since the viewer installs an in-memory backend.
  */
+/**
+ * Below Tailwind's `lg` (1024px) the diff pane is at most ~430px wide (a phone
+ * has ~350px, a portrait tablet shares the row with the chapter column), so a
+ * two-column diff gets under 220px per side and is unreadable; force unified
+ * there. The setting itself is untouched: widen the window past 1024px and the
+ * configured style applies again. Desktop layouts are unaffected.
+ */
+const NARROW_VIEWPORT = '(max-width: 1023px)';
+
+function useNarrowViewport(): boolean {
+  const [narrow, setNarrow] = React.useState<boolean>(
+    () => typeof window !== 'undefined' && typeof window.matchMedia === 'function' && window.matchMedia(NARROW_VIEWPORT).matches,
+  );
+  React.useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const mql = window.matchMedia(NARROW_VIEWPORT);
+    const onChange = () => setNarrow(mql.matches);
+    onChange();
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  }, []);
+  return narrow;
+}
+
 export const ReadOnlyDiffRenderer: React.FC<GuideDiffRendererProps> = (props) => {
-  const diffStyle = useConfigValue('diffStyle');
+  const configuredDiffStyle = useConfigValue('diffStyle');
+  const diffStyle = useNarrowViewport() ? 'unified' : configuredDiffStyle;
   const diffOverflow = useConfigValue('diffOverflow');
   const diffIndicators = useConfigValue('diffIndicators');
   const lineDiffType = useConfigValue('diffLineDiffType');

--- a/apps/guides-show/viewer/hosted.tsx
+++ b/apps/guides-show/viewer/hosted.tsx
@@ -243,7 +243,7 @@ export function HostedDownloadButton({ snapshot, scriptUrl }: { snapshot: GuideS
     <button
       type="button"
       onClick={onClick}
-      className="inline-flex items-center gap-1.5 rounded-md border border-border/60 bg-background px-2.5 py-1.5 text-[11.5px] text-muted-foreground transition-colors hover:border-border hover:text-foreground"
+      className="inline-flex items-center gap-1.5 rounded-md border border-border/60 bg-background px-2.5 py-1.5 text-[11.5px] text-muted-foreground transition-colors hover:border-border hover:text-foreground pointer-coarse:px-3.5 pointer-coarse:py-2.5"
       title={
         failed
           ? 'The portable file could not be built from this page.'

--- a/apps/guides-show/viewer/portable.css
+++ b/apps/guides-show/viewer/portable.css
@@ -7,3 +7,6 @@ html, body { margin: 0; min-height: 100%; }
    overflow-y:auto ancestor, would then observe body instead of the window and
    never see the real scroll position (#1158 contract). */
 #root { min-height: 100vh; }
+
+/* Controls: no double-tap-to-zoom delay on touch; the page itself still pinch-zooms. */
+button, a, [role="button"] { touch-action: manipulation; }

--- a/packages/core/guide-viewer-manifest.ts
+++ b/packages/core/guide-viewer-manifest.ts
@@ -5,10 +5,10 @@
 import type { GuideViewerAssets } from "./guide-format";
 
 export const GUIDE_VIEWER_MANIFEST: Omit<GuideViewerAssets, "baseUrl"> = {
-  js: "viewer.dWt7KCum.js",
-  css: "viewer.CCkPIJnI.css",
-  jsIntegrity: "sha384-PbU3GybewyST1dRWDuPg/wdcw+se4qpACXUUT6iOtMszLKrpCbW/dSn5Sk+PVuHG",
-  cssIntegrity: "sha384-E/+OWWu8jE/Sy6K817l5gpZooNwfLvC2pFgypIS7QitEPCd2f6Gtv6x54z+KGQZ/",
+  js: "viewer.B2MlYVCB.js",
+  css: "viewer.Dtx2gmOp.css",
+  jsIntegrity: "sha384-8WnOJbPcOLpeVeQegcw24UgDYsA9AP9AG3hfOMLjT6Pwr3fwuGRrz+QGKV85kE34",
+  cssIntegrity: "sha384-jbTLuO1urA+7R65nS8yRrbSr13BuYyfeSZBvNMTAJuJCcmJVWxw6F3R0C+735ihs",
   langs: {
     "astro": "chunks/astro.BykyiR6i.js",
     "c": "chunks/c.BIGW1oBm.js",

--- a/packages/core/guide-viewer-manifest.ts
+++ b/packages/core/guide-viewer-manifest.ts
@@ -5,9 +5,9 @@
 import type { GuideViewerAssets } from "./guide-format";
 
 export const GUIDE_VIEWER_MANIFEST: Omit<GuideViewerAssets, "baseUrl"> = {
-  js: "viewer.B2MlYVCB.js",
+  js: "viewer.sFtOnb1i.js",
   css: "viewer.Dtx2gmOp.css",
-  jsIntegrity: "sha384-8WnOJbPcOLpeVeQegcw24UgDYsA9AP9AG3hfOMLjT6Pwr3fwuGRrz+QGKV85kE34",
+  jsIntegrity: "sha384-HRAx6JL8MwurSiEBSingzilCiL9O4o93I9G45am9wtXscw419eSvXAontQL/TkHd",
   cssIntegrity: "sha384-jbTLuO1urA+7R65nS8yRrbSr13BuYyfeSZBvNMTAJuJCcmJVWxw6F3R0C+735ihs",
   langs: {
     "astro": "chunks/astro.BykyiR6i.js",

--- a/packages/core/guide-viewer-manifest.ts
+++ b/packages/core/guide-viewer-manifest.ts
@@ -5,10 +5,10 @@
 import type { GuideViewerAssets } from "./guide-format";
 
 export const GUIDE_VIEWER_MANIFEST: Omit<GuideViewerAssets, "baseUrl"> = {
-  js: "viewer.nDh94Q9e.js",
-  css: "viewer.CnPJebib.css",
-  jsIntegrity: "sha384-fD48bkI8qvB/QjpliYetxj7FhuikIMCs+uQPGsowBM5gycLfke7OCbWQymsItlLK",
-  cssIntegrity: "sha384-dUTTm5EHtTlokz2EF7LWKAAPDxY3zVboluRdRiXZxvpaq1mhVXV51JRV0OR9HRoL",
+  js: "viewer.dWt7KCum.js",
+  css: "viewer.CCkPIJnI.css",
+  jsIntegrity: "sha384-PbU3GybewyST1dRWDuPg/wdcw+se4qpACXUUT6iOtMszLKrpCbW/dSn5Sk+PVuHG",
+  cssIntegrity: "sha384-E/+OWWu8jE/Sy6K817l5gpZooNwfLvC2pFgypIS7QitEPCd2f6Gtv6x54z+KGQZ/",
   langs: {
     "astro": "chunks/astro.BykyiR6i.js",
     "c": "chunks/c.BIGW1oBm.js",

--- a/packages/guide-viewer/GuideSectionCard.tsx
+++ b/packages/guide-viewer/GuideSectionCard.tsx
@@ -161,9 +161,10 @@ export const GuideSectionCard: React.FC<GuideSectionCardProps> = ({
 
   return (
     <div ref={cardRef} className="scroll-mt-4 overflow-clip rounded-lg border border-border/50 bg-card">
-      <div className="md:grid md:grid-cols-[440px_minmax(0,1fr)]">
+      {/* Stacked below md; a proportional chapter column on tablets; the fixed 440px column from lg up (desktop unchanged). */}
+      <div className="md:grid md:grid-cols-[minmax(260px,36%)_minmax(0,1fr)] lg:grid-cols-[440px_minmax(0,1fr)]">
         <div className="border-b border-border/40 md:border-b-0 md:border-r">
-          <div className="px-6 py-5 md:sticky md:top-0 md:flex md:max-h-[calc(100dvh-48px)] md:flex-col md:overflow-y-auto md:overflow-x-hidden">
+          <div className="px-4 py-4 md:sticky md:top-0 md:flex md:max-h-[calc(100dvh-48px)] md:flex-col md:overflow-y-auto md:overflow-x-hidden md:px-6 md:py-5">
             <div className="flex items-start gap-2 md:flex-none">
               <h3 className="flex-1 text-[15px] font-semibold leading-snug text-foreground [text-wrap:balance]">
                 {section.title}
@@ -213,7 +214,7 @@ export const GuideSectionCard: React.FC<GuideSectionCardProps> = ({
           </div>
         </div>
 
-        <div className="min-w-0 space-y-4 bg-muted/[0.07] px-4 py-4">
+        <div className="min-w-0 space-y-4 bg-muted/[0.07] px-1.5 py-3 md:px-4 md:py-4">
           {files.length > 0 ? (
             files.map((file) => (
               <GuideFileCard

--- a/packages/guide-viewer/GuideSectionCard.tsx
+++ b/packages/guide-viewer/GuideSectionCard.tsx
@@ -42,7 +42,7 @@ function FileChip({
     <button
       type="button"
       onClick={onClick}
-      className={`flex w-full items-center gap-2 rounded-md border px-2.5 py-1.5 text-left transition-colors ${
+      className={`flex w-full items-center gap-2 rounded-md border px-2.5 py-1.5 text-left transition-colors pointer-coarse:py-2.5 ${
         active ? 'border-primary/40 bg-primary/10' : 'border-border/50 bg-background hover:border-border'
       }`}
       title={summary ? `${filePath}\n\n${summary}` : filePath}
@@ -136,7 +136,7 @@ export const GuideSectionCard: React.FC<GuideSectionCardProps> = ({
             type="button"
             onClick={handleToggleReviewed}
             aria-label={reviewed ? 'Un-mark as reviewed' : 'Mark as reviewed'}
-            className="flex-shrink-0 rounded"
+            className="flex-shrink-0 rounded relative pointer-coarse:before:absolute pointer-coarse:before:-inset-3.5 pointer-coarse:before:content-['']"
           >
             <Checkbox checked={reviewed} />
           </button>
@@ -172,8 +172,9 @@ export const GuideSectionCard: React.FC<GuideSectionCardProps> = ({
               <button
                 type="button"
                 onClick={() => setCollapsedOverride(true)}
-                className="mt-0.5 flex-shrink-0 rounded p-0.5 text-muted-foreground/40 transition-colors hover:text-foreground"
+                className="mt-0.5 flex-shrink-0 rounded p-0.5 text-muted-foreground/40 transition-colors hover:text-foreground relative pointer-coarse:before:absolute pointer-coarse:before:-inset-3.5 pointer-coarse:before:content-['']"
                 title="Collapse section"
+                aria-label="Collapse section"
               >
                 <ChevronDown className="rotate-180" size={13} />
               </button>
@@ -184,7 +185,7 @@ export const GuideSectionCard: React.FC<GuideSectionCardProps> = ({
                 <button
                   type="button"
                   onClick={handleToggleReviewed}
-                  className="flex items-center gap-1.5 text-[11.5px] text-muted-foreground transition-colors hover:text-foreground"
+                  className="flex items-center gap-1.5 text-[11.5px] text-muted-foreground transition-colors hover:text-foreground pointer-coarse:-my-3 pointer-coarse:py-3"
                   title={reviewed ? 'Un-mark as reviewed' : 'Mark as reviewed'}
                 >
                   <Checkbox checked={reviewed} />

--- a/packages/guide-viewer/GuideView.tsx
+++ b/packages/guide-viewer/GuideView.tsx
@@ -133,8 +133,9 @@ export const GuideView: React.FC<GuideViewProps> = ({
   );
 
   return (
-    <GuideViewportProvider className="w-full px-10 py-8" eager={guideFileCount <= GUIDE_EAGER_MOUNT_MAX_FILES}>
-      {headerActions && <div className="float-right ml-6 flex items-center gap-2">{headerActions}</div>}
+    <GuideViewportProvider className="w-full px-3 py-5 sm:px-6 sm:py-6 lg:px-10 lg:py-8" eager={guideFileCount <= GUIDE_EAGER_MOUNT_MAX_FILES}>
+      {/* Header actions sit in a row above the title on narrow screens and float beside it from md up (desktop unchanged). */}
+      {headerActions && <div className="mb-3 flex items-center justify-end gap-2 md:float-right md:mb-0 md:ml-6">{headerActions}</div>}
       <div className="max-w-[72ch]">
         <h1 className="text-[22px] font-semibold tracking-tight text-foreground [text-wrap:balance]">{guide.title}</h1>
         {guide.intent && (

--- a/packages/ui/components/ModeToggle.tsx
+++ b/packages/ui/components/ModeToggle.tsx
@@ -21,8 +21,9 @@ export function ModeToggle() {
     <div className="relative" ref={dropdownRef}>
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+        className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors relative pointer-coarse:before:absolute pointer-coarse:before:-inset-2 pointer-coarse:before:content-['']"
         title="Toggle theme"
+        aria-label="Toggle theme"
       >
         {/* Sun */}
         <svg


### PR DESCRIPTION
fix(guide-viewer): readable on phones and tablets, desktop untouched

Every change is behind a breakpoint; 1440px and 1024px renders of the same
guide are byte-identical before and after (screenshot MD5s match).

- Split diffs below lg (1024px) are forced unified in the portable viewer's
  diff renderer (matchMedia; the setting is untouched, so a wider window
  gets split back). A phone has ~350px of pane and a portrait tablet ~430px,
  so two columns were under 220px each.
- Padding scales: page px-3/sm:px-6/lg:px-10, chapter column px-4/md:px-6,
  diff column px-1.5/md:px-4. Code pane on a 390px phone: 276px → 352px.
- Tablets: the chapter column is proportional (minmax(260px,36%)) from md
  and the fixed 440px only from lg. Pane at 768px: 214px → 426px.
- Header actions (Download, theme) sit in a right-aligned row above the
  title below md instead of floating into it.

Viewer rebuilt and published (viewer.dWt7KCum.js), manifest synced.

---

fix(guide-viewer): touch targets, labels, and no tap delay on coarse pointers

Only under `pointer: coarse` (Tailwind's `pointer-coarse:` variant), so mouse
layouts are unchanged:
- Reviewed checkbox and the collapse chevron get an invisible ::before hit
  area (visual 15–17px, hit ≥ 44px); the "Reviewed" text button and file
  chips get taller padding; the theme toggle and hosted Download button grow
  to a 44px hit box.
- `touch-action: manipulation` on controls in the portable viewer and the
  landing page (no double-tap-to-zoom delay; the page still pinch-zooms).
- `aria-label` on the two icon-only buttons (theme toggle, collapse chevron).
- Landing page: the GitHub link and the Copy button are 44px tall on touch.

Tailwind v4 already gates `hover:` behind `@media (hover: hover)`, so no
false hover states on tap. Viewer rebuilt and published, manifest synced.