### PR TITLE
ci(security): allowlist guides.show share links in gitleaks

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -12,3 +12,19 @@ regexTarget = "match"
 regexes = [
   '''Sec-WebSocket-Key:\s*dGhlIHNhbXBsZSBub25jZQ==''',
 ]
+
+[[allowlists]]
+# Disposition: intentionally public by design; reviewed 2026-08-17.
+# A guides.show share link carries its decryption key in the URL fragment;
+# publishing the key IS the sharing mechanism (end-to-end encryption, key never
+# sent to the server). Example links in docs and landing pages are deliberately
+# world-readable, so their #key= fragments are not leaked secrets. The regex is
+# anchored to the guides.show share-path shape so real credentials elsewhere
+# still trip the generic rule.
+# Owner: Plannotator maintainers. Re-review by 2027-08-17 or if the share URL shape changes.
+description = "guides.show share links (key-in-fragment by design)"
+targetRules = ["generic-api-key"]
+regexTarget = "line"
+regexes = [
+  '''guides\.show/g/[A-Za-z0-9_-]+#key=[A-Za-z0-9_-]+''',
+]


### PR DESCRIPTION
## TLDR
Gitleaks flags the `#key=` fragment of guides.show share links as a Generic API Key (two hits on #1342). Those keys are intentionally public: publishing the key in the link is the sharing mechanism, and the server never sees it. This adds a narrowly anchored allowlist entry so example share links in docs and pages pass while everything else stays scanned.

## Verification
Fed gitleaks a fixture with the two #1342 links plus a planted `sk_live_...` token using the same `--config .gitleaks.toml` invocation the security workflow uses: before the change 3 findings, after the change exactly 1 (the planted token). The regex requires the full `guides.show/g/<id>#key=<key>` shape on the line, and the entry follows the existing config's disposition/owner/re-review comment convention.

*AI-assisted (Claude) under maintainer direction.*