### PR TITLE
fix(pi): render completed messages and errors

### DIFF
--- a/packages/ai/ai.test.ts
+++ b/packages/ai/ai.test.ts
@@ -1591,6 +1591,23 @@ describe("mapPiEvent", () => {
     expect(result).toEqual([]);
   });
 
+  test("completed assistant error maps to an error", () => {
+    const result = mapPiEvent({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [],
+        stopReason: "error",
+        errorMessage: "OpenAI API error (429): quota exceeded",
+      },
+    }, SESSION_ID);
+    expect(result).toEqual([{
+      type: "error",
+      error: "OpenAI API error (429): quota exceeded",
+      code: "pi_request_error",
+    }]);
+  });
+
   test("tool_execution_end maps to tool_result", () => {
     const result = mapPiEvent({
       type: "tool_execution_end",

--- a/packages/ai/ai.test.ts
+++ b/packages/ai/ai.test.ts
@@ -1567,6 +1567,30 @@ describe("mapPiEvent", () => {
     }]);
   });
 
+  test("completed assistant message maps to text", () => {
+    const result = mapPiEvent({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "Hidden reasoning" },
+          { type: "text", text: "Final answer" },
+          { type: "toolCall", id: "tc_1", name: "read", arguments: {} },
+          { type: "text", text: " continued" },
+        ],
+      },
+    }, SESSION_ID);
+    expect(result).toEqual([{ type: "text", text: "Final answer continued" }]);
+  });
+
+  test("completed non-assistant message is ignored", () => {
+    const result = mapPiEvent({
+      type: "message_end",
+      message: { role: "user", content: [{ type: "text", text: "Ignore" }] },
+    }, SESSION_ID);
+    expect(result).toEqual([]);
+  });
+
   test("tool_execution_end maps to tool_result", () => {
     const result = mapPiEvent({
       type: "tool_execution_end",

--- a/packages/ai/providers/pi-events.ts
+++ b/packages/ai/providers/pi-events.ts
@@ -15,6 +15,7 @@ import type { AIMessage } from "../types.ts";
  *
  * We extract:
  * - text_delta from message_update.assistantMessageEvent
+ * - text from completed assistant messages when no stream deltas arrived
  * - tool_use from toolcall_end
  * - tool_result from tool_execution_end
  * - result from agent_end
@@ -63,6 +64,19 @@ export function mapPiEvent(
 				default:
 					return [];
 			}
+		}
+
+		case "message_end": {
+			const message = event.message as Record<string, unknown> | undefined;
+			if (message?.role !== "assistant" || !Array.isArray(message.content)) return [];
+
+			const text = message.content
+				.filter((block): block is Record<string, unknown> =>
+					typeof block === "object" && block !== null && block.type === "text",
+				)
+				.map((block) => (typeof block.text === "string" ? block.text : ""))
+				.join("");
+			return text ? [{ type: "text", text }] : [];
 		}
 
 		case "tool_execution_end": {

--- a/packages/ai/providers/pi-events.ts
+++ b/packages/ai/providers/pi-events.ts
@@ -68,7 +68,15 @@ export function mapPiEvent(
 
 		case "message_end": {
 			const message = event.message as Record<string, unknown> | undefined;
-			if (message?.role !== "assistant" || !Array.isArray(message.content)) return [];
+			if (message?.role !== "assistant") return [];
+			if (message.stopReason === "error") {
+				return [{
+					type: "error",
+					error: typeof message.errorMessage === "string" ? message.errorMessage : "Pi request failed",
+					code: "pi_request_error",
+				}];
+			}
+			if (!Array.isArray(message.content)) return [];
 
 			const text = message.content
 				.filter((block): block is Record<string, unknown> =>


### PR DESCRIPTION
## Summary
- map text blocks from Pi RPC `message_end` events for completed assistant messages
- surface completed Pi request errors in Ask AI instead of reporting a successful empty response
- cover completed assistant, failed assistant, and non-assistant messages

Pi documents `message_end.message` as the authoritative completed assistant response. The completed-message fallback lets Ask AI render a response when a Pi provider does not emit usable `text_delta` events. In particular, a failed Pi request (such as an upstream 429) previously ended as a successful empty Plannotator response; the provider now sends its `errorMessage` to the UI. The UI retains its existing streamed-text preference, so normal delta streaming is not duplicated.

## Validation
- `bun run typecheck`
- `bun test packages/ai/ai.test.ts`