### PR TITLE
fix: build review before hook in root build

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build:opencode": "bun run --cwd apps/opencode-plugin build",
     "build:review": "bun run --cwd apps/review build",
     "build:pi": "bun run build:review && bun run build:hook && bun run --cwd apps/pi-extension build",
-    "build": "bun run build:hook && bun run build:opencode",
+    "build": "bun run build:review && bun run build:hook && bun run build:opencode",
     "dev:vscode": "bun run --cwd apps/vscode-extension watch",
     "build:vscode": "bun run --cwd apps/vscode-extension build",
     "package:vscode": "bun run --cwd apps/vscode-extension package",


### PR DESCRIPTION
Closes #1388.

### Rationale

`apps/hook` copies the review bundle during its build, so a clean checkout cannot run the root `bun run build` command when the review app has not already been built.

### Change scope

Update the root `package.json` build script to run `build:review`, then `build:hook`, then `build:opencode`.

### Validation

On a clean Linux checkout with Bun, `bun install --frozen-lockfile` completed, `bun run build:review` completed, and the corrected `bun run build` completed.

### Explicit omissions

This change does not alter the hook build script, generated bundles, package dependencies, or runtime behavior. Generated `node_modules` and `dist` outputs were removed after validation.
