### PR TITLE
fix(ai): a broken RPC pipe must fail the provider, not kill the host (#1378)

### DIFF
--- a/apps/pi-extension/vendor.sh
+++ b/apps/pi-extension/vendor.sh
@@ -124,7 +124,7 @@ for f in index types provider session-manager endpoints context base-session; do
     > "generated/ai/$f.ts"
 done
 
-for f in claude-agent-sdk codex-app-server opencode-sdk command-path pi-sdk pi-sdk-node pi-events; do
+for f in claude-agent-sdk codex-app-server opencode-sdk command-path child-io pi-sdk pi-sdk-node pi-events; do
   src="../../packages/ai/providers/$f.ts"
   printf '// @generated — DO NOT EDIT. Source: packages/ai/providers/%s.ts\n' "$f" | cat - "$src" > "generated/ai/providers/$f.ts"
 done

--- a/packages/ai/providers/child-io.ts
+++ b/packages/ai/providers/child-io.ts
@@ -1,0 +1,92 @@
+/**
+ * Stdio guards for the JSONL/JSON-RPC child processes the AI providers drive.
+ *
+ * Both `PiProcessNode` (pi-sdk-node.ts) and `CodexAppServerProcess`
+ * (codex-app-server.ts) talk to a nested agent over pipes, and a pipe can
+ * break at any instant — the child exits, is killed, or closes stdin while a
+ * command is in flight. Two Node behaviors turn that ordinary condition into
+ * a host-killing crash:
+ *
+ *  1. `stream.write()` on a broken pipe reports `EPIPE` either synchronously
+ *     (throw) or asynchronously (an `error` event on the stream), and which
+ *     one you get is a timing race. A `destroyed` check before the write
+ *     cannot close that race: the child can close the pipe between the check
+ *     and the write.
+ *  2. An `error` event on a Node stream (or on the `ChildProcess` itself)
+ *     with NO listener is re-thrown as an `uncaughtException`. Inside an
+ *     embedded extension that is not "the provider failed" — it terminates
+ *     the HOST agent process.
+ *
+ * That is issue #1378: a Plannotator plan review opened from Pi on Windows
+ * took the whole Pi host down with `write EPIPE` out of `PiProcessNode.send()`.
+ * Windows only made it likelier to land on the async path during teardown;
+ * the mechanism is platform-independent.
+ *
+ * The contract these helpers enforce: a broken pipe is a PROVIDER failure.
+ * It never escalates past the provider, it is reported exactly like any other
+ * process end (in-flight requests reject, listeners see the process end), and
+ * the provider is left dead so the next query re-spawns it.
+ */
+
+import type { ChildProcess } from "node:child_process";
+
+/** Normalize an unknown thrown/emitted value to an Error. */
+export function toChildError(err: unknown): Error {
+	return err instanceof Error ? err : new Error(String(err));
+}
+
+/**
+ * Attach `error` listeners to the child process and every piped stream so a
+ * broken pipe can never reach `uncaughtException`.
+ *
+ * Call this immediately after `spawn()` returns — before awaiting the spawn
+ * handshake — so a stream that fails during startup is already covered. The
+ * spawn handshake may register its own one-shot `error` listener; Node allows
+ * several, and `onFailure` is expected to be idempotent.
+ */
+export function guardChildStreams(
+	proc: ChildProcess,
+	label: string,
+	onFailure: (error: Error) => void,
+): void {
+	const report = (stream: string) => (err: unknown) => {
+		onFailure(new Error(`${label} ${stream} failed: ${toChildError(err).message}`));
+	};
+	proc.on("error", report("process"));
+	proc.stdin?.on("error", report("stdin"));
+	proc.stdout?.on("error", report("stdout"));
+	proc.stderr?.on("error", report("stderr"));
+}
+
+/**
+ * Write one already-newline-terminated line to a child's stdin.
+ *
+ * Returns the Error the write failed with, or `null` when the bytes were
+ * accepted by the stream. Failures that only surface later (the write
+ * callback, or an `error` event covered by {@link guardChildStreams}) are
+ * reported through `onAsyncFailure` instead, so BOTH the sync-throw and the
+ * async-event paths end up at the caller's failure handling.
+ */
+export function writeChildLine(
+	proc: ChildProcess | null,
+	line: string,
+	label: string,
+	onAsyncFailure: (error: Error) => void,
+): Error | null {
+	const stdin = proc?.stdin;
+	if (!stdin || stdin.destroyed || stdin.writableEnded) {
+		return new Error(`${label} stdin is closed`);
+	}
+	try {
+		stdin.write(line, (err) => {
+			if (err) {
+				onAsyncFailure(
+					new Error(`${label} stdin write failed: ${toChildError(err).message}`),
+				);
+			}
+		});
+	} catch (err) {
+		return new Error(`${label} stdin write failed: ${toChildError(err).message}`);
+	}
+	return null;
+}

--- a/packages/ai/providers/codex-app-server.ts
+++ b/packages/ai/providers/codex-app-server.ts
@@ -43,8 +43,10 @@ import {
   killWindowsProcessTree,
   resolveWindowsCommandShim,
 } from "./command-path.ts";
+import { guardChildStreams, writeChildLine } from "./child-io.ts";
 
 const PROVIDER_NAME = "codex-sdk";
+const CODEX_PROCESS_LABEL = "Codex app-server";
 const DEFAULT_MODEL = "gpt-5.6-sol";
 const CLIENT_NAME = "plannotator";
 /** Kill an idle app-server process after this long with no query. */
@@ -334,6 +336,10 @@ class CodexAppServerProcess {
     }
 
     this.proc = proc;
+    // Cover every pipe BEFORE the spawn handshake: an `error` event on a child
+    // stream with no listener becomes an uncaughtException and kills the host
+    // process, not just this provider (#1378).
+    guardChildStreams(proc, CODEX_PROCESS_LABEL, (error) => this.failProcess(error));
     proc.once("exit", () => {
       this.handleProcessEnd(new Error("Codex app-server exited unexpectedly"));
     });
@@ -375,6 +381,23 @@ class CodexAppServerProcess {
       throw err;
     }
     this.send({ method: "initialized", params: {} });
+  }
+
+  /**
+   * A pipe to the child broke: resolve it as a provider failure and reap the
+   * child, leaving `alive` false so the next query re-spawns (#1378).
+   */
+  private failProcess(error: Error): void {
+    const proc = this.proc;
+    this.startPromise = null;
+    this.handleProcessEnd(error);
+    if (proc) {
+      try {
+        if (!killWindowsProcessTree(proc.pid)) proc.kill();
+      } catch {
+        // Already gone.
+      }
+    }
   }
 
   private handleProcessEnd(error: Error): void {
@@ -438,9 +461,22 @@ class CodexAppServerProcess {
     }
   }
 
+  /**
+   * Send a JSON-RPC message without waiting for a response.
+   *
+   * A closed or broken stdin is a provider failure, never a throw at the
+   * caller and never an unhandled stream error: both the synchronous throw
+   * and the asynchronous `error`/write-callback paths land in failProcess,
+   * which rejects anything in flight.
+   */
   send(message: RpcMessage): void {
-    if (!this.proc?.stdin || this.proc.stdin.destroyed) return;
-    this.proc.stdin.write(`${JSON.stringify(message)}\n`);
+    const error = writeChildLine(
+      this.proc,
+      `${JSON.stringify(message)}\n`,
+      CODEX_PROCESS_LABEL,
+      (err) => this.failProcess(err),
+    );
+    if (error) this.failProcess(error);
   }
 
   sendAndWait(message: RpcMessage, timeoutMs = RPC_TIMEOUT_MS): Promise<RpcMessage> {

--- a/packages/ai/providers/pi-sdk-node.ts
+++ b/packages/ai/providers/pi-sdk-node.ts
@@ -24,11 +24,13 @@ import {
 	killWindowsProcessTree,
 	resolveWindowsCommandShim,
 } from "./command-path.ts";
+import { guardChildStreams, writeChildLine } from "./child-io.ts";
 
 // Re-export mapPiEvent from shared (runtime-agnostic)
 export { mapPiEvent } from "./pi-events.ts";
 
 const PROVIDER_NAME = "pi-sdk";
+const PI_PROCESS_LABEL = "Pi process";
 
 // ---------------------------------------------------------------------------
 // JSONL subprocess wrapper (Node.js)
@@ -36,7 +38,8 @@ const PROVIDER_NAME = "pi-sdk";
 
 type EventListener = (event: Record<string, unknown>) => void;
 
-class PiProcessNode {
+/** Exported for the stdio-failure regression tests (#1378). */
+export class PiProcessNode {
 	private proc: ChildProcess | null = null;
 	private listeners: EventListener[] = [];
 	private pendingRequests = new Map<
@@ -61,9 +64,12 @@ class PiProcessNode {
 		let proc: ChildProcess;
 		try {
 			const [file, ...args] = command;
+			// stderr is "ignore", not "pipe": we never read it, and an
+			// un-drained stderr pipe deadlocks the child once its buffer fills
+			// (same reasoning as codex-app-server.ts).
 			proc = spawn(file, args, {
 				cwd,
-				stdio: ["pipe", "pipe", "pipe"],
+				stdio: ["pipe", "pipe", "ignore"],
 			});
 		} catch (err) {
 			const error = err instanceof Error ? err : new Error(String(err));
@@ -72,6 +78,10 @@ class PiProcessNode {
 		}
 
 		this.proc = proc;
+		// Cover every pipe BEFORE the spawn handshake: an `error` event on a
+		// child stream with no listener becomes an uncaughtException and kills
+		// the host agent process, not just this provider (#1378).
+		guardChildStreams(proc, PI_PROCESS_LABEL, (error) => this.failProcess(error));
 		proc.once("exit", () => {
 			this.handleProcessEnd(new Error("Pi process exited unexpectedly"));
 		});
@@ -96,6 +106,24 @@ class PiProcessNode {
 			proc.once("spawn", onSpawn);
 			proc.once("error", onError);
 		});
+	}
+
+	/**
+	 * A pipe to the child broke. Resolve it as a provider failure: reject
+	 * everything in flight, tell listeners the process ended, and reap the
+	 * child so it cannot linger with an unusable RPC channel. `alive` flips
+	 * false, so the next query re-spawns a fresh process.
+	 */
+	private failProcess(error: Error): void {
+		const proc = this.proc;
+		this.handleProcessEnd(error);
+		if (proc) {
+			try {
+				if (!killWindowsProcessTree(proc.pid)) proc.kill();
+			} catch {
+				// Already gone.
+			}
+		}
 	}
 
 	private handleProcessEnd(error: Error): void {
@@ -152,9 +180,23 @@ class PiProcessNode {
 		}
 	}
 
+	/**
+	 * Send a command without waiting for a response.
+	 *
+	 * A closed or broken stdin is a provider failure, never a throw at the
+	 * caller and never an unhandled stream error: both the synchronous throw
+	 * and the asynchronous `error`/write-callback paths land in failProcess,
+	 * which rejects anything in flight (including the `sendAndWait` request
+	 * this call may be carrying).
+	 */
 	send(command: Record<string, unknown>): void {
-		if (!this.proc?.stdin || this.proc.stdin.destroyed) return;
-		this.proc.stdin.write(`${JSON.stringify(command)}\n`);
+		const error = writeChildLine(
+			this.proc,
+			`${JSON.stringify(command)}\n`,
+			PI_PROCESS_LABEL,
+			(err) => this.failProcess(err),
+		);
+		if (error) this.failProcess(error);
 	}
 
 	sendAndWait(

--- a/packages/ai/providers/pi-sdk.ts
+++ b/packages/ai/providers/pi-sdk.ts
@@ -57,11 +57,14 @@ class PiProcess {
 				"rpc",
 			];
 		try {
+			// stderr is "ignore", not "pipe": we never read it, and an
+			// un-drained stderr pipe deadlocks the child once its buffer fills
+			// (same reasoning as codex-app-server.ts).
 			this.proc = Bun.spawn(command, {
 				cwd,
 				stdin: "pipe",
 				stdout: "pipe",
-				stderr: "pipe",
+				stderr: "ignore",
 			});
 		} catch (err) {
 			const error = err instanceof Error ? err : new Error(String(err));
@@ -75,6 +78,22 @@ class PiProcess {
 		this.proc.exited.then(() => {
 			this.handleProcessEnd(new Error("Pi process exited unexpectedly"));
 		});
+	}
+
+	/**
+	 * A pipe to the child broke: resolve it as a provider failure and reap the
+	 * child, leaving `alive` false so the next query re-spawns.
+	 */
+	private failProcess(error: Error): void {
+		const proc = this.proc;
+		this.handleProcessEnd(error);
+		if (proc) {
+			try {
+				if (!killWindowsProcessTree(proc.pid)) proc.kill();
+			} catch {
+				// Already gone.
+			}
+		}
 	}
 
 	private handleProcessEnd(error: Error): void {
@@ -143,13 +162,42 @@ class PiProcess {
 		}
 	}
 
-	/** Send a command without waiting for a response. */
+	/**
+	 * Send a command without waiting for a response.
+	 *
+	 * The write is guarded for the same reason the Node variant's is (#1378):
+	 * the child can close the pipe between the liveness check and the write,
+	 * and a raw EPIPE escaping here would surface as a synchronous throw at
+	 * the caller (or an unhandled rejection out of flush()) instead of a
+	 * provider failure. Failing the process rejects anything in flight.
+	 */
 	send(command: Record<string, unknown>): void {
-		if (!this.proc?.stdin || typeof this.proc.stdin === "number") return;
+		const stdin = this.proc?.stdin;
+		if (!stdin || typeof stdin === "number") {
+			this.failProcess(new Error("Pi process stdin is closed"));
+			return;
+		}
 		// Bun.spawn stdin is a FileSink with .write(), not a WritableStream
-		const sink = this.proc.stdin as { write(data: string): void; flush(): void };
-		sink.write(`${JSON.stringify(command)}\n`);
-		sink.flush();
+		const sink = stdin as { write(data: string): void; flush(): unknown };
+		try {
+			sink.write(`${JSON.stringify(command)}\n`);
+			const flushed = sink.flush();
+			if (flushed && typeof (flushed as Promise<number>).then === "function") {
+				(flushed as Promise<number>).catch((err: unknown) => {
+					this.failProcess(
+						new Error(
+							`Pi process stdin write failed: ${err instanceof Error ? err.message : String(err)}`,
+						),
+					);
+				});
+			}
+		} catch (err) {
+			this.failProcess(
+				new Error(
+					`Pi process stdin write failed: ${err instanceof Error ? err.message : String(err)}`,
+				),
+			);
+		}
 	}
 
 	/** Send a command and wait for the correlated response. */

--- a/packages/ai/providers/pi-stdio-failure.child.ts
+++ b/packages/ai/providers/pi-stdio-failure.child.ts
@@ -1,0 +1,145 @@
+/**
+ * Test-only child entry for pi-stdio-failure.test.ts (#1378).
+ *
+ * Runs the Pi Node provider in a REAL `node` process, because that is the
+ * runtime under Pi (jiti on Node) and because the whole bug is a Node stream
+ * behavior: an `error` event with no listener becomes an `uncaughtException`.
+ * Bun's node:child_process / node:stream shims do not reproduce that faithfully,
+ * so an in-process `bun test` could pass against code that kills the host in
+ * production (the same lesson live-proxy-node.child.ts was created for).
+ *
+ * This entry deliberately installs NO `uncaughtException` handler: if the
+ * provider lets a stream error escape, this process dies and the suite sees a
+ * non-zero exit with no result line. Surviving to print the result line IS the
+ * "the host stays alive" assertion.
+ *
+ * Env contract: FAKE_PI (path to the executable fake Pi), FAKE_PI_MODE_FILE
+ * (file whose contents select the fake's behavior). Prints one JSON line of
+ * results on stdout, then exits 0.
+ */
+
+import { writeFileSync } from "node:fs";
+import { PiProcessNode, PiSDKNodeProvider } from "./pi-sdk-node.ts";
+import type { AIMessage } from "../types.ts";
+
+const fakePi = process.env.FAKE_PI;
+const modeFile = process.env.FAKE_PI_MODE_FILE;
+if (!fakePi || !modeFile) throw new Error("FAKE_PI and FAKE_PI_MODE_FILE are required");
+
+const cwd = process.cwd();
+const setMode = (mode: string) => writeFileSync(modeFile, mode);
+
+/** Resolve once the fake has announced itself on stdout. */
+function waitForEvent(
+	proc: PiProcessNode,
+	type: string,
+	timeoutMs = 10_000,
+): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const timer = setTimeout(() => {
+			off();
+			reject(new Error(`timed out waiting for ${type}`));
+		}, timeoutMs);
+		const off = proc.onEvent((event) => {
+			if (event.type === type) {
+				clearTimeout(timer);
+				off();
+				resolve();
+			}
+		});
+	});
+}
+
+async function collect(iter: AsyncIterable<AIMessage>, capMs = 15_000): Promise<AIMessage[]> {
+	const out: AIMessage[] = [];
+	const deadline = Date.now() + capMs;
+	for await (const msg of iter) {
+		out.push(msg);
+		if (Date.now() > deadline) break;
+	}
+	return out;
+}
+
+const results: Record<string, unknown> = {};
+
+// ---------------------------------------------------------------------------
+// 1. A broken stdin pipe rejects the in-flight request and kills nothing else.
+// ---------------------------------------------------------------------------
+{
+	setMode("closed-stdin");
+	const proc = new PiProcessNode();
+	await proc.spawn(fakePi, cwd);
+	// The fake has closed the read end of its stdin by the time it says this,
+	// so the very next write hits a pipe with no reader: EPIPE.
+	await waitForEvent(proc, "ready_broken");
+
+	let sawProcessExited = false;
+	proc.onEvent((event) => {
+		if (event.type === "process_exited") sawProcessExited = true;
+	});
+
+	try {
+		await proc.sendAndWait({ type: "get_state" });
+		results.brokenRejected = false;
+	} catch (err) {
+		results.brokenRejected = true;
+		results.brokenMessage = err instanceof Error ? err.message : String(err);
+	}
+	results.brokenAliveAfter = proc.alive;
+	results.brokenSawProcessExited = sawProcessExited;
+
+	// A fire-and-forget send on the already-failed process must not throw either.
+	try {
+		proc.send({ type: "abort" });
+		results.postFailureSendThrew = false;
+	} catch {
+		results.postFailureSendThrew = true;
+	}
+	proc.kill();
+}
+
+// ---------------------------------------------------------------------------
+// 2. The provider is restartable: a fresh process talks normally afterwards.
+// ---------------------------------------------------------------------------
+{
+	setMode("echo");
+	const proc = new PiProcessNode();
+	await proc.spawn(fakePi, cwd);
+	const state = await proc.sendAndWait({ type: "get_state" });
+	results.recoveredSessionId = state.sessionId;
+	results.recoveredAlive = proc.alive;
+	proc.kill();
+}
+
+// ---------------------------------------------------------------------------
+// 3. End to end through the session: the failure surfaces to the Ask AI UI as
+//    an error message, and a later query on the SAME session re-spawns and
+//    completes normally.
+// ---------------------------------------------------------------------------
+{
+	// "break-after-first" answers the session's opening get_state and closes its
+	// stdin in the same tick, so the prompt write that follows is guaranteed to
+	// hit a dead pipe. That is the reported shape: a session that came up fine
+	// and then lost the pipe mid-conversation.
+	setMode("break-after-first");
+	const provider = new PiSDKNodeProvider({ type: "pi-sdk", piExecutablePath: fakePi, cwd });
+	const session = await provider.createSession({
+		context: { mode: "plan-review", plan: { plan: "# Test plan" } },
+		cwd,
+	});
+
+	const failed = await collect(session.query("hello"));
+	results.sessionFailedMessages = failed.map((m) => ({
+		type: m.type,
+		code: (m as { code?: string }).code,
+	}));
+
+	setMode("echo");
+	const recovered = await collect(session.query("hello again"));
+	results.sessionRecoveredTypes = recovered.map((m) => m.type);
+
+	provider.dispose();
+}
+
+process.stdout.write(`${JSON.stringify(results)}\n`);
+process.exit(0);

--- a/packages/ai/providers/pi-stdio-failure.test.ts
+++ b/packages/ai/providers/pi-stdio-failure.test.ts
@@ -1,0 +1,290 @@
+/**
+ * A broken pipe to a nested RPC agent is a PROVIDER failure, never a host
+ * crash (#1378).
+ *
+ * The reported crash: opening a plan review from Pi on Windows exited the
+ * whole Pi host with `write EPIPE` out of `PiProcessNode.send()`. The child's
+ * stdin closed between the `destroyed` check and the write, and the resulting
+ * `error` event on a stream with no listener escalated to `uncaughtException`.
+ *
+ * Two layers of coverage:
+ *
+ *  - The end-to-end block runs the provider in a REAL `node` child against a
+ *    fake Pi that closes its own stdin. Node is the Pi runtime, and Bun's
+ *    node:stream / node:child_process shims do not reproduce the unhandled-
+ *    'error'-kills-the-process rule, so an in-process test could pass against
+ *    code that still kills the host (the lesson live-proxy-node.test.ts was
+ *    built on). The child installs no `uncaughtException` handler: it printing
+ *    its result line at all is the proof that nothing escaped.
+ *  - The unit block drives writeChildLine/guardChildStreams with stream
+ *    doubles, which is the only way to pin BOTH failure shapes deterministically
+ *    — a synchronous throw from write(), and an asynchronous error delivered to
+ *    the write callback / 'error' event. Which one a real pipe produces is a
+ *    platform and timing race.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ChildProcess } from "node:child_process";
+import { guardChildStreams, writeChildLine } from "./child-io.ts";
+
+// ---------------------------------------------------------------------------
+// End to end, in a real node process
+// ---------------------------------------------------------------------------
+
+/**
+ * A stand-in for `pi --mode rpc`. Reads its behavior from a file so one
+ * executable path can be healthy or broken across successive spawns, which is
+ * what lets the session-level recovery case be exercised.
+ *
+ * Three modes:
+ *  - "closed-stdin" closes fd 0 outright — the read end of the parent's stdin
+ *    pipe — and only then announces itself, so a parent that waits for that
+ *    announcement is guaranteed to find a pipe with no reader on its next
+ *    write. It stays alive afterwards, so the failure under test is the broken
+ *    PIPE and not an ordinary child exit.
+ *  - "break-after-first" answers one request and closes stdin in the same
+ *    tick, which breaks the pipe MID-session without the parent having to
+ *    synchronize on anything. That is the reported shape.
+ *  - "echo" is a healthy RPC peer, used for the recovery half.
+ */
+const FAKE_PI = `#!/usr/bin/env node
+import { closeSync, readFileSync, readSync } from "node:fs";
+
+const mode = readFileSync(process.env.FAKE_PI_MODE_FILE, "utf8").trim();
+const say = (obj) => process.stdout.write(JSON.stringify(obj) + "\\n");
+// Park forever: the failure under test must be a broken PIPE, not a child exit.
+const stayAlive = () => setInterval(() => {}, 3600_000);
+
+// Read one line straight off fd 0 WITHOUT ever constructing process.stdin.
+// A stream would keep its own reference to the descriptor, and destroying it
+// does not reliably close the pipe's read end — the parent's next write then
+// still succeeds into the pipe buffer, which is not the condition under test.
+function readLineRaw() {
+  const buf = Buffer.alloc(65536);
+  let acc = "";
+  while (!acc.includes("\\n")) {
+    let n;
+    try {
+      n = readSync(0, buf, 0, buf.length, null);
+    } catch (err) {
+      if (err.code === "EAGAIN") continue;
+      throw err;
+    }
+    if (n <= 0) break;
+    acc += buf.subarray(0, n).toString();
+  }
+  return acc.split("\\n")[0];
+}
+
+if (mode === "closed-stdin") {
+  closeSync(0);
+  say({ type: "ready_broken" });
+  stayAlive();
+} else if (mode === "break-after-first") {
+  const msg = JSON.parse(readLineRaw());
+  say({ type: "response", id: msg.id, success: true, data: { sessionId: "fake-session" } });
+  closeSync(0);
+  stayAlive();
+} else {
+  let buf = "";
+  process.stdin.on("data", (chunk) => {
+    buf += chunk.toString();
+    const lines = buf.split("\\n");
+    buf = lines.pop() ?? "";
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      const msg = JSON.parse(line);
+      if (msg.type === "get_state") {
+        say({ type: "response", id: msg.id, success: true, data: { sessionId: "fake-session" } });
+      } else if (msg.type === "prompt") {
+        say({ type: "response", id: msg.id, success: true, data: {} });
+        say({ type: "agent_end" });
+      } else if (msg.id) {
+        say({ type: "response", id: msg.id, success: true, data: {} });
+      }
+    }
+  });
+  say({ type: "ready" });
+}
+`;
+
+// The fake Pi is launched through a shebang, which Windows cannot do. The bug
+// itself is platform-independent and the unit block below covers it on every
+// platform; this block just needs a real POSIX pipe to break.
+const describeE2E = process.platform === "win32" ? describe.skip : describe;
+
+describeE2E("Pi provider stdio failure (real node child)", () => {
+	test("a broken stdin pipe fails the provider and leaves the host alive", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "pi-stdio-1378-"));
+		try {
+			const fakePi = join(dir, "fake-pi.mjs");
+			writeFileSync(fakePi, FAKE_PI);
+			chmodSync(fakePi, 0o755);
+			const modeFile = join(dir, "mode.txt");
+			writeFileSync(modeFile, "echo");
+
+			const build = await Bun.build({
+				entrypoints: [join(import.meta.dir, "pi-stdio-failure.child.ts")],
+				target: "node",
+				format: "esm",
+			});
+			if (!build.success) {
+				throw new Error(`child build failed: ${build.logs.map((l) => l.message).join("; ")}`);
+			}
+			const entry = join(dir, "child.mjs");
+			writeFileSync(entry, await build.outputs[0]!.text());
+
+			const child = Bun.spawn(["node", entry], {
+				cwd: dir,
+				env: { ...process.env, FAKE_PI: fakePi, FAKE_PI_MODE_FILE: modeFile },
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			const [stdout, stderr, exitCode] = await Promise.all([
+				new Response(child.stdout).text(),
+				new Response(child.stderr).text(),
+				child.exited,
+			]);
+
+			// The load-bearing assertion: an unguarded stream error would have
+			// terminated this process before it could print anything.
+			expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: "" });
+
+			const results = JSON.parse(stdout.trim().split("\n").pop()!);
+
+			// The in-flight request rejects, with a message that names the pipe.
+			expect(results.brokenRejected).toBe(true);
+			expect(String(results.brokenMessage).toLowerCase()).toContain("stdin");
+			// The provider is marked dead, so the next query re-spawns it...
+			expect(results.brokenAliveAfter).toBe(false);
+			// ...and listeners are told, which is what ends a streaming query.
+			expect(results.brokenSawProcessExited).toBe(true);
+			// A fire-and-forget send afterwards must not throw at its caller.
+			expect(results.postFailureSendThrew).toBe(false);
+
+			// A fresh process works normally afterwards.
+			expect(results.recoveredSessionId).toBe("fake-session");
+			expect(results.recoveredAlive).toBe(true);
+
+			// End to end: the query surfaces an error message rather than hanging
+			// or crashing, and the next query on the same session completes.
+			expect(results.sessionFailedMessages.some((m: { type: string }) => m.type === "error")).toBe(true);
+			expect(results.sessionRecoveredTypes).toContain("result");
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	}, 60_000);
+});
+
+// ---------------------------------------------------------------------------
+// Both write-failure shapes, deterministically
+// ---------------------------------------------------------------------------
+
+type WriteCb = (err?: Error | null) => void;
+
+/** Minimal stand-in for a child's stdin with a scriptable failure mode. */
+function fakeStdin(mode: "sync-throw" | "async-error" | "ok") {
+	const stream = new EventEmitter() as EventEmitter & {
+		destroyed: boolean;
+		writableEnded: boolean;
+		write: (chunk: string, cb?: WriteCb) => boolean;
+		written: string[];
+	};
+	stream.destroyed = false;
+	stream.writableEnded = false;
+	stream.written = [];
+	stream.write = (chunk: string, cb?: WriteCb) => {
+		if (mode === "sync-throw") {
+			const err = new Error("write EPIPE") as Error & { code: string };
+			err.code = "EPIPE";
+			throw err;
+		}
+		if (mode === "async-error") {
+			queueMicrotask(() => cb?.(new Error("write EPIPE")));
+			return false;
+		}
+		stream.written.push(chunk);
+		return true;
+	};
+	return stream;
+}
+
+const asProc = (stdin: unknown): ChildProcess => ({ stdin }) as unknown as ChildProcess;
+
+describe("writeChildLine", () => {
+	test("reports a synchronous EPIPE as a returned error, never a throw", () => {
+		const failures: Error[] = [];
+		let returned: Error | null = null;
+		expect(() => {
+			returned = writeChildLine(asProc(fakeStdin("sync-throw")), "x\n", "Pi process", (e) =>
+				failures.push(e),
+			);
+		}).not.toThrow();
+		expect(returned!.message).toContain("EPIPE");
+		expect(returned!.message).toContain("Pi process");
+		// The sync path reports through the return value only, so a caller that
+		// handles it cannot also be double-failed by the async channel.
+		expect(failures).toHaveLength(0);
+	});
+
+	test("routes an asynchronous EPIPE to the failure handler", async () => {
+		const failures: Error[] = [];
+		const returned = writeChildLine(asProc(fakeStdin("async-error")), "x\n", "Pi process", (e) =>
+			failures.push(e),
+		);
+		// The write was accepted, so nothing is known yet at call time.
+		expect(returned).toBeNull();
+		await new Promise((r) => setTimeout(r, 5));
+		expect(failures).toHaveLength(1);
+		expect(failures[0]!.message).toContain("EPIPE");
+	});
+
+	test("treats an absent, destroyed, or ended stdin as a failure rather than a silent no-op", () => {
+		const label = "Pi process";
+		const cb = () => {};
+		expect(writeChildLine(null, "x\n", label, cb)?.message).toContain("stdin is closed");
+		expect(writeChildLine(asProc(undefined), "x\n", label, cb)?.message).toContain("stdin is closed");
+
+		const destroyed = fakeStdin("ok");
+		destroyed.destroyed = true;
+		expect(writeChildLine(asProc(destroyed), "x\n", label, cb)?.message).toContain("stdin is closed");
+
+		const ended = fakeStdin("ok");
+		ended.writableEnded = true;
+		expect(writeChildLine(asProc(ended), "x\n", label, cb)?.message).toContain("stdin is closed");
+	});
+
+	test("passes the line through when the pipe is healthy", () => {
+		const stdin = fakeStdin("ok");
+		expect(writeChildLine(asProc(stdin), "hello\n", "Pi process", () => {})).toBeNull();
+		expect(stdin.written).toEqual(["hello\n"]);
+	});
+});
+
+describe("guardChildStreams", () => {
+	test("routes an error event from the child or any pipe to the failure handler", () => {
+		const proc = new EventEmitter() as EventEmitter & Record<string, unknown>;
+		proc.stdin = new EventEmitter();
+		proc.stdout = new EventEmitter();
+		proc.stderr = null; // stdio: "ignore" leaves this null
+
+		const failures: string[] = [];
+		guardChildStreams(proc as unknown as ChildProcess, "Pi process", (e) => failures.push(e.message));
+
+		// Without these listeners each of these emits would be an
+		// uncaughtException that takes the host agent down.
+		expect(() => proc.emit("error", new Error("spawn ENOENT"))).not.toThrow();
+		expect(() => (proc.stdin as EventEmitter).emit("error", new Error("write EPIPE"))).not.toThrow();
+		expect(() => (proc.stdout as EventEmitter).emit("error", new Error("read ECONNRESET"))).not.toThrow();
+
+		expect(failures).toHaveLength(3);
+		expect(failures[0]).toContain("process failed");
+		expect(failures[1]).toContain("stdin failed");
+		expect(failures[2]).toContain("stdout failed");
+		expect(failures.every((m) => m.startsWith("Pi process "))).toBe(true);
+	});
+});


### PR DESCRIPTION
## TLDR

Opening a Plannotator plan review from Pi could kill the **entire Pi host** with an uncaught `write EPIPE`. A broken pipe to the nested `pi --mode rpc` child is now handled as an ordinary provider failure: the in-flight query rejects with a clear message, the error surfaces in Ask AI, the provider is marked dead so the next query re-spawns it, and the host stays alive.

Closes #1378. Reported by @Kaelenx, who also did the root-cause analysis in the issue and pointed at the exact line.

## What was actually going wrong

The provider guarded its write like this:

```ts
if (!this.proc?.stdin || this.proc.stdin.destroyed) return;
this.proc.stdin.write(`${JSON.stringify(command)}\n`);
```

Two separate problems compound into a host kill.

**The check cannot close the race.** `destroyed` describes the stream a moment ago. The child can close its end of the pipe between the check and the write, and no amount of pre-checking fixes that; the write itself is the only place the truth is known.

**Nothing was listening for the failure.** Node reports EPIPE from a pipe write either as a synchronous throw or as an `error` event on the stream, and which one you get is a timing race. An `error` event on a Node stream with **no listener** is not "an error you can ignore"; Node re-throws it as an `uncaughtException`. Inside an embedded extension that does not fail the provider, it terminates the process that loaded it, which is the user's whole Pi session.

No stream here had an `error` listener. The `ChildProcess` did not have one either: the spawn handshake registered a one-shot `error` listener and then removed it on success, so from the moment a spawn succeeded the child was completely unguarded for the rest of its life.

Windows only made it likelier to land on the async path during teardown, which is why the report came from there. The mechanism is platform-independent.

There was a second, quieter bug behind the same line. `send()` was fire-and-forget, so a write that failed left the matching `sendAndWait` promise pending **forever** rather than rejecting. The Pi provider has no RPC timeout, so nothing else would have released it.

## The guard pattern

The two JSONL/JSON-RPC providers (Pi Node, Codex app-server) had byte-for-byte the same unguarded `send()`, so rather than patching the reported line twice, the pattern is fixed once in a shared module, `packages/ai/providers/child-io.ts`:

- **`guardChildStreams(proc, label, onFailure)`** attaches `error` listeners to the child process and every piped stream, immediately after spawn and **before** the spawn handshake, so nothing can escalate to `uncaughtException`.
- **`writeChildLine(proc, line, label, onAsyncFailure)`** returns the error for a synchronous failure and routes an asynchronous one through the write callback, so the sync-throw and error-event paths converge on the same handling.
- **`failProcess(error)`** in each provider resolves a broken pipe exactly like any other process end: reject everything in flight, broadcast the process end so a streaming query terminates instead of hanging, reap the child, and leave `alive` false so the existing lifecycle re-spawns on the next query.

I looked for a stronger pattern to copy first. `claude-agent-sdk` spawns nothing of its own, `opencode-sdk` delegates to its SDK, and `codex-app-server` had the identical defect, so there was no good pattern among the siblings to match; the best guards in the repo are elsewhere (`vcs.ts`, `semantic-diff.ts`, `call-flow.ts`) and are swallow-only, which is right for a fire-and-forget CLI write but wrong here, where the failure has to become a visible provider error.

## Scope

In this PR, all in `packages/ai/providers/`:

- `pi-sdk-node.ts` (the reported crash), `codex-app-server.ts` (identical defect, and the mechanism previously reported in #1039 / #1040), `pi-sdk.ts` (the Bun variant's `FileSink` write/flush, guarded symmetrically, including a flush that returns a promise).
- Pi's Node `stderr` moves from an un-drained `"pipe"` to `"ignore"`. Nothing ever read it, and a full stderr pipe deadlocks the child. This is the reasoning already documented in `codex-app-server.ts`; the Pi variant had simply not picked it up.

Deliberately **not** in this PR, found while sweeping for the same class and reported separately so the diff stays reviewable: unguarded `stdin` writes in `apps/pi-extension/server/agent-jobs.ts` and `server/pr.ts`, two fire-and-forget `spawn("open", ...)` calls in `server/integrations.ts` with no `error` listener at all (an ENOENT there is an immediate host kill on any machine without `open`), refusal-branch socket writes in `live-proxy-node.ts` that return before the socket's `error` listener is attached, and the missing RPC timeout that lets a silent-but-alive child hang a Pi query indefinitely.

## Test evidence

`packages/ai/providers/pi-stdio-failure.test.ts`, in two layers.

The end-to-end block runs the provider in a **real `node` child** against a fake Pi that closes its own stdin, following the harness already used by `live-proxy-node.test.ts`. Node is the runtime under Pi, and Bun's `node:stream` shims do not reproduce the unhandled-`error`-kills-the-process rule, so an in-process test could pass against code that still kills the host. The child installs **no** `uncaughtException` handler on purpose: surviving to print its result line is the assertion.

It asserts the in-flight request rejects naming the pipe, `alive` is false, listeners saw the process end, a later fire-and-forget send does not throw, a fresh process talks normally afterwards, and end to end through a session the failure surfaces as an error message while the **next** query on the same session re-spawns and completes.

Against the unfixed provider that child dies exactly as reported:

```
"exitCode": 1,
"stderr": Error: write EPIPE
  code: 'EPIPE',
```

With the fix, exit 0 and empty stderr.

The unit block drives `writeChildLine` / `guardChildStreams` with stream doubles, which is the only way to pin **both** shapes deterministically, since which one a real pipe produces is a platform and timing race: a synchronous throw from `write()`, and an asynchronous error delivered to the write callback.

Checks run: 6/6 new tests pass; `bun test packages/ai/` 122/122; full `bun test` 3819 pass with 15 failures that reproduce identically on unmodified `origin/main` (config-from-disk, improvement-hook and route-404 suites, environmental); `bun run typecheck` clean across all nine projects; `vendor.sh` re-run with `child-io` added to the provider list so `generated/ai/providers/` reflects the fix; `npm pack --dry-run` complete with `generated/ai/providers/child-io.ts` shipping.

AI-assisted (Claude) under maintainer direction.
