### PR TITLE
fix(review): clamp annotation toolbar to viewport

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,7 @@ jobs:
           packages/ui/components/sidebar/FileBrowser.test.ts
           packages/editor/editableDocumentsHook.test.tsx
           packages/review-editor/components/ReviewSubmissionDialog.ui.test.tsx
+          packages/review-editor/components/AnnotationToolbar.placement.test.tsx
           packages/review-editor/dock/panels/ReviewPROverviewPanel.ui.test.tsx
           packages/review-editor/components/FileHeader.edit.test.tsx
           packages/review-editor/edit/useEditSession.recovery.test.tsx

--- a/packages/review-editor/components/AnnotationToolbar.placement.test.tsx
+++ b/packages/review-editor/components/AnnotationToolbar.placement.test.tsx
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+const hasDom = typeof document !== 'undefined';
+const toolbarModule = hasDom ? await import('./AnnotationToolbar') : null;
+const AnnotationToolbar = toolbarModule?.AnnotationToolbar as typeof import('./AnnotationToolbar')['AnnotationToolbar'];
+
+let host: HTMLElement | null = null;
+let root: Root | null = null;
+let originalMatchMedia: typeof window.matchMedia | undefined;
+
+function finePointerMatchMedia(query: string): MediaQueryList {
+  return {
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => true,
+  };
+}
+
+beforeEach(() => {
+  if (!hasDom) return;
+  originalMatchMedia = window.matchMedia;
+  window.matchMedia = finePointerMatchMedia;
+});
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  root = null;
+  host?.remove();
+  host = null;
+  if (hasDom) {
+    document.body.replaceChildren();
+    if (originalMatchMedia) window.matchMedia = originalMatchMedia;
+  }
+});
+
+async function mountToolbar(positionLeft: number, askAIMode: boolean): Promise<HTMLElement> {
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  root = createRoot(host);
+  const toolbarRef = React.createRef<HTMLDivElement>();
+
+  await act(async () => {
+    root?.render(
+      <AnnotationToolbar
+        toolbarState={{
+          position: { top: 100, left: positionLeft },
+          range: { start: 6, end: 6, side: 'additions' },
+        }}
+        toolbarRef={toolbarRef}
+        commentText=""
+        setCommentText={() => {}}
+        suggestedCode=""
+        setSuggestedCode={() => {}}
+        showSuggestedCode={false}
+        setShowSuggestedCode={() => {}}
+        askAIMode={askAIMode}
+        setAskAIMode={() => {}}
+        setShowCodeModal={() => {}}
+        setShowCommentModal={() => {}}
+        onSubmit={() => {}}
+        onDismiss={() => {}}
+        onCancel={() => {}}
+        conventionalCommentsEnabled={false}
+        conventionalLabel={null}
+        onConventionalLabelChange={() => {}}
+        decorations={[]}
+        onDecorationsChange={() => {}}
+      />,
+    );
+  });
+
+  const toolbar = document.querySelector<HTMLElement>('.review-toolbar');
+  if (!toolbar) throw new Error('review annotation toolbar did not render');
+  return toolbar;
+}
+
+function toolbarHorizontalEdges(toolbar: HTMLElement): { left: number; right: number } {
+  const width = Number.parseFloat(toolbar.style.width);
+  const center = Number.parseFloat(toolbar.style.left);
+  return { left: center - width / 2, right: center + width / 2 };
+}
+
+for (const [mode, askAIMode] of [['Comment', false], ['Ask AI', true]] as const) {
+  describe(`${mode} toolbar placement`, () => {
+    test.skipIf(!hasDom)('keeps the full toolbar inside the left viewport edge', async () => {
+      const toolbar = await mountToolbar(0, askAIMode);
+      expect(toolbarHorizontalEdges(toolbar).left).toBeGreaterThanOrEqual(0);
+    });
+
+    test.skipIf(!hasDom)('keeps the full toolbar inside the right viewport edge', async () => {
+      const toolbar = await mountToolbar(window.innerWidth, askAIMode);
+      expect(toolbarHorizontalEdges(toolbar).right).toBeLessThanOrEqual(window.innerWidth);
+    });
+  });
+}

--- a/packages/review-editor/components/AnnotationToolbar.tsx
+++ b/packages/review-editor/components/AnnotationToolbar.tsx
@@ -16,7 +16,7 @@ import {
 
 interface AnnotationToolbarProps {
   toolbarState: ToolbarState;
-  toolbarRef: React.RefObject<HTMLDivElement>;
+  toolbarRef: React.RefObject<HTMLDivElement | null>;
   commentText: string;
   setCommentText: (text: string) => void;
   suggestedCode: string;
@@ -47,6 +47,9 @@ interface AnnotationToolbarProps {
   /** AI messages that overlap the current line selection */
   aiHistoryMessages?: AIChatEntry[];
 }
+
+// The 338px border box contains the 320px composer, padding, and border.
+const TOOLBAR_MAX_WIDTH = 338;
 
 /** Floating comment input form that appears after line selection */
 export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
@@ -81,7 +84,8 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
 }) => {
   const coarsePointer = hasPrimaryCoarsePointer();
   const visibleBounds = useVisibleViewportBounds(coarsePointer ? 16 : 0);
-  const horizontalInset = coarsePointer ? Math.min(160, visibleBounds.width / 2) : 150;
+  const toolbarWidth = Math.min(TOOLBAR_MAX_WIDTH, visibleBounds.width);
+  const horizontalInset = toolbarWidth / 2;
   const suggestedCodeRef = useRef<HTMLTextAreaElement>(null);
   const handleTabIndent = useTabIndent(setSuggestedCode);
   const { dragPosition, dragHandleProps, wasDragged, reset: resetDrag } = useDraggable(toolbarRef);
@@ -121,6 +125,8 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
             position: 'fixed',
             top: dragPosition.top,
             left: dragPosition.left,
+            width: toolbarWidth,
+            boxSizing: 'border-box',
             zIndex: 1000,
             maxHeight: visibleBounds.height,
             overflowY: 'auto',
@@ -139,6 +145,8 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
               ),
             ),
             transform: 'translateX(-50%)',
+            width: toolbarWidth,
+            boxSizing: 'border-box',
             zIndex: 1000,
             maxHeight: visibleBounds.height,
             overflowY: 'auto',

--- a/packages/review-editor/components/AskAIInput.tsx
+++ b/packages/review-editor/components/AskAIInput.tsx
@@ -42,7 +42,7 @@ export const AskAIInput: React.FC<AskAIInputProps> = ({
   };
 
   return (
-    <div className="w-80">
+    <div className="w-80 max-w-full">
       <div className="flex items-center justify-between mb-2" {...dragHandleProps}>
         <span className="text-xs text-muted-foreground flex items-center gap-1.5">
           <SparklesIcon className="w-3 h-3 text-primary" />


### PR DESCRIPTION
Currently, the annotation toolbar goes off-screen if the sidebar is closed:

https://github.com/user-attachments/assets/50adacb8-39d8-4178-affd-4007e6390419

After this change, the position is correctly calculated to handle sidebar being closed:

https://github.com/user-attachments/assets/68efac24-591d-486b-9be8-f218ccd6c07c

