### PR TITLE
guides-show: landing copy — "in order of importance"

### DIFF
--- a/apps/guides-show/site/index.html
+++ b/apps/guides-show/site/index.html
@@ -108,7 +108,7 @@
   <img class="banner" src="/banner.webp" alt="guides.show, by Plannotator" width="1774" height="887" decoding="async" fetchpriority="high">
 
   <h1>A code walkthrough you can send as a file.</h1>
-  <p>A <a href="https://plannotator.ai/docs/commands/code-review#guided-review">Guided Review</a> takes a diff and explains it in order: chapters, a short overview for each, and the files that belong to it, with the changes shown alongside. Exported, it is one HTML file. This site serves what displays it, and hosts guides shared as links.</p>
+  <p>A <a href="https://plannotator.ai/docs/commands/code-review#guided-review">Guided Review</a> takes a diff and explains it in order of importance: chapters, a short overview for each, and the files that belong to it, with the changes shown alongside. Exported, it is one HTML file. This site serves what displays it, and hosts guides shared as links.</p>
 
   <button type="button" class="shot" id="open-shot" aria-haspopup="dialog" aria-controls="shot-dialog">
     <figure style="margin:0">


### PR DESCRIPTION
The intro said a Guided Review "explains it in order", which reads as source order. The organizer prompt orders chapters by importance (guide-review.ts: "Order by IMPORTANCE, not by file path, diff size, or the order things happened"), so say that.