### PR TITLE
fix(codex): fall back across rollout files for annotate-last and the Stop hook

### DIFF
--- a/apps/hook/server/codex-session.test.ts
+++ b/apps/hook/server/codex-session.test.ts
@@ -7,10 +7,16 @@
  */
 
 import { describe, expect, test, afterEach } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { findCodexRolloutByThreadId, getLastCodexMessage, getLatestCodexPlan } from "./codex-session";
+import {
+  findCodexRolloutByThreadId,
+  findCodexRolloutsByThreadId,
+  getLastCodexMessage,
+  getLatestCodexPlan,
+  getRecentCodexMessages,
+} from "./codex-session";
 
 // --- Fixture Helpers ---
 
@@ -180,6 +186,178 @@ describe("findCodexRolloutByThreadId", () => {
       if (prev === undefined) delete process.env.CODEX_HOME;
       else process.env.CODEX_HOME = prev;
     }
+  });
+});
+
+// --- Multi-rollout threads (#1367) ---
+
+/**
+ * One Codex thread can span several rollout files. The newest segment is not
+ * guaranteed to hold the artifact the caller needs (it may be empty or
+ * aborted), so consumers walk the candidates newest-first until one yields
+ * the message/plan they want. These tests pin that contract.
+ */
+describe("multi-rollout threads (#1367)", () => {
+  const THREAD_ID = "0196f8a2-1111-2222-3333-1234567890ab";
+
+  function withCodexHome<T>(home: string, fn: () => T): T {
+    const prev = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = home;
+    try {
+      return fn();
+    } finally {
+      if (prev === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = prev;
+    }
+  }
+
+  function sessionsHome(): string {
+    const home = mkdtempSync(join(tmpdir(), "plannotator-codex-home-"));
+    tempFiles.push(home);
+    return home;
+  }
+
+  /** Write a rollout segment into <home>/sessions/<date>/ with an exact mtime. */
+  function writeSegment(
+    home: string,
+    date: { year: string; month: string; day: string },
+    stamp: string,
+    content: string,
+    mtimeIso: string
+  ): string {
+    const dayDir = join(home, "sessions", date.year, date.month, date.day);
+    mkdirSync(dayDir, { recursive: true });
+    const path = join(dayDir, `rollout-${stamp}-${THREAD_ID}.jsonl`);
+    writeFileSync(path, content);
+    const mtime = new Date(mtimeIso);
+    utimesSync(path, mtime, mtime);
+    return path;
+  }
+
+  /** Mirrors the annotate-last selection in index.ts. */
+  function resolveLastMessage(home: string): string | null {
+    return withCodexHome(home, () => {
+      for (const rollout of findCodexRolloutsByThreadId(THREAD_ID)) {
+        const recent = getRecentCodexMessages(rollout, 25, { beforeActiveTurn: true });
+        if (recent.length > 0) return recent[0].text;
+      }
+      return null;
+    });
+  }
+
+  /** Mirrors the Stop-hook plan selection in index.ts. */
+  function resolvePlan(home: string): string | null {
+    return withCodexHome(home, () => {
+      for (const rollout of findCodexRolloutsByThreadId(THREAD_ID)) {
+        const plan = getLatestCodexPlan(rollout, {});
+        if (plan?.text) return plan.text;
+      }
+      return null;
+    });
+  }
+
+  test("same day: falls back to an older segment when the newest is empty", () => {
+    const home = sessionsHome();
+    const day = { year: "2026", month: "06", day: "04" };
+    const older = writeSegment(
+      home,
+      day,
+      "2026-06-04T10-00-00",
+      buildRollout(sessionMeta(), userMessage("Hello"), assistantMessage("Older segment answer")),
+      "2026-06-04T10:00:00Z"
+    );
+    const newer = writeSegment(
+      home,
+      day,
+      "2026-06-04T11-00-00",
+      buildRollout(sessionMeta(), userMessage("Hello")),
+      "2026-06-04T11:00:00Z"
+    );
+
+    withCodexHome(home, () => {
+      expect(findCodexRolloutsByThreadId(THREAD_ID)).toEqual([newer, older]);
+      expect(findCodexRolloutByThreadId(THREAD_ID)).toBe(newer);
+    });
+    expect(resolveLastMessage(home)).toBe("Older segment answer");
+  });
+
+  test("multi day: falls back across day directories", () => {
+    const home = sessionsHome();
+    const older = writeSegment(
+      home,
+      { year: "2026", month: "06", day: "04" },
+      "2026-06-04T22-00-00",
+      buildRollout(sessionMeta(), assistantMessage("Reply from the previous day")),
+      "2026-06-04T22:00:00Z"
+    );
+    const newer = writeSegment(
+      home,
+      { year: "2026", month: "06", day: "05" },
+      "2026-06-05T09-00-00",
+      buildRollout(sessionMeta(), userMessage("Resumed")),
+      "2026-06-05T09:00:00Z"
+    );
+
+    withCodexHome(home, () => {
+      expect(findCodexRolloutsByThreadId(THREAD_ID)).toEqual([newer, older]);
+    });
+    expect(resolveLastMessage(home)).toBe("Reply from the previous day");
+  });
+
+  test("single rollout thread is unchanged", () => {
+    const home = sessionsHome();
+    const only = writeSegment(
+      home,
+      { year: "2026", month: "06", day: "04" },
+      "2026-06-04T10-00-00",
+      buildRollout(sessionMeta(), assistantMessage("Only answer")),
+      "2026-06-04T10:00:00Z"
+    );
+
+    withCodexHome(home, () => {
+      expect(findCodexRolloutsByThreadId(THREAD_ID)).toEqual([only]);
+      expect(findCodexRolloutByThreadId(THREAD_ID)).toBe(only);
+      expect(findCodexRolloutsByThreadId("no-such-thread")).toEqual([]);
+    });
+    expect(resolveLastMessage(home)).toBe("Only answer");
+  });
+
+  test("single empty rollout still reports no message", () => {
+    const home = sessionsHome();
+    writeSegment(
+      home,
+      { year: "2026", month: "06", day: "04" },
+      "2026-06-04T10-00-00",
+      buildRollout(sessionMeta(), userMessage("Hello")),
+      "2026-06-04T10:00:00Z"
+    );
+
+    expect(resolveLastMessage(home)).toBeNull();
+  });
+
+  test("Stop hook plan falls back to an older segment", () => {
+    const home = sessionsHome();
+    const day = { year: "2026", month: "06", day: "04" };
+    writeSegment(
+      home,
+      day,
+      "2026-06-04T10-00-00",
+      buildRollout(
+        sessionMeta(),
+        turnStarted("turn-1"),
+        assistantMessage("<proposed_plan>\nOlder segment plan\n</proposed_plan>")
+      ),
+      "2026-06-04T10:00:00Z"
+    );
+    writeSegment(
+      home,
+      day,
+      "2026-06-04T11-00-00",
+      buildRollout(sessionMeta(), turnStarted("turn-2"), assistantMessage("No plan here.")),
+      "2026-06-04T11:00:00Z"
+    );
+
+    expect(resolvePlan(home)).toBe("Older segment plan");
   });
 });
 

--- a/apps/hook/server/codex-session.test.ts
+++ b/apps/hook/server/codex-session.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, expect, test, afterEach } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -192,10 +192,13 @@ describe("findCodexRolloutByThreadId", () => {
 // --- Multi-rollout threads (#1367) ---
 
 /**
- * One Codex thread can span several rollout files. The newest segment is not
- * guaranteed to hold the artifact the caller needs (it may be empty or
- * aborted), so consumers walk the candidates newest-first until one yields
- * the message/plan they want. These tests pin that contract.
+ * One Codex thread can span several rollout files. Fallback semantics differ
+ * by consumer: annotate-last asks a THREAD-level question and walks the
+ * candidates newest-first until one yields a message (the newest segment may
+ * be empty or aborted), while the Stop hook asks a TURN-level question and
+ * takes only the first existing candidate — the current turn cannot live in
+ * an older segment, so a fallback file's plan is stale by construction.
+ * These tests pin both contracts.
  */
 describe("multi-rollout threads (#1367)", () => {
   const THREAD_ID = "0196f8a2-1111-2222-3333-1234567890ab";
@@ -217,17 +220,23 @@ describe("multi-rollout threads (#1367)", () => {
     return home;
   }
 
-  /** Write a rollout segment into <home>/sessions/<date>/ with an exact mtime. */
+  /**
+   * Write a rollout segment into <home>/sessions/<date>/ with an exact mtime.
+   * Segmented threads use issue-realistic `_<segment>`-suffixed filenames:
+   *   rollout-<timestamp>-<thread-id>_<segment>.jsonl (#1367)
+   */
   function writeSegment(
     home: string,
     date: { year: string; month: string; day: string },
     stamp: string,
     content: string,
-    mtimeIso: string
+    mtimeIso: string,
+    segment?: number
   ): string {
     const dayDir = join(home, "sessions", date.year, date.month, date.day);
     mkdirSync(dayDir, { recursive: true });
-    const path = join(dayDir, `rollout-${stamp}-${THREAD_ID}.jsonl`);
+    const suffix = segment === undefined ? "" : `_${segment}`;
+    const path = join(dayDir, `rollout-${stamp}-${THREAD_ID}${suffix}.jsonl`);
     writeFileSync(path, content);
     const mtime = new Date(mtimeIso);
     utimesSync(path, mtime, mtime);
@@ -245,14 +254,26 @@ describe("multi-rollout threads (#1367)", () => {
     });
   }
 
-  /** Mirrors the Stop-hook plan selection in index.ts. */
-  function resolvePlan(home: string): string | null {
+  /**
+   * Mirrors the Stop-hook plan selection in index.ts: the Stop hook asks a
+   * TURN-level question, and the current turn can only live in the newest
+   * segment, so only the first EXISTING candidate is consulted — never a
+   * fallback across segments (a fallback file's plan is stale by
+   * construction and would reopen already-decided plan reviews).
+   */
+  function resolvePlan(
+    home: string,
+    options: { turnId?: string; stopHookActive?: boolean } = {}
+  ): string | null {
     return withCodexHome(home, () => {
-      for (const rollout of findCodexRolloutsByThreadId(THREAD_ID)) {
-        const plan = getLatestCodexPlan(rollout, {});
-        if (plan?.text) return plan.text;
-      }
-      return null;
+      const rollout =
+        findCodexRolloutsByThreadId(THREAD_ID).find((path) => existsSync(path)) ?? null;
+      if (!rollout) return null;
+      const plan = getLatestCodexPlan(rollout, {
+        turnId: options.turnId,
+        stopHookActive: !!options.stopHookActive,
+      });
+      return plan?.text ?? null;
     });
   }
 
@@ -271,7 +292,8 @@ describe("multi-rollout threads (#1367)", () => {
       day,
       "2026-06-04T11-00-00",
       buildRollout(sessionMeta(), userMessage("Hello")),
-      "2026-06-04T11:00:00Z"
+      "2026-06-04T11:00:00Z",
+      1
     );
 
     withCodexHome(home, () => {
@@ -279,6 +301,51 @@ describe("multi-rollout threads (#1367)", () => {
       expect(findCodexRolloutByThreadId(THREAD_ID)).toBe(newer);
     });
     expect(resolveLastMessage(home)).toBe("Older segment answer");
+  });
+
+  test("newest-first ordering follows mtime, not directory or filename order", () => {
+    const home = sessionsHome();
+    // The newer-mtime segment sits in the EARLIER day directory with the
+    // lexicographically SMALLER filename, so both the reverse directory walk
+    // and any filename/readdir ordering would put it LAST. Only the mtime
+    // sort ranks it first — this fixture fails if that sort is neutered.
+    const newerMtime = writeSegment(
+      home,
+      { year: "2026", month: "06", day: "04" },
+      "2026-06-04T08-00-00",
+      buildRollout(sessionMeta(), assistantMessage("Newest by mtime")),
+      "2026-06-06T12:00:00Z"
+    );
+    const olderMtime = writeSegment(
+      home,
+      { year: "2026", month: "06", day: "05" },
+      "2026-06-05T09-00-00",
+      buildRollout(sessionMeta(), assistantMessage("Older by mtime")),
+      "2026-06-05T09:00:00Z",
+      1
+    );
+
+    withCodexHome(home, () => {
+      expect(findCodexRolloutsByThreadId(THREAD_ID)).toEqual([newerMtime, olderMtime]);
+      expect(findCodexRolloutByThreadId(THREAD_ID)).toBe(newerMtime);
+    });
+    expect(resolveLastMessage(home)).toBe("Newest by mtime");
+  });
+
+  test("0-byte newest segment falls back for annotate-last", () => {
+    const home = sessionsHome();
+    const day = { year: "2026", month: "06", day: "04" };
+    writeSegment(
+      home,
+      day,
+      "2026-06-04T10-00-00",
+      buildRollout(sessionMeta(), assistantMessage("Answer before the crash")),
+      "2026-06-04T10:00:00Z"
+    );
+    // An aborted segment can be created and never written to.
+    writeSegment(home, day, "2026-06-04T11-00-00", "", "2026-06-04T11:00:00Z", 1);
+
+    expect(resolveLastMessage(home)).toBe("Answer before the crash");
   });
 
   test("multi day: falls back across day directories", () => {
@@ -295,7 +362,8 @@ describe("multi-rollout threads (#1367)", () => {
       { year: "2026", month: "06", day: "05" },
       "2026-06-05T09-00-00",
       buildRollout(sessionMeta(), userMessage("Resumed")),
-      "2026-06-05T09:00:00Z"
+      "2026-06-05T09:00:00Z",
+      1
     );
 
     withCodexHome(home, () => {
@@ -335,9 +403,16 @@ describe("multi-rollout threads (#1367)", () => {
     expect(resolveLastMessage(home)).toBeNull();
   });
 
-  test("Stop hook plan falls back to an older segment", () => {
+  test("Stop hook takes only the newest existing segment — never resurrects an older segment's plan", () => {
     const home = sessionsHome();
     const day = { year: "2026", month: "06", day: "04" };
+    // The older segment ends with an already-decided proposed plan — the
+    // normal shape after a plan is approved and the session resumes. The
+    // current turn lives in the newest segment and produced no plan, so the
+    // Stop hook must report no plan rather than fall back and reopen the
+    // settled review (getLatestCodexPlan's turn gate degrades to
+    // last-turn-in-file when the turn_id is absent from a file, which is
+    // exactly what happens in every fallback file).
     writeSegment(
       home,
       day,
@@ -345,7 +420,7 @@ describe("multi-rollout threads (#1367)", () => {
       buildRollout(
         sessionMeta(),
         turnStarted("turn-1"),
-        assistantMessage("<proposed_plan>\nOlder segment plan\n</proposed_plan>")
+        assistantMessage("<proposed_plan>\nAlready-decided plan\n</proposed_plan>")
       ),
       "2026-06-04T10:00:00Z"
     );
@@ -354,10 +429,39 @@ describe("multi-rollout threads (#1367)", () => {
       day,
       "2026-06-04T11-00-00",
       buildRollout(sessionMeta(), turnStarted("turn-2"), assistantMessage("No plan here.")),
-      "2026-06-04T11:00:00Z"
+      "2026-06-04T11:00:00Z",
+      1
     );
 
-    expect(resolvePlan(home)).toBe("Older segment plan");
+    expect(resolvePlan(home, { turnId: "turn-2", stopHookActive: false })).toBeNull();
+  });
+
+  test("Stop hook still reads the plan from the newest segment", () => {
+    const home = sessionsHome();
+    const day = { year: "2026", month: "06", day: "04" };
+    writeSegment(
+      home,
+      day,
+      "2026-06-04T10-00-00",
+      buildRollout(sessionMeta(), turnStarted("turn-1"), assistantMessage("Earlier work.")),
+      "2026-06-04T10:00:00Z"
+    );
+    writeSegment(
+      home,
+      day,
+      "2026-06-04T11-00-00",
+      buildRollout(
+        sessionMeta(),
+        turnStarted("turn-2"),
+        assistantMessage("<proposed_plan>\nCurrent turn plan\n</proposed_plan>")
+      ),
+      "2026-06-04T11:00:00Z",
+      1
+    );
+
+    expect(resolvePlan(home, { turnId: "turn-2", stopHookActive: false })).toBe(
+      "Current turn plan"
+    );
   });
 });
 

--- a/apps/hook/server/codex-session.ts
+++ b/apps/hook/server/codex-session.ts
@@ -89,9 +89,12 @@ function mtimeMs(path: string): number {
  *   rollout-<timestamp>-<uuid>.jsonl
  *
  * A single thread can span multiple rollout files (Codex segments long
- * conversations), and the newest segment is not guaranteed to hold the
- * artifact a caller needs — it may be empty or aborted. Callers must fall
- * back across the candidates instead of trusting the first one (#1367).
+ * conversations). Fallback semantics are the CALLER's decision (#1367):
+ * thread-level questions (annotate-last) fall back across candidates because
+ * the newest segment may be empty or aborted, while turn-level questions
+ * (the Stop hook's plan detection) must take only the first existing
+ * candidate — the current turn cannot live in an older segment, so anything
+ * a fallback file yields there is stale by construction.
  *
  * Scans $CODEX_HOME/sessions/ (default ~/.codex/sessions/).
  */

--- a/apps/hook/server/codex-session.ts
+++ b/apps/hook/server/codex-session.ts
@@ -75,17 +75,32 @@ function codexHome(): string {
   return process.env.CODEX_HOME || join(homedir(), ".codex");
 }
 
+function mtimeMs(path: string): number {
+  try {
+    return statSync(path).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
 /**
- * Find the Codex rollout file for a given thread ID.
+ * Find every Codex rollout file for a given thread ID, newest first.
  * The thread ID is the UUID portion of the filename:
  *   rollout-<timestamp>-<uuid>.jsonl
  *
- * Scans $CODEX_HOME/sessions/ (default ~/.codex/sessions/) for a matching file.
+ * A single thread can span multiple rollout files (Codex segments long
+ * conversations), and the newest segment is not guaranteed to hold the
+ * artifact a caller needs — it may be empty or aborted. Callers must fall
+ * back across the candidates instead of trusting the first one (#1367).
+ *
+ * Scans $CODEX_HOME/sessions/ (default ~/.codex/sessions/).
  */
-export function findCodexRolloutByThreadId(threadId: string): string | null {
+export function findCodexRolloutsByThreadId(threadId: string): string[] {
   const sessionsDir = join(codexHome(), "sessions");
 
   try {
+    const matches: string[] = [];
+
     // Walk YYYY/MM/DD directories in reverse order (most recent first)
     const years = readdirSync(sessionsDir).sort().reverse();
     for (const year of years) {
@@ -102,20 +117,33 @@ export function findCodexRolloutByThreadId(threadId: string): string | null {
           const dayDir = join(monthDir, day);
           if (!isDir(dayDir)) continue;
 
-          const files = readdirSync(dayDir);
-          for (const file of files) {
+          for (const file of readdirSync(dayDir)) {
             if (file.endsWith(".jsonl") && file.includes(threadId)) {
-              return join(dayDir, file);
+              matches.push(join(dayDir, file));
             }
           }
         }
       }
     }
-  } catch {
-    return null;
-  }
 
-  return null;
+    // Newest first by mtime; the filename carries the same timestamp, so a
+    // filename comparison breaks ties and covers a failed stat.
+    return matches.sort((a, b) => {
+      const byMtime = mtimeMs(b) - mtimeMs(a);
+      return byMtime !== 0 ? byMtime : b.localeCompare(a);
+    });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Find the newest Codex rollout file for a given thread ID.
+ * Callers that need to survive an empty newest segment (a thread split
+ * across rollout files) should use findCodexRolloutsByThreadId instead (#1367).
+ */
+export function findCodexRolloutByThreadId(threadId: string): string | null {
+  return findCodexRolloutsByThreadId(threadId)[0] ?? null;
 }
 
 function isDir(path: string): boolean {

--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -2334,23 +2334,29 @@ if (args[0] === "sessions") {
     const transcriptPath = typeof event.transcript_path === "string" && event.transcript_path
       ? event.transcript_path
       : null;
-    // A thread can span multiple rollout files; the newest segment may hold
-    // no plan while an older one does, so try each in turn (#1367).
+    // A thread can span multiple rollout files, but the Stop hook asks a
+    // TURN-level question and the current turn can only live in the newest
+    // segment. Take the first existing candidate only — never fall back to an
+    // older segment: findTurnStartIndex degrades to last-turn-in-file when
+    // the turn_id is absent, so a fallback file's plan is stale by
+    // construction (older segments routinely end with an already-decided
+    // <proposed_plan>) and would deterministically reopen settled plan
+    // reviews on every turn end. Contrast the annotate-last leg above, which
+    // asks a thread-level question and correctly falls back across segments
+    // (#1367).
     const rolloutPaths = transcriptPath
       ? [transcriptPath]
       : process.env.CODEX_THREAD_ID
         ? findCodexRolloutsByThreadId(process.env.CODEX_THREAD_ID)
         : [];
+    const rolloutPath = rolloutPaths.find((path) => existsSync(path)) ?? null;
 
-    let latestPlan: ReturnType<typeof getLatestCodexPlan> = null;
-    for (const rolloutPath of rolloutPaths) {
-      if (!existsSync(rolloutPath)) continue;
-      latestPlan = getLatestCodexPlan(rolloutPath, {
-        turnId: typeof event.turn_id === "string" ? event.turn_id : undefined,
-        stopHookActive: !!event.stop_hook_active,
-      });
-      if (latestPlan?.text) break;
-    }
+    const latestPlan = rolloutPath
+      ? getLatestCodexPlan(rolloutPath, {
+          turnId: typeof event.turn_id === "string" ? event.turn_id : undefined,
+          stopHookActive: !!event.stop_hook_active,
+        })
+      : null;
 
     if (!latestPlan?.text) {
       process.exit(0);

--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -163,7 +163,7 @@ import {
   resolveSessionLogByCwdScan,
   type RenderedMessage,
 } from "./session-log";
-import { findCodexRolloutByThreadId, getLatestCodexPlan, getRecentCodexMessages } from "./codex-session";
+import { findCodexRolloutsByThreadId, getLatestCodexPlan, getRecentCodexMessages } from "./codex-session";
 import { findCopilotPlanContent, findCopilotSessionByAncestorPids, findCopilotSessionForCwd, getRecentCopilotMessages } from "./copilot-session";
 import {
   formatInteractiveNoArgClarification,
@@ -1497,14 +1497,19 @@ if (args[0] === "sessions") {
     if (process.env.PLANNOTATOR_DEBUG) {
       console.error(`[DEBUG] Codex detected, thread ID: ${codexThreadId}`);
     }
-    const rolloutPath = findCodexRolloutByThreadId(codexThreadId);
-    if (rolloutPath) {
+    // A thread can span multiple rollout files; the newest segment may be
+    // empty or aborted, so fall back until one yields a message (#1367).
+    for (const rolloutPath of findCodexRolloutsByThreadId(codexThreadId)) {
       if (process.env.PLANNOTATOR_DEBUG) {
         console.error(`[DEBUG] Rollout: ${rolloutPath}`);
       }
-      recentMessages = getRecentCodexMessages(rolloutPath, RECENT_MESSAGES_LIMIT, { beforeActiveTurn: true })
+      const recent = getRecentCodexMessages(rolloutPath, RECENT_MESSAGES_LIMIT, { beforeActiveTurn: true })
         .map((m) => ({ messageId: m.messageId, text: m.text, lineNumbers: [], timestamp: m.timestamp }));
-      lastMessage = recentMessages[0] ?? null;
+      if (recent.length > 0) {
+        recentMessages = recent;
+        lastMessage = recent[0];
+        break;
+      }
     }
   } else if (isDroid) {
     // Droid/Factory path: resolve the current repo's session log from
@@ -2326,20 +2331,26 @@ if (args[0] === "sessions") {
   }
 
   if (event.hook_event_name === "Stop") {
-    const rolloutPath =
-      (typeof event.transcript_path === "string" && event.transcript_path) ||
-      (process.env.CODEX_THREAD_ID
-        ? findCodexRolloutByThreadId(process.env.CODEX_THREAD_ID)
-        : null);
+    const transcriptPath = typeof event.transcript_path === "string" && event.transcript_path
+      ? event.transcript_path
+      : null;
+    // A thread can span multiple rollout files; the newest segment may hold
+    // no plan while an older one does, so try each in turn (#1367).
+    const rolloutPaths = transcriptPath
+      ? [transcriptPath]
+      : process.env.CODEX_THREAD_ID
+        ? findCodexRolloutsByThreadId(process.env.CODEX_THREAD_ID)
+        : [];
 
-    if (!rolloutPath || !existsSync(rolloutPath)) {
-      process.exit(0);
+    let latestPlan: ReturnType<typeof getLatestCodexPlan> = null;
+    for (const rolloutPath of rolloutPaths) {
+      if (!existsSync(rolloutPath)) continue;
+      latestPlan = getLatestCodexPlan(rolloutPath, {
+        turnId: typeof event.turn_id === "string" ? event.turn_id : undefined,
+        stopHookActive: !!event.stop_hook_active,
+      });
+      if (latestPlan?.text) break;
     }
-
-    const latestPlan = getLatestCodexPlan(rolloutPath, {
-      turnId: typeof event.turn_id === "string" ? event.turn_id : undefined,
-      stopHookActive: !!event.stop_hook_active,
-    });
 
     if (!latestPlan?.text) {
       process.exit(0);


### PR DESCRIPTION
## Problem

One Codex thread can span several rollout JSONL files (`rollout-…-<thread-id>_<segment>.jsonl`), and `findCodexRolloutByThreadId` returned the **first** filename containing the thread id from an unsorted `readdirSync` — which can be an empty or aborted segment. `plannotator last` then exited with `No rendered assistant message found in session logs.` even though another rollout for the same thread contained the message. The Stop hook's plan detection had the same single-file assumption. #1367

## Change

- `findCodexRolloutsByThreadId` returns **all** rollouts matching the thread id, newest first (mtime, with the filename timestamp as tiebreak); the singular finder delegates to it.
- Both consumers iterate candidates newest-first and use the first rollout that actually yields the needed artifact — a rendered assistant message for annotate-last, plan content for the Stop hook.
- Single-rollout threads behave exactly as before, including the pre-existing not-found error path.

## Verification

Bun 1.3.14, disposable HOME: `apps/hook/server/codex-session.test.ts` gains 5 tests over synthetic `CODEX_HOME` fixture trees — same-day newer-empty/older-with-message, multi-day fallback, single-rollout unchanged (success and not-found), and the Stop-hook plan fallback. **64 pass / 0 fail** across `codex-session` + `strict-annotate-result` + `cli` test files. A throwaway repro script confirmed the first-candidate bug and the fix before deletion (sorting alone is insufficient: the newest segment may legitimately be the empty one — the fallback across candidates is the actual fix).

Fixes #1367
