### PR TITLE
guides-show: "Made with Plannotator" link in the guide header

### DIFF
--- a/apps/guides-show/viewer/main.tsx
+++ b/apps/guides-show/viewer/main.tsx
@@ -89,15 +89,37 @@ function ErrorCard({ title, detail }: { title: string; detail: string }) {
   );
 }
 
+/**
+ * "Made with Plannotator" → plannotator.ai. Portable pages send no referrer
+ * (`<meta name="referrer" content="no-referrer">`), so the `ref` query is the
+ * only attribution the destination gets. Plain text, muted, no icon: it must
+ * read as a credit, not a call to action, next to the guide's own controls.
+ */
+function BrandLink() {
+  return (
+    <a
+      href="https://plannotator.ai/?ref=guide"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center rounded-md px-1.5 py-1.5 text-[11.5px] text-muted-foreground transition-colors hover:text-foreground pointer-coarse:px-2.5 pointer-coarse:py-2.5"
+      title="Guided Reviews are made with Plannotator"
+      data-testid="guide-brand-link"
+    >
+      Made with Plannotator
+    </a>
+  );
+}
+
 function App({ snapshot, workerFactory, hosted }: { snapshot: GuideSnapshot; workerFactory: (() => Worker) | null; hosted: boolean }) {
   // Only a hosted page offers the download: a downloaded file IS the export.
-  const headerActions = hosted ? (
+  // The attribution link is on every guides.show-rendered page (portable and
+  // hosted); the in-app review UI composes its own header and never sees this.
+  const headerActions = (
     <>
-      <HostedDownloadButton snapshot={snapshot} scriptUrl={import.meta.url} />
+      <BrandLink />
+      {hosted && <HostedDownloadButton snapshot={snapshot} scriptUrl={import.meta.url} />}
       <ModeToggle />
     </>
-  ) : (
-    <ModeToggle />
   );
   const view = (
     <GuideViewer

--- a/packages/core/guide-viewer-manifest.ts
+++ b/packages/core/guide-viewer-manifest.ts
@@ -5,10 +5,10 @@
 import type { GuideViewerAssets } from "./guide-format";
 
 export const GUIDE_VIEWER_MANIFEST: Omit<GuideViewerAssets, "baseUrl"> = {
-  js: "viewer.DXe-Vl2B.js",
-  css: "viewer.Cf89Ctv5.css",
-  jsIntegrity: "sha384-+UkFMu0hsC3CFdeY55prIXs2pcRazZuEuOJod2wyXV2aJ5rX6yIMDp+/0ZFWpUFe",
-  cssIntegrity: "sha384-22e4Zk+bV1yL0QDujIOQXs9uWIl+udNmeGh3TurrZAKVnP6QQaTBS7szWr7WW1Ek",
+  js: "viewer.CXFnHGgs.js",
+  css: "viewer.DgwM0Ujf.css",
+  jsIntegrity: "sha384-Kj71d4TJP9/j6dGXb/KUxF07IQuMIVyak9yomW+6B20uTq4jrlkQBGTSJ9n3N/uV",
+  cssIntegrity: "sha384-7WoUPritW0qvClDPhC0nVxkMLTziN0ZKhSwJ604m6q4OSqTQ5NV+KuN2cT4d+nAU",
   langs: {
     "astro": "chunks/astro.BykyiR6i.js",
     "c": "chunks/c.BIGW1oBm.js",


### PR DESCRIPTION
Adds a small muted "Made with Plannotator" link (→ https://plannotator.ai/?ref=guide, new tab) leftmost in the guides.show viewer's header actions, on portable files and hosted pages alike. Portable pages send no referrer, so the `ref` query is the only attribution the destination gets. Only `apps/guides-show/viewer/main.tsx` composes this row; the in-app review UI is untouched. Viewer rebuilt from a frozen install and manifest re-pinned (`viewer.CXFnHGgs.js`).