### PR TITLE
chore(packages): bump @plannotator/core to 0.25.0, @plannotator/ui to 0.32.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -85,7 +85,7 @@
     },
     "apps/opencode-plugin": {
       "name": "@plannotator/opencode",
-      "version": "0.27.7",
+      "version": "0.27.8",
       "devDependencies": {
         "@opencode-ai/plugin": "0.0.0-next-16775",
         "@plannotator/server": "workspace:*",
@@ -102,7 +102,7 @@
     },
     "apps/pi-extension": {
       "name": "@plannotator/pi-extension",
-      "version": "0.27.7",
+      "version": "0.27.8",
       "dependencies": {
         "@joplin/turndown-plugin-gfm": "^1.0.64",
         "@pierre/diffs": "1.3.2",
@@ -191,7 +191,7 @@
     },
     "packages/core": {
       "name": "@plannotator/core",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "devDependencies": {
         "typescript": "~5.8.2",
       },
@@ -260,7 +260,7 @@
     },
     "packages/server": {
       "name": "@plannotator/server",
-      "version": "0.27.7",
+      "version": "0.27.8",
       "dependencies": {
         "@pierre/diffs": "1.3.2",
         "@plannotator/ai": "workspace:*",
@@ -290,7 +290,7 @@
     },
     "packages/ui": {
       "name": "@plannotator/ui",
-      "version": "0.31.0",
+      "version": "0.32.0",
       "dependencies": {
         "@base-ui/react": "^1.6.0",
         "@codemirror/autocomplete": "^6.20.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plannotator/core",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "type": "module",
   "exports": {
     "./agents": "./agents.ts",

--- a/packages/ui/HANDOFF.md
+++ b/packages/ui/HANDOFF.md
@@ -406,7 +406,7 @@ Consumer-enablement round for wiki-links (Workspaces' `[[doc_01XYZ|label]]` link
 
 ---
 
-## Embed media picker (unreleased)
+## Embed media picker (0.31.0)
 
 The package now owns the reusable two-stage `/embed` authoring flow. The host still owns its target catalog, serialized embed grammar, and upload UI/API. This is a per-editor extension seam, not a `configurePlannotatorUI()` backend seam.
 
@@ -449,7 +449,7 @@ Behavior is pinned by `components/MarkdownEditor.embedPicker.test.ts`, the suppo
 
 ---
 
-## Lazy renderers and eager entries (unreleased)
+## Lazy renderers and eager entries (0.32.0)
 
 Four modules that used to ride every document read for a host that bundles by route now load on demand: the Mermaid runtime, the Graphviz engine, KaTeX, and the username dictionary. Plannotator's own apps register KaTeX and the dictionary eagerly in both the plan editor and the review editor, and the plan editor also registers the Mermaid runtime eagerly (the review editor never renders a Mermaid block and deliberately does not), so every surface renders exactly as before; the single-file builds are unchanged in size and first paint and the portal entry chunk keeps Mermaid as on main (the built-HTML markers and the A/B proof live in `tests/entry-assets.test.ts` and the PR that shipped this).
 
@@ -547,7 +547,7 @@ Pinned by "unanchored ids are reported on change" in `components/html-viewer/src
 
 ---
 
-## HTML annotation parity seams (unreleased)
+## HTML annotation parity seams (0.32.0)
 
 Nine additive seams so a host can run the raw-HTML annotation surface with the same experience Plannotator ships, without app-local code around `HtmlViewer`. Every default reproduces 0.31.0 behavior; Plannotator's own app passes the same defaults and renders the same DOM (proven by a real-browser A/B of the header, the overlay markers and the annotations panel on a main build versus this build).
 
@@ -571,11 +571,17 @@ Nine additive seams so a host can run the raw-HTML annotation surface with the s
 
 Behavior is pinned by `../core/html-anchor.test.ts`, `components/html-viewer/unanchored.test.ts` and the "unanchored report" suite in `components/html-viewer/htmlPinpointProtocol.test.tsx`, `hooks/useHtmlRefresh.test.tsx`, `components/HtmlSurfaceControls.test.tsx`, `components/AnnotationPanel.unanchored.test.tsx`, and the cap and scroll-to cases in `components/html-viewer/srcdoc.test.ts` and `htmlPinpointProtocol.test.tsx`.
 
+### `@plannotator/core` 0.25.0
+
+Additive only, but required: `@plannotator/ui` 0.32.0 imports the new `@plannotator/core/html-anchor` subpath (`projectHostThreads`, `buildPersistedHtmlAnchor`), absent from published core 0.24.0, so core 0.25.0 must be installed/published first. Also carries the regenerated `guide-viewer-manifest` that pins the guides.show stylesheet with the `HtmlSurfaceControls` rules (see "Publishing & versioning").
+
+0.32.0 also ships the WebMCP provider engine (`@plannotator/ui/webmcp`, the `webmcp` seam on `configurePlannotatorUI`, and the additive `Annotation.inReplyTo` field); see README.md "WebMCP provider".
+
 ---
 
 ## Publishing & versioning
 
-- The next pair is `@plannotator/ui` `0.32.0` with `@plannotator/core` `0.25.0`. **Publish `core` first**: ui 0.32.0 imports the new `@plannotator/core/html-anchor` subpath, which no published core (0.24.0 and earlier) has, just as ui 0.29.0 needed core 0.23.0 for `@plannotator/core/annotatable`. The ui→core dependency resolves exactly at pack time.
+- The current pair is `@plannotator/ui` `0.32.0` with `@plannotator/core` `0.25.0`. **Publish `core` first**: ui 0.32.0 imports the new `@plannotator/core/html-anchor` subpath, which no earlier published core (0.24.0 and before) has, just as ui 0.29.0 needed core 0.23.0 for `@plannotator/core/annotatable`. The ui→core dependency resolves exactly at pack time, from the lockfile: after a version bump, run `bun install` so `bun.lock` carries the new workspace versions, or `bun pm pack` will still stamp the previous core version into ui's tarball (the 0.31.0 lesson).
 - The HTML annotation seams also changed the guides.show viewer **stylesheet** (five utility rules from `HtmlSurfaceControls`; the viewer JS is unchanged), so `packages/core/guide-viewer-manifest.ts` now pins a CSS hash that exists on guides.show only after the deploy workflow has published this build's `/v1/` assets. A guide exported from this build before that deploy would pin a stylesheet the host does not serve yet: **deploy guides.show before any release that ships this manifest.**
 - They depend on each other via `workspace:*`. At publish time that must resolve to the **exact** version in the tarball, so publish with a tool that does that resolution (the repo's existing flow uses `bun pm pack` to build the tarball, then `npm publish *.tgz --access public`). Publish **`core` first, then `ui`**.
 - **`--provenance` only works from a supported CI environment (GitHub Actions OIDC)** — a local publish fails with `Automatic provenance generation not supported for provider: null`. Until a CI publish job exists for these two packages, local publishes drop the flag. Publishing under `--tag next` first lets the consumer preflight before `npm dist-tag add <pkg>@<version> latest` promotes it.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -50,7 +50,7 @@ The sidebar/panel resize handle exposes seams for hosts that want different edge
 
 Building your own tooltip and removing the built-in double-click reset are host-side concerns (override `onDoubleClick` where you render the handle).
 
-### Lazy renderers and the eager entries (`utils/math`, `utils/generateIdentity`, `utils/mermaid`)
+### Lazy renderers and the eager entries (`utils/math`, `utils/generateIdentity`, `utils/mermaid`; 0.32.0)
 
 The Mermaid runtime, the Graphviz engine, KaTeX and the username dictionary are off the static import graph of `Viewer`, so a host that bundles by route does not download them for a plain markdown read. Graphviz needs nothing from you (the block imports the engine inside its render effect and shows the source fence until the SVG lands, as it always did). Mermaid, KaTeX and the dictionary sit behind synchronous slots:
 
@@ -98,9 +98,9 @@ Requires `@plannotator/markdown-editor ^0.4.0` and `@plannotator/atomic-editor ^
 
 `components/html-viewer` is supported host surface as of 0.29.0: the overlay-projection annotation viewer for raw HTML (placed comment markers, pinpoint element anchors, shift-click multi-target comments). Its contract is **props plus the validated iframe message protocol** — not `configurePlannotatorUI()`, which only governs the backend surfaces around it. Drive the `annotations` prop (marker numbering derives from its array order); `readOnly` keeps markers painted and clickable while disabling all authoring. **0.29.0 also carries a breaking migration:** highlight.js is gone and `.hljs` selectors are inert — style code via the exported `pn-code` class (`CODE_BLOCK_CLASS` in `utils/codeHighlight`). See HANDOFF.md § "Raw-HTML annotation viewer + syntax-highlighting migration (0.29.0)" before upgrading from 0.28.0.
 
-#### HTML annotation parity seams
+#### HTML annotation parity seams (0.32.0)
 
-Everything a host needs around `HtmlViewer` to match Plannotator's HTML annotation experience, all additive and all defaulting to today's behavior:
+Everything a host needs around `HtmlViewer` to match Plannotator's HTML annotation experience, all additive and all defaulting to today's behavior. Requires `@plannotator/core` 0.25.0 (the `html-anchor` subpath), so install and publish core before ui:
 
 - **`projectHostThreads(threads, { openOnly?, documentLevel?, maxTargets? })`** and **`buildPersistedHtmlAnchor(source, { maxBytes?, maxTargets? })`** from `components/html-viewer` (pure, from `@plannotator/core/html-anchor`): project stored rows onto the `annotations` prop in the order that becomes the marker numbering, and trim a composed comment's anchor for persistence with cap drops and size drops reported separately. A row with nothing restorable projects as a document-level `GLOBAL_COMMENT` by default (`documentLevel: 'global'`, never reported as unanchored) or, with `documentLevel: 'unanchored'`, as a textless page `COMMENT` the unanchored report names.
 - **`onUnanchoredChange`** is keyed to the bridge's restore (one complete report per document after the restore batch, the empty set included) and complete over the `annotations` prop: textless page rows are reported without being posted, and a locally minted id the host swapped out of its list is not. It replaces a host's `mark-applied` bookkeeping for the unanchored set; the local-to-server mark swap itself stays host-side.
@@ -112,12 +112,12 @@ Everything a host needs around `HtmlViewer` to match Plannotator's HTML annotati
 
 See HANDOFF.md § "HTML annotation parity seams".
 
-#### Also blessed: `shortcuts` and `utils/inputMethod`
+#### Also blessed in 0.32.0: `shortcuts` and `utils/inputMethod`
 
 - **`@plannotator/ui/shortcuts`**: the declarative keyboard-shortcut engine (`defineShortcutScope`, `useShortcutScope`) and the per-surface scopes, including `useHtmlAnnotateShortcuts` for the Mod+Shift+A Annotate/Interact chord on HTML surfaces. Pure React plus `utils/platform`; no backend.
 - **`@plannotator/ui/utils/inputMethod`**: `getInputMethod(surface)` / `saveInputMethod(method, surface)` / `refreshInputMethodStamp(method)`, the per-surface pinpoint-or-drag preference with its TTL, persisted through the `storageBackend` seam.
 
-### WebMCP provider (`@plannotator/ui/webmcp`)
+### WebMCP provider (`@plannotator/ui/webmcp`; 0.32.0)
 
 The engine that lets a browser-integrated agent (Chrome/Edge WebMCP, `document.modelContext`) call in-page tools on a document surface. Feature-detected once; a browser without the API sees no registration, no DOM, no network, no timers. Seam: `configurePlannotatorUI({ webmcp: { enabled, namePrefix } })`, default enabled with the `plannotator.` prefix; pass `enabled: false` to keep a host page tool-free, or your own prefix to namespace the tools beside your own. There is deliberately no confirmation seam: the catalog is read-and-comment only (no approve / submit / close tools), and the agent may only edit or remove comments stamped `source: "browser-agent"`.
 
@@ -152,7 +152,7 @@ npm install @plannotator/ui @plannotator/core
 - `@plannotator/core` — pure utils + types, zero deps, browser-safe (CI enforces no `node:` imports). Published.
 - `@plannotator/ui` — React components/hooks + theme + `configure()`. Depends on `@plannotator/core` (exact-version lockstep). Published.
 - `@plannotator/shared`, `@plannotator/ai` — stay private to the monorepo; `shared` re-exports `core`'s modules via shims so Plannotator's internals are untouched.
-- Versioned in lockstep with the repo. Publish `core` then `ui`: build each tarball with **`bun pm pack`** (resolves `workspace:*` to the exact version at pack time), then **`npm publish *.tgz --provenance --access public`** — the repo's existing flow.
+- Versioned in lockstep with the repo (currently `@plannotator/core` 0.25.0 with `@plannotator/ui` 0.32.0). Publish `core` then `ui`: build each tarball with **`bun pm pack`** (resolves `workspace:*` to the exact version at pack time, from `bun.lock`, so run `bun install` after a bump), then **`npm publish *.tgz --provenance --access public`** — the repo's existing flow (`--provenance` needs CI OIDC; local publishes drop it, see HANDOFF.md "Publishing & versioning").
 
 ## The one rule
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plannotator/ui",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "type": "module",
   "exports": {
     "./components/*": "./components/*.tsx",


### PR DESCRIPTION
Lockstep npm release of @plannotator/core 0.25.0 and @plannotator/ui 0.32.0, in the shape of the 0.24.0 / 0.31.0 release (d257f7fa, 1080436d). Three commits: the two package.json bumps, the bun.lock refresh, and the docs that turn the "unreleased" wording in packages/ui/README.md and HANDOFF.md into the concrete versions.

What is in the pair: the HTML annotation parity seams from #1395 (projectHostThreads, buildPersistedHtmlAnchor, useHtmlRefresh, HtmlSurfaceControls, the unanchored report contract, scrollBehavior and maxAdditionalTargets on HtmlViewer, plus the blessed shortcuts and utils/inputMethod subpaths), the lazy renderers with eager entries from #1394 (utils/math, utils/math-eager, utils/mermaid, utils/mermaid-eager, utils/identity-tater), and the WebMCP provider engine from #1393 (@plannotator/ui/webmcp and the webmcp seam). Core gains the html-anchor subpath and the regenerated guide-viewer-manifest.

Why core first: ui 0.32.0 imports @plannotator/core/html-anchor, which no published core (0.24.0 and earlier) has. ui's workspace:* dependency resolves to the exact core version from bun.lock at pack time, which is why the lockfile refresh is its own commit; a stale lockfile would stamp 0.24.0 into the ui tarball. The app workspace entries in bun.lock also picked up 0.27.8 (they were stale at 0.27.7), the same side effect the previous lockfile commit had.

Tarball verification (bun pm pack from this branch):

- plannotator-core-0.25.0.tgz: 31 files, 176.81KB unpacked, 60.32KB packed. Includes html-anchor.ts, guide-viewer-manifest.ts, annotatable.ts. All 30 concrete exports-map targets exist in the extracted tarball.
- plannotator-ui-0.32.0.tgz: 361 files, 4.67MB unpacked, 2.56MB packed. Includes utils/math-eager, utils/math, utils/identity-tater, utils/mermaid-eager, utils/mermaid, components/HtmlSurfaceControls, hooks/useHtmlRefresh, utils/inputMethod, shortcuts/index.ts, components/html-viewer/index.ts, the full webmcp/ directory (10 modules), and styles.css. All 11 concrete exports-map targets exist and all 10 wildcard patterns resolve to populated directories. No *.test.* files are shipped.
- The ui tarball's package.json shows "@plannotator/core": "0.25.0", not stale.
- tsc --noEmit -p packages/ui/tsconfig.strict-consumer.json passes.
- Smoke: a throwaway project installed both tarballs by path (core first; ui's exact core dep is unpublished so both tarballs were given to one npm resolution), then compiled a TSX file importing HtmlViewer, projectHostThreads and buildPersistedHtmlAnchor from components/html-viewer, AnnotationPanel, configurePlannotatorUI, useHtmlRefresh, HtmlSurfaceControls, the shortcuts subpath, utils/inputMethod, utils/math, utils/mermaid, the three eager entries, webmcp, and core's guide-viewer-manifest and html-anchor, under the strict-consumer compiler flags. It typechecks clean. Note: a consumer that also enables noUncheckedIndexedAccess or noPropertyAccessFromIndexSignature (stricter than the published contract) will see errors in utils/vimNavigation.ts and webmcp/schema.ts; those flags are not part of the strict-consumer gate and this was also true before this release.
- bun run typecheck passes; bun test packages/ui packages/core: 882 pass, 0 fail.

Publish steps for the maintainer, after merge, from main:

    cd packages/core && npm publish --access public
    cd packages/ui && npm publish --access public

Publish core first. As last time, --provenance may need to be dropped for a local publish (it only works from GitHub Actions OIDC). Consider publishing under --tag next first and promoting with npm dist-tag add once the consumer preflights.

One doc correction that rides along: the HANDOFF "Embed media picker" section was still headed "(unreleased)" even though #1382 shipped in 0.31.0; it now reads (0.31.0). HANDOFF also notes that this manifest pins a guides.show stylesheet hash that exists only after the guides.show deploy workflow has run, so deploy guides.show before the app release that ships it.

AI-assisted (Claude) under maintainer direction.
