### PR TITLE
fix(opencode): queue-deliver the session URL notice (#1459)

### DIFF
--- a/apps/opencode-plugin/native-commands.test.ts
+++ b/apps/opencode-plugin/native-commands.test.ts
@@ -545,6 +545,10 @@ describe("V2 session URL delivery", () => {
   // Regression: without `resume: false` upstream calls `execution.wake`
   // (packages/core/src/session/session.ts), so merely showing a URL would start
   // a model turn the reviewer never asked for and burn tokens on every command.
+  // #1459 extension: resume: false only defers the immediate wake; the host
+  // default delivery is "steer", which any later wake (including spurious
+  // idle wakes on OpenCode 2 betas) promotes into its own model turn. The
+  // notice must therefore also pin queue delivery.
   test("the notice never wakes a model turn", async () => {
     const { synthetic, ctx } = makeSyntheticCtx();
     const client = createV2BridgeClient({ ctx, getAgents: async () => [], sessionID: "session-1" });
@@ -552,7 +556,7 @@ describe("V2 session URL delivery", () => {
     pushUrlLine(client);
     await Promise.resolve();
 
-    expect(synthetic.mock.calls[0]![0]).toMatchObject({ resume: false });
+    expect(synthetic.mock.calls[0]![0]).toMatchObject({ resume: false, delivery: "queue" });
   });
 
   // Regression: `session.synthetic` is absent on older V2 hosts, and a session

--- a/apps/opencode-plugin/server.test.ts
+++ b/apps/opencode-plugin/server.test.ts
@@ -401,6 +401,8 @@ describe("V2 plan review URL delivery", () => {
       sessionID: "session-1",
       description: formatSessionUrlNotice(SESSION_URL),
       resume: false,
+      // #1459: queue delivery keeps the notice out of steer-scoped promotion.
+      delivery: "queue",
     });
   });
 

--- a/apps/opencode-plugin/v2-client.ts
+++ b/apps/opencode-plugin/v2-client.ts
@@ -247,8 +247,12 @@ export function formatSessionUrlNotice(url: string): string {
  *  - Setting no `metadata.source` keeps it on the plain "Notice" row rather
  *    than the subagent/shell completion row.
  *
- * `delivery` is left at the host default, matching upstream's own synthetic
- * notices; only feedback (`FEEDBACK_DELIVERY`) needs an explicit queue.
+ * `delivery` is an explicit "queue", mirroring `FEEDBACK_DELIVERY` (#1459).
+ * The host default resolves to "steer", and a pending steer row is promoted
+ * FIRST by any wake, including spurious idle wakes observed on OpenCode 2
+ * betas where `resume: false` defers the immediate wake but a later wake
+ * turns the notice into its own model turn. Queue delivery keeps the notice
+ * out of every steer-scoped promotion and is a no-op on well-behaved hosts.
  *
  * This does not contradict the reason feedback avoids synthetic injection.
  * Upstream #44788 is about a synthetic message not reliably reaching the MODEL
@@ -267,7 +271,14 @@ export function createSessionUrlNotifier(
   if (typeof synthetic !== "function" || !sessionID) return undefined;
   return async ({ url }) => {
     const notice = formatSessionUrlNotice(url);
-    return await synthetic({ sessionID, text: notice, description: notice, resume: false });
+    return await synthetic({
+      sessionID,
+      text: notice,
+      description: notice,
+      resume: false,
+      // #1459: never ride the "steer" default; see the delivery note above.
+      delivery: FEEDBACK_DELIVERY,
+    });
   };
 }
 


### PR DESCRIPTION
Mitigation for #1459. Closes #1459. On OpenCode 2 beta-18866 the transcript notice "Plannotator session ready: <url>" starts a model turn while the reviewer is still annotating, despite resume: false, and queued feedback then lands behind that spurious turn.

Triage attribution: the plugin passes resume: false on exactly the path the reporter hit (createSessionUrlNotifier in v2-client.ts, the only producer of that notice text), and the pinned test drives that chain, so this is not an injection regression. Against upstream origin/v2 as of 2026-08-30 the resume guard behaves; the beta build postdates our checkout. The mechanism that makes the beta wake harmful on our side: resume: false only defers the immediate wake, and the notice previously rode the host default delivery, which resolves to steer. A pending steer row is promoted first by any later wake, so a spurious idle wake turns the notice into its own model turn.

The fix passes an explicit delivery: "queue" on the notice synthetic, mirroring what feedback already does (FEEDBACK_DELIVERY). Queue rows never ride steer-scoped promotion, so the notice renders in the transcript and waits for a genuinely user-initiated turn. No behavior change on hosts where the guard works.

Both pinned wake tests now assert resume: false and delivery: "queue" together. Plugin suite: 53 pass.

Caveat recorded in the triage: this does not defend against a hypothetical input-scoped spurious wake; if the reporter still reproduces, the remaining fix is upstream, and an upstream report is warranted either way since upstream's own resume: false synthetics would burn a turn under the same beta conditions.
