### PR TITLE
fix(review): open the References panel beside the diff

### DIFF
--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -1114,8 +1114,11 @@ const ReviewApp: React.FC = () => {
         id: REVIEW_CODE_NAV_PANEL_ID,
         component: REVIEW_PANEL_TYPES.CODE_NAV,
         title: `References: ${request.symbol}`,
-        position: { direction: 'below', referencePanel: refPanel },
-        initialHeight: 250,
+        // Open beside the code, not under it: a below-split steals vertical
+        // room from the diff being read, and the references list is a narrow
+        // column that reads naturally at the right edge.
+        position: { direction: 'right', referencePanel: refPanel },
+        initialWidth: 420,
       });
     }
   }, [codeNav.resolve, dockApi, isAllFilesActive, isCallFlowActive, isSemanticDiffActive, gitContext, agentCwd]);


### PR DESCRIPTION
The References panel (Cmd+click on a token, and hover card location links) opened as a below-split, which steals vertical room from exactly the code being read. It now opens as a right-split at 420px beside the active diff panel, where a references list reads naturally as a column. Reusing an already-open panel is unchanged, and the panel remains draggable to any position Dockview allows.