### PR TITLE
feat(review): send with additional feedback split control

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,6 +236,11 @@ raising the "No Annotations" dialog. The caret opens a right-anchored panel with
 a multi-line note field (Enter is a newline, `Mod+Enter` submits, `Escape` closes
 and KEEPS the text, outside pointerdown closes) whose own distinct action reads
 **Send with additional feedback**. The two actions are always different buttons.
+While the panel (or the compact dialog) is open, the header's primary Send
+Feedback fades to 40% and is disabled so the panel's action is unmistakably the
+submit; every close path restores it. The panel action itself always renders
+full-strength — an empty-note click is a no-op that refocuses the field (on
+touch, that raises the keyboard).
 
 The note is materialized at submit time by `commitReviewNote` in
 `packages/review-editor/App.tsx` as a `scope: 'general'` `CodeAnnotation`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,6 +224,36 @@ Send Feedback → feedback sent to agent session
 Approve → "LGTM" sent to agent session
 ```
 
+### Send with additional feedback
+
+The agent-mode review toolbar's Send Feedback is a joined split pill
+`[Send Feedback | v]` (`packages/review-editor/components/ReviewSendControl.tsx`,
+wired through `AgentReviewActions`'s optional `note` prop — omit it and the
+incumbent `FeedbackButton` renders unchanged). The LEFT segment never changes
+meaning: same label, icon, `labelBreakpoint="lg"` spans and `handleSendFeedback`
+as before, except that with nothing to send it opens the panel rather than
+raising the "No Annotations" dialog. The caret opens a right-anchored panel with
+a multi-line note field (Enter is a newline, `Mod+Enter` submits, `Escape` closes
+and KEEPS the text, outside pointerdown closes) whose own distinct action reads
+**Send with additional feedback**. The two actions are always different buttons.
+
+The note is materialized at submit time by `commitReviewNote` in
+`packages/review-editor/App.tsx` as a `scope: 'general'` `CodeAnnotation`
+(`filePath: ''`, `lineStart/lineEnd: 0` — the documented sentinels), so it rides
+the sidebar's General group, `renderGeneralComments`'s `## General` export
+section, `buildFileScopedBody`, the draft, and the `/api/feedback` annotations
+array with **zero server change** (`annotations` is `unknown[]` on both runtimes
+and is only counted and forwarded). It is deliberately NOT recorded in review
+undo history (it lives for one submit) and NOT stamped with PR context, so it
+survives an in-place PR switch or a layer/full-stack toggle. Submission waits one
+render, because `feedbackMarkdown` and `handleSendFeedback` close over
+`allAnnotations`. Compact/touch gets the same commit path through an additive
+`note` row in the header `ActionMenu` opening `ReviewNoteDialog`; platform (PR)
+mode deliberately has no caret, since `ReviewSubmissionDialog` already owns the
+general-comment field there. LGTM-with-a-note is a separate, coupled phase (four
+consumer call sites discard `result.feedback` on the approved path) and is not
+built.
+
 ### Since-main default review view
 
 The default code-review diff is **`since-base`** — a composite of `merge-base(base, HEAD)` vs the working tree plus untracked files ("everything a PR would show if you committed and pushed now"). It can render as a three-section **git status** panel (Committed / Changes / Untracked) via `SectionsPanel`, with a `Tree | Git status | Commits` toggle (`PanelViewToggle`). The Commits segment (git-local sessions only) is a linear `--first-parent` history rail (`CommitsPanel`): clicking a commit opens its own diff (`commit:<sha>`, vs its first parent) as the all-files view headed by the commit message rendered as markdown. The Commits view is a self-contained detour: entering it memoizes the previously active diff, exiting to Tree restores that diff verbatim (exiting to Git status resets to `since-base` as always), the memo clears whenever any non-commit diff is applied, and a reload that serves a commit-family diff with a non-Commits panel view snaps once to the session default so the commit diff cannot outlive the visit. The toggle never writes the persisted `reviewPanelView`/`defaultDiffType` pair (no server writes from a toggle click), but it does record a cookie-only last-used memo (`reviewPanelViewLastUsed`, `sections` | `tree` — never `commits`; the Commits view is session-only). A review OPENS on session choice ?? last-used memo ?? persisted `reviewPanelView` (cookie-only, written only by Settings and `ReviewSetupDialog` through `setReviewPanelView()`, which also syncs the memo so an explicit choice is never shadowed by a stale one — except the App self-heal, which passes `recordLastUsed: false` to repair the diff half of a conflicted pair without touching the memo). The first-run initializer marks review-setup-seen when it seeds the cookie-only Tree choice, not only on dismiss, so it is genuinely one-time per browser and cannot overwrite a returning reviewer's persisted or last-used view; it inherits the resolved `defaultDiffType` without a server config write. The persisted pair is coupled: the Sections view only renders `since-base`, so choosing a classic diff default snaps the persisted view to Tree and vice-versa (enforced in `ReviewSetupDialog`, the Settings Git tab, and the App first-run initializer).

--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -14,6 +14,7 @@ import { ConfirmDialog } from '@plannotator/ui/components/ConfirmDialog';
 import { Settings } from '@plannotator/ui/components/Settings';
 import { FeedbackButton, ApproveButton, ExitButton } from '@plannotator/ui/components/ToolbarButtons';
 import { AgentReviewActions } from './components/AgentReviewActions';
+import { ReviewNoteDialog, type ReviewSubmitNoteControl } from './components/ReviewSendControl';
 import { useUpdateCheck } from '@plannotator/ui/hooks/useUpdateCheck';
 import { storage } from '@plannotator/ui/utils/storage';
 import { CompletionOverlay } from '@plannotator/ui/components/CompletionOverlay';
@@ -3563,6 +3564,61 @@ const ReviewApp: React.FC = () => {
     }
   }, [getDraftGeneration]);
 
+  // --- Review-level note ("Send with additional feedback") ---------------
+  // The note is materialized at submit time as a scope:'general' annotation so
+  // it rides the existing export (## General) and the /api/feedback annotations
+  // array with no server change. Deliberately NOT recorded in review history
+  // (it lives for one submit) and deliberately NOT stamped with PR context, so
+  // it survives an in-place PR switch or a layer/full-stack toggle.
+  const [compactNoteOpen, setCompactNoteOpen] = useState(false);
+  const [pendingNoteId, setPendingNoteId] = useState<string | null>(null);
+
+  const commitReviewNote = useCallback((text: string): string | null => {
+    const trimmed = text.trim();
+    if (!trimmed) return null;
+    const note: CodeAnnotation = {
+      id: `review-note-${Date.now()}`,
+      type: 'comment',
+      scope: 'general',
+      filePath: '',
+      lineStart: 0,
+      lineEnd: 0,
+      side: 'new',
+      text: trimmed,
+      createdAt: Date.now(),
+      ...(identity ? { author: identity } : {}),
+    };
+    annotationsRef.current = [...annotationsRef.current, note];
+    setAnnotations(annotationsRef.current);
+    return note.id;
+  }, [identity]);
+
+  const handleSubmitReviewNote = useCallback((text: string) => {
+    if (isSendingFeedback || isApproving || isExiting || submitted) return;
+    const id = commitReviewNote(text);
+    if (!id) {
+      // Nothing typed: fall back to the incumbent send when there is something
+      // to send, and otherwise do nothing (an empty note is not a submission).
+      if (totalAnnotationCount > 0) void handleSendFeedback();
+      return;
+    }
+    setPendingNoteId(id);
+  }, [commitReviewNote, handleSendFeedback, isApproving, isExiting, isSendingFeedback, submitted, totalAnnotationCount]);
+
+  // feedbackMarkdown and handleSendFeedback close over allAnnotations, so the
+  // send has to wait for the render that carries the note.
+  useEffect(() => {
+    if (!pendingNoteId) return;
+    if (!allAnnotations.some(a => a.id === pendingNoteId)) return;
+    setPendingNoteId(null);
+    void handleSendFeedback();
+  }, [allAnnotations, handleSendFeedback, pendingNoteId]);
+
+  const reviewNoteControl = useMemo<ReviewSubmitNoteControl>(
+    () => ({ onSubmit: handleSubmitReviewNote }),
+    [handleSubmitReviewNote],
+  );
+
   // Submit reviews to one or more PRs via /api/pr-action
   const handlePlatformAction = useCallback(async (action: 'approve' | 'comment', plan: ReviewSubmission, generalComment?: string) => {
     setIsPlatformActioning(true);
@@ -3917,6 +3973,15 @@ const ReviewApp: React.FC = () => {
             onSelect: () => totalAnnotationCount > 0 ? setShowExitWarning(true) : handleExit(),
             disabled: compactActionBusy,
           },
+          ...(!platformMode
+            ? [{
+                id: 'note' as const,
+                label: 'Add a note',
+                ...(totalAnnotationCount > 0 ? { subtitle: 'Sent with your annotations' } : {}),
+                onSelect: () => setCompactNoteOpen(true),
+                disabled: compactActionBusy,
+              }]
+            : []),
           ...(totalAnnotationCount > 0
             ? [{
                 id: 'feedback' as const,
@@ -4289,6 +4354,7 @@ const ReviewApp: React.FC = () => {
                     onSendFeedback={handleSendFeedback}
                     onApprove={() => totalAnnotationCount > 0 ? setShowApproveWarning(true) : handleApprove()}
                     onExit={() => totalAnnotationCount > 0 ? setShowExitWarning(true) : handleExit()}
+                    note={submitted ? undefined : reviewNoteControl}
                   />
                 ) : (
                   <>
@@ -4966,6 +5032,15 @@ const ReviewApp: React.FC = () => {
             variant="info"
           />
         )}
+
+        {/* Compact/touch review-level note composer */}
+        <ReviewNoteDialog
+          isOpen={compactNoteOpen}
+          onClose={() => setCompactNoteOpen(false)}
+          note={reviewNoteControl}
+          disabled={compactActionBusy || !!submitted}
+          annotationCount={totalAnnotationCount}
+        />
 
         {/* No annotations dialog */}
         <ConfirmDialog

--- a/packages/review-editor/components/AgentReviewActions.tsx
+++ b/packages/review-editor/components/AgentReviewActions.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { FeedbackButton, ApproveButton, ExitButton } from '@plannotator/ui/components/ToolbarButtons';
+import { ReviewSendControl, type ReviewSubmitNoteControl } from './ReviewSendControl';
 
 interface AgentReviewActionsProps {
   totalAnnotationCount: number;
@@ -9,17 +10,20 @@ interface AgentReviewActionsProps {
   onSendFeedback: () => void;
   onApprove: () => void;
   onExit: () => void;
+  /** Enables the note half of the split Send control. Omitted (a host that
+   *  does not wire a note) falls back to the incumbent FeedbackButton. */
+  note?: ReviewSubmitNoteControl;
 }
 
 /**
  * Toolbar actions for agent review mode (all non-platform origins).
  *
- * The left button flips based on whether there are annotations:
- *   No annotations → [Close]  [Approve]
- *   Has annotations → [Send Feedback]  [Approve]
- *
  * - Close (Exit): closes the session without sending feedback
- * - Send Feedback: primary action when annotations exist
+ * - Send Feedback: the incumbent send. With a `note` it is the left segment of
+ *   a split pill whose caret opens a review-level note composer; the segment's
+ *   label, icon, breakpoints and handler are unchanged either way, and with no
+ *   note wired it is the plain FeedbackButton shown only when annotations
+ *   exist.
  * - Approve: LGTM; dimmed when annotations exist (they won't be sent)
  */
 export const AgentReviewActions: React.FC<AgentReviewActionsProps> = ({
@@ -30,6 +34,7 @@ export const AgentReviewActions: React.FC<AgentReviewActionsProps> = ({
   onSendFeedback,
   onApprove,
   onExit,
+  note,
 }) => {
   const busy = isSendingFeedback || isApproving || isExiting;
   const hasAnnotations = totalAnnotationCount > 0;
@@ -43,7 +48,15 @@ export const AgentReviewActions: React.FC<AgentReviewActionsProps> = ({
         labelBreakpoint="lg"
       />
 
-      {hasAnnotations && (
+      {note ? (
+        <ReviewSendControl
+          hasFeedback={hasAnnotations}
+          disabled={busy}
+          isLoading={isSendingFeedback}
+          onSend={onSendFeedback}
+          note={note}
+        />
+      ) : hasAnnotations ? (
         <FeedbackButton
           onClick={onSendFeedback}
           disabled={busy}
@@ -54,7 +67,7 @@ export const AgentReviewActions: React.FC<AgentReviewActionsProps> = ({
           title="Send feedback"
           labelBreakpoint="lg"
         />
-      )}
+      ) : null}
 
       <div className="relative group/approve inline-flex items-center">
         <ApproveButton

--- a/packages/review-editor/components/ReviewHeaderMenu.mobile.test.tsx
+++ b/packages/review-editor/components/ReviewHeaderMenu.mobile.test.tsx
@@ -69,4 +69,50 @@ describe('ReviewHeaderMenu compact review actions', () => {
     expect(onFeedback).toHaveBeenCalledTimes(1);
     expect(host?.textContent).not.toContain('Post comments');
   });
+
+  // Standing toolbar-integrity rule: the additive 'note' row must not remove,
+  // reorder, or disable any incumbent compact action. The closed-union id edit
+  // is where that actually risks breaking.
+  test.skipIf(!hasDom)('the additive note row joins the incumbent rows without displacing them', async () => {
+    const onNote = mock(() => {});
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+
+    await act(async () => root?.render(
+      <ThemeProvider defaultTheme="dark">
+        <ReviewHeaderMenu
+          onOpenSettings={() => {}}
+          onOpenExport={() => {}}
+          onCopyAgentInstructions={() => {}}
+          onToggleFileTree={() => {}}
+          onToggleSidebar={() => {}}
+          isFileTreeOpen={false}
+          isSidebarOpen={false}
+          compactTouchLayout
+          compactActions={[
+            { id: 'exit', label: 'Exit review', onSelect: () => {} },
+            { id: 'note', label: 'Add a note', subtitle: 'Sent with your annotations', onSelect: onNote },
+            { id: 'feedback', label: 'Send feedback', subtitle: '2 annotations', onSelect: () => {} },
+            { id: 'approve', label: 'Approve', onSelect: () => {} },
+          ]}
+          agentInstructionsEnabled={false}
+          appVersion="test"
+        />
+      </ThemeProvider>,
+    ));
+
+    await act(async () => host?.querySelector<HTMLButtonElement>('button[aria-label="Options"]')?.click());
+
+    const labels = ['Exit review', 'Add a note', 'Send feedback', 'Approve'];
+    const rows = Array.from(host?.querySelectorAll('button') ?? [])
+      .filter((button) => labels.some((label) => button.textContent?.includes(label)));
+    expect(rows.length).toBe(4);
+    expect(rows.map((button) => labels.find((label) => button.textContent?.includes(label)))).toEqual(labels);
+    expect(rows.every((button) => !button.disabled)).toBe(true);
+
+    const noteRow = rows[1];
+    await act(async () => noteRow.click());
+    expect(onNote).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/review-editor/components/ReviewHeaderMenu.tsx
+++ b/packages/review-editor/components/ReviewHeaderMenu.tsx
@@ -25,7 +25,7 @@ export interface CompactReviewDestination {
 }
 
 export interface CompactReviewAction {
-  id: 'exit' | 'feedback' | 'approve' | 'copy';
+  id: 'exit' | 'note' | 'feedback' | 'approve' | 'copy';
   label: string;
   subtitle?: string;
   onSelect: () => void;
@@ -400,6 +400,13 @@ const CompactReviewActionIcon: React.FC<{ kind: CompactReviewAction['id'] }> = (
     return (
       <svg className="w-3.5 h-3.5 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-4l-4 4v-4z" />
+      </svg>
+    );
+  }
+  if (kind === 'note') {
+    return (
+      <svg className="w-3.5 h-3.5 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
       </svg>
     );
   }

--- a/packages/review-editor/components/ReviewSendControl.test.tsx
+++ b/packages/review-editor/components/ReviewSendControl.test.tsx
@@ -117,13 +117,34 @@ describe('ReviewSendControl', () => {
   // Guards the most likely "helpful" regression: merging the two actions into
   // one button, at which point a reviewer who typed a note and clicked Send
   // loses it silently.
-  test.skipIf(!hasDom)('the left segment sends plainly and never carries the note', async () => {
+  test.skipIf(!hasDom)('the left segment sends plainly when the panel is closed', async () => {
     const { onSend, onSubmit } = await mount({ hasFeedback: true });
-    await openPanel();
-    await type('rebase before merging');
     await act(async () => primary().click());
     expect(onSend).toHaveBeenCalledTimes(1);
     expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  // Guards the maintainer-directed disambiguation: an open note panel fades
+  // and disables the header's primary send, so a typed note can never be
+  // silently dropped by a muscle-memory click on Send Feedback. Closing the
+  // panel restores it.
+  test.skipIf(!hasDom)('an open panel fades and disables the primary; closing restores it', async () => {
+    const { onSend } = await mount({ hasFeedback: true });
+    expect(primary().disabled).toBe(false);
+    expect(primary().className).not.toContain('opacity-40');
+
+    await openPanel();
+    await type('do not lose me');
+    expect(primary().disabled).toBe(true);
+    expect(primary().className).toContain('opacity-40');
+    await act(async () => primary().click());
+    expect(onSend).not.toHaveBeenCalled();
+
+    await key({ key: 'Escape' });
+    expect(primary().disabled).toBe(false);
+    expect(primary().className).not.toContain('opacity-40');
+    await act(async () => primary().click());
+    expect(onSend).toHaveBeenCalledTimes(1);
   });
 
   // Guards a revert to a one-line field, which would truncate a multi-line note
@@ -182,16 +203,24 @@ describe('ReviewSendControl', () => {
 
   // Guards submitting an empty scope:'general' annotation, which would export
   // as a blank bullet under ## General.
-  test.skipIf(!hasDom)('the distinct action is disabled for empty and whitespace-only text', async () => {
+  // Guards the maintainer-directed visual rule: the panel's action must stay
+  // full-strength (never grayed) while the panel is open — only the header
+  // primary fades. An empty or whitespace-only note is a click no-op.
+  test.skipIf(!hasDom)('the distinct action stays enabled-looking; empty text is a no-op', async () => {
     const { onSubmit } = await mount();
     await openPanel();
-    expect(noteSend().disabled).toBe(true);
-    await type('   \n  ');
-    expect(noteSend().disabled).toBe(true);
-    await key({ key: 'Enter', metaKey: true });
-    expect(onSubmit).not.toHaveBeenCalled();
-    await type('real');
     expect(noteSend().disabled).toBe(false);
+    await act(async () => noteSend().click());
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(panel()).not.toBeNull();
+
+    await type('   ');
+    await act(async () => noteSend().click());
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    await type('real note');
+    await act(async () => noteSend().click());
+    expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 
   // Guards a regression that raises the "No Annotations" dialog from a button

--- a/packages/review-editor/components/ReviewSendControl.test.tsx
+++ b/packages/review-editor/components/ReviewSendControl.test.tsx
@@ -1,0 +1,226 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { ReviewSendControl, REVIEW_NOTE_SEND_LABEL } from './ReviewSendControl';
+
+/**
+ * The split Send control's interaction contract (DOM-gated).
+ *
+ * Each test names the regression it guards; the load-bearing invariant is that
+ * "Send Feedback" and "Send with additional feedback" are DIFFERENT buttons —
+ * the incumbent left segment never acquires the note, and the note never
+ * arrives without an explicit distinct action.
+ */
+
+const hasDom = typeof document !== 'undefined';
+let root: Root | null = null;
+let host: HTMLElement | null = null;
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  root = null;
+  host?.remove();
+  host = null;
+  if (hasDom) document.body.replaceChildren();
+});
+
+interface Handlers {
+  onSend: ReturnType<typeof mock>;
+  onSubmit: ReturnType<typeof mock>;
+}
+
+async function mount(options: { hasFeedback?: boolean } = {}): Promise<Handlers> {
+  const onSend = mock(() => {});
+  const onSubmit = mock((_text: string) => {});
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  root = createRoot(host);
+  await act(async () => {
+    root?.render(
+      <ReviewSendControl
+        hasFeedback={options.hasFeedback ?? true}
+        onSend={onSend}
+        note={{ onSubmit }}
+      />,
+    );
+  });
+  return { onSend, onSubmit };
+}
+
+function primary(): HTMLButtonElement {
+  const button = host?.querySelector<HTMLButtonElement>(
+    'button:not([data-review-note-toggle]):not([data-review-note-send])',
+  );
+  if (!button) throw new Error('primary send segment did not render');
+  return button;
+}
+
+function caret(): HTMLButtonElement {
+  const button = host?.querySelector<HTMLButtonElement>('[data-review-note-toggle]');
+  if (!button) throw new Error('caret segment did not render');
+  return button;
+}
+
+function panel(): HTMLElement | null {
+  return host?.querySelector<HTMLElement>('[data-review-note-composer="anchored"]') ?? null;
+}
+
+function field(): HTMLTextAreaElement {
+  const input = host?.querySelector<HTMLTextAreaElement>('[data-review-note-input]');
+  if (!input) throw new Error('note field did not render');
+  return input;
+}
+
+function noteSend(): HTMLButtonElement {
+  const button = host?.querySelector<HTMLButtonElement>('[data-review-note-send]');
+  if (!button) throw new Error('note send button did not render');
+  return button;
+}
+
+async function openPanel() {
+  await act(async () => caret().click());
+}
+
+async function type(value: string) {
+  const input = field();
+  // React tracks the node's value, so the prototype setter is what makes the
+  // native input event read as a real change.
+  const setter = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(input), 'value')?.set;
+  await act(async () => {
+    if (setter) setter.call(input, value);
+    else input.value = value;
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+}
+
+async function key(init: KeyboardEventInit) {
+  await act(async () => {
+    field().dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init }));
+  });
+}
+
+describe('ReviewSendControl', () => {
+  test.skipIf(!hasDom)('renders both segments of one pill and starts closed', async () => {
+    await mount();
+    expect(primary()).toBeTruthy();
+    expect(caret().getAttribute('aria-expanded')).toBe('false');
+    expect(panel()).toBeNull();
+  });
+
+  test.skipIf(!hasDom)('the caret opens the note panel', async () => {
+    await mount();
+    await openPanel();
+    expect(panel()).toBeTruthy();
+    expect(caret().getAttribute('aria-expanded')).toBe('true');
+  });
+
+  // Guards the most likely "helpful" regression: merging the two actions into
+  // one button, at which point a reviewer who typed a note and clicked Send
+  // loses it silently.
+  test.skipIf(!hasDom)('the left segment sends plainly and never carries the note', async () => {
+    const { onSend, onSubmit } = await mount({ hasFeedback: true });
+    await openPanel();
+    await type('rebase before merging');
+    await act(async () => primary().click());
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  // Guards a revert to a one-line field, which would truncate a multi-line note
+  // at the first newline.
+  test.skipIf(!hasDom)('Enter is a newline; Mod+Enter submits the note', async () => {
+    const { onSubmit } = await mount();
+    await openPanel();
+    await type('first line');
+    await key({ key: 'Enter' });
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    await key({ key: 'Enter', metaKey: true });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0][0]).toBe('first line');
+
+    // ctrlKey is the same chord off macOS.
+    await openPanel();
+    await type('ctrl line');
+    await key({ key: 'Enter', ctrlKey: true });
+    expect(onSubmit).toHaveBeenCalledTimes(2);
+    expect(onSubmit.mock.calls[1][0]).toBe('ctrl line');
+  });
+
+  test.skipIf(!hasDom)('the distinct action submits exactly the typed note', async () => {
+    const { onSend, onSubmit } = await mount();
+    await openPanel();
+    await type('split the migration first');
+    await act(async () => noteSend().click());
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0][0]).toBe('split the migration first');
+    expect(onSend).not.toHaveBeenCalled();
+    expect(panel()).toBeNull();
+  });
+
+  // Guards clearing-on-close (throws away a half-typed note) and the
+  // stopPropagation that keeps Escape out of the review app's own ladder.
+  test.skipIf(!hasDom)('Escape closes, keeps the text, and does not submit', async () => {
+    const { onSubmit } = await mount();
+    let escapeReachedApp = false;
+    const listener = () => { escapeReachedApp = true; };
+    document.addEventListener('keydown', listener);
+    try {
+      await openPanel();
+      await type('half typed');
+      await key({ key: 'Escape' });
+    } finally {
+      document.removeEventListener('keydown', listener);
+    }
+    expect(panel()).toBeNull();
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(escapeReachedApp).toBe(false);
+
+    await openPanel();
+    expect(field().value).toBe('half typed');
+  });
+
+  // Guards submitting an empty scope:'general' annotation, which would export
+  // as a blank bullet under ## General.
+  test.skipIf(!hasDom)('the distinct action is disabled for empty and whitespace-only text', async () => {
+    const { onSubmit } = await mount();
+    await openPanel();
+    expect(noteSend().disabled).toBe(true);
+    await type('   \n  ');
+    expect(noteSend().disabled).toBe(true);
+    await key({ key: 'Enter', metaKey: true });
+    expect(onSubmit).not.toHaveBeenCalled();
+    await type('real');
+    expect(noteSend().disabled).toBe(false);
+  });
+
+  // Guards a regression that raises the "No Annotations" dialog from a button
+  // whose whole purpose at zero annotations is the note.
+  test.skipIf(!hasDom)('with nothing to send the primary opens the panel instead of sending', async () => {
+    const { onSend } = await mount({ hasFeedback: false });
+    await act(async () => primary().click());
+    expect(onSend).not.toHaveBeenCalled();
+    expect(panel()).toBeTruthy();
+  });
+
+  test.skipIf(!hasDom)('a pointerdown outside the control closes the panel', async () => {
+    await mount();
+    await openPanel();
+    const outside = document.createElement('div');
+    document.body.appendChild(outside);
+    await act(async () => {
+      outside.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+    });
+    outside.remove();
+    expect(panel()).toBeNull();
+  });
+
+  // Deliberately frozen, maintainer-approved label — the note action must stay
+  // distinguishable from the incumbent "Send Feedback". Not a prose snapshot.
+  test.skipIf(!hasDom)('the panel action reads "Send with additional feedback"', async () => {
+    await mount();
+    await openPanel();
+    expect(noteSend().textContent).toBe('Send with additional feedback');
+    expect(REVIEW_NOTE_SEND_LABEL).toBe('Send with additional feedback');
+  });
+});

--- a/packages/review-editor/components/ReviewSendControl.tsx
+++ b/packages/review-editor/components/ReviewSendControl.tsx
@@ -1,0 +1,335 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Send } from 'lucide-react';
+import { Button } from '@plannotator/ui/components/ui/button';
+import { submitHint } from '@plannotator/ui/utils/platform';
+import { useCompactTouchLayout } from '@plannotator/ui/hooks/useIsMobile';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@plannotator/ui/components/ui/dialog';
+
+/**
+ * One-step "send with a note" for the code review surface.
+ *
+ * The note itself is not owned here: App materializes it at submit time as a
+ * `scope: 'general'` CodeAnnotation so it rides `exportReviewFeedback`'s
+ * `## General` section and the `/api/feedback` annotations array with no server
+ * change. This component only owns the affordance and the typed text
+ * (deliberately local, so a keystroke never re-renders the review header).
+ *
+ * Interaction contract:
+ * - The control is ONE joined split button: [Send Feedback | v]. The left
+ *   segment is always the incumbent plain send, unchanged; the caret is a
+ *   separate segment of the same pill.
+ * - The caret opens a panel BELOW the pill with a multi-line note field and its
+ *   own distinct action, "Send with additional feedback", which sends the note
+ *   together with everything already in the session. The two actions never
+ *   share a button.
+ * - The note field: Enter inserts a newline, Mod+Enter submits with feedback,
+ *   Esc closes the panel and keeps the half-typed text.
+ *
+ * DUPLICATE, ON PURPOSE. Its annotate twin is
+ * `packages/editor/components/AnnotateSendControl.tsx`; the two share the field
+ * contract but not their props (this one carries responsive toolbar labels, a
+ * three-way busy expression and a compact dialog sibling). Tripwire: if a THIRD
+ * surface ever needs this field, extract the textarea + auto-grow + key
+ * handling as `packages/ui/components/SubmitNoteField.tsx` and have both
+ * controls compose it — as its own PR, never mixed into a feature.
+ */
+export interface ReviewSubmitNoteControl {
+  /** Submit this note together with any annotations already in the session. */
+  onSubmit: (text: string) => void;
+}
+
+export const REVIEW_NOTE_PLACEHOLDER = 'Add a note...';
+
+/** Deliberately frozen, maintainer-approved label for the distinct action. It
+ *  must never collapse into the incumbent Send Feedback button's label. */
+export const REVIEW_NOTE_SEND_LABEL = 'Send with additional feedback';
+
+/** Two lines tall at rest, grows with content, then scrolls. */
+const NOTE_MAX_HEIGHT_PX = 144;
+
+function useAutoGrow(text: string) {
+  const ref = useRef<HTMLTextAreaElement>(null);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${Math.min(el.scrollHeight, NOTE_MAX_HEIGHT_PX)}px`;
+  }, [text]);
+  return ref;
+}
+
+interface ReviewNoteFieldProps {
+  text: string;
+  onTextChange: (value: string) => void;
+  onSubmit: (text: string) => void;
+  onClose: () => void;
+  disabled?: boolean;
+  autoFocus?: boolean;
+}
+
+/** The multi-line note field. Controlled: the owner keeps the text so closing
+ *  and reopening does not discard a half-typed note. */
+const ReviewNoteField: React.FC<ReviewNoteFieldProps> = ({
+  text,
+  onTextChange,
+  onSubmit,
+  onClose,
+  disabled = false,
+  autoFocus = true,
+}) => {
+  const ref = useAutoGrow(text);
+
+  useEffect(() => {
+    if (autoFocus) ref.current?.focus();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoFocus]);
+
+  const canSend = text.trim().length > 0;
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key === 'Escape') {
+        // Stop here: the review app runs its own Escape ladder (file tree,
+        // sidebar, dialogs), and a bare Escape in this field is ours.
+        event.preventDefault();
+        event.stopPropagation();
+        onClose();
+        return;
+      }
+      if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!disabled && canSend) onSubmit(text);
+      }
+      // Plain Enter falls through: the field is multi-line and Enter's job is
+      // a newline.
+    },
+    [canSend, disabled, onClose, onSubmit, text],
+  );
+
+  return (
+    <textarea
+      ref={ref}
+      rows={2}
+      value={text}
+      onChange={(event) => onTextChange(event.target.value)}
+      onKeyDown={handleKeyDown}
+      placeholder={REVIEW_NOTE_PLACEHOLDER}
+      aria-label={REVIEW_NOTE_PLACEHOLDER}
+      data-review-note-input="true"
+      data-pn-mobile-editable
+      className="block w-full resize-none overflow-y-auto rounded-md border border-border bg-background px-2.5 py-1.5 text-sm leading-snug text-foreground outline-none placeholder:text-muted-foreground focus-visible:ring-1 focus-visible:ring-ring/40"
+      style={{ maxHeight: NOTE_MAX_HEIGHT_PX }}
+    />
+  );
+};
+
+interface ReviewNoteSendButtonProps {
+  onClick: () => void;
+  disabled: boolean;
+}
+
+const ReviewNoteSendButton: React.FC<ReviewNoteSendButtonProps> = ({ onClick, disabled }) => (
+  <Button
+    variant="outline"
+    size="xs"
+    data-review-note-send="true"
+    onClick={onClick}
+    disabled={disabled}
+    title={REVIEW_NOTE_SEND_LABEL}
+    iconLeft={<Send className="size-3.5" />}
+  >
+    {REVIEW_NOTE_SEND_LABEL}
+  </Button>
+);
+
+/**
+ * The compact/touch note composer. The desktop panel is an anchored dropdown,
+ * which is the wrong shape inside the header's scrollable ActionMenu popup
+ * (it closes on outside pointerdown and its max-height fights the soft
+ * keyboard), so compact gets a dialog opened from an additive menu row.
+ */
+export const ReviewNoteDialog: React.FC<{
+  isOpen: boolean;
+  onClose: () => void;
+  note: ReviewSubmitNoteControl;
+  disabled?: boolean;
+  annotationCount?: number;
+}> = ({ isOpen, onClose, note, disabled = false, annotationCount = 0 }) => {
+  const isCompactTouchLayout = useCompactTouchLayout();
+  const [text, setText] = useState('');
+  const canSend = text.trim().length > 0;
+
+  const submit = useCallback(() => {
+    if (disabled || !canSend) return;
+    note.onSubmit(text);
+    setText('');
+    onClose();
+  }, [canSend, disabled, note, onClose, text]);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent
+        data-review-note-composer="dialog"
+        // Opening the sheet must not raise the touch keyboard on its own.
+        initialFocus={isCompactTouchLayout ? false : undefined}
+        className="max-w-md rounded-xl bg-card p-4 text-foreground"
+      >
+        <DialogTitle className="font-semibold mb-1">Add a note</DialogTitle>
+        <DialogDescription className="text-sm text-muted-foreground mb-3">
+          {annotationCount > 0
+            ? `Sent with your ${annotationCount} annotation${annotationCount === 1 ? '' : 's'}.`
+            : 'Sent to the agent as review-level feedback.'}
+        </DialogDescription>
+        <ReviewNoteField
+          text={text}
+          onTextChange={setText}
+          onSubmit={submit}
+          onClose={onClose}
+          disabled={disabled}
+          autoFocus={!isCompactTouchLayout}
+        />
+        <div className="mt-3 flex items-center justify-between gap-2">
+          <span className="text-[11px] leading-snug text-muted-foreground">{submitHint}</span>
+          <ReviewNoteSendButton onClick={submit} disabled={disabled || !canSend} />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+interface ReviewSendControlProps {
+  /** True when the session already carries annotations (code, editor,
+   *  description or PR comment). False flips the primary into the
+   *  zero-annotation fast path. */
+  hasFeedback: boolean;
+  disabled?: boolean;
+  isLoading?: boolean;
+  /** The incumbent Send Feedback action. Always plain send, never the note. */
+  onSend: () => void;
+  note: ReviewSubmitNoteControl;
+}
+
+/**
+ * The joined split Send control for agent-mode code review. See the module doc
+ * for the interaction contract; the load-bearing detail is that Send Feedback
+ * and Send-with-additional-feedback are DIFFERENT buttons — the incumbent never
+ * changes meaning, and the note panel carries its own action.
+ */
+export const ReviewSendControl: React.FC<ReviewSendControlProps> = ({
+  hasFeedback,
+  disabled = false,
+  isLoading = false,
+  onSend,
+  note,
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState('');
+
+  const close = useCallback(() => setOpen(false), []);
+
+  useEffect(() => {
+    if (!open) return;
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    document.addEventListener('pointerdown', handlePointerDown);
+    return () => document.removeEventListener('pointerdown', handlePointerDown);
+  }, [open]);
+
+  // A submit in flight (or an approve/exit) must not leave the panel hanging
+  // over a toolbar whose buttons have all gone disabled.
+  useEffect(() => {
+    if (disabled) setOpen(false);
+  }, [disabled]);
+
+  const submitNote = useCallback(
+    (value: string) => {
+      setOpen(false);
+      setText('');
+      note.onSubmit(value);
+    },
+    [note],
+  );
+
+  /** The incumbent action. With feedback: plain send, exactly as before this
+   *  control existed. With none: sending nothing only raised the "No
+   *  Annotations" dialog, so the click opens the note panel instead. */
+  const primaryAction = useCallback(() => {
+    if (hasFeedback) onSend();
+    else setOpen(true);
+  }, [hasFeedback, onSend]);
+
+  const canSubmitNote = text.trim().length > 0;
+
+  return (
+    <div ref={containerRef} className="relative">
+      {/* One pill, two segments: a hairline divider where they meet. */}
+      <div className="inline-flex items-center">
+        <Button
+          variant="outline"
+          size="xs"
+          onClick={primaryAction}
+          disabled={disabled}
+          title={hasFeedback ? 'Send feedback' : 'Send Feedback: write a quick note'}
+          iconLeft={<Send className="size-3.5" />}
+          className="rounded-r-none border-r-0"
+        >
+          {/* Same responsive spans FeedbackButton renders at
+              labelBreakpoint="lg", so the toolbar width is unchanged. */}
+          <span className="hidden lg:inline xl:hidden">{isLoading ? 'Sending...' : 'Send'}</span>
+          <span className="hidden xl:inline">{isLoading ? 'Sending...' : 'Send Feedback'}</span>
+        </Button>
+        <Button
+          variant="outline"
+          size="xs"
+          data-review-note-toggle="true"
+          aria-expanded={open}
+          aria-label="Add a note and send with feedback"
+          title="Add a note and send with feedback"
+          disabled={disabled}
+          onClick={() => setOpen((value) => !value)}
+          className={`rounded-l-none px-1.5 ${open ? 'bg-muted text-foreground' : 'text-muted-foreground'}`}
+        >
+          <svg
+            className={`h-3.5 w-3.5 transition-transform duration-150 ${open ? 'rotate-180' : ''}`}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+          </svg>
+        </Button>
+      </div>
+      {open && (
+        <div
+          data-review-note-composer="anchored"
+          className="absolute right-0 top-full z-50 mt-1.5 w-[22rem] max-w-[calc(100vw-2rem)] rounded-lg border border-border bg-popover p-1.5 shadow-xl"
+        >
+          <ReviewNoteField
+            text={text}
+            onTextChange={setText}
+            onSubmit={submitNote}
+            onClose={close}
+            disabled={disabled}
+          />
+          <div className="mt-1.5 flex items-center justify-between gap-2 px-0.5">
+            <span className="text-[11px] leading-snug text-muted-foreground">{submitHint}</span>
+            <ReviewNoteSendButton
+              onClick={() => submitNote(text)}
+              disabled={disabled || !canSubmitNote}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/review-editor/components/ReviewSendControl.tsx
+++ b/packages/review-editor/components/ReviewSendControl.tsx
@@ -134,6 +134,10 @@ interface ReviewNoteSendButtonProps {
   disabled: boolean;
 }
 
+/** Always renders full-strength: while the panel is open this is THE submit,
+ *  and a grayed action beside the deliberately faded header primary read as
+ *  "everything is disabled" in maintainer review. An empty-note click is a
+ *  no-op that refocuses the field instead. */
 const ReviewNoteSendButton: React.FC<ReviewNoteSendButtonProps> = ({ onClick, disabled }) => (
   <Button
     variant="outline"
@@ -196,7 +200,7 @@ export const ReviewNoteDialog: React.FC<{
         />
         <div className="mt-3 flex items-center justify-between gap-2">
           <span className="text-[11px] leading-snug text-muted-foreground">{submitHint}</span>
-          <ReviewNoteSendButton onClick={submit} disabled={disabled || !canSend} />
+          <ReviewNoteSendButton onClick={submit} disabled={disabled} />
         </div>
       </DialogContent>
     </Dialog>
@@ -251,6 +255,14 @@ export const ReviewSendControl: React.FC<ReviewSendControlProps> = ({
 
   const submitNote = useCallback(
     (value: string) => {
+      if (value.trim().length === 0) {
+        // Empty note: keep the panel open and put the cursor back in the
+        // field. The action stays visually live (see ReviewNoteSendButton).
+        containerRef.current
+          ?.querySelector<HTMLTextAreaElement>('[data-review-note-input]')
+          ?.focus();
+        return;
+      }
       setOpen(false);
       setText('');
       note.onSubmit(value);
@@ -266,8 +278,6 @@ export const ReviewSendControl: React.FC<ReviewSendControlProps> = ({
     else setOpen(true);
   }, [hasFeedback, onSend]);
 
-  const canSubmitNote = text.trim().length > 0;
-
   return (
     <div ref={containerRef} className="relative">
       {/* One pill, two segments: a hairline divider where they meet. */}
@@ -276,10 +286,16 @@ export const ReviewSendControl: React.FC<ReviewSendControlProps> = ({
           variant="outline"
           size="xs"
           onClick={primaryAction}
-          disabled={disabled}
-          title={hasFeedback ? 'Send feedback' : 'Send Feedback: write a quick note'}
+          disabled={disabled || open}
+          title={
+            open
+              ? 'Close the note to send without it'
+              : hasFeedback
+                ? 'Send feedback'
+                : 'Send Feedback: write a quick note'
+          }
           iconLeft={<Send className="size-3.5" />}
-          className="rounded-r-none border-r-0"
+          className={`rounded-r-none border-r-0 transition-opacity ${open ? 'opacity-40' : ''}`}
         >
           {/* Same responsive spans FeedbackButton renders at
               labelBreakpoint="lg", so the toolbar width is unchanged. */}
@@ -325,7 +341,7 @@ export const ReviewSendControl: React.FC<ReviewSendControlProps> = ({
             <span className="text-[11px] leading-snug text-muted-foreground">{submitHint}</span>
             <ReviewNoteSendButton
               onClick={() => submitNote(text)}
-              disabled={disabled || !canSubmitNote}
+              disabled={disabled}
             />
           </div>
         </div>

--- a/packages/review-editor/components/ReviewSendControl.tsx
+++ b/packages/review-editor/components/ReviewSendControl.tsx
@@ -168,9 +168,26 @@ export const ReviewNoteDialog: React.FC<{
   const isCompactTouchLayout = useCompactTouchLayout();
   const [text, setText] = useState('');
   const canSend = text.trim().length > 0;
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  // Mirror the desktop panel: if the surface goes busy/submitted while the
+  // dialog is open, close it rather than leaving an editable field whose
+  // action can no longer do anything.
+  useEffect(() => {
+    if (disabled && isOpen) onClose();
+  }, [disabled, isOpen, onClose]);
 
   const submit = useCallback(() => {
-    if (disabled || !canSend) return;
+    if (disabled) return;
+    if (!canSend) {
+      // Same contract as the desktop panel: the action renders full-strength
+      // and an empty-note tap refocuses the field — on touch this also raises
+      // the keyboard, which is the affordance the tap was asking for.
+      contentRef.current
+        ?.querySelector<HTMLTextAreaElement>('[data-review-note-input]')
+        ?.focus();
+      return;
+    }
     note.onSubmit(text);
     setText('');
     onClose();
@@ -179,6 +196,7 @@ export const ReviewNoteDialog: React.FC<{
   return (
     <Dialog open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
       <DialogContent
+        ref={contentRef}
         data-review-note-composer="dialog"
         // Opening the sheet must not raise the touch keyboard on its own.
         initialFocus={isCompactTouchLayout ? false : undefined}

--- a/packages/review-editor/shortcuts.ts
+++ b/packages/review-editor/shortcuts.ts
@@ -8,6 +8,7 @@ import {
   reviewAllFilesDiffShortcuts,
   reviewAnnotationToolbarShortcuts,
   reviewFileTreeShortcuts,
+  reviewNoteShortcuts,
   reviewPrCommentsShortcuts,
   reviewSuggestionModalShortcuts,
   reviewTourDialogShortcuts,
@@ -110,6 +111,7 @@ export const useReviewEditorDoubleTap = createDoubleTapShortcutsHook(reviewEdito
 
 export const reviewSettingsShortcutRegistry = createShortcutRegistry([
   reviewEditorShortcuts,
+  reviewNoteShortcuts,
   historyShortcuts,
   reviewFileTreeShortcuts,
   reviewAllFilesDiffShortcuts,

--- a/packages/review-editor/utils/exportFeedback.reviewNote.test.ts
+++ b/packages/review-editor/utils/exportFeedback.reviewNote.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'bun:test';
+import { exportReviewFeedback } from './exportFeedback';
+import type { CodeAnnotation } from '@plannotator/ui/types';
+
+/**
+ * The review-level note produced by the Send control's "Send with additional
+ * feedback" action is a scope:'general' CodeAnnotation. These guard the export
+ * shape it depends on — the whole feature rides the existing ## General
+ * section, with no new export code.
+ */
+
+const note = (text: string): CodeAnnotation => ({
+  id: 'review-note-1',
+  type: 'comment',
+  scope: 'general',
+  filePath: '',
+  lineStart: 0,
+  lineEnd: 0,
+  side: 'new',
+  text,
+  createdAt: 1,
+});
+
+const lineComment = (): CodeAnnotation => ({
+  id: 'c1',
+  type: 'comment',
+  filePath: 'src/index.ts',
+  lineStart: 10,
+  lineEnd: 10,
+  side: 'new',
+  text: 'this branch is unreachable',
+  createdAt: 2,
+});
+
+describe('exportReviewFeedback - review-level note', () => {
+  // Guards giving the note a filePath or scope:'line', which would export it as
+  // a comment on a file that is not in the diff (and create a group for "").
+  it('renders under ## General and creates no file group', () => {
+    const output = exportReviewFeedback([note('rebase before merging')]);
+    const generalIndex = output.indexOf('## General');
+    expect(generalIndex).toBeGreaterThan(-1);
+    expect(output.indexOf('rebase before merging')).toBeGreaterThan(generalIndex);
+    // No group header for the empty sentinel path.
+    expect(output).not.toContain('## \n');
+    expect(output).not.toMatch(/^## $/m);
+  });
+
+  // Guards the general/placed partition being bypassed, which would drop one
+  // side or the other when a note is sent together with annotations.
+  it('co-exists with placed annotations: both the file group and General survive', () => {
+    const output = exportReviewFeedback([lineComment(), note('and split the migration')]);
+    expect(output).toContain('## src/index.ts');
+    expect(output).toContain('this branch is unreachable');
+    expect(output).toContain('## General');
+    expect(output).toContain('and split the migration');
+  });
+
+  it('a note alone is real feedback, not the empty-review message', () => {
+    const output = exportReviewFeedback([note('ship it after the docs land')]);
+    expect(output).not.toContain('No feedback provided.');
+  });
+});

--- a/packages/server/review-note-payload.test.ts
+++ b/packages/server/review-note-payload.test.ts
@@ -1,0 +1,181 @@
+/**
+ * The review-level note ("Send with additional feedback") rides the EXISTING
+ * /api/feedback payload: one extra `scope: 'general'` entry in the annotations
+ * array plus a `## General` section already inside the feedback markdown. That
+ * is the whole reason the feature needs no server change.
+ *
+ * Regression guarded: a future body validator, field whitelist, or
+ * CodeAnnotation schema landing on either runtime's /api/feedback handler and
+ * silently dropping (or rewriting) an annotation entry it does not recognise —
+ * which would deliver the reviewer's note nowhere while still reporting 200.
+ * Also guarded: the archive's hasContent computation demoting a note-carrying
+ * submission to a decision-only line.
+ *
+ * Both runtimes are exercised in one file (precedent: api-404-guard.test.ts).
+ * Every server here runs under a temp PLANNOTATOR_DATA_DIR set inside the test
+ * body; the archive is opted back in per test and restored afterwards.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startReviewServer as startBunReviewServer } from "./review";
+import { startReviewServer as startPiReviewServer } from "../../apps/pi-extension/server";
+import { parseFeedbackIndex } from "@plannotator/shared/feedback-archive";
+
+const MINIMAL_HTML = "<html><body>Plannotator</body></html>";
+const PATCH = "diff --git a/src/parse.ts b/src/parse.ts\n@@ -1 +1 @@\n-a\n+b\n";
+
+const NOTE_TEXT = "Rebase on main before merging; the migration should be its own PR.";
+const FEEDBACK = `# Code Review Feedback\n\n## src/parse.ts\n\n- L1: still drops null\n\n## General\n\n${NOTE_TEXT}\n`;
+
+/** Exactly what the client commits for a review-level note. */
+const NOTE = {
+  id: "review-note-1",
+  type: "comment",
+  scope: "general",
+  filePath: "",
+  lineStart: 0,
+  lineEnd: 0,
+  side: "new",
+  text: NOTE_TEXT,
+  createdAt: 1735689600000,
+  author: "reviewer",
+} as const;
+
+const LINE_COMMENT = {
+  id: "c1",
+  type: "comment",
+  filePath: "src/parse.ts",
+  lineStart: 1,
+  lineEnd: 1,
+  side: "new",
+  text: "still drops null",
+  createdAt: 1735689500000,
+} as const;
+
+const tempDirs: string[] = [];
+const savedEnv: Record<string, string | undefined> = {};
+
+function saveEnv(key: string) {
+  if (!(key in savedEnv)) savedEnv[key] = process.env[key];
+}
+
+function useTempDataDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "plannotator-review-note-"));
+  tempDirs.push(dir);
+  saveEnv("PLANNOTATOR_DATA_DIR");
+  process.env.PLANNOTATOR_DATA_DIR = dir;
+  return dir;
+}
+
+function enableArchive() {
+  saveEnv("PLANNOTATOR_FEEDBACK_HISTORY");
+  process.env.PLANNOTATOR_FEEDBACK_HISTORY = "1";
+}
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+    delete savedEnv[key];
+  }
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+interface RunningReview {
+  url: string;
+  stop(): void;
+  waitForDecision(): Promise<{
+    approved: boolean;
+    feedback: string;
+    annotations: unknown[];
+  }>;
+}
+
+const runtimes: Array<{ name: string; start: () => Promise<RunningReview> }> = [
+  {
+    name: "Bun review",
+    start: () =>
+      startBunReviewServer({
+        rawPatch: PATCH,
+        gitRef: "HEAD",
+        origin: "claude-code",
+        htmlContent: MINIMAL_HTML,
+      }) as unknown as Promise<RunningReview>,
+  },
+  {
+    name: "Pi review",
+    start: () =>
+      startPiReviewServer({
+        rawPatch: PATCH,
+        gitRef: "HEAD",
+        origin: "pi",
+        htmlContent: MINIMAL_HTML,
+      }) as unknown as Promise<RunningReview>,
+  },
+];
+
+async function postFeedback(url: string, annotations: readonly unknown[]) {
+  return fetch(`${url}/api/feedback`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ approved: false, feedback: FEEDBACK, annotations }),
+  });
+}
+
+for (const runtime of runtimes) {
+  describe(`review-level note payload (${runtime.name})`, () => {
+    test("the note reaches waitForDecision unmodified, with the feedback byte-identical", async () => {
+      useTempDataDir();
+      const server = await runtime.start();
+      try {
+        const decision = server.waitForDecision();
+        const response = await postFeedback(server.url, [LINE_COMMENT, NOTE]);
+        expect(response.status).toBe(200);
+
+        const result = await decision;
+        expect(result.approved).toBe(false);
+        // Byte-identical: the ## General section the note lives in is what the
+        // agent actually reads.
+        expect(result.feedback).toBe(FEEDBACK);
+        expect(result.annotations.length).toBe(2);
+        // Deep-equal, so a dropped `scope` or a rewritten sentinel path fails.
+        expect(result.annotations[1]).toEqual(NOTE);
+      } finally {
+        server.stop();
+      }
+    });
+
+    test("a note-carrying submission archives as a feedback decision that counts the note", async () => {
+      const dataDir = useTempDataDir();
+      enableArchive();
+      const server = await runtime.start();
+      try {
+        const decision = server.waitForDecision();
+        expect((await postFeedback(server.url, [LINE_COMMENT, NOTE])).status).toBe(200);
+        await decision;
+
+        const projects = readdirSync(join(dataDir, "feedback"));
+        expect(projects.length).toBe(1);
+        const records = parseFeedbackIndex(
+          readFileSync(join(dataDir, "feedback", projects[0], "index.jsonl"), "utf-8"),
+        );
+        expect(records.length).toBe(1);
+        expect(records[0].decision).toBe("feedback");
+        expect(records[0].counts.annotations).toBe(2);
+        // The sidecar exists and carries the note's text, so a submission whose
+        // only content is a review-level note is recoverable from disk.
+        expect(records[0].recordFile).toBeTruthy();
+        const sidecar = readFileSync(
+          join(dataDir, "feedback", projects[0], records[0].recordFile as string),
+          "utf-8",
+        );
+        expect(sidecar).toContain(NOTE_TEXT);
+      } finally {
+        server.stop();
+      }
+    });
+  });
+}

--- a/packages/ui/shortcuts/code-review/reviewNote.shortcuts.ts
+++ b/packages/ui/shortcuts/code-review/reviewNote.shortcuts.ts
@@ -1,0 +1,27 @@
+import { defineShortcutScope } from '../core';
+
+/** The "Add a note" field on the code review Send control (and its compact
+ * dialog). The field is multi-line, so a bare Enter is a newline and the send
+ * chord is Mod+Enter. The handlers are local to the input; this scope exists so
+ * the chords show up in the in-app help modal and the generated docs, the same
+ * way the comment editor's chords do. */
+export const reviewNoteShortcuts = defineShortcutScope({
+  id: 'review-note',
+  title: 'Quick Note',
+  shortcuts: {
+    submit: {
+      description: 'Send the note with your annotations',
+      bindings: ['Mod+Enter'],
+      section: 'Actions',
+      hint: 'Available while the Send control’s note field is open. Enter inserts a newline.',
+      displayOrder: 12,
+    },
+    cancel: {
+      description: 'Close the note field without sending',
+      bindings: ['Escape'],
+      section: 'Actions',
+      hint: 'The typed note is kept for the rest of the session but is not sent.',
+      displayOrder: 14,
+    },
+  },
+});

--- a/packages/ui/shortcuts/index.ts
+++ b/packages/ui/shortcuts/index.ts
@@ -33,3 +33,4 @@ export { reviewAllFilesDiffShortcuts, useReviewAllFilesDiffShortcuts } from './c
 export { reviewAiShortcuts, useReviewAiShortcuts } from './code-review/ai.shortcuts';
 export { reviewSuggestionModalShortcuts, useReviewSuggestionModalShortcuts } from './code-review/suggestionModal.shortcuts';
 export { reviewTourDialogShortcuts, useReviewTourDialogShortcuts } from './code-review/tourDialog.shortcuts';
+export { reviewNoteShortcuts } from './code-review/reviewNote.shortcuts';


### PR DESCRIPTION
## Summary

Brings the one-step note-with-submit affordance to code review, per the approved spec (DESIGN_review-send-with-note.md) and matching the maintainer-approved control on #1436 exactly:

- One joined split pill [Send Feedback | v]. The left segment is the incumbent plain send, unchanged in meaning; the caret opens a right-anchored panel with a multi-line auto-growing textarea and its own distinct action, "Send with additional feedback".
- The note materializes at submit as a `scope: 'general'` CodeAnnotation, riding the existing sidebar General group, `renderGeneralComments` export, `/api/feedback` payload, and the feedback archive — zero server changes on either runtime (both handlers forward the annotations array verbatim; verified in the spec and pinned by dual-runtime payload tests).
- While the panel is open, the header primary fades to 40% and is disabled so the panel's action is unmistakably the submit; the panel's action always renders full-strength (an empty-note click refocuses the field). Both details are maintainer-directed from live design review and regression-tested.
- Enter is a newline; Mod+Enter submits with feedback; Esc closes and keeps the half-typed text.
- Compact/touch surface gets an additive `note` row in the review ActionMenu opening a dialog with the same field.
- LGTM/Approve is deliberately untouched: four of five runtime consumers discard feedback on approve today, so approve-with-note is deferred to its own phase (see the spec's blocker analysis).

## Scope guarantees

Zero files changed under `packages/server` or `apps/pi-extension`. `packages/ui` changes are one additive shortcut scope file plus its barrel export. No existing button is removed or hidden — the split's left segment IS the incumbent Send Feedback.

## Tests

11 control DOM tests (pill anatomy, panel open/close, newline vs Mod+Enter, Esc-keeps-text, outside-click, fade+disable of the primary with restore, panel action never grayed, frozen action label), export trace through `renderGeneralComments`, dual-runtime payload assertions, compact menu row. Full `packages/review-editor` + shortcuts suite: 449 pass. Typecheck clean; `apps/review` build verified; reviewed live by the maintainer across three design iterations.

AI-assisted (Claude) under maintainer direction.