### PR TITLE
fix(ui): prevent skill autocomplete menu clipping

### DIFF
--- a/packages/ui/components/CommentPopover.tsx
+++ b/packages/ui/components/CommentPopover.tsx
@@ -529,6 +529,7 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
     hasUnsavedContent ||
     (allowEmptySubmit && initialText.trim().length > 0);
   const canAskAI = !!onAskAI && !askAIDisabled && text.trim().length > 0;
+  const showsSkillMenu = skillAc.menu !== null;
 
   // Shared by both footers. Disabled once anything is typed or attached so a
   // click can never discard a draft; with content present, Save is the path.
@@ -570,7 +571,9 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
           aria-modal="true"
           aria-label={isGlobal ? 'Global comment' : 'Comment'}
           tabIndex={-1}
-          className="relative w-full max-w-xl max-h-full min-h-0 bg-popover border border-border rounded-xl shadow-2xl flex flex-col overflow-hidden"
+          className={`relative w-full max-w-xl max-h-full min-h-0 bg-popover border border-border rounded-xl shadow-2xl flex flex-col ${
+            showsSkillMenu ? 'overflow-visible' : 'overflow-hidden'
+          }`}
           style={{
             animation: 'comment-dialog-in 0.15s ease-out',
           }}
@@ -617,7 +620,9 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
           {chipsRow}
 
           {/* Textarea */}
-          <div className="relative px-4 py-3 min-h-0 flex-1 overflow-y-auto">
+          <div className={`relative px-4 py-3 min-h-0 flex-1 ${
+            showsSkillMenu ? 'overflow-visible' : 'overflow-y-auto'
+          }`}>
             {skillAc.menu && (
               <SkillReferenceMenu
                 id={skillListboxId}
@@ -713,14 +718,14 @@ export const CommentPopover: React.FC<CommentPopoverProps> = ({
             left: dragPosition.left,
             width: position.width,
             maxHeight: visibleBounds.height,
-            overflowY: 'auto',
+            overflowY: showsSkillMenu ? 'visible' : 'auto',
           }
         : {
             top: position.top,
             left: position.left,
             width: position.width,
             maxHeight: position.maxHeight,
-            overflowY: 'auto',
+            overflowY: showsSkillMenu ? 'visible' : 'auto',
             ...(position.flipAbove ? { transform: 'translateY(-100%)' } : {}),
             animation: position.flipAbove
               ? 'comment-popover-in-above 0.15s ease-out'

--- a/packages/ui/components/SkillReferenceMenu.placement.test.tsx
+++ b/packages/ui/components/SkillReferenceMenu.placement.test.tsx
@@ -139,6 +139,18 @@ function list(): HTMLElement {
   return el;
 }
 
+function clippingAncestor(el: HTMLElement): HTMLElement | null {
+  let ancestor = el.parentElement;
+  while (ancestor && ancestor !== document.body) {
+    const style = window.getComputedStyle(ancestor);
+    const clipsOverflow = [style.overflow, style.overflowX, style.overflowY]
+      .some((value) => /^(auto|clip|hidden|scroll)$/.test(value));
+    if (clipsOverflow) return ancestor;
+    ancestor = ancestor.parentElement;
+  }
+  return null;
+}
+
 function makeRect(top: number, bottom: number): DOMRect {
   return {
     x: 100,
@@ -208,6 +220,15 @@ function assertMenuInsideViewport(): { direction: string; maxListHeight: number 
 }
 
 describe('SkillReferenceMenu adaptive placement', () => {
+  test.skipIf(!hasDom)(
+    'the menu escapes the comment card overflow instead of being clipped at its edge',
+    async () => {
+      await mountPopover();
+      await type(textarea(), '$');
+      expect(clippingAncestor(menu()) === null).toBe(true);
+    },
+  );
+
   test.skipIf(!hasDom)(
     'THE bug: composer near the top of the viewport opens the menu BELOW, on screen',
     async () => {


### PR DESCRIPTION
## Problem

Typing `/` or `$` in the annotate comment composer opens the skill autocomplete inside the composer card. The menu is positioned beyond that card, but the card's scrolling overflow clipped every row outside its bounds.

## Evidence

The failure reproduced in the README annotation flow: only the row touching the card edge remained visible. A focused DOM regression test also identified the comment card as the menu's clipping ancestor.

<img width="461" height="220" alt="dyn-6473746fcb207c4edbefcf21f7e3b2b1" src="https://github.com/user-attachments/assets/26cb1f0c-616a-45d4-8e50-80684cd5d4fa" />

## Fix

Allow visible overflow only while the skill menu is open, in both compact popover and expanded dialog modes. When the menu closes, the composer restores its existing scrolling and clipping behavior.

## Review Focus

- Confirm the conditional overflow preserves long-comment scrolling after the menu closes.
- Confirm both anchored and dragged popovers, plus the expanded dialog, expose the complete menu.

## Test Plan

- [x] `DOM_TESTS=1 bun test packages/ui/components/SkillReferenceMenu.placement.test.tsx` — 12 tests passed
- [x] `packages/ui/node_modules/.bin/tsc --noEmit -p packages/ui/tsconfig.json`
- [x] Rebuilt the hook bundle and manually verified `$` autocomplete through the repository CLI against `README.md`
- [x] `git diff --check`
