### PR TITLE
fix(browser): honor POSIX PLANNOTATOR_BROWSER under WSL and warn on launch failure

### DIFF
--- a/apps/pi-extension/server/network.test.ts
+++ b/apps/pi-extension/server/network.test.ts
@@ -1,5 +1,15 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import {
+	chmodSync,
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { createServer } from "node:http";
+import os, { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
 import { closeServer, occupyConsecutivePorts } from "../../../tests/helpers/ports.ts";
 import {
 	buildAdvertisedUrl,
@@ -7,6 +17,7 @@ import {
 	getServerPort,
 	getServerPorts,
 	isNoOpBrowserSentinel,
+	isPosixBrowserTarget,
 	isRemoteSession,
 	listenOnPort,
 	openBrowser,
@@ -328,5 +339,113 @@ describe("pi buildAdvertisedUrl", () => {
 		expect(getServerHostname()).toBe("127.0.0.1");
 		process.env.PLANNOTATOR_REMOTE = "1";
 		expect(getServerHostname()).toBe("0.0.0.0");
+	});
+});
+
+// --- WSL PLANNOTATOR_BROWSER routing (#1472) ---
+
+const realPlatform = process.platform;
+const realRelease = os.release;
+
+/** Pretend to run under WSL: the WSL test is process.platform + os.release(). */
+function mockWsl() {
+	Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+	os.release = () => "5.15.90.1-microsoft-standard-WSL2";
+}
+
+function restoreHostPlatform() {
+	Object.defineProperty(process, "platform", { value: realPlatform, configurable: true });
+	os.release = realRelease;
+}
+
+function writeExecutable(dir: string, name: string, body: string): string {
+	const file = join(dir, name);
+	writeFileSync(file, `#!/bin/sh\n${body}\n`);
+	chmodSync(file, 0o755);
+	return file;
+}
+
+async function waitForFile(file: string, timeoutMs = 2000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!existsSync(file)) {
+		if (Date.now() > deadline) throw new Error(`timed out waiting for ${file}`);
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+}
+
+const URL = "http://127.0.0.1:19432/plan";
+
+describe("pi WSL configured browser launch", () => {
+	afterEach(() => {
+		restoreHostPlatform();
+	});
+
+	test("a POSIX path is spawned directly with the URL", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "plannotator-pi-browser-"));
+		const log = join(dir, "args.txt");
+		const script = writeExecutable(dir, "fake-browser", `printf '%s' "$1" > '${log}'`);
+		try {
+			clearEnv();
+			mockWsl();
+			process.env.PLANNOTATOR_BROWSER = script;
+
+			expect(await openBrowser(URL)).toEqual({ opened: true });
+			await waitForFile(log);
+			expect(readFileSync(log, "utf8")).toBe(URL);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("a Windows .exe target still routes through cmd.exe", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "plannotator-pi-browser-"));
+		const cmdLog = join(dir, "cmd.txt");
+		const directLog = join(dir, "direct.txt");
+		writeExecutable(dir, "cmd.exe", `printf '%s' "$*" > '${cmdLog}'`);
+		writeExecutable(dir, "chrome.exe", `printf '%s' "$1" > '${directLog}'`);
+		const originalPath = process.env.PATH;
+		try {
+			process.env.PATH = `${dir}${delimiter}${originalPath ?? ""}`;
+			clearEnv();
+			mockWsl();
+			process.env.PLANNOTATOR_BROWSER = "chrome.exe";
+
+			expect(await openBrowser(URL)).toEqual({ opened: true });
+			await waitForFile(cmdLog);
+			expect(readFileSync(cmdLog, "utf8")).toContain("chrome.exe");
+			expect(existsSync(directLog)).toBe(false);
+		} finally {
+			if (originalPath === undefined) delete process.env.PATH;
+			else process.env.PATH = originalPath;
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("a missing configured browser warns and reports opened: false", async () => {
+		const missing = join(tmpdir(), "plannotator-missing-1472", "browser");
+		const originalWrite = process.stderr.write;
+		const chunks: string[] = [];
+		(process.stderr as { write: unknown }).write = (chunk: string) => {
+			chunks.push(String(chunk));
+			return true;
+		};
+		try {
+			clearEnv();
+			mockWsl();
+			process.env.PLANNOTATOR_BROWSER = missing;
+
+			expect(await openBrowser(URL)).toEqual({ opened: false });
+			const warning = chunks.join("");
+			expect(warning).toContain(missing);
+			expect(warning).toContain("PLANNOTATOR_BROWSER");
+		} finally {
+			(process.stderr as { write: unknown }).write = originalWrite;
+		}
+	});
+
+	test("Windows targets are excluded from POSIX routing", () => {
+		expect(isPosixBrowserTarget("/usr/bin/firefox")).toBe(true);
+		expect(isPosixBrowserTarget("chrome.exe")).toBe(false);
+		expect(isPosixBrowserTarget("/mnt/c/Program Files/Chrome/chrome.exe")).toBe(false);
 	});
 });

--- a/apps/pi-extension/server/network.ts
+++ b/apps/pi-extension/server/network.ts
@@ -4,9 +4,9 @@
  */
 
 import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import type { Server } from "node:http";
-import { release } from "node:os";
+import os from "node:os";
 import { delimiter, join } from "node:path";
 import { loadConfig, resolveUrlHost, resolveUseGlimpse } from "../generated/config.ts";
 import { parsePortSelection } from "../generated/port-range.ts";
@@ -26,6 +26,41 @@ function isAddressInUseError(err: unknown): boolean {
 export function isNoOpBrowserSentinel(value: string | undefined): boolean {
 	if (!value) return false;
 	return NOOP_BROWSER_VALUES.has(value.trim().toLowerCase());
+}
+
+/**
+ * True for a value that must be handed to cmd.exe under WSL: a Windows-style
+ * path (C:\..., C:/...) or a /mnt/<drive> mount of one, or a `.exe` name.
+ */
+function isWindowsBrowserTarget(value: string): boolean {
+	return (
+		/^[A-Za-z]:[\\/]/.test(value) ||
+		value.startsWith("/mnt/") ||
+		value.toLowerCase().endsWith(".exe")
+	);
+}
+
+/**
+ * True when PLANNOTATOR_BROWSER names something the Linux side can execute
+ * itself: a POSIX path (/..., ./..., ../...) or a bare name resolvable to an
+ * executable on the Linux PATH. Under WSL those must NOT go through cmd.exe,
+ * which cannot resolve them (#1472).
+ */
+export function isPosixBrowserTarget(value: string): boolean {
+	if (isWindowsBrowserTarget(value)) return false;
+	if (value.startsWith("/") || value.startsWith("./") || value.startsWith("../")) {
+		return true;
+	}
+	for (const entry of (process.env.PATH ?? "").split(delimiter)) {
+		if (!entry) continue;
+		try {
+			const stat = statSync(join(entry, value));
+			if (stat.isFile() && (stat.mode & 0o111) !== 0) return true;
+		} catch {
+			// Not an executable on this PATH entry.
+		}
+	}
+	return false;
 }
 
 /**
@@ -326,7 +361,13 @@ export async function openBrowser(url: string): Promise<{
 	try {
 		const platform = process.platform;
 		const wsl =
-			platform === "linux" && release().toLowerCase().includes("microsoft");
+			platform === "linux" && os.release().toLowerCase().includes("microsoft");
+		// Under WSL a Linux executable must run directly; cmd.exe only wins for
+		// Windows targets (a .exe, a C:\ path, a /mnt/<drive> path).
+		const viaCmdExe =
+			(platform === "win32" || wsl) &&
+			!!plannotatorBrowser &&
+			!(wsl && isPosixBrowserTarget(plannotatorBrowser));
 
 		let cmd: string;
 		let args: string[];
@@ -335,7 +376,7 @@ export async function openBrowser(url: string): Promise<{
 			if (plannotatorBrowser && platform === "darwin") {
 				cmd = "open";
 				args = ["-a", plannotatorBrowser, url];
-			} else if ((platform === "win32" || wsl) && plannotatorBrowser) {
+			} else if (viaCmdExe) {
 				cmd = "cmd.exe";
 				args = ["/c", "start", "", plannotatorBrowser, url];
 			} else {
@@ -354,7 +395,20 @@ export async function openBrowser(url: string): Promise<{
 		}
 
 		const child = spawn(cmd, args, { detached: true, stdio: "ignore" });
-		child.once("error", () => {});
+		// A failed launch exists only as an async "error" event; reporting
+		// opened: true unconditionally hides it (#1472).
+		const spawnError = await new Promise<Error | undefined>((resolve) => {
+			child.once("spawn", () => resolve(undefined));
+			child.once("error", (error) => resolve(error));
+		});
+		if (spawnError) {
+			if (plannotatorBrowser) {
+				process.stderr.write(
+					`Plannotator: could not launch PLANNOTATOR_BROWSER="${plannotatorBrowser}": ${spawnError.message}\n`,
+				);
+			}
+			return { opened: false };
+		}
 		child.unref();
 		return { opened: true };
 	} catch {

--- a/packages/server/browser.test.ts
+++ b/packages/server/browser.test.ts
@@ -1,5 +1,20 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { isNoOpBrowserSentinel, shouldTryRemoteBrowserFallback } from "./browser";
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os, { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import {
+  isNoOpBrowserSentinel,
+  isPosixBrowserTarget,
+  openBrowser,
+  resolvePosixBrowserTarget,
+  shouldTryRemoteBrowserFallback,
+} from "./browser";
 
 const savedEnv: Record<string, string | undefined> = {};
 const envKeys = ["PLANNOTATOR_BROWSER", "BROWSER"];
@@ -83,5 +98,129 @@ describe("isNoOpBrowserSentinel", () => {
     expect(isNoOpBrowserSentinel("Google Chrome")).toBe(false);
     expect(isNoOpBrowserSentinel("open")).toBe(false);
     expect(isNoOpBrowserSentinel("/usr/bin/true")).toBe(false);
+  });
+});
+
+describe("isPosixBrowserTarget", () => {
+  test("accepts POSIX paths and resolves bare names to their PATH location", () => {
+    expect(isPosixBrowserTarget("/usr/bin/fake-browser")).toBe(true);
+    expect(resolvePosixBrowserTarget("/usr/bin/fake-browser")).toBe("/usr/bin/fake-browser");
+    expect(resolvePosixBrowserTarget("./browser")).toBe("./browser");
+    expect(resolvePosixBrowserTarget("../browser")).toBe("../browser");
+    // A bare name is resolved against the Linux PATH at call time.
+    expect(resolvePosixBrowserTarget("sh")).toMatch(/\/sh$/);
+  });
+
+  test("rejects Windows targets that belong to cmd.exe", () => {
+    expect(resolvePosixBrowserTarget("chrome.exe")).toBeNull();
+    expect(resolvePosixBrowserTarget("C:\\Program Files\\Chrome\\chrome.exe")).toBeNull();
+    expect(resolvePosixBrowserTarget("/mnt/c/Program Files/Chrome/chrome.exe")).toBeNull();
+    expect(resolvePosixBrowserTarget("/mnt/c/Windows/System32/cmd.exe")).toBeNull();
+    expect(resolvePosixBrowserTarget("not-a-real-binary-1472")).toBeNull();
+  });
+});
+
+// --- WSL PLANNOTATOR_BROWSER routing (#1472) ---
+
+const realPlatform = process.platform;
+const realRelease = os.release;
+
+/** Pretend to run under WSL: isWSL() reads process.platform and os.release(). */
+function mockWsl() {
+  Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+  os.release = () => "5.15.90.1-microsoft-standard-WSL2";
+}
+
+function restoreHostPlatform() {
+  Object.defineProperty(process, "platform", { value: realPlatform, configurable: true });
+  os.release = realRelease;
+}
+
+function writeExecutable(dir: string, name: string, body: string): string {
+  const file = join(dir, name);
+  writeFileSync(file, `#!/bin/sh\n${body}\n`);
+  chmodSync(file, 0o755);
+  return file;
+}
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), "plannotator-browser-"));
+}
+
+const URL = "http://127.0.0.1:19432/plan";
+
+describe("WSL configured browser launch", () => {
+  afterEach(() => {
+    restoreHostPlatform();
+  });
+
+  test("a POSIX path is executed directly with the URL", async () => {
+    const dir = makeTempDir();
+    const log = join(dir, "args.txt");
+    const script = writeExecutable(dir, "fake-browser", `printf '%s' "$1" > '${log}'`);
+    try {
+      clearEnv();
+      mockWsl();
+      process.env.PLANNOTATOR_BROWSER = script;
+
+      expect(await openBrowser(URL)).toBe(true);
+      expect(readFileSync(log, "utf8")).toBe(URL);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // openBrowser spawns the RESOLVED absolute path, not the bare name: Bun
+  // 1.3's `$` resolves bare command names against the PATH captured at
+  // startup, so a runtime-prepended PATH entry would be invisible to it.
+  test("a bare Linux PATH executable name is executed directly", async () => {
+    const dir = makeTempDir();
+    const log = join(dir, "args.txt");
+    writeExecutable(dir, "fake-browser-wsl1472", `printf '%s' "$1" > '${log}'`);
+    const originalPath = process.env.PATH;
+    try {
+      process.env.PATH = `${dir}${delimiter}${originalPath ?? ""}`;
+      clearEnv();
+      mockWsl();
+      process.env.PLANNOTATOR_BROWSER = "fake-browser-wsl1472";
+
+      expect(await openBrowser(URL)).toBe(true);
+      expect(readFileSync(log, "utf8")).toBe(URL);
+    } finally {
+      if (originalPath === undefined) delete process.env.PATH;
+      else process.env.PATH = originalPath;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // The cmd.exe route itself cannot be execution-tested through Bun's `$` on
+  // a non-Windows host (see the note on the bare-name test above): a bare
+  // cmd.exe shim on a mutated PATH is invisible to Bun 1.3's shell. The Pi
+  // mirror pins it end-to-end in apps/pi-extension/server/network.test.ts
+  // (node:child_process spawn honors a mutated PATH on every Bun version),
+  // and the classifier tests above pin the routing decision.
+
+  test("a failing configured browser warns on stderr and still falls back", async () => {
+    const dir = makeTempDir();
+    const script = writeExecutable(dir, "broken-browser", "exit 3");
+    const originalWrite = process.stderr.write;
+    const chunks: string[] = [];
+    (process.stderr as { write: unknown }).write = (chunk: string) => {
+      chunks.push(String(chunk));
+      return true;
+    };
+    try {
+      clearEnv();
+      mockWsl();
+      process.env.PLANNOTATOR_BROWSER = script;
+
+      expect(await openBrowser(URL)).toBe(false);
+      const warning = chunks.join("");
+      expect(warning).toContain(script);
+      expect(warning).toContain("PLANNOTATOR_BROWSER");
+    } finally {
+      (process.stderr as { write: unknown }).write = originalWrite;
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/server/browser.ts
+++ b/packages/server/browser.ts
@@ -84,6 +84,51 @@ export async function isWSL(): Promise<boolean> {
 }
 
 /**
+ * True for a value that must be handed to cmd.exe under WSL: a Windows-style
+ * path (C:\..., C:/...) or a /mnt/<drive> mount of one, or a `.exe` name.
+ */
+function isWindowsBrowserTarget(value: string): boolean {
+  return (
+    /^[A-Za-z]:[\\/]/.test(value) ||
+    value.startsWith("/mnt/") ||
+    value.toLowerCase().endsWith(".exe")
+  );
+}
+
+/**
+ * Resolve PLANNOTATOR_BROWSER to an executable the Linux side can run
+ * directly: a POSIX path (/..., ./..., ../...) verbatim, or a bare name's
+ * absolute location on the Linux PATH. Null for values that must go through
+ * cmd.exe under WSL instead (a .exe, C:\\..., /mnt/<drive>) (#1472).
+ */
+export function resolvePosixBrowserTarget(value: string): string | null {
+  if (isWindowsBrowserTarget(value)) return null;
+  if (value.startsWith("/") || value.startsWith("./") || value.startsWith("../")) {
+    return value;
+  }
+  for (const entry of (process.env.PATH ?? "").split(path.delimiter)) {
+    if (!entry) continue;
+    try {
+      const candidate = path.join(entry, value);
+      const stat = fs.statSync(candidate);
+      if (stat.isFile() && (stat.mode & 0o111) !== 0) return candidate;
+    } catch {
+      // Not an executable on this PATH entry.
+    }
+  }
+  return null;
+}
+
+/**
+ * True when PLANNOTATOR_BROWSER names something the Linux side can execute
+ * itself. Under WSL those must NOT go through cmd.exe, which cannot resolve
+ * them (#1472).
+ */
+export function isPosixBrowserTarget(value: string): boolean {
+  return resolvePosixBrowserTarget(value) !== null;
+}
+
+/**
  * Open a URL in the browser
  *
  * Uses PLANNOTATOR_BROWSER env var if set, otherwise uses system default.
@@ -189,12 +234,12 @@ export async function openBrowser(
   url: string,
   options?: { isRemote?: boolean; useGlimpse?: boolean }
 ): Promise<boolean> {
+  const rawPlannotatorBrowser = process.env.PLANNOTATOR_BROWSER;
+  const plannotatorBrowser = isNoOpBrowserSentinel(rawPlannotatorBrowser)
+    ? undefined
+    : rawPlannotatorBrowser;
   try {
-    const rawPlannotatorBrowser = process.env.PLANNOTATOR_BROWSER;
     const rawBrowser = process.env.BROWSER;
-    const plannotatorBrowser = isNoOpBrowserSentinel(rawPlannotatorBrowser)
-      ? undefined
-      : rawPlannotatorBrowser;
     const envBrowser = isNoOpBrowserSentinel(rawBrowser) ? undefined : rawBrowser;
     const browser = plannotatorBrowser || envBrowser;
     const isRemote = options?.isRemote ?? false;
@@ -214,6 +259,17 @@ export async function openBrowser(
 
     const platform = process.platform;
     const wsl = await isWSL();
+    // Under WSL a Linux executable must run directly; cmd.exe only wins for
+    // Windows targets (a .exe, a C:\ path, a /mnt/<drive> path). Spawning the
+    // RESOLVED absolute path also sidesteps Bun 1.3's shell, which resolves
+    // bare command names against the PATH captured at startup (#1472).
+    const posixTarget = wsl && plannotatorBrowser
+      ? resolvePosixBrowserTarget(plannotatorBrowser)
+      : null;
+    const viaCmdExe =
+      (platform === "win32" || wsl) &&
+      !!plannotatorBrowser &&
+      posixTarget === null;
 
     if (browser) {
       if (plannotatorBrowser && platform === "darwin") {
@@ -222,10 +278,10 @@ export async function openBrowser(
         } else {
           await $`open -a ${plannotatorBrowser} ${url}`.quiet();
         }
-      } else if ((platform === "win32" || wsl) && plannotatorBrowser) {
+      } else if (viaCmdExe) {
         await $`cmd.exe /c start "" ${plannotatorBrowser} ${url}`.quiet();
       } else {
-        await $`${browser} ${url}`.quiet();
+        await $`${posixTarget ?? browser} ${url}`.quiet();
       }
     } else {
       // Default system browser
@@ -238,7 +294,15 @@ export async function openBrowser(
       }
     }
     return true;
-  } catch {
+  } catch (error) {
+    // An explicitly configured browser that fails is otherwise invisible:
+    // warn before falling back to the VS Code IPC registry (#1472).
+    if (plannotatorBrowser) {
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(
+        `Plannotator: could not launch PLANNOTATOR_BROWSER="${plannotatorBrowser}": ${message}\n`,
+      );
+    }
     // Shell-based open failed — try VS Code IPC registry as fallback
     return tryVscodeIpc(url);
   }


### PR DESCRIPTION
## Problem

With `PLANNOTATOR_BROWSER` explicitly set under WSL, the value was routed through `cmd.exe /c start` regardless of what it named, so a Linux path or script could never launch; the failure was swallowed by a bare `catch` and the ready output only printed the URL. A headless (agent-launched, no TTY) session then had every observable signal reporting success while the reviewer was never shown anything. The Pi runtime had the same branch and additionally reported `opened: true` on spawn errors. #1472

## Change

- Both runtimes classify the configured value first: Windows targets (`*.exe`, `C:\…`, `/mnt/<drive>/…`) keep the `cmd.exe` route; POSIX paths (`/…`, `./…`, `../…`) and bare names that resolve to an executable on the Linux PATH are executed directly — also under WSL.
- The Bun runtime spawns the **resolved absolute path**: Bun 1.3's `$` resolves bare command names against the PATH captured at process startup, so a bare name would otherwise be invisible to the shell. The end-to-end test pins this.
- When an explicitly configured browser fails, one stderr line names the executable and the error before the existing fallback (VS Code IPC / URL print) runs. The Pi runtime returns `opened: false` on spawn errors instead of claiming success.
- Non-WSL Linux and macOS paths are unchanged; the macOS branch recently fixed by #1429 is untouched.

## Verification

Bun 1.3.14, disposable HOME: `packages/server/browser.test.ts` + `apps/pi-extension/server/network.test.ts` → **49 pass / 0 fail**:

- direct spawn of a POSIX path and of a bare PATH name under mocked WSL, asserting the target script received the URL as its argument;
- `chrome.exe` still routed through a `cmd.exe` shim (end-to-end in the Pi runtime, whose `node:child_process` spawn honors a mutated PATH on every Bun version; the Bun-side resolver tests pin the same routing decision, since a `cmd.exe` shim cannot be spawned through Bun 1.3's `$` on a non-Windows host);
- a failing executable warns on stderr naming itself, and a missing one yields `opened: false` with the fallback intact.

On Bun 1.4.2 the only failures in these two files are the three pre-existing port-selection listener-count tests (baseline-verified before this change).

Fixes #1472
