### PR TITLE
fix(cli): exit on an unknown subcommand instead of blocking on stdin

### DIFF
--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -177,6 +177,7 @@ import {
   isUninstallConfirmationAccepted,
   parseUninstallOptions,
 } from "./cli";
+import { exitOnUnknownSubcommand } from "./unknown-subcommand";
 import { completeAnnotateCommand } from "./annotate-command";
 import {
   annotateStartupFailureExitCode,
@@ -383,6 +384,8 @@ if (helpSubcommand) {
   console.log(formatSubcommandHelp(helpSubcommand));
   process.exit(0);
 }
+
+exitOnUnknownSubcommand(args);
 
 if (args[0] === "uninstall") {
   let options: ReturnType<typeof parseUninstallOptions>;

--- a/apps/hook/server/unknown-subcommand.test.ts
+++ b/apps/hook/server/unknown-subcommand.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  findClosestSubcommand,
+  findUnknownSubcommand,
+  formatUnknownSubcommandError,
+  KNOWN_SUBCOMMANDS,
+} from "./unknown-subcommand";
+
+describe("unknown subcommand", () => {
+  test("the known command registry matches the dispatcher", () => {
+    const source = readFileSync(resolve(import.meta.dir, "index.ts"), "utf8");
+    const dispatched = new Set(
+      [...source.matchAll(/args\[0\] === "([^"]+)"/g)].map((match) => match[1]),
+    );
+
+    expect(dispatched.size).toBeGreaterThan(10);
+    expect(dispatched).toEqual(KNOWN_SUBCOMMANDS);
+  });
+
+  test("leaves flags and the no-argument hook invocation to the dispatcher", () => {
+    expect(findUnknownSubcommand([])).toBeNull();
+    expect(findUnknownSubcommand(["--help"])).toBeNull();
+    expect(findUnknownSubcommand(["-v"])).toBeNull();
+    expect(findUnknownSubcommand(["review", "--nonsense"])).toBeNull();
+  });
+
+  test("reports the offending token", () => {
+    expect(findUnknownSubcommand(["annotatte", "README.md"])).toBe("annotatte");
+    expect(findUnknownSubcommand(["xyzzy"])).toBe("xyzzy");
+  });
+
+  test("suggests the nearest documented command", () => {
+    expect(findClosestSubcommand("annotatte")).toBe("annotate");
+    expect(findClosestSubcommand("revieww")).toBe("review");
+    expect(findClosestSubcommand("guid")).toBe("guide");
+    expect(findClosestSubcommand("annot")).toBe("annotate");
+    expect(findClosestSubcommand("a")).toBeNull();
+    expect(findClosestSubcommand("xyzzy")).toBeNull();
+    expect(findClosestSubcommand("x".repeat(10_000))).toBeNull();
+  });
+
+  test("error text names the typo and points at --help", () => {
+    const message = formatUnknownSubcommandError("annotatte");
+    expect(message).toContain("Unknown command: annotatte");
+    expect(message).toContain("plannotator annotate");
+    expect(message).toContain("--help");
+  });
+
+  test("a typo'd subcommand exits instead of blocking on an open stdin", async () => {
+    const proc = Bun.spawn(
+      [
+        "bun",
+        "run",
+        resolve(import.meta.dir, "index.ts"),
+        "annotatte",
+        "README.md",
+      ],
+      {
+        stdin: "pipe",
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+    const timeout = setTimeout(() => proc.kill(), 15_000);
+    const [stderr, code] = await Promise.all([
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    clearTimeout(timeout);
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("Unknown command: annotatte");
+    expect(stderr).toContain("plannotator annotate");
+  }, 30_000);
+});

--- a/apps/hook/server/unknown-subcommand.ts
+++ b/apps/hook/server/unknown-subcommand.ts
@@ -1,0 +1,91 @@
+import { SUBCOMMAND_HELP, SUBCOMMAND_HELP_ALIASES } from "./cli";
+
+const INTERNAL_SUBCOMMANDS = [
+  "install-runtime",
+  "opencode-plan",
+  "opencode-review",
+  "opencode-annotate-last",
+  "copilot-plan",
+] as const;
+
+const SUGGESTABLE_SUBCOMMANDS = [
+  ...Object.keys(SUBCOMMAND_HELP),
+  ...Object.keys(SUBCOMMAND_HELP_ALIASES),
+];
+
+export const KNOWN_SUBCOMMANDS: ReadonlySet<string> = new Set([
+  ...SUGGESTABLE_SUBCOMMANDS,
+  ...INTERNAL_SUBCOMMANDS,
+]);
+
+function levenshteinDistance(left: string, right: string): number {
+  let previous = Array.from({ length: right.length + 1 }, (_, index) => index);
+
+  for (let leftIndex = 1; leftIndex <= left.length; leftIndex += 1) {
+    const current = [leftIndex];
+    for (let rightIndex = 1; rightIndex <= right.length; rightIndex += 1) {
+      current[rightIndex] = Math.min(
+        previous[rightIndex] + 1,
+        current[rightIndex - 1] + 1,
+        previous[rightIndex - 1] +
+          (left[leftIndex - 1] === right[rightIndex - 1] ? 0 : 1),
+      );
+    }
+    previous = current;
+  }
+
+  return previous[right.length];
+}
+
+export function findClosestSubcommand(token: string): string | null {
+  const normalized = token.toLowerCase();
+  if (!normalized) return null;
+
+  if (normalized.length >= 3) {
+    const prefixMatch = SUGGESTABLE_SUBCOMMANDS.find((candidate) =>
+      candidate.startsWith(normalized),
+    );
+    if (prefixMatch) return prefixMatch;
+  }
+
+  const tolerance =
+    normalized.length <= 4 ? 1 : normalized.length <= 8 ? 2 : 3;
+  let closest: string | null = null;
+  let closestDistance = Infinity;
+
+  for (const candidate of SUGGESTABLE_SUBCOMMANDS) {
+    if (Math.abs(normalized.length - candidate.length) > tolerance) continue;
+
+    const distance = levenshteinDistance(normalized, candidate);
+    if (distance <= tolerance && distance < closestDistance) {
+      closest = candidate;
+      closestDistance = distance;
+    }
+  }
+
+  return closest;
+}
+
+export function findUnknownSubcommand(args: readonly string[]): string | null {
+  const first = args[0];
+  if (!first || first.startsWith("-")) return null;
+  return KNOWN_SUBCOMMANDS.has(first) ? null : first;
+}
+
+export function formatUnknownSubcommandError(subcommand: string): string {
+  const suggestion = findClosestSubcommand(subcommand);
+  return [
+    `Unknown command: ${subcommand}`,
+    ...(suggestion ? ["", `Did you mean 'plannotator ${suggestion}'?`] : []),
+    "",
+    "Run 'plannotator --help' for the list of commands.",
+  ].join("\n");
+}
+
+export function exitOnUnknownSubcommand(args: readonly string[]): void {
+  const unknownSubcommand = findUnknownSubcommand(args);
+  if (!unknownSubcommand) return;
+
+  console.error(formatUnknownSubcommandError(unknownSubcommand));
+  process.exit(1);
+}


### PR DESCRIPTION
A typo'd subcommand produced no output and no exit. `plannotator annotatte README.md` simply hung.

The cause is the dispatcher's shape. `apps/hook/server/index.ts` routes on a chain of `args[0] === "…"` tests, and the chain's final `else` is plan review mode, which opens with `await Bun.stdin.text()` to read the `PermissionRequest` hook event. That fallthrough is correct for the hook, which is spawned with a payload on stdin and a closed pipe. From a terminal there is no payload and stdin never closes, so an unrecognized word inherits the hook path and waits forever. Nothing distinguished "the hook invoked us" from "the user misspelled a command".

## The guard

One check before the dispatcher runs, at `apps/hook/server/index.ts:388`, immediately after the `--version` and `--help` branches and before every subcommand test:

```
Unknown command: annotatte

Did you mean 'plannotator annotate'?

Run 'plannotator --help' for the list of commands.
```

On stderr, exit 1.

**What it refuses to touch.** The guard fires only on a first token that is a bare word not in the registry. An empty `args` returns null, so the no-argument hook invocation still reaches stdin and `isInteractiveNoArgInvocation` still gets its TTY clarification. A leading `-` returns null, so `--help`, `-v` and `plannotator --browser <name>` are untouched. Only `args[0]` is examined, so a bad flag on a good subcommand (`review --nonsense`) stays with the subcommand's own parser, which already reports it properly.

**The registry cannot drift.** `KNOWN_SUBCOMMANDS` is `SUBCOMMAND_HELP` plus `SUBCOMMAND_HELP_ALIASES` from `cli.ts`, plus five internal commands that are dispatched but deliberately undocumented (`install-runtime`, `opencode-plan`, `opencode-review`, `opencode-annotate-last`, `copilot-plan`). A registry that falls behind the dispatcher would reject a real command, which is worse than the hang it replaces, so the test scrapes every `args[0] === "…"` literal out of `index.ts` and asserts set equality with `KNOWN_SUBCOMMANDS`. Adding a subcommand without registering it fails the suite.

Suggestions come from the documented commands only, never the internal five. Prefix match first for tokens of three characters or more (`guid` → `guide`, `annot` → `annotate`), then Levenshtein within a length-scaled tolerance of 1/2/3. A candidate whose length differs by more than the tolerance is skipped before the distance is computed, which is what keeps a 10,000-character token cheap. Below three characters nothing is suggested — `a` has too many neighbours to guess at — and the message then carries only the `--help` line.

## Tests

`apps/hook/server/unknown-subcommand.test.ts`, six cases: the registry/dispatcher equality above, the flag and no-argument exemptions, the reported token, the suggestion cascade including the two null cases, the message content, and one end-to-end spawn with an **open** stdin pipe asserting exit 1 and the error text. That last one is the regression itself — with the guard removed it hangs until the 15s kill.

## Footprint

| File | Added | Removed |
| --- | ---: | ---: |
| `apps/hook/server/unknown-subcommand.ts` (new) | 91 | 0 |
| `apps/hook/server/unknown-subcommand.test.ts` (new) | 77 | 0 |
| `apps/hook/server/index.ts` | 3 | 0 |

## Verification

`bun test` → 4120 pass, 787 skip, 3 fail. The three failures (`git-background.test.ts` × 2, `review-core.test.ts` × 1) reproduce on a clean `main` checkout with the branch stashed, so they are unrelated. `bun run typecheck` clean.
