### PR TITLE
docs: complete the local compile command in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -797,8 +797,11 @@ Running only `build:hook` after review-editor changes will copy stale HTML files
 
 ```bash
 bun run --cwd apps/review build && bun run build:hook && \
-  bun build apps/hook/server/index.ts --compile --outfile ~/.local/bin/plannotator
+  bun build apps/hook/server/index.ts --compile --no-compile-autoload-bunfig \
+  --define "__CLI_VERSION__=\"0.0.0-dev\"" --outfile ~/.local/bin/plannotator
 ```
+
+These are the flags `.github/workflows/release.yml` compiles with; without the `__CLI_VERSION__` define `plannotator --version` falls back to `plannotator dev` and the binary cannot be told apart from any other local build. On macOS build with bun >= 1.3.14 (what CI pins): 1.3.12 loses the linker signature and the compiled binary is SIGKILLed on launch with no error (#541).
 
 Running only `build:opencode` will copy stale HTML files.
 


### PR DESCRIPTION
The local compile command in `AGENTS.md` (`## Build`) drops both flags the release workflow uses, so a binary built by following the docs differs from a released one.

Source of truth: `.github/workflows/release.yml:111` compiles with `--no-compile-autoload-bunfig` and `--define "__CLI_VERSION__=\"$VERSION\""`.

Two concrete failure modes:

- **No version identity.** Without the `__CLI_VERSION__` define, `plannotator --version` takes the fallback in `apps/hook/server/cli.ts:128` and prints `plannotator dev` — a locally built binary can't be told apart from any other. Verified locally: the documented command prints `plannotator dev`; with the define it prints `plannotator 0.0.0-dev`.
- **SIGKILL on macOS with bun 1.3.12.** The cross-compile signing regression tracked in #541 loses the linker signature; the binary is killed on launch with no error and `codesign -dv` reports it as unsigned. This is why `release.yml` pins `bun-version: 1.3.14` and keeps the macOS smoke leg (`release.yml:174-175`). Hit for real; upgrading bun resolved it. The docs said nothing about the floor.

Docs-only change: the corrected command with an obviously-local `0.0.0-dev` placeholder, plus one sentence naming the flags' source and the macOS bun floor. No restructuring.

`bun run check:release-version` passes.

Per `CONTRIBUTING.md` this is a fork → PR contribution under the repo's dual Apache-2.0/MIT licensing.
