### PR TITLE
feat(opencode): preserve model choice on plan handoff

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,6 +149,7 @@ jobs:
           packages/editor/App.archiveReadOnly.test.tsx
           packages/editor/App.htmlChrome.test.tsx
           packages/ui/components/HtmlSurfaceControls.test.tsx
+          packages/ui/components/ApproveDropdown.currentModel.test.tsx
           packages/ui/components/AnnotationPanel.unanchored.test.tsx
           packages/ui/hooks/useHtmlRefresh.test.tsx
           packages/ui/hooks/useSharing.contentRevision.test.tsx

--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -564,6 +564,14 @@ function getBridgePasteApiUrl(input: OpenCodeBridgeInput): string | undefined {
   return typeof input.pasteApiUrl === "string" && input.pasteApiUrl ? input.pasteApiUrl : pasteApiUrl;
 }
 
+function parseBridgeModel(value: unknown): { providerID: string; modelID: string } | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const record = value as Record<string, unknown>;
+  if (typeof record.providerID !== "string" || !record.providerID) return undefined;
+  if (typeof record.modelID !== "string" || !record.modelID) return undefined;
+  return { providerID: record.providerID, modelID: record.modelID };
+}
+
 function normalizeOpenCodeBridgeAgents(value: unknown): OpenCodeBridgeAgent[] | undefined {
   if (!Array.isArray(value)) return undefined;
 
@@ -1635,7 +1643,7 @@ if (args[0] === "sessions") {
   // that cannot import Bun-only server modules directly.
 
   const inputJson = await Bun.stdin.text();
-  const input = parseOpenCodeBridgeInput<{ plan?: unknown; timeoutSeconds?: unknown }>(
+  const input = parseOpenCodeBridgeInput<{ plan?: unknown; timeoutSeconds?: unknown; currentModel?: unknown }>(
     "opencode-plan",
     inputJson,
   );
@@ -1664,6 +1672,7 @@ if (args[0] === "sessions") {
     pasteApiUrl: bridgePasteApiUrl,
     htmlContent: planHtmlContent,
     opencodeClient: makeOpenCodeBridgeClient(input.agents),
+    currentModel: parseBridgeModel(input.currentModel),
     onReady: async (url, isRemote, port) => {
       await handleServerReady(url, isRemote, port);
 

--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -1703,6 +1703,7 @@ if (args[0] === "sessions") {
     ...(result.feedback && { feedback: result.feedback }),
     ...(result.savedPath && { savedPath: result.savedPath }),
     ...(result.agentSwitch && { agentSwitch: result.agentSwitch }),
+    ...(result.agentModelPreference && { agentModelPreference: result.agentModelPreference }),
   }));
   process.exit(0);
 

--- a/apps/opencode-plugin/agent-switch.test.ts
+++ b/apps/opencode-plugin/agent-switch.test.ts
@@ -3,9 +3,15 @@ import {
   getAssistantMessageModel,
   resolveTargetAgent,
   resolveValidatedTargetAgent,
+  shouldPreserveActiveModel,
 } from "./agent-switch";
 
 describe("OpenCode agent switch validation", () => {
+  test("preserves the active model unless the target agent's default is explicitly requested", () => {
+    expect(shouldPreserveActiveModel(undefined)).toBe(true);
+    expect(shouldPreserveActiveModel("current")).toBe(true);
+    expect(shouldPreserveActiveModel("agent-default")).toBe(false);
+  });
   test("reads the model from the assistant message that submitted the plan", async () => {
     const message = mock(async () => ({
       data: {

--- a/apps/opencode-plugin/agent-switch.test.ts
+++ b/apps/opencode-plugin/agent-switch.test.ts
@@ -1,7 +1,55 @@
 import { describe, expect, mock, test } from "bun:test";
-import { resolveTargetAgent, resolveValidatedTargetAgent } from "./agent-switch";
+import {
+  getAssistantMessageModel,
+  resolveTargetAgent,
+  resolveValidatedTargetAgent,
+} from "./agent-switch";
 
 describe("OpenCode agent switch validation", () => {
+  test("reads the model from the assistant message that submitted the plan", async () => {
+    const message = mock(async () => ({
+      data: {
+        info: {
+          role: "assistant",
+          providerID: "anthropic",
+          modelID: "claude-opus-5",
+        },
+      },
+    }));
+
+    await expect(getAssistantMessageModel({
+      client: { session: { message } },
+      sessionId: "session-1",
+      messageId: "message-1",
+    })).resolves.toEqual({ providerID: "anthropic", modelID: "claude-opus-5" });
+
+    expect(message).toHaveBeenCalledWith({
+      path: { id: "session-1", messageID: "message-1" },
+    });
+  });
+
+  test("omits unavailable or malformed assistant message models", async () => {
+    const malformed = await getAssistantMessageModel({
+      client: {
+        session: {
+          message: async () => ({
+            data: { info: { role: "assistant", providerID: "anthropic" } },
+          }),
+        },
+      },
+      sessionId: "session-1",
+      messageId: "message-1",
+    });
+    expect(malformed).toBeUndefined();
+
+    const unavailable = await getAssistantMessageModel({
+      client: { session: { message: async () => { throw new Error("not found"); } } },
+      sessionId: "session-1",
+      messageId: "message-1",
+    });
+    expect(unavailable).toBeUndefined();
+  });
+
   test("preserves no-agent defaults", () => {
     expect(resolveTargetAgent(undefined)).toBeUndefined();
     expect(resolveTargetAgent("disabled")).toBeUndefined();

--- a/apps/opencode-plugin/agent-switch.ts
+++ b/apps/opencode-plugin/agent-switch.ts
@@ -2,6 +2,11 @@ export interface OpenCodeAgentLike {
   name?: string;
 }
 
+export interface OpenCodeModel {
+  providerID: string;
+  modelID: string;
+}
+
 interface OpenCodeClientLike {
   app?: {
     agents?: (input?: unknown) => Promise<{ data?: OpenCodeAgentLike[] }>;
@@ -9,6 +14,17 @@ interface OpenCodeClientLike {
   };
   tui?: {
     showToast?: (input: unknown) => unknown;
+  };
+  session?: {
+    message?: (input: unknown) => Promise<{
+      data?: {
+        info?: {
+          role?: string;
+          providerID?: string;
+          modelID?: string;
+        };
+      };
+    }>;
   };
 }
 
@@ -18,6 +34,35 @@ export type AgentSwitchDelivery = "feedback" | "plan-approval";
 export function resolveTargetAgent(agentSwitch?: string): string | undefined {
   const trimmed = agentSwitch?.trim();
   return trimmed && trimmed !== "disabled" ? trimmed : undefined;
+}
+
+/**
+ * The submit_plan tool context identifies the assistant message that made the
+ * request. Its recorded model is more reliable than an agent's configured
+ * default when approval hands work to a different agent.
+ */
+export async function getAssistantMessageModel(input: {
+  client: OpenCodeClientLike;
+  sessionId: string;
+  messageId: string;
+}): Promise<OpenCodeModel | undefined> {
+  try {
+    const response = await input.client.session?.message?.({
+      path: { id: input.sessionId, messageID: input.messageId },
+    });
+    const info = response?.data?.info;
+    if (
+      info?.role !== "assistant" ||
+      typeof info.providerID !== "string" || !info.providerID ||
+      typeof info.modelID !== "string" || !info.modelID
+    ) {
+      return undefined;
+    }
+    return { providerID: info.providerID, modelID: info.modelID };
+  } catch {
+    // Approval can still proceed when an older OpenCode host cannot fetch it.
+    return undefined;
+  }
 }
 
 function warnAgentUnavailable(

--- a/apps/opencode-plugin/agent-switch.ts
+++ b/apps/opencode-plugin/agent-switch.ts
@@ -65,6 +65,16 @@ export async function getAssistantMessageModel(input: {
   }
 }
 
+/**
+ * Whether the approval handoff should look up and pin the session's active
+ * model. False only when the user explicitly opted into the target agent's
+ * own configured model ('agent-default'); any other value (including
+ * unset) keeps today's default of preserving the active model.
+ */
+export function shouldPreserveActiveModel(agentModelPreference?: string): boolean {
+  return agentModelPreference !== "agent-default";
+}
+
 function warnAgentUnavailable(
   client: OpenCodeClientLike,
   targetAgent: string,

--- a/apps/opencode-plugin/cli-bridge.ts
+++ b/apps/opencode-plugin/cli-bridge.ts
@@ -476,6 +476,7 @@ export async function runCliPlanReview(input: {
   timeoutSeconds: number | null;
   abortSignal?: AbortSignal;
   bridge?: OpenCodeBridgeContext;
+  currentModel?: { providerID: string; modelID: string };
 }): Promise<OpenCodePlanReviewResult> {
   const result = await runPlannotatorCli({
     client: input.client,
@@ -484,6 +485,7 @@ export async function runCliPlanReview(input: {
     input: JSON.stringify({
       plan: input.planContent,
       timeoutSeconds: input.timeoutSeconds,
+      currentModel: input.currentModel,
       ...buildBridgePayload(input.bridge),
     }),
     readyLabel: "plan review",

--- a/apps/opencode-plugin/cli-bridge.ts
+++ b/apps/opencode-plugin/cli-bridge.ts
@@ -38,6 +38,7 @@ export interface OpenCodePlanReviewResult {
   feedback?: string;
   savedPath?: string;
   agentSwitch?: string;
+  agentModelPreference?: string;
 }
 
 export interface OpenCodeBridgeAgent {

--- a/apps/opencode-plugin/embedded.ts
+++ b/apps/opencode-plugin/embedded.ts
@@ -19,6 +19,7 @@ export interface EmbeddedPlanReviewInput {
   timeoutSeconds: number | null;
   abortSignal?: AbortSignal;
   logReady: (url: string, isRemote: boolean, port: number) => void;
+  currentModel?: { providerID: string; modelID: string };
 }
 
 export interface EmbeddedPlanReviewResult {
@@ -80,6 +81,7 @@ export async function runEmbeddedPlanReview(
     pasteApiUrl: input.pasteApiUrl,
     htmlContent: input.htmlContent,
     opencodeClient: input.client,
+    currentModel: input.currentModel,
     onReady: async (url, isRemote, port) => {
       await handleServerReady(url, isRemote, port);
       input.logReady(url, isRemote, port);

--- a/apps/opencode-plugin/embedded.ts
+++ b/apps/opencode-plugin/embedded.ts
@@ -26,6 +26,7 @@ export interface EmbeddedPlanReviewResult {
   feedback?: string;
   savedPath?: string;
   agentSwitch?: string;
+  agentModelPreference?: string;
 }
 
 async function loadPlanServer() {

--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -189,6 +189,7 @@ async function runPlanReview(input: {
   abortSignal: AbortSignal;
   cwd?: string;
   bridge: OpenCodeBridgeContext;
+  currentModel?: { providerID: string; modelID: string };
 }): Promise<OpenCodePlanReviewResult> {
   input.abortSignal.throwIfAborted();
   if (input.runtime === "embedded" && !hasEmbeddedRuntime()) {
@@ -207,6 +208,7 @@ async function runPlanReview(input: {
         htmlContent: input.htmlContent,
         timeoutSeconds: input.timeoutSeconds,
         abortSignal: input.abortSignal,
+        currentModel: input.currentModel,
         logReady: (url) => logPlannotatorReady(input.client, "plan review", url),
       });
     } catch (error) {
@@ -228,6 +230,7 @@ async function runPlanReview(input: {
     timeoutSeconds: input.timeoutSeconds,
     abortSignal: input.abortSignal,
     bridge: input.bridge,
+    currentModel: input.currentModel,
   });
 }
 
@@ -555,6 +558,11 @@ Do NOT proceed with implementation until your plan is approved.`;
               abortSignal: context.abort,
               cwd: ctx.directory,
               bridge: await getBridgeContext(),
+              currentModel: await getAssistantMessageModel({
+                client: ctx.client,
+                sessionId: context.sessionID,
+                messageId: context.messageID,
+              }),
             }),
             resolveTargetAgent: async ({ requestedAgent, directory, delivery }) =>
               await resolveValidatedTargetAgent({

--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -45,7 +45,7 @@ import {
   type OpenCodeBridgeContext,
   type OpenCodePlanReviewResult,
 } from "./cli-bridge";
-import { resolveValidatedTargetAgent } from "./agent-switch";
+import { getAssistantMessageModel, resolveValidatedTargetAgent } from "./agent-switch";
 import { shouldFallbackAfterEmbeddedError } from "./prompt-delivery-error";
 import { executeSubmitPlan } from "./submit-plan-executor";
 import { getPlanningPrompt } from "./planning-prompt";
@@ -564,10 +564,16 @@ Do NOT proceed with implementation until your plan is approved.`;
                 delivery,
               }),
             sendApprovalHandoff: async ({ sessionId, targetAgent, text }) => {
+              const model = await getAssistantMessageModel({
+                client: ctx.client,
+                sessionId,
+                messageId: context.messageID,
+              });
               await ctx.client.session.prompt({
                 path: { id: sessionId },
                 body: {
                   agent: targetAgent,
+                  ...(model && { model }),
                   noReply: true,
                   parts: [{ type: "text", text }],
                 },

--- a/apps/opencode-plugin/index.ts
+++ b/apps/opencode-plugin/index.ts
@@ -45,7 +45,7 @@ import {
   type OpenCodeBridgeContext,
   type OpenCodePlanReviewResult,
 } from "./cli-bridge";
-import { getAssistantMessageModel, resolveValidatedTargetAgent } from "./agent-switch";
+import { getAssistantMessageModel, resolveValidatedTargetAgent, shouldPreserveActiveModel } from "./agent-switch";
 import { shouldFallbackAfterEmbeddedError } from "./prompt-delivery-error";
 import { executeSubmitPlan } from "./submit-plan-executor";
 import { getPlanningPrompt } from "./planning-prompt";
@@ -563,12 +563,14 @@ Do NOT proceed with implementation until your plan is approved.`;
                 directory,
                 delivery,
               }),
-            sendApprovalHandoff: async ({ sessionId, targetAgent, text }) => {
-              const model = await getAssistantMessageModel({
-                client: ctx.client,
-                sessionId,
-                messageId: context.messageID,
-              });
+            sendApprovalHandoff: async ({ sessionId, targetAgent, text, agentModelPreference }) => {
+              const model = shouldPreserveActiveModel(agentModelPreference)
+                ? await getAssistantMessageModel({
+                    client: ctx.client,
+                    sessionId,
+                    messageId: context.messageID,
+                  })
+                : undefined;
               await ctx.client.session.prompt({
                 path: { id: sessionId },
                 body: {

--- a/apps/opencode-plugin/submit-plan-executor.test.ts
+++ b/apps/opencode-plugin/submit-plan-executor.test.ts
@@ -76,6 +76,35 @@ describe("executeSubmitPlan", () => {
     expect(result).toBe("Plan approved!");
   });
 
+  test("forwards the model preference chosen alongside the agent switch", async () => {
+    prepareDataDir();
+    const sendApprovalHandoff = mock(async () => {});
+
+    await executeSubmitPlan({
+      edits: [{ start: 1, content: "# Approved" }],
+      invokingAgent: "plan",
+      sessionId: "session-5",
+      abortSignal: new AbortController().signal,
+      directory: "/workspace/example",
+      workflowOptions: normalizeWorkflowOptions(undefined),
+    }, {
+      reviewPlan: async () => ({
+        approved: true,
+        agentSwitch: "build",
+        agentModelPreference: "agent-default",
+      }),
+      resolveTargetAgent: async () => "build",
+      sendApprovalHandoff,
+    });
+
+    expect(sendApprovalHandoff).toHaveBeenCalledWith({
+      sessionId: "session-5",
+      targetAgent: "build",
+      text: "Proceed with implementation",
+      agentModelPreference: "agent-default",
+    });
+  });
+
   test("preserves backing state when review startup fails", async () => {
     prepareDataDir();
 

--- a/apps/opencode-plugin/submit-plan-executor.ts
+++ b/apps/opencode-plugin/submit-plan-executor.ts
@@ -27,6 +27,12 @@ export interface SubmitPlanReviewResult {
   feedback?: string;
   savedPath?: string;
   agentSwitch?: string;
+  /**
+   * 'current' (default when unset) keeps the model this session is already
+   * running; 'agent-default' opts into the target agent's own configured
+   * model from opencode.json.
+   */
+  agentModelPreference?: string;
 }
 
 export interface SubmitPlanInvocation {
@@ -52,6 +58,7 @@ export interface SubmitPlanHost {
     sessionId: string;
     targetAgent: string;
     text: string;
+    agentModelPreference?: string;
   }): Promise<void>;
 }
 
@@ -141,6 +148,7 @@ Use /plannotator-last or /plannotator-annotate for manual review, or set workflo
         text: shouldStartImplementation
           ? "Proceed with implementation"
           : "Plan approved. Plan mode remains active; no implementation has been requested.",
+        agentModelPreference: reviewResult.agentModelPreference,
       });
     } catch {
       // The session can still be busy while the tool result is being delivered.

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -417,6 +417,7 @@ const App: React.FC = () => {
     if (isApiMode) primeSkillCatalog();
   }, [isApiMode]);
   const [origin, setOrigin] = useState<Origin | null>(null);
+  const [currentModel, setCurrentModel] = useState<{ providerID: string; modelID: string } | undefined>(undefined);
   const [gitUser, setGitUser] = useState<string | undefined>();
   const [isWSL, setIsWSL] = useState(false);
   const updateInfo = useUpdateCheck();
@@ -2898,7 +2899,7 @@ const App: React.FC = () => {
         if (!res.ok) throw new Error('Not in API mode');
         return res.json();
       })
-      .then((data: { plan: string; origin?: Origin; mode?: 'annotate' | 'annotate-last' | 'annotate-folder' | 'annotate-app' | 'archive' | 'goal-setup'; goalSetup?: GoalSetupBundle; filePath?: string; appUrl?: string; targetUrl?: string; liveToken?: string; sourceInfo?: string; sourceConverted?: boolean; sourceSave?: SourceSaveCapability; gate?: boolean; approvalNotesSupported?: boolean; clientLease?: AnnotateClientLeaseConfig; renderAs?: 'html' | 'markdown'; rawHtml?: string; shareHtml?: string; diffHtml?: string; convertHtml?: boolean; sharingEnabled?: boolean; shareBaseUrl?: string; pasteApiUrl?: string; repoInfo?: { display: string; branch?: string; host?: string }; previousPlan?: string | null; versionInfo?: { version: number; totalVersions: number; project: string }; archivePlans?: ArchivedPlan[]; projectRoot?: string; isWSL?: boolean; markdownExtensions?: string[]; serverConfig?: { displayName?: string; gitUser?: string }; recentMessages?: PickerMessage[]; agentTerminal?: AgentTerminalCapability; feedbackTemplates?: AnnotateFeedbackTemplates }) => {
+      .then((data: { plan: string; origin?: Origin; mode?: 'annotate' | 'annotate-last' | 'annotate-folder' | 'annotate-app' | 'archive' | 'goal-setup'; goalSetup?: GoalSetupBundle; filePath?: string; appUrl?: string; targetUrl?: string; liveToken?: string; sourceInfo?: string; sourceConverted?: boolean; sourceSave?: SourceSaveCapability; gate?: boolean; approvalNotesSupported?: boolean; clientLease?: AnnotateClientLeaseConfig; renderAs?: 'html' | 'markdown'; rawHtml?: string; shareHtml?: string; diffHtml?: string; convertHtml?: boolean; sharingEnabled?: boolean; shareBaseUrl?: string; pasteApiUrl?: string; repoInfo?: { display: string; branch?: string; host?: string }; previousPlan?: string | null; versionInfo?: { version: number; totalVersions: number; project: string }; archivePlans?: ArchivedPlan[]; projectRoot?: string; isWSL?: boolean; markdownExtensions?: string[]; serverConfig?: { displayName?: string; gitUser?: string }; recentMessages?: PickerMessage[]; agentTerminal?: AgentTerminalCapability; feedbackTemplates?: AnnotateFeedbackTemplates; currentModel?: { providerID: string; modelID: string } }) => {
         // Initialize config store with server-provided values (config file > cookie > default)
         configStore.init(data.serverConfig);
         // Extra extensions the user registered as markdown (#1307) — the
@@ -3012,6 +3013,7 @@ const App: React.FC = () => {
         }
         if (data.origin) {
           setOrigin(data.origin);
+          setCurrentModel(data.currentModel);
           // For Claude Code, check if user needs to configure permission mode.
           // Plan review only: the setting decides what happens after a plan is
           // APPROVED, which is meaningless in annotate / annotate-last /
@@ -5180,6 +5182,7 @@ const App: React.FC = () => {
           canShareCurrentSession={canShareCurrentSession}
           agentName={agentName}
           availableAgents={availableAgents}
+          currentModel={currentModel}
           showAnnotationsWarning={hasFeedbackToSend}
           annotateApproveLabel={annotateApprovalPolicy.label}
           annotateApproveTitle={annotateApprovalPolicy.title}

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -47,7 +47,7 @@ import { getObsidianSettings, getEffectiveVaultPath, isObsidianConfigured, CUSTO
 import { getBearSettings } from '@plannotator/ui/utils/bear';
 import { getOctarineSettings, isOctarineConfigured } from '@plannotator/ui/utils/octarine';
 import { getDefaultNotesApp } from '@plannotator/ui/utils/defaultNotesApp';
-import { getAgentSwitchSettings, getEffectiveAgentName } from '@plannotator/ui/utils/agentSwitch';
+import { getAgentSwitchSettings, getEffectiveAgentName, getEffectiveModelPreference } from '@plannotator/ui/utils/agentSwitch';
 import { getPlanSaveSettings } from '@plannotator/ui/utils/planSave';
 import { type AIProviderOption } from '@plannotator/ui/utils/aiProvider';
 import { useAIProviderConfig } from '@plannotator/ui/hooks/useAIProviderConfig';
@@ -3358,7 +3358,7 @@ const App: React.FC = () => {
         : autoSaveResultsRef.current;
 
       // Build request body - include integrations if enabled
-      const body: { draftGeneration: number; obsidian?: object; bear?: object; octarine?: object; feedback?: string; agentSwitch?: string; planSave?: { enabled: boolean; customPath?: string }; permissionMode?: string } = {
+      const body: { draftGeneration: number; obsidian?: object; bear?: object; octarine?: object; feedback?: string; agentSwitch?: string; agentModelPreference?: string; planSave?: { enabled: boolean; customPath?: string }; permissionMode?: string } = {
         draftGeneration: getDraftGeneration(),
       };
 
@@ -3367,9 +3367,11 @@ const App: React.FC = () => {
         body.permissionMode = permissionMode;
       }
 
-      const effectiveAgent = getEffectiveAgentName(getAgentSwitchSettings('plan'));
+      const agentSwitchSettings = getAgentSwitchSettings('plan');
+      const effectiveAgent = getEffectiveAgentName(agentSwitchSettings);
       if (effectiveAgent) {
         body.agentSwitch = effectiveAgent;
+        body.agentModelPreference = getEffectiveModelPreference(agentSwitchSettings);
       }
 
       // Include plan save settings

--- a/packages/editor/components/AppHeader.tsx
+++ b/packages/editor/components/AppHeader.tsx
@@ -72,6 +72,7 @@ interface AppHeaderProps {
   canShareCurrentSession: boolean;
   agentName: string;
   availableAgents: Agent[];
+  currentModel?: { providerID: string; modelID: string };
   showAnnotationsWarning: boolean;
   annotateApproveLabel: string;
   annotateApproveTitle: string;
@@ -171,6 +172,7 @@ export const AppHeader = React.memo<AppHeaderProps>(({
   canShareCurrentSession,
   agentName,
   availableAgents,
+  currentModel,
   showAnnotationsWarning,
   annotateApproveLabel,
   annotateApproveTitle,
@@ -343,6 +345,7 @@ export const AppHeader = React.memo<AppHeaderProps>(({
                 <ApproveDropdown
                   onApprove={onApprove}
                   agents={availableAgents}
+                  currentModel={currentModel}
                   disabled={isSubmitting}
                   isLoading={isSubmitting}
                 />

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -86,6 +86,9 @@ export interface ServerOptions {
   onReady?: (url: string, isRemote: boolean, port: number) => void | Promise<void>;
   /** OpenCode client for querying available agents (OpenCode only) */
   opencodeClient?: OpencodeClient;
+  /** The model the current OpenCode session is running (OpenCode only), used to
+   *  show the actual model name in the Approve dropdown's "current model" preview. */
+  currentModel?: { providerID: string; modelID: string };
   /** When set to "archive", server runs in read-only archive browser mode */
   mode?: "archive";
   /** Custom plan save path — used by archive mode to find saved plans */
@@ -128,7 +131,7 @@ export interface ServerResult {
 export async function startPlannotatorServer(
   options: ServerOptions
 ): Promise<ServerResult> {
-  const { plan, origin, htmlContent, permissionMode, sharingEnabled = true, shareBaseUrl, pasteApiUrl, onReady, mode, customPlanPath } = options;
+  const { plan, origin, htmlContent, permissionMode, sharingEnabled = true, shareBaseUrl, pasteApiUrl, onReady, mode, customPlanPath, currentModel } = options;
 
   const isRemote = isRemoteSession();
   const wslFlag = await isWSL();
@@ -288,7 +291,7 @@ export async function startPlannotatorServer(
                 serverConfig: getServerConfig(gitUser),
               });
             }
-            return Response.json({ plan, origin, permissionMode, sharingEnabled, shareBaseUrl, pasteApiUrl, repoInfo, previousPlan, versionInfo, projectRoot: process.cwd(), isWSL: wslFlag, serverConfig: getServerConfig(gitUser) });
+            return Response.json({ plan, origin, permissionMode, sharingEnabled, shareBaseUrl, pasteApiUrl, repoInfo, previousPlan, versionInfo, projectRoot: process.cwd(), isWSL: wslFlag, serverConfig: getServerConfig(gitUser), currentModel });
           }
 
           // API: Serve a linked markdown document

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -105,6 +105,7 @@ export interface ServerResult {
     feedback?: string;
     savedPath?: string;
     agentSwitch?: string;
+    agentModelPreference?: string;
     permissionMode?: string;
   }>;
   /** Wait for user to close (archive mode only) */
@@ -169,6 +170,7 @@ export async function startPlannotatorServer(
     feedback?: string;
     savedPath?: string;
     agentSwitch?: string;
+    agentModelPreference?: string;
     permissionMode?: string;
   }) => void;
   let decisionPromise: Promise<{
@@ -176,6 +178,7 @@ export async function startPlannotatorServer(
     feedback?: string;
     savedPath?: string;
     agentSwitch?: string;
+    agentModelPreference?: string;
     permissionMode?: string;
   }>;
 
@@ -462,6 +465,7 @@ export async function startPlannotatorServer(
             // Check for note integrations and optional feedback
             let feedback: string | undefined;
             let agentSwitch: string | undefined;
+            let agentModelPreference: string | undefined;
             let requestedPermissionMode: string | undefined;
             let planSaveEnabled = true; // default to enabled for backwards compat
             let planSaveCustomPath: string | undefined;
@@ -473,6 +477,7 @@ export async function startPlannotatorServer(
                 octarine?: OctarineConfig;
                 feedback?: string;
                 agentSwitch?: string;
+                agentModelPreference?: string;
                 planSave?: { enabled: boolean; customPath?: string };
                 permissionMode?: string;
                 draftGeneration?: number;
@@ -487,6 +492,7 @@ export async function startPlannotatorServer(
               // Capture agent switch setting for OpenCode
               if (body.agentSwitch) {
                 agentSwitch = body.agentSwitch;
+                agentModelPreference = body.agentModelPreference;
               }
 
               // Capture permission mode from client request (Claude Code)
@@ -539,7 +545,7 @@ export async function startPlannotatorServer(
 
             // Use permission mode from client request if provided, otherwise fall back to hook input
             const effectivePermissionMode = requestedPermissionMode || permissionMode;
-            resolveDecision({ approved: true, feedback, savedPath, agentSwitch, permissionMode: effectivePermissionMode });
+            resolveDecision({ approved: true, feedback, savedPath, agentSwitch, agentModelPreference, permissionMode: effectivePermissionMode });
             return Response.json({ ok: true, savedPath });
           }
 

--- a/packages/server/plan-current-model.test.ts
+++ b/packages/server/plan-current-model.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createTestEnvironment } from "../../tests/helpers/environment";
+import { startPlannotatorServer } from "./index";
+
+const envKeys = [
+  "PLANNOTATOR_PORT",
+  "PLANNOTATOR_REMOTE",
+  "PLANNOTATOR_DATA_DIR",
+] as const;
+const environment = createTestEnvironment(envKeys, "plannotator-current-model-");
+
+afterEach(() => environment.restore());
+
+describe("/api/plan currentModel", () => {
+  test("includes currentModel when the caller supplies it", async () => {
+    environment.reset();
+    process.env.PLANNOTATOR_REMOTE = "0";
+    process.env.PLANNOTATOR_DATA_DIR = environment.makeTempDir();
+
+    const server = await startPlannotatorServer({
+      plan: "# Current model test",
+      origin: "opencode",
+      htmlContent: "<!doctype html><html><body>plan</body></html>",
+      currentModel: { providerID: "openai", modelID: "gpt-5.6-terra" },
+    });
+
+    try {
+      const response = await fetch(`${server.url}/api/plan`);
+      expect(response.status).toBe(200);
+      const body = await response.json() as { currentModel?: unknown };
+      expect(body.currentModel).toEqual({ providerID: "openai", modelID: "gpt-5.6-terra" });
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("omits currentModel when the caller does not supply it", async () => {
+    environment.reset();
+    process.env.PLANNOTATOR_REMOTE = "0";
+    process.env.PLANNOTATOR_DATA_DIR = environment.makeTempDir();
+
+    const server = await startPlannotatorServer({
+      plan: "# Current model test",
+      origin: "opencode",
+      htmlContent: "<!doctype html><html><body>plan</body></html>",
+    });
+
+    try {
+      const response = await fetch(`${server.url}/api/plan`);
+      expect(response.status).toBe(200);
+      const body = await response.json() as { currentModel?: unknown };
+      expect(body.currentModel).toBeUndefined();
+    } finally {
+      await server.stop();
+    }
+  });
+});

--- a/packages/server/shared-handlers.ts
+++ b/packages/server/shared-handlers.ts
@@ -100,7 +100,13 @@ export async function handleUpload(req: Request): Promise<Response> {
 export interface OpencodeClient {
   app: {
     agents: (options?: object) => Promise<{
-      data?: Array<{ name: string; description?: string; mode: string; hidden?: boolean }>;
+      data?: Array<{
+        name: string;
+        description?: string;
+        mode: string;
+        hidden?: boolean;
+        model?: { providerID: string; modelID: string };
+      }>;
     }>;
   };
 }
@@ -115,7 +121,7 @@ export async function handleAgents(opencodeClient?: OpencodeClient): Promise<Res
     const result = await opencodeClient.app.agents({});
     const agents = (result.data ?? [])
       .filter((a) => a.mode === "primary" && !a.hidden)
-      .map((a) => ({ id: a.name, name: a.name, description: a.description }));
+      .map((a) => ({ id: a.name, name: a.name, description: a.description, model: a.model }));
 
     return Response.json({ agents });
   } catch {

--- a/packages/ui/components/ApproveDropdown.currentModel.test.tsx
+++ b/packages/ui/components/ApproveDropdown.currentModel.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * ApproveDropdown's "current model" preview: the split button and the
+ * "Keep current model" menu item must show the real model id when the host
+ * supplies one, and fall back to the old generic text when it doesn't
+ * (older OpenCode hosts, or the lookup failing server-side).
+ */
+import React, { act } from 'react';
+import { afterEach, describe, expect, test } from 'bun:test';
+import { createRoot, type Root } from 'react-dom/client';
+import { resetStorageBackend, setStorageBackend, type StorageBackend } from '../utils/storage';
+import { ApproveDropdown } from './ApproveDropdown';
+import type { Agent } from '../hooks/useAgents';
+
+const hasDom = typeof document !== 'undefined';
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+function memoryStorage(): StorageBackend {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+    removeItem: (key) => values.delete(key),
+  };
+}
+
+const AGENTS: Agent[] = [
+  { id: 'build', name: 'build', model: { providerID: 'openai', modelID: 'gpt-5.6-terra' } },
+  { id: 'plan', name: 'plan', model: { providerID: 'openai', modelID: 'gpt-5.6-sol' } },
+];
+
+afterEach(() => {
+  if (!hasDom) return;
+  act(() => root?.unmount());
+  root = null;
+  container?.remove();
+  container = null;
+  resetStorageBackend();
+});
+
+function render(props: Partial<React.ComponentProps<typeof ApproveDropdown>> = {}) {
+  setStorageBackend(memoryStorage());
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(
+      <ApproveDropdown
+        onApprove={() => {}}
+        agents={AGENTS}
+        {...props}
+      />,
+    );
+  });
+  return container;
+}
+
+describe.if(hasDom)('ApproveDropdown current model preview', () => {
+  test('shows the real model id in the split button when known', () => {
+    const el = render({ currentModel: { providerID: 'openai', modelID: 'gpt-5.6-terra' } });
+    expect(el.textContent).toContain('gpt-5.6-terra');
+    expect(el.textContent).not.toContain('current model');
+  });
+
+  test('falls back to the generic label when the current model is unknown', () => {
+    const el = render();
+    expect(el.textContent).toContain('current model');
+  });
+
+  test('the "Keep current model" menu item shows the resolved model id', () => {
+    const el = render({ currentModel: { providerID: 'openai', modelID: 'gpt-5.6-terra' } });
+    const toggle = el.querySelectorAll('button')[2] as HTMLButtonElement;
+    act(() => toggle.click());
+
+    const keepCurrent = Array.from(el.querySelectorAll('button'))
+      .find((b) => b.textContent?.includes('Keep current model'));
+    expect(keepCurrent?.textContent).toContain('gpt-5.6-terra');
+  });
+});

--- a/packages/ui/components/ApproveDropdown.tsx
+++ b/packages/ui/components/ApproveDropdown.tsx
@@ -11,6 +11,8 @@ import {
 interface ApproveDropdownProps {
   onApprove: () => void;
   agents: Agent[];
+  /** The model this session is currently running (OpenCode only), when known. */
+  currentModel?: { providerID: string; modelID: string };
   disabled?: boolean;
   isLoading?: boolean;
 }
@@ -31,9 +33,13 @@ function getMatchedAgent(setting: AgentSwitchSettings, agents: Agent[]): Agent |
 }
 
 /** Short model preview shown next to the target agent name in the split button. */
-function getModelPreview(setting: AgentSwitchSettings, agents: Agent[]): string | null {
+function getModelPreview(
+  setting: AgentSwitchSettings,
+  agents: Agent[],
+  currentModel?: { providerID: string; modelID: string },
+): string | null {
   if (setting.switchTo === 'disabled') return null;
-  if (getEffectiveModelPreference(setting) === 'current') return 'current model';
+  if (getEffectiveModelPreference(setting) === 'current') return currentModel?.modelID ?? 'current model';
   return getMatchedAgent(setting, agents)?.model?.modelID ?? null;
 }
 
@@ -52,6 +58,7 @@ const Checkmark = () => (
 export const ApproveDropdown: React.FC<ApproveDropdownProps> = ({
   onApprove,
   agents,
+  currentModel,
   disabled = false,
   isLoading = false,
 }) => {
@@ -91,7 +98,7 @@ export const ApproveDropdown: React.FC<ApproveDropdownProps> = ({
   };
 
   const agentLabel = getSelectedLabel(setting, agents);
-  const modelPreview = getModelPreview(setting, agents);
+  const modelPreview = getModelPreview(setting, agents, currentModel);
   const modelPreference = getEffectiveModelPreference(setting);
   const matchedAgent = getMatchedAgent(setting, agents);
   const isNoSwitch = setting.switchTo === 'disabled';
@@ -134,7 +141,7 @@ export const ApproveDropdown: React.FC<ApproveDropdownProps> = ({
                 <span className="max-w-[120px] truncate">{agentLabel}</span>
                 {notFound && <span className="opacity-60 text-[10px]">(?)</span>}
                 {modelPreview && (
-                  <span className="opacity-60 text-[10px] truncate max-w-[90px]">&middot; {modelPreview}</span>
+                  <span className="opacity-60 text-[10px] truncate max-w-[110px]">&middot; {modelPreview}</span>
                 )}
               </span>
             ) : 'Approve'
@@ -153,7 +160,7 @@ export const ApproveDropdown: React.FC<ApproveDropdownProps> = ({
 
       {/* Dropdown */}
       {isOpen && (
-        <div className="absolute right-0 top-full mt-1 w-52 rounded-lg border border-border bg-popover shadow-xl z-[70] overflow-hidden py-1">
+        <div className="absolute right-0 top-full mt-1 w-72 rounded-lg border border-border bg-popover shadow-xl z-[70] overflow-hidden py-1">
           <div className="px-3 py-1.5 text-[10px] uppercase tracking-wider text-muted-foreground/70 font-medium">
             Switch to agent
           </div>
@@ -172,7 +179,7 @@ export const ApproveDropdown: React.FC<ApproveDropdownProps> = ({
                 <span className="w-4 flex-shrink-0">{selected && <Checkmark />}</span>
                 <span className="truncate">{agent.name}</span>
                 {agent.model?.modelID && (
-                  <span className="text-[10px] text-muted-foreground ml-auto truncate max-w-[70px]">
+                  <span className="text-[10px] text-muted-foreground ml-auto truncate max-w-[110px]">
                     {agent.model.modelID}
                   </span>
                 )}
@@ -216,7 +223,12 @@ export const ApproveDropdown: React.FC<ApproveDropdownProps> = ({
                 }`}
               >
                 <span className="w-4 flex-shrink-0">{modelPreference === 'current' && <Checkmark />}</span>
-                Keep current model
+                <span className="truncate">
+                  Keep current model
+                  {currentModel?.modelID && (
+                    <span className="text-muted-foreground"> ({currentModel.modelID})</span>
+                  )}
+                </span>
               </button>
               <button
                 onClick={() => handleModelPreferenceSelect('agent-default')}

--- a/packages/ui/components/ApproveDropdown.tsx
+++ b/packages/ui/components/ApproveDropdown.tsx
@@ -1,6 +1,12 @@
 import React, { useState, useRef, useEffect } from 'react';
 import type { Agent } from '../hooks/useAgents';
-import { getAgentSwitchSettings, saveAgentSwitchSettings, type AgentSwitchSettings } from '../utils/agentSwitch';
+import {
+  getAgentSwitchSettings,
+  getEffectiveModelPreference,
+  saveAgentSwitchSettings,
+  type AgentModelPreference,
+  type AgentSwitchSettings,
+} from '../utils/agentSwitch';
 
 interface ApproveDropdownProps {
   onApprove: () => void;
@@ -16,6 +22,19 @@ function getSelectedLabel(setting: AgentSwitchSettings, agents: Agent[]): string
   }
   const match = agents.find(a => a.id.toLowerCase() === setting.switchTo.toLowerCase());
   return match?.name ?? setting.switchTo;
+}
+
+function getMatchedAgent(setting: AgentSwitchSettings, agents: Agent[]): Agent | undefined {
+  const name = setting.switchTo === 'custom' ? setting.customName : setting.switchTo;
+  if (!name) return undefined;
+  return agents.find(a => a.id.toLowerCase() === name.toLowerCase());
+}
+
+/** Short model preview shown next to the target agent name in the split button. */
+function getModelPreview(setting: AgentSwitchSettings, agents: Agent[]): string | null {
+  if (setting.switchTo === 'disabled') return null;
+  if (getEffectiveModelPreference(setting) === 'current') return 'current model';
+  return getMatchedAgent(setting, agents)?.model?.modelID ?? null;
 }
 
 function isSelected(agentId: string, setting: AgentSwitchSettings): boolean {
@@ -58,12 +77,23 @@ export const ApproveDropdown: React.FC<ApproveDropdownProps> = ({
   }, []);
 
   const handleSelect = (newSetting: AgentSwitchSettings) => {
-    setSetting(newSetting);
-    saveAgentSwitchSettings(newSetting);
+    const merged: AgentSwitchSettings = { ...newSetting, modelPreference: setting.modelPreference };
+    setSetting(merged);
+    saveAgentSwitchSettings(merged);
+    setIsOpen(false);
+  };
+
+  const handleModelPreferenceSelect = (modelPreference: AgentModelPreference) => {
+    const merged: AgentSwitchSettings = { ...setting, modelPreference };
+    setSetting(merged);
+    saveAgentSwitchSettings(merged);
     setIsOpen(false);
   };
 
   const agentLabel = getSelectedLabel(setting, agents);
+  const modelPreview = getModelPreview(setting, agents);
+  const modelPreference = getEffectiveModelPreference(setting);
+  const matchedAgent = getMatchedAgent(setting, agents);
   const isNoSwitch = setting.switchTo === 'disabled';
   const isCustom = setting.switchTo === 'custom';
   const notFound = agentLabel && !isNoSwitch && !isCustom
@@ -103,6 +133,9 @@ export const ApproveDropdown: React.FC<ApproveDropdownProps> = ({
                 <span className="opacity-60">&rarr;</span>
                 <span className="max-w-[120px] truncate">{agentLabel}</span>
                 {notFound && <span className="opacity-60 text-[10px]">(?)</span>}
+                {modelPreview && (
+                  <span className="opacity-60 text-[10px] truncate max-w-[90px]">&middot; {modelPreview}</span>
+                )}
               </span>
             ) : 'Approve'
           )}
@@ -138,6 +171,11 @@ export const ApproveDropdown: React.FC<ApproveDropdownProps> = ({
               >
                 <span className="w-4 flex-shrink-0">{selected && <Checkmark />}</span>
                 <span className="truncate">{agent.name}</span>
+                {agent.model?.modelID && (
+                  <span className="text-[10px] text-muted-foreground ml-auto truncate max-w-[70px]">
+                    {agent.model.modelID}
+                  </span>
+                )}
               </button>
             );
           })}
@@ -163,6 +201,41 @@ export const ApproveDropdown: React.FC<ApproveDropdownProps> = ({
             <span className="w-4 flex-shrink-0">{isNoSwitch && <Checkmark />}</span>
             No switch
           </button>
+          {!isNoSwitch && (
+            <>
+              <div className="border-t border-border my-1" />
+              <div className="px-3 py-1.5 text-[10px] uppercase tracking-wider text-muted-foreground/70 font-medium">
+                Model after switch
+              </div>
+              <button
+                onClick={() => handleModelPreferenceSelect('current')}
+                className={`w-full px-3 py-1.5 text-left text-xs transition-colors flex items-center gap-2 ${
+                  modelPreference === 'current'
+                    ? 'text-primary bg-primary/10 font-medium'
+                    : 'text-popover-foreground hover:bg-muted'
+                }`}
+              >
+                <span className="w-4 flex-shrink-0">{modelPreference === 'current' && <Checkmark />}</span>
+                Keep current model
+              </button>
+              <button
+                onClick={() => handleModelPreferenceSelect('agent-default')}
+                className={`w-full px-3 py-1.5 text-left text-xs transition-colors flex items-center gap-2 ${
+                  modelPreference === 'agent-default'
+                    ? 'text-primary bg-primary/10 font-medium'
+                    : 'text-popover-foreground hover:bg-muted'
+                }`}
+              >
+                <span className="w-4 flex-shrink-0">{modelPreference === 'agent-default' && <Checkmark />}</span>
+                <span className="truncate">
+                  Use agent&apos;s default
+                  {matchedAgent?.model?.modelID && (
+                    <span className="text-muted-foreground"> ({matchedAgent.model.modelID})</span>
+                  )}
+                </span>
+              </button>
+            </>
+          )}
         </div>
       )}
     </div>

--- a/packages/ui/components/Settings.tsx
+++ b/packages/ui/components/Settings.tsx
@@ -31,8 +31,10 @@ import {
 import {
   getAgentSwitchSettings,
   getAgentSwitchDefaults,
+  getEffectiveModelPreference,
   saveAgentSwitchSettings,
   AGENT_OPTIONS,
+  type AgentModelPreference,
   type AgentSwitchSettings,
   type AgentSwitchSurface,
 } from '../utils/agentSwitch';
@@ -1066,7 +1068,13 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
   };
 
   const handleAgentChange = (switchTo: AgentSwitchSettings['switchTo'], customName?: string) => {
-    const newSettings = { switchTo, customName: customName ?? agent.customName };
+    const newSettings = { switchTo, customName: customName ?? agent.customName, modelPreference: agent.modelPreference };
+    setAgent(newSettings);
+    saveAgentSwitchSettings(newSettings);
+  };
+
+  const handleAgentModelPreferenceChange = (modelPreference: AgentModelPreference) => {
+    const newSettings = { ...agent, modelPreference };
     setAgent(newSettings);
     saveAgentSwitchSettings(newSettings);
   };
@@ -1432,6 +1440,27 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
                                 ? 'Stay on current agent after approval'
                                 : `Switch to ${agent.switchTo} agent after approval`}
                           </div>
+
+                          {agentSurface === 'plan' && agent.switchTo !== 'disabled' && (
+                            <div className="space-y-1.5 pt-1">
+                              <div className="text-xs text-muted-foreground">
+                                Model to use after switching agent
+                              </div>
+                              <SegmentedControl<AgentModelPreference>
+                                options={[
+                                  { value: 'current', label: 'Keep current model' },
+                                  { value: 'agent-default', label: "Use agent's default" },
+                                ]}
+                                value={getEffectiveModelPreference(agent)}
+                                onChange={handleAgentModelPreferenceChange}
+                              />
+                              <div className="text-[10px] text-muted-foreground/70">
+                                {getEffectiveModelPreference(agent) === 'current'
+                                  ? "Keeps the model this session is currently running, even when switching agent."
+                                  : `Uses the model configured for the ${agent.switchTo === 'custom' ? (agent.customName || 'target') : agent.switchTo} agent in opencode.json.`}
+                              </div>
+                            </div>
+                          )}
                         </div>
                       </>
                     )}

--- a/packages/ui/hooks/useAgents.ts
+++ b/packages/ui/hooks/useAgents.ts
@@ -10,6 +10,8 @@ export interface Agent {
   id: string;
   name: string;
   description?: string;
+  /** The agent's configured default model, when OpenCode reports one. */
+  model?: { providerID: string; modelID: string };
 }
 
 export interface UseAgentsResult {

--- a/packages/ui/utils/agentSwitch.test.ts
+++ b/packages/ui/utils/agentSwitch.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { resetStorageBackend, setStorageBackend, type StorageBackend } from "./storage";
-import { getAgentSwitchSettings, getEffectiveAgentName, saveAgentSwitchSettings } from "./agentSwitch";
+import {
+  getAgentSwitchSettings,
+  getEffectiveAgentName,
+  getEffectiveModelPreference,
+  saveAgentSwitchSettings,
+} from "./agentSwitch";
 
 function memoryStorage(initial: Record<string, string> = {}): StorageBackend {
   const values = new Map(Object.entries(initial));
@@ -56,5 +61,25 @@ describe("agent switch settings", () => {
 
   test("does not emit custom as an agent when no custom name is set", () => {
     expect(getEffectiveAgentName({ switchTo: "custom" })).toBeUndefined();
+  });
+
+  test("defaults model preference to keeping the current session model", () => {
+    setStorageBackend(memoryStorage());
+
+    const settings = getAgentSwitchSettings("plan");
+
+    expect(settings.modelPreference).toBe("current");
+    expect(getEffectiveModelPreference(settings)).toBe("current");
+    expect(getEffectiveModelPreference({ switchTo: "build" })).toBe("current");
+  });
+
+  test("persists an explicit choice to use the target agent's default model", () => {
+    setStorageBackend(memoryStorage());
+
+    saveAgentSwitchSettings({ switchTo: "build", modelPreference: "agent-default" });
+
+    const settings = getAgentSwitchSettings("plan");
+    expect(settings.modelPreference).toBe("agent-default");
+    expect(getEffectiveModelPreference(settings)).toBe("agent-default");
   });
 });

--- a/packages/ui/utils/agentSwitch.ts
+++ b/packages/ui/utils/agentSwitch.ts
@@ -17,13 +17,24 @@ import { storage } from './storage';
 
 const STORAGE_KEY = 'plannotator-agent-switch';
 const CUSTOM_NAME_KEY = 'plannotator-agent-custom';
+const MODEL_PREFERENCE_KEY = 'plannotator-agent-model-preference';
 
 // AgentSwitchOption is now a string to support dynamic agent names from OpenCode
 export type AgentSwitchOption = string;
 
+/**
+ * Which model OpenCode should use after switching agents on plan approval.
+ * 'current' keeps the model the session was already running (the default,
+ * fixed behavior); 'agent-default' opts into the target agent's own
+ * configured model from opencode.json. Plan-surface only; the review surface
+ * ignores this field.
+ */
+export type AgentModelPreference = 'current' | 'agent-default';
+
 export interface AgentSwitchSettings {
   switchTo: AgentSwitchOption;
   customName?: string;
+  modelPreference?: AgentModelPreference;
 }
 
 // Fallback options when API is unavailable or for non-OpenCode origins
@@ -38,6 +49,7 @@ export type AgentSwitchSurface = 'plan' | 'review';
 
 const PLAN_DEFAULT_SETTINGS: AgentSwitchSettings = {
   switchTo: 'build',
+  modelPreference: 'current',
 };
 
 const REVIEW_DEFAULT_SETTINGS: AgentSwitchSettings = {
@@ -61,12 +73,15 @@ export function getAgentSwitchDefaults(surface: AgentSwitchSurface = 'plan'): Ag
 export function getAgentSwitchSettings(surface: AgentSwitchSurface = 'plan'): AgentSwitchSettings {
   const stored = storage.getItem(STORAGE_KEY);
   const customName = storage.getItem(CUSTOM_NAME_KEY) || undefined;
+  const storedModelPreference = storage.getItem(MODEL_PREFERENCE_KEY);
+  const modelPreference: AgentModelPreference =
+    storedModelPreference === 'agent-default' ? 'agent-default' : 'current';
 
   // Accept any non-empty string (supports dynamic agent names from OpenCode)
   if (stored) {
-    return { switchTo: stored, customName };
+    return { switchTo: stored, customName, modelPreference };
   }
-  return getAgentSwitchDefaults(surface);
+  return { ...getAgentSwitchDefaults(surface), modelPreference };
 }
 
 /**
@@ -76,6 +91,9 @@ export function saveAgentSwitchSettings(settings: AgentSwitchSettings): void {
   storage.setItem(STORAGE_KEY, settings.switchTo);
   if (settings.customName) {
     storage.setItem(CUSTOM_NAME_KEY, settings.customName);
+  }
+  if (settings.modelPreference) {
+    storage.setItem(MODEL_PREFERENCE_KEY, settings.modelPreference);
   }
 }
 
@@ -94,4 +112,12 @@ export function getEffectiveAgentName(settings: AgentSwitchSettings): string | u
     return undefined;
   }
   return settings.switchTo;
+}
+
+/**
+ * Get the effective model preference, defaulting to 'current' (keep the
+ * session's active model) when unset.
+ */
+export function getEffectiveModelPreference(settings: AgentSwitchSettings): AgentModelPreference {
+  return settings.modelPreference ?? 'current';
 }


### PR DESCRIPTION
## Summary
- preserve the active OpenCode model when approving a plan
- let reviewers choose an agent default or a specific available model before handoff
- display the resolved current model in the Approve dropdown and widen it to avoid truncation

<img width="390" height="393" alt="image" src="https://github.com/user-attachments/assets/1e73ffd1-4c33-431c-bb43-8122b5f719e1" />

## Verification
- `bun test apps/opencode-plugin packages/ui packages/editor packages/server apps/hook`
- `DOM_TESTS=1 bun test packages/ui/components/HtmlSurfaceControls.test.tsx packages/ui/components/ApproveDropdown.currentModel.test.tsx`
- `bunx tsc --noEmit -p packages/ui/tsconfig.json`
- `bunx tsc --noEmit -p packages/server/tsconfig.json`
- `bun run --cwd apps/review build && bun run build:hook && bun run build:opencode`
- Manually submitted and approved a dummy plan through OpenCode; confirmed the current model appears in the handoff dropdown.