### PR TITLE
fix(annotate): pre-release QA fixes for the armed-mode interaction seams

### DIFF
--- a/apps/hook/server/annotate-live-resolution.test.ts
+++ b/apps/hook/server/annotate-live-resolution.test.ts
@@ -188,6 +188,37 @@ describe("annotate URL resolution: live app probe", () => {
     }
   });
 
+  test("a failed probe announces the static downgrade on the log line, naming --app", async () => {
+    // The cold-dev-server case: the probe fails (server not up yet) and the
+    // session silently opened as a static conversion. The downgrade must be
+    // said out loud, with --app as the way to force live mode.
+    const lines: string[] = [];
+    await resolveAnnotateTarget({
+      rawFilePath: unreachableUrl,
+      projectRoot: process.cwd(),
+      noJina: true,
+      renderMarkdown: false,
+      log: (line) => lines.push(line),
+    });
+    const notice = lines.find((line) => line.includes("static conversion"));
+    expect(notice).toBeDefined();
+    expect(notice).toContain(unreachableUrl);
+    expect(notice).toContain("--app");
+  });
+
+  test("a live-eligible probe emits no downgrade notice", async () => {
+    const lines: string[] = [];
+    const result = await resolveAnnotateTarget({
+      rawFilePath: htmlUrl,
+      projectRoot: process.cwd(),
+      noJina: true,
+      renderMarkdown: false,
+      log: (line) => lines.push(line),
+    });
+    expect(result.ok).toBe(true);
+    expect(lines.some((line) => line.includes("static conversion"))).toBe(false);
+  });
+
   test("a 127.-prefixed DNS name is not loopback: --app rejects it before any probe", async () => {
     const result = await resolve("http://127.0.0.1.evil.example:5173/", { forceApp: true });
     expect(result.ok).toBe(false);

--- a/apps/hook/server/annotate-resolution.ts
+++ b/apps/hook/server/annotate-resolution.ts
@@ -199,7 +199,15 @@ export async function resolveAnnotateTarget(options: {
       }
       // Probe failure or non-HTML without --app: fall through to the static
       // pipeline, whose own error surfaces verbatim (preserves the legacy
-      // behavior for dead URLs and JSON endpoints).
+      // behavior for dead URLs and JSON endpoints). A failed probe says so
+      // first: a dev server still starting up probes as unreachable, and a
+      // silent downgrade to static conversion reads as a broken live session.
+      if (probeError !== null) {
+        log(
+          `Live probe failed for ${filePath} (${probeError}); using static conversion. `
+          + `If a dev server is still starting up, retry with --app to force live mode.`,
+        );
+      }
     }
 
     const useJina = resolveUseJina(noJina, loadConfig());

--- a/apps/pi-extension/phase-prompts.test.ts
+++ b/apps/pi-extension/phase-prompts.test.ts
@@ -648,6 +648,53 @@ describe("Plannotator plan-mode-off countermand (#1320)", () => {
 		expect(await startAgent(runtime, context)).toBeUndefined();
 	});
 
+	test("resync fallback: a recorded executing phase whose plan file is gone demotes to idle WITH the notice armed", async () => {
+		// The session provably used plan mode (only a persisted executing entry
+		// reaches this fallback), so its framing residue is in history and the
+		// countermand is owed. Deleting the idleNoticePending arm in the
+		// missing-plan-file fallback must fail here.
+		const cwd = makeWorkspace();
+		// Deliberately NO PLAN.md on disk.
+		const runtime = createRuntime();
+		const context = executingContext(cwd, { framingDelivered: true });
+		await runtime.run("session_start", context);
+
+		expect(runtime.lastPersistedState()).toMatchObject({
+			phase: "idle",
+			idleNoticePending: true,
+		});
+		const notice = await startAgent(runtime, context);
+		expect(notice?.message?.content).toContain("[PLANNOTATOR - PLAN MODE OFF]");
+		expect(await startAgent(runtime, context)).toBeUndefined();
+	});
+
+	test("resync fallback: a recorded executing phase with no submitted path demotes to idle WITH the notice armed", async () => {
+		// Same recorded-executing demotion as the missing-file case, hit when
+		// the state entry never captured lastSubmittedPath. Deleting the
+		// idleNoticePending arm in the no-path fallback must fail here.
+		const cwd = makeWorkspace();
+		const runtime = createRuntime();
+		const context = createContext({
+			cwd,
+			entries: [
+				{
+					type: "custom",
+					customType: "plannotator",
+					data: { phase: "executing", framingDelivered: true },
+				},
+			],
+		});
+		await runtime.run("session_start", context);
+
+		expect(runtime.lastPersistedState()).toMatchObject({
+			phase: "idle",
+			idleNoticePending: true,
+		});
+		const notice = await startAgent(runtime, context);
+		expect(notice?.message?.content).toContain("[PLANNOTATOR - PLAN MODE OFF]");
+		expect(await startAgent(runtime, context)).toBeUndefined();
+	});
+
 	test("fresh sessions never deliver the notice: the #1269 inject-nothing promise holds", async () => {
 		const cwd = makeWorkspace();
 		const runtime = createRuntime();

--- a/apps/pi-extension/server/serverAnnotate.ts
+++ b/apps/pi-extension/server/serverAnnotate.ts
@@ -937,18 +937,32 @@ export async function startAnnotateServer(options: {
 		url: buildAdvertisedUrl(port),
 		waitForDecision: () => decisionPromise,
 		stop: () => {
-			// try/finally: a throwing dispose must never leave the listener bound.
-			try {
+			// Per-step guard (mirrors the Bun server's runGuardedShutdown): one
+			// throwing disposal must not skip the steps after it — agent-terminal
+			// teardown is historically fragile (#1314) — and must never leave the
+			// listener bound.
+			const disposals: Array<[string, () => void]> = [
 				// First: watchers hold the embedded host process alive, and a
 				// throwing disposal below must not strand them.
-				closeAllFileBrowserWatchers();
-				clientLease.cancel();
+				["file browser watchers", () => closeAllFileBrowserWatchers()],
 				// Long-lived host process: an unclosed lease stream would keep its
 				// heartbeat timer and socket alive past the session, and would keep
 				// server.close() from ever completing.
-				clientLease.closeSessions();
-				aiRuntime?.dispose();
-				agentTerminal.dispose();
+				["client lease", () => {
+					clientLease.cancel();
+					clientLease.closeSessions();
+				}],
+				["AI runtime", () => aiRuntime?.dispose()],
+				["agent terminal", () => agentTerminal.dispose()],
+			];
+			try {
+				for (const [name, dispose] of disposals) {
+					try {
+						dispose();
+					} catch (error) {
+						console.error(`[plannotator] annotate shutdown: ${name} disposal failed:`, error);
+					}
+				}
 			} finally {
 				server.close();
 				// close() only stops the listener; drain browser keep-alive sockets so a

--- a/packages/editor/App.htmlChrome.test.tsx
+++ b/packages/editor/App.htmlChrome.test.tsx
@@ -29,6 +29,22 @@ const appModule = hasDom ? await import("./App") : null;
 const App = appModule?.default as typeof import("./App")["default"];
 const originalFetch = globalThis.fetch;
 const originalEventSource = globalThis.EventSource;
+const originalMatchMedia = hasDom ? window.matchMedia : undefined;
+
+// SAFETY: implements the MediaQueryList surface the shell hooks consume.
+// Coarse-pointer matches put the app in its compact touch layout.
+function coarseMatchMedia(query: string): MediaQueryList {
+  return {
+    matches: query.includes("pointer: coarse"),
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => true,
+  } as unknown as MediaQueryList;
+}
 
 const RAW_HTML = "<h1>Rendered page</h1><p>Body copy.</p>";
 
@@ -156,7 +172,10 @@ afterEach(async () => {
   globalThis.EventSource = originalEventSource;
   memory.clear();
   resetStorageBackend();
-  if (hasDom) document.body.replaceChildren();
+  if (hasDom) {
+    if (originalMatchMedia) window.matchMedia = originalMatchMedia;
+    document.body.replaceChildren();
+  }
 });
 
 afterAll(() => {
@@ -212,6 +231,41 @@ describe.if(hasDom)("HTML annotate chrome (tools toggle + pen toggle)", () => {
     expect(toggle!.getAttribute("aria-pressed")).toBe("true");
     await act(async () => toggle!.click());
     expect(sidebarTabs()).not.toBeNull();
+  });
+
+  test("a toolsHidden:true cookie is NOT applied on the compact touch layout (no eye toggle there = no way back)", async () => {
+    setStorageBackend(memoryBackend);
+    seedAnnouncementsSeen();
+    memory.set(
+      "plannotator-html-chrome",
+      JSON.stringify({ toolsHidden: true, sidebarOpen: false, panelOpen: false, savedAt: Date.now() }),
+    );
+    window.matchMedia = coarseMatchMedia as typeof window.matchMedia;
+
+    // Compact never renders the pen toggle, so mount manually and wait on the
+    // floating cluster itself: with the fix it must render despite the cookie.
+    globalThis.fetch = annotateFetch;
+    // SAFETY: the App only uses EventSource's constructor, handlers, and close.
+    globalThis.EventSource = SilentEventSource as unknown as typeof EventSource;
+    host = document.createElement("div");
+    document.body.appendChild(host);
+    root = createRoot(host);
+    await act(async () => {
+      root?.render(<App />);
+    });
+    for (let attempt = 0; attempt < 20 && !floatingCluster(); attempt += 1) {
+      await settle();
+    }
+
+    // The chrome renders: toolsHidden is treated as visible on compact.
+    expect(floatingCluster()).not.toBeNull();
+    // Desktop-only toggles are absent, which is exactly why applying the
+    // cookie here would strand the user.
+    expect(toolsToggle()).toBeNull();
+    // The cookie itself is untouched: the next desktop session still restores
+    // the user's hidden preference.
+    const record = JSON.parse(memory.get("plannotator-html-chrome") ?? "{}") as { toolsHidden?: boolean };
+    expect(record.toolsHidden).toBe(true);
   });
 
   test("the sidebar-open half of the persisted chrome still restores", async () => {

--- a/packages/editor/App.htmlChrome.test.tsx
+++ b/packages/editor/App.htmlChrome.test.tsx
@@ -159,6 +159,39 @@ async function mountHtmlAnnotate(): Promise<void> {
   if (!penToggle()) throw new Error("HTML surface did not finish mounting (pen toggle missing)");
 }
 
+function armedRing(): HTMLElement | null {
+  return document.querySelector<HTMLElement>("[data-annotate-armed-ring]");
+}
+
+/** Compact mounts wait on the armed ring: neither the pen nor the eye toggle
+ * exists on the compact touch shell (that absence is what these tests guard). */
+async function mountCompactHtmlAnnotate(): Promise<void> {
+  globalThis.fetch = annotateFetch;
+  // SAFETY: the App only uses EventSource's constructor, handlers, and close.
+  globalThis.EventSource = SilentEventSource as unknown as typeof EventSource;
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  root = createRoot(host);
+  await act(async () => {
+    root?.render(<App />);
+  });
+  for (let attempt = 0; attempt < 20 && !armedRing(); attempt += 1) {
+    await settle();
+  }
+  if (!armedRing()) throw new Error("compact HTML surface did not finish mounting (armed ring missing)");
+}
+
+async function openOptionsMenu(): Promise<void> {
+  const trigger = document.querySelector<HTMLButtonElement>('button[aria-label="Options"]');
+  if (!trigger) throw new Error("Options menu trigger missing");
+  await act(async () => trigger.click());
+}
+
+function findMenuItem(label: string): HTMLButtonElement | undefined {
+  return Array.from(document.querySelectorAll("button"))
+    .find((button) => button.textContent?.includes(label));
+}
+
 async function unmountHtmlAnnotate(): Promise<void> {
   if (root) await act(async () => root?.unmount());
   root = null;
@@ -233,7 +266,7 @@ describe.if(hasDom)("HTML annotate chrome (tools toggle + pen toggle)", () => {
     expect(sidebarTabs()).not.toBeNull();
   });
 
-  test("a toolsHidden:true cookie is NOT applied on the compact touch layout (no eye toggle there = no way back)", async () => {
+  test("compact touch layout: a toolsHidden:true cookie is undoable through the Options menu 'Show tools' action", async () => {
     setStorageBackend(memoryBackend);
     seedAnnouncementsSeen();
     memory.set(
@@ -241,31 +274,98 @@ describe.if(hasDom)("HTML annotate chrome (tools toggle + pen toggle)", () => {
       JSON.stringify({ toolsHidden: true, sidebarOpen: false, panelOpen: false, savedAt: Date.now() }),
     );
     window.matchMedia = coarseMatchMedia as typeof window.matchMedia;
+    await mountCompactHtmlAnnotate();
 
-    // Compact never renders the pen toggle, so mount manually and wait on the
-    // floating cluster itself: with the fix it must render despite the cookie.
-    globalThis.fetch = annotateFetch;
-    // SAFETY: the App only uses EventSource's constructor, handlers, and close.
-    globalThis.EventSource = SilentEventSource as unknown as typeof EventSource;
-    host = document.createElement("div");
-    document.body.appendChild(host);
-    root = createRoot(host);
-    await act(async () => {
-      root?.render(<App />);
-    });
-    for (let attempt = 0; attempt < 20 && !floatingCluster(); attempt += 1) {
-      await settle();
-    }
-
-    // The chrome renders: toolsHidden is treated as visible on compact.
-    expect(floatingCluster()).not.toBeNull();
-    // Desktop-only toggles are absent, which is exactly why applying the
-    // cookie here would strand the user.
+    // The cookie applies (desktop parity), but compact is not stranded: the
+    // desktop-only eye toggle is absent and the menu action is the way back.
+    expect(floatingCluster()).toBeNull();
     expect(toolsToggle()).toBeNull();
-    // The cookie itself is untouched: the next desktop session still restores
-    // the user's hidden preference.
-    const record = JSON.parse(memory.get("plannotator-html-chrome") ?? "{}") as { toolsHidden?: boolean };
-    expect(record.toolsHidden).toBe(true);
+
+    await openOptionsMenu();
+    const show = findMenuItem("Show tools");
+    if (!show) throw new Error('compact menu is missing the "Show tools" action');
+    await act(async () => show.click());
+    expect(floatingCluster()).not.toBeNull();
+  });
+
+  test("compact touch layout: annotate mode is disarmable through the Options menu (no pen, no keyboard needed)", async () => {
+    setStorageBackend(memoryBackend);
+    seedAnnouncementsSeen();
+    window.matchMedia = coarseMatchMedia as typeof window.matchMedia;
+    await mountCompactHtmlAnnotate();
+
+    // Armed by default, and the desktop pen is absent on compact — without
+    // the menu action every tap annotates and the page is unreachable.
+    expect(penToggle()).toBeNull();
+    expect(armedRing()).not.toBeNull();
+
+    await openOptionsMenu();
+    const interact = findMenuItem("Interact with page");
+    if (!interact) throw new Error('compact menu is missing the "Interact with page" action');
+    await act(async () => interact.click());
+    expect(armedRing()).toBeNull();
+
+    // And back: the same slot re-arms.
+    await openOptionsMenu();
+    const annotate = findMenuItem("Annotate page");
+    if (!annotate) throw new Error('compact menu is missing the "Annotate page" action');
+    await act(async () => annotate.click());
+    expect(armedRing()).not.toBeNull();
+  });
+
+  test("the restore commit never writes stale pre-restore values to the cookie", async () => {
+    // The chrome writer runs in the same commit as the restore effect, before
+    // the restored state has landed. If it saved there, a returning user's
+    // remembered state would be transiently inverted in the cookie — and a
+    // page ending between the two writes would freeze the inversion.
+    // Instrument every chrome write: no write may ever carry a state other
+    // than the remembered one, because this session never changes any chrome.
+    const chromeWrites: string[] = [];
+    setStorageBackend({
+      getItem: (key) => memory.get(key) ?? null,
+      setItem: (key, value) => {
+        if (key === "plannotator-html-chrome") chromeWrites.push(value);
+        memory.set(key, value);
+      },
+      removeItem: (key) => void memory.delete(key),
+    });
+    seedAnnouncementsSeen();
+    const rememberedState = { toolsHidden: false, sidebarOpen: true, panelOpen: false };
+    memory.set(
+      "plannotator-html-chrome",
+      JSON.stringify({ ...rememberedState, savedAt: Date.now() }),
+    );
+    await mountHtmlAnnotate();
+    await settle();
+
+    // Writes re-stamp savedAt, so compare the semantic fields, not bytes.
+    const semantic = (raw: string) => {
+      const { toolsHidden, sidebarOpen, panelOpen } = JSON.parse(raw) as Record<string, unknown>;
+      return { toolsHidden, sidebarOpen, panelOpen };
+    };
+    for (const write of chromeWrites) {
+      expect(semantic(write)).toEqual(rememberedState);
+    }
+    expect(semantic(memory.get("plannotator-html-chrome")!)).toEqual(rememberedState);
+  });
+
+  test("the sidebar is still reachable by keyboard (Mod+B) while tools are hidden", async () => {
+    setStorageBackend(memoryBackend);
+    seedAnnouncementsSeen();
+    memory.set(
+      "plannotator-html-chrome",
+      JSON.stringify({ toolsHidden: true, sidebarOpen: false, panelOpen: false, savedAt: Date.now() }),
+    );
+    await mountHtmlAnnotate();
+    await settle();
+    expect(sidebarTabs()).toBeNull();
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "b", metaKey: true, bubbles: true }));
+    });
+    await settle();
+
+    expect(findButtonByText("Contents")).not.toBeUndefined();
   });
 
   test("the sidebar-open half of the persisted chrome still restores", async () => {

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -1897,13 +1897,14 @@ const App: React.FC = () => {
 
   // Restore-on-entry: every time the session transitions ONTO an HTML surface
   // (a root raw-HTML session, or a linked .html doc opened from markdown),
-  // apply the sidebar/panel state the user last left an HTML session with
-  // (first-ever run: both closed). The old "Hide tools" chrome flag is gone —
-  // annotation chrome is always visible on HTML surfaces now, and an old
-  // cookie still carrying toolsHidden is simply ignored, so a stale record
-  // can never strand a user with hidden chrome. Re-restoring on each entry is
-  // also what keeps a markdown surface's sidebar state from leaking into the
-  // HTML cookie on the way back.
+  // apply the sidebar/panel/toolsHidden state the user last left an HTML
+  // session with (first-ever run: both closed, tools visible). toolsHidden is
+  // restored into state here but only APPLIED on desktop layouts — the compact
+  // touch shell has neither the eye toggle nor a menu action to undo it, so it
+  // renders tools visible regardless (see the hideControls site) while the
+  // cookie keeps its value for the next desktop visit. Re-restoring on each
+  // entry is also what keeps a markdown surface's sidebar state from leaking
+  // into the HTML cookie on the way back.
   const prevHtmlChromeSurfaceRef = useRef(false);
   useEffect(() => {
     if (isLoading || isLoadingShared) return;
@@ -5490,7 +5491,12 @@ const App: React.FC = () => {
                     onRemoveGlobalAttachment={handleRemoveGlobalAttachment}
                     maxWidth={isHtmlSurface ? null : annotateReaderMaxWidth}
                     fullViewport={isHtmlSurface}
-                    hideControls={isHtmlSurface && htmlToolsHidden}
+                    // toolsHidden is desktop-only: the eye toggle is hidden on
+                    // the compact touch shell, so applying a restored
+                    // toolsHidden:true there would strand the user with no way
+                    // back. Compact treats tools as visible while the cookie
+                    // keeps its value for the next desktop visit.
+                    hideControls={isHtmlSurface && !isCompactTouchLayout && htmlToolsHidden}
                     diffAvailable={!liveApp && !!htmlDiffHtml}
                     diffActive={!liveApp && isPlanDiffActive && !!htmlDiffHtml}
                     onToggleDiff={() => setIsPlanDiffActive((v) => !v)}

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -1898,13 +1898,12 @@ const App: React.FC = () => {
   // Restore-on-entry: every time the session transitions ONTO an HTML surface
   // (a root raw-HTML session, or a linked .html doc opened from markdown),
   // apply the sidebar/panel/toolsHidden state the user last left an HTML
-  // session with (first-ever run: both closed, tools visible). toolsHidden is
-  // restored into state here but only APPLIED on desktop layouts — the compact
-  // touch shell has neither the eye toggle nor a menu action to undo it, so it
-  // renders tools visible regardless (see the hideControls site) while the
-  // cookie keeps its value for the next desktop visit. Re-restoring on each
-  // entry is also what keeps a markdown surface's sidebar state from leaking
-  // into the HTML cookie on the way back.
+  // session with (first-ever run: both closed, tools visible). A restored
+  // toolsHidden:true always has a way back on every layout: the desktop
+  // header eye toggle, and the compact Options menu "Show tools" action
+  // (compactDocumentActions). Re-restoring on each entry is also what keeps
+  // a markdown surface's sidebar state from leaking into the HTML cookie on
+  // the way back.
   const prevHtmlChromeSurfaceRef = useRef(false);
   useEffect(() => {
     if (isLoading || isLoadingShared) return;
@@ -4714,6 +4713,31 @@ const App: React.FC = () => {
               onSelect: handleEditExitClick,
             }]
           : []),
+        // HTML/live surfaces on the compact touch shell: the desktop pen and
+        // eye toggles are header-only and hidden here, and Mod+Shift+A is
+        // keyboard-only, so without these menu actions a touch user has NO
+        // way to disarm annotate mode (every tap annotates, the page beneath
+        // is unreachable) or to bring hidden tools back.
+        ...(isHtmlSurface && !documentReadOnly
+          ? [{
+              id: 'annotate' as const,
+              label: htmlAnnotateArmed ? 'Interact with page' : 'Annotate page',
+              subtitle: htmlAnnotateArmed
+                ? 'Taps annotate. Switch to use the page itself.'
+                : 'Taps use the page. Switch to add annotations.',
+              onSelect: handleHtmlAnnotateToggle,
+            }]
+          : []),
+        ...(isHtmlSurface
+          ? [{
+              id: 'tools' as const,
+              label: htmlToolsHidden ? 'Show tools' : 'Hide tools',
+              subtitle: htmlToolsHidden
+                ? 'Bring the annotation chrome back over the page'
+                : 'Remove all floating chrome from over the page',
+              onSelect: () => setHtmlToolsHidden((v) => !v),
+            }]
+          : []),
       ];
 
   const planMaxWidth = useMemo(() => {
@@ -5491,12 +5515,11 @@ const App: React.FC = () => {
                     onRemoveGlobalAttachment={handleRemoveGlobalAttachment}
                     maxWidth={isHtmlSurface ? null : annotateReaderMaxWidth}
                     fullViewport={isHtmlSurface}
-                    // toolsHidden is desktop-only: the eye toggle is hidden on
-                    // the compact touch shell, so applying a restored
-                    // toolsHidden:true there would strand the user with no way
-                    // back. Compact treats tools as visible while the cookie
-                    // keeps its value for the next desktop visit.
-                    hideControls={isHtmlSurface && !isCompactTouchLayout && htmlToolsHidden}
+                    // Applied on every layout: desktop has the header eye
+                    // toggle, and the compact touch shell has the Options
+                    // menu "Show tools" action (compactDocumentActions), so
+                    // a restored toolsHidden:true always has a way back.
+                    hideControls={isHtmlSurface && htmlToolsHidden}
                     diffAvailable={!liveApp && !!htmlDiffHtml}
                     diffActive={!liveApp && isPlanDiffActive && !!htmlDiffHtml}
                     onToggleDiff={() => setIsPlanDiffActive((v) => !v)}

--- a/packages/editor/components/AnnotateAgentTerminalPanel.displayReset.test.tsx
+++ b/packages/editor/components/AnnotateAgentTerminalPanel.displayReset.test.tsx
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  AgentTerminalDisplayPopover,
+  DEFAULT_DISPLAY_SETTINGS,
+  type AgentTerminalDisplaySettings,
+} from './AnnotateAgentTerminalPanel';
+import type { AnnotateAgentTerminalSide } from '@plannotator/ui/utils/annotateAgentTerminal';
+
+/**
+ * The Display popover's reset button (DOM-gated).
+ *
+ * "Reset terminal display settings" must do exactly what its label says:
+ * reset the DISPLAY settings. Position (left/right/hidden) is a durable
+ * layout preference persisted to config.json through onSideChange — the
+ * regression this guards is the reset button also firing onSideChange("left"),
+ * silently overwriting a user's chosen right/hidden placement with no
+ * disclosure. The Position segmented control stays the one explicit way to
+ * change placement.
+ */
+
+const hasDom = typeof document !== 'undefined';
+let root: Root | null = null;
+let host: HTMLElement | null = null;
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  root = null;
+  host?.remove();
+  host = null;
+  if (hasDom) document.body.replaceChildren();
+});
+
+const NON_DEFAULT_SETTINGS: AgentTerminalDisplaySettings = {
+  fontFamily: 'geist',
+  fontSize: 18,
+  fontWeight: 'light',
+  lineHeight: 1.35,
+};
+
+async function mountPopover(options: {
+  side: AnnotateAgentTerminalSide;
+  onChange: (updates: Partial<AgentTerminalDisplaySettings>) => void;
+  onSideChange: (side: AnnotateAgentTerminalSide) => void;
+}): Promise<void> {
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  root = createRoot(host);
+  await act(async () => {
+    root?.render(
+      <AgentTerminalDisplayPopover
+        settings={NON_DEFAULT_SETTINGS}
+        side={options.side}
+        onChange={options.onChange}
+        onSideChange={options.onSideChange}
+        defaultOpen
+      />,
+    );
+  });
+}
+
+function resetButton(): HTMLButtonElement {
+  const button = document.querySelector<HTMLButtonElement>(
+    'button[aria-label="Reset terminal display settings"]',
+  );
+  if (!button) throw new Error('reset button missing (popover did not open)');
+  return button;
+}
+
+describe.if(hasDom)('agent terminal Display popover reset', () => {
+  test('reset restores the display defaults and leaves the side/placement untouched', async () => {
+    const changes: Array<Partial<AgentTerminalDisplaySettings>> = [];
+    const sideChanges: AnnotateAgentTerminalSide[] = [];
+    await mountPopover({
+      side: 'right',
+      onChange: (updates) => changes.push(updates),
+      onSideChange: (side) => sideChanges.push(side),
+    });
+
+    await act(async () => resetButton().click());
+
+    // Display settings reset to the defaults through the panel's one
+    // sanitized update path...
+    expect(changes).toEqual([DEFAULT_DISPLAY_SETTINGS]);
+    // ...and the durable placement preference is NOT touched: a user who
+    // chose "right" (or "hidden") keeps it.
+    expect(sideChanges).toEqual([]);
+  });
+
+  test('the Position control stays the explicit way to change placement', async () => {
+    const sideChanges: AnnotateAgentTerminalSide[] = [];
+    await mountPopover({
+      side: 'left',
+      onChange: () => {},
+      onSideChange: (side) => sideChanges.push(side),
+    });
+
+    const rightOption = Array.from(document.querySelectorAll('button'))
+      .find((button) => button.textContent?.trim() === 'Right');
+    if (!rightOption) throw new Error('Position "Right" option missing');
+    await act(async () => rightOption.click());
+
+    expect(sideChanges).toEqual(['right']);
+  });
+});

--- a/packages/editor/components/AnnotateAgentTerminalPanel.tsx
+++ b/packages/editor/components/AnnotateAgentTerminalPanel.tsx
@@ -55,7 +55,7 @@ type TerminalStatus = "idle" | "starting" | "running" | "stopping" | "exited";
 type AgentTerminalFontFamily = "theme" | "system" | "geist";
 type AgentTerminalFontWeight = "light" | "regular" | "medium";
 
-type AgentTerminalDisplaySettings = {
+export type AgentTerminalDisplaySettings = {
   fontFamily: AgentTerminalFontFamily;
   fontSize: number;
   fontWeight: AgentTerminalFontWeight;
@@ -79,7 +79,7 @@ const DISPLAY_STORAGE_KEY = "plannotator-agent-terminal-display";
 const MIN_FONT_SIZE = 10;
 const MAX_FONT_SIZE = 24;
 
-const DEFAULT_DISPLAY_SETTINGS: AgentTerminalDisplaySettings = {
+export const DEFAULT_DISPLAY_SETTINGS: AgentTerminalDisplaySettings = {
   fontFamily: "theme",
   fontSize: 14,
   fontWeight: "regular",
@@ -235,12 +235,6 @@ export const AnnotateAgentTerminalPanel = forwardRef<
     [],
   );
 
-  const resetDisplaySettings = useCallback(() => {
-    setDisplaySettings(DEFAULT_DISPLAY_SETTINGS);
-    writeDisplaySettings(DEFAULT_DISPLAY_SETTINGS);
-    onSideChange("left");
-  }, [onSideChange]);
-
   const selectedAgent =
     availableAgents.find((agent) => agent.id === selectedAgentId) ?? null;
   const canStart =
@@ -354,7 +348,6 @@ export const AnnotateAgentTerminalPanel = forwardRef<
                 side={side}
                 onChange={updateDisplaySettings}
                 onSideChange={onSideChange}
-                onReset={resetDisplaySettings}
               />
               <button
                 type="button"
@@ -537,21 +530,23 @@ function formatExit(event: PtyExit): string {
   return `Exited ${event.exitCode}`;
 }
 
-function AgentTerminalDisplayPopover({
+/** Exported for tests (the surrounding panel needs a live WebTUI session to
+ * render this popover). `defaultOpen` is a test seam only. */
+export function AgentTerminalDisplayPopover({
   settings,
   side,
   onChange,
   onSideChange,
-  onReset,
+  defaultOpen,
 }: {
   settings: AgentTerminalDisplaySettings;
   side: AnnotateAgentTerminalSide;
   onChange: (updates: Partial<AgentTerminalDisplaySettings>) => void;
   onSideChange: (side: AnnotateAgentTerminalSide) => void;
-  onReset: () => void;
+  defaultOpen?: boolean;
 }) {
   return (
-    <Popover>
+    <Popover defaultOpen={defaultOpen}>
       <PopoverTrigger
         render={
           <button
@@ -568,10 +563,16 @@ function AgentTerminalDisplayPopover({
         <div className="space-y-2.5">
           <div className="flex items-center justify-between gap-2">
             <div className="text-xs font-medium text-foreground">Display</div>
+            {/* Resets DISPLAY settings only, exactly as the label says.
+                Position is deliberately untouched: it is a durable layout
+                preference (config.json via onSideChange), not a display
+                setting, and the segmented control below is its one explicit,
+                disclosed way to change. Resetting it here silently overwrote
+                a chosen right/hidden placement. */}
             <button
               type="button"
               aria-label="Reset terminal display settings"
-              onClick={onReset}
+              onClick={() => onChange(DEFAULT_DISPLAY_SETTINGS)}
               className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted/70 hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring"
             >
               <RotateCcw className="h-3.5 w-3.5" />

--- a/packages/server/annotate.test.ts
+++ b/packages/server/annotate.test.ts
@@ -18,7 +18,7 @@ import { afterAll, afterEach, beforeEach, describe, expect, test } from "bun:tes
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, realpathSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "os";
 import { join, resolve } from "path";
-import { startAnnotateServer } from "./annotate";
+import { runGuardedShutdown, startAnnotateServer } from "./annotate";
 import { getServerConfig, loadConfig } from "./config";
 import { deriveAnnotateHistorySlug } from "@plannotator/shared/annotate-history";
 import { getPlannotatorDataDir } from "@plannotator/shared/data-dir";
@@ -1986,5 +1986,46 @@ describe("annotate server: live app mode (annotate-app)", () => {
     await expect(
       startLiveServer("http://127.0.0.1:65500", { tailnetPublished: true }),
     ).rejects.toThrow("Live app annotation is unavailable in tailnet-published sessions");
+  });
+});
+
+describe("annotate server: guarded shutdown (runGuardedShutdown)", () => {
+  // The live-proxy leak this guards: stop() disposes the agent terminal
+  // BEFORE the live proxy, and agent-terminal teardown is historically
+  // fragile (#1314). In a flat sequence a throw there orphaned the proxy's
+  // listener and upstream WebSockets. Each step must run even when an
+  // earlier one throws, and the listener close must run regardless.
+  test("a throwing disposer does not skip later steps or the listener close", () => {
+    const ran: string[] = [];
+    const logged: string[] = [];
+    runGuardedShutdown(
+      [
+        ["agent terminal", () => {
+          ran.push("agent terminal");
+          throw new Error("pty teardown exploded");
+        }],
+        ["live proxy", () => ran.push("live proxy")],
+      ],
+      () => ran.push("listener"),
+      (message) => logged.push(message),
+    );
+    expect(ran).toEqual(["agent terminal", "live proxy", "listener"]);
+    // The failure is reported, named after the step that threw.
+    expect(logged.some((line) => line.includes("agent terminal"))).toBe(true);
+  });
+
+  test("all steps clean: everything runs once in order, nothing is logged", () => {
+    const ran: string[] = [];
+    const logged: string[] = [];
+    runGuardedShutdown(
+      [
+        ["a", () => ran.push("a")],
+        ["b", () => ran.push("b")],
+      ],
+      () => ran.push("listener"),
+      (message) => logged.push(message),
+    );
+    expect(ran).toEqual(["a", "b", "listener"]);
+    expect(logged).toEqual([]);
   });
 });

--- a/packages/server/annotate.ts
+++ b/packages/server/annotate.ts
@@ -177,6 +177,34 @@ export interface AnnotateServerResult {
 // --- Server Implementation ---
 
 /**
+ * Run shutdown disposal steps with per-step isolation, then close the
+ * listener. One throwing step (agent-terminal teardown is historically
+ * fragile, #1314) must never skip the steps after it — before this guard, a
+ * throw mid-sequence orphaned the live proxy's listener and its upstream
+ * WebSockets. Failures are reported through `log` (stderr by default) with
+ * the step's name; `closeListener` runs unconditionally, even against a
+ * pathological throw outside the steps.
+ */
+export function runGuardedShutdown(
+  steps: ReadonlyArray<readonly [name: string, dispose: () => void]>,
+  closeListener: () => void,
+  log: (message: string, error: unknown) => void = (message, error) =>
+    console.error(message, error),
+): void {
+  try {
+    for (const [name, dispose] of steps) {
+      try {
+        dispose();
+      } catch (error) {
+        log(`[plannotator] annotate shutdown: ${name} disposal failed:`, error);
+      }
+    }
+  } finally {
+    closeListener();
+  }
+}
+
+/**
  * Start the Annotate server
  *
  * Handles:
@@ -1137,17 +1165,25 @@ export async function startAnnotateServer(
   void warmFileListCache(process.cwd(), "code");
 
   const stop = () => {
-    // try/finally: a throwing disposal must never leave the listener bound.
-    try {
-      closeAllFileBrowserWatchers();
-      clientLease.cancel();
-      clientLease.closeSessions();
-      aiRuntime?.dispose();
-      agentTerminal.dispose();
-      liveProxy?.stop();
-    } finally {
-      server.stop();
-    }
+    // Every disposal step is guarded individually (runGuardedShutdown):
+    // agent-terminal teardown is historically fragile (#1314), and in a flat
+    // sequence one throwing step would skip everything after it — notably
+    // liveProxy.stop(), orphaning the live proxy's listener and its upstream
+    // WebSockets. A failed step is reported and the rest still run; the
+    // listener itself closes regardless.
+    runGuardedShutdown(
+      [
+        ["file browser watchers", () => closeAllFileBrowserWatchers()],
+        ["client lease", () => {
+          clientLease.cancel();
+          clientLease.closeSessions();
+        }],
+        ["AI runtime", () => aiRuntime?.dispose()],
+        ["agent terminal", () => agentTerminal.dispose()],
+        ["live proxy", () => liveProxy?.stop()],
+      ],
+      () => server.stop(),
+    );
   };
 
   // Notify caller that server is ready. An async ready handler that rejects

--- a/packages/ui/components/AnnotationToolbar.modeShortcutGuard.test.tsx
+++ b/packages/ui/components/AnnotationToolbar.modeShortcutGuard.test.tsx
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { AnnotationToolbar } from './AnnotationToolbar';
+import { useAnnotationModeShortcuts } from '../shortcuts/plan-review/annotationMode.shortcuts';
+
+/**
+ * Shift+1..4 vs type-to-comment (DOM-gated, #1244 follow-up).
+ *
+ * The annotation-mode shortcuts produce printable characters (! @ # $).
+ * While the annotation toolbar's type-to-comment listener is active (a
+ * selection exists and the toolbar is open), those keys belong to the
+ * comment being started: the failure this guards is Shift+3 ("#") silently
+ * arming Redline while the user thinks they are typing into the toolbar.
+ * With no toolbar open, the shortcuts must keep working.
+ */
+
+const hasDom = typeof document !== 'undefined';
+let root: Root | null = null;
+let host: HTMLElement | null = null;
+let anchor: HTMLElement | null = null;
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  root = null;
+  host?.remove();
+  host = null;
+  anchor?.remove();
+  anchor = null;
+  if (hasDom) document.body.replaceChildren();
+});
+
+function ModeShortcutHost({ onMode }: { onMode: (mode: string) => void }) {
+  useAnnotationModeShortcuts({
+    handlers: {
+      selectMarkupMode: () => onMode('selection'),
+      selectCommentMode: () => onMode('comment'),
+      selectRedlineMode: () => onMode('redline'),
+      selectQuickLabelMode: () => onMode('quickLabel'),
+    },
+  });
+  return null;
+}
+
+function pressShiftDigit(digit: number, key: string): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    code: `Digit${digit}`,
+    shiftKey: true,
+    bubbles: true,
+    cancelable: true,
+  });
+  window.dispatchEvent(event);
+  return event;
+}
+
+async function mount(ui: React.ReactElement): Promise<void> {
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  root = createRoot(host);
+  await act(async () => {
+    root?.render(ui);
+  });
+}
+
+describe.if(hasDom)('annotation-mode shortcuts vs type-to-comment', () => {
+  test('with no toolbar open, Shift+3 switches to redline', async () => {
+    const modes: string[] = [];
+    await mount(<ModeShortcutHost onMode={(m) => modes.push(m)} />);
+    await act(async () => {
+      pressShiftDigit(3, '#');
+    });
+    expect(modes).toEqual(['redline']);
+  });
+
+  test('with the toolbar open, typing "!" starts a comment and does NOT switch mode', async () => {
+    const modes: string[] = [];
+    const commentChars: Array<string | undefined> = [];
+    anchor = document.createElement('p');
+    anchor.textContent = 'annotated paragraph';
+    document.body.appendChild(anchor);
+    await mount(
+      <>
+        <ModeShortcutHost onMode={(m) => modes.push(m)} />
+        <AnnotationToolbar
+          element={anchor}
+          positionMode="center-above"
+          onAnnotate={() => {}}
+          onClose={() => {}}
+          onRequestComment={(initialChar) => commentChars.push(initialChar)}
+        />
+      </>,
+    );
+    expect(document.querySelector('.annotation-toolbar')).not.toBeNull();
+    await act(async () => {
+      pressShiftDigit(1, '!');
+    });
+    // The character reached the comment path with its identity intact...
+    expect(commentChars).toEqual(['!']);
+    // ...and no mode changed underneath the user.
+    expect(modes).toEqual([]);
+  });
+
+  test('closing the toolbar releases the capture: the shortcut works again', async () => {
+    const modes: string[] = [];
+    anchor = document.createElement('p');
+    anchor.textContent = 'annotated paragraph';
+    document.body.appendChild(anchor);
+    const withToolbar = (
+      <>
+        <ModeShortcutHost onMode={(m) => modes.push(m)} />
+        <AnnotationToolbar
+          element={anchor}
+          positionMode="center-above"
+          onAnnotate={() => {}}
+          onClose={() => {}}
+          onRequestComment={() => {}}
+        />
+      </>
+    );
+    await mount(withToolbar);
+    await act(async () => {
+      pressShiftDigit(2, '@');
+    });
+    expect(modes).toEqual([]);
+    // The toolbar unmounts (selection resolved/dismissed): shortcuts return.
+    await act(async () => {
+      root?.render(<ModeShortcutHost onMode={(m) => modes.push(m)} />);
+    });
+    await act(async () => {
+      pressShiftDigit(2, '@');
+    });
+    expect(modes).toEqual(['comment']);
+  });
+});

--- a/packages/ui/components/AnnotationToolbar.tsx
+++ b/packages/ui/components/AnnotationToolbar.tsx
@@ -4,6 +4,7 @@ import { createPortal } from "react-dom";
 import { useDismissOnOutsideAndEscape } from "../hooks/useDismissOnOutsideAndEscape";
 import { type QuickLabel, getQuickLabels } from "../utils/quickLabels";
 import { copyTextToClipboard } from "../utils/clipboard";
+import { acquireTypeToCommentCapture } from "../shortcuts/plan-review/annotationMode.shortcuts";
 import { FloatingQuickLabelPicker } from "./FloatingQuickLabelPicker";
 
 type PositionMode = 'center-above' | 'top-right';
@@ -151,7 +152,14 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
     };
 
     window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
+    // While this listener owns printable keys, the Shift+1..4 annotation-mode
+    // shortcuts must not fire: Shift+3 is "#", and a user typing "#" into a
+    // starting comment must not silently arm Redline (#1244 follow-up).
+    const releaseCapture = acquireTypeToCommentCapture();
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      releaseCapture();
+    };
   }, [onClose, onRequestComment, onQuickLabel, quickLabels, showQuickLabels]);
 
   useDismissOnOutsideAndEscape({

--- a/packages/ui/components/PlanHeaderMenu.tsx
+++ b/packages/ui/components/PlanHeaderMenu.tsx
@@ -40,7 +40,7 @@ interface PlanHeaderMenuProps {
 }
 
 export interface CompactPlanAction {
-  id: 'exit' | 'feedback' | 'approve' | 'copy' | 'done' | 'edit' | 'tools' | 'annotations' | 'ai' | 'review';
+  id: 'exit' | 'feedback' | 'approve' | 'copy' | 'done' | 'edit' | 'tools' | 'annotate' | 'annotations' | 'ai' | 'review';
   label: string;
   subtitle?: string;
   onSelect: () => void;
@@ -359,10 +359,19 @@ const CompactPlanActionIcon = ({ kind }: { kind: CompactPlanAction['id'] }) => {
       </svg>
     );
   }
-  if (kind === 'edit' || kind === 'tools') {
+  if (kind === 'edit' || kind === 'annotate') {
     return (
       <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+      </svg>
+    );
+  }
+  if (kind === 'tools') {
+    // Eye, matching the desktop header's show/hide-tools toggle.
+    return (
+      <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
       </svg>
     );
   }

--- a/packages/ui/components/html-viewer/bridge-script.ts
+++ b/packages/ui/components/html-viewer/bridge-script.ts
@@ -1422,16 +1422,28 @@ export const BRIDGE_SCRIPT = `(function() {
   document.addEventListener('mouseup', function() {
     // Text drag-selection commenting is ALWAYS live: both surfaces, armed or
     // Interact. In armed pinpoint a plain click belongs to the pinpoint
-    // handler — only a REAL drag (>4px with the button held) schedules the
-    // selection pass, so annotateElement's own selection is never re-posted
-    // by its trailing mouseup. Everywhere else the classic always-schedule
-    // behavior stays: handleSelection only acts on a real selection, posts
-    // the clear that dismisses a stale draft, and never preventDefaults —
-    // a plain click is never swallowed.
+    // handler — only a drag that actually PRODUCED a text selection owns its
+    // trailing click, so annotateElement's own selection is never re-posted
+    // by its trailing mouseup. The >4px drift alone is NOT enough to arm the
+    // click suppression: a drifted click (common on trackpads) that selected
+    // nothing must stay a click, or armed pinpoint would silently swallow it
+    // while the unprevented click leaks through to the page. Browsers clear
+    // a prior selection on the mousedown that starts the drag, so the
+    // selection observed here is the one THIS drag produced. Everywhere else
+    // the classic always-schedule behavior stays: handleSelection only acts
+    // on a real selection, posts the clear that dismisses a stale draft, and
+    // never preventDefaults — a plain click is never swallowed.
     var dragged = dragYieldActive;
-    dragEndedClick = dragged;
     endDragYield();
-    if (annotateModeActive && currentInputMethod === 'pinpoint' && !dragged) return;
+    var draggedSelection = false;
+    if (dragged) {
+      try {
+        var s = window.getSelection();
+        draggedSelection = !!(s && !s.isCollapsed && s.rangeCount && (s.toString() || '').trim());
+      } catch (ex) {}
+    }
+    dragEndedClick = draggedSelection;
+    if (annotateModeActive && currentInputMethod === 'pinpoint' && !draggedSelection) return;
     setTimeout(handleSelection, 10);
   }, true);
 
@@ -3018,10 +3030,11 @@ export const BRIDGE_SCRIPT = `(function() {
     // A drag that ended in this click owns the surface: the drag-selection
     // pass is about to post the selected text, and pinpoint-annotating the
     // element under the pointer would clobber it (annotateElement rewrites
-    // the selection). Keyed off the >4px drag arming, not selection state, so
-    // the selection a previous text-element pin left behind never blocks the
-    // next plain re-pin click. One-shot: only the drag's own trailing click
-    // is suppressed.
+    // the selection). Armed at mouseup only when the drag actually produced
+    // a selection — a drifted click arms nothing and pins normally below —
+    // and mousedown clears a prior pin's leftover selection, so stale
+    // selection state never blocks the next plain re-pin click. One-shot:
+    // only the drag's own trailing click is suppressed.
     if (dragEndedClick) { dragEndedClick = false; return; }
     // Shift-click while an ARMED pinpoint draft is open: toggle the element
     // in/out of the SAME draft comment instead of replacing the selection.
@@ -3073,9 +3086,12 @@ export const BRIDGE_SCRIPT = `(function() {
     }
     if (pendingSelection) {
       closePendingDraft();
-    } else if (currentInputMethod === 'pinpoint' && pinpointHover) {
-      clearPinpointHover();
     } else {
+      // Hover-clear is NOT a rung: the hover outline is a pointer
+      // affordance, not a state the user perceives as a step, so clearing
+      // it and exiting to Interact happen on the SAME press. Only an open
+      // draft earns its own press.
+      if (currentInputMethod === 'pinpoint' && pinpointHover) clearPinpointHover();
       postToParent({ type: PREFIX + 'annotate-exit' });
     }
   });

--- a/packages/ui/components/html-viewer/htmlLiveProtocol.test.tsx
+++ b/packages/ui/components/html-viewer/htmlLiveProtocol.test.tsx
@@ -506,6 +506,60 @@ describe.if(hasDom)('live bridge gate (composed body in the eval harness)', () =
     bridgeWindow.getSelection()!.removeAllRanges();
   });
 
+  test('ARMED: a drifted click (>4px travel, no selection) still pinpoint-pins and never reaches the page', async () => {
+    // Trackpad reality: mousedown → a few pixels of travel → mouseup with
+    // nothing selected. The >4px drift alone must not arm the trailing-click
+    // suppression — that regression both swallowed the pin AND let the
+    // unprevented click through to the page.
+    const btn = probeButton();
+    bridgeWindow.getSelection()!.removeAllRanges();
+    let pageClicks = 0;
+    const pageListener = () => { pageClicks += 1; };
+    btn.addEventListener('click', pageListener);
+    try {
+      const before = selectionPosts().length;
+      btn.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 0, clientX: 5, clientY: 5 }));
+      btn.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, cancelable: true, buttons: 1, clientX: 15, clientY: 12 }));
+      btn.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, cancelable: true, button: 0, clientX: 15, clientY: 12 }));
+      const click = new MouseEvent('click', { bubbles: true, cancelable: true, clientX: 15, clientY: 12 });
+      btn.dispatchEvent(click);
+      // The click pinned the element under the pointer...
+      expect(click.defaultPrevented).toBe(true);
+      expect(selectionPosts().length).toBe(before + 1);
+      expect(selectionPosts().at(-1)!.data.pinpoint).toBe(true);
+      // ...and the page's own handler never saw it (capture-phase stop).
+      expect(pageClicks).toBe(0);
+      // No trailing drag-selection pass runs to clear the draft just opened.
+      const clearsBefore = primaryPosts('selection-clear').length;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(primaryPosts('selection-clear').length).toBe(clearsBefore);
+    } finally {
+      btn.removeEventListener('click', pageListener);
+    }
+    postToBridge({ type: 'plannotator-bridge-cancel-selection', token: bridgeToken });
+    bridgeWindow.getSelection()!.removeAllRanges();
+  });
+
+  test('Esc with only a hover outline: hover clears AND annotate-exit posts on the SAME press', () => {
+    // Armed from the previous test, no pending draft. Hover an element so the
+    // pinpoint outline is showing:
+    const btn = probeButton();
+    btn.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, cancelable: true, clientX: 8, clientY: 8 }));
+    const box = bridgeDocument.querySelector<HTMLElement>('[data-plannotator-pinpoint-box]');
+    if (!box) throw new Error('pinpoint hover box missing');
+    expect(box.style.display).toBe('block');
+    const exitsBefore = primaryPosts('annotate-exit').length;
+    const clearsBefore = primaryPosts('selection-clear').length;
+    pressEscape();
+    // One press: the outline is gone AND the exit request went out. Clearing
+    // the outline is not a rung the user perceives — only a draft earns one.
+    expect(box.style.display).toBe('none');
+    expect(primaryPosts('annotate-exit').length).toBe(exitsBefore + 1);
+    expect(primaryPosts('selection-clear').length).toBe(clearsBefore);
+    // The bridge stays armed until the parent answers set-annotate-mode.
+    expect(bridgeDocument.body.hasAttribute('data-plannotator-pinpoint-cursor')).toBe(true);
+  });
+
   test('Esc ladder: a pending draft clears first, then Esc asks to exit Annotate; the parent flips the mode', () => {
     // Armed from the previous test. A fresh pending pinpoint draft:
     const probe = clickProbe(probeButton());
@@ -553,6 +607,30 @@ describe.if(hasDom)('live bridge gate (composed body in the eval harness)', () =
     const native = clickProbe(probeButton());
     expect(native.prevented).toBe(false);
     expect(native.selections).toBe(0);
+  });
+
+  test('INTERACT: a drifted click reaches the page untouched', async () => {
+    // Same trackpad drift as the armed test above, but in Interact the click
+    // belongs to the page: nothing is prevented, nothing posts.
+    const btn = probeButton();
+    bridgeWindow.getSelection()!.removeAllRanges();
+    let pageClicks = 0;
+    const pageListener = () => { pageClicks += 1; };
+    btn.addEventListener('click', pageListener);
+    try {
+      const before = selectionPosts().length;
+      btn.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 0, clientX: 5, clientY: 5 }));
+      btn.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, cancelable: true, buttons: 1, clientX: 15, clientY: 12 }));
+      btn.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, cancelable: true, button: 0, clientX: 15, clientY: 12 }));
+      const click = new MouseEvent('click', { bubbles: true, cancelable: true, clientX: 15, clientY: 12 });
+      btn.dispatchEvent(click);
+      expect(click.defaultPrevented).toBe(false);
+      expect(pageClicks).toBe(1);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(selectionPosts().length).toBe(before);
+    } finally {
+      btn.removeEventListener('click', pageListener);
+    }
   });
 
   test('Mod+Shift+A inside the iframe forwards a toggle request to the parent in both modes', () => {

--- a/packages/ui/shortcuts/plan-review/annotationMode.shortcuts.ts
+++ b/packages/ui/shortcuts/plan-review/annotationMode.shortcuts.ts
@@ -1,5 +1,9 @@
 import { defineShortcutScope } from '../core';
-import { createShortcutScopeHook } from '../runtime';
+import {
+  useShortcutScope,
+  type ShortcutHandlers,
+  type UseShortcutScopeOptions,
+} from '../runtime';
 
 // Shift+digit rather than mnemonic letters: bare letters are swallowed by
 // type-to-comment, bare digits by the label picker, Mod+digit by the browser's
@@ -44,4 +48,44 @@ export const annotationModeShortcuts = defineShortcutScope({
   },
 });
 
-export const useAnnotationModeShortcuts = createShortcutScopeHook(annotationModeShortcuts);
+// --- Type-to-comment capture guard (#1244 follow-up) ---
+// Shift+1..4 produce printable characters (! @ # $). While a surface's
+// type-to-comment listener owns printable keys (a selection exists and the
+// annotation toolbar is open), those characters belong to the comment being
+// started: a mode shortcut firing there both eats the character and silently
+// re-arms the mode (Shift+3 arming Redline mid-thought). The toolbar
+// registers its capture here; the scope hook refuses to dispatch while any
+// capture is held.
+let typeToCommentCaptures = 0;
+
+/**
+ * Held by AnnotationToolbar for the lifetime of its type-to-comment keydown
+ * listener. Returns a release function; releasing more than once is safe.
+ */
+export function acquireTypeToCommentCapture(): () => void {
+  typeToCommentCaptures += 1;
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    typeToCommentCaptures -= 1;
+  };
+}
+
+type AnnotationModeScope = typeof annotationModeShortcuts;
+type AnnotationModeOptions = Omit<UseShortcutScopeOptions<AnnotationModeScope>, 'scope'>;
+
+export function useAnnotationModeShortcuts(options: AnnotationModeOptions): void {
+  const guarded: ShortcutHandlers<AnnotationModeScope> = {};
+  for (const actionId of Object.keys(options.handlers) as Array<keyof typeof options.handlers>) {
+    const handler = options.handlers[actionId];
+    if (!handler) continue;
+    const config = typeof handler === 'function' ? { handle: handler } : handler;
+    guarded[actionId] = {
+      ...config,
+      when: (event: KeyboardEvent) =>
+        typeToCommentCaptures === 0 && (config.when ? config.when(event) : true),
+    };
+  }
+  useShortcutScope({ scope: annotationModeShortcuts, ...options, handlers: guarded });
+}

--- a/packages/ui/utils/parser.test.ts
+++ b/packages/ui/utils/parser.test.ts
@@ -1817,6 +1817,67 @@ describe("exportAnnotations — multi-target raw-HTML comments", () => {
   });
 });
 
+describe("exportAnnotations — live-app page grouping (heading hierarchy)", () => {
+  // Live sessions stamp annotations with the page they were made on; the
+  // export groups entries under per-page headers. The headers must OUTRANK
+  // the entries (## Page over ### N.) or every page section renders nested
+  // under the previous entry.
+  const liveAnn = (num: string, pageUrl?: string, extra: object = {}) => ({
+    blockId: "",
+    startOffset: 0,
+    endOffset: 0,
+    type: "COMMENT",
+    text: `note ${num}`,
+    originalText: `target ${num}`,
+    ...(pageUrl ? { pageUrl } : {}),
+    ...extra,
+  });
+
+  test("page headers are ## and entries demote to ###, so entries nest below their page", () => {
+    const output = exportAnnotations([], [
+      liveAnn("a", "/dashboard"),
+      liveAnn("b", "/dashboard"),
+      liveAnn("c", "/settings"),
+    ]);
+    // Header level outranks entry level.
+    expect(output).toMatch(/^## Page: \/dashboard$/m);
+    expect(output).toMatch(/^## Page: \/settings$/m);
+    expect(output).toMatch(/^### 1\. /m);
+    expect(output).toMatch(/^### 2\. /m);
+    expect(output).toMatch(/^### 3\. /m);
+    expect(output).not.toMatch(/^### Page: /m);
+    expect(output).not.toMatch(/^## \d+\. /m);
+    // Entries sit BELOW the page header they belong to.
+    expect(output.indexOf("## Page: /dashboard")).toBeLessThan(output.indexOf("### 1. "));
+    expect(output.indexOf("### 2. ")).toBeLessThan(output.indexOf("## Page: /settings"));
+    expect(output.indexOf("## Page: /settings")).toBeLessThan(output.indexOf("### 3. "));
+  });
+
+  test("unpaged entries lead at the same ### level, and global numbering survives grouping", () => {
+    const output = exportAnnotations([], [
+      liveAnn("g", undefined, { type: "GLOBAL_COMMENT", originalText: "" }),
+      liveAnn("a", "/b-page"),
+      liveAnn("c", "/a-page"),
+      liveAnn("d", "/b-page"),
+    ]);
+    // The pageless global leads, before any page header, at entry level.
+    expect(output.indexOf("### 1. ")).toBeLessThan(output.indexOf("## Page: "));
+    // Grouping regroups pages by first appearance but keeps the GLOBAL
+    // numbers (matching on-page markers), so /b-page shows 2 and 4.
+    const bPage = output.slice(output.indexOf("## Page: /b-page"), output.indexOf("## Page: /a-page"));
+    expect(bPage).toContain("### 2. ");
+    expect(bPage).toContain("### 4. ");
+  });
+
+  test("without any pageUrl the export keeps its classic ## entries and no page headers", () => {
+    const output = exportAnnotations([], [liveAnn("a"), liveAnn("b")]);
+    expect(output).toMatch(/^## 1\. /m);
+    expect(output).toMatch(/^## 2\. /m);
+    expect(output).not.toContain("Page: ");
+    expect(output).not.toContain("### ");
+  });
+});
+
 describe("parseMarkdownToBlocks — non-markdown plain text (#1029)", () => {
   /**
    * Annotate now accepts YAML/JSON/TOML-style config files and renders them

--- a/packages/ui/utils/parser.ts
+++ b/packages/ui/utils/parser.ts
@@ -1180,12 +1180,15 @@ export const exportAnnotations = (
 
   // Live app sessions stamp annotations with the page they were made on.
   // When any exported annotation carries a pageUrl, entries are grouped under
-  // per-page headings in order of first appearance; annotations without one
-  // (e.g. globals) come first under no heading. Numbers stay GLOBAL: each
-  // entry keeps the number of its position in the ungrouped order, matching
-  // the on-page marker numbering, so grouped sections may show
-  // non-contiguous numbers. With no pageUrl anywhere the output is
-  // byte-identical to the ungrouped export.
+  // per-page `## Page:` headings in order of first appearance and every entry
+  // demotes to `###` so it nests BELOW its page header (a `### Page:` header
+  // over `##` entries would invert the hierarchy); annotations without a page
+  // (e.g. globals) come first under no heading, at the same `###` level so
+  // entries render uniformly. Numbers stay GLOBAL: each entry keeps the
+  // number of its position in the ungrouped order, matching the on-page
+  // marker numbering, so grouped sections may show non-contiguous numbers.
+  // With no pageUrl anywhere the output is byte-identical to the ungrouped
+  // export (`## N.` entries, no page headers).
   const hasPageGroups = sortedAnns.some(
     (a: any) => typeof a.pageUrl === 'string' && a.pageUrl.length > 0,
   );
@@ -1208,10 +1211,10 @@ export const exportAnnotations = (
   let lastEmittedPage: string | null = null;
   emitOrder.forEach((ann) => {
     if (hasPageGroups && ann.pageUrl && ann.pageUrl !== lastEmittedPage) {
-      output += `### Page: ${ann.pageUrl}\n\n`;
+      output += `## Page: ${ann.pageUrl}\n\n`;
       lastEmittedPage = ann.pageUrl;
     }
-    output += `## ${annotationNumbers.get(ann)}. `;
+    output += `${hasPageGroups ? '###' : '##'} ${annotationNumbers.get(ann)}. `;
 
     // Add diff context label if annotation was created in diff view
     if (ann.diffContext) {


### PR DESCRIPTION
Pre-release fix round for v0.28.0: six confirmed QA findings on the HTML/live annotate surface and its export path, three additions from a parallel forensics sweep, plus missing pi-extension resync coverage. All changes branch off origin/main (81ecd67e).

## Findings and fixes

**1. Armed pinpoint: drifted click swallowed AND leaked to the page (regression, root-caused)**
The always-on drag work removed the pinpoint guard from the drag-yield mousedown listener, so pinpoint began arming drag-yield; mouseup then set the trailing-click suppression from >4px drift alone, and the pinpoint click handler consumed it before preventDefault. A trackpad click with a few pixels of travel neither pinned nor stayed off the page. Fixed at the arming site in `bridge-script.ts`: the mouseup handler only arms the trailing-click suppression (and only schedules the drag-selection pass in armed pinpoint) when the drag actually produced a non-empty text selection. Drifted clicks pin normally and are prevented/stopped; real drags keep the selection-toolbar behavior; Interact is untouched. Bridge tests cover all three: drifted click while armed pins and never reaches page handlers, real drag opens the drag selection without a trailing re-pin, drifted click in Interact reaches the page. A Playwright smoke against real Chromium confirms the fix (and reproduces the leak on the pre-fix bridge).

**2. Esc-to-Interact needed two presses when hovering**
Hover-clear is no longer a ladder rung: with no pending draft, one Esc clears the pinpoint hover outline and posts annotate-exit on the same press. Draft-close keeps its own press. Ladder tests updated, plus a new same-press hover test.

**3. Compact/mobile stranding by a toolsHidden cookie** (superseded by addition A below)
Solved together with the armed-mode stranding: the compact Options menu now carries the tools toggle, so the restored cookie stays applied on every layout and always has a way back.

**4. Cold-dev-server silent downgrade**
When the loopback live-app probe fails without `--app`, the fallback to static conversion is kept but now emits one stderr line naming the URL, the probe error, and `--app` as the way to force live mode. Tested via the injectable `log` seam, including the no-notice path for live-eligible probes.

**5. Live-app export heading inversion**
Page group headers were `### Page:` above `## N.` entries, nesting each page under the previous entry. Page-grouped exports now emit `## Page:` headers with `### N.` entries nested below (unpaged entries lead at the same entry level); exports without any pageUrl stay byte-identical to the classic `## N.` format. Export tests added for hierarchy, global numbering across groups, and the unchanged non-live format.

**6. Shift+1-4 shadowing type-to-comment**
While the annotation toolbar's type-to-comment listener owns printable keys, the Shift+1-4 mode shortcuts (`! @ # $`) no longer fire, so typing into a starting comment cannot silently arm Redline. The toolbar acquires a capture in `annotationMode.shortcuts.ts` for the lifetime of its listener; the scope hook refuses to dispatch while any capture is held. Tests cover both directions: shortcut works with no toolbar, and `!` with the toolbar open starts a comment with the character intact and no mode change.

## Forensics sweep additions

**A. Touch/compact devices could not disarm annotate mode (HIGH)**
`htmlAnnotateArmed` defaults true, but the pen and eye toggles are desktop-header-only and Mod+Shift+A is keyboard-only, so on touch every tap annotated and the page beneath was unreachable. The compact Options menu's Document section now carries both affordances, matching the existing compact idiom: "Annotate page"/"Interact with page" (new `annotate` action id, pen icon) and "Show tools"/"Hide tools" (restored `tools` action id, eye icon). This also supersedes finding 3: with a reachable toggle, the `toolsHidden` cookie applies on compact again (desktop parity) instead of being ignored. Tests: compact menu disarms and re-arms the mode (armed ring appears/disappears with no pen present), and a `toolsHidden: true` cookie is undoable through "Show tools".

**B. Live-proxy leak on shutdown (MEDIUM)**
`stop()` disposed the agent terminal before the live proxy in a flat try with only `server.stop()` in finally; a throwing disposal (agent-terminal teardown is historically fragile, see #1314) orphaned the proxy's listener and upstream WebSockets. Every disposal step is now individually guarded via an exported `runGuardedShutdown` helper (failures logged with the step name, later steps and the listener close still run), mirrored inline in the Pi server's stop(). Unit tests: a throwing disposer does not skip later steps or the listener close.

**C. Dropped chrome regression guards (SMALL)**
Re-added the two tests lost in the htmlHideTools to htmlChrome rename, adapted to current behavior: the restore commit never writes stale pre-restore chrome values to the cookie (guards the skipNextHtmlChromeSaveRef/htmlChromeRestoredRef ordering), and the sidebar stays reachable via Mod+B while tools are hidden.

**D. Agent TUI display reset silently overwrote terminal placement (HIGH, state sweep)**
The Display popover's "Reset terminal display settings" button also called onSideChange("left"), durably overwriting a chosen right/hidden placement in config.json even though the label scopes the reset to font/appearance. Placement is a layout preference with its own explicit Position control in the same popover, so the reset now touches display settings only: the button resets exactly the display defaults through the panel's one sanitized update path, and the popover no longer has any code path from reset to the side. The popover is exported with a defaultOpen test seam (the surrounding panel needs a live WebTUI session to render it); tests assert reset restores the display defaults without firing onSideChange, and that the Position control remains the explicit way to change placement.

**Also:** tests for the two `resyncPhaseFromSession` executing-to-idle fallbacks that arm `idleNoticePending` (missing plan file, missing submitted path). Verified by mutation: flipping either arm to `false` fails exactly its new test.

## Verification

- `bun run typecheck` clean
- htmlLiveProtocol, htmlPinpointProtocol, srcdoc, parser/export, shortcut registry, App chrome, toolbar, and agent-terminal display suites green: 1219 pass across `packages/ui` + `packages/editor` (DOM_TESTS=1)
- `apps/hook` + `apps/pi-extension` + annotate/live-proxy server suites green: 537 pass
- Builds: `apps/review` build then `build:hook` succeed
- Guide-viewer rebuilt and manifest re-synced after both commits: hashes did not move, no manifest change
- Playwright smoke (real Chromium, live bridge composition): drifted click while armed posts one pinpoint selection and the page click handler never fires; the same smoke fails on the pre-fix bridge

AI-assisted (Claude) under maintainer direction.

