### PR TITLE
fix(vscode): re-seed the legacy auto-dark panel theme to System once

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,13 @@ jobs:
       - name: Type check
         run: bun run typecheck
 
+      # The extension has its own tsconfig (Node libs, no DOM) and is not part
+      # of the root typecheck, so nothing was checking it. A type error in the
+      # panel cookie seed shipped that way; this is the step that would have
+      # caught it.
+      - name: Type check VS Code extension
+        run: bun run --cwd apps/vscode-extension lint
+
       - name: Run tests
         run: bun test
 

--- a/apps/vscode-extension/README.md
+++ b/apps/vscode-extension/README.md
@@ -37,7 +37,7 @@ Review code changes with a full diff viewer, file tree, inline annotations, and 
 - **In-editor plan review** — approve or deny plans with annotated feedback, directly in a VS Code tab
 - **In-editor code review** — review git diffs and PR changes with inline comments and suggestions
 - **Editor annotations** — select code directly in your editor and annotate it with `Cmd+Shift+.` — annotations appear in the Plannotator review UI alongside inline comments
-- **Theme sync** — Plannotator adapts to your VS Code color theme automatically, and steps aside as soon as you pick a theme of your own in Plannotator's settings. A palette you chose is always used verbatim, and choosing Light or Dark pins the panel to that mode whatever the IDE is set to. Leave the mode on System to keep following the editor.
+- **Theme sync** — Plannotator adapts to your VS Code color theme automatically, and steps aside as soon as you pick a theme of your own in Plannotator's settings. A palette you chose is always used verbatim, and choosing Light or Dark pins the panel to that mode whatever the IDE is set to. Leave the mode on System to keep following the editor. Panels that predate theme sync stored Dark before the mode was ever a choice, so the first panel you open after upgrading resets that one stored Dark to System. It happens once: pick Dark again and it stays.
 - **Cookie persistence** — your identity, settings, and preferences persist across sessions
 - **Auto-close** — panels close automatically when you approve or send feedback
 

--- a/apps/vscode-extension/src/cookie-proxy.test.ts
+++ b/apps/vscode-extension/src/cookie-proxy.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, mock, afterEach } from "bun:test";
-import { applyPanelCookieDefaults, createCookieProxy } from "./cookie-proxy";
+import {
+  applyPanelCookieDefaults,
+  createCookieProxy,
+  PANEL_SEED_COOKIE,
+  PANEL_SEED_VERSION,
+} from "./cookie-proxy";
 import type { CookieProxy } from "./cookie-proxy";
 
 describe("applyPanelCookieDefaults", () => {
@@ -18,6 +23,60 @@ describe("applyPanelCookieDefaults", () => {
     const seeded = applyPanelCookieDefaults({ "plannotator-identity": "tater-42" });
     expect(seeded["plannotator-identity"]).toBe("tater-42");
     expect(seeded["plannotator-auto-close"]).toBe("true");
+  });
+});
+
+describe("applyPanelCookieDefaults: legacy auto-seeded mode", () => {
+  /**
+   * What a panel opened before the seeding rules existed carries: the app
+   * persisted the mode it resolved on first mount, and its default is Dark.
+   * The user never chose it, and nothing in the store says so.
+   */
+  const legacyStore = {
+    "plannotator-identity": "tater-42",
+    "plannotator-theme": "dark",
+    "plannotator-dark-theme": "plannotator",
+  };
+
+  it("re-seeds a legacy dark store to System so the panel follows the IDE again", () => {
+    const seeded = applyPanelCookieDefaults(legacyStore);
+    expect(seeded["plannotator-theme"]).toBe("system");
+    // Only the mode is reconsidered; the rest of the store is untouched.
+    expect(seeded["plannotator-identity"]).toBe("tater-42");
+    expect(seeded["plannotator-dark-theme"]).toBe("plannotator");
+  });
+
+  it("marks every store it touches, fresh or legacy", () => {
+    expect(applyPanelCookieDefaults({})[PANEL_SEED_COOKIE]).toBe(PANEL_SEED_VERSION);
+    expect(applyPanelCookieDefaults(legacyStore)[PANEL_SEED_COOKIE]).toBe(PANEL_SEED_VERSION);
+  });
+
+  it("leaves Dark alone once the store has been marked", () => {
+    // The case that must never be clobbered: a Dark the user picked after the
+    // migration already ran. The marker is what tells the two apart.
+    const chosen = applyPanelCookieDefaults({
+      ...legacyStore,
+      [PANEL_SEED_COOKIE]: PANEL_SEED_VERSION,
+    });
+    expect(chosen["plannotator-theme"]).toBe("dark");
+  });
+
+  it("runs at most once: re-seeded, then Dark chosen, then left alone", () => {
+    // The store as it round-trips: seeded jar -> page -> globalState -> jar.
+    const migrated = applyPanelCookieDefaults(legacyStore);
+    expect(migrated["plannotator-theme"]).toBe("system");
+
+    const afterUserPicksDark = { ...migrated, "plannotator-theme": "dark" };
+    expect(applyPanelCookieDefaults(afterUserPicksDark)["plannotator-theme"]).toBe("dark");
+  });
+
+  it("never re-seeds a mode the auto-seed could not have written", () => {
+    // Dark is the app's default and always has been, so Light and System are
+    // choices no matter how old the store is.
+    for (const mode of ["light", "system"]) {
+      const seeded = applyPanelCookieDefaults({ ...legacyStore, "plannotator-theme": mode });
+      expect(seeded["plannotator-theme"]).toBe(mode);
+    }
   });
 });
 

--- a/apps/vscode-extension/src/cookie-proxy.ts
+++ b/apps/vscode-extension/src/cookie-proxy.ts
@@ -162,6 +162,42 @@ function parseCookieString(str: string): Record<string, string> {
 }
 
 /**
+ * Marks a cookie store as having been through the seeding rules below, and at
+ * which version. Written on every load, so its ABSENCE means exactly one thing:
+ * this store was last written by an extension that predates the rules. That is
+ * the only condition under which the legacy re-seed runs, which is what makes
+ * it a one-time migration rather than a policy that keeps re-applying.
+ *
+ * It rides in the same jar as everything else: the page POSTs its whole
+ * `document.cookie` back every 2s, so the marker lands in `globalState` with
+ * the rest. If a panel closes before that first sync, nothing was persisted at
+ * all and the migration simply runs again next time, on the same store.
+ *
+ * `plannotator-` prefixed so it travels with the rest of the store — that
+ * prefix is what `buildSetCookieHeaders` restores as real cookies, so the jar
+ * and the document agree about it. The app ignores cookies it does not know.
+ *
+ * The version is recorded for a future migration to read; the legacy re-seed
+ * below gates on the marker being ABSENT rather than on the version matching,
+ * because a bumped version must not re-run a rule whose whole justification is
+ * that the stored value predates it.
+ */
+export const PANEL_SEED_COOKIE = "plannotator-vscode-seed";
+export const PANEL_SEED_VERSION = "1";
+
+/**
+ * The mode a legacy panel store carries when the user never picked one.
+ *
+ * Plannotator's ThemeProvider persists the mode it resolved on its FIRST mount,
+ * default included (`writeThemePairCookies` in packages/ui/config/settings.ts,
+ * driven by the mirror effect in ThemeProvider.tsx and by the store's
+ * cookie backfill in configStore.ensureLoaded). So any panel that ever loaded
+ * has a mode cookie, and for a user who never chose one it is `dark` — the
+ * app's default, which has never been anything else.
+ */
+const LEGACY_AUTO_SEEDED_MODE = "dark";
+
+/**
  * Values the panel starts its virtual cookie jar with, on top of whatever the
  * user has already stored.
  *
@@ -172,12 +208,60 @@ function parseCookieString(str: string): Record<string, string> {
  * VS Code color theme" means here. It is a seed and not a write: an already
  * stored mode is never touched, so the moment the user picks one this stops
  * applying.
+ *
+ * ---
+ *
+ * Upgrade path (issue #1053 again, for the users who reported it). Seeding an
+ * absent mode only ever helped panels opened for the FIRST time on this
+ * version. Every panel opened before it already stored `dark` — written by the
+ * app, not chosen by the user — so the seed above never fired for them and the
+ * panel stayed dark in a light IDE: the exact bug, still broken for exactly the
+ * people who hit it.
+ *
+ * There is no provenance to read. The store is one flat cookie string in
+ * `globalState` with no timestamps and no per-cookie metadata, and the app
+ * writes the same `plannotator-theme=dark` whether the user picked Dark or
+ * never opened the theme settings. So `dark` alone cannot be interpreted, and
+ * this migration leans on the three things that CAN be:
+ *
+ *  1. Value. `light` and `system` are never what the auto-seed writes, so a
+ *     store carrying either is a choice and is left alone. Only the exact
+ *     legacy default is re-seeded.
+ *  2. The marker above. The re-seed runs once per store, so a Dark chosen
+ *     after the migration is permanent — that is the case that must never be
+ *     clobbered, and it cannot be, because by then the marker is present.
+ *  3. The app's own record of the choice. `configStore.set` (what the theme
+ *     picker calls) writes the mode to ~/.plannotator/config.json, while
+ *     `seed`/`ensureLoaded` deliberately never do. `configStore.init` then
+ *     applies that server value OVER the cookie and rewrites the cookie to
+ *     match. So for any mode the user actually picked while a Plannotator
+ *     server was running — which is every panel session — the choice outranks
+ *     whatever we seed, re-asserts itself in the same page load, and syncs
+ *     back into the store alongside the marker.
+ *
+ * What that leaves: a user whose explicit Dark exists ONLY as a cookie, with
+ * nothing in config.json to restore it. They are indistinguishable from a user
+ * who never chose, and they get System once. In a dark IDE that resolves to
+ * dark and nothing changes; in a light IDE the panel turns light and re-picking
+ * Dark makes it stick for good. That one-time cost is the price of unbreaking
+ * every user who never chose at all, and it is paid at most once.
  */
 export function applyPanelCookieDefaults(
   store: Record<string, string>,
 ): Record<string, string> {
-  const seeded = { ...store, "plannotator-auto-close": "true" };
-  if (!seeded[THEME_MODE_COOKIE]) seeded[THEME_MODE_COOKIE] = "system";
+  const seeded: Record<string, string> = {
+    ...store,
+    "plannotator-auto-close": "true",
+  };
+  const storedMode = seeded[THEME_MODE_COOKIE];
+  const alreadyMarked = seeded[PANEL_SEED_COOKIE] !== undefined;
+  if (!storedMode || (!alreadyMarked && storedMode === LEGACY_AUTO_SEEDED_MODE)) {
+    seeded[THEME_MODE_COOKIE] = "system";
+  }
+  // Unconditional, and unconditional on a fresh store too: a user who picks
+  // Dark right after their first panel opens must not look like a legacy store
+  // the next time one does.
+  seeded[PANEL_SEED_COOKIE] = PANEL_SEED_VERSION;
   return seeded;
 }
 

--- a/apps/vscode-extension/src/vscode-theme.test.ts
+++ b/apps/vscode-extension/src/vscode-theme.test.ts
@@ -22,6 +22,11 @@
 // for browser globals by accident. Only this harness runs in a DOM.
 import { describe, it, expect } from "bun:test";
 import { buildThemeListenerScript, DEFAULT_THEME_CLASS } from "./vscode-theme";
+import {
+  applyPanelCookieDefaults,
+  PANEL_SEED_COOKIE,
+  PANEL_SEED_VERSION,
+} from "./cookie-proxy";
 
 const hasDom = typeof document !== "undefined";
 
@@ -181,5 +186,74 @@ describe.skipIf(!hasDom)("theme bridge precedence", () => {
   it("marks the window so the app knows it runs inside VS Code", () => {
     // useEditorAnnotations keys off this flag; the bridge is where it is set.
     expect(mountBridge(DEFAULT_THEME_CLASS).vscodeFlag()).toBe(true);
+  });
+});
+
+/**
+ * The seed and the bridge are correct on their own and were still wrong
+ * together: seeding only an ABSENT mode meant an upgraded panel kept the `dark`
+ * the app had auto-persisted, and the bridge — correctly — read that as a
+ * choice and stayed off. These run the real seeding function into the real
+ * bridge, which is the only place that gap is visible.
+ */
+describe.skipIf(!hasDom)("panel cookie seed feeding the bridge", () => {
+  /** The jar the proxy hands the page, as a cookie string. */
+  function seededCookie(store: Record<string, string>): string {
+    return Object.entries(applyPanelCookieDefaults(store))
+      .map(([k, v]) => `${k}=${v}`)
+      .join("; ");
+  }
+
+  it("upgrades a legacy dark panel to follow a light IDE (issue #1053)", () => {
+    // A panel that ran before the seeding rules: `dark` in the store, written
+    // by the app on first mount, never chosen by anyone.
+    const bridge = mountBridge(
+      DEFAULT_THEME_CLASS,
+      seededCookie({ "plannotator-theme": "dark" }),
+    );
+
+    bridge.post(IDE_LIGHT);
+
+    expect(bridge.root.classList.contains("light")).toBe(true);
+    expect(bridge.override("--background")).toBe("#ffffff");
+  });
+
+  it("keeps a Dark chosen after the migration pinned in a light IDE", () => {
+    const bridge = mountBridge(
+      DEFAULT_THEME_CLASS,
+      seededCookie({
+        "plannotator-theme": "dark",
+        [PANEL_SEED_COOKIE]: PANEL_SEED_VERSION,
+      }),
+    );
+
+    bridge.post(IDE_LIGHT);
+
+    expect(bridge.root.classList.contains("light")).toBe(false);
+    expect(bridge.override("--background")).toBe("");
+  });
+
+  it("still follows the IDE on a fresh install", () => {
+    const bridge = mountBridge(DEFAULT_THEME_CLASS, seededCookie({}));
+
+    bridge.post(IDE_LIGHT);
+
+    expect(bridge.root.classList.contains("light")).toBe(true);
+    expect(bridge.override("--background")).toBe("#ffffff");
+  });
+
+  it("leaves a stored Light pinned in a dark IDE, marked or not", () => {
+    const stores: Record<string, string>[] = [
+      { "plannotator-theme": "light" },
+      { "plannotator-theme": "light", [PANEL_SEED_COOKIE]: PANEL_SEED_VERSION },
+    ];
+    for (const store of stores) {
+      const bridge = mountBridge(`${DEFAULT_THEME_CLASS} light`, seededCookie(store));
+
+      bridge.post(IDE_DARK);
+
+      expect(bridge.root.classList.contains("light")).toBe(true);
+      expect(bridge.override("--background")).toBe("");
+    }
   });
 });


### PR DESCRIPTION
Pre-release fix for v0.28.0. Follow-up to #1357, which fixed issue #1053 for new panels and left it broken for the users who reported it.

## The gap

#1357 made the theme bridge defer to the app's stored theme mode, and seeded System only when no mode was stored:

```ts
if (!seeded[THEME_MODE_COOKIE]) seeded[THEME_MODE_COOKIE] = "system";
```

That guard checks whether the cookie is *present*, and the app writes it on its very first mount whether or not anyone chose anything. `ThemeProvider` persists the mode it resolved, default included (the mirror effect writing `writeThemePairCookies`, plus the cookie backfill in `configStore.ensureLoaded`), and that default is Dark and always has been. So every panel opened before this release carries `plannotator-theme=dark` that the user never picked, the seed never fires for them, and after upgrading the panel is still dark in a light IDE. Issue #1053, unchanged, for exactly the population that filed it.

## What signal exists

Almost none, and it is worth stating plainly. The panel cookie store is a single flat cookie string in `context.globalState` (`plannotator-cookies`), written by the page POSTing its whole `document.cookie` back every two seconds. No timestamps, no per-cookie metadata, no versioning, and nothing that records who wrote a value. The extension never wrote a theme cookie before #1357, so there is no recognizable extension-authored format either. A stored `dark` from an explicit choice and a stored `dark` from the app's auto-persist are byte-identical.

Three things can still be interpreted, and the migration is built only from those:

1. **Value asymmetry.** `light` and `system` are values the auto-persist cannot produce, because the app's default has been `dark` since the first commit. A store carrying either is a choice, and is never touched.
2. **A one-time marker.** A new `plannotator-vscode-seed` cookie is written on every load, fresh stores included. Its absence means the store was last written by an extension that predates these rules, and that is the only condition under which the re-seed runs. So a Dark picked after the migration is permanent: by then the marker is there.
3. **The app's own record of the choice.** `configStore.set` (what the theme picker calls) writes the mode to `~/.plannotator/config.json` under `theme`, while `seed` and `ensureLoaded` deliberately never write to the server. `configStore.init` then applies that server value over the cookie and rewrites the cookie to match. So a mode the user actually picked while a Plannotator server was running, which is every panel session, outranks whatever the extension seeds, re-asserts itself in the same page load, and syncs back into the store alongside the marker. The extension does not read `config.json`; the app already does the right thing with it, and that is the backstop.

## The tradeoff, stated plainly

One case is genuinely indistinguishable: an explicit Dark that exists only as a cookie with nothing in `config.json` behind it. It gets reset to System once. In a dark IDE, System resolves to dark and nothing visibly changes. In a light IDE the panel turns light, and one re-pick of Dark makes it stick for good. That is the price of unbreaking every user who never chose at all, and it is paid at most once per store. The alternative, leaving `dark` alone, keeps the reported bug broken for everyone who reported it.

Deliberately not done: reading `~/.plannotator/config.json` from the extension to narrow that case further. It would add a filesystem and same-host dependency to a pure function for a population the app already handles, and the theme picker writes the whole pair on a palette change too, so the file's presence is weaker evidence than it first looks.

## Migration semantics

```
mode absent                      -> seed "system"      (unchanged from #1357)
mode "dark",  marker absent      -> re-seed "system"   (the migration)
mode "dark",  marker present     -> untouched
mode "light" / "system", either  -> untouched
always                           -> write the marker
```

The marker records a version but the re-seed gates on its *absence*, not on a version match: a future bumped version must not re-run a rule whose only justification is that the stored value predates it. The marker rides in the same jar as everything else, so it persists through the existing sync. If a panel closes before its first sync nothing was persisted at all, and the migration simply runs again next time on the same store.

## Tests

`apps/vscode-extension/src/cookie-proxy.test.ts` covers the seeding rules: legacy dark re-seeds to System, every store gets marked, Dark under a marker is left alone, the round trip (re-seed, user picks Dark, left alone from then on), and Light or System never re-seeded.

`apps/vscode-extension/src/vscode-theme.test.ts` adds a block that runs the real seeding function into the real bridge, which is the only place this gap was ever visible, since both units were correct alone: upgrade-from-legacy-dark now follows a light IDE, an explicitly chosen Dark under the marker stays dark in a light IDE, a fresh install is unchanged, and a stored Light stays pinned in a dark IDE with or without the marker.

Both new cases were verified to fail against the pre-fix logic before being committed.

```
bun test apps/vscode-extension/src/            31 pass, 12 skip, 0 fail
DOM_TESTS=1 bun test .../vscode-theme.test.ts  12 pass, 0 fail
bun run typecheck                              clean
bun run build:vscode                           clean
```

## Drive-by

#1357 also shipped a type error in `applyPanelCookieDefaults` (`TS7053`, from the untyped object spread), which is fixed here. It shipped because the extension has its own tsconfig and is not part of the root `typecheck`, so nothing ever checked it. Added `Type check VS Code extension` to the test workflow; it passes on this branch. Easy to drop if it belongs in a separate change.

AI-assisted (Claude) under maintainer direction.
