### PR TITLE
fix(call-flow): keep big-but-valid tree lists instead of failing

### DIFF
--- a/packages/shared/call-flow-types.test.ts
+++ b/packages/shared/call-flow-types.test.ts
@@ -133,13 +133,45 @@ describe("parseCallDiffWorkerResult", () => {
     expect(() => parseCallDiffWorkerResult(responseForFile(`${"a".repeat(2_100)}/../secret.ts`))).toThrow("unsafe source path");
   });
 
-  test("rejects rather than truncating an over-budget tree list", () => {
+  test("keeps a big-but-valid tree list instead of rejecting it (#1351)", () => {
     const tree = { entry: "x", tree: { key: "x", label: "x", status: "same", children: [] } };
+    const parsed = parseCallDiffWorkerResult({
+      protocol: 1,
+      ok: true,
+      version: "0.4.1",
+      result: { from: "a", to: "b", ascii: "raw", trees: Array.from({ length: 470 }, (_unused, index) => ({ ...tree, entry: `entry-${index}` })) },
+    });
+    expect(parsed.trees).toHaveLength(470);
+    expect(parsed.diagnostics).toEqual([]);
+  });
+
+  test("truncates an over-budget tree list and reports the omission (#1351)", () => {
+    const tree = { entry: "x", tree: { key: "x", label: "x", status: "same", children: [] } };
+    const parsed = parseCallDiffWorkerResult({
+      protocol: 1,
+      ok: true,
+      version: "0.4.1",
+      result: { from: "a", to: "b", ascii: "raw", trees: Array.from({ length: 2_001 }, (_unused, index) => ({ ...tree, entry: `entry-${index}` })) },
+    });
+    expect(parsed.trees).toHaveLength(2_000);
+    expect(parsed.trees[0]?.entry).toBe("entry-0");
+    expect(parsed.diagnostics).toHaveLength(1);
+    expect(parsed.diagnostics[0]?.level).toBe("warning");
+    expect(parsed.diagnostics[0]?.message).toContain("2,000");
+    expect(parsed.diagnostics[0]?.message).toContain("2,001");
+  });
+
+  test("still rejects results whose node budget is genuinely exceeded", () => {
+    const child = { key: "c", label: "c", status: "same", children: [] };
+    const wideTree = {
+      entry: "x",
+      tree: { key: "x", label: "x", status: "same", children: Array.from({ length: 5_001 }, () => child) },
+    };
     expect(() => parseCallDiffWorkerResult({
       protocol: 1,
       ok: true,
       version: "0.4.1",
-      result: { from: "a", to: "b", ascii: "raw", trees: Array.from({ length: 101 }, () => tree) },
+      result: { from: "a", to: "b", ascii: "raw", trees: [wideTree] },
     })).toThrow("tree limits");
   });
 

--- a/packages/shared/call-flow-types.ts
+++ b/packages/shared/call-flow-types.ts
@@ -160,7 +160,7 @@ export interface ParsedCallDiffWorkerResult {
   diagnostics: CallFlowDiagnostic[];
 }
 
-const MAX_TREES = 100;
+const MAX_TREES = 2_000;
 const MAX_NODES = 5_000;
 const MAX_TREE_DEPTH = 32;
 const MAX_DIAGNOSTICS = 100;
@@ -217,9 +217,16 @@ export function parseCallDiffWorkerResult(value: unknown): ParsedCallDiffWorkerR
   if (!isRecord(value.result) || !Array.isArray(value.result.trees)) {
     throw new Error("CallDiff worker response is missing its diff trees.");
   }
-  if (value.result.trees.length > MAX_TREES) {
-    throw new Error("CallDiff result exceeded Plannotator's tree limits.");
-  }
+  // A large-but-valid result (many small entry trees — common in Swift, TS,
+  // and other per-function languages) degrades instead of failing: keep the
+  // first MAX_TREES trees and say so in diagnostics (#1351). The caps that
+  // guard against genuinely unbounded worker output (total nodes, depth, raw
+  // length) still throw below.
+  const totalTreeCount = value.result.trees.length;
+  const truncatedTrees = totalTreeCount > MAX_TREES;
+  const boundedTreeCandidates = truncatedTrees
+    ? value.result.trees.slice(0, MAX_TREES)
+    : value.result.trees;
 
   let nodeCount = 0;
   const parseNode = (candidate: unknown, depth: number): CallFlowNode => {
@@ -253,7 +260,7 @@ export function parseCallDiffWorkerResult(value: unknown): ParsedCallDiffWorkerR
   };
 
   const raw = boundedRaw(value.result.ascii);
-  const trees = value.result.trees.map((candidate): CallFlowTree => {
+  const trees = boundedTreeCandidates.map((candidate): CallFlowTree => {
     if (!isRecord(candidate)) throw new Error("CallDiff worker returned an invalid tree.");
     const entry = boundedString(candidate.entry, "tree entry");
     const tree = parseNode(candidate.tree, 0);
@@ -285,6 +292,12 @@ export function parseCallDiffWorkerResult(value: unknown): ParsedCallDiffWorkerR
         message: candidate.message.slice(0, MAX_TEXT_LENGTH),
       });
     }
+  }
+  if (truncatedTrees) {
+    diagnostics.push({
+      level: "warning",
+      message: `Showing the first ${MAX_TREES.toLocaleString("en-US")} of ${totalTreeCount.toLocaleString("en-US")} call trees; the rest were truncated to bound the result.`,
+    });
   }
 
   return {


### PR DESCRIPTION
## Problem

Call Flow fails with `CallDiff result exceeded Plannotator's tree limits.` on normal branch reviews in languages that emit many small per-entry trees. From #1351's measurements (Swift repo):

| Range | Changed files | Trees | Nodes |
|---|---|---|---|
| `HEAD~9..HEAD` | 41 | **119** | 1,092 |
| `HEAD~20..HEAD` | 161 | **470** | 3,138 |

`MAX_TREES = 100` was the only cap ever hit; `MAX_NODES = 5_000` was never reached even at 161 changed files, and analysis stayed under 800 ms. So a valid, cheap result was being rejected whole, taking the entire Call Flow view down instead of degrading.

## Change

`packages/shared/call-flow-types.ts`:

- **`MAX_TREES` 100 → 2,000.** A normal multi-file branch review in a many-small-entry language (Swift, TS) now parses untouched. Node count and raw-length caps remain the real payload bounds — the issue's data shows they are what actually track payload size.
- **Truncate instead of throw at the cap.** If a result still exceeds 2,000 trees, keep the first 2,000 and push a warning diagnostic: `Showing the first 2,000 of N call trees; the rest were truncated to bound the result.` The existing diagnostics `<details>` surface in the Call Flow panel renders it, so the omission is visible, never silent.
- **Hard failures preserved** for the caps that guard against genuinely unbounded worker output: `MAX_NODES`, `MAX_TREE_DEPTH`, and the raw-length limits still throw exactly as before.

## Tests

Replaced the test that codified reject-at-101 with three:

1. **470 trees parse cleanly** (the issue's scenario) — kept in full, no diagnostics.
2. **2,001 trees truncate to 2,000** — first entry preserved, one warning diagnostic naming both `2,000` and `2,001`.
3. **Node-budget excess still throws** `"tree limits"` — the pathological-output guard is intact.

Fixes #1351