### PR TITLE
fix(ui): keep selection toolbar within compact touch viewport

### DIFF
--- a/packages/core/guide-viewer-manifest.ts
+++ b/packages/core/guide-viewer-manifest.ts
@@ -6,9 +6,9 @@ import type { GuideViewerAssets } from "./guide-format";
 
 export const GUIDE_VIEWER_MANIFEST: Omit<GuideViewerAssets, "baseUrl"> = {
   js: "viewer.C8JgNbZu.js",
-  css: "viewer.DPA8Hcib.css",
+  css: "viewer.KIp-iPxY.css",
   jsIntegrity: "sha384-dqRkZ2N5WNwLIuwa+1kdrvswkOVHpkBxrrJ5mTU4YrUWzO/8fRS5MRTlDGV9t7eB",
-  cssIntegrity: "sha384-Bs19ETlOYAovT/ItKvQ9S93jOGOSYjsC6QQk4+oTMunGv7TJ0kxWApsP7hF2fHGE",
+  cssIntegrity: "sha384-Ty9hGpag8KIAGMDPg7ImsB4L5RabqvonNVjrj/CnYqSJDqIgPRBwjEMoK9/EvgXm",
   langs: {
     "astro": "chunks/astro.BykyiR6i.js",
     "c": "chunks/c.BIGW1oBm.js",

--- a/packages/ui/components/AnnotationToolbar.commentOnly.test.tsx
+++ b/packages/ui/components/AnnotationToolbar.commentOnly.test.tsx
@@ -26,7 +26,7 @@ afterEach(async () => {
   if (hasDom) document.body.replaceChildren();
 });
 
-async function mount(props: { commentOnly?: boolean; withQuickLabels?: boolean }) {
+async function mount(props: { commentOnly?: boolean; withQuickLabels?: boolean; positionMode?: 'center-above' | 'top-right' }) {
   anchor = document.createElement('p');
   anchor.textContent = 'annotated paragraph';
   document.body.appendChild(anchor);
@@ -37,7 +37,7 @@ async function mount(props: { commentOnly?: boolean; withQuickLabels?: boolean }
     root?.render(
       <AnnotationToolbar
         element={anchor!}
-        positionMode="center-above"
+        positionMode={props.positionMode ?? 'center-above'}
         onAnnotate={() => {}}
         onClose={() => {}}
         onRequestComment={() => {}}
@@ -52,6 +52,24 @@ async function mount(props: { commentOnly?: boolean; withQuickLabels?: boolean }
 }
 
 describe.if(hasDom)('AnnotationToolbar commentOnly seam', () => {
+  test('centered placement exposes its anchor without changing the existing transform or animation', async () => {
+    await mount({});
+    const toolbar = document.querySelector<HTMLElement>('.annotation-toolbar')!;
+    expect(toolbar.dataset.pnAnnotationToolbarCentered).toBe('true');
+    expect(toolbar.style.getPropertyValue('--pn-annotation-toolbar-anchor-x')).toBe(toolbar.style.left);
+    expect(toolbar.style.transform).toBe('translateX(-50%)');
+    expect(toolbar.style.animation).toBe('annotation-toolbar-in 0.15s ease-out');
+  });
+
+  test('right-aligned placement does not opt into horizontal correction', async () => {
+    await mount({ positionMode: 'top-right' });
+    const toolbar = document.querySelector<HTMLElement>('.annotation-toolbar')!;
+    expect(toolbar.hasAttribute('data-pn-annotation-toolbar-centered')).toBe(false);
+    expect(toolbar.style.getPropertyValue('--pn-annotation-toolbar-anchor-x')).toBe('');
+    expect(toolbar.style.left).toBe('');
+    expect(toolbar.style.right).not.toBe('');
+  });
+
   test('commentOnly without a label handler hides Delete and every label affordance', async () => {
     const titles = await mount({ commentOnly: true });
     expect(titles).toContain('Comment');

--- a/packages/ui/components/AnnotationToolbar.tsx
+++ b/packages/ui/components/AnnotationToolbar.tsx
@@ -179,8 +179,9 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
   const isCentered = position.left !== undefined;
   const translateX = isCentered ? ' translateX(-50%)' : '';
 
-  const style: React.CSSProperties = {
+  const style: React.CSSProperties & { '--pn-annotation-toolbar-anchor-x'?: string } = {
     top: position.top,
+    '--pn-annotation-toolbar-anchor-x': isCentered ? `${position.left}px` : undefined,
     ...(isCentered
       ? { left: position.left, transform: 'translateX(-50%)' }
       : { right: position.right }),
@@ -192,6 +193,7 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
   return createPortal(
     <div
       ref={toolbarRef}
+      data-pn-annotation-toolbar-centered={isCentered ? 'true' : undefined}
       className="annotation-toolbar fixed z-[100] bg-popover border border-border rounded-lg shadow-2xl"
       style={style}
       onMouseDown={(e) => e.stopPropagation()}

--- a/packages/ui/theme.css
+++ b/packages/ui/theme.css
@@ -912,6 +912,17 @@ html:has([data-pn-compact-touch-layout='true'])
   gap: 0.5rem;
 }
 
+/* Percentages in translate use the toolbar's own width. Correct only its
+ * horizontal overflow; leave the existing transform animation untouched. */
+html:has([data-pn-compact-touch-layout='true'])
+  [data-pn-annotation-toolbar-centered='true'] {
+  translate: clamp(
+    calc(var(--pn-viewport-offset-left, 0px) + var(--pn-safe-left, 0px) - var(--pn-annotation-toolbar-anchor-x) + 50%),
+    0px,
+    calc(var(--pn-viewport-offset-left, 0px) + var(--pn-viewport-width, 100vw) - var(--pn-safe-right, 0px) - var(--pn-annotation-toolbar-anchor-x) - 50%)
+  ) 0;
+}
+
 html:has([data-pn-compact-touch-layout='true'])
   [data-pn-touch-target]:not(:disabled):not([aria-disabled='true']):active {
   filter: brightness(0.92);


### PR DESCRIPTION
## Summary

Fix horizontal overflow of the text-selection toolbar when selecting short text near a screen edge in compact touch layouts.

- Use the existing compact-touch marker and viewport/safe-area CSS variables with `translate: clamp(...)` to constrain horizontal placement. Keep the existing centered position when it fits.
- Preserve vertical positioning, display timing, animations, selection handling, and button layout.
- Leave desktop placement and the right-aligned code-block toolbar unchanged.

## Testing

- Added regression tests for the existing placement/animation declarations and for keeping right-aligned toolbars outside the correction.
- Passed 8 related DOM tests, the UI typecheck, and review/hook builds.
- Checked left- and right-edge overflow correction in Chromium and WebKit at a 390px touch viewport, and unchanged placement at 1200px and 390px desktop viewports.
- Verified display and interaction on a physical iPhone.

The existing happy-dom environment does not calculate CSS layout, so automated layout assertions are not included. Happy to add them using the project's preferred browser-testing setup if desired.
