### PR TITLE
fix(server): live-proxy injection and config write hardening for v0.28.0

### DIFF
--- a/apps/pi-extension/vendored-config-write.test.ts
+++ b/apps/pi-extension/vendored-config-write.test.ts
@@ -1,0 +1,68 @@
+/**
+ * The Pi server shares one ~/.plannotator data dir with whatever Bun-runtime
+ * Plannotator session the user has open, and settles POST /api/config through
+ * the SAME saveConfig — but through the vendored copy in generated/, not the
+ * package under packages/shared. This asserts the write serialization is
+ * actually present on that side of the vendor boundary, so a vendor.sh rule
+ * that stopped copying it (or a Pi-only reimplementation) fails here rather
+ * than in a user's config file.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  loadConfig,
+  saveConfig,
+  getConfigLockPath,
+  isAgentTerminalSide,
+  __setConfigSaveMergeWindowHookForTest,
+  __setConfigLockTimingsForTest,
+} from "./generated/config.ts";
+
+describe("vendored config write path", () => {
+  const originalDataDir = process.env.PLANNOTATOR_DATA_DIR;
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "plannotator-pi-config-"));
+    process.env.PLANNOTATOR_DATA_DIR = tempDir;
+  });
+
+  afterEach(() => {
+    __setConfigSaveMergeWindowHookForTest(null);
+    __setConfigLockTimingsForTest(null);
+    if (originalDataDir !== undefined) {
+      process.env.PLANNOTATOR_DATA_DIR = originalDataDir;
+    } else {
+      delete process.env.PLANNOTATOR_DATA_DIR;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test("saveConfig holds the same advisory lock across its read-merge-write", () => {
+    const lockPath = getConfigLockPath();
+    expect(lockPath).toBe(join(tempDir, "config.json.lock"));
+
+    let lockedDuringMerge = false;
+    __setConfigSaveMergeWindowHookForTest(() => {
+      lockedDuringMerge = existsSync(lockPath);
+    });
+    saveConfig({ agentTerminalSide: "right" });
+
+    expect(lockedDuringMerge).toBe(true);
+    expect(existsSync(lockPath)).toBe(false);
+    expect(loadConfig().agentTerminalSide).toBe("right");
+  });
+
+  test("the side guard the annotate endpoint uses accepts exactly the core sides", () => {
+    // serverAnnotate.ts gates POST /api/config on this; it now delegates to
+    // the single definition vendored from @plannotator/core.
+    expect(isAgentTerminalSide("left")).toBe(true);
+    expect(isAgentTerminalSide("right")).toBe(true);
+    expect(isAgentTerminalSide("hidden")).toBe(true);
+    expect(isAgentTerminalSide("top")).toBe(false);
+    expect(isAgentTerminalSide(undefined)).toBe(false);
+  });
+});

--- a/packages/server/annotate.test.ts
+++ b/packages/server/annotate.test.ts
@@ -16,9 +16,10 @@
 
 import { afterAll, afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, realpathSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { tmpdir } from "os";
 import { join, resolve } from "path";
-import { startAnnotateServer } from "./annotate";
+import { startAnnotateServer, liveAppDraftIdentity } from "./annotate";
 import { getServerConfig, loadConfig } from "./config";
 import { deriveAnnotateHistorySlug } from "@plannotator/shared/annotate-history";
 import { getPlannotatorDataDir } from "@plannotator/shared/data-dir";
@@ -1969,6 +1970,127 @@ describe("annotate server: live app mode (annotate-app)", () => {
     }
     expect(closed).toBe(true);
     app.stop(true);
+  });
+
+  describe("draft isolation between live sessions", () => {
+    // A live session holds no document text (markdown is "" by construction),
+    // so keying its draft by content gave every live session on the machine
+    // the one hash of the empty string: two sessions against different dev
+    // servers shared a single draft slot and overwrote each other.
+    const savedDataDir = process.env.PLANNOTATOR_DATA_DIR;
+    let draftDataDir: string;
+
+    beforeEach(() => {
+      draftDataDir = mkdtempSync(join(tmpdir(), "plannotator-live-draft-"));
+      process.env.PLANNOTATOR_DATA_DIR = draftDataDir;
+    });
+
+    afterEach(() => {
+      if (savedDataDir === undefined) delete process.env.PLANNOTATOR_DATA_DIR;
+      else process.env.PLANNOTATOR_DATA_DIR = savedDataDir;
+      rmSync(draftDataDir, { recursive: true, force: true });
+    });
+
+    async function saveDraft(server: { url: string }, feedback: string): Promise<void> {
+      const res = await fetch(`${server.url}/api/draft`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ feedback, annotations: [] }),
+      });
+      expect(res.status).toBe(200);
+    }
+
+    async function loadDraft(server: { url: string }): Promise<{ feedback?: string } | null> {
+      const res = await fetch(`${server.url}/api/draft`);
+      if (res.status === 404) return null;
+      expect(res.status).toBe(200);
+      return (await res.json()) as { feedback?: string };
+    }
+
+    test("two live sessions on different targets keep independent drafts", async () => {
+      const appX = startFakeApp();
+      const appY = startFakeApp();
+      const serverX = await startLiveServer(`http://127.0.0.1:${appX.port}`);
+      const serverY = await startLiveServer(`http://127.0.0.1:${appY.port}`);
+      try {
+        await saveDraft(serverX, "notes for X");
+        await saveDraft(serverY, "notes for Y");
+
+        // Neither session sees the other's text, in either direction.
+        expect((await loadDraft(serverX))?.feedback).toBe("notes for X");
+        expect((await loadDraft(serverY))?.feedback).toBe("notes for Y");
+        expect(readdirSync(join(draftDataDir, "drafts")).length).toBe(2);
+      } finally {
+        serverX.stop();
+        serverY.stop();
+        appX.stop(true);
+        appY.stop(true);
+      }
+    });
+
+    test("the same target recovers its draft after a restart", async () => {
+      const app = startFakeApp();
+      const targetUrl = `http://127.0.0.1:${app.port}`;
+      const first = await startLiveServer(targetUrl);
+      try {
+        await saveDraft(first, "survives the crash");
+      } finally {
+        first.stop();
+      }
+      // Same target, spelled with a trailing slash the way a browser would
+      // hand it back: the draft is the point of the key, so it must survive.
+      const second = await startLiveServer(`${targetUrl}/`);
+      try {
+        expect((await loadDraft(second))?.feedback).toBe("survives the crash");
+      } finally {
+        second.stop();
+        app.stop(true);
+      }
+    });
+
+    test("live identities separate distinct targets and are stable across spellings", () => {
+      const a = liveAppDraftIdentity("http://127.0.0.1:5173");
+      expect(liveAppDraftIdentity("http://127.0.0.1:5173/")).toBe(a);
+      expect(liveAppDraftIdentity("http://127.0.0.1:5174")).not.toBe(a);
+      // Different pages of one app are different targets, and stay so.
+      expect(liveAppDraftIdentity("http://127.0.0.1:5173/admin")).not.toBe(a);
+      expect(liveAppDraftIdentity("http://127.0.0.1:5173/admin/")).toBe(
+        liveAppDraftIdentity("http://127.0.0.1:5173/admin"),
+      );
+      // Unparseable input still yields a per-target value rather than throwing.
+      expect(liveAppDraftIdentity("not a url")).toBe("not a url");
+    });
+  });
+
+  test("classic file annotate still keys its draft by content", async () => {
+    // The live fix must not move any existing draft: a file session's key is
+    // the hash of its markdown, exactly as before, so drafts written by an
+    // earlier release are still found.
+    const savedDataDir = process.env.PLANNOTATOR_DATA_DIR;
+    const dataDir = mkdtempSync(join(tmpdir(), "plannotator-file-draft-"));
+    process.env.PLANNOTATOR_DATA_DIR = dataDir;
+    const markdown = "# Doc\n\nbody text\n";
+    const server = await startAnnotateServer({
+      markdown,
+      filePath: join(dataDir, "doc.md"),
+      htmlContent: MINIMAL_HTML,
+      mode: "annotate",
+    });
+    try {
+      const res = await fetch(`${server.url}/api/draft`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ feedback: "file note", annotations: [] }),
+      });
+      expect(res.status).toBe(200);
+      const expectedKey = createHash("sha256").update(markdown).digest("hex").slice(0, 16);
+      expect(existsSync(join(dataDir, "drafts", `${expectedKey}.json`))).toBe(true);
+    } finally {
+      server.stop();
+      if (savedDataDir === undefined) delete process.env.PLANNOTATOR_DATA_DIR;
+      else process.env.PLANNOTATOR_DATA_DIR = savedDataDir;
+      rmSync(dataDir, { recursive: true, force: true });
+    }
   });
 
   test("remote mode rejects live app sessions outright", async () => {

--- a/packages/server/annotate.ts
+++ b/packages/server/annotate.ts
@@ -177,6 +177,27 @@ export interface AnnotateServerResult {
 // --- Server Implementation ---
 
 /**
+ * Stable identity for a live app session's annotation draft.
+ *
+ * A live session's draft has to key off WHICH APP is being annotated, since
+ * the session holds no document text of its own. Normalizing through the URL
+ * parser first so the same dev server recovers its draft when the target is
+ * spelled slightly differently on a later run (a trailing slash, an uppercase
+ * host, an explicit :80). Unparseable values fall back to the trimmed string:
+ * a target that never reached the URL parser cannot have started a proxy
+ * anyway, and a per-target key that is merely raw is still per-target.
+ */
+export function liveAppDraftIdentity(targetUrl: string): string {
+  try {
+    const url = new URL(targetUrl);
+    const path = url.pathname.replace(/\/+$/, "");
+    return `${url.origin}${path}${url.search}`;
+  } catch {
+    return targetUrl.trim();
+  }
+}
+
+/**
  * Start the Annotate server
  *
  * Handles:
@@ -290,10 +311,23 @@ export async function startAnnotateServer(
     folderAnnotateHistoryCache.set(resolvedFilePath, result);
     return result;
   }
+  // Draft identity. Content-derived for the modes that HAVE content, and
+  // path-derived for the modes that do not.
+  //
+  // A live app session has no document body at all: annotate-app resolves
+  // `markdown` to "" by construction, because the page lives behind the
+  // proxy rather than in a string the server holds. Hashing that empty body
+  // gave EVERY live session on the machine the one hash of "", so two
+  // sessions against different dev servers shared a single draft slot and
+  // deterministically overwrote each other's in-progress annotations. The
+  // session's target is its identity here, exactly as the folder path is the
+  // folder session's identity.
   const draftSource =
-    mode === "annotate-folder" && folderPath
-      ? `folder:${resolvePath(folderPath)}`
-      : renderHtml && rawHtml ? rawHtml : markdown;
+    mode === "annotate-app" && liveApp
+      ? `annotate-app\0${liveAppDraftIdentity(liveApp.targetUrl)}`
+      : mode === "annotate-folder" && folderPath
+        ? `folder:${resolvePath(folderPath)}`
+        : renderHtml && rawHtml ? rawHtml : markdown;
   const draftKey = contentHash(draftSource);
 
   // Durable submit records (#678): the caller consuming waitForDecision() may

--- a/packages/server/live-proxy.test.ts
+++ b/packages/server/live-proxy.test.ts
@@ -31,6 +31,7 @@ const EDITOR_ORIGINS = ["http://localhost:4100", "http://127.0.0.1:4100"];
 
 const HTML_PAGE = "<!doctype html><html><head><title>Fake App</title><link rel=\"stylesheet\" href=\"/style.css\"></head><body><div id=\"root\">hi</div><script src=\"/asset.js\"></script></body></html>";
 const NO_HEAD_PAGE = "<html><body><p>bare</p></body></html>";
+const BANNER_COMMENT_PAGE = "<!doctype html><!-- @generated: do not edit <head> manually --><html><head><title>Gen</title></head><body>ok</body></html>";
 const BINARY_BYTES = new Uint8Array([0, 1, 2, 3, 250, 251, 252, 253, 254, 255]);
 
 let upstreamHits: string[] = [];
@@ -93,6 +94,32 @@ beforeAll(() => {
           });
           return new Response(stream, { headers: { "Content-Type": "text/html" } });
         }
+        case "/banner-comment":
+          // Codegen banner naming <head> inside a comment BEFORE the real
+          // head: injecting into the comment ships a bridge the browser
+          // never executes, and annotation breaks with no warning at all.
+          return new Response(BANNER_COMMENT_PAGE, {
+            headers: { "Content-Type": "text/html" },
+          });
+        case "/chunked-banner-comment": {
+          // The same banner, with the stream split inside the comment.
+          const parts = ["<!-- do not edit <he", "ad> by hand --><html><head><title>c</title></head><body>ok</body></html>"];
+          const stream = new ReadableStream<Uint8Array>({
+            async start(controller) {
+              for (const part of parts) {
+                controller.enqueue(new TextEncoder().encode(part));
+                await Bun.sleep(10);
+              }
+              controller.close();
+            },
+          });
+          return new Response(stream, { headers: { "Content-Type": "text/html" } });
+        }
+        case "/uppercase-content-type":
+          // Media types are case-insensitive: this is HTML.
+          return new Response(HTML_PAGE, {
+            headers: { "Content-Type": "TEXT/HTML; charset=UTF-8", "X-Frame-Options": "DENY" },
+          });
         case "/asset.js":
           recordedHeaders["asset-accept-encoding"] = req.headers.get("accept-encoding");
           return new Response("console.log('asset');", {
@@ -224,6 +251,31 @@ describe("live proxy: HTML injection", () => {
     const html = await (await fetch(proxyUrl("/chunked-head-close"))).text();
     expect(html.split(INJECT_TAG).length - 1).toBe(1);
     expect(html).toContain(`${INJECT_TAG}</head>`);
+  });
+
+  test("a comment naming <head> before the real head does not capture the injection", async () => {
+    const html = await (await fetch(proxyUrl("/banner-comment"))).text();
+    expect(html.split(INJECT_TAG).length - 1).toBe(1);
+    // The tag lands after the REAL head open tag, not inside the banner.
+    expect(html).toContain(`<html><head>${INJECT_TAG}`);
+    expect(html.indexOf(INJECT_TAG)).toBeGreaterThan(html.indexOf("-->"));
+    expect(html.replace(INJECT_TAG, "")).toBe(BANNER_COMMENT_PAGE);
+  });
+
+  test("a comment split across chunks is still skipped whole", async () => {
+    const html = await (await fetch(proxyUrl("/chunked-banner-comment"))).text();
+    expect(html.split(INJECT_TAG).length - 1).toBe(1);
+    expect(html).toContain(`<head>${INJECT_TAG}`);
+    expect(html.indexOf(INJECT_TAG)).toBeGreaterThan(html.indexOf("-->"));
+  });
+
+  test("an uppercase TEXT/HTML content type is still injected and reframed", async () => {
+    const res = await fetch(proxyUrl("/uppercase-content-type"));
+    const html = await res.text();
+    expect(html.split(INJECT_TAG).length - 1).toBe(1);
+    // The framing rewrites ride on the same content-type test.
+    expect(res.headers.get("x-frame-options")).toBeNull();
+    expect(res.headers.get("content-security-policy")).toContain("frame-ancestors");
   });
 
   test("content-length is not present (or correct) on injected responses", async () => {
@@ -442,6 +494,20 @@ describe("live proxy: security posture", () => {
     expect(upstreamHits).toEqual([]);
   });
 
+  test("a Host-less HTTP/1.0 request gets the plain 403, never a runtime error page", async () => {
+    // With no Host header req.url is a bare "/", so constructing a URL from it
+    // throws. Doing that before the Host check served Bun's internal debug
+    // page (tens of KB, with a stack trace) from a port whose entire contract
+    // is refusing requests that do not name it.
+    upstreamHits = [];
+    const raw = await rawHttpRequest(proxy.port, ["GET / HTTP/1.0"]);
+    expect(raw.head.startsWith("http/1.0 403") || raw.head.startsWith("http/1.1 403")).toBe(true);
+    const body = Buffer.from(raw.body).toString("utf-8");
+    expect(body).toBe("Forbidden");
+    expect(raw.head).toContain("text/plain");
+    expect(upstreamHits).toEqual([]);
+  });
+
   test("the proxy origin and bind are loopback, independent of PLANNOTATOR_REMOTE", () => {
     expect(proxy.origin).toBe(`http://127.0.0.1:${proxy.port}`);
     // The bind is a source-level contract: the literal loopback constant,
@@ -570,6 +636,64 @@ describe("live proxy: unit helpers", () => {
     expect(rewriteLoopbackLocation("/relative", target, proxyOrigin)).toBeNull();
   });
 
+  test("createHtmlInjector ignores head markers inside comments and declarations", () => {
+    // Each input pairs a decoy in an ignored span with the real head, so a
+    // scanner that is not span-aware injects into bytes the browser drops.
+    const cases: { html: string; expected: string }[] = [
+      // Comment before the real head open tag (the reported codegen banner).
+      {
+        html: "<!-- do not edit <head> --><html><head><title>t</title></head></html>",
+        expected: "<!-- do not edit <head> --><html><head><INJ><title>t</title></head></html>",
+      },
+      // Decoy </head> in a comment, real </head> with no head open tag.
+      {
+        html: "<html><!-- </head> --><body>x</body></head></html>",
+        expected: "<html><!-- </head> --><body>x</body><INJ></head></html>",
+      },
+      // Legacy --!> comment terminator.
+      {
+        html: "<!-- <head> --!><html><head>a</head></html>",
+        expected: "<!-- <head> --!><html><head><INJ>a</head></html>",
+      },
+      // Bogus comment / CDATA-ish: the HTML parser ends it at the first '>',
+      // which is the one inside the decoy, so the decoy is hidden either way.
+      {
+        html: "<![CDATA[<head>]]><html><head>a</head></html>",
+        expected: "<![CDATA[<head>]]><html><head><INJ>a</head></html>",
+      },
+      // Consecutive comments, and a comment AFTER the injection point is
+      // simply passed through.
+      {
+        html: "<!--a--><!--<head>--><head x><!--<head>--></head>",
+        expected: "<!--a--><!--<head>--><head x><INJ><!--<head>--></head>",
+      },
+    ];
+    for (const { html, expected } of cases) {
+      expect(runInjector(html, [html.length])).toBe(expected);
+    }
+  });
+
+  test("createHtmlInjector: comments survive every chunk boundary", () => {
+    // The scanner holds back a fixed tail across chunks, so every split point
+    // through a comment open, its body, its terminator and the head marker
+    // after it must produce the identical single injection.
+    const html = "<!doctype html><!-- gen: keep <head> as is --><html><head lang=\"en\"><title>t</title></head><body>b</body></html>";
+    const expected = html.replace("<head lang=\"en\">", "<head lang=\"en\"><INJ>");
+    for (let split = 0; split <= html.length; split++) {
+      expect(runInjector(html, [split, html.length])).toBe(expected);
+    }
+    // And byte-at-a-time, the worst case for a holdback-based scanner.
+    expect(runInjector(html, html.split("").map((_, i) => i + 1))).toBe(expected);
+  });
+
+  test("createHtmlInjector falls back to appending when a comment never closes", () => {
+    // Degenerate input: an unterminated comment swallows the rest of the
+    // document, so there is no live injection point left. Appending keeps the
+    // existing no-marker behavior rather than dropping the bridge silently.
+    const html = "<html><!-- oops <head><body>x</body></html>";
+    expect(runInjector(html, [html.length])).toBe(html + "<INJ>");
+  });
+
   test("createHtmlInjector does not treat <header> as a head open tag", () => {
     const injector = createHtmlInjector("<INJ>");
     const out: string[] = [];
@@ -582,6 +706,32 @@ describe("live proxy: unit helpers", () => {
     expect(html).toBe("<html><body><header>x</header></body></html><INJ>");
   });
 });
+
+/**
+ * Feed `html` through a fresh injector, cut at the given cumulative byte
+ * offsets, and return the reassembled output. Concatenating before decoding
+ * matters: a cut can land inside a multi-byte character.
+ */
+function runInjector(html: string, cuts: number[]): string {
+  const injector = createHtmlInjector("<INJ>");
+  const bytes = new TextEncoder().encode(html);
+  const out: Uint8Array[] = [];
+  let prev = 0;
+  for (const cut of cuts) {
+    const end = Math.min(cut, bytes.length);
+    if (end > prev) out.push(...injector.push(bytes.subarray(prev, end)));
+    prev = end;
+  }
+  if (prev < bytes.length) out.push(...injector.push(bytes.subarray(prev)));
+  out.push(...injector.flush());
+  const merged = new Uint8Array(out.reduce((n, p) => n + p.length, 0));
+  let cursor = 0;
+  for (const part of out) {
+    merged.set(part, cursor);
+    cursor += part.length;
+  }
+  return new TextDecoder().decode(merged);
+}
 
 /** Minimal raw HTTP/1.1 client: needed to send a forged Host header and to
  * observe exact relayed bytes without fetch's transparent decompression. */

--- a/packages/server/live-proxy.ts
+++ b/packages/server/live-proxy.ts
@@ -139,17 +139,50 @@ export function isDocumentIntentRequest(headers: Headers): boolean {
 // Byte-level scan (the markers are ASCII, safe in UTF-8) holding back at most
 // 8 bytes across chunk boundaries; a head open tag split across chunks is
 // handled by a state machine rather than unbounded buffering.
+//
+// The scan is comment-aware. Head markers that appear inside a comment are
+// not head markers: a codegen banner like
+//   <!-- generated file; do not edit <head> by hand -->
+// preceding the real document head used to swallow the bridge into a span the
+// browser never executes, so annotation broke with no diagnostic at all. The
+// scanner therefore skips three kinds of ignored span before matching:
+//   - comments:            <!-- ... -->  (also the legacy --!> terminator)
+//   - markup declarations
+//     and bogus comments:  <!...>  (DOCTYPE, CDATA-ish <![CDATA[ ... )
+//   - processing-instruction-ish bogus comments: <?...>
+// The last two end at the first ">", which is exactly how the HTML parser
+// treats them outside foreign content, so `<![CDATA[<head>]]>` hides the same
+// bytes here as it does in a browser.
+//
+// Honestly out of scope: raw-text element contents are NOT tracked, so a
+// literal "<!--" inside a <script> or <style> string that precedes the head
+// markers is read as a comment open. Reaching that requires script/style
+// content before the document head (invalid in the head-open case, since the
+// scan stops at the first <head), and the degraded outcome is the existing
+// no-marker fallback (injection appended at end of stream) rather than a
+// silent injection into dead bytes. Conditional comments and unterminated
+// comments degrade the same way.
 
 const HEAD_OPEN = "<head";
 const HEAD_CLOSE = "</head>";
+const COMMENT_OPEN = "<!--";
+const GT = 0x3e; /* > */
+const LT = 0x3c; /* < */
+const BANG = 0x21; /* ! */
+const QUESTION = 0x3f; /* ? */
+const HYPHEN = 0x2d; /* - */
+/** Longest marker the scan must be able to defer is "</head>" (7 bytes), so
+ * holding back 8 keeps every partial marker available for the next chunk. */
 const HOLDBACK = 8;
 
-type InjectorState = "searching" | "in-head-open-tag" | "done";
+type InjectorState = "searching" | "in-ignored-span" | "in-head-open-tag" | "done";
 
 export function createHtmlInjector(injection: string) {
   const encoder = new TextEncoder();
   const injectionBytes = encoder.encode(injection);
   let state: InjectorState = "searching";
+  /** While in-ignored-span: "comment" ends at --> / --!>, "gt" ends at >. */
+  let ignoredSpanKind: "comment" | "gt" = "comment";
   let carry = new Uint8Array(0);
 
   function concat(a: Uint8Array, b: Uint8Array): Uint8Array {
@@ -183,6 +216,44 @@ export function createHtmlInjector(injection: string) {
       || byte === 0x0d;
   }
 
+  /**
+   * Classify an ignored span starting at a '<'. Returns null when this is not
+   * one, or when the buffer does not yet hold enough bytes to tell "<!--" from
+   * a bogus comment: undecided positions fall through to the holdback and are
+   * re-examined against the next chunk.
+   */
+  function ignoredSpanAt(
+    buf: Uint8Array,
+    i: number,
+  ): { kind: "comment" | "gt"; openLength: number } | null {
+    const next = buf[i + 1];
+    if (next === undefined) return null; // undecided: defer
+    if (next === QUESTION) return { kind: "gt", openLength: 2 };
+    if (next !== BANG) return null;
+    if (matchesAt(buf, i, COMMENT_OPEN)) return { kind: "comment", openLength: COMMENT_OPEN.length };
+    // "<!" that is not yet known to be "<!--" (chunk ends mid-marker): defer.
+    if (i + COMMENT_OPEN.length > buf.length) return null;
+    return { kind: "gt", openLength: 2 };
+  }
+
+  /**
+   * End of the ignored span that is currently open, or -1 when this buffer
+   * does not contain it yet. Comments accept the legacy "--!>" terminator
+   * alongside "-->", matching the HTML parser's comment end states.
+   */
+  function ignoredSpanEnd(buf: Uint8Array, from: number): number {
+    if (ignoredSpanKind === "gt") {
+      const gt = buf.indexOf(GT, from);
+      return gt === -1 ? -1 : gt + 1;
+    }
+    for (let i = from; i + 2 < buf.length; i++) {
+      if (buf[i] !== HYPHEN || buf[i + 1] !== HYPHEN) continue;
+      if (buf[i + 2] === GT) return i + 3;
+      if (buf[i + 2] === BANG && buf[i + 3] === GT) return i + 4;
+    }
+    return -1;
+  }
+
   /** Process buffered bytes, returning output and retaining a small carry. */
   function scan(buf: Uint8Array, flush: boolean): Uint8Array[] {
     const out: Uint8Array[] = [];
@@ -190,11 +261,10 @@ export function createHtmlInjector(injection: string) {
 
     while (cursor < buf.length && state !== "done") {
       if (state === "in-head-open-tag") {
-        const gt = buf.indexOf(0x3e, cursor);
+        const gt = buf.indexOf(GT, cursor);
         if (gt === -1) {
           out.push(buf.subarray(cursor));
           cursor = buf.length;
-          buf = new Uint8Array(0);
           break;
         }
         out.push(buf.subarray(cursor, gt + 1));
@@ -204,10 +274,33 @@ export function createHtmlInjector(injection: string) {
         break;
       }
 
+      if (state === "in-ignored-span") {
+        // Comment / declaration bytes pass through verbatim; only the search
+        // for head markers is suspended until the span closes.
+        const end = ignoredSpanEnd(buf, cursor);
+        if (end === -1) break; // need more bytes: holdback below
+        out.push(buf.subarray(cursor, end));
+        cursor = end;
+        state = "searching";
+        continue;
+      }
+
       // searching: look for the earliest full or partial marker.
       let emitted = false;
       for (let i = cursor; i < buf.length; i++) {
-        if (lowerAt(buf, i) !== 0x3c /* < */) continue;
+        if (buf[i] !== LT) continue;
+        // Comments and declarations hide whatever they contain, head markers
+        // included: enter the span before testing for head markers.
+        const ignored = ignoredSpanAt(buf, i);
+        if (ignored) {
+          const openEnd = i + ignored.openLength;
+          out.push(buf.subarray(cursor, openEnd));
+          cursor = openEnd;
+          ignoredSpanKind = ignored.kind;
+          state = "in-ignored-span";
+          emitted = true;
+          break;
+        }
         // Full </head> (no head open tag seen): inject before it.
         if (matchesAt(buf, i, HEAD_CLOSE)) {
           out.push(buf.subarray(cursor, i));
@@ -249,8 +342,11 @@ export function createHtmlInjector(injection: string) {
       return out;
     }
 
-    // searching: hold back the trailing bytes that could begin a marker.
+    // searching / in-ignored-span: hold back the trailing bytes that could be
+    // a partial marker ("</hea", "<!-", "--"), so the next chunk re-reads them.
     if (flush) {
+      // Stream ended with no usable head marker (including inside an
+      // unterminated comment): append rather than drop the bridge.
       out.push(buf.subarray(cursor));
       out.push(injectionBytes);
       state = "done";
@@ -328,11 +424,24 @@ export function startLiveAppProxy(opts: LiveAppProxyOptions): LiveAppProxy {
     idleTimeout: 0,
 
     async fetch(req, srv) {
-      const url = new URL(req.url);
-
-      // Host validation first: anything not naming this loopback proxy is
-      // refused before any upstream contact or upgrade.
+      // Host validation FIRST, before req.url is even parsed: an HTTP/1.0
+      // request with no Host header leaves req.url a bare "/", and letting
+      // `new URL` throw on it hands the client Bun's ~67KB internal error
+      // page (stack trace and all) from a port whose whole contract is that
+      // it refuses anything not naming this loopback proxy. The invariant is
+      // "Host validation runs before any upstream contact" for ALL inputs,
+      // well-formed or not.
       if (!isAllowedProxyHost(req.headers.get("host"), srv.port!)) {
+        return new Response("Forbidden", { status: 403, headers: { "Content-Type": "text/plain" } });
+      }
+
+      // A Host that passed the check should always yield a parseable URL, but
+      // parsing must not be the thing that decides: an unparseable request
+      // takes the same refusal path rather than any error page.
+      let url: URL;
+      try {
+        url = new URL(req.url);
+      } catch {
         return new Response("Forbidden", { status: 403, headers: { "Content-Type": "text/plain" } });
       }
 
@@ -433,7 +542,11 @@ export function startLiveAppProxy(opts: LiveAppProxyOptions): LiveAppProxy {
         if (rewritten !== null) responseHeaders.set("location", rewritten);
       }
 
-      const contentType = responseHeaders.get("content-type") ?? "";
+      // Media types are case-insensitive (RFC 9110 8.3): a dev server that
+      // answers "TEXT/HTML" is serving HTML, and a case-sensitive test would
+      // silently skip both the bridge injection and the framing-header
+      // rewrites for it.
+      const contentType = (responseHeaders.get("content-type") ?? "").toLowerCase();
       const isHtml = contentType.includes("text/html");
 
       if (isHtml) {

--- a/packages/shared/config.test.ts
+++ b/packages/shared/config.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test, beforeEach, afterEach, afterAll, spyOn } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  mkdirSync,
+  writeFileSync,
+  openSync,
+  closeSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -19,6 +27,8 @@ import {
   resolveGuideShareUrl,
   resolveSharingEnabled,
   DEFAULT_GUIDE_SHARE_URL,
+  __setConfigLockTimingsForTest,
+  __setConfigSaveMergeWindowHookForTest,
 } from "./config";
 import type { PlannotatorConfig } from "./config";
 
@@ -376,6 +386,163 @@ describe("favicon config persistence", () => {
     expect(getServerConfig(null).favicon).toBeUndefined();
   });
 });
+
+describe("saveConfig write serialization", () => {
+  const originalDataDir = process.env.PLANNOTATOR_DATA_DIR;
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "plannotator-config-lock-"));
+    process.env.PLANNOTATOR_DATA_DIR = tempDir;
+  });
+
+  afterEach(() => {
+    __setConfigSaveMergeWindowHookForTest(null);
+    __setConfigLockTimingsForTest(null);
+    if (originalDataDir !== undefined) {
+      process.env.PLANNOTATOR_DATA_DIR = originalDataDir;
+    } else {
+      delete process.env.PLANNOTATOR_DATA_DIR;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test("holds an exclusive lock across the whole read-merge-write, and releases it", () => {
+    // The lost update the lock exists to stop happens between the read and
+    // the write, so that is exactly the window mutual exclusion has to cover.
+    const lockPath = join(tempDir, "config.json.lock");
+    let observedInsideWindow: { exists: boolean; exclusiveCreateFailed: boolean } | null = null;
+    __setConfigSaveMergeWindowHookForTest(() => {
+      let exclusiveCreateFailed = false;
+      try {
+        closeSync(openSync(lockPath, "wx"));
+      } catch (e) {
+        exclusiveCreateFailed = (e as NodeJS.ErrnoException).code === "EEXIST";
+      }
+      observedInsideWindow = { exists: existsSync(lockPath), exclusiveCreateFailed };
+    });
+
+    saveConfig({ displayName: "held" });
+
+    expect(observedInsideWindow).toEqual({ exists: true, exclusiveCreateFailed: true });
+    expect(existsSync(lockPath)).toBe(false);
+    expect(loadConfig().displayName).toBe("held");
+  });
+
+  test("concurrent saves in one process all land", async () => {
+    await Promise.all([
+      (async () => saveConfig({ displayName: "a" }))(),
+      (async () => saveConfig({ conventionalComments: true }))(),
+      (async () => saveConfig({ favicon: "classic" }))(),
+    ]);
+    const cfg = loadConfig();
+    expect(cfg.displayName).toBe("a");
+    expect(cfg.conventionalComments).toBe(true);
+    expect(cfg.favicon).toBe("classic");
+  });
+
+  test("a lock left behind by a dead writer is taken over, not waited out", () => {
+    const lockPath = join(tempDir, "config.json.lock");
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(lockPath, "999999 dead\n");
+    // Ancient by the shipping stale window; no timing dependence in the test.
+    __setConfigLockTimingsForTest({ staleMs: 0, waitBudgetMs: 5000 });
+
+    saveConfig({ displayName: "after-takeover" });
+
+    expect(loadConfig().displayName).toBe("after-takeover");
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  test("a lock that never frees is waited out, then written past with a warning", () => {
+    // Deadlock is the one outcome worse than a lost update: a lock that stays
+    // fresh forever must cost a bounded wait and a warning, not a hung server.
+    const lockPath = join(tempDir, "config.json.lock");
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(lockPath, "1 forever\n");
+    __setConfigLockTimingsForTest({ staleMs: 60_000, waitBudgetMs: 30 });
+
+    const writes: string[] = [];
+    const spy = spyOn(process.stderr, "write").mockImplementation(((chunk: unknown) => {
+      writes.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write);
+    const startedAt = Date.now();
+    try {
+      saveConfig({ displayName: "not-blocked" });
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(Date.now() - startedAt).toBeLessThan(3000);
+    expect(loadConfig().displayName).toBe("not-blocked");
+    expect(writes.some((w) => w.includes("config.json lock unavailable"))).toBe(true);
+    // Someone else's lock is left for them.
+    expect(existsSync(lockPath)).toBe(true);
+  });
+
+  test("two processes sharing a data dir do not drop each other's keys", async () => {
+    // The reported race: one annotate server and one review server settling
+    // POST /api/config at the same time. Ordering here is barrier-driven, not
+    // sleep-driven: the holder announces the lock, the contender announces it
+    // has started, and only then is the holder released.
+    const scriptPath = join(tempDir, "writer.ts");
+    writeFileSync(
+      scriptPath,
+      `import { saveConfig, __setConfigSaveMergeWindowHookForTest, __setConfigLockTimingsForTest } from ${JSON.stringify(join(import.meta.dir, "config.ts"))};
+import { existsSync, writeFileSync } from "node:fs";
+const key = process.env.TEST_KEY!;
+const holdUntil = process.env.TEST_HOLD_UNTIL;
+// Long stale window: the holder is deliberately slow, and must not be robbed.
+__setConfigLockTimingsForTest({ staleMs: 60000, waitBudgetMs: 30000 });
+if (holdUntil) {
+  __setConfigSaveMergeWindowHookForTest(() => {
+    writeFileSync(process.env.TEST_HOLDING_FLAG!, "1");
+    while (!existsSync(holdUntil)) { /* spin: saveConfig is synchronous */ }
+  });
+}
+saveConfig({ prompts: { [key]: "v" } } as never);
+`,
+    );
+
+    const holdingFlag = join(tempDir, "holding");
+    const releaseFlag = join(tempDir, "release");
+    const contenderStarted = join(tempDir, "contender-started");
+    const env = { ...process.env, PLANNOTATOR_DATA_DIR: tempDir };
+
+    const holder = Bun.spawn(["bun", "run", scriptPath], {
+      env: { ...env, TEST_KEY: "holder", TEST_HOLD_UNTIL: releaseFlag, TEST_HOLDING_FLAG: holdingFlag },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    await waitForFile(holdingFlag);
+
+    const contender = Bun.spawn(["bun", "run", scriptPath], {
+      env: { ...env, TEST_KEY: "contender", TEST_HOLDING_FLAG: contenderStarted },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    // The contender is running and can only be inside acquire: nothing else in
+    // that script blocks. Release the holder and let both finish.
+    await Bun.sleep(150);
+    writeFileSync(releaseFlag, "1");
+
+    expect(await holder.exited).toBe(0);
+    expect(await contender.exited).toBe(0);
+
+    const prompts = loadConfig().prompts as Record<string, unknown> | undefined;
+    expect(prompts?.holder).toBe("v");
+    expect(prompts?.contender).toBe("v");
+  }, 20_000);
+});
+
+async function waitForFile(path: string): Promise<void> {
+  for (let i = 0; i < 400; i++) {
+    if (existsSync(path)) return;
+    await Bun.sleep(25);
+  }
+  throw new Error(`timed out waiting for ${path}`);
+}
 
 describe("resolveGuideShareUrl", () => {
   test("defaults to guides.show; config key is honored; env wins", () => {

--- a/packages/shared/config.ts
+++ b/packages/shared/config.ts
@@ -7,11 +7,24 @@
 
 import { join } from "path";
 import { getPlannotatorDataDir } from "./data-dir";
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+  openSync,
+  writeSync,
+  closeSync,
+  statSync,
+  unlinkSync,
+  renameSync,
+  realpathSync,
+} from "fs";
 import { execSync } from "child_process";
 
 import type { DefaultDiffType, DiffLineBgIntensity, DiffOptions, ThemeConfig } from '@plannotator/core/config-types';
 import { isFaviconStyle, type FaviconStyle } from './favicon';
+import { isAnnotateAgentTerminalSide, type AnnotateAgentTerminalSide } from './agent-terminal';
 export type { DefaultDiffType, DiffLineBgIntensity, DiffOptions, ThemeConfig, FaviconStyle };
 
 /** Single conventional comment label entry stored in config.json */
@@ -112,8 +125,12 @@ export interface PlannotatorConfig {
    * for a session. Written by the UI through POST /api/config, because every
    * annotate session runs on its own random port — a cookie alone would make
    * the choice per-session rather than per-user.
+   *
+   * Typed from @plannotator/core rather than restating the union, so this
+   * field and `isAgentTerminalSide` cannot disagree with the client-side
+   * placement logic about which sides exist.
    */
-  agentTerminalSide?: "left" | "right" | "hidden";
+  agentTerminalSide?: AnnotateAgentTerminalSide;
   /**
    * Which agent the annotate-mode Agent TUI preselects (an agent id such as
    * "claude"). Unset means the first available agent wins. Persisted here for
@@ -294,13 +311,182 @@ export function loadConfig(): PlannotatorConfig {
   }
 }
 
+// --- config.json write serialization ----------------------------------------
+//
+// saveConfig is a read-merge-write, and one data dir is routinely shared by
+// several Plannotator processes (an annotate session and a review session at
+// once is ordinary). Two of them settling a POST /api/config in the same
+// window both read the pre-change file, both merge onto it, and the second
+// write silently drops the first writer's key while both callers are told the
+// save succeeded. An advisory lockfile makes the read-merge-write a critical
+// section across processes.
+//
+// Advisory, bounded, and never fatal, in that order of priority:
+//  - O_EXCL create of `${configDir}/config.json.lock` is the only primitive
+//    required, so this stays node:fs-only and portable to every runtime that
+//    vendors this file (no flock, no native deps, no fcntl semantics).
+//  - A lock whose mtime is older than the stale window is assumed to belong
+//    to a process that died holding it and is taken over. Holding the lock
+//    spans one read plus one write, i.e. microseconds, so a lock this old is
+//    not a live writer.
+//  - Waiting is bounded by the wait budget. When the budget runs out the
+//    write proceeds unlocked with a warning: a lost update is a bad outcome,
+//    a server wedged forever on a lockfile is a worse one.
+//
+// Residual failure mode, stated plainly: two writers that both judge the same
+// lock stale in the same instant can both take it, and one update is lost
+// exactly as it was before. That needs a >1.5s stall inside a critical
+// section that costs microseconds, and the cost of closing it (owner tokens,
+// re-verification, a second lock) is not worth paying for a settings file.
+
+const CONFIG_LOCK_SUFFIX = ".lock";
+const DEFAULT_CONFIG_LOCK_WAIT_BUDGET_MS = 3000;
+const DEFAULT_CONFIG_LOCK_STALE_MS = 1500;
+const CONFIG_LOCK_POLL_MS = 10;
+
+let configLockWaitBudgetMs = DEFAULT_CONFIG_LOCK_WAIT_BUDGET_MS;
+let configLockStaleMs = DEFAULT_CONFIG_LOCK_STALE_MS;
+
+/**
+ * Test-only seam for the lock windows. The bounded-wait and stale-takeover
+ * paths are otherwise only reachable by waiting out multi-second real time
+ * inside a synchronous function, which no test should do. Pass null to
+ * restore the shipping values.
+ */
+export function __setConfigLockTimingsForTest(
+  timings: { waitBudgetMs?: number; staleMs?: number } | null,
+): void {
+  configLockWaitBudgetMs = timings?.waitBudgetMs ?? DEFAULT_CONFIG_LOCK_WAIT_BUDGET_MS;
+  configLockStaleMs = timings?.staleMs ?? DEFAULT_CONFIG_LOCK_STALE_MS;
+}
+
+/**
+ * Test-only seam: runs inside the lock, after the config has been read and
+ * before the merged result is written. It exists so a test can inspect the
+ * critical section itself (is the lock actually held across the merge?)
+ * rather than racing two writers and hoping the interleaving reproduces.
+ */
+let configSaveMergeWindowHook: (() => void) | null = null;
+export function __setConfigSaveMergeWindowHookForTest(hook: (() => void) | null): void {
+  configSaveMergeWindowHook = hook;
+}
+
+export function getConfigLockPath(): string {
+  return getConfigPath() + CONFIG_LOCK_SUFFIX;
+}
+
+/** Block the calling thread without a timer: saveConfig is synchronous, so an
+ * event-loop-based sleep would never run. Falls back to a spin when
+ * SharedArrayBuffer/Atomics.wait is unavailable on the host runtime. */
+function sleepSync(ms: number): void {
+  try {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+  } catch {
+    const until = Date.now() + ms;
+    while (Date.now() < until) { /* spin */ }
+  }
+}
+
+/**
+ * Take the advisory config lock, or return false when the wait budget ran out
+ * (the caller then writes unlocked rather than hanging).
+ */
+function acquireConfigLock(lockPath: string): boolean {
+  const deadline = Date.now() + configLockWaitBudgetMs;
+  for (;;) {
+    try {
+      // wx: create-exclusive. Whoever wins the create owns the section.
+      const handle = openSync(lockPath, "wx");
+      try {
+        writeSync(handle, `${process.pid} ${new Date().toISOString()}\n`);
+      } catch { /* the lock is the file's existence, not its contents */ }
+      closeSync(handle);
+      return true;
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException)?.code !== "EEXIST") {
+        // Unwritable directory, read-only fs: locking is not available here,
+        // so do not let it block the write it was only meant to serialize.
+        return false;
+      }
+    }
+
+    // Held by someone else. Take it over once it is too old to be live.
+    try {
+      const age = Date.now() - statSync(lockPath).mtimeMs;
+      if (age > configLockStaleMs) {
+        unlinkSync(lockPath);
+        continue;
+      }
+    } catch { /* vanished between the create and the stat: just retry */ }
+
+    if (Date.now() >= deadline) return false;
+    sleepSync(CONFIG_LOCK_POLL_MS);
+  }
+}
+
+function releaseConfigLock(lockPath: string): void {
+  try {
+    unlinkSync(lockPath);
+  } catch { /* already gone (stale takeover by another writer): nothing to do */ }
+}
+
+/**
+ * Write config.json in one step so a concurrent reader never observes a
+ * half-written file: readers deliberately take no lock, and loadConfig treats
+ * malformed JSON as an empty config, which would silently present as "all
+ * settings reset". Writes through an existing symlink rather than replacing
+ * it, so a dotfile-managed config.json keeps its link.
+ */
+function writeConfigAtomic(configPath: string, contents: string): void {
+  let targetPath = configPath;
+  try {
+    if (existsSync(configPath)) targetPath = realpathSync(configPath);
+  } catch { /* unreadable link: fall back to the literal path */ }
+  // Rename replaces the destination's metadata with the temp file's, so carry
+  // the existing file's permissions across instead of re-deciding them.
+  let mode = 0o600;
+  try {
+    if (existsSync(targetPath)) mode = statSync(targetPath).mode & 0o777;
+  } catch { /* new file: keep the private default */ }
+  const tempPath = `${targetPath}.${process.pid}.${Math.random().toString(36).slice(2, 10)}.tmp`;
+  try {
+    writeFileSync(tempPath, contents, { encoding: "utf-8", mode });
+    renameSync(tempPath, targetPath);
+  } catch {
+    try {
+      unlinkSync(tempPath);
+    } catch { /* nothing to clean up */ }
+    // Same-directory rename should not fail, but a write that lands is better
+    // than a settings change that is lost to an exotic filesystem.
+    writeFileSync(targetPath, contents, "utf-8");
+  }
+}
+
 /**
  * Save config by merging partial values into the existing file.
  * Creates ~/.plannotator/ directory if needed.
+ *
+ * The read-merge-write runs under an advisory lockfile so concurrent writers
+ * (in this process or another one sharing the data dir) cannot drop each
+ * other's keys. See the lock notes above for the failure mode: it degrades to
+ * the old unlocked behavior with a warning, never to a hang.
  */
 export function saveConfig(partial: Partial<PlannotatorConfig>): void {
+  let lockPath: string | null = null;
+  let locked = false;
   try {
+    mkdirSync(getConfigDir(), { recursive: true });
+    lockPath = getConfigLockPath();
+    locked = acquireConfigLock(lockPath);
+    if (!locked) {
+      process.stderr.write(
+        `[plannotator] Warning: config.json lock unavailable after ${configLockWaitBudgetMs}ms; `
+        + `saving without it (a concurrent save may be overwritten).\n`,
+      );
+    }
+
     const current = loadConfig();
+    configSaveMergeWindowHook?.();
     const mergedDiffOptions = (current.diffOptions || partial.diffOptions)
       ? { ...current.diffOptions, ...partial.diffOptions }
       : undefined;
@@ -319,10 +505,11 @@ export function saveConfig(partial: Partial<PlannotatorConfig>): void {
       reviewAnalysis: mergedReviewAnalysis,
       prompts: mergedPrompts,
     };
-    mkdirSync(getConfigDir(), { recursive: true });
-    writeFileSync(getConfigPath(), JSON.stringify(merged, null, 2) + "\n", "utf-8");
+    writeConfigAtomic(getConfigPath(), JSON.stringify(merged, null, 2) + "\n");
   } catch (e) {
     process.stderr.write(`[plannotator] Warning: failed to write config.json: ${e}\n`);
+  } finally {
+    if (locked && lockPath) releaseConfigLock(lockPath);
   }
 }
 
@@ -383,11 +570,19 @@ export function getServerConfig(gitUser: string | null): {
  * Guard for the annotate Agent TUI placement. config.json is hand-editable, so
  * a bogus value must simply not be advertised — the client then keeps its own
  * resolved default instead of adopting a side that does not exist.
+ *
+ * The set of sides has exactly one definition, `AnnotateAgentTerminalSide` in
+ * @plannotator/core: `PlannotatorConfig.agentTerminalSide` IS that type and
+ * this predicate delegates to that module's guard, so neither the union nor
+ * its membership test can drift on one side of the boundary. Direct import
+ * rather than a duplicated literal check: the Pi vendor step rewrites the
+ * relative specifier to the flat `./agent-terminal.ts` it already vendors
+ * from core, so both runtimes end up on the same implementation.
  */
 export function isAgentTerminalSide(
   value: unknown,
 ): value is NonNullable<PlannotatorConfig["agentTerminalSide"]> {
-  return value === "left" || value === "right" || value === "hidden";
+  return isAnnotateAgentTerminalSide(value);
 }
 
 /**


### PR DESCRIPTION
Five confirmed pre-release QA findings against the live annotate proxy, the shared config writer and the annotate draft store, plus one adjacent duplication cleanup. All five were reproduced live before the fix, and each has a test that fails on the pre-fix source.

## 1. MAJOR: the live-proxy HTML injector was comment-unaware

`createHtmlInjector` scanned bytes for `<head` / `</head>` with no notion of HTML comments. A page whose markup carries a comment mentioning `<head>` before the real tag (codegen banners such as `<!-- Do not edit <head> manually -->`) had the bridge script injected inside the dead comment: never executed, annotation silently broken, no warning anywhere.

The scanner now skips ignored spans before it matches head markers. Comments (`<!-- ... -->`, including the legacy `--!>` terminator) and the `>`-terminated spans the HTML parser calls markup declarations and bogus comments (`<!doctype ...>`, `<![CDATA[ ... ]]>`, `<? ... >`) are passed through verbatim while marker matching is suspended, which is why `<![CDATA[<head>]]>` now hides the same bytes here as it does in a browser. Streaming correctness is unchanged in shape: the new state is part of the same chunk-boundary state machine, and the existing fixed holdback already exceeds every partial marker it has to defer (`</head>` at 7 bytes is the longest; `<!--` and `-->` are shorter).

Out of scope, stated honestly in the source: raw-text element contents are not tracked, so a literal `<!--` inside a `<script>` or `<style>` string ahead of the head markers still reads as a comment open. Reaching that needs script or style content before the document head, and the degraded outcome is the pre-existing no-marker fallback (append at end of stream), not a silent injection into dead bytes. Unterminated comments degrade the same way.

Tests: a banner comment naming `<head>` before the real head; the same comment split across a chunk boundary; a sweep that cuts the same document at every one of its byte offsets and byte-at-a-time; decoy `</head>` inside a comment; `--!>`; CDATA-ish; consecutive comments; unterminated comment.

## 2. MAJOR: a Host-less request leaked a Bun crash page

`new URL(req.url)` ran before Host validation. An HTTP/1.0 request with no Host header leaves `req.url` a bare `/`, so the constructor threw and Bun served its internal debug page (about 67KB, with a stack trace) from a port whose entire contract is refusing anything that does not name it. Repro: `printf 'GET / HTTP/1.0\r\n\r\n' | nc 127.0.0.1 <proxyPort>`.

Host validation now runs first, before `req.url` is parsed at all, and URL construction is additionally wrapped so an unparseable request takes the same 403 path rather than any error page. The invariant "Host validation runs before any upstream contact" now holds for all inputs, well-formed or not. Tested over a raw socket, asserting the body is exactly `Forbidden` and that upstream saw nothing.

## 3. MINOR: the HTML content-type test was case-sensitive

`contentType.includes("text/html")` skipped both bridge injection and the framing header rewrites for a valid `TEXT/HTML` response. Media types are case-insensitive (RFC 9110 8.3); the comparison is now lowercased. Tested through the proxy against an upstream that answers `TEXT/HTML; charset=UTF-8`, asserting the injection and the `X-Frame-Options` strip plus `frame-ancestors` replacement.

## 4. MAJOR: cross-process lost update on config.json

`saveConfig` is an unlocked read-merge-write. Two processes sharing a data dir (one annotate session plus one review session is ordinary) racing on `POST /api/config` silently dropped one writer's change while both callers were told the save succeeded.

The read-merge-write now runs inside an advisory lockfile beside the config (`config.json.lock`), acquired with an `O_EXCL` create so nothing beyond `node:fs` is needed and the module stays runtime-agnostic. A lock older than the stale window (1.5s) is taken over, on the reasoning that the critical section costs one read plus one write; waiting is bounded by a 3s budget, after which the write proceeds unlocked with an explicit stderr warning. Deadlock is the one outcome worse than a lost update, so the lock can never do more than degrade to the old behavior. The residual race (two writers judging the same lock stale in the same instant) is documented in the source rather than papered over.

The write itself is now a same-directory temp file plus rename, since readers deliberately take no lock and a torn read would present to the user as "all settings reset". It resolves an existing symlink first so a dotfile-managed config.json keeps its link, and carries the existing file's permissions across the rename.

Shared code, so it is vendored to Pi: `vendor.sh` was re-run, and there is a Pi-side test that imports `generated/config.ts` and asserts the lock is held across that copy's merge window, so a vendoring rule that stopped carrying it fails in CI rather than in a user's config file.

Tests: the lock is held across the read-merge window and released after (deterministic, via an exported merge-window seam, asserting an `O_EXCL` create fails while it is held); concurrent saves in one process all land; a lock left by a dead writer is taken over rather than waited out; a lock that never frees is waited out and written past with a warning inside a bounded time; and a barrier-driven two-process test that reproduces the original lost update on the unlocked code and passes with the lock.

## 5. CRITICAL: live app annotation sessions shared one global draft slot

`mode: "annotate-app"` resolves `markdown` to `""` by construction, because a live session's page lives behind the proxy rather than in a string the server holds. The autosave draft key was `contentHash(draftSource)` over that body, so every live session on the machine collapsed to the single hash of the empty string. Two concurrent live sessions against different dev servers read and overwrote each other's in-progress annotations, deterministically: session Y's draft POST returned session X's draft verbatim and then replaced it.

A live session's identity is its target, exactly as a folder session's identity is its folder path, so the key is now derived from the target URL rather than from content. The URL is normalized through the URL parser first (trailing slash, host case, default port) so the same dev server recovers its draft on a later run when the target is spelled slightly differently; an unparseable target falls back to the trimmed string, which is still per-target. Classic file, HTML and folder keying is byte-identical to before.

Pi needs no mirror: it has no live app mode at all. There is no `annotate-app`, `liveApp` or live-proxy reference anywhere in `apps/pi-extension` outside its vendored `generated/` tree.

Tests: two live sessions on different targets keep independent drafts and write two distinct draft files; the same target recovers its draft across a restart including across a trailing-slash spelling change; identity separates distinct targets and distinct paths while staying stable across spellings; and a classic file session still writes its draft under `contentHash(markdown)`. The first of those is the regression guard and fails on the pre-fix key; the others guard the opposite direction, that the new key does not rotate when it should not.

## Adjacent: one definition of the agent-terminal side set

`isAgentTerminalSide` in `packages/shared/config.ts` restated the `left | right | hidden` membership test that `isAnnotateAgentTerminalSide` in `packages/core/agent-terminal.ts` already owns. Consolidated by direct import rather than a type-level assertion: `PlannotatorConfig.agentTerminalSide` is now typed as core's `AnnotateAgentTerminalSide` and the predicate delegates to core's guard, so the union and its membership test cannot drift.

Direct import is safe across the vendor boundary because `packages/shared/agent-terminal.ts` is already a shim over the core module, and `vendor.sh` rewrites the relative specifier to the flat `./agent-terminal.ts` it vendors from core, which the Pi typecheck and the new Pi test both confirm.

## Verification

- `bun run typecheck` clean, which also re-runs `vendor.sh`.
- The four affected suites together (`live-proxy`, `annotate`, shared `config`, and the new Pi vendored-config test): 154 pass, 0 fail.
- `packages/server/live-proxy.test.ts` alone: 39 pass. All 7 new tests fail on the pre-fix source.
- `packages/shared/config.test.ts` alone: 61 pass. The two-process test fails on the unlocked write path.
- Full `bun test` from the worktree root against a temporary `PLANNOTATOR_DATA_DIR`, compared against the same run on a clean `origin/main` worktree. The failure sets are the same pre-existing ones: 15 of them (12 `prompts integration (config from disk)` and 3 `readImprovementHook`) reproduce identically on unmodified `origin/main` under a temp data dir, and the remainder are the server-spawning `API route 404 guards` tests, which pass in isolation on both branches and vary run to run under load. Nothing failed on the branch that did not also fail on the baseline.

No build outputs were touched; none of the changed surfaces ship prebuilt HTML.

AI-assisted (Claude) under maintainer direction.
