### PR TITLE
fix(pi): accept every Pi thinking level in plannotator.json

### DIFF
--- a/apps/pi-extension/README.md
+++ b/apps/pi-extension/README.md
@@ -164,7 +164,7 @@ Later layers overwrite earlier ones. If a field is omitted, it inherits the valu
 | `phases.executing` | object | Settings for execution mode |
 | `phases.reviewing` | object | Reserved for future review-mode customization |
 | `model` | `{ provider, id }` \| `null` | Sets the model for the phase; `null` leaves the current model unchanged |
-| `thinking` | `minimal` \| `low` \| `medium` \| `high` \| `xhigh` \| `null` | Sets the thinking level; `null` leaves the current level unchanged |
+| `thinking` | `off` \| `minimal` \| `low` \| `medium` \| `high` \| `xhigh` \| `max` \| `null` | Sets the thinking level; `null` leaves the current level unchanged. Pi clamps a level the running model does not support, and an unrecognized value is reported as a warning instead of being ignored |
 | `activeTools` | string[] \| `null` | Tools to turn on for the phase. Setting it **replaces** the inherited list rather than adding to it (phase overrides `defaults`, your config overrides the built-in one); `[]` or `null` means no extra phase tools. `plannotator_submit_plan` is always enabled during planning regardless of this setting |
 | `statusLabel` | string \| `null` | Optional UI label for the phase; empty/null clears it |
 | `instructions` | string \| `null` | Phase framing template, delivered **once** as a hidden conversation message when the phase is entered; empty/null disables the framing message. Replaces the removed `systemPrompt` key, which is now ignored with a warning |

--- a/apps/pi-extension/config.test.ts
+++ b/apps/pi-extension/config.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildPromptVariables, loadPlannotatorConfig, formatTodoList, renderTemplate, resolveExecutionMode, resolvePhaseProfile } from "./config.ts";
+import { buildPromptVariables, loadPlannotatorConfig, formatTodoList, renderTemplate, resolveExecutionMode, resolvePhaseProfile, THINKING_LEVELS } from "./config.ts";
 
 const tempDirs: string[] = [];
 const originalHome = process.env.HOME;
@@ -113,6 +113,76 @@ describe("plannotator config", () => {
     expect(loaded.warnings[0]).toContain('Ignoring unknown executionMode "handoff"');
     expect(loaded.warnings[0]).toContain("Falling back to automatic");
     expect(resolveExecutionMode(loaded.config)).toBe("automatic");
+  });
+
+  test("accepts every thinking level Pi supports, including max", () => {
+    // #1304: the whitelist was frozen at pi's Apr-2026 level set, so "max"
+    // (added to pi's ThinkingLevel in 0.84) resolved to nothing at all. The
+    // loop covers the whole list so a level cannot quietly fall out of it; the
+    // compile-time guard in config.ts covers the other direction.
+    for (const level of THINKING_LEVELS) {
+      const homeDir = makeTempDir("plannotator-config-home-thinking-");
+      const cwdDir = makeTempDir("plannotator-config-cwd-thinking-");
+      process.env.HOME = homeDir;
+
+      const projectConfigDir = join(cwdDir, ".pi");
+      mkdirSync(projectConfigDir, { recursive: true });
+      writeFileSync(
+        join(projectConfigDir, "plannotator.json"),
+        JSON.stringify({ phases: { planning: { thinking: level } } }),
+        "utf-8",
+      );
+
+      const loaded = loadPlannotatorConfig(cwdDir, { projectTrusted: true });
+
+      expect(loaded.warnings).toEqual([]);
+      expect(resolvePhaseProfile(loaded.config, "planning").thinking).toBe(level);
+    }
+  });
+
+  test("warns instead of silently dropping an unrecognized thinking level", () => {
+    const homeDir = makeTempDir("plannotator-config-home-thinking-bad-");
+    const cwdDir = makeTempDir("plannotator-config-cwd-thinking-bad-");
+    process.env.HOME = homeDir;
+
+    const globalConfigDir = join(homeDir, ".pi", "agent");
+    const projectConfigDir = join(cwdDir, ".pi");
+    mkdirSync(globalConfigDir, { recursive: true });
+    mkdirSync(projectConfigDir, { recursive: true });
+    writeFileSync(join(globalConfigDir, "plannotator.json"), JSON.stringify({ defaults: { thinking: "low" } }), "utf-8");
+    writeFileSync(
+      join(projectConfigDir, "plannotator.json"),
+      JSON.stringify({ phases: { planning: { thinking: "maximum" } } }),
+      "utf-8",
+    );
+
+    const loaded = loadPlannotatorConfig(cwdDir, { projectTrusted: true });
+
+    expect(loaded.warnings).toHaveLength(1);
+    // The value, the JSON path and the file are what make the warning actionable.
+    expect(loaded.warnings[0]).toContain('"maximum"');
+    expect(loaded.warnings[0]).toContain("phases.planning");
+    expect(loaded.warnings[0]).toContain(join(projectConfigDir, "plannotator.json"));
+    expect(loaded.warnings[0]).toContain('"max"');
+    // Rejected value keeps the inherited level rather than clearing it.
+    expect(resolvePhaseProfile(loaded.config, "planning").thinking).toBe("low");
+  });
+
+  test("warns for a non-string thinking value under defaults", () => {
+    const homeDir = makeTempDir("plannotator-config-home-thinking-type-");
+    const cwdDir = makeTempDir("plannotator-config-cwd-thinking-type-");
+    process.env.HOME = homeDir;
+
+    const projectConfigDir = join(cwdDir, ".pi");
+    mkdirSync(projectConfigDir, { recursive: true });
+    writeFileSync(join(projectConfigDir, "plannotator.json"), JSON.stringify({ defaults: { thinking: 3 } }), "utf-8");
+
+    const loaded = loadPlannotatorConfig(cwdDir, { projectTrusted: true });
+
+    expect(loaded.warnings).toHaveLength(1);
+    expect(loaded.warnings[0]).toContain("defaults");
+    expect(loaded.warnings[0]).toContain("3");
+    expect(resolvePhaseProfile(loaded.config, "planning").thinking).toBeUndefined();
   });
 
   test("allows a project config to clear an inherited phase with null", () => {

--- a/apps/pi-extension/config.ts
+++ b/apps/pi-extension/config.ts
@@ -22,7 +22,7 @@ export interface PhaseModelRef {
  */
 export interface PhaseProfile {
   model?: PhaseModelRef | null;
-  thinking?: ThinkingLevel | null;
+  thinking?: ConfiguredThinkingLevel | null;
   activeTools?: string[] | null;
   statusLabel?: string | null;
   /**
@@ -51,7 +51,7 @@ export interface LoadPlannotatorConfigOptions {
 
 export interface ResolvedPhaseProfile {
   model?: PhaseModelRef;
-  thinking?: ThinkingLevel;
+  thinking?: ConfiguredThinkingLevel;
   activeTools?: string[];
   statusLabel?: string;
   instructions?: string;
@@ -73,7 +73,27 @@ export interface PromptRenderResult {
 
 const INTERNAL_CONFIG_PATH = join(dirname(fileURLToPath(import.meta.url)), "plannotator.json");
 const PHASES: PhaseName[] = ["planning", "executing", "reviewing"];
-const THINKING_LEVELS = new Set<string>(["minimal", "low", "medium", "high", "xhigh"]);
+/**
+ * Thinking levels accepted in plannotator.json, in Pi's own order.
+ *
+ * This list is deliberately a SUPERSET of the `ThinkingLevel` union of the
+ * pinned `@earendil-works/pi-agent-core` floor (>=0.79.1, which stops at
+ * "xhigh"): Pi added "max" in 0.84 and clamps a level the running model does
+ * not support (`clampThinkingLevel`), so accepting a newer level costs nothing
+ * on an older Pi while silently rejecting it breaks the config on a newer one
+ * (#1304). The compile-time guard below runs the check in the other direction —
+ * every level the pinned Pi type knows must be accepted here — so the next
+ * level Pi adds fails the typecheck instead of being silently dropped.
+ */
+export const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
+
+export type ConfiguredThinkingLevel = (typeof THINKING_LEVELS)[number];
+
+const THINKING_LEVEL_SET = new Set<string>(THINKING_LEVELS);
+
+type AcceptedThinkingLevel<T extends ConfiguredThinkingLevel> = T;
+/** Compile-time assertion: adding a level to Pi's `ThinkingLevel` fails here until it is listed above. */
+export type AllPiThinkingLevelsAccepted = AcceptedThinkingLevel<ThinkingLevel>;
 
 function getAgentConfigDir(): string {
   const envDir = process.env.PI_CODING_AGENT_DIR;
@@ -105,13 +125,31 @@ function normalizeModel(value: unknown): PhaseModelRef | null | undefined {
   return { provider, id };
 }
 
-function normalizeThinking(value: unknown): ThinkingLevel | null | undefined {
-  if (value === null) return null;
-  if (typeof value !== "string") return undefined;
-  const trimmed = value.trim();
-  if (!trimmed) return null;
+/**
+ * Where a profile came from, so a rejected value can name itself instead of
+ * disappearing. `scope` is the JSON path of the profile ("defaults",
+ * "phases.planning"); `path` is the config file it was read from.
+ */
+interface ProfileContext {
+  path: string;
+  scope: string;
+  warnings: string[];
+}
 
-  return THINKING_LEVELS.has(trimmed as ThinkingLevel) ? (trimmed as ThinkingLevel) : undefined;
+function normalizeThinking(value: unknown, key: string, ctx: ProfileContext): ConfiguredThinkingLevel | null | undefined {
+  if (value === null) return null;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    if (THINKING_LEVEL_SET.has(trimmed)) return trimmed as ConfiguredThinkingLevel;
+  }
+
+  // An unrecognized level falls through to the inherited one, which looks
+  // exactly like the configured level having been applied (#1304). Say so.
+  ctx.warnings.push(
+    `Ignoring unknown ${key} ${JSON.stringify(value)} at ${ctx.scope} in ${ctx.path}: expected one of ${THINKING_LEVELS.map((level) => `"${level}"`).join(", ")}. Keeping the inherited thinking level.`,
+  );
+  return undefined;
 }
 
 function normalizeTools(value: unknown): string[] | null | undefined {
@@ -136,15 +174,17 @@ function normalizePrompt(value: unknown): string | null | undefined {
   return value.length > 0 ? value : null;
 }
 
-function normalizeProfile(raw: unknown): PhaseProfile | null | undefined {
+function normalizeProfile(raw: unknown, ctx: ProfileContext): PhaseProfile | null | undefined {
   if (raw === null) return null;
   if (!isRecord(raw)) return undefined;
 
   const profile: PhaseProfile = {};
 
   if ("model" in raw) profile.model = normalizeModel(raw.model);
-  if ("thinking" in raw) profile.thinking = normalizeThinking(raw.thinking);
-  if ("thinkingLevel" in raw && profile.thinking === undefined) profile.thinking = normalizeThinking(raw.thinkingLevel);
+  if ("thinking" in raw) profile.thinking = normalizeThinking(raw.thinking, "thinking", ctx);
+  if ("thinkingLevel" in raw && profile.thinking === undefined) {
+    profile.thinking = normalizeThinking(raw.thinkingLevel, "thinkingLevel", ctx);
+  }
   if ("activeTools" in raw) profile.activeTools = normalizeTools(raw.activeTools);
   if ("statusLabel" in raw) profile.statusLabel = normalizeLabel(raw.statusLabel);
   if ("instructions" in raw) profile.instructions = normalizePrompt(raw.instructions);
@@ -207,12 +247,12 @@ function loadConfigSource(path: string): { config: PlannotatorConfig; warnings: 
       `Ignoring unknown executionMode ${JSON.stringify(raw.executionMode)} in ${path}: expected "automatic" or "external". Falling back to automatic.`,
     );
   }
-  if ("defaults" in raw) config.defaults = normalizeProfile(raw.defaults);
+  if ("defaults" in raw) config.defaults = normalizeProfile(raw.defaults, { path, scope: "defaults", warnings });
 
   if ("phases" in raw && isRecord(raw.phases)) {
     const phases: Partial<Record<PhaseName, PhaseProfile | null>> = {};
     for (const phase of PHASES) {
-      const normalized = normalizeProfile(raw.phases[phase]);
+      const normalized = normalizeProfile(raw.phases[phase], { path, scope: `phases.${phase}`, warnings });
       if (normalized !== undefined) phases[phase] = normalized;
     }
     if (Object.keys(phases).length > 0) config.phases = phases;
@@ -294,7 +334,10 @@ function resolveModel(base: PhaseModelRef | null | undefined, override: PhaseMod
   return base ?? undefined;
 }
 
-function resolveThinking(base: ThinkingLevel | null | undefined, override: ThinkingLevel | null | undefined): ThinkingLevel | undefined {
+function resolveThinking(
+  base: ConfiguredThinkingLevel | null | undefined,
+  override: ConfiguredThinkingLevel | null | undefined,
+): ConfiguredThinkingLevel | undefined {
   if (override !== undefined) {
     return override ?? undefined;
   }

--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -520,7 +520,11 @@ export default function plannotator(pi: ExtensionAPI): void {
 		}
 
 		if (profile?.thinking) {
-			pi.setThinkingLevel(profile.thinking);
+			// The config accepts every level current Pi knows, which is a superset
+			// of the `ThinkingLevel` union of the pinned Pi floor (#1304). Pi clamps
+			// a level the running model does not support, so handing it one this
+			// build's types have not heard of yet is safe.
+			pi.setThinkingLevel(profile.thinking as ThinkingLevel);
 		}
 
 		updateStatus(ctx);


### PR DESCRIPTION
**TLDR:** `phases.*.thinking: "max"` in `plannotator.json` was rejected by a hardcoded whitelist in the Pi extension and dropped without a word. The whitelist now covers Pi's full level set (`off` through `max`), a compile-time guard makes the next level Pi adds a typecheck failure instead of a silent drop, and any unrecognized thinking value now warns with the value, the JSON path and the file.

### Provenance (the first question worth answering)

Plannotator has supported a thinking config since **2026-04-01**: PR #446, commit `fc4e6347` ("feat(pi): support phase config files"), which created `apps/pi-extension/config.ts` with

```ts
const THINKING_LEVELS = new Set<string>(["minimal", "low", "medium", "high", "xhigh"]);
```

It applies to the **Pi extension only** (`defaults.thinking` and `phases.<phase>.thinking`, plus the `thinkingLevel` alias); no other runtime reads it.

Pi's own `ThinkingLevel` lives in `packages/agent/src/types.ts` of the pi repo:

| Date | Pi commit | `ThinkingLevel` |
|------|-----------|-----------------|
| 2025-10-17 | `ffc9be886` | `off, minimal, low, medium, high` |
| 2025-12-08 | `00370cab3` | adds `xhigh` |
| 2026-07-09 | `fbdd46389` | adds `max` |

So the whitelist was accurate on the day it was written and drifted three months later when Pi grew `max`. @edision's report is correct.

### Root cause

Two defects, one visible and one structural.

1. `max` was missing from the list. `off` was missing too, and has been valid in Pi since the type was created, so `thinking: "off"` was equally dead.
2. `normalizeThinking` returns `undefined` for anything it does not recognize, and `normalizeProfile` had no access to the `warnings` array that `executionMode` and the obsolete `systemPrompt` key already use. Every invalid value vanished, and an ignored level is indistinguishable from an applied one, which is why this could sit unnoticed.

### Fix

- The accepted set is `["off", "minimal", "low", "medium", "high", "xhigh", "max"]`, deliberately a **superset** of the pinned `@earendil-works/pi-agent-core` floor (`>=0.79.1`, whose type stops at `xhigh`). This is safe in both directions: Pi's `setThinkingLevel` clamps a level the running model does not support (`clampThinkingLevel`), so passing `max` to an older Pi degrades gracefully, while rejecting it breaks the config on a current one.
- Compile-time guard, so the whitelist is checked against Pi's actual exported type rather than only duplicated:

  ```ts
  type AcceptedThinkingLevel<T extends ConfiguredThinkingLevel> = T;
  export type AllPiThinkingLevelsAccepted = AcceptedThinkingLevel<ThinkingLevel>;
  ```

  If Pi adds a level and the pinned dependency picks it up, `tsc` fails and names the missing member (verified by temporarily dropping `xhigh`: `Type '"xhigh"' is not assignable...`). A runtime derivation is not possible since `ThinkingLevel` is a type-only union, and this catches the same drift without parsing `.d.ts` files.
- Unrecognized values (including wrong types such as `thinking: 3`) now push a warning naming the value, the scope (`defaults`, `phases.planning`) and the config file. It reaches the user through the existing `ctx.ui.notify` loop in `index.ts` alongside the other config warnings. The rejected value still falls back to the inherited level, which is unchanged behavior, only now it says so.
- README option table updated.

### Tests

`apps/pi-extension/config.test.ts`:

- every level in the accepted list resolves through a real project config, so a level cannot quietly fall out of the list (this is the test that fails on `main` for `max`);
- an unrecognized level warns with value, path and file, and keeps the inherited level;
- a non-string value warns rather than disappearing.

`bun test apps/pi-extension` gives 225 pass / 6 fail, the 6 being the known environmental pi review server failures (GitButler, semantic diff, workspace) present on `main`. `bun run typecheck` is clean.

Reported by @edision.

Closes #1304

AI-assisted (Claude) under maintainer direction.
