### PR TITLE
seo: index the live Grill Me blog post

### DIFF
--- a/apps/marketing/astro.config.mjs
+++ b/apps/marketing/astro.config.mjs
@@ -3,6 +3,11 @@ import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
 import tailwindcss from '@tailwindcss/vite';
 
+const indexableBlogPages = new Set([
+  'https://plannotator.ai/blog/',
+  'https://plannotator.ai/blog/an-interactive-ui-for-the-grill-me-skill/',
+]);
+
 export default defineConfig({
   site: 'https://plannotator.ai',
   output: 'static',
@@ -15,7 +20,8 @@ export default defineConfig({
     sitemap({
       filter: (page) =>
         !page.startsWith('https://plannotator.ai/docs/') &&
-        !page.startsWith('https://plannotator.ai/blog/'),
+        (!page.startsWith('https://plannotator.ai/blog/') ||
+          indexableBlogPages.has(page)),
     }),
   ],
   markdown: {

--- a/apps/marketing/security-build.test.ts
+++ b/apps/marketing/security-build.test.ts
@@ -103,4 +103,19 @@ describe('marketing security build', () => {
     expect(files.some((file) => /(^|\/)manifest(?:\.|$)/.test(file))).toBe(false);
     expect(files.some((file) => /\.(?:cjs|mjs)$/.test(file))).toBe(false);
   });
+
+  test('indexes live root blog pages without indexing migrated redirects', async () => {
+    const sitemap = await readFile(join(outputRoot, 'sitemap-0.xml'), 'utf8');
+
+    expect(sitemap).toContain('<loc>https://plannotator.ai/blog/</loc>');
+    expect(sitemap).toContain(
+      '<loc>https://plannotator.ai/blog/an-interactive-ui-for-the-grill-me-skill/</loc>',
+    );
+    expect(sitemap).not.toContain(
+      '<loc>https://plannotator.ai/blog/annotate-any-web-page-or-html-file/</loc>',
+    );
+    expect(sitemap).not.toContain(
+      '<loc>https://plannotator.ai/blog/sharing-plans-with-your-team/</loc>',
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- include the live root blog index and Grill Me article in the generated sitemap
- keep the seven migrated blog routes excluded
- add a build regression test for both behaviors

## Verification

- `bun test apps/marketing/security-build.test.ts`
- `bun run build:marketing`
- generated sitemap contains six URLs, including `/blog/` and `/blog/an-interactive-ui-for-the-grill-me-skill/`