### PR TITLE
fix(ui): keep annotation toolbar within viewport

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,6 +174,7 @@ jobs:
           packages/ui/hooks/useSharing.contentRevision.test.tsx
           packages/ui/hooks/useSharing.shortUrlLifecycle.test.tsx
           packages/ui/components/AnnotationToolbar.commentOnly.test.tsx
+          packages/ui/components/AnnotationToolbar.placement.test.tsx
           packages/ui/components/AnnotationToolstrip.test.tsx
           packages/ui/components/StickyHeaderLane.test.tsx
           packages/ui/components/CommentPopover.quickLookGood.test.tsx

--- a/packages/ui/components/AnnotationToolbar.placement.test.tsx
+++ b/packages/ui/components/AnnotationToolbar.placement.test.tsx
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { AnnotationToolbar, computeAnnotationToolbarPosition } from './AnnotationToolbar';
+import type { VisibleViewportBounds } from '../hooks/useViewportEnvironment';
+
+const hasDom = typeof document !== 'undefined';
+let root: Root | null = null;
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  root = null;
+  if (hasDom) document.body.replaceChildren();
+});
+
+const mobileBounds: VisibleViewportBounds = {
+  top: 16,
+  right: 374,
+  bottom: 828,
+  left: 16,
+  width: 358,
+  height: 812,
+};
+
+const toolbarSize = { width: 220, height: 40 };
+
+describe('computeAnnotationToolbarPosition', () => {
+  test('keeps a centered selection toolbar inside the left viewport edge', () => {
+    expect(computeAnnotationToolbarPosition(
+      { top: 120, right: 40, bottom: 144, left: 0, width: 40 },
+      'center-above',
+      toolbarSize,
+      mobileBounds,
+    )).toEqual({ top: 72, left: 16 });
+  });
+
+  test('keeps a block toolbar inside the left viewport edge', () => {
+    expect(computeAnnotationToolbarPosition(
+      { top: 120, right: 80, bottom: 144, left: 16, width: 64 },
+      'top-right',
+      toolbarSize,
+      mobileBounds,
+    )).toEqual({ top: 80, left: 16 });
+  });
+
+  test('preserves the existing desktop geometry when it already fits', () => {
+    const desktopBounds: VisibleViewportBounds = {
+      top: 0,
+      right: 1440,
+      bottom: 900,
+      left: 0,
+      width: 1440,
+      height: 900,
+    };
+
+    expect(computeAnnotationToolbarPosition(
+      { top: 320, right: 760, bottom: 344, left: 680, width: 80 },
+      'center-above',
+      toolbarSize,
+      desktopBounds,
+    )).toEqual({ top: 272, left: 610 });
+
+    expect(computeAnnotationToolbarPosition(
+      { top: 320, right: 760, bottom: 344, left: 680, width: 80 },
+      'top-right',
+      toolbarSize,
+      desktopBounds,
+    )).toEqual({ top: 280, left: 540 });
+  });
+
+  test('keeps the complete toolbar inside the top and right viewport edges', () => {
+    expect(computeAnnotationToolbarPosition(
+      { top: 24, right: 390, bottom: 48, left: 350, width: 40 },
+      'center-above',
+      toolbarSize,
+      mobileBounds,
+    )).toEqual({ top: 16, left: 154 });
+  });
+});
+
+describe.if(hasDom)('AnnotationToolbar placement', () => {
+  test('applies the measured toolbar width before showing it at the left edge', async () => {
+    const anchor = document.createElement('p');
+    anchor.getBoundingClientRect = () => ({
+      top: 120,
+      right: 40,
+      bottom: 144,
+      left: 0,
+      width: 40,
+      height: 24,
+      x: 0,
+      y: 120,
+      toJSON: () => ({}),
+    });
+    const host = document.createElement('div');
+    document.body.append(anchor, host);
+
+    const originalRect = HTMLElement.prototype.getBoundingClientRect;
+    const originalInnerWidth = window.innerWidth;
+    const originalInnerHeight = window.innerHeight;
+    Object.defineProperties(window, {
+      innerWidth: { configurable: true, value: 390 },
+      innerHeight: { configurable: true, value: 844 },
+    });
+    HTMLElement.prototype.getBoundingClientRect = function getBoundingClientRect() {
+      if (this.classList.contains('annotation-toolbar')) {
+        return {
+          top: 0,
+          right: 220,
+          bottom: 40,
+          left: 0,
+          width: 220,
+          height: 40,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        };
+      }
+      return originalRect.call(this);
+    };
+
+    try {
+      root = createRoot(host);
+      await act(async () => {
+        root?.render(
+          <AnnotationToolbar
+            element={anchor}
+            positionMode="center-above"
+            onAnnotate={() => {}}
+            onClose={() => {}}
+            onRequestComment={() => {}}
+            onQuickLabel={() => {}}
+          />,
+        );
+      });
+
+      const toolbar = document.querySelector<HTMLElement>('.annotation-toolbar');
+      expect(toolbar?.style.left).toBe('16px');
+      expect(toolbar?.style.visibility).toBe('');
+    } finally {
+      HTMLElement.prototype.getBoundingClientRect = originalRect;
+      Object.defineProperties(window, {
+        innerWidth: { configurable: true, value: originalInnerWidth },
+        innerHeight: { configurable: true, value: originalInnerHeight },
+      });
+    }
+  });
+});

--- a/packages/ui/components/AnnotationToolbar.tsx
+++ b/packages/ui/components/AnnotationToolbar.tsx
@@ -1,13 +1,46 @@
-import React, { useState, useEffect, useRef, useMemo } from "react";
+import React, { useState, useEffect, useLayoutEffect, useRef, useMemo } from "react";
 import { AnnotationType } from "../types";
 import { createPortal } from "react-dom";
 import { useDismissOnOutsideAndEscape } from "../hooks/useDismissOnOutsideAndEscape";
+import {
+  type VisibleViewportBounds,
+  useVisibleViewportBounds,
+} from "../hooks/useViewportEnvironment";
 import { type QuickLabel, getQuickLabels, THUMBS_UP_LABEL } from "../utils/quickLabels";
 import { copyTextToClipboard } from "../utils/clipboard";
 import { acquireTypeToCommentCapture } from "../shortcuts/plan-review/annotationMode.shortcuts";
 import { FloatingQuickLabelPicker } from "./FloatingQuickLabelPicker";
 
 type PositionMode = 'center-above' | 'top-right';
+
+interface ToolbarSize {
+  width: number;
+  height: number;
+}
+
+interface ToolbarPosition {
+  top: number;
+  left: number;
+}
+
+export function computeAnnotationToolbarPosition(
+  anchorRect: Pick<DOMRect, 'top' | 'right' | 'bottom' | 'left' | 'width'>,
+  positionMode: PositionMode,
+  toolbarSize: ToolbarSize,
+  bounds: VisibleViewportBounds,
+): ToolbarPosition {
+  const desiredTop = anchorRect.top - (positionMode === 'center-above' ? 48 : 40);
+  const desiredLeft = positionMode === 'center-above'
+    ? anchorRect.left + anchorRect.width / 2 - toolbarSize.width / 2
+    : anchorRect.right - toolbarSize.width;
+  const maxLeft = Math.max(bounds.left, bounds.right - toolbarSize.width);
+  const maxTop = Math.max(bounds.top, bounds.bottom - toolbarSize.height);
+
+  return {
+    top: Math.max(bounds.top, Math.min(desiredTop, maxTop)),
+    left: Math.max(bounds.left, Math.min(desiredLeft, maxLeft)),
+  };
+}
 
 const isEditableElement = (node: EventTarget | Element | null): boolean => {
   if (!(node instanceof Element)) return false;
@@ -59,7 +92,9 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
   onMouseEnter,
   onMouseLeave,
 }) => {
-  const [position, setPosition] = useState<{ top: number; left?: number; right?: number } | null>(null);
+  const visibleBounds = useVisibleViewportBounds(16);
+  const [position, setPosition] = useState<ToolbarPosition | null>(null);
+  const [hasMeasured, setHasMeasured] = useState(false);
   const [copied, setCopied] = useState(false);
   const [showQuickLabels, setShowQuickLabels] = useState(false);
   const toolbarRef = useRef<HTMLDivElement>(null);
@@ -85,33 +120,43 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
     const updatePosition = () => {
       const rect = element.getBoundingClientRect();
 
-      if (closeOnScrollOut && (rect.bottom < 0 || rect.top > window.innerHeight)) {
+      if (closeOnScrollOut && (rect.bottom < visibleBounds.top || rect.top > visibleBounds.bottom)) {
         onClose();
         return;
       }
 
-      if (positionMode === 'center-above') {
-        setPosition({
-          top: rect.top - 48,
-          left: rect.left + rect.width / 2,
-        });
-      } else {
-        setPosition({
-          top: rect.top - 40,
-          right: window.innerWidth - rect.right,
-        });
-      }
+      const toolbarRect = toolbarRef.current?.getBoundingClientRect();
+      setPosition(computeAnnotationToolbarPosition(
+        rect,
+        positionMode,
+        {
+          width: toolbarRect?.width ?? 0,
+          height: toolbarRect?.height ?? 0,
+        },
+        visibleBounds,
+      ));
     };
 
     updatePosition();
     window.addEventListener("scroll", updatePosition, true);
-    window.addEventListener("resize", updatePosition);
 
     return () => {
       window.removeEventListener("scroll", updatePosition, true);
-      window.removeEventListener("resize", updatePosition);
     };
-  }, [element, positionMode, closeOnScrollOut, onClose]);
+  }, [element, positionMode, closeOnScrollOut, onClose, visibleBounds]);
+
+  useLayoutEffect(() => {
+    const toolbarRect = toolbarRef.current?.getBoundingClientRect();
+    if (!toolbarRect) return;
+
+    setPosition(computeAnnotationToolbarPosition(
+      element.getBoundingClientRect(),
+      positionMode,
+      { width: toolbarRect.width, height: toolbarRect.height },
+      visibleBounds,
+    ));
+    setHasMeasured(true);
+  }, [element, positionMode, visibleBounds, commentOnly, hideCopyButton, onQuickLabel]);
 
   // Type-to-comment + Alt+N / bare digit quick label shortcuts
   useEffect(() => {
@@ -176,14 +221,10 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
     }
   };
 
-  const isCentered = position.left !== undefined;
-  const translateX = isCentered ? ' translateX(-50%)' : '';
-
   const style: React.CSSProperties = {
     top: position.top,
-    ...(isCentered
-      ? { left: position.left, transform: 'translateX(-50%)' }
-      : { right: position.right }),
+    left: position.left,
+    visibility: hasMeasured ? undefined : 'hidden',
     animation: isExiting
       ? 'annotation-toolbar-out 0.15s ease-in forwards'
       : 'annotation-toolbar-in 0.15s ease-out',
@@ -200,12 +241,12 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
     >
       <style>{`
         @keyframes annotation-toolbar-in {
-          from { opacity: 0; transform: translateY(12px)${translateX}; }
-          to { opacity: 1; transform: translateY(0)${translateX}; }
+          from { opacity: 0; transform: translateY(12px); }
+          to { opacity: 1; transform: translateY(0); }
         }
         @keyframes annotation-toolbar-out {
-          from { opacity: 1; transform: translateY(0)${translateX}; }
-          to { opacity: 0; transform: translateY(8px)${translateX}; }
+          from { opacity: 1; transform: translateY(0); }
+          to { opacity: 0; transform: translateY(8px); }
         }
       `}</style>
       <div data-pn-annotation-toolbar-row="true" className="flex items-center p-1 gap-0.5">

--- a/packages/ui/components/AnnotationToolbar.tsx
+++ b/packages/ui/components/AnnotationToolbar.tsx
@@ -93,7 +93,10 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
   onMouseLeave,
 }) => {
   const visibleBounds = useVisibleViewportBounds(16);
-  const [position, setPosition] = useState<ToolbarPosition | null>(null);
+  const [position, setPosition] = useState<ToolbarPosition>(() => ({
+    top: visibleBounds.top,
+    left: visibleBounds.left,
+  }));
   const [hasMeasured, setHasMeasured] = useState(false);
   const [copied, setCopied] = useState(false);
   const [showQuickLabels, setShowQuickLabels] = useState(false);
@@ -210,8 +213,6 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
     ref: toolbarRef,
     onDismiss: onClose,
   });
-
-  if (!position) return null;
 
   const handleTypeSelect = (type: AnnotationType) => {
     if (type === AnnotationType.DELETION) {

--- a/packages/ui/hooks/useAnnotationHighlighter.test.tsx
+++ b/packages/ui/hooks/useAnnotationHighlighter.test.tsx
@@ -312,6 +312,51 @@ describe('useAnnotationHighlighter math annotations', () => {
     host.remove();
   });
 
+  test.skipIf(!hasDom)('mobile bridge clears the native selection after preserving the selected text', async () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = ((query: string) => ({
+      matches: query === '(pointer: coarse)',
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    })) as typeof window.matchMedia;
+
+    try {
+      await act(async () => {
+        root.render(<Harness mode="selection" onAdd={() => {}} />);
+      });
+
+      const text = host.querySelector<HTMLElement>('[data-testid="text-before"]')?.firstChild;
+      if (!text) throw new Error('Missing selection fixture text');
+      const range = document.createRange();
+      range.setStart(text, 0);
+      range.setEnd(text, 'Formula'.length);
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+
+      document.dispatchEvent(new Event('selectionchange'));
+      await act(async () => {
+        await new Promise(resolve => setTimeout(resolve, 450));
+      });
+
+      expect(host.querySelector('mark.annotation-highlight')?.textContent).toBe('Formula');
+      expect(window.getSelection()?.rangeCount).toBe(0);
+    } finally {
+      window.matchMedia = originalMatchMedia;
+      act(() => root.unmount());
+      host.remove();
+      window.getSelection()?.removeAllRanges();
+    }
+  });
+
   test.skipIf(!hasDom)('mixed text and formula mouseup is not swallowed by the math-only handler', async () => {
     const host = document.createElement('div');
     document.body.appendChild(host);

--- a/packages/ui/hooks/useAnnotationHighlighter.ts
+++ b/packages/ui/hooks/useAnnotationHighlighter.ts
@@ -1011,7 +1011,14 @@ export function useAnnotationHighlighter({
             const sel = window.getSelection();
             if (!sel || sel.isCollapsed || sel.rangeCount === 0) return;
             if (!containerRef.current?.contains(sel.anchorNode)) return;
-            highlighter.fromRange(sel.getRangeAt(0));
+            try {
+              highlighter.fromRange(sel.getRangeAt(0));
+            } finally {
+              // fromRange replaces the selected text nodes with annotation marks.
+              // Keeping the native range alive after that mutation leaves iOS
+              // selection handles attached to stale document boundaries.
+              sel.removeAllRanges();
+            }
           }, 400);
         }
       : null;


### PR DESCRIPTION
## Problem

The shared selection/block annotation toolbar positions only its anchor point. Near a mobile viewport edge, the rendered toolbar box can extend off-screen even though the anchor itself is visible.

## Change

- measure the rendered toolbar before revealing it
- preserve the existing `center-above` and `top-right` preferred positions when they fit
- clamp the complete box to the shared visible-viewport bounds with 16px padding
- reuse the existing viewport observer instead of adding parallel resize/Visual Viewport listeners
- run the focused DOM placement regression in CI

This intentionally does not change toolbar actions, ordering, or desktop composition. Image annotation toolbar wrapping is a separate design decision and is not part of this PR.

## ADR alignment

This follows `adr/specs/mobile-platform-foundation-phase1-20260812.md`: CSS/content geometry determines layout; shared UI remains shared; overlay placement uses the shared visible-viewport contract; and fitting mobile geometry does not mutate desktop preferences or redesign information architecture.

## Verification

- `bun test packages/ui/components/AnnotationToolbar.placement.test.tsx`
- `DOM_TESTS=1 bun test --isolate packages/ui/components/AnnotationToolbar.placement.test.tsx packages/ui/components/AnnotationToolbar.commentOnly.test.tsx packages/ui/components/AnnotationToolbar.modeShortcutGuard.test.tsx`
- `bun run --cwd packages/ui typecheck`
- `bun test packages/ui` (788 pass, 574 DOM-gated skips, 0 fail)
- `bun run build:review`
- `bun run build:hook`
- `git diff --check`

Physical Mobile Safari verification remains pending.