### PR TITLE
fix(review): show setup after fresh-profile settings initialization

### DIFF
--- a/packages/core/guide-viewer-manifest.ts
+++ b/packages/core/guide-viewer-manifest.ts
@@ -5,9 +5,9 @@
 import type { GuideViewerAssets } from "./guide-format";
 
 export const GUIDE_VIEWER_MANIFEST: Omit<GuideViewerAssets, "baseUrl"> = {
-  js: "viewer.C8JgNbZu.js",
+  js: "viewer.-z4hZ-DF.js",
   css: "viewer.KIp-iPxY.css",
-  jsIntegrity: "sha384-dqRkZ2N5WNwLIuwa+1kdrvswkOVHpkBxrrJ5mTU4YrUWzO/8fRS5MRTlDGV9t7eB",
+  jsIntegrity: "sha384-0m4lvEvRi8w3vafYuzG3N918AAH78sDPytVzerfzpOBxU63u3VrdyhHpBOVpDT4u",
   cssIntegrity: "sha384-Ty9hGpag8KIAGMDPg7ImsB4L5RabqvonNVjrj/CnYqSJDqIgPRBwjEMoK9/EvgXm",
   langs: {
     "astro": "chunks/astro.BykyiR6i.js",

--- a/packages/review-editor/utils/reviewSetup.test.ts
+++ b/packages/review-editor/utils/reviewSetup.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { resetStorageBackend, setStorageBackend } from '@plannotator/ui/utils/storage';
 import { ConfigStoreForTest } from '../../ui/config/configStore';
+import { setReviewPanelView } from '../../ui/config/reviewView';
 import {
   initializeReviewSetup,
   needsReviewSetup,
@@ -32,15 +33,27 @@ afterEach(() => {
 });
 
 describe('initializeReviewSetup', () => {
-  test('a genuinely new reviewer starts with Tree while keeping the since-base diff default', () => {
+  test('a fresh reviewer reaches setup once after normal settings startup', () => {
     installMemoryBackend();
     const store = makeStore();
+
+    // Rendering reads settings before /api/diff initializes server config.
+    // Neither step is evidence that the reviewer chose the registry default.
+    store.get('displayName');
+    store.init();
 
     expect(initializeReviewSetup(store)).toBe(true);
     expect(store.get('reviewPanelView')).toBe('tree');
     expect(store.get('reviewPanelViewLastUsed')).toBe('tree');
     expect(store.get('defaultDiffType')).toBe('since-base');
     expect(needsReviewSetup()).toBe(false);
+
+    expect(initializeReviewSetup(store)).toBe(false);
+    const nextSession = makeStore();
+    nextSession.init();
+    expect(initializeReviewSetup(nextSession)).toBe(false);
+    expect(nextSession.get('reviewPanelView')).toBe('tree');
+    expect(nextSession.get('reviewPanelViewLastUsed')).toBe('tree');
   });
 
   test('an unseen reviewer inherits an existing classic diff default', () => {
@@ -48,6 +61,8 @@ describe('initializeReviewSetup', () => {
       'plannotator-default-diff-type': 'uncommitted',
     });
     const store = makeStore();
+    store.get('reviewPanelView');
+    store.init();
 
     expect(initializeReviewSetup(store)).toBe(true);
     expect(store.get('reviewPanelView')).toBe('tree');
@@ -55,15 +70,22 @@ describe('initializeReviewSetup', () => {
     expect(store.get('defaultDiffType')).toBe('uncommitted');
   });
 
-  test('an unseen reviewer inherits a local-vs-remote default', () => {
+  test('first-run setup preserves the server diff default without writing it back', async () => {
     installMemoryBackend({
-      'plannotator-default-diff-type': 'local-vs-remote',
+      'plannotator-default-diff-type': 'uncommitted',
     });
     const store = makeStore();
+    const synced: Record<string, unknown>[] = [];
+    store.setServerSync(payload => { synced.push(payload); });
+    store.get('reviewPanelView');
+    store.init({ diffOptions: { defaultDiffType: 'local-vs-remote' } });
 
     expect(initializeReviewSetup(store)).toBe(true);
     expect(store.get('reviewPanelView')).toBe('tree');
     expect(store.get('defaultDiffType')).toBe('local-vs-remote');
+
+    await new Promise<void>(resolve => setTimeout(resolve, 350));
+    expect(synced).toEqual([]);
   });
 
   test('an explicit persisted view survives a session that never tripped the seen gate', () => {
@@ -71,13 +93,19 @@ describe('initializeReviewSetup', () => {
     // initializer, so a reviewer can persist a view from Settings while
     // "seen" stays unset. The next plain git session must not seed over it.
     installMemoryBackend({
-      'plannotator-review-panel-view': 'sections',
-      'plannotator-default-diff-type': 'since-base',
+      'plannotator-review-panel-view-last-used': 'tree',
     });
+    const settingsStore = makeStore();
+    settingsStore.get('displayName');
+    // Even choosing the built-in default is an explicit choice.
+    setReviewPanelView('sections', undefined, settingsStore);
+
     const store = makeStore();
+    store.init();
 
     expect(initializeReviewSetup(store)).toBe(false);
     expect(store.get('reviewPanelView')).toBe('sections');
+    expect(store.get('reviewPanelViewLastUsed')).toBe('sections');
     expect(store.get('defaultDiffType')).toBe('since-base');
     // The one-time setup is consumed, so this cannot be re-evaluated later.
     expect(needsReviewSetup()).toBe(false);
@@ -89,6 +117,7 @@ describe('initializeReviewSetup', () => {
       'plannotator-review-panel-view-last-used': 'sections',
     });
     const store = makeStore();
+    store.init();
 
     expect(initializeReviewSetup(store)).toBe(false);
     expect(store.get('reviewPanelView')).toBe('tree');
@@ -106,6 +135,8 @@ describe('initializeReviewSetup', () => {
       'plannotator-default-diff-type': 'since-base',
     });
     const store = makeStore();
+    store.get('reviewPanelView');
+    store.init();
 
     expect(initializeReviewSetup(store)).toBe(false);
     expect(store.get('reviewPanelView')).toBe('sections');

--- a/packages/review-editor/utils/reviewSetup.ts
+++ b/packages/review-editor/utils/reviewSetup.ts
@@ -83,6 +83,8 @@ export function initializeReviewSetup(store: typeof configStore = configStore): 
   // let Settings persist a panel view, so a reviewer can hold an explicit
   // choice while "seen" stays unset. Seeding Tree there would overwrite it.
   // A persisted view IS the decision: consume the one-time setup and leave it.
+  // The registry keeps this default in memory only, so a settings read cannot
+  // manufacture that evidence before this initializer runs.
   if (getPersistedReviewPanelView() !== undefined) {
     markReviewSetupSeen();
     return false;

--- a/packages/ui/config/configStore.lazyInit.seam.test.ts
+++ b/packages/ui/config/configStore.lazyInit.seam.test.ts
@@ -70,4 +70,22 @@ describe('configStore lazy resolution', () => {
     expect(second).toBe(first);
     expect(reads.length).toBe(readsAfterLoad);
   });
+
+  test('default seeding leaves review setup undecided on load and backend hydration', () => {
+    setStorageBackend(hostBackend);
+    const store = new ConfigStoreForTest();
+    const identity = store.get('displayName');
+
+    expect(store.get('reviewPanelView')).toBe('sections');
+    expect(stored.has('plannotator-review-panel-view')).toBe(false);
+
+    // A host may install an empty backend after settings were already read.
+    stored.clear();
+    store.loadFromBackend();
+
+    // Generated defaults still persist, but a panel default is not a choice.
+    expect(stored.get('plannotator-identity')).toBe(identity);
+    expect(stored.has('plannotator-review-panel-view')).toBe(false);
+    expect(new ConfigStoreForTest().get('displayName')).toBe(identity);
+  });
 });

--- a/packages/ui/config/configStore.ts
+++ b/packages/ui/config/configStore.ts
@@ -89,7 +89,7 @@ class ConfigStore {
    * first use — deliberately not in the constructor. The singleton is created
    * at module import, which for a host app is before configurePlannotatorUI()
    * can install its StorageBackend; resolving eagerly there would write every
-   * missing default (including a generated identity) as cookies onto the host's
+   * eligible missing default (including a generated identity) onto the host's
    * origin. Deferring to first use means a host that configures at startup gets
    * its own backend for the initial resolution too — no cookies are ever
    * written on a configured host. Plannotator is unchanged: same resolution,
@@ -105,8 +105,8 @@ class ConfigStore {
         : def.defaultValue;
       const resolved = fromCookie ?? defaultVal;
       this.values.set(name, resolved);
-      // Persist generated defaults to cookie so the value is stable across calls
-      if (fromCookie === undefined) {
+      // Persist defaults for stability unless absence must remain distinguishable.
+      if (fromCookie === undefined && !('persistDefault' in def && def.persistDefault === false)) {
         def.toCookie(resolved as never);
       }
     }
@@ -127,9 +127,9 @@ class ConfigStore {
       const fromBackend = def.fromCookie();
       if (fromBackend !== undefined) {
         this.values.set(name, fromBackend);
-      } else {
-        // Seed the host backend with the resolved default. This matters when
-        // the store was already resolved BEFORE the host installed its
+      } else if (!('persistDefault' in def && def.persistDefault === false)) {
+        // Seed the host backend with the resolved default unless it opts out.
+        // This matters when the store was resolved BEFORE the host installed its
         // StorageBackend (e.g. something read a setting pre-configure): those
         // default-seeding writes went to the earlier backend, not this one.
         // Without this, a fresh host store is never populated, so generated

--- a/packages/ui/config/settings.ts
+++ b/packages/ui/config/settings.ts
@@ -95,6 +95,8 @@ function isDiffLineBgIntensity(v: unknown): v is DiffLineBgIntensity {
 
 export interface SettingDef<T> {
   defaultValue: T | (() => T);
+  /** Persist missing defaults automatically unless false; explicit writes are unaffected. */
+  persistDefault?: boolean;
   fromCookie: () => T | undefined;
   toCookie: (value: T) => void;
   /** If set, this setting syncs to server via POST /api/config */
@@ -223,6 +225,8 @@ export const SETTINGS = {
   // previously-persisted 'commits' cookie is treated as unset.
   reviewPanelView: {
     defaultValue: 'sections' as 'sections' | 'tree',
+    // An absent cookie means no user choice yet, so first-run setup can choose its default.
+    persistDefault: false,
     fromCookie: () => {
       const v = storage.getItem('plannotator-review-panel-view');
       return v === 'tree' || v === 'sections' ? v : undefined;


### PR DESCRIPTION
> *This was generated by AI during triage.*

Fixes #1463.

## Summary
`configStore` seeded `reviewPanelView` before the review setup gate ran, so a fresh profile looked like a returning reviewer with a saved choice.

- Add a per-setting `persistDefault` opt-out and apply it only to `reviewPanelView`, in both default-loading paths.
- Keep the resolved default in memory; explicit choices still persist normally.
- Preserve existing initialization, last-used memo, server diff-default precedence, and all other settings' default persistence. No new migration cookie or startup server write.

## Verification
- Focused setup/config regression suite: **22 passed**. Tests hydrate the real settings store before the setup initializer and cover returning/explicit choices.
- Full `bun test` with repository-pinned Bun 1.3.14, disposable HOME, and local macOS environment (`CI` unset): **4,303 passed, 904 skipped, 0 failed**.
- `bun run typecheck`, `git diff --check`, and review → hook production builds: passed.
- Real rebuilt CLI/browser smoke: fresh-profile look-and-feel → **Set up your review view** → Edit Mode → token-hover announcement; reload does not repeat setup and retains the Tree preference/memo.
- Independent Standards and Spec reviews completed. Pierre renderer integration is unchanged.

No pending PR addressing this issue was found in the open-PR inventory or issue timeline before starting; the inventory was rechecked before publication.

### CI correction (`c558b50d`)

Resolved the import-order bug behind #1464: storage now resolves the active data directory for every plan/history read and write instead of retaining an early test's temporary override. Added a regression for changing that override after import; no sleeps, retries, or weakened assertions. The ordered OpenCode→annotate reproduction fails four tests before this fix and passes after it on both macOS and Linux. Unprivileged Linux verification: 83 pass, 0 fail. Latest local full suite: 4,304 pass, 904 skip, 0 fail; typecheck passes.
