### PR TITLE
fix(vscode): stop theme sync overriding the user's chosen theme (#1053)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,7 @@ jobs:
           packages/ui/utils/inputMethod.test.ts
           packages/ui/utils/vimNavigation.test.ts
           packages/ui/utils/clipboard.test.ts
+          apps/vscode-extension/src/vscode-theme.test.ts
           packages/ui/utils/vimScroll.test.ts
           packages/ui/components/InlineMarkdown.resolveLinkedDoc.test.tsx
           packages/ui/components/MarkdownDiff.frozen.test.tsx

--- a/apps/vscode-extension/README.md
+++ b/apps/vscode-extension/README.md
@@ -37,7 +37,7 @@ Review code changes with a full diff viewer, file tree, inline annotations, and 
 - **In-editor plan review** — approve or deny plans with annotated feedback, directly in a VS Code tab
 - **In-editor code review** — review git diffs and PR changes with inline comments and suggestions
 - **Editor annotations** — select code directly in your editor and annotate it with `Cmd+Shift+.` — annotations appear in the Plannotator review UI alongside inline comments
-- **Theme sync** — Plannotator adapts to your VS Code color theme automatically
+- **Theme sync** — Plannotator adapts to your VS Code color theme automatically, and steps aside as soon as you pick a theme of your own in Plannotator's settings. A palette you chose is always used verbatim, and choosing Light or Dark pins the panel to that mode whatever the IDE is set to. Leave the mode on System to keep following the editor.
 - **Cookie persistence** — your identity, settings, and preferences persist across sessions
 - **Auto-close** — panels close automatically when you approve or send feedback
 

--- a/apps/vscode-extension/src/cookie-proxy.test.ts
+++ b/apps/vscode-extension/src/cookie-proxy.test.ts
@@ -1,6 +1,25 @@
 import { describe, it, expect, mock, afterEach } from "bun:test";
-import { createCookieProxy } from "./cookie-proxy";
+import { applyPanelCookieDefaults, createCookieProxy } from "./cookie-proxy";
 import type { CookieProxy } from "./cookie-proxy";
+
+describe("applyPanelCookieDefaults", () => {
+  it("seeds System mode for a panel that has never stored one", () => {
+    // Plannotator's own default is Dark; inside VS Code the panel should follow
+    // the IDE instead, which is what System resolves to there (issue #1053).
+    expect(applyPanelCookieDefaults({})["plannotator-theme"]).toBe("system");
+  });
+
+  it("never overwrites a mode the user already chose", () => {
+    const seeded = applyPanelCookieDefaults({ "plannotator-theme": "light" });
+    expect(seeded["plannotator-theme"]).toBe("light");
+  });
+
+  it("keeps stored cookies and the auto-close flag", () => {
+    const seeded = applyPanelCookieDefaults({ "plannotator-identity": "tater-42" });
+    expect(seeded["plannotator-identity"]).toBe("tater-42");
+    expect(seeded["plannotator-auto-close"]).toBe("true");
+  });
+});
 
 describe("createCookieProxy", () => {
   let proxy: CookieProxy | undefined;

--- a/apps/vscode-extension/src/cookie-proxy.ts
+++ b/apps/vscode-extension/src/cookie-proxy.ts
@@ -1,6 +1,6 @@
 import * as http from "http";
 import { EventEmitter } from "events";
-import { buildThemeListenerScript } from "./vscode-theme";
+import { buildThemeListenerScript, THEME_MODE_COOKIE } from "./vscode-theme";
 
 export interface CookieProxyOptions {
   loadCookies: () => string;
@@ -161,14 +161,36 @@ function parseCookieString(str: string): Record<string, string> {
   return store;
 }
 
+/**
+ * Values the panel starts its virtual cookie jar with, on top of whatever the
+ * user has already stored.
+ *
+ * The theme mode is SEEDED to System on a panel that has never stored one.
+ * Plannotator's own default is Dark, which would leave a first-time user in a
+ * light IDE staring at a dark panel now that the theme bridge no longer forces
+ * the mode onto the app (see vscode-theme.ts). System is what "adapts to your
+ * VS Code color theme" means here. It is a seed and not a write: an already
+ * stored mode is never touched, so the moment the user picks one this stops
+ * applying.
+ */
+export function applyPanelCookieDefaults(
+  store: Record<string, string>,
+): Record<string, string> {
+  const seeded = { ...store, "plannotator-auto-close": "true" };
+  if (!seeded[THEME_MODE_COOKIE]) seeded[THEME_MODE_COOKIE] = "system";
+  return seeded;
+}
+
 function injectScript(html: string, savedCookies: string): string {
-  const initial = JSON.stringify(parseCookieString(savedCookies));
+  const initial = JSON.stringify(
+    applyPanelCookieDefaults(parseCookieString(savedCookies)),
+  );
   const themeListener = buildThemeListenerScript();
 
   // Virtual cookie jar: overrides document.cookie so plannotator works even
   // when the browser blocks third-party cookies inside the iframe.
   const script = themeListener + `<script>(function(){
-      var S=${initial};S["plannotator-auto-close"]="true";
+      var S=${initial};
       Object.defineProperty(document,"cookie",{configurable:true,
         get:function(){return Object.keys(S).map(function(k){return k+"="+S[k]}).join("; ");},
         set:function(v){

--- a/apps/vscode-extension/src/vscode-theme.test.ts
+++ b/apps/vscode-extension/src/vscode-theme.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Theme-bridge precedence tests (issue #1053).
+ *
+ * The bridge writes INLINE custom properties on <html>, the element
+ * ThemeProvider stamps `theme-<palette>` / `light` on. An inline property beats
+ * every `.theme-*` rule, so a bridge that paints unconditionally makes the
+ * user's own theme choice unreachable: picking Light in a dark IDE used to
+ * leave dark VS Code tokens under a `.light` class. These tests pin who wins.
+ *
+ * The listener is a string of browser JS, so it is evaluated with `window`,
+ * `document` and `MutationObserver` passed in as parameters. That shadows the
+ * globals, which both isolates each test (its own root element, its own message
+ * listeners, its own cookie jar) and keeps the harness honest: only the two
+ * DOM surfaces the bridge is allowed to read are provided.
+ *
+ * Requires DOM_TESTS=1 (happy-dom preload). Run:
+ *   DOM_TESTS=1 bun test apps/vscode-extension/src/vscode-theme.test.ts
+ */
+/// <reference lib="dom" />
+// DOM types are pulled in for this file alone: the extension host is Node and
+// its tsconfig deliberately ships `lib: ["ESNext"]`, so the source cannot reach
+// for browser globals by accident. Only this harness runs in a DOM.
+import { describe, it, expect } from "bun:test";
+import { buildThemeListenerScript, DEFAULT_THEME_CLASS } from "./vscode-theme";
+
+const hasDom = typeof document !== "undefined";
+
+interface ThemeMessage {
+  type: string;
+  tokens: Record<string, string>;
+  themeKind: string;
+}
+
+/** A dark VS Code theme, as the wrapper page reports it. */
+const IDE_DARK: ThemeMessage = {
+  type: "plannotator-vscode-theme",
+  themeKind: "vscode-dark",
+  tokens: {
+    "--vscode-editor-background": "#1e1e1e",
+    "--vscode-editor-foreground": "#d4d4d4",
+  },
+};
+
+/** A light VS Code theme. */
+const IDE_LIGHT: ThemeMessage = {
+  type: "plannotator-vscode-theme",
+  themeKind: "vscode-light",
+  tokens: {
+    "--vscode-editor-background": "#ffffff",
+    "--vscode-editor-foreground": "#333333",
+  },
+};
+
+interface Bridge {
+  /** Stands in for the app's <html>, which ThemeProvider owns. */
+  root: HTMLElement;
+  /** Deliver a theme message from the wrapper webview. */
+  post: (msg: ThemeMessage) => void;
+  /** Whether the bridge painted a given Plannotator variable. */
+  override: (name: string) => string;
+  vscodeFlag: () => unknown;
+}
+
+/** Evaluate the injected listener against an isolated DOM. */
+function mountBridge(classes: string, cookie = ""): Bridge {
+  const root = document.createElement("html");
+  root.className = classes;
+
+  const listeners: Array<(e: { data: unknown }) => void> = [];
+  const fakeWindow: Record<string, unknown> = {
+    addEventListener(type: string, fn: (e: { data: unknown }) => void) {
+      if (type === "message") listeners.push(fn);
+    },
+  };
+  const fakeDocument = { documentElement: root, cookie };
+
+  const js = buildThemeListenerScript()
+    .replace(/^<script>/, "")
+    .replace(/<\/script>$/, "");
+  new Function("window", "document", "MutationObserver", js)(
+    fakeWindow,
+    fakeDocument,
+    MutationObserver,
+  );
+
+  return {
+    root,
+    post: (msg) => {
+      for (const fn of listeners) fn({ data: msg });
+    },
+    override: (name) => root.style.getPropertyValue(name),
+    vscodeFlag: () => fakeWindow.__PLANNOTATOR_VSCODE,
+  };
+}
+
+/** Let a MutationObserver callback run. */
+async function settle(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe.skipIf(!hasDom)("theme bridge precedence", () => {
+  it("leaves the app's light theme alone in a dark IDE (issue #1053)", () => {
+    const bridge = mountBridge(`${DEFAULT_THEME_CLASS} light`, "plannotator-theme=light");
+
+    bridge.post(IDE_DARK);
+
+    // The reported bug: dark editor tokens painted over a light surface.
+    expect(bridge.override("--background")).toBe("");
+    expect(bridge.override("--foreground")).toBe("");
+    expect(bridge.override("--muted")).toBe("");
+    // And the class the user's choice produced survives.
+    expect(bridge.root.classList.contains("light")).toBe(true);
+  });
+
+  it("still syncs VS Code colors when the app is on the IDE's side", () => {
+    const bridge = mountBridge(DEFAULT_THEME_CLASS, "plannotator-theme=dark");
+
+    bridge.post(IDE_DARK);
+
+    expect(bridge.override("--background")).toBe("#1e1e1e");
+    expect(bridge.override("--foreground")).toBe("#d4d4d4");
+    // --muted is derived by brightening the editor background for a dark IDE.
+    expect(bridge.override("--muted")).toBe("rgb(50,50,50)");
+  });
+
+  it("never stands in for a palette the user picked", () => {
+    // Modes agree, so only the palette choice keeps the bridge off.
+    const bridge = mountBridge("theme-nord", "plannotator-theme=dark");
+
+    bridge.post(IDE_DARK);
+
+    expect(bridge.override("--background")).toBe("");
+  });
+
+  it("removes its overrides when the user switches to Light mid-session", async () => {
+    const bridge = mountBridge(DEFAULT_THEME_CLASS, "plannotator-theme=dark");
+    bridge.post(IDE_DARK);
+    expect(bridge.override("--background")).toBe("#1e1e1e");
+
+    // What ThemeProvider.applyThemeClasses does when Light is chosen.
+    bridge.root.className = `${DEFAULT_THEME_CLASS} light`;
+    await settle();
+
+    expect(bridge.override("--background")).toBe("");
+    expect(bridge.override("--muted")).toBe("");
+  });
+
+  it("maps System onto the IDE's theme kind", () => {
+    // Inside VS Code the surrounding system is the IDE, so System defers to it
+    // even though the app rendered dark from its own signal.
+    const bridge = mountBridge(DEFAULT_THEME_CLASS, "plannotator-theme=system");
+
+    bridge.post(IDE_LIGHT);
+
+    expect(bridge.root.classList.contains("light")).toBe(true);
+    expect(bridge.override("--background")).toBe("#ffffff");
+  });
+
+  it("does not force the mode of a user who pinned Dark in a light IDE", () => {
+    const bridge = mountBridge(DEFAULT_THEME_CLASS, "plannotator-theme=dark");
+
+    bridge.post(IDE_LIGHT);
+
+    expect(bridge.root.classList.contains("light")).toBe(false);
+    expect(bridge.override("--background")).toBe("");
+  });
+
+  it("waits for ThemeProvider to mount before deciding", async () => {
+    // The wrapper posts on load, which can beat the app's first render; the
+    // class list is empty until then and must not be read as "default palette".
+    const bridge = mountBridge("", "plannotator-theme=dark");
+    bridge.post(IDE_DARK);
+    expect(bridge.override("--background")).toBe("");
+
+    bridge.root.className = DEFAULT_THEME_CLASS;
+    await settle();
+
+    expect(bridge.override("--background")).toBe("#1e1e1e");
+  });
+
+  it("marks the window so the app knows it runs inside VS Code", () => {
+    // useEditorAnnotations keys off this flag; the bridge is where it is set.
+    expect(mountBridge(DEFAULT_THEME_CLASS).vscodeFlag()).toBe(true);
+  });
+});

--- a/apps/vscode-extension/src/vscode-theme.ts
+++ b/apps/vscode-extension/src/vscode-theme.ts
@@ -4,6 +4,24 @@
  * Maps VS Code CSS custom properties to Plannotator's CSS variable system.
  * Used by the cookie proxy to inject a theme listener into the webview iframe,
  * and by the panel manager to read+send theme tokens from the wrapper page.
+ *
+ * Precedence contract (issue #1053): the app owns its own appearance. The
+ * bridge writes INLINE custom properties on <html>, the same element
+ * ThemeProvider stamps `theme-<palette>` / `light` on, and an inline property
+ * outranks every `.theme-*` rule in the cascade. So the bridge only fills in
+ * for a user who has expressed no conflicting preference:
+ *
+ *   - a palette the user picked always wins; the bridge stays off entirely;
+ *   - the mode the app is rendering always wins, so VS Code colors are only
+ *     painted while the app is already showing the same light/dark side the
+ *     IDE is on. Choosing Light in a dark IDE now yields Plannotator's light
+ *     theme instead of dark VS Code tokens under a `.light` class;
+ *   - "System" is the one mode that defers: inside VS Code the surrounding
+ *     system is the IDE, so the bridge maps it onto the IDE's theme kind.
+ *
+ * Anything the bridge painted is removed again the moment that stops holding,
+ * which is why every decision runs through `reconcile()` rather than being
+ * applied once on arrival.
  */
 
 // Each VS Code CSS variable can map to multiple Plannotator variables
@@ -29,6 +47,22 @@ const TOKEN_PAIRS: [string, string][] = [
 
 /** VS Code variable names the wrapper page needs to read */
 export const VSCODE_VARS = [...new Set(TOKEN_PAIRS.map(([v]) => v))];
+
+/**
+ * Plannotator's default palette (`DEFAULT_COLOR_THEME` in
+ * packages/ui/utils/themeRegistry.ts) as the class ThemeProvider puts on
+ * <html>. Seeing it means the user never picked a palette, which is the only
+ * case VS Code colors may stand in for one. If the id ever drifts, the bridge
+ * simply stops syncing and the app renders its own theme: the safe direction
+ * for this comparison to fail.
+ */
+export const DEFAULT_THEME_CLASS = "theme-plannotator";
+
+/**
+ * Cookie ThemeProvider persists the mode under (its default `storageKey`).
+ * Read to recognize System, the one mode that asks to follow the environment.
+ */
+export const THEME_MODE_COOKIE = "plannotator-theme";
 
 /**
  * Returns inline JS for the wrapper page (panel-manager.ts).
@@ -61,13 +95,21 @@ export function buildWrapperThemeScript(): string {
 
 /**
  * Returns inline JS injected into the iframe HTML (via cookie proxy).
- * Listens for theme messages from the wrapper and applies CSS overrides.
+ * Listens for theme messages from the wrapper and applies CSS overrides,
+ * subject to the precedence contract documented at the top of this file.
  */
 export function buildThemeListenerScript(): string {
   const pairsJson = JSON.stringify(TOKEN_PAIRS);
+  const defaultThemeClass = JSON.stringify(DEFAULT_THEME_CLASS);
+  const modeCookie = JSON.stringify(THEME_MODE_COOKIE);
   return `<script>(function(){
   window.__PLANNOTATOR_VSCODE=true;
   var pairs=${pairsJson};
+  var DEFAULT_THEME_CLASS=${defaultThemeClass};
+  var MODE_COOKIE=${modeCookie};
+  var root=document.documentElement;
+  var latest=null;
+  var applied=false;
   function hexToComponents(h){
     h=h.replace("#","");
     if(h.length===3)h=h[0]+h[0]+h[1]+h[1]+h[2]+h[2];
@@ -81,25 +123,65 @@ export function buildThemeListenerScript(): string {
     var b=Math.min(255,Math.max(0,c[2]+amount));
     return"rgb("+r+","+g+","+b+")";
   }
-  window.addEventListener("message",function(e){
-    if(!e.data||e.data.type!=="plannotator-vscode-theme")return;
-    var tokens=e.data.tokens;
-    var kind=e.data.themeKind;
-    var root=document.documentElement;
+  function ideIsLight(kind){return kind==="vscode-light"||kind==="vscode-high-contrast-light";}
+  function appIsLight(){return root.classList.contains("light");}
+  /* The palette ThemeProvider is currently rendering, "" before it mounts. */
+  function appPalette(){
+    var list=root.classList;
+    for(var i=0;i<list.length;i++){if(list[i].indexOf("theme-")===0)return list[i];}
+    return"";
+  }
+  /* Read lazily: the virtual cookie jar is installed by a later script. */
+  function appMode(){
+    var parts=String(document.cookie||"").split("; ");
+    for(var i=0;i<parts.length;i++){
+      var eq=parts[i].indexOf("=");
+      if(eq>0&&parts[i].slice(0,eq)===MODE_COOKIE)return decodeURIComponent(parts[i].slice(eq+1));
+    }
+    return"";
+  }
+  function clearOverrides(){
+    if(!applied)return;
+    for(var i=0;i<pairs.length;i++)root.style.removeProperty(pairs[i][1]);
+    root.style.removeProperty("--muted");
+    applied=false;
+  }
+  function applyOverrides(){
+    var tokens=latest.tokens||{};
     for(var i=0;i<pairs.length;i++){
       var val=tokens[pairs[i][0]];
       if(val)root.style.setProperty(pairs[i][1],val);
     }
     var bg=tokens["--vscode-editor-background"];
     if(bg){
-      var isDark=kind==="vscode-dark"||kind==="vscode-high-contrast";
-      var muted=adjustBrightness(bg,isDark?20:-20);
+      var muted=adjustBrightness(bg,ideIsLight(latest.themeKind)?-20:20);
       if(muted)root.style.setProperty("--muted",muted);
     }
-    root.classList.remove("light");
-    if(kind==="vscode-light"||kind==="vscode-high-contrast-light"){
-      root.classList.add("light");
+    applied=true;
+  }
+  function reconcile(){
+    if(!latest)return;
+    /* A palette the user picked is never stood in for. */
+    if(appPalette()!==DEFAULT_THEME_CLASS){clearOverrides();return;}
+    var wantLight=ideIsLight(latest.themeKind);
+    /* System means "follow the environment", and here that is the IDE. */
+    if(appMode()==="system"&&appIsLight()!==wantLight){
+      if(wantLight)root.classList.add("light");
+      else root.classList.remove("light");
     }
+    /* Never paint one mode's colors onto the other mode's surface. */
+    if(appIsLight()!==wantLight){clearOverrides();return;}
+    applyOverrides();
+  }
+  window.addEventListener("message",function(e){
+    if(!e.data||e.data.type!=="plannotator-vscode-theme")return;
+    latest=e.data;
+    reconcile();
   });
+  /* ThemeProvider rewrites these classes whenever the user changes theme. */
+  if(typeof MutationObserver!=="undefined"){
+    new MutationObserver(function(){reconcile();})
+      .observe(root,{attributes:true,attributeFilter:["class"]});
+  }
 })();</script>`;
 }


### PR DESCRIPTION
**TLDR:** Choosing Plannotator's light theme inside a dark VS Code did nothing, because the extension's theme bridge painted the IDE's colors as *inline* CSS custom properties on `<html>` and forced the `light` class to the IDE's theme kind. Inline properties outrank every `.theme-*` rule, so the user's own choice was unreachable. The bridge now steps aside whenever the user has expressed a preference of their own. Reported by @it-sha in #1053.

## Root cause

`ThemeProvider.applyThemeClasses` (`packages/ui/components/ThemeProvider.tsx:65`) owns the app's appearance by stamping `theme-<palette>` and `light` on `<html>`, and the palettes are class scoped (`.theme-plannotator` / `.theme-plannotator.light`).

The bridge wrote to that same element:

* `apps/vscode-extension/src/vscode-theme.ts:91` (old) set 16 mapped VS Code colors with `root.style.setProperty(...)`. An inline custom property beats any class selector, so whatever palette the user picked was painted over and could never win.
* `apps/vscode-extension/src/vscode-theme.ts:99-102` (old) then ran `root.classList.remove("light")` and re-added it only for a light IDE, stripping the class the user's Light choice had just produced.

The result for the reported case is the worst of both: dark VS Code tokens under a `.light` class. It applied once per message and never reconsidered, so a theme change made from Plannotator's settings mid session left the injected colors in place.

## Precedence contract

The app owns its own appearance. The bridge only fills in for a user who has expressed no conflicting preference:

1. **A palette the user picked always wins.** If `<html>` carries any palette other than the default, the bridge paints nothing and removes anything it painted earlier.
2. **The mode the app is rendering always wins.** VS Code colors are applied only while the app is already showing the same light or dark side the IDE is on. Choosing Light in a dark IDE now yields Plannotator's light theme rather than dark IDE tokens.
3. **System defers to the IDE.** Inside VS Code the surrounding system is the editor, so System is the one mode the bridge maps onto the IDE's theme kind.
4. **Every decision is reconciled, not applied once.** A `MutationObserver` on the app's class list re-decides whenever `ThemeProvider` rewrites it, so switching themes in Settings mid session removes the injected colors immediately, and a theme message that arrives before the app has mounted no longer paints an empty class list.

Failure direction is deliberate: if the default palette id ever drifts from `themeRegistry.DEFAULT_COLOR_THEME`, the bridge stops syncing and the app renders its own theme, which is safe, rather than painting over it.

## Why the cookie seed is part of the fix

Plannotator's own default mode is Dark. With the bridge no longer forcing the mode, a first-time user in a *light* IDE would have been left with a dark panel, which would have traded one bug for another. So a panel that has never stored a mode now seeds System (`applyPanelCookieDefaults` in `cookie-proxy.ts`), which is what "adapts to your VS Code color theme" means here. It is a seed and not a write: an already stored mode is never touched, so it stops applying the moment the user picks a mode. This is the one piece that is a judgement call rather than a straight bug fix, so it is easy to drop if you would rather keep Dark as the in-editor default.

## Tests

New `apps/vscode-extension/src/vscode-theme.test.ts` (8 tests) evaluates the injected listener against an isolated DOM, passing `window`, `document` and `MutationObserver` in as parameters so each test gets its own root element, message listeners and cookie jar, and so the harness can only offer the two DOM surfaces the bridge is allowed to read. `vscode-theme.ts` previously had no test coverage at all.

Covered: the reported case, sync still working when the modes agree, a chosen palette never being stood in for, overrides being removed when the user switches to Light mid session, System mapping onto the IDE, a pinned Dark surviving a light IDE, and the pre-mount race.

**Non-vacuity check:** reverting `buildThemeListenerScript` to its old body and re-running fails 5 to 6 of the 8, including the headline `leaves the app's light theme alone in a dark IDE (issue #1053)`.

Three more tests in `cookie-proxy.test.ts` cover the seed: absent means System, an existing mode is never overwritten, stored cookies and the auto-close flag survive.

* `bun test apps/vscode-extension/src`: 26 pass, 8 skip, 0 fail
* `DOM_TESTS=1 bun test apps/vscode-extension/src/vscode-theme.test.ts`: 8 pass
* `bun run typecheck`: clean. `bun run build:vscode`: clean.
* Registered the DOM gated file in `.github/workflows/test.yml` alongside the other `DOM_TESTS=1` suites.

**On the full suite:** `bun test` on this branch reports a few failures beyond the 12 stable baseline ones, all in unrelated server tests (`api-404-guard`, and a favicon assertion that reads the real `~/.plannotator`). This is not from this change. Dropping an empty placeholder test file at the same path on a clean tree reproduces the same class of extra failures, so it is shared process ordering interacting with suite tests that touch the real data directory.

## Not done here

No opt-out setting was added. With the precedence fixed, turning sync off is just picking a theme in Plannotator's settings. Say the word if you want an explicit `plannotatorWebview.syncTheme` toggle as well.

Closes #1053.

AI-assisted (Claude) under maintainer direction.
