### PR TITLE
feat(opencode): add native V2 slash commands

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -184,7 +184,7 @@ jobs:
         # zizmor: ignore[adhoc-packages] This integration test requires the exact
         # globally installed CLI. Owner: maintainers; reassess a locked fixture
         # by 2027-08-11.
-        run: npm install --global @opencode-ai/cli@0.0.0-next-16775
+        run: npm install --global @opencode-ai/cli@0.0.0-beta-18684
 
       - name: Build OpenCode plugin assets
         run: bun run build:review && bun run build:hook && bun run build:opencode

--- a/apps/opencode-plugin/README.md
+++ b/apps/opencode-plugin/README.md
@@ -38,7 +38,7 @@ Install OpenCode 2 from npm's `beta` tag, then add Plannotator to the V2 `plugin
 }
 ```
 
-Restart OpenCode 2 and verify that `/plannotator-review`, `/plannotator-annotate`, and `/plannotator-last` appear in the command menu.
+Restart OpenCode 2 and run `/plannotator-annotate README.md`. The annotation UI should open directly without sending the command through the model; the other native commands are `/plannotator-review` and `/plannotator-last`.
 
 OpenCode 2 support is experimental while its plugin API is in beta. The core `submit_plan` review flow and native `/plannotator-review`, `/plannotator-annotate`, and `/plannotator-last` commands work, but the current API has these limitations:
 

--- a/apps/opencode-plugin/README.md
+++ b/apps/opencode-plugin/README.md
@@ -21,7 +21,7 @@ Obsidian users can auto-save approved plans to Obsidian as well. [See details](#
 
 ### OpenCode 2 beta
 
-Install OpenCode 2 from npm's `next` tag, then add Plannotator to the V2 `plugins` field:
+Install OpenCode 2 from npm's `beta` tag, then add Plannotator to the V2 `plugins` field:
 
 ```json
 {
@@ -38,13 +38,11 @@ Install OpenCode 2 from npm's `next` tag, then add Plannotator to the V2 `plugin
 }
 ```
 
-Restart OpenCode 2 and verify that `plannotator` appears in `opencode2 plugin list`.
+Restart OpenCode 2 and verify that `/plannotator-review`, `/plannotator-annotate`, and `/plannotator-last` appear in the command menu.
 
-OpenCode 2 support is experimental while its plugin API is in beta. The core `submit_plan` review flow works, but the current API has these limitations:
+OpenCode 2 support is experimental while its plugin API is in beta. The core `submit_plan` review flow and native `/plannotator-review`, `/plannotator-annotate`, and `/plannotator-last` commands work, but the current API has these limitations:
 
-- OpenCode 2 does not expose a native slash-command execution hook. Its command definitions expand to model prompts, so `/plannotator-review`, `/plannotator-annotate`, and `/plannotator-last` remain OpenCode 1-only instead of silently becoming model-mediated commands.
 - V2 tool execution does not expose an abort signal. Cancelling a turn cannot yet stop a running review server or CLI child immediately.
-- The V2 plugin context cannot switch the active session agent. Agent switching selected in the review UI is ignored with a server-log warning; switch to `build` manually after approval before implementation.
 - The V2 plugin context has no TUI toast/log API, so remote session URLs are written to the server output rather than shown as a toast.
 
 ### OpenCode 1
@@ -68,7 +66,7 @@ Restart OpenCode. By default, the `submit_plan` tool is available to OpenCode's 
 
 ## Workflow Modes
 
-The examples below use the OpenCode 1 config shape. OpenCode 2 places the same option keys under the plugin entry's `options` object shown above. In V2, `manual` intentionally registers no tool and native slash-command handlers are unavailable, so it currently leaves the integration inactive.
+The examples below use the OpenCode 1 config shape. OpenCode 2 places the same option keys under the plugin entry's `options` object shown above. In V2, `manual` registers the native slash-command handlers without registering `submit_plan` or modifying model prompts.
 
 - **`plan-agent`** (default): `submit_plan` is available to OpenCode's built-in `plan` agent plus any extra agents listed in `planningAgents`. This keeps Plannotator integrated with OpenCode plan mode without nudging `build` to call it.
 - **`manual`**: `submit_plan` is not registered. Use `/plannotator-last`, `/plannotator-annotate`, and `/plannotator-review` when you want Plannotator.

--- a/apps/opencode-plugin/commands.test.ts
+++ b/apps/opencode-plugin/commands.test.ts
@@ -56,7 +56,8 @@ afterEach(() => {
 
 describe("handleAnnotateCommand", () => {
   test("advertises approval notes only when an OpenCode session is available", async () => {
-    const projectRoot = makeTempDir();
+    const projectRoot = path.join(makeTempDir(), "session-project");
+    mkdirSync(projectRoot);
     const filePath = path.join(projectRoot, "plan.md");
     writeFileSync(filePath, "# Plan\n");
 
@@ -67,6 +68,7 @@ describe("handleAnnotateCommand", () => {
       withSession,
     );
     expect(startAnnotateServerMock.mock.calls[0]?.[0].approvalNotesSupported).toBe(true);
+    expect(startAnnotateServerMock.mock.calls[0]?.[0].project).toBe("session-project");
 
     startAnnotateServerMock.mockClear();
     const withoutSession = makeDeps();
@@ -266,6 +268,8 @@ describe("handleAnnotateLastCommand", () => {
 
   test("forwards pasteApiUrl for annotate-last sessions", async () => {
     const deps = makeDeps();
+    deps.directory = path.join(makeTempDir(), "last-session-project");
+    mkdirSync(deps.directory);
     deps.client.session.messages = mock(async (_input: unknown) => ({
       data: [
         {
@@ -286,5 +290,6 @@ describe("handleAnnotateLastCommand", () => {
     expect(options.filePath).toBe("last-message");
     expect(options.pasteApiUrl).toBe("https://paste.example.test");
     expect(options.markdown).toBe("Latest assistant message");
+    expect(options.project).toBe("last-session-project");
   });
 });

--- a/apps/opencode-plugin/commands.ts
+++ b/apps/opencode-plugin/commands.ts
@@ -366,7 +366,7 @@ export async function handleAnnotateCommand(
   // Per-project scoping for the annotate version history — matches the hook
   // and Pi runtimes, which both pass it (otherwise history lands in the
   // shared "_unknown" bucket).
-  const annotateProject = (await detectProjectName()) ?? undefined;
+  const annotateProject = (await detectProjectName(directory)) ?? undefined;
   const server = await startServer({
     markdown,
     filePath: absolutePath,
@@ -440,7 +440,7 @@ export async function handleAnnotateLastCommand(
   event: any,
   deps: CommandDeps
 ): Promise<{ approved: boolean; feedback: string } | null> {
-  const { client, htmlContent, getSharingEnabled, getShareBaseUrl, getPasteApiUrl } = deps;
+  const { client, htmlContent, getSharingEnabled, getShareBaseUrl, getPasteApiUrl, directory } = deps;
   const startServer = deps.startAnnotateServer ?? startAnnotateServer;
 
   // @ts-ignore - Event properties contain arguments
@@ -489,7 +489,7 @@ export async function handleAnnotateLastCommand(
 
   const pickerMessages = recentMessages.length > 1 ? recentMessages : undefined;
 
-  const lastProject = (await detectProjectName()) ?? undefined;
+  const lastProject = (await detectProjectName(directory)) ?? undefined;
   const server = await startServer({
     markdown: lastText,
     filePath: "last-message",

--- a/apps/opencode-plugin/commands.ts
+++ b/apps/opencode-plugin/commands.ts
@@ -433,8 +433,8 @@ export async function handleAnnotateCommand(
 
 /**
  * Handle /plannotator-last command.
- * Called from command.execute.before — returns approval-aware feedback so the
- * caller can choose the correct prompt semantics before injecting it.
+ * Returns approval-aware feedback so the command adapter can choose the
+ * correct prompt semantics before injecting it.
  */
 export async function handleAnnotateLastCommand(
   event: any,

--- a/apps/opencode-plugin/fixtures/v2-installed-smoke.ts
+++ b/apps/opencode-plugin/fixtures/v2-installed-smoke.ts
@@ -19,6 +19,7 @@ const PLUGIN_TIMEOUT_MS = readTimeout("PLANNOTATOR_SMOKE_PLUGIN_TIMEOUT_MS", 300
 // Per-request cap so one wedged request can never swallow the whole budget: the loop has to
 // keep polling (and keep reporting) instead of blocking on a single fetch that never settles.
 const REQUEST_TIMEOUT_MS = readTimeout("PLANNOTATOR_SMOKE_REQUEST_TIMEOUT_MS", 15_000);
+const COMMAND_TIMEOUT_MS = readTimeout("PLANNOTATOR_SMOKE_COMMAND_TIMEOUT_MS", 60_000);
 const SHUTDOWN_TIMEOUT_MS = 10_000;
 const PROGRESS_INTERVAL_MS = 15_000;
 
@@ -30,11 +31,15 @@ const packageJson = JSON.parse(readFileSync(path.join(import.meta.dir, "..", "pa
 const root = mkdtempSync(path.join(tmpdir(), "plannotator-opencode-v2-smoke-"));
 const port = await getFreePort();
 const registryPort = await getFreePort();
+const annotatePort = await getFreePort();
 const url = `http://127.0.0.1:${port}`;
 const registryUrl = `http://127.0.0.1:${registryPort}`;
+const annotateUrl = `http://127.0.0.1:${annotatePort}`;
+const commandTarget = path.join(root, "native-command.md");
 mkdirSync(path.join(root, "config"), { recursive: true });
 mkdirSync(path.join(root, "data"), { recursive: true });
 mkdirSync(path.join(root, "cache"), { recursive: true });
+await Bun.write(commandTarget, "# Native command smoke\n\nClose this annotation session.\n");
 
 const env = {
   ...process.env,
@@ -48,6 +53,8 @@ const env = {
   OPENCODE_LOG_LEVEL: "DEBUG",
   OPENCODE_PASSWORD: "plannotator-smoke",
   OPENCODE_SERVER_PASSWORD: "plannotator-smoke",
+  PLANNOTATOR_DATA_DIR: path.join(root, "plannotator"),
+  PLANNOTATOR_PORT: String(annotatePort),
   NPM_CONFIG_REGISTRY: registryUrl,
   npm_config_registry: registryUrl,
 };
@@ -88,7 +95,7 @@ const registry = Bun.serve({
 console.error(`opencode2 binary: ${opencodeBin} (${resolveOpencodeVersion()})`);
 console.error(`plugin tarball: ${path.resolve(pluginTarball)}`);
 console.error(`plugin package: ${packageJson.name}@${packageJson.version}`);
-console.error(`server ${url} · throwaway registry ${registryUrl} · sandbox ${root}`);
+console.error(`server ${url} · annotate server ${annotateUrl} · throwaway registry ${registryUrl} · sandbox ${root}`);
 
 const startedAt = Date.now();
 const server = Bun.spawn([
@@ -112,7 +119,7 @@ try {
   await waitForHealthyServer(url);
   const plugins = await waitForPlugin(url);
   const commands = await getCommands(url);
-  await executeCommand(url, commands);
+  await executeCommand(url, commands, commandTarget, annotateUrl);
   console.log(JSON.stringify({ plugins, commands }));
 } catch (error) {
   failed = true;
@@ -242,7 +249,12 @@ async function getCommands(url: string): Promise<Array<{ name: string }>> {
   return commands.filter((command) => expected.includes(command.name));
 }
 
-async function executeCommand(url: string, commands: Array<{ name: string }>): Promise<void> {
+async function executeCommand(
+  url: string,
+  commands: Array<{ name: string }>,
+  target: string,
+  annotateUrl: string,
+): Promise<void> {
   const sessionResponse = await fetch(`${url}/api/session`, {
     method: "POST",
     headers: { ...authHeaders(), "content-type": "application/json" },
@@ -258,13 +270,23 @@ async function executeCommand(url: string, commands: Array<{ name: string }>): P
 
   const command = commands.find((item) => item.name === "plannotator-annotate")?.name;
   if (!command) throw new Error("Native annotate command was not available for execution.");
-  const sentinel = `plannotator-native-command-smoke-${Date.now()}`;
-  const response = await fetch(`${url}/api/session/${sessionID}/command`, {
+  const commandResponse = fetch(`${url}/api/session/${sessionID}/command`, {
     method: "POST",
     headers: { ...authHeaders(), "content-type": "application/json" },
-    body: JSON.stringify({ command, text: sentinel }),
+    body: JSON.stringify({ command, text: target }),
+    signal: AbortSignal.timeout(COMMAND_TIMEOUT_MS),
+  });
+  await waitForAnnotateServer(annotateUrl);
+  const exitResponse = await fetch(`${annotateUrl}/api/exit`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: "{}",
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
+  const exitOutput = await exitResponse.text();
+  if (!exitResponse.ok) throw new Error(`Plannotator exit API returned ${exitResponse.status}: ${exitOutput}`);
+
+  const response = await commandResponse;
   const output = await response.text();
   if (!response.ok) throw new Error(`OpenCode command execution returned ${response.status}: ${output}`);
 
@@ -285,10 +307,29 @@ async function executeCommand(url: string, commands: Array<{ name: string }>): P
   if (!inboxResponse.ok) {
     throw new Error(`OpenCode session inbox returned ${inboxResponse.status}: ${inboxOutput}`);
   }
-  if (contextOutput.includes(sentinel) || inboxOutput.includes(sentinel)) {
+  if (contextOutput.includes(target) || inboxOutput.includes(target)) {
     throw new Error("The V1 Markdown command overrode the native callback and submitted a model prompt.");
   }
-  console.error("native command callback executed without a model prompt");
+  console.error("native command opened and closed the annotation server without a model prompt");
+}
+
+async function waitForAnnotateServer(url: string): Promise<void> {
+  const deadline = Date.now() + COMMAND_TIMEOUT_MS;
+  let lastSeen = "no response yet";
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${url}/api/plan`, {
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+      const output = await response.text();
+      if (response.ok) return;
+      lastSeen = `HTTP ${response.status}: ${output.slice(0, 500)}`;
+    } catch (error) {
+      lastSeen = `${(error as Error).name}: ${(error as Error).message}`;
+    }
+    await Bun.sleep(100);
+  }
+  throw new Error(`Native annotate command did not open its server within ${COMMAND_TIMEOUT_MS}ms. Last result: ${lastSeen}`);
 }
 
 // A stuck teardown used to turn a failing smoke into a multi-minute CI wall-clock burn that

--- a/apps/opencode-plugin/fixtures/v2-installed-smoke.ts
+++ b/apps/opencode-plugin/fixtures/v2-installed-smoke.ts
@@ -111,7 +111,9 @@ let failed = false;
 try {
   await waitForHealthyServer(url);
   const plugins = await waitForPlugin(url);
-  console.log(JSON.stringify(plugins));
+  const commands = await getCommands(url);
+  await executeCommand(url, commands);
+  console.log(JSON.stringify({ plugins, commands }));
 } catch (error) {
   failed = true;
   throw error;
@@ -223,6 +225,70 @@ async function waitForPlugin(url: string): Promise<unknown> {
     `Plannotator did not activate in OpenCode 2 within ${PLUGIN_TIMEOUT_MS}ms (waited ${elapsed()}). ` +
       `Last response: ${lastOutput}`,
   );
+}
+
+async function getCommands(url: string): Promise<Array<{ name: string }>> {
+  const response = await fetch(`${url}/api/command?directory=${encodeURIComponent(process.cwd())}`, {
+    headers: authHeaders(),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const output = await response.text();
+  if (!response.ok) throw new Error(`OpenCode command API returned ${response.status}: ${output}`);
+  const commands = (JSON.parse(output) as { data?: Array<{ name: string }> }).data ?? [];
+  const expected = ["plannotator-review", "plannotator-annotate", "plannotator-last"];
+  const missing = expected.filter((name) => !commands.some((command) => command.name === name));
+  if (missing.length > 0) throw new Error(`OpenCode did not register native commands: ${missing.join(", ")}`);
+  console.error(`native commands registered: ${expected.join(", ")}`);
+  return commands.filter((command) => expected.includes(command.name));
+}
+
+async function executeCommand(url: string, commands: Array<{ name: string }>): Promise<void> {
+  const sessionResponse = await fetch(`${url}/api/session`, {
+    method: "POST",
+    headers: { ...authHeaders(), "content-type": "application/json" },
+    body: "{}",
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const sessionOutput = await sessionResponse.text();
+  if (!sessionResponse.ok) {
+    throw new Error(`OpenCode session API returned ${sessionResponse.status}: ${sessionOutput}`);
+  }
+  const sessionID = (JSON.parse(sessionOutput) as { data?: { id?: string } }).data?.id;
+  if (!sessionID) throw new Error(`OpenCode session API returned no session ID: ${sessionOutput}`);
+
+  const command = commands.find((item) => item.name === "plannotator-annotate")?.name;
+  if (!command) throw new Error("Native annotate command was not available for execution.");
+  const sentinel = `plannotator-native-command-smoke-${Date.now()}`;
+  const response = await fetch(`${url}/api/session/${sessionID}/command`, {
+    method: "POST",
+    headers: { ...authHeaders(), "content-type": "application/json" },
+    body: JSON.stringify({ command, text: sentinel }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const output = await response.text();
+  if (!response.ok) throw new Error(`OpenCode command execution returned ${response.status}: ${output}`);
+
+  const contextResponse = await fetch(`${url}/api/session/${sessionID}/context`, {
+    headers: authHeaders(),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const contextOutput = await contextResponse.text();
+  if (!contextResponse.ok) {
+    throw new Error(`OpenCode session context returned ${contextResponse.status}: ${contextOutput}`);
+  }
+
+  const inboxResponse = await fetch(`${url}/api/session/${sessionID}/inbox`, {
+    headers: authHeaders(),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const inboxOutput = await inboxResponse.text();
+  if (!inboxResponse.ok) {
+    throw new Error(`OpenCode session inbox returned ${inboxResponse.status}: ${inboxOutput}`);
+  }
+  if (contextOutput.includes(sentinel) || inboxOutput.includes(sentinel)) {
+    throw new Error("The V1 Markdown command overrode the native callback and submitted a model prompt.");
+  }
+  console.error("native command callback executed without a model prompt");
 }
 
 // A stuck teardown used to turn a failing smoke into a multi-minute CI wall-clock burn that

--- a/apps/opencode-plugin/server.test.ts
+++ b/apps/opencode-plugin/server.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import serverPlugin, {
+  createV2Client,
   pushComposedSystemReminder,
   replacePlanningSystemParts,
 } from "./server";
@@ -21,8 +22,10 @@ type SessionContextHook = (event: {
 function createContext(
   options: Record<string, unknown> = {},
   agents: Array<{ id: string; description?: string; mode: string; hidden: boolean }> = [],
+  commandPluginLoaded?: (commands: Record<string, any>[]) => void,
 ) {
   let toolDefinition: Record<string, any> | undefined;
+  const commandDefinitions: Record<string, any>[] = [];
   let sessionContextHook: SessionContextHook | undefined;
   const sessionGet = mock(async () => ({ location: { directory: "/project" } }));
 
@@ -35,9 +38,29 @@ function createContext(
       },
       session: {
         get: sessionGet,
+        context: mock(async () => ({ data: [] })),
+        prompt: mock(async () => ({})),
+        switchAgent: mock(async () => {}),
         hook: async (name: string, callback: SessionContextHook) => {
           if (name === "context") sessionContextHook = callback;
           return { dispose: async () => {} };
+        },
+      },
+      command: {
+        transform: async (callback: (draft: { add: (command: Record<string, any>) => void }) => void) => {
+          callback({
+            add(command) {
+              commandDefinitions.push(command);
+            },
+          });
+          return { dispose: async () => {} };
+        },
+      },
+      event: {
+        subscribe: async function* () {
+          if (!commandPluginLoaded) return;
+          commandPluginLoaded(commandDefinitions);
+          yield { type: "plugin.added", data: { id: "opencode.config.command" } };
         },
       },
       tool: {
@@ -52,6 +75,7 @@ function createContext(
       },
     },
     getToolDefinition: () => toolDefinition,
+    getCommandDefinitions: () => commandDefinitions,
     getSessionContextHook: () => sessionContextHook,
     sessionGet,
   };
@@ -95,6 +119,77 @@ describe("OpenCode V2 server plugin", () => {
     });
     expect(tool?.options).toEqual({ codemode: false });
     expect(tool?.execute).toBeInstanceOf(Function);
+  });
+
+  test("registers native callbacks for all manual commands", async () => {
+    const testContext = createContext({ workflow: "manual" });
+    await serverPlugin.setup(testContext.context as never);
+
+    expect(testContext.getToolDefinition()).toBeUndefined();
+    expect(testContext.getCommandDefinitions().map((command) => command.name)).toEqual([
+      "plannotator-review",
+      "plannotator-annotate",
+      "plannotator-last",
+    ]);
+    expect(testContext.getCommandDefinitions().every((command) => typeof command.execute === "function")).toBe(true);
+  });
+
+  test("restores native callbacks after V1 Markdown commands overwrite them", async () => {
+    const testContext = createContext({ workflow: "manual" }, [], (commands) => {
+      for (const name of ["plannotator-review", "plannotator-annotate", "plannotator-last"]) {
+        commands.push({ name, description: "Markdown stub" });
+      }
+    });
+    await serverPlugin.setup(testContext.context as never);
+    await Bun.sleep(0);
+
+    const active = new Map(
+      testContext.getCommandDefinitions().map((command) => [command.name, command]),
+    );
+    expect([...active.keys()]).toEqual([
+      "plannotator-review",
+      "plannotator-annotate",
+      "plannotator-last",
+    ]);
+    expect([...active.values()].every((command) => typeof command.execute === "function")).toBe(true);
+  });
+
+  test("adapts V2 message history and deliberate feedback prompts for command handlers", async () => {
+    const context = mock(async () => [{
+      id: "message-1",
+      type: "assistant",
+      time: { created: 123 },
+      content: [
+        { type: "reasoning", text: "Hidden reasoning" },
+        { type: "text", text: "Latest answer" },
+      ],
+    }]);
+    const prompt = mock(async () => ({}));
+    const switchAgent = mock(async () => {});
+    const client = createV2Client({
+      session: { context, prompt, switchAgent, get: mock(async () => ({})) },
+    }, async () => [], "queue");
+
+    expect(await client.session.messages({ path: { id: "session-1" } })).toEqual({
+      data: [{
+        info: { id: "message-1", role: "assistant", time: { created: 123 } },
+        parts: [{ type: "text", text: "Latest answer" }],
+      }],
+    });
+
+    await client.session.prompt({
+      path: { id: "session-1" },
+      body: {
+        agent: "build",
+        parts: [{ type: "text", text: "Address this feedback." }],
+      },
+    });
+    expect(switchAgent).toHaveBeenCalledWith({ sessionID: "session-1", agent: "build" });
+    expect(prompt).toHaveBeenCalledWith({
+      sessionID: "session-1",
+      text: "Address this feedback.",
+      delivery: "queue",
+    });
   });
 
   test("resolves cwd from the V2 session and returns V2 tool content", async () => {

--- a/apps/opencode-plugin/server.test.ts
+++ b/apps/opencode-plugin/server.test.ts
@@ -3,6 +3,7 @@ import serverPlugin, {
   createV2Client,
   pushComposedSystemReminder,
   replacePlanningSystemParts,
+  sendV2ApprovalHandoff,
 } from "./server";
 
 const originalAllowSubagents = process.env.PLANNOTATOR_ALLOW_SUBAGENTS;
@@ -189,6 +190,32 @@ describe("OpenCode V2 server plugin", () => {
       sessionID: "session-1",
       text: "Address this feedback.",
       delivery: "queue",
+    });
+  });
+
+  test("switches agents before steering the approved plan handoff", async () => {
+    const calls: string[] = [];
+    const switchAgent = mock(async () => {
+      calls.push("switch");
+    });
+    const prompt = mock(async () => {
+      calls.push("prompt");
+    });
+
+    await sendV2ApprovalHandoff({
+      session: { switchAgent, prompt },
+    }, {
+      sessionId: "session-1",
+      targetAgent: "build",
+      text: "Proceed with implementation",
+    });
+
+    expect(calls).toEqual(["switch", "prompt"]);
+    expect(switchAgent).toHaveBeenCalledWith({ sessionID: "session-1", agent: "build" });
+    expect(prompt).toHaveBeenCalledWith({
+      sessionID: "session-1",
+      text: "Proceed with implementation",
+      delivery: "steer",
     });
   });
 

--- a/apps/opencode-plugin/server.ts
+++ b/apps/opencode-plugin/server.ts
@@ -312,10 +312,7 @@ const serverPlugin = {
                 directory,
                 delivery,
             }),
-            sendApprovalHandoff: async ({ sessionId, targetAgent }) => {
-              const session = ctx.session as unknown as V2SessionApi;
-              await session.switchAgent?.({ sessionID: sessionId, agent: targetAgent });
-            },
+            sendApprovalHandoff: async (handoff) => await sendV2ApprovalHandoff(ctx, handoff),
           });
 
           return { content: result };
@@ -383,6 +380,20 @@ export function createV2Client(
       },
     },
   };
+}
+
+export async function sendV2ApprovalHandoff(
+  ctx: { session: unknown },
+  input: { sessionId: string; targetAgent: string; text: string },
+): Promise<void> {
+  const session = ctx.session as V2SessionApi;
+  if (!session.switchAgent) return;
+  await session.switchAgent({ sessionID: input.sessionId, agent: input.targetAgent });
+  await session.prompt({
+    sessionID: input.sessionId,
+    text: input.text,
+    delivery: "steer",
+  });
 }
 
 async function restoreNativeCommandsAfterConfigPlugin(

--- a/apps/opencode-plugin/server.ts
+++ b/apps/opencode-plugin/server.ts
@@ -17,12 +17,14 @@ import {
   type RuntimeMode,
 } from "./workflow";
 import {
+  handleCliCommand,
   runCliPlanReview,
   type OpenCodeBridgeAgent,
   type OpenCodeBridgeContext,
   type OpenCodePlanReviewResult,
 } from "./cli-bridge";
-import { resolveTargetAgent } from "./agent-switch";
+import { resolveValidatedTargetAgent } from "./agent-switch";
+import { shouldFallbackAfterEmbeddedError } from "./prompt-delivery-error";
 import { executeSubmitPlan } from "./submit-plan-executor";
 import type { PlanEdit } from "./plan-edits";
 import { getPlanningPrompt } from "./planning-prompt";
@@ -36,6 +38,54 @@ type V2Client = {
     agents: () => Promise<{ data: OpenCodeBridgeAgent[] }>;
     log: (entry: { level: "info" | "error"; message: string }) => void;
   };
+  session: {
+    messages: (input: { path: { id: string } }) => Promise<{ data: LegacyMessage[] }>;
+    prompt: (input: LegacyPromptInput) => Promise<unknown>;
+  };
+};
+
+type LegacyMessage = {
+  info: {
+    id?: string;
+    role: string;
+    time?: { created?: string | number | Date };
+  };
+  parts: Array<{ type: string; text?: string }>;
+};
+
+type LegacyPromptInput = {
+  path: { id: string };
+  body: {
+    agent?: string;
+    parts: Array<{ type: string; text?: string }>;
+  };
+};
+
+type NativeCommandInvocation = {
+  sessionID: string;
+  prompt: { text: string };
+  delivery: "steer" | "queue";
+};
+
+type NativeCommandDefinition = {
+  name: string;
+  description: string;
+  execute: (input: NativeCommandInvocation) => Promise<void>;
+};
+
+type NativeCommandDraft = {
+  add?: (definition: NativeCommandDefinition) => void;
+};
+
+type V2SessionApi = {
+  context: (input: { sessionID: string }) => Promise<unknown>;
+  get: (input: { sessionID: string }) => Promise<unknown>;
+  prompt: (input: {
+    sessionID: string;
+    text: string;
+    delivery?: "steer" | "queue";
+  }) => Promise<unknown>;
+  switchAgent?: (input: { sessionID: string; agent: string }) => Promise<unknown>;
 };
 
 type EmbeddedRuntimeModule = {
@@ -50,7 +100,41 @@ type EmbeddedRuntimeModule = {
     abortSignal?: AbortSignal;
     logReady: (url: string, isRemote: boolean, port: number) => void;
   }) => Promise<OpenCodePlanReviewResult>;
+  handleEmbeddedCommand: (
+    command: string,
+    event: { properties: { sessionID: string; arguments: string } },
+    deps: {
+      client: V2Client;
+      htmlContent: string;
+      reviewHtmlContent: string;
+      getSharingEnabled: () => Promise<boolean>;
+      getShareBaseUrl: () => string | undefined;
+      getPasteApiUrl: () => string | undefined;
+      directory?: string;
+    },
+  ) => Promise<{ approved?: boolean; feedback?: string | null }>;
+  deliverEmbeddedAnnotateMessagePrompt: (input: {
+    client: V2Client;
+    sessionId: string;
+    approved: boolean;
+    feedback: string;
+  }) => Promise<void>;
 };
+
+const nativeCommands = [
+  {
+    name: "plannotator-review",
+    description: "Open interactive code review for current changes or a PR URL; pass --git or --gitbutler to force that provider",
+  },
+  {
+    name: "plannotator-annotate",
+    description: "Open interactive annotation UI for a file, folder, or URL",
+  },
+  {
+    name: "plannotator-last",
+    description: "Annotate the last assistant message",
+  },
+] as const;
 
 // `Plugin.define` is an identity function in @opencode-ai/plugin; keeping the import
 // type-only avoids shipping a runtime dependency on an exact prerelease nightly.
@@ -64,7 +148,8 @@ const serverPlugin = {
       if (cachedAgents) return cachedAgents;
       try {
         const response = await ctx.agent.list();
-        cachedAgents = response.data.map((agent) => ({
+        const agents = unwrapData(response);
+        cachedAgents = (Array.isArray(agents) ? agents : []).map((agent) => ({
           name: agent.id,
           description: agent.description,
           mode: agent.mode,
@@ -75,6 +160,33 @@ const serverPlugin = {
       }
       return cachedAgents;
     };
+
+    const client = createV2Client(ctx, getAgents);
+
+    const registerNativeCommands = async () => {
+      await ctx.command.transform((commands) => {
+        const draft = commands as NativeCommandDraft;
+        // Older V2 nightlies expose command transforms but not executable definitions.
+        if (typeof draft.add !== "function") return;
+        addNativeCommands(draft, async (command, input) => {
+          const session = unwrapData(await ctx.session.get({ sessionID: input.sessionID })) as {
+            location?: { directory?: string };
+          };
+          await runNativeCommand({
+            command,
+            sessionID: input.sessionID,
+            arguments: input.prompt.text,
+            directory: session.location?.directory ?? process.cwd(),
+            runtime: workflowOptions.runtime,
+            client: createV2Client(ctx, getAgents, input.delivery),
+            bridge: await getBridgeContext(getAgents),
+          });
+        });
+      });
+    };
+
+    await registerNativeCommands();
+    void restoreNativeCommandsAfterConfigPlugin(ctx, registerNativeCommands);
 
     if (shouldModifyPrompts(workflowOptions)) {
       await ctx.session.hook("context", async (event) => {
@@ -173,9 +285,8 @@ const serverPlugin = {
         options: { codemode: false },
         execute: async (input, toolContext) => {
           const session = await ctx.session.get({ sessionID: toolContext.sessionID });
-          const directory = session.location.directory;
+          const directory = (unwrapData(session) as { location: { directory: string } }).location.directory;
           const bridge = await getBridgeContext(getAgents);
-          const client = createV2Client(getAgents);
           const result = await executeSubmitPlan({
             edits: getPlanEdits(input),
             invokingAgent: toolContext.agent,
@@ -194,19 +305,17 @@ const serverPlugin = {
               directory,
               bridge,
             }),
-            resolveTargetAgent: async ({ requestedAgent }) => {
-              const targetAgent = resolveTargetAgent(requestedAgent);
-              if (!targetAgent) return undefined;
-              const available = (await getAgents()).some((agent) => agent.name === targetAgent);
-              if (!available) {
-                console.error(`[Plannotator] Configured OpenCode agent "${targetAgent}" is not available; approving the plan without switching agents.`);
-                return undefined;
-              }
-              // The current OpenCode 2 API exposes no session-agent switch operation to plugins.
-              console.error("[Plannotator] OpenCode 2 does not currently expose agent switching to plugins; approving the plan without switching agents.");
-              return undefined;
+            resolveTargetAgent: async ({ requestedAgent, directory, delivery }) =>
+              await resolveValidatedTargetAgent({
+                client,
+                targetAgent: requestedAgent,
+                directory,
+                delivery,
+            }),
+            sendApprovalHandoff: async ({ sessionId, targetAgent }) => {
+              const session = ctx.session as unknown as V2SessionApi;
+              await session.switchAgent?.({ sessionID: sessionId, agent: targetAgent });
             },
-            sendApprovalHandoff: async () => {},
           });
 
           return { content: result };
@@ -233,10 +342,13 @@ function getPlanTimeoutSeconds(): number | null {
   return parsed === 0 ? null : parsed;
 }
 
-function createV2Client(
+export function createV2Client(
+  ctx: { session: unknown },
   getAgents: () => Promise<OpenCodeBridgeAgent[]>,
+  delivery: "steer" | "queue" = "steer",
 ): V2Client {
   const loggedUrls = new Set<string>();
+  const session = ctx.session as V2SessionApi;
   return {
     app: {
       agents: async () => ({ data: await getAgents() }),
@@ -247,7 +359,148 @@ function createV2Client(
         console.error(message);
       },
     },
+    session: {
+      messages: async ({ path }) => {
+        const messages = unwrapData(await session.context({ sessionID: path.id }));
+        return {
+          data: Array.isArray(messages)
+            ? messages.flatMap(toLegacyMessage)
+            : [],
+        };
+      },
+      prompt: async ({ path, body }) => {
+        if (body.agent && session.switchAgent) {
+          await session.switchAgent({ sessionID: path.id, agent: body.agent });
+        }
+        return await session.prompt({
+          sessionID: path.id,
+          text: body.parts
+            .filter((part) => part.type === "text" && part.text)
+            .map((part) => part.text)
+            .join("\n"),
+          delivery,
+        });
+      },
+    },
   };
+}
+
+async function restoreNativeCommandsAfterConfigPlugin(
+  ctx: { event: { subscribe: () => AsyncIterable<unknown> } },
+  register: () => Promise<void>,
+): Promise<void> {
+  try {
+    for await (const event of ctx.event.subscribe()) {
+      if (
+        !event
+        || typeof event !== "object"
+        || Reflect.get(event, "type") !== "plugin.added"
+      ) continue;
+      const data = Reflect.get(event, "data");
+      if (!data || typeof data !== "object" || Reflect.get(data, "id") !== "opencode.config.command") continue;
+
+      // Config commands load after package plugins and overwrite duplicate names.
+      // Register once more so these executable callbacks win over the V1 stubs.
+      await register();
+      return;
+    }
+  } catch (error) {
+    console.error(`[Plannotator] Could not finalize native command registration: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function unwrapData(value: unknown): unknown {
+  if (!value || typeof value !== "object" || !("data" in value)) return value;
+  return Reflect.get(value, "data");
+}
+
+function toLegacyMessage(message: unknown): LegacyMessage[] {
+  if (!message || typeof message !== "object" || Reflect.get(message, "type") !== "assistant") return [];
+  const content = Reflect.get(message, "content");
+  if (!Array.isArray(content)) return [];
+  return [{
+    info: {
+      id: typeof Reflect.get(message, "id") === "string" ? Reflect.get(message, "id") : undefined,
+      role: "assistant",
+      time: Reflect.get(message, "time") as LegacyMessage["info"]["time"],
+    },
+    parts: content.flatMap((part) =>
+      part && typeof part === "object" && Reflect.get(part, "type") === "text"
+        ? [{ type: "text", text: String(Reflect.get(part, "text") ?? "") }]
+        : []
+    ),
+  }];
+}
+
+function addNativeCommands(
+  draft: NativeCommandDraft,
+  execute: (command: string, input: NativeCommandInvocation) => Promise<void>,
+): void {
+  if (!draft.add) return;
+  for (const command of nativeCommands) {
+    draft.add({
+      ...command,
+      execute: async (input) => await execute(command.name, input),
+    });
+  }
+}
+
+async function runNativeCommand(input: {
+  command: string;
+  sessionID: string;
+  arguments: string;
+  directory?: string;
+  runtime: RuntimeMode;
+  client: V2Client;
+  bridge: OpenCodeBridgeContext;
+}): Promise<void> {
+  const event = {
+    properties: {
+      sessionID: input.sessionID,
+      arguments: input.arguments,
+    },
+  };
+
+  if (input.runtime !== "cli" && hasEmbeddedRuntime()) {
+    try {
+      const embedded = await importEmbeddedRuntime();
+      const result = await embedded.handleEmbeddedCommand(input.command, event, {
+        client: input.client,
+        htmlContent: getPlanHtml(),
+        reviewHtmlContent: getReviewHtml(),
+        getSharingEnabled: async () => input.bridge.sharingEnabled ?? true,
+        getShareBaseUrl: () => input.bridge.shareBaseUrl,
+        getPasteApiUrl: () => input.bridge.pasteApiUrl,
+        directory: input.directory,
+      });
+      if (input.command === "plannotator-last" && result.feedback) {
+        await embedded.deliverEmbeddedAnnotateMessagePrompt({
+          client: input.client,
+          sessionId: input.sessionID,
+          approved: Boolean(result.approved),
+          feedback: result.feedback,
+        });
+      }
+      return;
+    } catch (error) {
+      if (!shouldFallbackAfterEmbeddedError(input.runtime, error)) throw error;
+      console.error(`[Plannotator] Embedded runtime unavailable; falling back to CLI: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  if (input.runtime === "embedded") {
+    console.error("[Plannotator] runtime \"embedded\" requires a Bun-hosted OpenCode plugin runtime. Use runtime \"auto\" or \"cli\" with this OpenCode host.");
+    return;
+  }
+
+  await handleCliCommand({
+    command: input.command,
+    client: input.client,
+    sessionId: input.sessionID,
+    rawArgs: input.arguments,
+    cwd: input.directory,
+    bridge: input.bridge,
+  });
 }
 
 function allowSubagents(): boolean {
@@ -289,6 +542,16 @@ function getPlanHtml(): string {
   if (!htmlPath) throw new Error("Could not find bundled HTML asset: plannotator.html");
   planHtml = readFileSync(htmlPath, "utf-8");
   return planHtml;
+}
+
+function getReviewHtml(): string {
+  const candidates = [
+    path.join(moduleDir, "review-editor.html"),
+    path.join(moduleDir, "..", "review-editor.html"),
+  ];
+  const htmlPath = candidates.find((candidate) => existsSync(candidate));
+  if (!htmlPath) throw new Error("Could not find bundled HTML asset: review-editor.html");
+  return readFileSync(htmlPath, "utf-8");
 }
 
 async function runPlanReview(input: {

--- a/packages/server/project.ts
+++ b/packages/server/project.ts
@@ -20,10 +20,17 @@ export { sanitizeTag, extractRepoName, extractDirName } from "@plannotator/share
  * 2. Current directory name (fallback)
  * 3. null (if nothing useful found)
  */
-export async function detectProjectName(): Promise<string | null> {
+export async function detectProjectName(directory?: string): Promise<string | null> {
+  let cwd: string;
+  try {
+    cwd = directory ?? process.cwd();
+  } catch {
+    return null;
+  }
+
   // Try git repo name first
   try {
-    const result = await $`git rev-parse --show-toplevel`.quiet().nothrow();
+    const result = await $`git rev-parse --show-toplevel`.cwd(cwd).quiet().nothrow();
     if (result.exitCode === 0) {
       const repoName = extractRepoName(result.stdout.toString());
       if (repoName) return repoName;
@@ -34,7 +41,6 @@ export async function detectProjectName(): Promise<string | null> {
 
   // Fallback to current directory name
   try {
-    const cwd = process.cwd();
     const dirName = extractDirName(cwd);
     if (dirName) return dirName;
   } catch {


### PR DESCRIPTION
## Summary
- register native OpenCode 2 callbacks for `/plannotator-review`, `/plannotator-annotate`, and `/plannotator-last`
- adapt V2 session history, feedback delivery, delivery mode, and agent switching to the existing command handlers
- switch agents and steer the implementation handoff after plan approval instead of dropping its text
- scope annotation history metadata to each OpenCode session directory
- restore native callbacks after legacy Markdown command stubs load so commands remain model-free until feedback is intentionally submitted
- update the V2 beta documentation and installed-package smoke coverage

## Verification
- `bun test apps/opencode-plugin packages/server/project.test.ts` (143 passed)
- `bun run typecheck`
- `bun run build:review`
- `bun run build:hook`
- `bun run build:opencode`
- `bun test tests/entry-assets.test.ts` (26 passed)
- packed-tarball smoke against `opencode2 v0.0.0-beta-18684`
- manually exercised all three commands through the normal OpenCode TUI with configured models/providers

## Notes
- The installed-package smoke loads a real markdown target, opens and closes the bundled annotation server, and verifies the command text was never admitted as a model prompt.
- The existing `@opencode-ai/plugin` development pin remains type-only. Bumping it to beta-18684 currently pulls a newly published Effect RC blocked by the repository minimum-release-age policy; CI and the packed smoke exercise the real beta-18684 host API instead.

Closes #1421