### PR TITLE
fix(review): error loudly on unknown review options instead of silently dropping them

### DIFF
--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -736,6 +736,15 @@ if (args[0] === "sessions") {
   // ============================================
 
   const reviewArgs = parseReviewArgs(args.slice(1));
+  // Argument-shape failures (unknown/typo'd flags) refuse to start a session:
+  // silently dropping them is how `--bse main` used to open a review as if
+  // nothing happened. Review has no strict-gate mode, so this is exit 1 like
+  // every other review startup failure.
+  if (reviewArgs.errors.length > 0) {
+    for (const parseError of reviewArgs.errors) console.error(parseError);
+    console.error("Run 'plannotator review --help' for usage.");
+    process.exit(1);
+  }
   const urlArg = reviewArgs.prUrl;
   const isPRMode = urlArg !== undefined;
   const useLocal = isPRMode && reviewArgs.useLocal;
@@ -1714,6 +1723,13 @@ if (args[0] === "sessions") {
     inputJson,
   );
   const reviewArgs = parseReviewArgs(typeof input.arguments === "string" ? input.arguments : "");
+  // Same refusal as the direct `review` branch. Errors go to stderr so the
+  // bridge's machine-readable stdout contract stays untouched.
+  if (reviewArgs.errors.length > 0) {
+    for (const parseError of reviewArgs.errors) console.error(parseError);
+    console.error("Run 'plannotator review --help' for usage.");
+    process.exit(1);
+  }
   const urlArg = reviewArgs.prUrl;
   const isPRMode = urlArg !== undefined;
 

--- a/apps/opencode-plugin/commands.ts
+++ b/apps/opencode-plugin/commands.ts
@@ -67,6 +67,14 @@ export async function handleReviewCommand(
 
   // @ts-ignore - Event properties contain arguments
   const reviewArgs = parseReviewArgs(event.properties?.arguments || "");
+  // Argument-shape failures refuse to start a session (same contract as the
+  // CLI's exit 1) — surfaced through the plugin's existing log path.
+  if (reviewArgs.errors.length > 0) {
+    for (const parseError of reviewArgs.errors) {
+      client.app.log({ level: "error", message: `[Plannotator] ${parseError}` });
+    }
+    return;
+  }
   const urlArg = reviewArgs.prUrl;
   const isPRMode = urlArg !== undefined;
 

--- a/apps/pi-extension/index.ts
+++ b/apps/pi-extension/index.ts
@@ -651,6 +651,12 @@ export default function plannotator(pi: ExtensionAPI): void {
 			try {
 				const { parseReviewArgs } = await import("./generated/review-args.ts");
 				const reviewArgs = parseReviewArgs(args ?? "");
+				// Argument-shape failures refuse to start a session (same contract
+				// as the CLI's exit 1), surfaced through Pi's notifier.
+				if (reviewArgs.errors.length > 0) {
+					ctx.ui.notify(`Plannotator: ${reviewArgs.errors.join("; ")}`, "error");
+					return;
+				}
 				const session = await startCodeReviewBrowserSession(ctx, {
 					prUrl: reviewArgs.prUrl,
 					vcsType: reviewArgs.vcsType,

--- a/apps/pi-extension/review-args-parity.test.ts
+++ b/apps/pi-extension/review-args-parity.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+
+/**
+ * Parity guard for the VENDORED review-args copy (generated/review-args.ts,
+ * written by vendor.sh). Pi's /plannotator-review parses through this copy,
+ * so a forgotten vendor run would leave Pi on a parser that silently swallows
+ * flags the shared parser now reports — the exact cross-host drift the
+ * `errors` contract exists to prevent.
+ */
+describe("vendored review-args parity", () => {
+  test("the vendored parser reports unknown dash-prefixed tokens", async () => {
+    const { parseReviewArgs } = await import("./generated/review-args.ts");
+    const parsed = parseReviewArgs("--bse main");
+    expect(parsed.errors).toEqual(["Unknown review option: --bse"]);
+  });
+});

--- a/packages/shared/review-args.test.ts
+++ b/packages/shared/review-args.test.ts
@@ -7,6 +7,7 @@ describe("parseReviewArgs", () => {
       prUrl: undefined,
       vcsType: undefined,
       useLocal: true,
+      errors: [],
     });
   });
 
@@ -15,6 +16,7 @@ describe("parseReviewArgs", () => {
       prUrl: undefined,
       vcsType: "git",
       useLocal: true,
+      errors: [],
     });
   });
 
@@ -23,6 +25,7 @@ describe("parseReviewArgs", () => {
       prUrl: undefined,
       vcsType: "gitbutler",
       useLocal: true,
+      errors: [],
     });
   });
 
@@ -31,11 +34,13 @@ describe("parseReviewArgs", () => {
       prUrl: "https://github.com/acme/repo/pull/12",
       vcsType: "git",
       useLocal: true,
+      errors: [],
     });
     expect(parseReviewArgs("https://github.com/acme/repo/pull/12 --git")).toEqual({
       prUrl: "https://github.com/acme/repo/pull/12",
       vcsType: "git",
       useLocal: true,
+      errors: [],
     });
   });
 
@@ -44,6 +49,7 @@ describe("parseReviewArgs", () => {
       prUrl: "https://github.com/acme/repo/pull/12",
       vcsType: undefined,
       useLocal: false,
+      errors: [],
     });
   });
 
@@ -52,6 +58,7 @@ describe("parseReviewArgs", () => {
       prUrl: "https://github.com/acme/repo/pull/12",
       vcsType: "git",
       useLocal: false,
+      errors: [],
     });
   });
 
@@ -63,10 +70,43 @@ describe("parseReviewArgs", () => {
   });
 
   test("keeps non-url positional input as local review mode", () => {
+    // Positional word tolerance is load-bearing: slash-command hosts forward
+    // raw user prose to `plannotator review` verbatim. Over-tightening this
+    // would break every /plannotator-review invocation that carries words.
     expect(parseReviewArgs("--git not-a-url")).toEqual({
       prUrl: undefined,
       vcsType: "git",
       useLocal: true,
+      errors: [],
     });
+  });
+
+  test("reports unknown dash-prefixed tokens instead of silently dropping them", () => {
+    // The pre-existing silent-swallow bug: `--bse main` used to land in
+    // `positional`, be ignored, and the session opened as if nothing happened —
+    // on every host. A typo'd flag must fail loudly, exactly as on annotate.
+    const parsed = parseReviewArgs("--bse main");
+    expect(parsed.errors).toEqual(["Unknown review option: --bse"]);
+    // The stray value token stays a tolerated positional word.
+    expect(parsed.prUrl).toBeUndefined();
+  });
+
+  test("reports every unknown dashed token, including = forms", () => {
+    // `--base=main` is not a supported value syntax (space-separated only), so
+    // it must surface as an unknown option rather than being half-parsed.
+    const parsed = parseReviewArgs("--verbose --base=main");
+    expect(parsed.errors).toEqual([
+      "Unknown review option: --verbose",
+      "Unknown review option: --base=main",
+    ]);
+  });
+
+  test("an unknown dashed token cannot shadow a PR URL", () => {
+    // Before the errors[] contract, `--bse` landed in positional[0] and the
+    // real PR URL in positional[1] was never inspected — the PR silently
+    // became a local review. Now the invocation refuses instead.
+    const parsed = parseReviewArgs("--bse https://github.com/acme/repo/pull/12");
+    expect(parsed.errors).toEqual(["Unknown review option: --bse"]);
+    expect(parsed.prUrl).toBe("https://github.com/acme/repo/pull/12");
   });
 });

--- a/packages/shared/review-args.ts
+++ b/packages/shared/review-args.ts
@@ -5,6 +5,13 @@ export interface ParsedReviewArgs {
   prUrl?: string;
   vcsType?: VcsSelection;
   useLocal: boolean;
+  /**
+   * Argument-shape problems the host must surface before starting a session.
+   * Always present; empty means the invocation parsed cleanly. Hosts differ in
+   * how they surface these (CLI exits 1, Pi/OpenCode notify), which is why the
+   * parser reports rather than throws.
+   */
+  errors: string[];
 }
 
 export function parseReviewArgs(input: string | string[]): ParsedReviewArgs {
@@ -14,9 +21,13 @@ export function parseReviewArgs(input: string | string[]): ParsedReviewArgs {
 
   let vcsType: VcsSelection | undefined;
   let useLocal = true;
+  const errors: string[] = [];
   const positional: string[] = [];
 
-  for (const token of tokens) {
+  // Index-based so value-taking flags can consume their value token before the
+  // positional collector sees it.
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i]!;
     switch (token) {
       case "--git":
         vcsType = "git";
@@ -31,7 +42,17 @@ export function parseReviewArgs(input: string | string[]): ParsedReviewArgs {
         useLocal = false;
         break;
       default:
-        positional.push(token);
+        if (token.startsWith("-")) {
+          // Unknown dash-prefixed tokens error loudly, matching the annotate
+          // contract ("a typo'd flag errors the way it always did"). Silently
+          // dropping them meant a mistyped flag vanished on every host — and a
+          // dashed token in positional[0] could even shadow a PR URL.
+          errors.push(`Unknown review option: ${token}`);
+        } else {
+          // Plain words stay tolerated: slash-command hosts forward raw user
+          // prose verbatim, and only positional[0] is ever inspected (as a URL).
+          positional.push(token);
+        }
         break;
     }
   }
@@ -41,6 +62,7 @@ export function parseReviewArgs(input: string | string[]): ParsedReviewArgs {
     prUrl: target && isReviewUrl(target) ? target : undefined,
     vcsType,
     useLocal,
+    errors,
   };
 }
 


### PR DESCRIPTION
## What

`parseReviewArgs` now reports argument-shape problems through an always-present `errors: string[]` field, and unknown dash-prefixed tokens become loud errors instead of being silently dropped. All four host surfaces refuse to start a session on a parse error:

- **CLI** (`plannotator review`): errors on stderr + `Run 'plannotator review --help' for usage.`, exit 1
- **opencode-review bridge**: same, on stderr — the bridge's machine-readable stdout contract is untouched
- **OpenCode embedded plugin**: surfaces errors through `client.app.log` and returns
- **Pi extension**: notifies through `ctx.ui.notify` and returns (vendored parser; a parity test guards a forgotten re-vendor)

Plain non-dashed words stay tolerated — slash-command hosts forward raw user prose verbatim, and that tolerance is load-bearing (pinned by the existing test). The parser loop is now index-based so value-taking flags can consume their value token (prerequisite for `--base` / `--diff-type`, which land separately and are **not** part of this PR).

## Release-note-worthy behavior change

**`plannotator review` (and `/plannotator-review` on Claude Code, OpenCode, and Pi) now errors on unknown dash-prefixed options instead of silently ignoring them.** Previously `plannotator review --bse main` — or any typo'd/unsupported flag — silently opened an ordinary review as if nothing happened; a dashed token could even shadow a PR URL (`review --bse <PR_URL>` silently became a local review). Now such invocations fail loudly with `Unknown review option: --bse`, matching the annotate contract ("unrecognized dash-prefixed tokens … error the way it always did"). Invocations like `/plannotator-review --verbose` that previously "worked" by accident will now refuse.

## Why now

This is the prerequisite for the `--base` / `--diff-type` review open-state flags: without strict unknown-flag handling, an old binary or a stale vendored parser would silently swallow the new flags on some hosts — the degrade matrix must have no "silently ignored" cell.

## Tests

- `packages/shared/review-args.test.ts`: existing whole-object assertions updated for `errors: []`; new tests for the silent-swallow bug (`--bse main`), `=`-form flags, multiple unknown tokens, and PR-URL shadowing.
- `apps/pi-extension/review-args-parity.test.ts` (new): the **vendored** parser must report unknown tokens — catches a forgotten `vendor.sh` run.
- Revert-verified: with the old parser restored, 10/11 parser tests fail; restored, all pass.
- `bun run typecheck` clean; full `bun test` under a temp `PLANNOTATOR_DATA_DIR`: 4357 pass / 902 skip, 3 timing-flaky failures in unrelated server suites that did not reproduce on re-run (0 fails).
