### PR TITLE
feat(annotate): one-step submit with a quick note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,6 +298,12 @@ User annotates content, provides feedback
 Send Annotations → feedback sent to agent session
 ```
 
+### Submit with a note
+
+Every annotate surface (file, folder, `annotate-last` message, URL, live app) has a split Send control: the primary button is the incumbent Send Feedback, and the caret beside it opens a one-line "Add a note..." field whose Enter submits the note TOGETHER with any annotations already queued, in one interaction. With nothing queued the primary button opens that field instead of staying hidden, which is what it did before (submitting an empty review was never useful). Escape closes the field without submitting and keeps the typed text for the rest of the session; an unsent note is deliberately not drafted, because it becomes a real, drafted annotation the moment it is sent.
+
+The note is created as a `GLOBAL_COMMENT` at SUBMIT time and committed into `annotations` (`commitSubmitNote` in `packages/editor/App.tsx`), so it rides `exportAnnotations` and the `/api/feedback` annotations array exactly like a composer-made global comment: **zero server change on either runtime** — both `/api/feedback` handlers take a pre-rendered feedback string plus an opaque `unknown[]`. Committing it into state rather than threading it through the payload builders is what makes `annotate-last`'s multi-message export pick it up, since those entries are rebuilt from the live linked-doc session snapshot rather than from `allAnnotations`; the submit therefore waits one render for the commit (an effect keyed on the pending note id). It is NOT recorded in the annotation undo/redo history: it exists for the duration of one submit. On HTML and live-app surfaces the comment-only clamp does not apply — that clamp sits on the iframe's postMessage ingest, and this note is created in the parent. Plan mode is untouched: the control is annotate-only. The compact touch shell has no header Send control, so the field lives in its "Review and finish" surface instead. The affordance is `packages/editor/components/AnnotateSendControl.tsx`; the chords are documented by the `annotate-note` shortcut scope.
+
 ### Tolerant argument resolution
 
 Slash-command hosts forward raw user words to `plannotator annotate` verbatim (on Claude Code through a bash-substitution prefix that runs before the model sees anything), so non-strict invocations resolve their arguments in three tiers. The shared logic lives in `packages/shared/annotate-target.ts` (vendored to Pi) and is wired into the CLI's annotate branch plus the OpenCode and Pi command parsers:

--- a/packages/editor/App.submitNote.test.tsx
+++ b/packages/editor/App.submitNote.test.tsx
@@ -1,0 +1,350 @@
+/**
+ * One-step "submit with a note" on the annotate surfaces (DOM-gated).
+ *
+ * Regressions each test guards:
+ *  - The note must reach the agent AS A GLOBAL COMMENT, in the exported
+ *    feedback string AND in the `/api/feedback` annotations array. If it were
+ *    only spliced into the feedback text, the annotations array (which both
+ *    servers persist as the durable submission record) would lose it; if it
+ *    were only put in the array, the agent-facing text would not mention it.
+ *  - It must be sent ALONGSIDE annotations already in the session, not
+ *    instead of them. The note is committed into state and submitted a render
+ *    later, so a regression that submits in the same tick would send the
+ *    pre-note payload and silently drop the note.
+ *  - The zero-annotation fast path: the incumbent header hid Send entirely
+ *    with nothing to send, so Send must open the note field instead of
+ *    submitting an empty review.
+ *  - Escape must close the field WITHOUT submitting: on HTML surfaces Escape
+ *    also walks the pinpoint ladder, so a missed stopPropagation would both
+ *    submit and disarm.
+ *  - Plan mode must not grow the control at all: it has its own
+ *    approve/deny-with-feedback semantics and is deliberately untouched.
+ */
+import { afterAll, afterEach, describe, expect, test } from "bun:test";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  resetStorageBackend,
+  setStorageBackend,
+  type StorageBackend,
+} from "@plannotator/ui/utils/storage";
+
+const hasDom = typeof document !== "undefined";
+
+if (hasDom) {
+  document.cookie = "plannotator-look-feel-announcement-seen=2; path=/";
+  document.cookie = "plannotator-vim-mode-announcement-seen=2; path=/";
+  document.cookie = "plannotator-plan-ai-announcement-seen=1; path=/";
+}
+
+const appModule = hasDom ? await import("./App") : null;
+const App = appModule?.default as typeof import("./App")["default"];
+const originalFetch = globalThis.fetch;
+const originalEventSource = globalThis.EventSource;
+
+const memory = new Map<string, string>();
+const memoryBackend: StorageBackend = {
+  getItem: (key) => memory.get(key) ?? null,
+  setItem: (key, value) => void memory.set(key, value),
+  removeItem: (key) => void memory.delete(key),
+};
+
+function seedAnnouncementsSeen(): void {
+  memory.set("plannotator-look-feel-announcement-seen", "2");
+  memory.set("plannotator-vim-mode-announcement-seen", "2");
+  memory.set("plannotator-plan-ai-announcement-seen", "1");
+}
+
+/** External annotations to deliver as the stream's opening snapshot, so a test
+ *  can seed the session with pre-existing feedback without driving the DOM
+ *  annotation flow. Read by the EventSource double at construction time. */
+let seededExternalAnnotations: unknown[] = [];
+
+class StubEventSource {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
+
+  readonly CONNECTING = 0;
+  readonly OPEN = 1;
+  readonly CLOSED = 2;
+  readonly readyState = StubEventSource.OPEN;
+  readonly url: string;
+  readonly withCredentials = false;
+  onerror: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onopen: ((event: Event) => void) | null = null;
+
+  constructor(url: string | URL) {
+    this.url = String(url);
+    const payload = seededExternalAnnotations;
+    if (payload.length > 0) {
+      // Handlers are assigned right after construction; deliver on the next
+      // task, the way a real stream's first snapshot arrives.
+      setTimeout(() => {
+        this.onmessage?.({
+          data: JSON.stringify({ type: "snapshot", annotations: payload }),
+        } as MessageEvent);
+      }, 0);
+    }
+  }
+
+  addEventListener(): void {}
+  close(): void {}
+  dispatchEvent(): boolean { return true; }
+  removeEventListener(): void {}
+}
+
+interface SubmittedFeedback {
+  feedback?: string;
+  annotations?: Array<{ type?: string; text?: string; originalText?: string }>;
+}
+
+let submissions: SubmittedFeedback[] = [];
+
+const MARKDOWN = "# Notes\n\nSome body text.\n";
+const RAW_HTML = "<h1>Rendered page</h1><p>Body copy.</p>";
+
+function annotatePlan(extra: Record<string, unknown> = {}) {
+  return {
+    plan: MARKDOWN,
+    origin: "codex",
+    mode: "annotate",
+    filePath: "/tmp/notes.md",
+    sharingEnabled: false,
+    serverConfig: {},
+    ...extra,
+  };
+}
+
+const planReviewPlan = {
+  plan: MARKDOWN,
+  origin: "claude-code",
+  sharingEnabled: false,
+  serverConfig: {},
+};
+
+function makeFetch(plan: unknown): typeof fetch {
+  // SAFETY: the app only ever calls fetch(input, init); the double implements
+  // that call signature and not `fetch.preconnect`.
+  const impl = async (input: RequestInfo | URL, init?: RequestInit) => {
+    const rawUrl = input instanceof Request ? input.url : String(input);
+    if (rawUrl.startsWith("https://api.github.com/")) return new Response(null, { status: 404 });
+
+    const url = new URL(rawUrl, "http://localhost");
+    if (url.pathname === "/api/plan") return Response.json(plan);
+    if (url.pathname === "/api/ai/capabilities") return Response.json({ available: false, providers: [] });
+    if (url.pathname === "/api/draft") return Response.json({ error: "Not found" }, { status: 404 });
+    if (url.pathname === "/api/feedback" || url.pathname === "/api/deny") {
+      submissions.push(JSON.parse(String(init?.body ?? "{}")) as SubmittedFeedback);
+      return Response.json({ ok: true });
+    }
+    return Response.json({});
+  };
+  return impl as unknown as typeof fetch;
+}
+
+let root: Root | null = null;
+let host: HTMLElement | null = null;
+
+function sendButton(): HTMLButtonElement | undefined {
+  return Array.from(document.querySelectorAll("button"))
+    .find((button) => button.title.startsWith("Send Feedback"));
+}
+
+function noteToggle(): HTMLButtonElement | null {
+  return document.querySelector<HTMLButtonElement>("[data-annotate-note-toggle]");
+}
+
+function noteInput(): HTMLInputElement | null {
+  return document.querySelector<HTMLInputElement>("[data-annotate-note-input]");
+}
+
+async function settle(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function mount(plan: unknown, waitFor: () => unknown): Promise<void> {
+  globalThis.fetch = makeFetch(plan);
+  // SAFETY: the App only uses EventSource's constructor, handlers, and close.
+  globalThis.EventSource = StubEventSource as unknown as typeof EventSource;
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  root = createRoot(host);
+  await act(async () => {
+    root?.render(<App />);
+  });
+  for (let attempt = 0; attempt < 20 && !waitFor(); attempt += 1) {
+    await settle();
+  }
+  if (!waitFor()) throw new Error("app did not finish mounting");
+}
+
+const mountAnnotate = (extra: Record<string, unknown> = {}) =>
+  mount(annotatePlan(extra), () => noteToggle());
+
+async function typeNote(text: string): Promise<void> {
+  const input = noteInput();
+  if (!input) throw new Error("note field is not open");
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+    setter.call(input, text);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+async function pressKey(key: string): Promise<void> {
+  const input = noteInput();
+  if (!input) throw new Error("note field is not open");
+  await act(async () => {
+    input.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+  });
+  await settle();
+}
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  root = null;
+  host?.remove();
+  host = null;
+  globalThis.fetch = originalFetch;
+  globalThis.EventSource = originalEventSource;
+  submissions = [];
+  seededExternalAnnotations = [];
+  memory.clear();
+  resetStorageBackend();
+  if (hasDom) document.body.replaceChildren();
+});
+
+afterAll(() => {
+  resetStorageBackend();
+});
+
+describe.if(hasDom)("annotate submit-with-note", () => {
+  test("zero annotations: Send opens the note field and submits nothing", async () => {
+    setStorageBackend(memoryBackend);
+    seedAnnouncementsSeen();
+    await mountAnnotate();
+
+    // The incumbent header hid Send with nothing to send; the fast path
+    // replaces that absence rather than restoring a dead button.
+    expect(noteInput()).toBeNull();
+    const send = sendButton();
+    expect(send).toBeDefined();
+
+    await act(async () => send!.click());
+    await settle();
+
+    expect(noteInput()).not.toBeNull();
+    expect(submissions).toHaveLength(0);
+  });
+
+  test("Enter sends the note as a GLOBAL_COMMENT in one step", async () => {
+    setStorageBackend(memoryBackend);
+    seedAnnouncementsSeen();
+    await mountAnnotate();
+
+    await act(async () => noteToggle()!.click());
+    await settle();
+    await typeNote("looks fine, watch the migration");
+    await pressKey("Enter");
+
+    expect(submissions).toHaveLength(1);
+    const body = submissions[0]!;
+    const notes = (body.annotations ?? []).filter((a) => a.type === "GLOBAL_COMMENT");
+    expect(notes).toHaveLength(1);
+    expect(notes[0]!.text).toBe("looks fine, watch the migration");
+    // The exported feedback is what the agent actually reads.
+    expect(body.feedback).toContain("looks fine, watch the migration");
+  });
+
+  test("the note rides alongside annotations already in the session", async () => {
+    setStorageBackend(memoryBackend);
+    seedAnnouncementsSeen();
+    seededExternalAnnotations = [{
+      id: "ext-1",
+      blockId: "",
+      startOffset: 0,
+      endOffset: 0,
+      type: "COMMENT",
+      text: "existing finding",
+      originalText: "Some body text.",
+      createdA: 1,
+      source: "eslint",
+    }];
+    await mountAnnotate();
+    // Wait for the seeded snapshot to land before opening the composer.
+    await settle();
+    await settle();
+
+    await act(async () => noteToggle()!.click());
+    await settle();
+    await typeNote("also: ship it");
+    await pressKey("Enter");
+
+    expect(submissions).toHaveLength(1);
+    const annotations = submissions[0]!.annotations ?? [];
+    expect(annotations.some((a) => a.text === "existing finding")).toBe(true);
+    expect(annotations.some((a) => a.type === "GLOBAL_COMMENT" && a.text === "also: ship it")).toBe(true);
+    expect(submissions[0]!.feedback).toContain("existing finding");
+    expect(submissions[0]!.feedback).toContain("also: ship it");
+  });
+
+  test("Escape closes the field without submitting and keeps the typed text", async () => {
+    setStorageBackend(memoryBackend);
+    seedAnnouncementsSeen();
+    await mountAnnotate();
+
+    await act(async () => noteToggle()!.click());
+    await settle();
+    await typeNote("not ready to send");
+    await pressKey("Escape");
+
+    expect(noteInput()).toBeNull();
+    expect(submissions).toHaveLength(0);
+
+    // Reopening restores the text rather than discarding a half-typed note.
+    await act(async () => noteToggle()!.click());
+    await settle();
+    expect(noteInput()?.value).toBe("not ready to send");
+  });
+
+  test("HTML surface: the same one-step note reaches the agent", async () => {
+    setStorageBackend(memoryBackend);
+    seedAnnouncementsSeen();
+    // Raw-HTML sessions are comment-only, but the clamp lives on the iframe's
+    // postMessage ingest — a GLOBAL_COMMENT made in the parent is unaffected.
+    await mountAnnotate({
+      filePath: "/tmp/page.html",
+      renderAs: "html",
+      rawHtml: RAW_HTML,
+      plan: "",
+    });
+
+    await act(async () => noteToggle()!.click());
+    await settle();
+    await typeNote("the header spacing is off");
+    await pressKey("Enter");
+
+    expect(submissions).toHaveLength(1);
+    const notes = (submissions[0]!.annotations ?? []).filter((a) => a.type === "GLOBAL_COMMENT");
+    expect(notes).toHaveLength(1);
+    expect(notes[0]!.text).toBe("the header spacing is off");
+  });
+
+  test("plan review is untouched: no note control, Send Feedback still submits", async () => {
+    setStorageBackend(memoryBackend);
+    seedAnnouncementsSeen();
+    await mount(planReviewPlan, () => sendButton());
+
+    expect(noteToggle()).toBeNull();
+    expect(noteInput()).toBeNull();
+    // Plan mode's Send with no feedback opens its own prompt, not a note field.
+    await act(async () => sendButton()!.click());
+    await settle();
+    expect(noteInput()).toBeNull();
+    expect(submissions).toHaveLength(0);
+  });
+});

--- a/packages/editor/App.submitNote.test.tsx
+++ b/packages/editor/App.submitNote.test.tsx
@@ -156,8 +156,8 @@ function noteToggle(): HTMLButtonElement | null {
   return document.querySelector<HTMLButtonElement>("[data-annotate-note-toggle]");
 }
 
-function noteInput(): HTMLInputElement | null {
-  return document.querySelector<HTMLInputElement>("[data-annotate-note-input]");
+function noteInput(): HTMLTextAreaElement | null {
+  return document.querySelector<HTMLTextAreaElement>("[data-annotate-note-input]");
 }
 
 async function settle(): Promise<void> {
@@ -189,17 +189,17 @@ async function typeNote(text: string): Promise<void> {
   const input = noteInput();
   if (!input) throw new Error("note field is not open");
   await act(async () => {
-    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+    const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")!.set!;
     setter.call(input, text);
     input.dispatchEvent(new Event("input", { bubbles: true }));
   });
 }
 
-async function pressKey(key: string): Promise<void> {
+async function pressKey(key: string, init: KeyboardEventInit = {}): Promise<void> {
   const input = noteInput();
   if (!input) throw new Error("note field is not open");
   await act(async () => {
-    input.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+    input.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, ...init }));
   });
   await settle();
 }
@@ -241,7 +241,7 @@ describe.if(hasDom)("annotate submit-with-note", () => {
     expect(submissions).toHaveLength(0);
   });
 
-  test("Enter sends the note as a GLOBAL_COMMENT in one step", async () => {
+  test("Mod+Enter sends the note as a GLOBAL_COMMENT in one step", async () => {
     setStorageBackend(memoryBackend);
     seedAnnouncementsSeen();
     await mountAnnotate();
@@ -249,7 +249,10 @@ describe.if(hasDom)("annotate submit-with-note", () => {
     await act(async () => noteToggle()!.click());
     await settle();
     await typeNote("looks fine, watch the migration");
+    // The field is multi-line now: a bare Enter is a newline, never a send.
     await pressKey("Enter");
+    expect(submissions).toHaveLength(0);
+    await pressKey("Enter", { metaKey: true });
 
     expect(submissions).toHaveLength(1);
     const body = submissions[0]!;
@@ -282,7 +285,7 @@ describe.if(hasDom)("annotate submit-with-note", () => {
     await act(async () => noteToggle()!.click());
     await settle();
     await typeNote("also: ship it");
-    await pressKey("Enter");
+    await pressKey("Enter", { metaKey: true });
 
     expect(submissions).toHaveLength(1);
     const annotations = submissions[0]!.annotations ?? [];
@@ -326,7 +329,7 @@ describe.if(hasDom)("annotate submit-with-note", () => {
     await act(async () => noteToggle()!.click());
     await settle();
     await typeNote("the header spacing is off");
-    await pressKey("Enter");
+    await pressKey("Enter", { ctrlKey: true });
 
     expect(submissions).toHaveLength(1);
     const notes = (submissions[0]!.annotations ?? []).filter((a) => a.type === "GLOBAL_COMMENT");

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -38,6 +38,7 @@ import { getCallbackConfig, CallbackAction, executeCallback } from '@plannotator
 import { useAgents } from '@plannotator/ui/hooks/useAgents';
 import { useActiveSection } from '@plannotator/ui/hooks/useActiveSection';
 import { storage } from '@plannotator/ui/utils/storage';
+import { getIdentity } from '@plannotator/ui/utils/identity';
 import { copyTextToClipboard } from '@plannotator/ui/utils/clipboard';
 import { configStore, useConfigValue } from '@plannotator/ui/config';
 import { CompletionOverlay } from '@plannotator/ui/components/CompletionOverlay';
@@ -174,6 +175,7 @@ import {
   CompactPlanReview,
   type CompactPlanReviewAction,
 } from './components/CompactPlanReview';
+import type { AnnotateSubmitNoteControl } from './components/AnnotateSendControl';
 import {
   COMPACT_PLAN_ARTIFACT,
   openCompactPlanNavigator,
@@ -521,6 +523,12 @@ const App: React.FC = () => {
   const [annotateMode, setAnnotateMode] = useState(false);
   const [gate, setGate] = useState(false);
   const [approvalNotesSupported, setApprovalNotesSupported] = useState(false);
+  // One-step "submit with a note" (annotate surfaces). The typed text lives in
+  // the control itself; App only tracks the note it has committed and is
+  // waiting to submit. An unsent note is deliberately NOT persisted: it becomes
+  // a real, drafted annotation the moment it is sent, and a one-liner is
+  // cheaper to retype than a second draft channel is to maintain.
+  const [pendingSubmitNoteId, setPendingSubmitNoteId] = useState<string | null>(null);
   const [clientLease, setClientLease] = useState<AnnotateClientLeaseConfig | null>(null);
   const [annotateSource, setAnnotateSource] = useState<'file' | 'message' | 'folder' | null>(null);
   const [recentMessages, setRecentMessages] = useState<PickerMessage[]>([]);
@@ -4958,6 +4966,75 @@ const App: React.FC = () => {
     sendFeedback();
   }, [maybeConfirmUnsavedSourceFileEdits]);
 
+  // --- One-step submit with a note (annotate surfaces only) -----------------
+  // Reading an agent's message and wanting to reply "that's fine, but watch the
+  // migration" took four interactions (open the global-comment composer, type,
+  // save, Send). The note is created as a GLOBAL_COMMENT at SUBMIT time, so it
+  // rides exportAnnotations and the /api/feedback annotations array exactly
+  // like a composer-made global comment: zero server change on either runtime.
+  //
+  // It is committed into `annotations` (not threaded through the payload
+  // builders) so every annotate export path picks it up for free — including
+  // annotate-last's multi-message export, whose entries are rebuilt from the
+  // live linked-doc session snapshot rather than from `allAnnotations`.
+  // The submit itself waits a render for that commit; see the effect below.
+  const commitSubmitNote = useCallback((text: string): string | null => {
+    const trimmed = text.trim();
+    if (!trimmed) return null;
+    const note: Annotation = {
+      id: `global-note-${Date.now()}`,
+      blockId: '',
+      startOffset: 0,
+      endOffset: 0,
+      type: AnnotationType.GLOBAL_COMMENT,
+      text: trimmed,
+      originalText: '',
+      createdA: Date.now(),
+      author: getIdentity(),
+    };
+    // Deliberately NOT annotationHistory.record: the note exists for the
+    // duration of one submit, and an undo of it after the send would restore
+    // nothing the agent has not already been told.
+    annotationsRef.current = [...annotationsRef.current, note];
+    setAnnotations(annotationsRef.current);
+    return note.id;
+  }, []);
+
+  const handleSubmitNote = useCallback((text: string) => {
+    if (isSubmitting || isExiting) return;
+    const noteId = commitSubmitNote(text);
+    if (!noteId) {
+      // Empty field: fall back to the plain send when something is queued,
+      // otherwise there is genuinely nothing to submit.
+      if (hasFeedbackToSend) handleHeaderAnnotateFeedback();
+      return;
+    }
+    setPendingSubmitNoteId(noteId);
+  }, [
+    commitSubmitNote,
+    handleHeaderAnnotateFeedback,
+    hasFeedbackToSend,
+    isExiting,
+    isSubmitting,
+  ]);
+
+  // The commit above is a state write, so the feedback payload builders (which
+  // close over `allAnnotations`) only see the note on the NEXT render. Submit
+  // from an effect once the note is actually in state rather than guessing.
+  useEffect(() => {
+    if (!pendingSubmitNoteId) return;
+    if (!annotations.some((a) => a.id === pendingSubmitNoteId)) return;
+    setPendingSubmitNoteId(null);
+    handleHeaderAnnotateFeedback();
+  }, [annotations, handleHeaderAnnotateFeedback, pendingSubmitNoteId]);
+
+  const submitNoteControl = useMemo<AnnotateSubmitNoteControl | undefined>(
+    () => (annotateMode && isApiMode && !documentReadOnly
+      ? { onSubmit: handleSubmitNote }
+      : undefined),
+    [annotateMode, documentReadOnly, handleSubmitNote, isApiMode],
+  );
+
   const handleHeaderAnnotateApprove = useCallback(() => {
     if (maybeConfirmUnsavedSourceFileEdits('approve', requestAnnotateApprove)) return;
     requestAnnotateApprove();
@@ -5508,6 +5585,7 @@ const App: React.FC = () => {
           onGoalSetupExit={handleGoalSetupExit}
           onGoalSetupSubmit={handleGoalSetupSubmit}
           onAnnotateFeedback={handleHeaderAnnotateFeedback}
+          submitNote={submitNoteControl}
           onAnnotateApprove={handleHeaderAnnotateApprove}
           onFeedback={handleHeaderFeedback}
           onApprove={handleHeaderApprove}
@@ -5588,6 +5666,8 @@ const App: React.FC = () => {
               primaryActionId={compactPrimaryReviewActionId}
               onOpenAnnotations={() => switchCompactPlanSurface('annotations')}
               onOpenAI={canUseAskAI ? () => switchCompactPlanSurface('ai') : undefined}
+              submitNote={submitNoteControl}
+              submitNoteDisabled={compactActionBusy}
             />
           </CompactPlanStage>
         )}

--- a/packages/editor/components/AnnotateSendControl.tsx
+++ b/packages/editor/components/AnnotateSendControl.tsx
@@ -1,0 +1,232 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { FeedbackButton } from '@plannotator/ui/components/ToolbarButtons';
+
+/**
+ * One-step "send with a note" for the annotate surfaces.
+ *
+ * The note itself is not owned here: App creates it as a GLOBAL_COMMENT at
+ * submit time so it rides `exportAnnotations` and the `/api/feedback`
+ * annotations array with no server change. This component only owns the
+ * affordance — the split Send control, its one-line field, and the typed text
+ * (deliberately local, so a keystroke never re-renders the whole header).
+ */
+export interface AnnotateSubmitNoteControl {
+  /** Submit this note together with any annotations already in the session. */
+  onSubmit: (text: string) => void;
+}
+
+export const ANNOTATE_NOTE_PLACEHOLDER = 'Add a note...';
+
+interface AnnotateNoteComposerProps {
+  text: string;
+  onTextChange: (value: string) => void;
+  onSubmit: (text: string) => void;
+  onClose: () => void;
+  disabled?: boolean;
+  /** `anchored` hangs under the header's Send control; `sheet` is the compact
+   *  touch review surface, where there is no header control to hang from. */
+  variant?: 'anchored' | 'sheet';
+  /** Hint under the field, e.g. what the note will be sent alongside. */
+  hint?: string;
+  /** Anchored fields open in response to a click and take focus. The compact
+   *  sheet is always expanded, so focusing it would raise the touch keyboard
+   *  every time the Review surface opens. */
+  autoFocus?: boolean;
+}
+
+/** The one-line note field plus its send action. Controlled: the owner keeps
+ *  the text so closing and reopening does not discard a half-typed note. */
+export const AnnotateNoteComposer: React.FC<AnnotateNoteComposerProps> = ({
+  text,
+  onTextChange,
+  onSubmit,
+  onClose,
+  disabled = false,
+  variant = 'anchored',
+  hint,
+  autoFocus = variant === 'anchored',
+}) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (autoFocus) inputRef.current?.focus();
+  }, [autoFocus]);
+
+  const canSend = text.trim().length > 0;
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'Escape') {
+        // Stop here: the surrounding surfaces (the HTML pinpoint ladder,
+        // popovers, the plan-diff exit) all treat a bare Escape as theirs.
+        event.preventDefault();
+        event.stopPropagation();
+        onClose();
+        return;
+      }
+      if (event.key === 'Enter' && !event.shiftKey) {
+        // The field is one line, so Enter has no other job. Mod+Enter also
+        // lands here rather than reaching the window-level submit shortcut,
+        // which deliberately ignores text fields.
+        event.preventDefault();
+        event.stopPropagation();
+        if (!disabled && canSend) onSubmit(text);
+      }
+    },
+    [canSend, disabled, onClose, onSubmit, text],
+  );
+
+  return (
+    <div
+      data-annotate-note-composer={variant}
+      className={
+        variant === 'anchored'
+          ? 'absolute right-0 top-full z-50 mt-2 w-80 rounded-lg border border-border bg-popover p-2 shadow-xl'
+          : 'rounded-xl border border-border bg-background/40 p-2'
+      }
+    >
+      <div className="flex items-center gap-1.5">
+        <input
+          ref={inputRef}
+          type="text"
+          value={text}
+          onChange={(event) => onTextChange(event.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={ANNOTATE_NOTE_PLACEHOLDER}
+          aria-label={ANNOTATE_NOTE_PLACEHOLDER}
+          data-annotate-note-input="true"
+          className="min-w-0 flex-1 rounded-md border border-border bg-background px-2.5 py-1.5 text-sm text-foreground outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring/60"
+        />
+        <button
+          type="button"
+          data-annotate-note-send="true"
+          onClick={() => onSubmit(text)}
+          disabled={disabled || !canSend}
+          title="Send"
+          className="flex-shrink-0 rounded-md bg-primary px-2.5 py-1.5 text-xs font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-45"
+        >
+          Send
+        </button>
+      </div>
+      <p className="mt-1.5 px-0.5 text-[11px] leading-snug text-muted-foreground">
+        {hint ?? 'Enter to send, Esc to close.'}
+      </p>
+    </div>
+  );
+};
+
+/** The compact touch review surface's always-expanded note field. Owns its own
+ *  text so `CompactPlanReview` stays a presentational list. */
+export const AnnotateNoteSheet: React.FC<{
+  note: AnnotateSubmitNoteControl;
+  disabled?: boolean;
+  hint?: string;
+}> = ({ note, disabled = false, hint }) => {
+  const [text, setText] = useState('');
+  return (
+    <AnnotateNoteComposer
+      text={text}
+      onTextChange={setText}
+      onSubmit={note.onSubmit}
+      onClose={() => setText('')}
+      disabled={disabled}
+      variant="sheet"
+      hint={hint}
+      autoFocus={false}
+    />
+  );
+};
+
+interface AnnotateSendControlProps {
+  /** True when the session already carries annotations or document edits.
+   *  False flips the primary action into the zero-annotation fast path. */
+  hasFeedback: boolean;
+  disabled?: boolean;
+  isLoading?: boolean;
+  /** The incumbent Send Feedback action. Unchanged when feedback exists. */
+  onSend: () => void;
+  note: AnnotateSubmitNoteControl;
+}
+
+/**
+ * Split Send control for annotate sessions.
+ *
+ * With feedback present the primary button is the incumbent Send Feedback,
+ * unchanged; the caret opens a note that is sent WITH it in one action.
+ * With no feedback the primary button opens the note field directly — sending
+ * nothing was never useful, which is why the incumbent header hid the button
+ * entirely in that state.
+ */
+export const AnnotateSendControl: React.FC<AnnotateSendControlProps> = ({
+  hasFeedback,
+  disabled = false,
+  isLoading = false,
+  onSend,
+  note,
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState('');
+
+  const close = useCallback(() => setOpen(false), []);
+
+  useEffect(() => {
+    if (!open) return;
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    document.addEventListener('pointerdown', handlePointerDown);
+    return () => document.removeEventListener('pointerdown', handlePointerDown);
+  }, [open]);
+
+  const submit = useCallback(
+    (value: string) => {
+      setOpen(false);
+      setText('');
+      note.onSubmit(value);
+    },
+    [note],
+  );
+
+  return (
+    <div ref={containerRef} className="relative flex items-center gap-1">
+      <FeedbackButton
+        onClick={hasFeedback ? onSend : () => setOpen(true)}
+        disabled={disabled}
+        isLoading={isLoading}
+        label="Send Feedback"
+        title={hasFeedback ? 'Send Feedback' : 'Send Feedback: write a quick note'}
+      />
+      <button
+        type="button"
+        data-annotate-note-toggle="true"
+        aria-expanded={open}
+        aria-label="Send with a note"
+        title="Send with a note"
+        disabled={disabled}
+        onClick={() => setOpen((value) => !value)}
+        className={`flex h-7 w-6 flex-shrink-0 items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50 ${
+          open ? 'bg-muted text-foreground' : ''
+        }`}
+      >
+        <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      {open && (
+        <AnnotateNoteComposer
+          text={text}
+          onTextChange={setText}
+          onSubmit={submit}
+          onClose={close}
+          disabled={disabled}
+          hint={
+            hasFeedback
+              ? 'Sent with your annotations. Enter to send, Esc to close.'
+              : 'Enter to send, Esc to close.'
+          }
+        />
+      )}
+    </div>
+  );
+};

--- a/packages/editor/components/AnnotateSendControl.tsx
+++ b/packages/editor/components/AnnotateSendControl.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { FeedbackButton } from '@plannotator/ui/components/ToolbarButtons';
+import { Send } from 'lucide-react';
+import { Button } from '@plannotator/ui/components/ui/button';
+import { submitHint } from '@plannotator/ui/utils/platform';
 
 /**
  * One-step "send with a note" for the annotate surfaces.
@@ -7,8 +9,19 @@ import { FeedbackButton } from '@plannotator/ui/components/ToolbarButtons';
  * The note itself is not owned here: App creates it as a GLOBAL_COMMENT at
  * submit time so it rides `exportAnnotations` and the `/api/feedback`
  * annotations array with no server change. This component only owns the
- * affordance — the split Send control, its one-line field, and the typed text
- * (deliberately local, so a keystroke never re-renders the whole header).
+ * affordance and the typed text (deliberately local, so a keystroke never
+ * re-renders the whole header).
+ *
+ * Interaction contract:
+ * - The control is ONE joined split button: [Send Feedback | v]. The left
+ *   segment is always the incumbent plain send, unchanged; the caret is a
+ *   separate segment of the same pill.
+ * - The caret opens a panel BELOW the pill with a multi-line note field and
+ *   its own distinct action, "Submit with feedback", which sends the note
+ *   together with everything already in the session. The two actions never
+ *   share a button.
+ * - The note field: Enter inserts a newline, Mod+Enter submits with feedback,
+ *   Esc closes the panel and keeps the half-typed text.
  */
 export interface AnnotateSubmitNoteControl {
   /** Submit this note together with any annotations already in the session. */
@@ -17,45 +30,50 @@ export interface AnnotateSubmitNoteControl {
 
 export const ANNOTATE_NOTE_PLACEHOLDER = 'Add a note...';
 
-interface AnnotateNoteComposerProps {
+/** One line tall at rest, grows with content, then scrolls. */
+const NOTE_MAX_HEIGHT_PX = 144;
+
+function useAutoGrow(text: string) {
+  const ref = useRef<HTMLTextAreaElement>(null);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${Math.min(el.scrollHeight, NOTE_MAX_HEIGHT_PX)}px`;
+  }, [text]);
+  return ref;
+}
+
+interface AnnotateNoteFieldProps {
   text: string;
   onTextChange: (value: string) => void;
   onSubmit: (text: string) => void;
   onClose: () => void;
   disabled?: boolean;
-  /** `anchored` hangs under the header's Send control; `sheet` is the compact
-   *  touch review surface, where there is no header control to hang from. */
-  variant?: 'anchored' | 'sheet';
-  /** Hint under the field, e.g. what the note will be sent alongside. */
-  hint?: string;
-  /** Anchored fields open in response to a click and take focus. The compact
-   *  sheet is always expanded, so focusing it would raise the touch keyboard
-   *  every time the Review surface opens. */
   autoFocus?: boolean;
 }
 
-/** The one-line note field plus its send action. Controlled: the owner keeps
- *  the text so closing and reopening does not discard a half-typed note. */
-export const AnnotateNoteComposer: React.FC<AnnotateNoteComposerProps> = ({
+/** The multi-line note field. Controlled: the owner keeps the text so closing
+ *  and reopening does not discard a half-typed note. */
+const AnnotateNoteField: React.FC<AnnotateNoteFieldProps> = ({
   text,
   onTextChange,
   onSubmit,
   onClose,
   disabled = false,
-  variant = 'anchored',
-  hint,
-  autoFocus = variant === 'anchored',
+  autoFocus = true,
 }) => {
-  const inputRef = useRef<HTMLInputElement>(null);
+  const ref = useAutoGrow(text);
 
   useEffect(() => {
-    if (autoFocus) inputRef.current?.focus();
+    if (autoFocus) ref.current?.focus();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoFocus]);
 
   const canSend = text.trim().length > 0;
 
   const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLInputElement>) => {
+    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if (event.key === 'Escape') {
         // Stop here: the surrounding surfaces (the HTML pinpoint ladder,
         // popovers, the plan-diff exit) all treat a bare Escape as theirs.
@@ -64,54 +82,30 @@ export const AnnotateNoteComposer: React.FC<AnnotateNoteComposerProps> = ({
         onClose();
         return;
       }
-      if (event.key === 'Enter' && !event.shiftKey) {
-        // The field is one line, so Enter has no other job. Mod+Enter also
-        // lands here rather than reaching the window-level submit shortcut,
-        // which deliberately ignores text fields.
+      if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
         event.preventDefault();
         event.stopPropagation();
         if (!disabled && canSend) onSubmit(text);
       }
+      // Plain Enter falls through: the field is multi-line and Enter's job is
+      // a newline.
     },
     [canSend, disabled, onClose, onSubmit, text],
   );
 
   return (
-    <div
-      data-annotate-note-composer={variant}
-      className={
-        variant === 'anchored'
-          ? 'absolute right-0 top-full z-50 mt-2 w-80 rounded-lg border border-border bg-popover p-2 shadow-xl'
-          : 'rounded-xl border border-border bg-background/40 p-2'
-      }
-    >
-      <div className="flex items-center gap-1.5">
-        <input
-          ref={inputRef}
-          type="text"
-          value={text}
-          onChange={(event) => onTextChange(event.target.value)}
-          onKeyDown={handleKeyDown}
-          placeholder={ANNOTATE_NOTE_PLACEHOLDER}
-          aria-label={ANNOTATE_NOTE_PLACEHOLDER}
-          data-annotate-note-input="true"
-          className="min-w-0 flex-1 rounded-md border border-border bg-background px-2.5 py-1.5 text-sm text-foreground outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring/60"
-        />
-        <button
-          type="button"
-          data-annotate-note-send="true"
-          onClick={() => onSubmit(text)}
-          disabled={disabled || !canSend}
-          title="Send"
-          className="flex-shrink-0 rounded-md bg-primary px-2.5 py-1.5 text-xs font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-45"
-        >
-          Send
-        </button>
-      </div>
-      <p className="mt-1.5 px-0.5 text-[11px] leading-snug text-muted-foreground">
-        {hint ?? 'Enter to send, Esc to close.'}
-      </p>
-    </div>
+    <textarea
+      ref={ref}
+      rows={2}
+      value={text}
+      onChange={(event) => onTextChange(event.target.value)}
+      onKeyDown={handleKeyDown}
+      placeholder={ANNOTATE_NOTE_PLACEHOLDER}
+      aria-label={ANNOTATE_NOTE_PLACEHOLDER}
+      data-annotate-note-input="true"
+      className="block w-full resize-none overflow-y-auto rounded-md border border-border bg-background px-2.5 py-1.5 text-sm leading-snug text-foreground outline-none placeholder:text-muted-foreground focus-visible:ring-1 focus-visible:ring-ring/40"
+      style={{ maxHeight: NOTE_MAX_HEIGHT_PX }}
+    />
   );
 };
 
@@ -124,16 +118,24 @@ export const AnnotateNoteSheet: React.FC<{
 }> = ({ note, disabled = false, hint }) => {
   const [text, setText] = useState('');
   return (
-    <AnnotateNoteComposer
-      text={text}
-      onTextChange={setText}
-      onSubmit={note.onSubmit}
-      onClose={() => setText('')}
-      disabled={disabled}
-      variant="sheet"
-      hint={hint}
-      autoFocus={false}
-    />
+    <div data-annotate-note-composer="sheet" className="rounded-xl border border-border bg-background/40 p-2">
+      <AnnotateNoteField
+        text={text}
+        onTextChange={setText}
+        onSubmit={(value) => {
+          note.onSubmit(value);
+          setText('');
+        }}
+        onClose={() => setText('')}
+        disabled={disabled}
+        // The sheet is always expanded; focusing it would raise the touch
+        // keyboard every time the Review surface opens.
+        autoFocus={false}
+      />
+      <p className="mt-1.5 px-0.5 text-right text-[11px] leading-snug text-muted-foreground">
+        {hint ?? `${submitHint} to send`}
+      </p>
+    </div>
   );
 };
 
@@ -143,19 +145,16 @@ interface AnnotateSendControlProps {
   hasFeedback: boolean;
   disabled?: boolean;
   isLoading?: boolean;
-  /** The incumbent Send Feedback action. Unchanged when feedback exists. */
+  /** The incumbent Send Feedback action. Always plain send, never the note. */
   onSend: () => void;
   note: AnnotateSubmitNoteControl;
 }
 
 /**
- * Split Send control for annotate sessions.
- *
- * With feedback present the primary button is the incumbent Send Feedback,
- * unchanged; the caret opens a note that is sent WITH it in one action.
- * With no feedback the primary button opens the note field directly — sending
- * nothing was never useful, which is why the incumbent header hid the button
- * entirely in that state.
+ * The joined split Send control for annotate sessions. See the module doc for
+ * the interaction contract; the load-bearing detail is that Send Feedback and
+ * Submit-with-feedback are DIFFERENT buttons — the incumbent never changes
+ * meaning, and the note panel carries its own action.
  */
 export const AnnotateSendControl: React.FC<AnnotateSendControlProps> = ({
   hasFeedback,
@@ -179,7 +178,7 @@ export const AnnotateSendControl: React.FC<AnnotateSendControlProps> = ({
     return () => document.removeEventListener('pointerdown', handlePointerDown);
   }, [open]);
 
-  const submit = useCallback(
+  const submitNote = useCallback(
     (value: string) => {
       setOpen(false);
       setText('');
@@ -188,44 +187,81 @@ export const AnnotateSendControl: React.FC<AnnotateSendControlProps> = ({
     [note],
   );
 
+  /** The incumbent action. With feedback: plain send, exactly as before this
+   *  control existed. With none: sending nothing was never useful (the old
+   *  header hid the button entirely), so the click opens the note panel. */
+  const primaryAction = useCallback(() => {
+    if (hasFeedback) onSend();
+    else setOpen(true);
+  }, [hasFeedback, onSend]);
+
+  const canSubmitNote = text.trim().length > 0;
+
   return (
-    <div ref={containerRef} className="relative flex items-center gap-1">
-      <FeedbackButton
-        onClick={hasFeedback ? onSend : () => setOpen(true)}
-        disabled={disabled}
-        isLoading={isLoading}
-        label="Send Feedback"
-        title={hasFeedback ? 'Send Feedback' : 'Send Feedback: write a quick note'}
-      />
-      <button
-        type="button"
-        data-annotate-note-toggle="true"
-        aria-expanded={open}
-        aria-label="Send with a note"
-        title="Send with a note"
-        disabled={disabled}
-        onClick={() => setOpen((value) => !value)}
-        className={`flex h-7 w-6 flex-shrink-0 items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50 ${
-          open ? 'bg-muted text-foreground' : ''
-        }`}
-      >
-        <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
-          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-        </svg>
-      </button>
-      {open && (
-        <AnnotateNoteComposer
-          text={text}
-          onTextChange={setText}
-          onSubmit={submit}
-          onClose={close}
+    <div ref={containerRef} className="relative">
+      {/* One pill, two segments: a hairline divider where they meet. */}
+      <div className="inline-flex items-center">
+        <Button
+          variant="outline"
+          size="xs"
+          onClick={primaryAction}
           disabled={disabled}
-          hint={
-            hasFeedback
-              ? 'Sent with your annotations. Enter to send, Esc to close.'
-              : 'Enter to send, Esc to close.'
-          }
-        />
+          title={hasFeedback ? 'Send Feedback' : 'Send Feedback: write a quick note'}
+          iconLeft={<Send className="size-3.5" />}
+          className="rounded-r-none border-r-0"
+        >
+          {isLoading ? 'Sending...' : 'Send Feedback'}
+        </Button>
+        <Button
+          variant="outline"
+          size="xs"
+          data-annotate-note-toggle="true"
+          aria-expanded={open}
+          aria-label="Add a note and submit with feedback"
+          title="Add a note and submit with feedback"
+          disabled={disabled}
+          onClick={() => setOpen((value) => !value)}
+          className={`rounded-l-none px-1.5 ${open ? 'bg-muted text-foreground' : 'text-muted-foreground'}`}
+        >
+          <svg
+            className={`h-3.5 w-3.5 transition-transform duration-150 ${open ? 'rotate-180' : ''}`}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+          </svg>
+        </Button>
+      </div>
+      {open && (
+        <div
+          data-annotate-note-composer="anchored"
+          className="absolute right-0 top-full z-50 mt-1.5 w-[22rem] max-w-[calc(100vw-2rem)] rounded-lg border border-border bg-popover p-1.5 shadow-xl"
+        >
+          <AnnotateNoteField
+            text={text}
+            onTextChange={setText}
+            onSubmit={submitNote}
+            onClose={close}
+            disabled={disabled}
+          />
+          <div className="mt-1.5 flex items-center justify-between gap-2 px-0.5">
+            <span className="text-[11px] leading-snug text-muted-foreground">{submitHint}</span>
+            <Button
+              variant="outline"
+              size="xs"
+              data-annotate-note-send="true"
+              onClick={() => submitNote(text)}
+              disabled={disabled || !canSubmitNote}
+              title="Send with additional feedback"
+              iconLeft={<Send className="size-3.5" />}
+            >
+              Send with additional feedback
+            </Button>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/packages/editor/components/AnnotateSendControl.tsx
+++ b/packages/editor/components/AnnotateSendControl.tsx
@@ -180,6 +180,15 @@ export const AnnotateSendControl: React.FC<AnnotateSendControlProps> = ({
 
   const submitNote = useCallback(
     (value: string) => {
+      if (value.trim().length === 0) {
+        // Empty note: keep the panel open and put the cursor back in the
+        // field. The action stays visually live — a grayed action beside the
+        // deliberately faded header primary read as "everything is disabled".
+        containerRef.current
+          ?.querySelector<HTMLTextAreaElement>('[data-annotate-note-input]')
+          ?.focus();
+        return;
+      }
       setOpen(false);
       setText('');
       note.onSubmit(value);
@@ -195,8 +204,6 @@ export const AnnotateSendControl: React.FC<AnnotateSendControlProps> = ({
     else setOpen(true);
   }, [hasFeedback, onSend]);
 
-  const canSubmitNote = text.trim().length > 0;
-
   return (
     <div ref={containerRef} className="relative">
       {/* One pill, two segments: a hairline divider where they meet. */}
@@ -205,10 +212,16 @@ export const AnnotateSendControl: React.FC<AnnotateSendControlProps> = ({
           variant="outline"
           size="xs"
           onClick={primaryAction}
-          disabled={disabled}
-          title={hasFeedback ? 'Send Feedback' : 'Send Feedback: write a quick note'}
+          disabled={disabled || open}
+          title={
+            open
+              ? 'Close the note to send without it'
+              : hasFeedback
+                ? 'Send Feedback'
+                : 'Send Feedback: write a quick note'
+          }
           iconLeft={<Send className="size-3.5" />}
-          className="rounded-r-none border-r-0"
+          className={`rounded-r-none border-r-0 transition-opacity ${open ? 'opacity-40' : ''}`}
         >
           {isLoading ? 'Sending...' : 'Send Feedback'}
         </Button>
@@ -254,7 +267,7 @@ export const AnnotateSendControl: React.FC<AnnotateSendControlProps> = ({
               size="xs"
               data-annotate-note-send="true"
               onClick={() => submitNote(text)}
-              disabled={disabled || !canSubmitNote}
+              disabled={disabled}
               title="Send with additional feedback"
               iconLeft={<Send className="size-3.5" />}
             >

--- a/packages/editor/components/AppHeader.tsx
+++ b/packages/editor/components/AppHeader.tsx
@@ -11,6 +11,7 @@ import type { UIPreferences } from '@plannotator/ui/utils/uiPreferences';
 import { SparklesIcon } from '@plannotator/ui/components/SparklesIcon';
 import type { CompactPlanAction } from '@plannotator/ui/components/PlanHeaderMenu';
 import { HtmlSurfaceControls } from '@plannotator/ui/components/HtmlSurfaceControls';
+import { AnnotateSendControl, type AnnotateSubmitNoteControl } from './AnnotateSendControl';
 
 /** Plannotator's refresh strings for the published control: the document
  * is a file on disk, so the refresh says so. */
@@ -99,6 +100,10 @@ interface AppHeaderProps {
   onGoalSetupExit: () => void;
   onGoalSetupSubmit: () => void;
   onAnnotateFeedback: () => void;
+  /** Annotate surfaces only: the split Send control's quick-note field.
+   *  Absent (plan review, and any host that does not wire it) keeps the
+   *  incumbent header exactly as it was. */
+  submitNote?: AnnotateSubmitNoteControl;
   onAnnotateApprove: () => void;
   onFeedback: () => void;
   onApprove: () => void;
@@ -187,6 +192,7 @@ export const AppHeader = React.memo<AppHeaderProps>(({
   onGoalSetupExit,
   onGoalSetupSubmit,
   onAnnotateFeedback,
+  submitNote,
   onAnnotateApprove,
   onFeedback,
   onApprove,
@@ -318,14 +324,28 @@ export const AppHeader = React.memo<AppHeaderProps>(({
                   disabled={isSubmitting || isExiting}
                   isLoading={isExiting}
                 />
-                {hasAnyAnnotations && (
-                  <FeedbackButton
-                    onClick={onAnnotateFeedback}
+                {submitNote ? (
+                  // The split control renders in BOTH states: with feedback the
+                  // primary button is the incumbent Send Feedback, and without
+                  // it the same button opens the note field instead of staying
+                  // hidden (its incumbent zero-annotation behavior).
+                  <AnnotateSendControl
+                    hasFeedback={hasAnyAnnotations}
                     disabled={isSubmitting || isExiting}
                     isLoading={isSubmitting}
-                    label="Send Feedback"
-                    title="Send Feedback"
+                    onSend={onAnnotateFeedback}
+                    note={submitNote}
                   />
+                ) : (
+                  hasAnyAnnotations && (
+                    <FeedbackButton
+                      onClick={onAnnotateFeedback}
+                      disabled={isSubmitting || isExiting}
+                      isLoading={isSubmitting}
+                      label="Send Feedback"
+                      title="Send Feedback"
+                    />
+                  )
                 )}
               </>
             ) : (

--- a/packages/editor/components/CompactPlanReview.tsx
+++ b/packages/editor/components/CompactPlanReview.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { CompactPlanAction } from '@plannotator/ui/components/PlanHeaderMenu';
+import { AnnotateNoteSheet, type AnnotateSubmitNoteControl } from './AnnotateSendControl';
 
 type CompactPlanDecisionActionId = Extract<
   CompactPlanAction['id'],
@@ -58,6 +59,11 @@ interface CompactPlanReviewProps {
   primaryActionId?: CompactPlanReviewAction['id'];
   onOpenAnnotations: () => void;
   onOpenAI?: () => void;
+  /** Annotate surfaces only. The compact shell has no header Send control, so
+   *  the quick note lives here, always expanded — a menu row cannot hold a
+   *  text field, and the decision list's ids are a closed union. */
+  submitNote?: AnnotateSubmitNoteControl;
+  submitNoteDisabled?: boolean;
 }
 
 /** Compact review summary and the incumbent session decision actions. */
@@ -67,6 +73,8 @@ export const CompactPlanReview: React.FC<CompactPlanReviewProps> = ({
   primaryActionId,
   onOpenAnnotations,
   onOpenAI,
+  submitNote,
+  submitNoteDisabled = false,
 }) => {
   const orderedActions = [...actions].sort((left, right) => {
     if (left.id === primaryActionId) return -1;
@@ -107,6 +115,21 @@ export const CompactPlanReview: React.FC<CompactPlanReviewProps> = ({
             )}
           </div>
         </section>
+
+        {submitNote && (
+          <section aria-labelledby="pn-compact-review-note-title">
+            <h2 id="pn-compact-review-note-title" className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+              Quick note
+            </h2>
+            <div className="mt-2">
+              <AnnotateNoteSheet
+                note={submitNote}
+                disabled={submitNoteDisabled}
+                hint="Sent in one step, with anything you have already annotated."
+              />
+            </div>
+          </section>
+        )}
 
         <section aria-labelledby="pn-compact-review-decision-title">
           <h2 id="pn-compact-review-decision-title" className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">

--- a/packages/editor/shortcuts.ts
+++ b/packages/editor/shortcuts.ts
@@ -1,4 +1,5 @@
 import {
+  annotateNoteShortcuts,
   annotationModeShortcuts,
   annotationPanelShortcuts,
   annotationToolbarShortcuts,
@@ -103,6 +104,9 @@ export const planReviewSettingsShortcutRegistry = createShortcutRegistry([
 
 export const annotateSettingsShortcutRegistry = createShortcutRegistry([
   annotateEditorSettingsShortcuts,
+  // Annotate-only: the quick-note field lives on the annotate Send control and
+  // has no plan-review counterpart.
+  annotateNoteShortcuts,
   annotateSidebarShortcuts,
   ...sharedPlanSurfaceShortcuts,
 ] as const);

--- a/packages/ui/shortcuts/index.ts
+++ b/packages/ui/shortcuts/index.ts
@@ -6,6 +6,7 @@ export { historyShortcuts, useHistoryShortcuts } from './history.shortcuts';
 export { annotationModeShortcuts, useAnnotationModeShortcuts } from './plan-review/annotationMode.shortcuts';
 export { annotationToolbarShortcuts, useAnnotationToolbarShortcuts } from './plan-review/annotationToolbar.shortcuts';
 export { annotationPanelShortcuts, useAnnotationPanelShortcuts } from './plan-review/annotationPanel.shortcuts';
+export { annotateNoteShortcuts } from './plan-review/annotateNote.shortcuts';
 export { commentPopoverShortcuts } from './plan-review/commentPopover.shortcuts';
 export { imageAnnotatorShortcuts, useImageAnnotatorShortcuts } from './plan-review/imageAnnotator.shortcuts';
 export { inputMethodShortcuts } from './plan-review/inputMethod.shortcuts';

--- a/packages/ui/shortcuts/plan-review/annotateNote.shortcuts.ts
+++ b/packages/ui/shortcuts/plan-review/annotateNote.shortcuts.ts
@@ -1,0 +1,28 @@
+import { defineShortcutScope } from '../core';
+
+/** The one-line "Add a note" field on the annotate Send control. Enter sends
+ * (deliberately NOT Mod+Enter — the field is one line, so a bare Enter has no
+ * other job and the whole point of the affordance is one interaction). The
+ * handlers are local to the input; this scope exists so the chords show up in
+ * the in-app help modal and the generated docs, the same way the comment
+ * editor's chords do. */
+export const annotateNoteShortcuts = defineShortcutScope({
+  id: 'annotate-note',
+  title: 'Quick Note',
+  shortcuts: {
+    submit: {
+      description: 'Send the note with your annotations',
+      bindings: ['Enter'],
+      section: 'Actions',
+      hint: 'Available while the Send control’s note field is open.',
+      displayOrder: 12,
+    },
+    cancel: {
+      description: 'Close the note field without sending',
+      bindings: ['Escape'],
+      section: 'Actions',
+      hint: 'The typed note is kept for the rest of the session but is not sent.',
+      displayOrder: 14,
+    },
+  },
+});


### PR DESCRIPTION
## Why

A user asked for a one-step "that's fine" submit on `/plannotator-last`: they read the agent's message and want to send a quick overall note without opening the annotation machinery. Today that is four interactions (open the global-comment composer, type, save, Send Annotations), and with no annotations at all the Send button is not even rendered, so there is nothing to press.

## What ships

Every annotate surface now has a split Send control:

* **With feedback queued** the primary button is the incumbent Send Feedback, unchanged. The caret beside it opens a one-line `Add a note...` field, and sending from there submits the note **together with** the queued annotations in one action.
* **With nothing queued** the primary button opens that field directly. This replaces the incumbent behaviour of hiding the button entirely, which is the right guard to replace: submitting an empty review was never useful, so there was nothing to press.
* **Enter** sends, **Escape** closes the field without submitting and keeps the typed text for the rest of the session.

Surfaces covered: `annotate` (file), `annotate-last` (message, single and multi-message), `annotate-folder`, `annotate-app` (live), and URL sessions. Plan mode is deliberately untouched.

## Zero server changes, verified

The note is created as a `GLOBAL_COMMENT` at submit time, so it is just another annotation on the wire. Both `/api/feedback` handlers were read to confirm nothing else is needed:

* `packages/server/annotate.ts` reads the body as `{ feedback: string; annotations: unknown[]; ... }`, settles the decision with them, and passes the same pair to `persistSubmittedDecision`. The annotations array is opaque; no type or shape is inspected.
* `apps/pi-extension/server/serverAnnotate.ts` mirrors that exactly, including the same "does not type-validate its body" comment and the same `Array.isArray(annotations)` degradation.

The exported feedback string is produced client side by `exportAnnotations`, which already renders `GLOBAL_COMMENT` entries. So the note reaches the agent through the text **and** is persisted in the durable submission record, with no endpoint, schema or runtime change on either the Bun or the Pi side. No server file is touched by this PR.

## How it is wired

The note is committed into the `annotations` state (`commitSubmitNote` in `App.tsx`) rather than threaded through the payload builders. That is deliberate: `annotate-last`'s multi-message export rebuilds its per-message entries from the live linked-doc session snapshot, not from `allAnnotations`, so a note spliced into the builder call would be silently dropped there. Committing into state makes every annotate export path pick it up for free. Because that commit is a state write, the submit waits one render for it, via an effect keyed on the pending note id.

Other decisions:

* **Undo/redo (#1426):** the note is deliberately not recorded in the annotation history. It exists for the duration of one submit, and an undo after the send would restore nothing the agent has not already been told.
* **HTML and live-app surfaces:** the comment-only clamp does not apply. That clamp sits on the parent's postMessage ingest of iframe selections (`useHtmlAnnotation`), and this note is created in the parent App, never posted from the page. Verified in code and covered by a test on the raw-HTML surface.
* **Draft persistence:** an unsent note is not drafted. It becomes a real, drafted annotation the moment it is sent, and a one-liner is cheaper to retype than a second draft channel is to maintain. Escape keeps the text in the control for the rest of the session, so the loss window is a page reload only. A failed submit leaves the note as a committed annotation, so nothing is lost there either.
* **Compact touch shell:** it renders no header Send control, and the compact decision list's action ids are a closed union that a text field cannot live in, so the field is a small always-expanded section in the "Review and finish" surface instead. It does not autofocus, so opening Review does not raise the keyboard.
* **feedbackTemplates:** untouched. Templates wrap the finished feedback string on delivery; the note is inside that string like any other comment.

## Footprint

`App.tsx` grows by one memoised control object, one commit helper, one submit handler and one effect. The affordance itself is a new `packages/editor/components/AnnotateSendControl.tsx`, following the auto-viewed and global-comments precedent. Nothing in `@plannotator/ui` changes behaviour: the only edit there is a new shortcut scope plus its barrel export, and `AppHeader`'s new `submitNote` prop is optional, so a header rendered without it keeps today's markup exactly.

`Enter` and `Escape` are handled locally on the input, and the `annotate-note` scope documents them in the annotate registry only. This follows the `comment-popover` precedent, which is documentation only with local handlers. `Enter` rather than `Mod+Enter` is a deliberate choice for a one-line field where a bare Enter has no other job.

## Tests

New `packages/editor/App.submitNote.test.tsx`, six tests, each named after the regression it guards:

1. Zero annotations: Send opens the note field and submits nothing.
2. Enter sends the note as a `GLOBAL_COMMENT`, present in both the `/api/feedback` annotations array and the exported feedback text.
3. The note rides alongside an annotation already in the session, and neither is dropped.
4. Escape closes without submitting and preserves the typed text.
5. The HTML surface sends the same one-step note (the comment-only clamp does not block it).
6. Plan review grows no note control and its Send still behaves as before.

Falsified: removing the header wiring fails 5 of the 6, and the plan-mode test correctly keeps passing.

Results:

* `DOM_TESTS=1 bun test packages/editor packages/ui` : 1476 pass, 0 fail
* `bun test packages/editor packages/ui` : 880 pass, 0 fail
* `bun run typecheck` : clean
* `bun test` (whole repo): 4104 pass, 12 fail, all pre-existing and unrelated (semantic diff, GitButler and workspace review-server tests, which fail identically on a clean tree)
* `bun run --cwd apps/review build && bun run build:hook` : both succeed, build order respected

AI-assisted (Claude) under maintainer direction.
