### PR TITLE
feat(editor): Mod+E shortcut to enter and leave Edit mode in place

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -188,6 +188,7 @@ jobs:
           packages/ui/components/ActionMenu.test.tsx
           packages/ui/components/PlanHeaderMenu.mobile.test.tsx
           packages/review-editor/components/ReviewHeaderMenu.mobile.test.tsx
+          packages/editor/App.editModeShortcut.test.tsx
 
   opencode-v2:
     name: OpenCode 2 installed package

--- a/packages/editor/App.editModeShortcut.test.tsx
+++ b/packages/editor/App.editModeShortcut.test.tsx
@@ -221,6 +221,30 @@ describe.if(hasDom)("Mod+E edit-mode toggle", () => {
     expect(document.querySelector(".cm-editor")).toBeNull();
   });
 
+  test("leaves the chord to a foreign text field, but still exits from CodeMirror", async () => {
+    await mount(ANNOTATE_PLAN);
+
+    await act(async () => { pressModE(document.body); });
+    const content = document.querySelector<HTMLElement>(".cm-editor .cm-content");
+    if (!content) throw new Error("CodeMirror content DOM did not render");
+
+    // Mod+E dispatched from a textarea outside the editor (Ask AI box, an
+    // annotation comment mid-edit-session) must stay the field's own chord:
+    // the session may not commit-and-exit underneath it.
+    const foreign = document.createElement("textarea");
+    document.body.appendChild(foreign);
+    try {
+      await act(async () => { pressModE(foreign); });
+      expect(document.querySelector(".cm-editor")).not.toBeNull();
+    } finally {
+      foreign.remove();
+    }
+
+    // From inside CodeMirror's contenteditable the exit still fires.
+    await act(async () => { pressModE(content); });
+    expect(document.querySelector(".cm-editor")).toBeNull();
+  });
+
   test("never discards an unsaved source-backed buffer silently", async () => {
     await mount({
       plan: "# Source document\n\nEditable body.\n",
@@ -248,13 +272,32 @@ describe.if(hasDom)("Mod+E edit-mode toggle", () => {
     if (!content) throw new Error("CodeMirror content DOM did not render");
     expect(saveLabel()).toBe("Saved");
 
-    // Dirty the buffer through the editor's own DOM observer, the way typing
-    // does. The toolstrip's Save/Saved pair and its `Done`/`Cancel` exit
-    // control are the state machine's readouts.
+    // Dirty the buffer through the editor's own input pipeline: a
+    // document-changing dispatch on the mounted view. (Mutating the
+    // contentEditable's DOM and waiting on CodeMirror's MutationObserver is
+    // not viable under happy-dom: after CodeMirror's stop()/start() observer
+    // cycling, happy-dom intermittently never re-delivers records, so the
+    // mutation is lost no matter how long the test waits — the CI flake this
+    // replaced.) The view is resolved from CodeMirror's DOM back-reference —
+    // the same property EditorView.findFromDOM reads; @codemirror/view is not
+    // a dependency of this package, and both of the property's historical
+    // names are tried so a rename fails loudly here rather than silently.
+    const backRef = content as unknown as {
+      cmTile?: { view?: { state: { doc: { toString(): string } }; dispatch(spec: unknown): void } };
+      cmView?: { view?: { state: { doc: { toString(): string } }; dispatch(spec: unknown): void } };
+    };
+    const view = backRef.cmTile?.view ?? backRef.cmView?.view;
+    if (!view) throw new Error("EditorView not found from CodeMirror DOM back-reference");
     await act(async () => {
-      content.textContent = `${content.textContent ?? ""}x`;
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      view.dispatch({
+        changes: { from: view.state.doc.toString().trimEnd().length, insert: "x" },
+      });
     });
+    // The dirty flip lands through React state — poll (bounded) rather than
+    // racing a single macrotask, same settle pattern as mount().
+    for (let attempt = 0; attempt < 40 && saveLabel() !== "Save"; attempt += 1) {
+      await settle();
+    }
     expect(saveLabel()).toBe("Save");
     expect(findButton("Cancel")).not.toBeUndefined();
 

--- a/packages/editor/App.editModeShortcut.test.tsx
+++ b/packages/editor/App.editModeShortcut.test.tsx
@@ -1,0 +1,268 @@
+/**
+ * Mod+E toggles the markdown edit session from the keyboard, in place (#1479).
+ *
+ * Both halves are exercised the way a real keypress reaches them: the enter
+ * chord through the `document-view` scope's window listener, and the exit chord
+ * bubbling out of CodeMirror's contentEditable — the case the chrome-shortcut
+ * guard deliberately refuses to serve. Mounts the real App, so the capability
+ * gates (`canEditMarkdown`, the `Done`/`Cancel` exit semantics) and the
+ * Viewer ↔ editor scroll carry are the shipped ones.
+ */
+
+import { afterAll, afterEach, describe, expect, test } from "bun:test";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  resetStorageBackend,
+  setStorageBackend,
+  type StorageBackend,
+} from "@plannotator/ui/utils/storage";
+
+const hasDom = typeof document !== "undefined";
+
+const appModule = hasDom ? await import("./App") : null;
+const App = appModule?.default as typeof import("./App")["default"];
+
+const originalFetch = globalThis.fetch;
+const originalEventSource = globalThis.EventSource;
+
+const memory = new Map<string, string>();
+const memoryBackend: StorageBackend = {
+  getItem: (key) => memory.get(key) ?? null,
+  setItem: (key, value) => void memory.set(key, value),
+  removeItem: (key) => void memory.delete(key),
+};
+
+function seedAnnouncementsSeen(): void {
+  memory.set("plannotator-look-feel-announcement-seen", "2");
+  memory.set("plannotator-vim-mode-announcement-seen", "2");
+  memory.set("plannotator-plan-ai-announcement-seen", "1");
+}
+
+class SilentEventSource {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
+
+  readonly CONNECTING = 0;
+  readonly OPEN = 1;
+  readonly CLOSED = 2;
+  readonly readyState = SilentEventSource.OPEN;
+  readonly url: string;
+  readonly withCredentials = false;
+  onerror: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onopen: ((event: Event) => void) | null = null;
+
+  constructor(url: string | URL) {
+    this.url = String(url);
+  }
+
+  addEventListener(): void {}
+  close(): void {}
+  dispatchEvent(): boolean { return true; }
+  removeEventListener(): void {}
+}
+
+function fetchForPlan(plan: Record<string, unknown>): typeof fetch {
+  return async (input) => {
+    const rawUrl = input instanceof Request ? input.url : String(input);
+    if (rawUrl.startsWith("https://api.github.com/")) return new Response(null, { status: 404 });
+    const url = new URL(rawUrl, "http://localhost");
+    if (url.pathname === "/api/plan") return Response.json(plan);
+    if (url.pathname === "/api/archive/plans") return Response.json({ plans: [] });
+    if (url.pathname === "/api/ai/capabilities") return Response.json({ available: false, providers: [] });
+    if (url.pathname === "/api/draft") return Response.json({ error: "Not found" }, { status: 404 });
+    return Response.json({});
+  };
+}
+
+let root: Root | null = null;
+let host: HTMLElement | null = null;
+
+async function settle(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function mount(plan: Record<string, unknown>): Promise<void> {
+  setStorageBackend(memoryBackend);
+  seedAnnouncementsSeen();
+  globalThis.fetch = fetchForPlan(plan);
+  // SAFETY: the App only uses EventSource's constructor, handlers, and close.
+  globalThis.EventSource = SilentEventSource as unknown as typeof EventSource;
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  root = createRoot(host);
+  await act(async () => { root?.render(<App />); });
+  for (let attempt = 0; attempt < 10; attempt += 1) await settle();
+}
+
+const ANNOTATE_PLAN = {
+  plan: "# Scroll target\n\nFirst body paragraph.\n\n## Second section\n\nSecond body paragraph.\n",
+  origin: "claude-code",
+  mode: "annotate",
+  filePath: "/tmp/scroll.md",
+  sharingEnabled: false,
+  serverConfig: {},
+};
+
+const documentViewport = (): HTMLElement | null =>
+  document.querySelector<HTMLElement>('main[data-print-region="document"]');
+
+const editorScroller = (): HTMLElement | null =>
+  document.querySelector<HTMLElement>(".cm-editor .cm-scroller");
+
+const findButton = (label: string): HTMLButtonElement | undefined =>
+  Array.from(document.querySelectorAll("button"))
+    .find((button) => button.textContent?.trim() === label);
+
+/** The toolstrip's Save control carries a width-reserving "Saving" ghost span
+ *  in front of its live label, so `textContent` is never the label alone. */
+function saveLabel(): string | undefined {
+  const button = Array.from(document.querySelectorAll("button"))
+    .find((candidate) => candidate.textContent?.startsWith("Saving"));
+  if (!button) return undefined;
+  return Array.from(button.querySelectorAll("span"))
+    .map((span) => span.textContent ?? "")
+    .find((text) => text === "Saved" || text === "Save");
+}
+
+function pressModE(target: EventTarget): void {
+  target.dispatchEvent(new KeyboardEvent("keydown", {
+    key: "e",
+    metaKey: true,
+    bubbles: true,
+    cancelable: true,
+  }));
+}
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  root = null;
+  host?.remove();
+  host = null;
+  globalThis.fetch = originalFetch;
+  globalThis.EventSource = originalEventSource;
+  if (hasDom) document.body.replaceChildren();
+  memory.clear();
+  resetStorageBackend();
+});
+
+afterAll(() => {
+  resetStorageBackend();
+});
+
+describe.if(hasDom)("Mod+E edit-mode toggle", () => {
+  test("enters edit mode from the viewer, commits and returns when pressed inside the editor", async () => {
+    await mount(ANNOTATE_PLAN);
+    expect(document.querySelector(".cm-editor")).toBeNull();
+
+    await act(async () => { pressModE(document.body); });
+    const scroller = editorScroller();
+    expect(scroller).not.toBeNull();
+
+    // The exit chord has to work from the focused editor: the event bubbles out
+    // of CodeMirror's contentEditable, which the chrome guard refuses.
+    const content = document.querySelector<HTMLElement>(".cm-editor .cm-content");
+    if (!content) throw new Error("CodeMirror content DOM did not render");
+    await act(async () => { pressModE(content); });
+    expect(document.querySelector(".cm-editor")).toBeNull();
+    expect(document.body.textContent).toContain("Scroll target");
+  });
+
+  test("carries the scroll offset across both swaps", async () => {
+    await mount(ANNOTATE_PLAN);
+
+    const viewport = documentViewport();
+    if (!viewport) throw new Error("Document viewport did not render");
+
+    // happy-dom has no layout, so a swapped child cannot clamp the container the
+    // way a real browser does (the jump #1479 reports). Record the writes
+    // instead: the contract is that the offset read before a swap is written
+    // back to the surface that scrolls once the new one has mounted. Which
+    // element that is, is pinned by `editScroll.test.ts`.
+    const written: number[] = [];
+    let current = 0;
+    Object.defineProperty(viewport, "scrollTop", {
+      configurable: true,
+      get: () => current,
+      set: (next: number) => { current = next; written.push(next); },
+    });
+
+    viewport.scrollTop = 480;
+    written.length = 0;
+    await act(async () => { pressModE(document.body); });
+    expect(document.querySelector(".cm-editor")).not.toBeNull();
+    expect(written).toContain(480);
+
+    // Whatever the reader scrolled to in the editor is where the viewer lands.
+    viewport.scrollTop = 260;
+    written.length = 0;
+    const content = document.querySelector<HTMLElement>(".cm-editor .cm-content");
+    if (!content) throw new Error("CodeMirror content DOM did not render");
+    await act(async () => { pressModE(content); });
+    expect(document.querySelector(".cm-editor")).toBeNull();
+    expect(written).toContain(260);
+  });
+
+  test("is a no-op on a read-only surface", async () => {
+    await mount({
+      plan: "# Archived document\n\nRead-only body.\n",
+      origin: "claude-code",
+      mode: "archive",
+      archivePlans: [],
+      sharingEnabled: false,
+      serverConfig: {},
+    });
+
+    await act(async () => { pressModE(document.body); });
+    expect(document.querySelector(".cm-editor")).toBeNull();
+  });
+
+  test("never discards an unsaved source-backed buffer silently", async () => {
+    await mount({
+      plan: "# Source document\n\nEditable body.\n",
+      origin: "claude-code",
+      mode: "annotate",
+      filePath: "/tmp/source.md",
+      sourceSave: {
+        enabled: true,
+        kind: "local-text-file",
+        scope: "single-file",
+        path: "/tmp/source.md",
+        basename: "source.md",
+        language: "markdown",
+        hash: "sha256:source",
+        mtimeMs: 1_000,
+        size: 32,
+        eol: "lf",
+      },
+      sharingEnabled: false,
+      serverConfig: {},
+    });
+
+    await act(async () => { pressModE(document.body); });
+    const content = document.querySelector<HTMLElement>(".cm-editor .cm-content");
+    if (!content) throw new Error("CodeMirror content DOM did not render");
+    expect(saveLabel()).toBe("Saved");
+
+    // Dirty the buffer through the editor's own DOM observer, the way typing
+    // does. The toolstrip's Save/Saved pair and its `Done`/`Cancel` exit
+    // control are the state machine's readouts.
+    await act(async () => {
+      content.textContent = `${content.textContent ?? ""}x`;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(saveLabel()).toBe("Save");
+    expect(findButton("Cancel")).not.toBeUndefined();
+
+    // The two-step `Cancel → Discard?` refusal is deliberate: the chord refuses
+    // rather than committing, and never drops the buffer silently.
+    await act(async () => { pressModE(content); });
+    expect(document.querySelector(".cm-editor")).not.toBeNull();
+    expect(findButton("Cancel")).not.toBeUndefined();
+    expect(content.textContent).toContain("Editable body.x");
+  });
+});

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -2797,10 +2797,24 @@ const App: React.FC = () => {
   // mirrors the card's `Done` exactly, including the two-step `Cancel →
   // Discard` refusal: with unsaved source-backed changes the chord is a no-op,
   // never a silent discard.
+  //
+  // NOTE: mounting atomic-editor's `selectionToolbar()` on this CodeMirror
+  // instance would dead-key this chord — that extension claims Mod-e and
+  // preventDefaults it before the event ever bubbles out to this listener.
   useEffect(() => {
     if (!isEditingMarkdown) return;
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== 'e' || !(event.metaKey || event.ctrlKey) || event.shiftKey || event.altKey) return;
+      if (event.key.toLowerCase() !== 'e' || !(event.metaKey || event.ctrlKey) || event.shiftKey || event.altKey) return;
+      // Native text fields keep Mod+E (macOS "use selection for find", etc.):
+      // only serve the chord from CodeMirror's contenteditable or the chrome.
+      // CodeMirror's content DOM is contenteditable, never INPUT/TEXTAREA, so
+      // this cannot break the exit-from-editor path.
+      const target = event.target;
+      if (
+        target instanceof HTMLElement &&
+        (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') &&
+        !target.closest('.cm-editor')
+      ) return;
       if (chromeShortcutBlocked(event)) return;
       event.preventDefault();
       if (cancelMode) return;

--- a/packages/editor/App.tsx
+++ b/packages/editor/App.tsx
@@ -243,6 +243,7 @@ import {
   pathIsInsideDir,
 } from './sourceDocumentPaths';
 import { pickRestoredSingleFileDraftToDisplay } from './draftRestoreSelection';
+import { scrollableEditSurface } from './editScroll';
 
 type NoteAutoSaveResults = {
   obsidian?: boolean;
@@ -461,6 +462,10 @@ const App: React.FC = () => {
   // render-assigned ref (same pattern as headerHandlersRef) so keyboard and
   // header share literally one submitPrimaryDecision.
   const submitPrimaryDecisionRef = useRef<() => void>(() => {});
+  // The `document-view` scope is registered above `handleEditToggle`; the
+  // handler is read through a render-assigned ref (same pattern as above) so
+  // the chord and the card's `Edit` control share one enter path.
+  const handleEditToggleRef = useRef<() => void>(() => {});
   const [agentWarningMessage, setAgentWarningMessage] = useState('');
   const [isPanelOpen, setIsPanelOpen] = useState(() => window.innerWidth >= 768);
   const [rightSidebarTab, setRightSidebarTab] = useState<'annotations' | 'ai'>('annotations');
@@ -1458,18 +1463,14 @@ const App: React.FC = () => {
   // Shared gate for the chrome-level keyboard commands (sidebars, focus mode):
   // never while a dialog, an overlay, a submission, or a text field owns the
   // keystroke. Annotate-only commands layer their own conditions on top.
-  const canHandleDocumentChromeShortcut = useCallback((event: KeyboardEvent) => {
-    if (archive.archiveMode || goalSetupMode) return false;
-    if (event.defaultPrevented) return false;
-    if (document.querySelector('[data-plannotator-confirm-dialog="true"]')) return false;
+  const chromeShortcutBlocked = useCallback((event: KeyboardEvent) => {
+    if (archive.archiveMode || goalSetupMode) return true;
+    if (event.defaultPrevented) return true;
+    if (document.querySelector('[data-plannotator-confirm-dialog="true"]')) return true;
     if (showExport || showImport || showFeedbackPrompt || showClaudeCodeWarning ||
         showSourceFileEditWarning ||
-        showExitWarning || showAgentWarning || showPermissionModeSetup || pendingPasteImage) return false;
-    if (submitted || isSubmitting || isExiting || isEditingMarkdown) return false;
-
-    const target = event.target as HTMLElement | null;
-    const tag = target?.tagName;
-    return tag !== 'INPUT' && tag !== 'TEXTAREA' && !target?.isContentEditable;
+        showExitWarning || showAgentWarning || showPermissionModeSetup || pendingPasteImage) return true;
+    return submitted || isSubmitting || isExiting;
   }, [
     archive.archiveMode,
     goalSetupMode,
@@ -1485,6 +1486,19 @@ const App: React.FC = () => {
     submitted,
     isSubmitting,
     isExiting,
+  ]);
+
+  const canHandleDocumentChromeShortcut = useCallback((event: KeyboardEvent) => {
+    if (chromeShortcutBlocked(event)) return false;
+    // The editor owns its own keystrokes: chrome commands stand down while a
+    // markdown edit session is open (the exit chord has its own path below).
+    if (isEditingMarkdown) return false;
+
+    const target = event.target as HTMLElement | null;
+    const tag = target?.tagName;
+    return tag !== 'INPUT' && tag !== 'TEXTAREA' && !target?.isContentEditable;
+  }, [
+    chromeShortcutBlocked,
     isEditingMarkdown,
   ]);
 
@@ -1534,6 +1548,15 @@ const App: React.FC = () => {
           canHandleDocumentChromeShortcut(event)
           && ((canUseWideMode && !isHtmlSurface) || wideModeType !== null),
         handle: handleToggleFocusMode,
+      },
+      // Enter only. `canEditMarkdown` is the same gate the card's `Edit`
+      // control uses, so the chord is a no-op on every read-only surface
+      // (archive, HTML/live, plan diff, gate, linked docs). The exit half
+      // lives below: while the editor has focus the chrome guard stands down
+      // on purpose, so it needs its own listener.
+      toggleEditMode: {
+        when: (event) => canEditMarkdown && canHandleDocumentChromeShortcut(event),
+        handle: () => handleEditToggleRef.current(),
       },
     },
   });
@@ -2621,7 +2644,21 @@ const App: React.FC = () => {
     scheduleDraftSave();
   }, [annotationHistory, restoreDraft, validateDraftSavedFileChanges, editStats, isEditingMarkdown, editableDocuments, activeEditableDocument, markdown, applyEditedDocument, repaintHighlights, scheduleDraftSave]);
 
+  // The Viewer ↔ MarkdownEditor swap replaces the content of the scroll
+  // container, and a real browser clamps that container to the top as the old
+  // subtree leaves it. Carry the offset across the swap so toggling stays in
+  // place (#1479); `scrollableEditSurface` decides where the offset lives —
+  // desktop scrolls the document viewport, a bounded shell scrolls the editor.
+  const editScrollRestoreRef = useRef<number | null>(null);
+  const captureEditScroll = useCallback(() => {
+    const editorScroller = markdownEditorHandleRef.current?.getContentDOM()?.parentElement ?? null;
+    const viewport = usesDocumentScroll ? getDocumentScrollViewport() : mainViewportRef.current;
+    const source = scrollableEditSurface(editorScroller, viewport, isEditingMarkdown);
+    editScrollRestoreRef.current = source ? source.scrollTop : null;
+  }, [isEditingMarkdown, usesDocumentScroll]);
+
   const handleEditToggle = useCallback(() => {
+    captureEditScroll();
     if (isEditingMarkdown) {
       commitMarkdownEdits();
       return;
@@ -2650,7 +2687,29 @@ const App: React.FC = () => {
         : base !== null && normalized !== base
     );
     setIsEditingMarkdown(true);
-  }, [activeEditableDocument, displayedMarkdown, editableDocuments, isEditingMarkdown, commitMarkdownEdits]);
+  }, [activeEditableDocument, displayedMarkdown, editableDocuments, isEditingMarkdown, commitMarkdownEdits, captureEditScroll]);
+  handleEditToggleRef.current = handleEditToggle;
+
+  // Restore after the swap has committed. Two timing facts decide the shape:
+  // the editor publishes its handle, and establishes its height, in its own
+  // effects — the surface comes up short for one frame, so a single write
+  // clamps to the top; and either surface can be the scroller depending on the
+  // shell. Write both (the one that cannot scroll clamps to a no-op) now and
+  // again once CodeMirror has measured.
+  useEffect(() => {
+    const target = editScrollRestoreRef.current;
+    if (target === null) return;
+    editScrollRestoreRef.current = null;
+    const viewport = usesDocumentScroll ? getDocumentScrollViewport() : mainViewportRef.current;
+    const apply = () => {
+      const editorScroller = markdownEditorHandleRef.current?.getContentDOM()?.parentElement ?? null;
+      if (viewport) viewport.scrollTop = target;
+      if (editorScroller) editorScroller.scrollTop = target;
+    };
+    apply();
+    const frame = requestAnimationFrame(apply);
+    return () => cancelAnimationFrame(frame);
+  }, [isEditingMarkdown, usesDocumentScroll]);
 
   // Live dirty tracking for the open editor session. String compare per
   // keystroke is fine at plan sizes; setState bails out on unchanged values.
@@ -2732,6 +2791,24 @@ const App: React.FC = () => {
     }
     handleEditToggle();                                          // commit edits + exit
   }, [isEditingMarkdown, cancelMode, confirmCancelEdits, handleEditToggle, handleDiscardEdits]);
+  // Mod+E while the editor owns focus. The chrome-shortcut guard deliberately
+  // stands down inside the editor (contenteditable target + open edit session),
+  // so the exit gets its own listener rather than weakening that guard. It
+  // mirrors the card's `Done` exactly, including the two-step `Cancel →
+  // Discard` refusal: with unsaved source-backed changes the chord is a no-op,
+  // never a silent discard.
+  useEffect(() => {
+    if (!isEditingMarkdown) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'e' || !(event.metaKey || event.ctrlKey) || event.shiftKey || event.altKey) return;
+      if (chromeShortcutBlocked(event)) return;
+      event.preventDefault();
+      if (cancelMode) return;
+      handleEditToggle();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isEditingMarkdown, cancelMode, chromeShortcutBlocked, handleEditToggle]);
   // Drop the discard confirmation once it no longer applies — exited the editor,
   // or the doc went clean (e.g. the user saved).
   useEffect(() => {

--- a/packages/editor/editScroll.test.ts
+++ b/packages/editor/editScroll.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { scrollableEditSurface } from "./editScroll";
+
+const scrollElement = (scrollHeight: number, clientHeight: number): HTMLElement =>
+  ({ scrollHeight, clientHeight }) as unknown as HTMLElement;
+
+describe("scrollableEditSurface", () => {
+  // The desktop layout: CodeMirror grows to full content height inside the
+  // document viewport, so `.cm-scroller` has nothing to scroll. Restoring the
+  // offset into it would silently lose the reader's place (#1479).
+  test("falls back to the document viewport when the editor cannot scroll", () => {
+    const viewport = scrollElement(8_204, 1_055);
+    const scroller = scrollElement(8_106, 8_106);
+
+    expect(scrollableEditSurface(scroller, viewport, true)).toBe(viewport);
+  });
+
+  // A height-bounded shell (compact touch) bounds the editor instead, so the
+  // offset lives inside CodeMirror.
+  test("uses the editor scroller when the shell bounds the editor", () => {
+    const viewport = scrollElement(700, 700);
+    const scroller = scrollElement(2_000, 600);
+
+    expect(scrollableEditSurface(scroller, viewport, true)).toBe(scroller);
+  });
+
+  // Capturing on the way in happens while the viewer is still mounted: the
+  // editor's scroller is stale there, and the viewer's offset is the one to keep.
+  test("always reads the document viewport while not editing", () => {
+    const viewport = scrollElement(8_204, 1_055);
+    const scroller = scrollElement(2_000, 600);
+
+    expect(scrollableEditSurface(scroller, viewport, false)).toBe(viewport);
+  });
+
+  test("stays null when the viewport is unavailable", () => {
+    expect(scrollableEditSurface(null, null, true)).toBeNull();
+  });
+});

--- a/packages/editor/editScroll.ts
+++ b/packages/editor/editScroll.ts
@@ -1,0 +1,30 @@
+/**
+ * Which element a markdown edit session's scroll offset actually lives on.
+ *
+ * The Viewer ↔ MarkdownEditor swap replaces the document area's children, and a
+ * real browser clamps the scroll container to the top the moment the old subtree
+ * leaves it — that is the jump #1479 reports. Carrying the offset across the
+ * swap needs the right target, and the target depends on the shell:
+ *
+ *   - The desktop layout leaves the editor unbounded, so CodeMirror grows to
+ *     full content height inside the document viewport: the VIEWPORT scrolls and
+ *     `.cm-scroller` never overflows (restoring into it is a silent no-op).
+ *   - A height-bounded shell (compact touch) bounds the editor, so CodeMirror
+ *     scrolls itself and `.cm-scroller` is the scroller.
+ *
+ * Resolve the element that can actually scroll when the offset is READ (before
+ * the swap): the surface on screen has settled by then, so its overflow test is
+ * trustworthy. Restoring is deliberately not routed through this test — the
+ * surface that just mounted has no reliable measurement yet; see the restore
+ * effect in `App.tsx`.
+ */
+export function scrollableEditSurface(
+  editorScroller: HTMLElement | null,
+  documentViewport: HTMLElement | null,
+  isEditing: boolean,
+): HTMLElement | null {
+  if (isEditing && editorScroller && editorScroller.scrollHeight > editorScroller.clientHeight) {
+    return editorScroller;
+  }
+  return documentViewport;
+}

--- a/packages/ui/components/KeyboardShortcuts.tsx
+++ b/packages/ui/components/KeyboardShortcuts.tsx
@@ -88,6 +88,7 @@ const documentViewShortcuts: ShortcutSection = {
   title: 'View',
   shortcuts: [
     { keys: [modKey, '.'], desc: 'Toggle focus mode', hint: 'Collapses the Contents sidebar and the right-hand panel together; press again to restore whatever was open before. Markdown documents only; HTML pages keep their own layout.' },
+    { keys: [modKey, 'E'], desc: 'Toggle edit mode', hint: 'Opens the markdown source editor in place, keeping your scroll position; press again to commit your edits and return to annotating. Markdown documents only; a source-backed document with unsaved changes keeps its two-step discard.' },
   ],
 };
 

--- a/packages/ui/shortcuts/plan-review/documentView.shortcuts.ts
+++ b/packages/ui/shortcuts/plan-review/documentView.shortcuts.ts
@@ -7,6 +7,11 @@ import { createShortcutScopeHook } from '../runtime';
  * Focus mode is the keyboard entry point to the same view state the document
  * card's `Focus` control drives: both side panels collapse in one press and the
  * previous arrangement comes back on the next one.
+ *
+ * Edit mode is its sibling: the same chord the card's `Edit` / `Done` control
+ * drives, opening the markdown source editor in place and committing back to
+ * the viewer — the scroll position survives both directions, so a mid-document
+ * fix never costs a scroll to the top and back.
  */
 export const documentViewShortcuts = defineShortcutScope({
   id: 'document-view',
@@ -18,6 +23,14 @@ export const documentViewShortcuts = defineShortcutScope({
       section: 'View',
       hint: 'Collapses the Contents sidebar and the right-hand panel together; press again to restore whatever was open before.',
       displayOrder: 10,
+      preventDefault: true,
+    },
+    toggleEditMode: {
+      description: 'Toggle edit mode',
+      bindings: ['Mod+E'],
+      section: 'View',
+      hint: 'Opens the markdown source editor in place, keeping your scroll position; press again to commit your edits and return to annotating.',
+      displayOrder: 20,
       preventDefault: true,
     },
   },


### PR DESCRIPTION
## Problem

Edit mode was reachable only through the Edit/Done control at the top of the document card, so alternating between "annotate this" and "just fix this word" mid-document cost a scroll to the top and back — twice. `Mod+S` already covers saving in edit mode; entering and leaving the mode had no chord. #1479

## Change

- The `document-view` scope gains `toggleEditMode`, bound to `Mod+E` (unclaimed repo-wide; the sibling `toggleFocusMode` is `Mod+.`).
- **Enter** runs through the existing `handleEditToggle` behind the same `canEditMarkdown` gate the card's Edit control uses, so read-only/archive/HTML/live/plan-diff surfaces no-op.
- **Exit** works while CodeMirror has focus, via a window keydown listener mounted only while editing that routes to the card's Done path (`commitMarkdownEdits`). With unsaved source-backed changes (`cancelMode`) it no-ops — never a silent discard. The `isEditingMarkdown`/contentEditable refusal in `canHandleDocumentChromeShortcut` is untouched; the exit listener shares only the dialog/overlay half of the guard.
- **Scroll carry**: the offset is captured before the Viewer↔editor swap and re-applied after it (immediate + one rAF — CodeMirror settles its height a frame after mount, and a single write clamps to the top). New `packages/editor/editScroll.ts` makes explicit which surface actually scrolls: on desktop CodeMirror grows inside the document viewport, while a height-bounded compact shell scrolls internally.
- Settings → Shortcuts → View lists the new row (that list is hand-maintained, not registry-driven).

## Verification

- Bun 1.3.14, disposable HOME: `shortcuts.test.ts` **17/17**; `App.editModeShortcut.test.tsx` **4/4**; `editScroll.test.ts` **4/4**; combined regression run of 10 App/Settings files **46/46**. Each load-bearing piece (restore effect, exit listener, `cancelMode` guard) has a stash-the-fix red control.
- Real browser (Chrome for Testing over CDP against the hook dev server): viewer at scrollTop 3000 → `Mod+E` → editor mounted with the offset preserved; scrolled to 4321 and focus placed inside `.cm-content` → `Mod+E` → back in the viewer at the captured offset. The chord fires from inside CodeMirror; no keymap swallows it.
- guides-show gate in this tree: `build:viewer`, `sync:manifest`, `check:budgets`, `check:manifest` all pass, with no manifest drift.

Fixes #1479
