### PR TITLE
fix(review): stop the call-flow Lens closing mid-scroll and opening on drive-by hovers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -244,13 +244,15 @@ jobs:
         if: steps.gate.outputs.run == 'true'
         run: bun run --cwd apps/guides-show check:budgets
 
-      # The viewer build is deterministic per platform but NOT across platforms
-      # (macOS and Linux produce different content hashes), and this Linux build
-      # is the one the pin must match. Publishing the built manifest lets a
-      # maintainer on any machine regenerate packages/core/guide-viewer-manifest.ts
-      # from the authoritative bytes when the check below fails:
-      # download it to apps/guides-show/dist/viewer/manifest.json, then run
-      # `bun run --cwd apps/guides-show sync:manifest` and commit the result.
+      # The viewer build is deterministic across platforms at the pinned Bun and
+      # lockfile (macOS and Linux produce identical hashes from a clean install),
+      # but a drifted local environment silently builds different bytes: a bun
+      # store with stale duplicate package versions reproduced exactly that. This
+      # Linux build is the authority the pin must match, so publish its manifest;
+      # when the check below fails and a fresh local regen still disagrees,
+      # download this artifact to apps/guides-show/dist/viewer/manifest.json, run
+      # `bun run --cwd apps/guides-show sync:manifest`, commit the result, and
+      # rebuild your environment (rm -rf node_modules && bun install --frozen-lockfile).
       - name: Publish built viewer manifest for pin regeneration
         if: always() && steps.gate.outputs.run == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v6.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -244,6 +244,21 @@ jobs:
         if: steps.gate.outputs.run == 'true'
         run: bun run --cwd apps/guides-show check:budgets
 
+      # The viewer build is deterministic per platform but NOT across platforms
+      # (macOS and Linux produce different content hashes), and this Linux build
+      # is the one the pin must match. Publishing the built manifest lets a
+      # maintainer on any machine regenerate packages/core/guide-viewer-manifest.ts
+      # from the authoritative bytes when the check below fails:
+      # download it to apps/guides-show/dist/viewer/manifest.json, then run
+      # `bun run --cwd apps/guides-show sync:manifest` and commit the result.
+      - name: Publish built viewer manifest for pin regeneration
+        if: always() && steps.gate.outputs.run == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v6.0.0
+        with:
+          name: guide-viewer-manifest
+          path: apps/guides-show/dist/viewer/manifest.json
+          retention-days: 7
+
       - name: Checked-in manifest matches this build
         if: steps.gate.outputs.run == 'true'
         run: bun run --cwd apps/guides-show check:manifest

--- a/packages/core/guide-viewer-manifest.ts
+++ b/packages/core/guide-viewer-manifest.ts
@@ -5,10 +5,10 @@
 import type { GuideViewerAssets } from "./guide-format";
 
 export const GUIDE_VIEWER_MANIFEST: Omit<GuideViewerAssets, "baseUrl"> = {
-  js: "viewer.C2OX3dSq.js",
-  css: "viewer.Dtx2gmOp.css",
-  jsIntegrity: "sha384-yTWAxiAtRTJuH19w67kfAK0DL8GJEQuZpDpU/+zHw+TjVx1GxejdFYwUplvgPCx6",
-  cssIntegrity: "sha384-jbTLuO1urA+7R65nS8yRrbSr13BuYyfeSZBvNMTAJuJCcmJVWxw6F3R0C+735ihs",
+  js: "viewer.DXe-Vl2B.js",
+  css: "viewer.Cf89Ctv5.css",
+  jsIntegrity: "sha384-+UkFMu0hsC3CFdeY55prIXs2pcRazZuEuOJod2wyXV2aJ5rX6yIMDp+/0ZFWpUFe",
+  cssIntegrity: "sha384-22e4Zk+bV1yL0QDujIOQXs9uWIl+udNmeGh3TurrZAKVnP6QQaTBS7szWr7WW1Ek",
   langs: {
     "astro": "chunks/astro.BykyiR6i.js",
     "c": "chunks/c.BIGW1oBm.js",

--- a/packages/review-editor/components/CallFlowFileBadge.interaction.test.tsx
+++ b/packages/review-editor/components/CallFlowFileBadge.interaction.test.tsx
@@ -236,4 +236,74 @@ describe('CallFlowFileBadge Lens', () => {
     await act(async () => rawLine?.click());
     expect(document.querySelector('[data-comment-popover="true"]')).not.toBeNull();
   });
+
+  // Guards the hover-intent delay: scrolling a diff drags file headers under a
+  // stationary pointer, and instant open made every passing badge pop the Lens.
+  test.skipIf(!hasDom)('hover opens only after the intent delay', async () => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    await act(async () => {
+      root?.render(
+        <ReviewStateProvider value={lensState()}>
+          <CallFlowFileBadge filePath="src/order.ts" />
+        </ReviewStateProvider>,
+      );
+    });
+
+    const trigger = host.querySelector<HTMLButtonElement>('.call-flow-file-badge');
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent('mouseover', { bubbles: true, relatedTarget: document.body }));
+    });
+    expect(document.querySelector('.call-flow-popover')).toBeNull();
+
+    // A pointer that leaves before the delay elapses must not open the Lens.
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent('mouseout', { bubbles: true, relatedTarget: document.body }));
+      await new Promise((resolve) => setTimeout(resolve, 180));
+    });
+    expect(document.querySelector('.call-flow-popover')).toBeNull();
+
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent('mouseover', { bubbles: true, relatedTarget: document.body }));
+      await new Promise((resolve) => setTimeout(resolve, 180));
+    });
+    expect(document.querySelector('.call-flow-popover')).not.toBeNull();
+  });
+
+  // Guards the Safari scroll-chaining regression: a page scroll slides the
+  // anchored popup out from under a stationary pointer, fires mouseleave, and
+  // used to close the Lens mid-scroll. In-flight scrolls must hold the close;
+  // a pointer genuinely outside after the scroll settles still closes it.
+  test.skipIf(!hasDom)('scroll holds a pending hover-close, then closes once settled', async () => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    await act(async () => {
+      root?.render(
+        <ReviewStateProvider value={lensState()}>
+          <CallFlowFileBadge filePath="src/order.ts" />
+        </ReviewStateProvider>,
+      );
+    });
+
+    const trigger = host.querySelector<HTMLButtonElement>('.call-flow-file-badge');
+    await act(async () => trigger?.click());
+    const popup = document.querySelector<HTMLElement>('.call-flow-popover');
+    expect(popup).not.toBeNull();
+
+    // Pointer slides off the popup (schedules the close), then a scroll lands.
+    await act(async () => {
+      popup?.dispatchEvent(new MouseEvent('mouseout', { bubbles: true, relatedTarget: document.body }));
+      document.body.dispatchEvent(new Event('scroll', { bubbles: true }));
+      await new Promise((resolve) => setTimeout(resolve, 320));
+    });
+    expect(document.querySelector('.call-flow-popover')).not.toBeNull();
+
+    // Scroll settled with the pointer outside: the Lens now closes gracefully.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 400));
+    });
+    expect(document.querySelector('.call-flow-popover')).toBeNull();
+  });
 });

--- a/packages/review-editor/components/CallFlowFileBadge.tsx
+++ b/packages/review-editor/components/CallFlowFileBadge.tsx
@@ -10,7 +10,14 @@ import {
 import { CallFlowRawView } from './CallFlowRawView';
 import { splitCallFlowFilePath } from '../utils/callFlowPresentation';
 
-const CLOSE_DELAY_MS = 140;
+const CLOSE_DELAY_MS = 250;
+// Hover intent: scrolling the diff drags file headers under a stationary
+// pointer; without a delay every badge that passes under the cursor pops the
+// Lens open.
+const OPEN_DELAY_MS = 100;
+// After the last scroll event, how long before a pointer that ended up outside
+// the Lens is allowed to close it.
+const SCROLL_SETTLE_MS = 160;
 
 /** Per-file call-flow Lens. The same shared analysis powers this and the Dock. */
 export const CallFlowFileBadge: React.FC<{ filePath: string; oldPath?: string }> = ({ filePath, oldPath }) => {
@@ -19,8 +26,11 @@ export const CallFlowFileBadge: React.FC<{ filePath: string; oldPath?: string }>
   const [view, setView] = useState<'paths' | 'raw'>('paths');
   const annotationDraftActiveRef = useRef(false);
   const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pointerInsideRef = useRef(false);
   useEffect(() => () => {
     if (closeTimer.current) clearTimeout(closeTimer.current);
+    if (openTimer.current) clearTimeout(openTimer.current);
   }, []);
   const analysis = state?.callFlowAnalysis;
   const focusFiles = useMemo(
@@ -51,7 +61,6 @@ export const CallFlowFileBadge: React.FC<{ filePath: string; oldPath?: string }>
   const skippedLanguage = useMemo(() => analysis?.status === 'ready'
     ? analysis.data.skippedLanguages.find((language) => language.files.some((file) => focusFiles.includes(file)))
     : undefined, [analysis, focusFiles]);
-  if (!state || !state.callFlowAvailable || !analysis) return null;
   const cancelClose = () => {
     if (!closeTimer.current) return;
     clearTimeout(closeTimer.current);
@@ -63,10 +72,55 @@ export const CallFlowFileBadge: React.FC<{ filePath: string; oldPath?: string }>
       if (!annotationDraftActiveRef.current) setOpen(false);
     }, CLOSE_DELAY_MS);
   };
+  const cancelScheduledOpen = () => {
+    if (!openTimer.current) return;
+    clearTimeout(openTimer.current);
+    openTimer.current = null;
+  };
+  const scheduleOpen = () => {
+    cancelClose();
+    if (open || openTimer.current) return;
+    openTimer.current = setTimeout(() => {
+      openTimer.current = null;
+      setOpen(true);
+    }, OPEN_DELAY_MS);
+  };
   const closeLens = () => {
     annotationDraftActiveRef.current = false;
+    cancelScheduledOpen();
     setOpen(false);
   };
+  // Scroll-chaining guard (reported on X for Safari): when the page scrolls —
+  // including momentum chained out of the Lens's own scroll container — the
+  // popup tracks its moving anchor and can slide out from under a stationary
+  // pointer, firing mouseleave and closing the Lens mid-scroll. While a scroll
+  // is in flight, hold any pending close; once it settles, close only if the
+  // pointer really ended up outside.
+  useEffect(() => {
+    if (!open) return;
+    let settleTimer: ReturnType<typeof setTimeout> | null = null;
+    const onScroll = () => {
+      if (closeTimer.current) {
+        clearTimeout(closeTimer.current);
+        closeTimer.current = null;
+      }
+      if (settleTimer) clearTimeout(settleTimer);
+      settleTimer = setTimeout(() => {
+        settleTimer = null;
+        if (!pointerInsideRef.current && !annotationDraftActiveRef.current) {
+          closeTimer.current = setTimeout(() => {
+            if (!annotationDraftActiveRef.current) setOpen(false);
+          }, CLOSE_DELAY_MS);
+        }
+      }, SCROLL_SETTLE_MS);
+    };
+    window.addEventListener('scroll', onScroll, { capture: true, passive: true });
+    return () => {
+      window.removeEventListener('scroll', onScroll, { capture: true });
+      if (settleTimer) clearTimeout(settleTimer);
+    };
+  }, [open]);
+  if (!state || !state.callFlowAvailable || !analysis) return null;
   const openNode = (node: CallFlowNode) => {
     if (!node.file) return;
     state.openDiffFile(node.file);
@@ -108,6 +162,7 @@ export const CallFlowFileBadge: React.FC<{ filePath: string; oldPath?: string }>
       open={open}
       onOpenChange={(nextOpen) => {
         if (!nextOpen && annotationDraftActiveRef.current) return;
+        cancelScheduledOpen();
         setOpen(nextOpen);
       }}
     >
@@ -115,8 +170,8 @@ export const CallFlowFileBadge: React.FC<{ filePath: string; oldPath?: string }>
         <button
           type="button"
           className="call-flow-file-badge"
-          onMouseEnter={() => { cancelClose(); setOpen(true); }}
-          onMouseLeave={scheduleClose}
+          onMouseEnter={() => { pointerInsideRef.current = true; scheduleOpen(); }}
+          onMouseLeave={() => { pointerInsideRef.current = false; cancelScheduledOpen(); scheduleClose(); }}
           title={`${impacts.length} changed call-flow ${impacts.length === 1 ? 'step' : 'steps'} in this file`}
           aria-label={`Call-flow impact for ${filePath}`}
         />
@@ -130,8 +185,8 @@ export const CallFlowFileBadge: React.FC<{ filePath: string; oldPath?: string }>
             className="call-flow-popover shadow-lg popover-enter"
             data-call-flow-lens="true"
             initialFocus={false}
-            onMouseEnter={cancelClose}
-            onMouseLeave={scheduleClose}
+            onMouseEnter={() => { pointerInsideRef.current = true; cancelClose(); }}
+            onMouseLeave={() => { pointerInsideRef.current = false; scheduleClose(); }}
           >
             <div className="call-flow-popover-header">
               <div className="call-flow-popover-title" title={filePath}>

--- a/packages/review-editor/index.css
+++ b/packages/review-editor/index.css
@@ -1400,6 +1400,10 @@ diffs-container {
   width: min(38rem, 94vw);
   max-height: min(30rem, 78vh);
   overflow: auto;
+  /* Momentum scroll that hits the Lens's edge must not chain to the page:
+     the page scroll moves the anchor, drags the popup out from under the
+     pointer, and hover-closes the Lens (worst under Safari rubber-banding). */
+  overscroll-behavior: contain;
   padding: 0;
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);


### PR DESCRIPTION
## TLDR
The per-file call-flow Lens closed randomly while scrolling (worst in Safari) and popped open for every badge that scrolled under a stationary cursor. Reported by @acewhocares on X. Four coordinated changes make hover intent explicit and scroll-safe, plus one CI addition that unblocks viewer-pin regeneration from non-Linux machines.

## What was wrong
The Lens popup scrolls internally but never contained overscroll, so trackpad momentum that hit its edge chained to the page. The page scroll moved the anchor, the popup tracked it out from under the pointer, and the resulting mouseleave closed the Lens after 140ms. Safari's rubber-band momentum makes the chain far more aggressive than Chrome, which is why the reporter saw it there. Separately, hover-open had zero delay, so scrolling the diff opened Lenses uninvited as file headers passed under the cursor.

## Changes
- `overscroll-behavior: contain` on `.call-flow-popover` kills the scroll chain at the source
- 100ms hover-intent delay before opening; a pointer that leaves first never opens it
- close grace 140ms -> 250ms
- while a scroll is in flight, pending hover-closes are held; once it settles the Lens closes only if the pointer is genuinely outside
- CI: the guides-show job now uploads its built `manifest.json` as an artifact, because the viewer build hashes differently on macOS vs Linux and the committed pin must match the Linux build

Click-to-open, the annotation-draft hold, and Escape behavior are unchanged.

## Tests
Two new interaction tests pin the regressions (hover-intent delay; scroll holds a pending close, then closes after settle). Full review-editor suite: 361 pass / 0 fail. Review app builds clean; viewer typecheck delta vs main is zero.

Note: the first CI run is expected to fail the viewer manifest check since this changes the viewer bundle; the pin will be regenerated from this PR's own CI artifact and committed.

*AI-assisted (Claude) under maintainer direction.*
