### PR TITLE
fix(pi): honest capability warning when the host lacks ctx.isProjectTrusted

### DIFF
--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -278,6 +278,19 @@ function sendUserMessageWithCurrentSessionFallback(
 	}
 }
 
+/**
+ * Warning for hosts whose extension context lacks `ctx.isProjectTrusted`
+ * (#1353). Two audiences reach this path: real Pi older than 0.79.1 (the
+ * release that added the capability) and forks like oh-my-pi that have not
+ * adopted it. Neither Pi's nor oh-my-pi's extension context exposes a host
+ * name or version, so the two are not reliably distinguishable at runtime —
+ * the message states the capability gap without guessing which host it is,
+ * and must stay true for both. "Bundled and global config still load" is a
+ * fact of loadPlannotatorConfig: only project-local config is trust-gated.
+ */
+export const PROJECT_TRUST_CAPABILITY_WARNING =
+	"This host does not expose project trust (ctx.isProjectTrusted, Pi 0.79.1+). Project-local config (.pi/plannotator.json) is disabled; bundled and global config still load.";
+
 export default function plannotator(pi: ExtensionAPI): void {
 	const currentPiSession = registerCurrentPiSession(pi);
 	let phase: Phase = "idle";
@@ -1690,13 +1703,18 @@ Mark completed steps with [DONE:n] in your response.`
 	}
 
 	pi.on("session_start", async (_event, ctx) => {
+		// Project trust gate (#1291). Capability absent = fail closed: the
+		// project-local config is skipped and the honest capability warning
+		// fires (see PROJECT_TRUST_CAPABILITY_WARNING). A host that provides
+		// the function is honored verbatim — including one that hardcodes
+		// `true` because it has no project-trust gate by policy (oh-my-pi's
+		// planned shim). A throwing trustFn (real Pi throws on a stale
+		// context) propagates deliberately: config loading never runs, so
+		// project-local config still cannot load.
 		const trustFn = ctx.isProjectTrusted as (() => boolean) | undefined;
 		const projectTrusted = typeof trustFn === "function" ? trustFn.call(ctx) : false;
 		if (typeof trustFn !== "function") {
-			ctx.ui.notify(
-				"Plannotator requires Pi 0.79.1 or newer. Update Pi; project-local config is disabled on this host.",
-				"warning",
-			);
+			ctx.ui.notify(PROJECT_TRUST_CAPABILITY_WARNING, "warning");
 		}
 		const loadedConfig = loadPlannotatorConfig(ctx.cwd, {
 			projectTrusted,

--- a/apps/pi-extension/phase-prompts.test.ts
+++ b/apps/pi-extension/phase-prompts.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import plannotator from "./index.ts";
+import plannotator, { PROJECT_TRUST_CAPABILITY_WARNING } from "./index.ts";
 
 type Handler = (event: unknown, context: ReturnType<typeof createContext>) => unknown;
 
@@ -386,9 +386,35 @@ describe("Plannotator phase framing messages", () => {
 		const result = await startAgent(runtime, context);
 		expect(result?.message?.content).toContain("[PLANNOTATOR - PLANNING PHASE]");
 		expect(result?.message?.content).not.toContain("untrusted-project-instructions");
+		// An honest trust denial is not a capability gap: the host DID answer,
+		// so the capability warning must not fire (#1353).
+		expect(context.notifications).not.toContainEqual({
+			message: PROJECT_TRUST_CAPABILITY_WARNING,
+			level: "warning",
+		});
 	});
 
-	test("fails closed with an update warning when an older Pi host lacks project trust", async () => {
+	test("loads project Plannotator config when the host reports project trust", async () => {
+		// This is both the trusted real-Pi path and the oh-my-pi path once its
+		// isProjectTrusted() === true shim ships (can1357/oh-my-pi#7958): any
+		// host-provided true is honored, with no warning.
+		const cwd = makeWorkspace({
+			phases: { planning: { instructions: "trusted-project-instructions" } },
+		});
+		const runtime = createRuntime();
+		const context = createContext({ cwd, projectTrusted: true });
+		await runtime.run("session_start", context);
+		await runtime.commands.get("plannotator-plan-mode")?.handler("", context);
+
+		const result = await startAgent(runtime, context);
+		expect(result?.message?.content).toContain("trusted-project-instructions");
+		expect(context.notifications).not.toContainEqual({
+			message: PROJECT_TRUST_CAPABILITY_WARNING,
+			level: "warning",
+		});
+	});
+
+	test("fails closed with the capability warning when the host lacks project trust support", async () => {
 		const cwd = makeWorkspace({
 			phases: { planning: { instructions: "untrusted-project-instructions" } },
 		});
@@ -409,10 +435,37 @@ describe("Plannotator phase framing messages", () => {
 		const result = await startAgent(runtime, context);
 		expect(result?.message?.content).toContain("trusted-global-instructions");
 		expect(result?.message?.content).not.toContain("untrusted-project-instructions");
+		// Deliberate copy pin (#1353): this warning reaches two audiences that
+		// cannot be told apart at runtime (pre-0.79.1 Pi and forks that never
+		// implemented the capability, e.g. oh-my-pi), and the previous text
+		// ("update Pi") misled the fork audience. It must state the capability
+		// gap without guessing the host; do not edit it casually.
 		expect(context.notifications).toContainEqual({
-			message: "Plannotator requires Pi 0.79.1 or newer. Update Pi; project-local config is disabled on this host.",
+			message:
+				"This host does not expose project trust (ctx.isProjectTrusted, Pi 0.79.1+). Project-local config (.pi/plannotator.json) is disabled; bundled and global config still load.",
 			level: "warning",
 		});
+	});
+
+	test("a throwing isProjectTrusted propagates and keeps project config unloaded", async () => {
+		// Real Pi's isProjectTrusted throws on a stale extension context
+		// (runner.assertActive). The guard deliberately does not swallow that:
+		// the session_start handler rejects and config loading never runs, so
+		// project-local config still cannot load (fail closed). Wrapping the
+		// call in a try/catch that defaults to trusted would fail here.
+		const cwd = makeWorkspace({
+			phases: { planning: { instructions: "untrusted-project-instructions" } },
+		});
+		const runtime = createRuntime();
+		const context = createContext({ cwd });
+		(context as { isProjectTrusted: () => boolean }).isProjectTrusted = () => {
+			throw new Error("stale context");
+		};
+
+		await expect(runtime.run("session_start", context)).rejects.toThrow("stale context");
+		await runtime.commands.get("plannotator-plan-mode")?.handler("", context);
+		const result = await startAgent(runtime, context);
+		expect(result?.message?.content ?? "").not.toContain("untrusted-project-instructions");
 	});
 
 	test("persistState records the framing latch on both sides", async () => {


### PR DESCRIPTION
**TLDR:** The Pi extension's capability-absent trust warning told every host to "update Pi". That is correct advice on a real Pi older than 0.79.1, but wrong and confusing on forks like oh-my-pi (17.4.0) that never implemented `ctx.isProjectTrusted()`. The two cases are not reliably distinguishable at runtime, so the warning now states the capability gap honestly for both audiences, without guessing the host. Fail-closed behavior is byte-for-byte unchanged; only the warning text changed.

New message:

> This host does not expose project trust (ctx.isProjectTrusted, Pi 0.79.1+). Project-local config (.pi/plannotator.json) is disabled; bundled and global config still load.

Closes #1353. Thanks to @materemias for the report.

## The two audiences

1. **Real Pi older than 0.79.1.** `ctx.isProjectTrusted()` shipped in Pi commit `db3f9953e` ("feat(coding-agent): expose project trust to extensions", closes pi#5523), whose earliest release tag is `v0.79.1`, confirmed by Pi's CHANGELOG entry under `[0.79.1] - 2026-06-09`. For this audience "update Pi" was correct.
2. **oh-my-pi 17.4.0.** The current OMP tree has zero occurrences of `isProjectTrusted`; its `ExtensionContext` (`packages/coding-agent/src/extensibility/extensions/types.ts:454-524`, built in `runner.ts:1146-1194`) simply never adopted the capability. "Update Pi" is wrong advice here: no update fixes it, and the user is not even running Pi.

## Why one message instead of host detection

Neither host gives an extension a reliable identity from the context:

* Pi's `ExtensionContext` (`packages/coding-agent/src/core/extensions/types.ts:307-348`) has no version or app-name field. The branding constants Pi itself uses for fork detection (`APP_NAME`, `PACKAGE_NAME` in `src/config.ts:488-491`) are not exported to extensions.
* OMP's `ExtensionContext` likewise exposes no host name or version. Identity exists only via the `pi` API object (`pi.pi.VERSION`) or shape sniffing (`pi.zod`, `ctx.invokeTool`), all heuristic and version-fragile, and a fork resolving the host package resolves to its own values anyway.

Since detection cannot be proven reliable, the message is one sentence pair that is true for both audiences: it names the missing capability and the Pi version that introduced it (so a real-Pi user knows to update), and says what still works. The "bundled and global config still load" claim is verified in code: `loadPlannotatorConfig` (`apps/pi-extension/config.ts:240-271`) always loads the internal and global configs and gates only project-local `.pi/plannotator.json` on `projectTrusted`.

## Behavior and capability contract: unchanged

* Capability absent: still fails closed (project-local config skipped), now with the honest warning.
* Capability returns `true`: project-local config loads. This is both the trusted real-Pi path and the OMP path once can1357/oh-my-pi#7958 ships its `isProjectTrusted: () => true` shim; that shim adds a plain function on both of OMP's context builders, and our `typeof` probe works through OMP's prototype-delegated handler contexts, so the existing guard works there with no change on our side.
* Capability returns `false`: still fails closed, no warning (the host answered; that is not a capability gap).
* Capability throws (real Pi throws on a stale context via `runner.assertActive`): still propagates, config loading never runs, project-local config still cannot load. Now pinned by a test so a future try/catch cannot silently flip it to trusted.

Nothing else in the extension breaks under OMP's context shape: the only members we touch (`ui`, `hasUI`, `cwd`, `sessionManager`, `modelRegistry`, `model`, `isIdle`, `isProjectTrusted`) all exist on OMP's context except the feature-detected `isProjectTrusted`.

## Tests

* Updated the capability-absent test to pin the new message deliberately (marked as a copy pin: this string is user-facing advice that #1353 proved can mislead).
* New test: host reports trust, project-local config loads (the OMP-after-7958 and trusted-Pi path), no warning.
* Extended: explicit `false` fails closed with no capability warning.
* New test: throwing `isProjectTrusted` propagates and project config stays unloaded.

`bun test apps/pi-extension`: 224 pass; the only 6 failures are the pre-existing environmental "pi review server" GitButler/semantic-diff/workspace failures, identical before and after this change. `bun run typecheck` green.

Smoke: real Pi 0.84.1 (installed binary) loaded the modified extension from source in both trusted (`--approve`) and untrusted (`--no-approve`) print-mode runs; both reached the model call with no capability warning and no errors (a control run without `-e` rejects the extension-registered `--plan` flag, proving the extension loaded). The warning path itself requires an old Pi or an OMP host, neither of which is runnable in this environment (installed Pi is 0.84.1; OMP has no binary and its checkout is read-only), so that path is covered by the unit tests with context doubles derived from the two checkouts' actual shapes.

AI-assisted (Claude) under maintainer direction.
