### PR TITLE
fix(ai): keep OpenCode Ask AI subscribed before prompting

### DIFF
--- a/packages/ai/ai.test.ts
+++ b/packages/ai/ai.test.ts
@@ -1663,7 +1663,12 @@ describe("mapPiEvent", () => {
 // OpenCode event mapping
 // ---------------------------------------------------------------------------
 
-import { mapOpenCodeEvent } from "./providers/opencode-sdk.ts";
+import {
+  assistantTextFromPartUpdate,
+  fallbackAssistantText,
+  mapOpenCodeEvent,
+  openCodeEventSessionId,
+} from "./providers/opencode-sdk.ts";
 
 describe("mapOpenCodeEvent", () => {
   const SESSION_ID = "oc_session_1";
@@ -1826,5 +1831,58 @@ describe("mapOpenCodeEvent", () => {
     expect(mapOpenCodeEvent("session.updated", { sessionID: SESSION_ID }, SESSION_ID)).toEqual([]);
     expect(mapOpenCodeEvent("server.connected", {}, SESSION_ID)).toEqual([]);
     expect(mapOpenCodeEvent("file.edited", { file: "foo.ts" }, SESSION_ID)).toEqual([]);
+  });
+
+  test("message.part.updated text snapshots are not streamed as deltas", () => {
+    expect(
+      mapOpenCodeEvent("message.part.updated", {
+        sessionID: SESSION_ID,
+        part: { type: "text", text: "pong", sessionID: SESSION_ID },
+      }, SESSION_ID),
+    ).toEqual([]);
+  });
+
+  test("openCodeEventSessionId reads nested part and info ids", () => {
+    expect(openCodeEventSessionId({ sessionID: SESSION_ID })).toBe(SESSION_ID);
+    expect(
+      openCodeEventSessionId({ info: { sessionID: SESSION_ID } }),
+    ).toBe(SESSION_ID);
+    expect(
+      openCodeEventSessionId({ part: { sessionID: SESSION_ID } }),
+    ).toBe(SESSION_ID);
+  });
+
+  test("assistantTextFromPartUpdate keeps only non-empty assistant text parts", () => {
+    expect(
+      assistantTextFromPartUpdate({ type: "text", text: "pong" }),
+    ).toBe("pong");
+    expect(assistantTextFromPartUpdate({ type: "text", text: "" })).toBeUndefined();
+    expect(
+      assistantTextFromPartUpdate({ type: "reasoning", text: "thinking" }),
+    ).toBeUndefined();
+  });
+
+  test("fallbackAssistantText emits the snapshot only when deltas were missed", () => {
+    expect(
+      fallbackAssistantText({
+        turnStarted: true,
+        sawTextDelta: false,
+        lastAssistantText: "pong",
+      }),
+    ).toEqual([{ type: "text_delta", delta: "pong" }]);
+    expect(
+      fallbackAssistantText({
+        turnStarted: true,
+        sawTextDelta: true,
+        lastAssistantText: "pong",
+      }),
+    ).toEqual([]);
+    expect(
+      fallbackAssistantText({
+        turnStarted: false,
+        sawTextDelta: false,
+        lastAssistantText: "pong",
+      }),
+    ).toEqual([]);
   });
 });

--- a/packages/ai/ai.test.ts
+++ b/packages/ai/ai.test.ts
@@ -1665,9 +1665,10 @@ describe("mapPiEvent", () => {
 
 import {
   assistantTextFromPartUpdate,
+  consumeOpenCodeEvent,
+  createOpenCodeQueryState,
   fallbackAssistantText,
   mapOpenCodeEvent,
-  openCodeEventSessionId,
 } from "./providers/opencode-sdk.ts";
 
 describe("mapOpenCodeEvent", () => {
@@ -1839,57 +1840,117 @@ describe("mapOpenCodeEvent", () => {
     expect(
       mapOpenCodeEvent("message.part.updated", {
         sessionID: SESSION_ID,
-        part: { type: "text", text: "pong", sessionID: SESSION_ID },
+        part: { type: "text", text: "pong", sessionID: SESSION_ID, time: { start: 1 } },
       }, SESSION_ID),
     ).toEqual([]);
   });
 
-  // Session filter used to miss events whose id lived only on info/part.
-  test("openCodeEventSessionId reads nested part and info ids", () => {
-    expect(openCodeEventSessionId({ sessionID: SESSION_ID })).toBe(SESSION_ID);
+  // User prompt snapshots have no `time`. Using them as the answer would echo
+  // the question into the Ask AI bubble (#514 empty-bubble / #907).
+  test("assistantTextFromPartUpdate ignores user prompts and reasoning", () => {
     expect(
-      openCodeEventSessionId({ info: { sessionID: SESSION_ID } }),
-    ).toBe(SESSION_ID);
-    expect(
-      openCodeEventSessionId({ part: { sessionID: SESSION_ID } }),
-    ).toBe(SESSION_ID);
-  });
-
-  // Reasoning parts share the same snapshot event; using them as the answer
-  // would dump thinking into the Ask AI bubble.
-  test("assistantTextFromPartUpdate keeps only non-empty assistant text parts", () => {
-    expect(
-      assistantTextFromPartUpdate({ type: "text", text: "pong" }),
+      assistantTextFromPartUpdate({ type: "text", text: "pong", time: { start: 1 } }),
     ).toBe("pong");
-    expect(assistantTextFromPartUpdate({ type: "text", text: "" })).toBeUndefined();
     expect(
-      assistantTextFromPartUpdate({ type: "reasoning", text: "thinking" }),
+      assistantTextFromPartUpdate({ type: "text", text: "Reply with pong" }),
+    ).toBeUndefined();
+    expect(
+      assistantTextFromPartUpdate({ type: "reasoning", text: "thinking", time: { start: 1 } }),
     ).toBeUndefined();
   });
 
-  // Failure this guards: Ask AI hangs with Failed to fetch when deltas never
-  // arrive. Idle-before-busy must not emit leftover text from another turn.
   test("fallbackAssistantText emits the snapshot only when deltas were missed", () => {
     expect(
       fallbackAssistantText({
-        turnStarted: true,
         sawTextDelta: false,
         lastAssistantText: "pong",
       }),
     ).toEqual([{ type: "text_delta", delta: "pong" }]);
     expect(
       fallbackAssistantText({
-        turnStarted: true,
         sawTextDelta: true,
         lastAssistantText: "pong",
       }),
     ).toEqual([]);
-    expect(
-      fallbackAssistantText({
-        turnStarted: false,
-        sawTextDelta: false,
-        lastAssistantText: "pong",
-      }),
-    ).toEqual([]);
+  });
+
+  // Failure this guards: Ask AI hangs with Failed to fetch (#514 / #907)
+  // when the turn only lands a snapshot, never message.part.delta.
+  test("consumeOpenCodeEvent falls back to the assistant snapshot on idle", () => {
+    const state = createOpenCodeQueryState();
+    consumeOpenCodeEvent(
+      {
+        type: "message.part.updated",
+        properties: {
+          sessionID: SESSION_ID,
+          part: { type: "text", text: "Reply with pong", sessionID: SESSION_ID },
+        },
+      },
+      SESSION_ID,
+      state,
+    );
+    consumeOpenCodeEvent(
+      {
+        type: "message.part.updated",
+        properties: {
+          sessionID: SESSION_ID,
+          part: {
+            type: "text",
+            text: "pong",
+            sessionID: SESSION_ID,
+            time: { start: 1, end: 2 },
+          },
+        },
+      },
+      SESSION_ID,
+      state,
+    );
+    const idle = consumeOpenCodeEvent(
+      {
+        type: "session.status",
+        properties: { sessionID: SESSION_ID, status: { type: "idle" } },
+      },
+      SESSION_ID,
+      state,
+    );
+    expect(idle.done).toBe(true);
+    expect(idle.messages).toEqual([
+      { type: "text_delta", delta: "pong" },
+      { type: "result", sessionId: SESSION_ID, success: true },
+    ]);
+  });
+
+  test("consumeOpenCodeEvent does not duplicate streamed deltas", () => {
+    const state = createOpenCodeQueryState();
+    consumeOpenCodeEvent(
+      {
+        type: "message.part.delta",
+        properties: { sessionID: SESSION_ID, field: "text", delta: "pong" },
+      },
+      SESSION_ID,
+      state,
+    );
+    consumeOpenCodeEvent(
+      {
+        type: "message.part.updated",
+        properties: {
+          sessionID: SESSION_ID,
+          part: { type: "text", text: "pong", sessionID: SESSION_ID, time: { start: 1 } },
+        },
+      },
+      SESSION_ID,
+      state,
+    );
+    const idle = consumeOpenCodeEvent(
+      {
+        type: "session.status",
+        properties: { sessionID: SESSION_ID, status: { type: "idle" } },
+      },
+      SESSION_ID,
+      state,
+    );
+    expect(idle.messages).toEqual([
+      { type: "result", sessionId: SESSION_ID, success: true },
+    ]);
   });
 });

--- a/packages/ai/ai.test.ts
+++ b/packages/ai/ai.test.ts
@@ -1833,6 +1833,8 @@ describe("mapOpenCodeEvent", () => {
     expect(mapOpenCodeEvent("file.edited", { file: "foo.ts" }, SESSION_ID)).toEqual([]);
   });
 
+  // OpenCode 1.18 lands the answer as a text snapshot. Mapping that as a
+  // delta would duplicate streamed tokens; Ask AI would show "pongpong".
   test("message.part.updated text snapshots are not streamed as deltas", () => {
     expect(
       mapOpenCodeEvent("message.part.updated", {
@@ -1842,6 +1844,7 @@ describe("mapOpenCodeEvent", () => {
     ).toEqual([]);
   });
 
+  // Session filter used to miss events whose id lived only on info/part.
   test("openCodeEventSessionId reads nested part and info ids", () => {
     expect(openCodeEventSessionId({ sessionID: SESSION_ID })).toBe(SESSION_ID);
     expect(
@@ -1852,6 +1855,8 @@ describe("mapOpenCodeEvent", () => {
     ).toBe(SESSION_ID);
   });
 
+  // Reasoning parts share the same snapshot event; using them as the answer
+  // would dump thinking into the Ask AI bubble.
   test("assistantTextFromPartUpdate keeps only non-empty assistant text parts", () => {
     expect(
       assistantTextFromPartUpdate({ type: "text", text: "pong" }),
@@ -1862,6 +1867,8 @@ describe("mapOpenCodeEvent", () => {
     ).toBeUndefined();
   });
 
+  // Failure this guards: Ask AI hangs with Failed to fetch when deltas never
+  // arrive. Idle-before-busy must not emit leftover text from another turn.
   test("fallbackAssistantText emits the snapshot only when deltas were missed", () => {
     expect(
       fallbackAssistantText({

--- a/packages/ai/providers/opencode-sdk.ts
+++ b/packages/ai/providers/opencode-sdk.ts
@@ -303,6 +303,9 @@ class OpenCodeSession extends BaseSession {
 			const iterator = stream[Symbol.asyncIterator]();
 
 			try {
+				// First frame only proves the subscriber is live. Do not treat it as
+				// this turn — it can be server.connected or leftover idle from a
+				// previous query on the same session.
 				const first = await iterator.next();
 				if (first.done) {
 					yield {
@@ -335,78 +338,26 @@ class OpenCodeSession extends BaseSession {
 				}
 				this._firstQuerySent = true;
 
-				let turnStarted = false;
-				let sawTextDelta = false;
-				let lastAssistantText = "";
-				let completed = false;
-
-				const handle = function* (
-					event: { type?: string; properties?: Record<string, unknown> },
-				): Generator<AIMessage> {
-					const eventType = event.type as string;
-					const props = event.properties;
-					if (props == null) return;
-
-					const eventSessionId = openCodeEventSessionId(props);
-					if (eventSessionId && eventSessionId !== this.config.sessionId) return;
-
-					if (eventType === "session.status") {
-						const status = props.status as Record<string, unknown> | undefined;
-						if (status?.type === "busy") turnStarted = true;
-					}
-
-					if (eventType === "message.part.updated" && turnStarted) {
-						const snapshot = assistantTextFromPartUpdate(
-							props.part as Record<string, unknown> | undefined,
-						);
-						if (snapshot) lastAssistantText = snapshot;
-					}
-
-					const mapped = mapOpenCodeEvent(eventType, props, this.id);
-					for (const msg of mapped) {
-						if (msg.type === "text_delta") sawTextDelta = true;
-						if (msg.type === "result") {
-							if (!turnStarted) continue;
-							for (const fallback of fallbackAssistantText({
-								turnStarted,
-								sawTextDelta,
-								lastAssistantText,
-							})) {
-								yield fallback;
-							}
-							completed = true;
-						}
-						yield msg;
-					}
-				}.bind(this);
-
-				for (const msg of handle(first.value)) {
-					yield msg;
-					if (msg.type === "result" || (msg.type === "error" && isTerminalEvent(String(first.value?.type)))) {
-						return;
-					}
-				}
-
+				const state = createOpenCodeQueryState();
 				while (!signal.aborted) {
 					const next = await iterator.next();
 					if (next.done) break;
-					for (const msg of handle(next.value)) {
-						yield msg;
-						if (msg.type === "result" || (msg.type === "error" && isTerminalEvent(String(next.value?.type)))) {
-							return;
-						}
-					}
+					const { messages, done } = consumeOpenCodeEvent(
+						next.value,
+						this.config.sessionId,
+						state,
+					);
+					for (const msg of messages) yield msg;
+					if (done) return;
 				}
 
-				if (!completed) {
-					yield {
-						type: "error",
-						error: signal.aborted
-							? "OpenCode query aborted."
-							: "OpenCode event stream ended without a result.",
-						code: "provider_error",
-					};
-				}
+				yield {
+					type: "error",
+					error: signal.aborted
+						? "OpenCode query aborted."
+						: "OpenCode event stream ended without a result.",
+					code: "provider_error",
+				};
 			} finally {
 				await iterator.return?.();
 			}
@@ -469,29 +420,74 @@ export function openCodeEventSessionId(
  * OpenCode 1.18 still emits `message.part.delta` for streaming text, but some
  * turns only land a final `message.part.updated` snapshot (or a late
  * subscriber misses the deltas). Capture assistant text parts so Ask AI can
- * still render an answer.
+ * still render an answer. User-prompt snapshots have no `time` stamp.
  */
 export function assistantTextFromPartUpdate(
 	part: Record<string, unknown> | undefined,
 ): string | undefined {
 	if (!part || part.type !== "text") return undefined;
+	if (part.time == null) return undefined;
 	const text = part.text;
 	return typeof text === "string" && text.length > 0 ? text : undefined;
 }
 
-/**
- * If this turn never streamed `message.part.delta` text, emit the last
- * assistant snapshot so Ask AI still has something to render.
- */
-export function fallbackAssistantText(opts: {
-	turnStarted: boolean;
+export interface OpenCodeQueryState {
 	sawTextDelta: boolean;
 	lastAssistantText: string;
-}): AIMessage[] {
-	if (!opts.turnStarted || opts.sawTextDelta || !opts.lastAssistantText) {
-		return [];
+}
+
+export function createOpenCodeQueryState(): OpenCodeQueryState {
+	return { sawTextDelta: false, lastAssistantText: "" };
+}
+
+/**
+ * If this turn never streamed `message.part.delta` text, emit the last
+ * assistant snapshot so Ask AI still has something to render (#514 / #907).
+ */
+export function fallbackAssistantText(state: OpenCodeQueryState): AIMessage[] {
+	if (state.sawTextDelta || !state.lastAssistantText) return [];
+	return [{ type: "text_delta", delta: state.lastAssistantText }];
+}
+
+/**
+ * Consume one OpenCode SSE event after promptAsync. Returns mapped Ask AI
+ * messages and whether the query should stop. Pre-prompt leftover idle is
+ * ignored by only calling this after the prompt is sent.
+ */
+export function consumeOpenCodeEvent(
+	event: { type?: string; properties?: Record<string, unknown> },
+	sessionId: string,
+	state: OpenCodeQueryState,
+): { messages: AIMessage[]; done: boolean } {
+	const eventType = event.type as string;
+	const props = event.properties;
+	if (props == null) return { messages: [], done: false };
+
+	const eventSessionId = openCodeEventSessionId(props);
+	if (eventSessionId && eventSessionId !== sessionId) {
+		return { messages: [], done: false };
 	}
-	return [{ type: "text_delta", delta: opts.lastAssistantText }];
+
+	if (eventType === "message.part.updated") {
+		const snapshot = assistantTextFromPartUpdate(
+			props.part as Record<string, unknown> | undefined,
+		);
+		if (snapshot) state.lastAssistantText = snapshot;
+	}
+
+	const mapped = mapOpenCodeEvent(eventType, props, sessionId);
+	const messages: AIMessage[] = [];
+	let done = false;
+	for (const msg of mapped) {
+		if (msg.type === "text_delta") state.sawTextDelta = true;
+		if (msg.type === "result") {
+			messages.push(...fallbackAssistantText(state));
+			done = true;
+		}
+		messages.push(msg);
+		if (msg.type === "error" && isTerminalEvent(eventType)) done = true;
+	}
+	return { messages, done };
 }
 
 /**

--- a/packages/ai/providers/opencode-sdk.ts
+++ b/packages/ai/providers/opencode-sdk.ts
@@ -280,7 +280,7 @@ class OpenCodeSession extends BaseSession {
 			yield BaseSession.BUSY_ERROR;
 			return;
 		}
-		const { gen } = started;
+		const { gen, signal } = started;
 
 		try {
 			// Build model param if specified
@@ -293,11 +293,26 @@ class OpenCodeSession extends BaseSession {
 				}
 			}
 
-			// Subscribe to SSE events
-			const { stream } = await this.config.client.event.subscribe();
+			// Open the SSE stream and wait for the first frame *before* prompting.
+			// OpenCode 1.18+ can finish a short turn before a late subscriber
+			// connects; Ask AI then hangs until the browser reports Failed to fetch.
+			const { stream } = await this.config.client.event.subscribe(
+				undefined,
+				{ signal },
+			);
+			const iterator = stream[Symbol.asyncIterator]();
 
 			try {
-				// Send prompt asynchronously
+				const first = await iterator.next();
+				if (first.done) {
+					yield {
+						type: "error",
+						error: "OpenCode event stream closed before the prompt was sent.",
+						code: "provider_error",
+					};
+					return;
+				}
+
 				try {
 					await this.config.client.session.promptAsync({
 						path: { id: this.config.sessionId },
@@ -320,29 +335,80 @@ class OpenCodeSession extends BaseSession {
 				}
 				this._firstQuerySent = true;
 
-				// Drain SSE events filtered by session ID
-				for await (const event of stream) {
-					const eventType = event.type as string;
-					const props = event.properties as Record<string, unknown> | undefined;
-					if (!props) continue;
+				let turnStarted = false;
+				let sawTextDelta = false;
+				let lastAssistantText = "";
+				let completed = false;
 
-					// Filter: only events for our session
-					const eventSessionId =
-						(props.sessionID as string) ??
-						((props.info as Record<string, unknown>)?.sessionID as string) ??
-						((props.part as Record<string, unknown>)?.sessionID as string);
-					if (eventSessionId && eventSessionId !== this.config.sessionId) continue;
+				const handle = function* (
+					event: { type?: string; properties?: Record<string, unknown> },
+				): Generator<AIMessage> {
+					const eventType = event.type as string;
+					const props = event.properties;
+					if (props == null) return;
+
+					const eventSessionId = openCodeEventSessionId(props);
+					if (eventSessionId && eventSessionId !== this.config.sessionId) return;
+
+					if (eventType === "session.status") {
+						const status = props.status as Record<string, unknown> | undefined;
+						if (status?.type === "busy") turnStarted = true;
+					}
+
+					if (eventType === "message.part.updated" && turnStarted) {
+						const snapshot = assistantTextFromPartUpdate(
+							props.part as Record<string, unknown> | undefined,
+						);
+						if (snapshot) lastAssistantText = snapshot;
+					}
 
 					const mapped = mapOpenCodeEvent(eventType, props, this.id);
 					for (const msg of mapped) {
+						if (msg.type === "text_delta") sawTextDelta = true;
+						if (msg.type === "result") {
+							if (!turnStarted) continue;
+							for (const fallback of fallbackAssistantText({
+								turnStarted,
+								sawTextDelta,
+								lastAssistantText,
+							})) {
+								yield fallback;
+							}
+							completed = true;
+						}
 						yield msg;
-						if (msg.type === "result" || (msg.type === "error" && isTerminalEvent(eventType))) {
+					}
+				}.bind(this);
+
+				for (const msg of handle(first.value)) {
+					yield msg;
+					if (msg.type === "result" || (msg.type === "error" && isTerminalEvent(String(first.value?.type)))) {
+						return;
+					}
+				}
+
+				while (!signal.aborted) {
+					const next = await iterator.next();
+					if (next.done) break;
+					for (const msg of handle(next.value)) {
+						yield msg;
+						if (msg.type === "result" || (msg.type === "error" && isTerminalEvent(String(next.value?.type)))) {
 							return;
 						}
 					}
 				}
+
+				if (!completed) {
+					yield {
+						type: "error",
+						error: signal.aborted
+							? "OpenCode query aborted."
+							: "OpenCode event stream ended without a result.",
+						code: "provider_error",
+					};
+				}
 			} finally {
-				stream.return?.();
+				await iterator.return?.();
 			}
 		} catch (err) {
 			yield {
@@ -385,6 +451,49 @@ function isTerminalEvent(eventType: string): boolean {
 	return eventType === "session.error" || eventType === "session.status";
 }
 
+export function openCodeEventSessionId(
+	props: Record<string, unknown>,
+): string | undefined {
+	return (
+		(props.sessionID as string | undefined) ??
+		((props.info as Record<string, unknown> | undefined)?.sessionID as
+			| string
+			| undefined) ??
+		((props.part as Record<string, unknown> | undefined)?.sessionID as
+			| string
+			| undefined)
+	);
+}
+
+/**
+ * OpenCode 1.18 still emits `message.part.delta` for streaming text, but some
+ * turns only land a final `message.part.updated` snapshot (or a late
+ * subscriber misses the deltas). Capture assistant text parts so Ask AI can
+ * still render an answer.
+ */
+export function assistantTextFromPartUpdate(
+	part: Record<string, unknown> | undefined,
+): string | undefined {
+	if (!part || part.type !== "text") return undefined;
+	const text = part.text;
+	return typeof text === "string" && text.length > 0 ? text : undefined;
+}
+
+/**
+ * If this turn never streamed `message.part.delta` text, emit the last
+ * assistant snapshot so Ask AI still has something to render.
+ */
+export function fallbackAssistantText(opts: {
+	turnStarted: boolean;
+	sawTextDelta: boolean;
+	lastAssistantText: string;
+}): AIMessage[] {
+	if (!opts.turnStarted || opts.sawTextDelta || !opts.lastAssistantText) {
+		return [];
+	}
+	return [{ type: "text_delta", delta: opts.lastAssistantText }];
+}
+
 /**
  * Map an OpenCode SSE event to AIMessage[].
  *
@@ -404,6 +513,8 @@ export function mapOpenCodeEvent(
 		case "message.part.delta": {
 			const field = props.field as string;
 			const delta = props.delta as string;
+			// Reasoning/thinking deltas share this event; Ask AI only renders
+			// assistant answer text.
 			if (field === "text" && delta) {
 				return [{ type: "text_delta", delta }];
 			}


### PR DESCRIPTION
Fixes the OpenCode half of #907 (source: #514). OpenCode Ask AI hung with **Failed to fetch** on 1.18.20: `/api/ai/session` succeeded, `/api/ai/query` returned SSE headers, then never emitted events.

Related: #513 (port conflict when attaching to an existing `opencode serve`).

## The failure

`OpenCodeSession.query` subscribed to `/event` *after* `promptAsync`. A short turn can finish before that subscriber is live, so the query loop never sees idle and the browser times out.

Even when events arrive, 1.18 still streams `message.part.delta` for tokens but also lands a final `message.part.updated` text snapshot. The mapper treated snapshots as no-ops, so a late subscriber with no deltas rendered an empty bubble (#514).

## The fix

Bun source of truth is `packages/ai/providers/opencode-sdk.ts`. Pi picks it up through `vendor.sh` (`generated/ai/providers/opencode-sdk.ts`); no hand-mirrored HTTP routes.

- Subscribe first and wait for the first SSE frame before `promptAsync`. That frame is only a liveness check — leftover idle from a previous turn is not consumed as this query's result.
- Drive the rest of the turn through `consumeOpenCodeEvent` (unit-tested). Idle after the prompt completes the query even if OpenCode never emitted `busy`.
- If the turn never streamed text deltas, emit the last *assistant* text snapshot (parts with a `time` stamp) before the result. User-prompt snapshots have no `time` and are ignored, so the question is not echoed into the bubble.
- Reasoning deltas stay ignored. Existing tool / permission mapping is unchanged.

## Two-runtime note

Ask AI lives in `@plannotator/ai`. Both Bun (`packages/server/ai-runtime.ts`) and Pi (`apps/pi-extension/server/ai-runtime.ts`) load this provider. `vendor.sh` already copies `opencode-sdk.ts`; no Pi server edit.

## Testing

- `bun test packages/ai/ai.test.ts`: 121 pass. New cases cover snapshot-only idle (#514 empty bubble), no duplicate tokens when deltas already streamed, and ignoring the user-prompt snapshot.
- `bun run typecheck` was not run in this checkout: `tsc` is not on PATH and the isolated install has no `bun-types`. CI `test.yml` should cover it.

Not done here: live Ask AI against a compiled `plannotator` binary. That still needs a release after merge. #907's anchored plan Q&A / thinking-vs-answer UI criteria are out of scope.

AI-assisted (Claude) under user direction.
