### PR TITLE
fix(review): keep the annotation toolbar inside the viewport when suggested code expands

### DIFF
--- a/packages/review-editor/components/AnnotationToolbar.placement.test.tsx
+++ b/packages/review-editor/components/AnnotationToolbar.placement.test.tsx
@@ -6,8 +6,20 @@ const hasDom = typeof document !== 'undefined';
 const toolbarModule = hasDom ? await import('./AnnotationToolbar') : null;
 const AnnotationToolbar = toolbarModule?.AnnotationToolbar as typeof import('./AnnotationToolbar')['AnnotationToolbar'];
 
+/** Laid-out height of the toolbar. happy-dom does no layout, so we stub the
+ * height the component measures: the collapsed composer vs. the same toolbar
+ * with the suggested-code section expanded. */
+const COLLAPSED_TOOLBAR_HEIGHT = 236;
+const EXPANDED_TOOLBAR_HEIGHT = 360;
+let toolbarHeight = EXPANDED_TOOLBAR_HEIGHT;
+
+const originalScrollHeight = hasDom
+  ? Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight')
+  : undefined;
+
 let host: HTMLElement | null = null;
 let root: Root | null = null;
+let toolbarRef: React.RefObject<HTMLDivElement | null> | null = null;
 let originalMatchMedia: typeof window.matchMedia | undefined;
 
 function finePointerMatchMedia(query: string): MediaQueryList {
@@ -25,8 +37,15 @@ function finePointerMatchMedia(query: string): MediaQueryList {
 
 beforeEach(() => {
   if (!hasDom) return;
+  toolbarHeight = EXPANDED_TOOLBAR_HEIGHT;
   originalMatchMedia = window.matchMedia;
   window.matchMedia = finePointerMatchMedia;
+  Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+    configurable: true,
+    get(this: HTMLElement) {
+      return this.classList?.contains('review-toolbar') ? toolbarHeight : 0;
+    },
+  });
 });
 
 afterEach(async () => {
@@ -34,31 +53,41 @@ afterEach(async () => {
   root = null;
   host?.remove();
   host = null;
+  toolbarRef = null;
   if (hasDom) {
     document.body.replaceChildren();
     if (originalMatchMedia) window.matchMedia = originalMatchMedia;
+    if (originalScrollHeight) {
+      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', originalScrollHeight);
+    } else {
+      delete (HTMLElement.prototype as { scrollHeight?: number }).scrollHeight;
+    }
   }
 });
 
-async function mountToolbar(positionLeft: number, askAIMode: boolean): Promise<HTMLElement> {
-  host = document.createElement('div');
-  document.body.appendChild(host);
-  root = createRoot(host);
-  const toolbarRef = React.createRef<HTMLDivElement>();
+interface ToolbarOverrides {
+  positionTop?: number;
+  showSuggestedCode?: boolean;
+}
 
+async function renderToolbar(
+  positionLeft: number,
+  askAIMode: boolean,
+  { positionTop = 100, showSuggestedCode = false }: ToolbarOverrides = {},
+): Promise<HTMLElement> {
   await act(async () => {
     root?.render(
       <AnnotationToolbar
         toolbarState={{
-          position: { top: 100, left: positionLeft },
+          position: { top: positionTop, left: positionLeft },
           range: { start: 6, end: 6, side: 'additions' },
         }}
-        toolbarRef={toolbarRef}
+        toolbarRef={toolbarRef!}
         commentText=""
         setCommentText={() => {}}
         suggestedCode=""
         setSuggestedCode={() => {}}
-        showSuggestedCode={false}
+        showSuggestedCode={showSuggestedCode}
         setShowSuggestedCode={() => {}}
         askAIMode={askAIMode}
         setAskAIMode={() => {}}
@@ -81,10 +110,46 @@ async function mountToolbar(positionLeft: number, askAIMode: boolean): Promise<H
   return toolbar;
 }
 
+async function mountToolbar(
+  positionLeft: number,
+  askAIMode: boolean,
+  overrides: ToolbarOverrides = {},
+): Promise<HTMLElement> {
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  root = createRoot(host);
+  toolbarRef = React.createRef<HTMLDivElement>();
+  return renderToolbar(positionLeft, askAIMode, overrides);
+}
+
+/** Simulates the pointer drag the toolbar header enables. */
+async function dragToolbarTo(toolbar: HTMLElement, clientY: number): Promise<void> {
+  const handle = toolbar.firstElementChild?.firstElementChild;
+  if (!handle) throw new Error('annotation toolbar drag handle did not render');
+
+  await act(async () => {
+    handle.dispatchEvent(
+      new PointerEvent('pointerdown', { bubbles: true, button: 0, clientX: 200, clientY: 100 }),
+    );
+  });
+  await act(async () => {
+    document.dispatchEvent(
+      new PointerEvent('pointermove', { bubbles: true, clientX: 200, clientY }),
+    );
+    document.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+  });
+}
+
 function toolbarHorizontalEdges(toolbar: HTMLElement): { left: number; right: number } {
   const width = Number.parseFloat(toolbar.style.width);
   const center = Number.parseFloat(toolbar.style.left);
   return { left: center - width / 2, right: center + width / 2 };
+}
+
+/** Vertical edges as laid out, from the committed top plus the stubbed height. */
+function toolbarVerticalEdges(toolbar: HTMLElement): { top: number; bottom: number } {
+  const top = Number.parseFloat(toolbar.style.top);
+  return { top, bottom: top + toolbarHeight };
 }
 
 for (const [mode, askAIMode] of [['Comment', false], ['Ask AI', true]] as const) {
@@ -98,5 +163,79 @@ for (const [mode, askAIMode] of [['Comment', false], ['Ask AI', true]] as const)
       const toolbar = await mountToolbar(window.innerWidth, askAIMode);
       expect(toolbarHorizontalEdges(toolbar).right).toBeLessThanOrEqual(window.innerWidth);
     });
+
+    test.skipIf(!hasDom)(
+      'flips above the anchor so an expanded compose row stays on screen',
+      async () => {
+        const anchorTop = window.innerHeight - 60;
+        const toolbar = await mountToolbar(window.innerWidth / 2, askAIMode, {
+          positionTop: anchorTop,
+          showSuggestedCode: true,
+        });
+
+        const { top, bottom } = toolbarVerticalEdges(toolbar);
+        expect(bottom).toBeLessThanOrEqual(window.innerHeight);
+        expect(top).toBeLessThan(anchorTop);
+      },
+    );
+
+    test.skipIf(!hasDom)('sits at the anchor when the toolbar fits below it', async () => {
+      const toolbar = await mountToolbar(window.innerWidth / 2, askAIMode, {
+        positionTop: 120,
+        showSuggestedCode: true,
+      });
+
+      expect(toolbarVerticalEdges(toolbar)).toEqual({
+        top: 120,
+        bottom: 120 + EXPANDED_TOOLBAR_HEIGHT,
+      });
+    });
+
+    test.skipIf(!hasDom)('stays clamped to the visible top edge', async () => {
+      const toolbar = await mountToolbar(window.innerWidth / 2, askAIMode, { positionTop: -200 });
+      expect(toolbarVerticalEdges(toolbar).top).toBe(0);
+    });
+
+    test.skipIf(!hasDom)(
+      'pins a toolbar taller than the viewport to the top and clamps its height',
+      async () => {
+        toolbarHeight = window.innerHeight + 200;
+        const toolbar = await mountToolbar(window.innerWidth / 2, askAIMode, {
+          positionTop: window.innerHeight - 40,
+          showSuggestedCode: true,
+        });
+
+        expect(toolbarVerticalEdges(toolbar).top).toBe(0);
+        expect(Number.parseFloat(toolbar.style.maxHeight)).toBe(window.innerHeight);
+      },
+    );
   });
 }
+
+describe('dragged toolbar placement', () => {
+  test.skipIf(!hasDom)(
+    'stays in bounds when the suggested-code section expands after a drag',
+    async () => {
+      toolbarHeight = COLLAPSED_TOOLBAR_HEIGHT;
+      const toolbar = await mountToolbar(window.innerWidth / 2, false, { positionTop: 100 });
+
+      // Drag the toolbar down to the bottom edge of the viewport; it clamps
+      // flush against it rather than hanging off the edge.
+      await dragToolbarTo(toolbar, window.innerHeight - 30);
+      expect(toolbarVerticalEdges(toolbar)).toEqual({
+        top: window.innerHeight - COLLAPSED_TOOLBAR_HEIGHT,
+        bottom: window.innerHeight,
+      });
+
+      // Expanding the composer grows the box; it must slide back into bounds
+      // instead of running off the bottom of the viewport.
+      toolbarHeight = EXPANDED_TOOLBAR_HEIGHT;
+      await renderToolbar(window.innerWidth / 2, false, { positionTop: 100, showSuggestedCode: true });
+
+      expect(toolbarVerticalEdges(toolbar)).toEqual({
+        top: window.innerHeight - EXPANDED_TOOLBAR_HEIGHT,
+        bottom: window.innerHeight,
+      });
+    },
+  );
+});

--- a/packages/review-editor/components/AnnotationToolbar.tsx
+++ b/packages/review-editor/components/AnnotationToolbar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { ToolbarState } from '../hooks/useAnnotationToolbar';
 import { useTabIndent } from '../hooks/useTabIndent';
@@ -12,6 +12,7 @@ import { useDraggable } from '@plannotator/ui/hooks/useDraggable';
 import {
   hasPrimaryCoarsePointer,
   useVisibleViewportBounds,
+  type VisibleViewportBounds,
 } from '@plannotator/ui/hooks/useViewportEnvironment';
 
 interface AnnotationToolbarProps {
@@ -50,6 +51,46 @@ interface AnnotationToolbarProps {
 
 // The 338px border box contains the 320px composer, padding, and border.
 const TOOLBAR_MAX_WIDTH = 338;
+// Gap between the anchor and the toolbar's near edge when it flips above.
+const TOOLBAR_ANCHOR_GAP = 10;
+// Stand-in for the first render only, before the real height is measured.
+const TOOLBAR_ESTIMATED_HEIGHT = 200;
+
+interface ToolbarVerticalPlacement {
+  top: number;
+  maxHeight: number;
+}
+
+/**
+ * Keeps the WHOLE toolbar — submit row included — inside the visible viewport.
+ *
+ * `anchorTop` is the toolbar's top when it sits below the anchor. When that
+ * would push its bottom past the viewport (a selection on the last lines of a
+ * file), the toolbar flips above the anchor instead of sliding up, so the
+ * submit button stays on screen without scrolling (#1424). A toolbar taller
+ * than the viewport has nowhere to go: it is pinned to the top edge and scrolls
+ * internally, which is the only case where `maxHeight` actually binds.
+ */
+function computeToolbarVerticalPlacement(
+  anchorTop: number,
+  height: number | null,
+  bounds: VisibleViewportBounds,
+  { flip = false }: { flip?: boolean } = {},
+): ToolbarVerticalPlacement {
+  if (height !== null && height > bounds.height) {
+    return { top: bounds.top, maxHeight: bounds.height };
+  }
+
+  const measured = height ?? TOOLBAR_ESTIMATED_HEIGHT;
+  const preferred = flip && anchorTop + measured > bounds.bottom
+    ? anchorTop - TOOLBAR_ANCHOR_GAP - measured
+    : anchorTop;
+
+  return {
+    top: Math.max(bounds.top, Math.min(preferred, bounds.bottom - measured)),
+    maxHeight: bounds.height,
+  };
+}
 
 /** Floating comment input form that appears after line selection */
 export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
@@ -87,8 +128,32 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
   const toolbarWidth = Math.min(TOOLBAR_MAX_WIDTH, visibleBounds.width);
   const horizontalInset = toolbarWidth / 2;
   const suggestedCodeRef = useRef<HTMLTextAreaElement>(null);
+  const [toolbarHeight, setToolbarHeight] = useState<number | null>(null);
   const handleTabIndent = useTabIndent(setSuggestedCode);
   const { dragPosition, dragHandleProps, wasDragged, reset: resetDrag } = useDraggable(toolbarRef);
+
+  // The clamp below needs the real box height, not a guess: a fixed reserve let
+  // the expanded suggested-code section push the submit row past the viewport
+  // bottom. Measured after every commit because the height changes with the
+  // suggested-code toggle, Ask AI history, and a manual textarea resize;
+  // setState bails out whenever the measurement is unchanged.
+  // scrollHeight is the UNCLAMPED content height, so a maxHeight this effect
+  // already applied can never feed back into the next measurement.
+  useLayoutEffect(() => {
+    const element = toolbarRef.current;
+    if (!element) return;
+    const measured = Math.max(element.scrollHeight, element.offsetHeight);
+    setToolbarHeight((previous) => (previous === measured ? previous : measured));
+  });
+
+  // Dragged toolbars keep the user's chosen position (clamped into bounds);
+  // anchored ones also flip above the anchor when they would not fit below.
+  const placement = computeToolbarVerticalPlacement(
+    dragPosition ? dragPosition.top : toolbarState.position.top,
+    toolbarHeight,
+    visibleBounds,
+    { flip: !dragPosition },
+  );
 
   // Reset drag when toolbar reopens for a new selection
   useEffect(() => {
@@ -123,20 +188,17 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
       style={dragPosition
         ? {
             position: 'fixed',
-            top: dragPosition.top,
+            top: placement.top,
             left: dragPosition.left,
             width: toolbarWidth,
             boxSizing: 'border-box',
             zIndex: 1000,
-            maxHeight: visibleBounds.height,
+            maxHeight: placement.maxHeight,
             overflowY: 'auto',
           }
         : {
             position: 'fixed',
-            top: Math.max(
-              visibleBounds.top,
-              Math.min(toolbarState.position.top, visibleBounds.bottom - 200),
-            ),
+            top: placement.top,
             left: Math.max(
               visibleBounds.left + horizontalInset,
               Math.min(
@@ -148,7 +210,7 @@ export const AnnotationToolbar: React.FC<AnnotationToolbarProps> = ({
             width: toolbarWidth,
             boxSizing: 'border-box',
             zIndex: 1000,
-            maxHeight: visibleBounds.height,
+            maxHeight: placement.maxHeight,
             overflowY: 'auto',
           }
       }


### PR DESCRIPTION
## Problem

Selecting lines near the bottom of a diff and expanding **Add suggested code** pushed the submit row off-screen: the toolbar's vertical clamp reserved a hardcoded `visibleBounds.bottom - 200` while `maxHeight` was set to the *entire* viewport height, so internal scrolling could never engage and the grown toolbar simply extended past the bottom edge. Both the anchored and the dragged branch had the flaw, and Ask AI mode renders inside the same container. #1424

## Change

The toolbar measures its real height (`useLayoutEffect` after every commit, so the suggested-code toggle, Ask AI history growth and manual textarea resizes all land) and a shared placement helper keeps the whole box — submit row included — inside `visibleBounds`:

- anchored toolbars flip above the anchor when they would not fit below;
- a toolbar taller than the viewport is pinned to the top with a bounded `maxHeight` (the only case where internal scroll engages);
- dragged toolbars keep the user's chosen position, clamped into bounds.

Horizontal clamping is untouched.

## Verification

Bun 1.3.14, `DOM_TESTS=1`, disposable HOME: `bun test packages/review-editor/components/AnnotationToolbar.placement.test.tsx` → **13 pass / 0 fail** (previously 4 pass / 4 skip). Pre-fix control with the component change stashed: 8 pass / 5 fail (flip-above in both Comment and Ask AI modes, oversized pin in both branches, dragged-expand) — the new tests fail on the old code. Coverage: flip-above when expanded at the bottom edge in both modes, no move when it fits below, top-edge clamp, oversized pin + height clamp, and a real pointer-drag → expand sequence.

Fixes #1424
