### PR TITLE
Replace broken markdown images with a stable fallback

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,7 @@ jobs:
           packages/ui/utils/vimNavigation.test.ts
           packages/ui/utils/clipboard.test.ts
           packages/ui/utils/vimScroll.test.ts
+          packages/ui/components/InlineMarkdown.imageFailure.test.tsx
           packages/ui/components/InlineMarkdown.resolveLinkedDoc.test.tsx
           packages/ui/components/MarkdownDiff.frozen.test.tsx
           packages/ui/components/MarkdownEditor.extensions.test.tsx

--- a/packages/core/guide-viewer-manifest.ts
+++ b/packages/core/guide-viewer-manifest.ts
@@ -6,9 +6,9 @@ import type { GuideViewerAssets } from "./guide-format";
 
 export const GUIDE_VIEWER_MANIFEST: Omit<GuideViewerAssets, "baseUrl"> = {
   js: "viewer.CpDlIFcA.js",
-  css: "viewer.DgwM0Ujf.css",
+  css: "viewer.CgJVR2VV.css",
   jsIntegrity: "sha384-AL8vNhcGQZd8DuYJQfpqGrNTVWBusWhMZEyeki9HMOj6ryXhrvqzPj7EuR7DOt9I",
-  cssIntegrity: "sha384-7WoUPritW0qvClDPhC0nVxkMLTziN0ZKhSwJ604m6q4OSqTQ5NV+KuN2cT4d+nAU",
+  cssIntegrity: "sha384-6nzfs82Q91DxWfIr1ZIAZ/1f3yvJuQPEsbQFOJl06ekhApkg3f6Etc3O12y5ZlxY",
   langs: {
     "astro": "chunks/astro.BykyiR6i.js",
     "c": "chunks/c.BIGW1oBm.js",

--- a/packages/ui/components/InlineMarkdown.imageFailure.test.tsx
+++ b/packages/ui/components/InlineMarkdown.imageFailure.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Broken markdown images must resolve to a stable, accessible fallback instead
+ * of leaving the browser's native broken-image glyph in document content.
+ *
+ * Requires DOM (happy-dom) — run with DOM_TESTS=1 bun test.
+ */
+import { afterEach, describe, expect, test } from 'bun:test';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { InlineMarkdown } from './InlineMarkdown';
+
+const hasDom = typeof document !== 'undefined';
+const DATA_IMAGE = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
+
+let mountedRoot: Root | null = null;
+
+afterEach(async () => {
+  if (!hasDom) return;
+  if (mountedRoot) {
+    await act(async () => mountedRoot?.unmount());
+    mountedRoot = null;
+  }
+  document.body.innerHTML = '';
+});
+
+async function render(element: React.ReactElement): Promise<HTMLElement> {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  mountedRoot = createRoot(host);
+  await act(async () => mountedRoot?.render(element));
+  return host;
+}
+
+describe('InlineMarkdown image failure fallback', () => {
+  test.skipIf(!hasDom)('keeps successful images clickable for the lightbox', async () => {
+    const opened: Array<{ src: string; alt: string }> = [];
+    const host = await render(
+      <InlineMarkdown
+        text={`![Atlas release map](${DATA_IMAGE})`}
+        onImageClick={(src, alt) => opened.push({ src, alt })}
+      />,
+    );
+
+    const image = host.querySelector('img');
+    expect(image).not.toBeNull();
+    expect(image?.className).toContain('cursor-zoom-in');
+
+    await act(async () => {
+      image?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(opened).toEqual([
+      { src: DATA_IMAGE, alt: 'Atlas release map' },
+    ]);
+  });
+
+  test.skipIf(!hasDom)('replaces a failed image with a safe, themed status block', async () => {
+    const host = await render(
+      <InlineMarkdown text="![Atlas release map](assets/diagram.png)" />,
+    );
+    const image = host.querySelector('img');
+
+    await act(async () => {
+      image?.dispatchEvent(new Event('error'));
+    });
+
+    const fallback = host.querySelector<HTMLElement>('[data-image-unavailable="true"]');
+    expect(fallback).not.toBeNull();
+    expect(host.querySelector('img')).toBeNull();
+    expect(fallback?.getAttribute('role')).toBe('img');
+    // Deliberate UX copy: the fallback must explain the failure without
+    // leaking the source path or presenting browser-specific error text.
+    expect(fallback?.getAttribute('aria-label')).toBe('Atlas release map. Image unavailable');
+    expect(fallback?.textContent).toContain('Atlas release map');
+    expect(fallback?.textContent).toContain('Image unavailable');
+    expect(fallback?.className).toContain('border-border');
+    expect(fallback?.className).toContain('bg-muted/40');
+    expect(fallback?.className).not.toContain('cursor-zoom-in');
+    expect(host.innerHTML).not.toContain('assets/diagram.png');
+  });
+
+  test.skipIf(!hasDom)('gives an empty-alt failure one useful accessible label', async () => {
+    const host = await render(<InlineMarkdown text="![](missing.png)" />);
+    const image = host.querySelector('img');
+
+    await act(async () => {
+      image?.dispatchEvent(new Event('error'));
+    });
+
+    const fallback = host.querySelector<HTMLElement>('[data-image-unavailable="true"]');
+    expect(fallback?.getAttribute('aria-label')).toBe('Image unavailable');
+    expect(fallback?.textContent).toBe('Image unavailable');
+  });
+
+  test.skipIf(!hasDom)('wraps a long authored description without exposing the source', async () => {
+    const alt = 'A very long release-map description that must remain readable inside a narrow document column';
+    const host = await render(<InlineMarkdown text={`![${alt}](private/path/diagram.png)`} />);
+    const image = host.querySelector('img');
+
+    await act(async () => {
+      image?.dispatchEvent(new Event('error'));
+    });
+
+    const fallback = host.querySelector<HTMLElement>('[data-image-unavailable="true"]');
+    const copy = fallback?.querySelector('[class*="overflow-wrap"]');
+    expect(fallback?.textContent).toContain(alt);
+    expect(copy?.className).toContain('[overflow-wrap:anywhere]');
+    expect(host.innerHTML).not.toContain('private/path/diagram.png');
+  });
+
+  test.skipIf(!hasDom)('does not retry automatically and resets only when the image source changes', async () => {
+    const host = await render(<InlineMarkdown text="![First](missing-one.png)" />);
+    const firstImage = host.querySelector('img');
+
+    await act(async () => {
+      firstImage?.dispatchEvent(new Event('error'));
+    });
+    expect(host.querySelector('img')).toBeNull();
+
+    await act(async () => {
+      mountedRoot?.render(<InlineMarkdown text="![First](missing-one.png)" />);
+    });
+    expect(host.querySelector('img')).toBeNull();
+
+    await act(async () => {
+      mountedRoot?.render(<InlineMarkdown text={`![Second](${DATA_IMAGE})`} />);
+    });
+    expect(host.querySelector('img')?.getAttribute('alt')).toBe('Second');
+    expect(host.querySelector('[data-image-unavailable="true"]')).toBeNull();
+  });
+});

--- a/packages/ui/components/InlineMarkdown.tsx
+++ b/packages/ui/components/InlineMarkdown.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import { createPortal } from "react-dom";
+import { ImageOff } from "lucide-react";
 import { isCodeFilePath, isCodeFilePathStrict, CODE_PATH_BARE_REGEX, parseCodePath } from "@plannotator/core/code-file";
 import { ensureHighlight, highlightToHtml } from "../utils/codeHighlight";
 import { useFenceTheme } from "../hooks/useFenceTheme";
@@ -306,6 +307,53 @@ const CodeFileIcon = () => (
     <path strokeLinecap="round" strokeLinejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
   </svg>
 );
+
+const MarkdownImage: React.FC<{
+  src: string;
+  alt: string;
+  onImageClick?: (src: string, alt: string) => void;
+}> = ({ src, alt, onImageClick }) => {
+  const [unavailable, setUnavailable] = useState(false);
+
+  if (unavailable) {
+    const accessibleLabel = alt ? `${alt}. Image unavailable` : 'Image unavailable';
+
+    return (
+      <span
+        role="img"
+        aria-label={accessibleLabel}
+        data-image-unavailable="true"
+        className="my-2 flex min-h-20 max-w-full items-center gap-3 rounded-lg border border-border bg-muted/40 px-4 py-3 text-muted-foreground"
+      >
+        <ImageOff className="h-5 w-5 shrink-0" aria-hidden="true" />
+        <span className="min-w-0 text-sm leading-snug [overflow-wrap:anywhere]">
+          {alt ? (
+            <>
+              <span className="block font-medium text-foreground">{alt}</span>
+              <span className="mt-0.5 block text-xs">Image unavailable</span>
+            </>
+          ) : (
+            <span className="block font-medium text-foreground">Image unavailable</span>
+          )}
+        </span>
+      </span>
+    );
+  }
+
+  return (
+    <img
+      src={src}
+      alt={alt}
+      className="max-w-full rounded my-2 cursor-zoom-in"
+      loading="lazy"
+      onError={() => setUnavailable(true)}
+      onClick={(event) => {
+        event.stopPropagation();
+        onImageClick?.(src, alt);
+      }}
+    />
+  );
+};
 
 const InlineMath: React.FC<{ tex: string }> = ({ tex }) => {
   const normalizedTex = normalizeMathTex(tex);
@@ -943,17 +991,13 @@ export const InlineMarkdown: React.FC<{
       const imgSrc = /^(https?:\/\/|data:|blob:)/i.test(src)
         ? src
         : getImageSrc(src, imageBaseDir);
+      const imageKey = key++;
       parts.push(
-        <img
-          key={key++}
+        <MarkdownImage
+          key={`${imageKey}:${imgSrc}`}
           src={imgSrc}
           alt={alt}
-          className="max-w-full rounded my-2 cursor-zoom-in"
-          loading="lazy"
-          onClick={(e) => {
-            e.stopPropagation();
-            onImageClick?.(imgSrc, alt);
-          }}
+          onImageClick={onImageClick}
         />,
       );
       remaining = remaining.slice(match[0].length);


### PR DESCRIPTION
## Summary
- replace native broken-image glyphs with a quiet themed fallback in the shared markdown renderer
- preserve authored alt text while hiding source paths and technical failure details
- preserve successful-image lightbox behavior and reset only when the image source changes
- run the failure contract in the existing DOM CI batch

## Local verification
- `DOM_TESTS=1 bun test packages/ui/components/InlineMarkdown.imageFailure.test.tsx packages/ui/components/InlineMarkdown.seam.test.tsx packages/ui/components/InlineMarkdown.resolveLinkedDoc.test.tsx`
- `bun run typecheck`
- `bun run --cwd apps/review build && bun run build:hook`
- `bun pm pack --dry-run` in `packages/ui`
- `bun run check:release-version`

## Scope
This changes the upstream `@plannotator/ui` renderer only. It does not republish the missing Atlas fixture asset.