### PR TITLE
fix(pi): notify review URL in RPC sessions

### DIFF
--- a/apps/pi-extension/plannotator-browser.test.ts
+++ b/apps/pi-extension/plannotator-browser.test.ts
@@ -40,6 +40,48 @@ describe("shouldUseLocalPrCheckout", () => {
 	});
 });
 
+describe("browser URL notification", () => {
+	test("notifies RPC sessions even when the browser launcher reports success", async () => {
+		const previousRemote = process.env.PLANNOTATOR_REMOTE;
+		const previousPlannotatorBrowser = process.env.PLANNOTATOR_BROWSER;
+		const previousBrowser = process.env.BROWSER;
+		const notifications: string[] = [];
+
+		process.env.PLANNOTATOR_REMOTE = "0";
+		delete process.env.PLANNOTATOR_BROWSER;
+		process.env.BROWSER = process.execPath;
+
+		try {
+			const ctx = {
+				mode: "rpc",
+				hasUI: true,
+				ui: {
+					notify(message: string) {
+						notifications.push(message);
+					},
+				},
+			} as any;
+			const session = startBrowserDecisionSession(
+				{ url: "http://localhost:4321", stop() {} },
+				ctx,
+				() => new Promise<never>(() => {}),
+			);
+
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			session.stop();
+
+			expect(notifications).toEqual(["[Plannotator] http://localhost:4321"]);
+		} finally {
+			if (previousRemote === undefined) delete process.env.PLANNOTATOR_REMOTE;
+			else process.env.PLANNOTATOR_REMOTE = previousRemote;
+			if (previousPlannotatorBrowser === undefined) delete process.env.PLANNOTATOR_BROWSER;
+			else process.env.PLANNOTATOR_BROWSER = previousPlannotatorBrowser;
+			if (previousBrowser === undefined) delete process.env.BROWSER;
+			else process.env.BROWSER = previousBrowser;
+		}
+	});
+});
+
 describe("browser session cleanup", () => {
 	const ctx = {
 		hasUI: true,

--- a/apps/pi-extension/plannotator-browser.ts
+++ b/apps/pi-extension/plannotator-browser.ts
@@ -180,7 +180,7 @@ export async function startServerWithSelfPreemption<T>(
 
 async function openBrowserForServer(serverUrl: string, ctx: ExtensionContext): Promise<void> {
 	const browserResult = await openBrowser(serverUrl);
-	if (isRemoteSession()) {
+	if (ctx.mode === "rpc" || isRemoteSession()) {
 		ctx.ui.notify(`[Plannotator] ${serverUrl}`, "info");
 	} else if (!browserResult.opened) {
 		ctx.ui.notify(`Open this URL to review: ${serverUrl}`, "info");


### PR DESCRIPTION
## Summary

Pi Web runs extensions with `ExtensionContext.mode === "rpc"`. In this mode,
Plannotator's `isRemoteSession()` can remain false even though the user cannot
directly access the browser launched by the Pi Web host process.

`openBrowserForServer()` currently notifies the URL only for remote sessions or
when browser launch reports failure. A successful browser spawn in the Pi Web
host can therefore hide the URL from the RPC session.

Treat RPC extension contexts like remote sessions for the purpose of URL
notification:

```diff
- if (isRemoteSession()) {
+ if (ctx.mode === "rpc" || isRemoteSession()) {
    ctx.ui.notify(`[Plannotator] ${serverUrl}`, "info");
  }
```

## Behavior

- Local interactive sessions keep their existing behavior.
- Existing SSH and `PLANNOTATOR_REMOTE` sessions keep their existing behavior.
- Pi Web RPC sessions receive the review URL through `ctx.ui.notify()` even
  when the browser launcher reports success.
- Server binding, hostname selection, ports, authentication, browser launch,
  and port forwarding are unchanged.
- This does not make the random review port directly reachable through Pi Web;
  it only exposes the URL to the user so an explicitly configured access path
  can be used.

## Test plan

- Added a regression test for an RPC context with `PLANNOTATOR_REMOTE=0`.
- The test points `BROWSER` at the current Node executable, so no real browser
  is opened while the launcher still reports success.
- The test verifies that the RPC context receives the `[Plannotator] <url>`
  notification.
- `git diff --check` passes.
- The full Bun test suite could not be run locally because Bun is not installed
  in the development environment; GitHub Actions should run the repository's
  standard checks.

Closes #1406
