### PR TITLE
fix(review): stabilize JJ line-of-work bases

### DIFF
--- a/apps/pi-extension/server.test.ts
+++ b/apps/pi-extension/server.test.ts
@@ -1786,11 +1786,30 @@ describe("pi review server", () => {
       expect(last.diffType).toBe("jj-last");
       expect(last.rawPatch).toContain("last.txt");
 
+      const automaticLineResponse = await fetch(`${server.url}/api/diff/switch`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ diffType: "jj-line" }),
+      });
+      expect(automaticLineResponse.status).toBe(200);
+      const automaticLine = await automaticLineResponse.json() as {
+        diffType: string;
+        gitContext?: { diffFallback?: { requestedDiffType: string; effectiveDiffType: string } };
+      };
+      expect(automaticLine.diffType).toBe("jj-current");
+      expect(automaticLine.gitContext?.diffFallback).toEqual({
+        requestedDiffType: "jj-line",
+        effectiveDiffType: "jj-current",
+        message: "The line of work starts at the repository root. Showing Current change instead.",
+      });
+
       for (const nextType of ["jj-line", "jj-all"] as const) {
         const response = await fetch(`${server.url}/api/diff/switch`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ diffType: nextType }),
+          body: JSON.stringify(nextType === "jj-line"
+            ? { diffType: nextType, base: expectedJjBase, explicitBase: true }
+            : { diffType: nextType }),
         });
         expect(response.status).toBe(200);
         const payload = await response.json() as { diffType: string; rawPatch: string };

--- a/apps/pi-extension/server.test.ts
+++ b/apps/pi-extension/server.test.ts
@@ -1797,6 +1797,8 @@ describe("pi review server", () => {
         gitContext?: { diffFallback?: { requestedDiffType: string; effectiveDiffType: string } };
       };
       expect(automaticLine.diffType).toBe("jj-current");
+      // Deliberate copy pin: the sentence is the only discriminator between
+      // the root-fork and ambiguous-fork fallback branches on the wire.
       expect(automaticLine.gitContext?.diffFallback).toEqual({
         requestedDiffType: "jj-line",
         effectiveDiffType: "jj-current",

--- a/apps/pi-extension/server/serverReview.ts
+++ b/apps/pi-extension/server/serverReview.ts
@@ -191,6 +191,7 @@ import {
 	getVcsDiffFingerprint,
 	getVcsFileContentsForDiff,
 	resolveVcsCwd,
+	resolveAvailableDiffType,
 	reviewRuntime,
 	materializeVcsSnapshot,
 	runVcsDiff,
@@ -2362,7 +2363,7 @@ export async function startReviewServer(options: {
 			}
 			try {
 				const body = await parseBody(req);
-				const newType = body.diffType as DiffType | WorkspaceDiffType;
+				let newType = body.diffType as DiffType | WorkspaceDiffType;
 				if (typeof newType !== "string" || !newType) {
 					json(res, { error: "Missing diffType" }, 400);
 					return;
@@ -2417,6 +2418,11 @@ export async function startReviewServer(options: {
 				// (diff-type switches, refreshes) must not re-canonicalize it.
 				const nextBaseExplicitlyChosen = baseExplicitlyChosen ||
 					(body.explicitBase === true && typeof body.base === "string" && !!body.base);
+				const requestedDiffType = newType as DiffType;
+				const availability = clientGitContext
+					? resolveAvailableDiffType(clientGitContext, requestedDiffType, nextBaseExplicitlyChosen)
+					: { diffType: requestedDiffType };
+				newType = availability.diffType;
 				const base = resolveReviewBase(
 					typeof body.base === "string" ? body.base : undefined,
 					nextBaseExplicitlyChosen,
@@ -2496,8 +2502,21 @@ export async function startReviewServer(options: {
 				baseBehindRemote = nextBaseBehindRemote;
 				currentError = result.error;
 				draftKey = contentHash(currentPatch);
+				const nextClientContext = updatedContext ?? clientGitContext;
+				if (nextClientContext) {
+					clientGitContext = {
+						...nextClientContext,
+						diffFallback: availability.fallback
+							? {
+								requestedDiffType,
+								effectiveDiffType: newType,
+								message: availability.fallback.message,
+								candidates: availability.fallback.candidates,
+							}
+							: undefined,
+					};
+				}
 				if (updatedContext && sessionVcsType === "gitbutler") {
-					clientGitContext = updatedContext;
 					currentContextRevision = updatedContextRevision ?? "";
 				}
 				captureDiffFingerprint(result.fingerprint);
@@ -2520,7 +2539,7 @@ export async function startReviewServer(options: {
 					...(commitInfo ? { commitInfo } : {}),
 					...(generatedFiles ? { generatedFiles } : {}),
 					...(baseBehindRemote ? { baseBehindRemote: true } : {}),
-					...(updatedContext ? { gitContext: updatedContext } : {}),
+					...(clientGitContext ? { gitContext: clientGitContext } : {}),
 					...(currentError ? { error: currentError } : {}),
 					semanticDiff: switchSemanticDiff,
 					callFlow: switchCallFlow,

--- a/apps/pi-extension/server/serverReview.ts
+++ b/apps/pi-extension/server/serverReview.ts
@@ -2502,7 +2502,20 @@ export async function startReviewServer(options: {
 				baseBehindRemote = nextBaseBehindRemote;
 				currentError = result.error;
 				draftKey = contentHash(currentPatch);
-				const nextClientContext = updatedContext ?? clientGitContext;
+				// Session-context adoption is provider-scoped: gitbutler (as
+				// before this change) because its stack topology is the
+				// context, and jj so the jj-line availability/fallback stays
+				// fresh across reloads. Plain git keeps the launch-frozen
+				// session context — currentBranch labels the launch cwd in
+				// WorktreePicker and the feedback branch label, and adopting a
+				// switched worktree's recomputed context here would repoint
+				// those on the next reload.
+				const adoptContext =
+					updatedContext !== undefined &&
+					(sessionVcsType === "gitbutler" || sessionVcsType === "jj");
+				const nextClientContext = adoptContext
+					? updatedContext
+					: clientGitContext;
 				if (nextClientContext) {
 					clientGitContext = {
 						...nextClientContext,
@@ -2539,7 +2552,19 @@ export async function startReviewServer(options: {
 					...(commitInfo ? { commitInfo } : {}),
 					...(generatedFiles ? { generatedFiles } : {}),
 					...(baseBehindRemote ? { baseBehindRemote: true } : {}),
-					...(clientGitContext ? { gitContext: clientGitContext } : {}),
+					// The response still carries a transiently recomputed context
+					// (worktree switches on plain git) even when the session did
+					// not adopt it — matching the pre-jj-line behavior.
+					...(updatedContext || clientGitContext
+						? {
+							gitContext: updatedContext
+								? {
+									...updatedContext,
+									diffFallback: clientGitContext?.diffFallback,
+								}
+								: clientGitContext,
+						}
+						: {}),
 					...(currentError ? { error: currentError } : {}),
 					semanticDiff: switchSemanticDiff,
 					callFlow: switchCallFlow,

--- a/apps/pi-extension/server/vcs.ts
+++ b/apps/pi-extension/server/vcs.ts
@@ -26,6 +26,7 @@ import {
 	createGitProvider,
 	createJjProvider,
 	createVcsApi,
+	resolveAvailableDiffType,
 	resolveInitialDiffType,
 } from "../generated/vcs-core.ts";
 
@@ -210,7 +211,7 @@ export const {
 	materializeVcsSnapshot,
 } = api;
 
-export { resolveInitialDiffType };
+export { resolveAvailableDiffType, resolveInitialDiffType };
 export type { VcsSelection };
 
 export function getGitContext(cwd?: string): Promise<GitContext> {

--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -2893,6 +2893,8 @@ const ReviewApp: React.FC = () => {
             defaultBranch: data.gitContext!.defaultBranch,
             diffOptions: data.gitContext!.diffOptions,
             compareTarget: data.gitContext!.compareTarget,
+            diffAvailability: data.gitContext!.diffAvailability,
+            diffFallback: data.gitContext!.diffFallback,
             jjEvologs: data.gitContext!.jjEvologs,
             // HEAD differs per worktree, so refresh the commit-baseline picker.
             recentCommits: data.gitContext!.recentCommits,
@@ -4967,6 +4969,31 @@ const ReviewApp: React.FC = () => {
               </button>
             </div>
           ) : null
+        )}
+
+        {gitContext?.diffFallback && (
+          <div className="shrink-0 border-b border-warning/20 bg-warning/10 px-3 py-2 text-xs text-warning">
+            <div>{gitContext.diffFallback.message}</div>
+            {!!gitContext.diffFallback.candidates?.length && (
+              <div className="mt-2 flex flex-wrap gap-2">
+                {gitContext.diffFallback.candidates.map((candidate) => (
+                  <button
+                    key={candidate.revision}
+                    type="button"
+                    className="rounded border border-warning/30 bg-background/50 px-2 py-1 text-left hover:bg-background"
+                    title={candidate.subject || candidate.revision}
+                    onClick={() => {
+                      setSelectedBase(candidate.revision);
+                      void fetchDiffSwitch(gitContext.diffFallback!.requestedDiffType, candidate.revision, { explicitBase: true });
+                    }}
+                  >
+                    {candidate.labels[0] ?? candidate.revision.slice(0, 8)}
+                    {candidate.subject && <span className="ml-1 text-muted-foreground">· {candidate.subject}</span>}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
         )}
 
         {/* Main content */}

--- a/packages/server/jj.test.ts
+++ b/packages/server/jj.test.ts
@@ -45,35 +45,19 @@ describe("jj diff args", () => {
 });
 
 describe("jj compare targets", () => {
-  test("resolves a readable target for the detected line base", async () => {
-    await expect(selectDefaultJjCompareTarget({
-      async runJj() {
-        return { stdout: '[{"name":"main"},{"name":"main","remote":"origin"}]\\t0123456789abcdef\\n', stderr: "", exitCode: 0 };
-      },
-    })).resolves.toBe("main@origin");
-
-    await expect(selectDefaultJjCompareTarget({
-      async runJj() {
-        return { stdout: '[{"name":"main"}]\\t0123456789abcdef\\n', stderr: "", exitCode: 0 };
-      },
-    })).resolves.toBe("main");
-
-    await expect(selectDefaultJjCompareTarget({
-      async runJj() {
-        return { stdout: "[]\\t0123456789abcdef\\n", stderr: "", exitCode: 0 };
-      },
-    })).resolves.toBe("0123456789abcdef");
-
-    // Generated `jj git push --change` bookmarks are never a readable target.
-    await expect(selectDefaultJjCompareTarget({
-      async runJj() {
-        return {
-          stdout: '[{"name":"push-vmopwunwxopv","remote":"origin"}]\\t0123456789abcdef\\n',
-          stderr: "",
-          exitCode: 0,
-        };
-      },
-    })).resolves.toBe("0123456789abcdef");
+  test("uses the exact commit ID for the detected line base", async () => {
+    for (const bookmarks of [
+      '[{"name":"main"},{"name":"main","remote":"origin"}]',
+      '[{"name":"main"}]',
+      "[]",
+      '[{"name":"push-vmopwunwxopv","remote":"origin"}]',
+    ]) {
+      await expect(selectDefaultJjCompareTarget({
+        async runJj() {
+          return { stdout: `${bookmarks}\\t0123456789abcdef\\t"Base"\\n`, stderr: "", exitCode: 0 };
+        },
+      })).resolves.toBe("0123456789abcdef");
+    }
 
     // An unresolvable base degrades to the previous default instead of aborting
     // review startup, which has no handler for a throw.

--- a/packages/server/review.ts
+++ b/packages/server/review.ts
@@ -11,7 +11,7 @@
 
 import { isRemoteSession, getServerHostname, startBunServerOnAvailablePort, buildAdvertisedUrl } from "./remote";
 import type { Origin } from "@plannotator/shared/agents";
-import { type DiffType, type GitContext, runVcsDiff, getVcsFileContentsForDiff, getVcsDiffFingerprint, canStageFiles, stageFile, unstageFile, resolveVcsCwd, validateFilePath, getVcsContext, detectRemoteDefaultCompareTarget, vcsOwnsDiffType, vcsSupportsSnapshot, materializeVcsSnapshot, gitRuntime } from "./vcs";
+import { type DiffType, type GitContext, runVcsDiff, getVcsFileContentsForDiff, getVcsDiffFingerprint, canStageFiles, stageFile, unstageFile, resolveVcsCwd, validateFilePath, getVcsContext, detectRemoteDefaultCompareTarget, resolveAvailableDiffType, vcsOwnsDiffType, vcsSupportsSnapshot, materializeVcsSnapshot, gitRuntime } from "./vcs";
 import { basename } from "node:path";
 import { existsSync } from "node:fs";
 import { SingleFlight } from "@plannotator/shared/single-flight";
@@ -2467,6 +2467,11 @@ export async function startReviewServer(
               // (diff-type switches, refreshes) must not re-canonicalize it.
               const nextBaseExplicitlyChosen = baseExplicitlyChosen ||
                 (body.explicitBase === true && !!requestedBase);
+              const requestedDiffType = newDiffType as DiffType;
+              const availability = clientGitContext
+                ? resolveAvailableDiffType(clientGitContext, requestedDiffType, nextBaseExplicitlyChosen)
+                : { diffType: requestedDiffType };
+              newDiffType = availability.diffType;
               const base = resolveReviewBase(
                 requestedBase,
                 nextBaseExplicitlyChosen,
@@ -2556,8 +2561,21 @@ export async function startReviewServer(
               baseBehindRemote = nextBaseBehindRemote;
               currentError = result.error;
               draftKey = contentHash(currentPatch);
+              const nextClientContext = updatedContext ?? clientGitContext;
+              if (nextClientContext) {
+                clientGitContext = {
+                  ...nextClientContext,
+                  diffFallback: availability.fallback
+                    ? {
+                        requestedDiffType,
+                        effectiveDiffType: newDiffType,
+                        message: availability.fallback.message,
+                        candidates: availability.fallback.candidates,
+                      }
+                    : undefined,
+                };
+              }
               if (updatedContext && sessionVcsType === "gitbutler") {
-                clientGitContext = updatedContext;
                 currentContextRevision = updatedContextRevision ?? "";
               }
               captureDiffFingerprint(result.fingerprint);
@@ -2580,7 +2598,7 @@ export async function startReviewServer(
                 ...(commitInfo && { commitInfo }),
                 ...(generatedFiles && { generatedFiles }),
                 ...(baseBehindRemote && { baseBehindRemote: true }),
-                ...(updatedContext && { gitContext: updatedContext }),
+                ...(clientGitContext && { gitContext: clientGitContext }),
                 ...(currentError && { error: currentError }),
                 semanticDiff: switchSemanticDiff,
                 callFlow: switchCallFlow,

--- a/packages/server/review.ts
+++ b/packages/server/review.ts
@@ -2561,7 +2561,20 @@ export async function startReviewServer(
               baseBehindRemote = nextBaseBehindRemote;
               currentError = result.error;
               draftKey = contentHash(currentPatch);
-              const nextClientContext = updatedContext ?? clientGitContext;
+              // Session-context adoption is provider-scoped: gitbutler (as
+              // before this change) because its stack topology is the
+              // context, and jj so the jj-line availability/fallback stays
+              // fresh across reloads. Plain git keeps the launch-frozen
+              // session context — currentBranch labels the launch cwd in
+              // WorktreePicker and the feedback branch label, and adopting a
+              // switched worktree's recomputed context here would repoint
+              // those on the next reload.
+              const adoptContext =
+                updatedContext !== undefined &&
+                (sessionVcsType === "gitbutler" || sessionVcsType === "jj");
+              const nextClientContext = adoptContext
+                ? updatedContext
+                : clientGitContext;
               if (nextClientContext) {
                 clientGitContext = {
                   ...nextClientContext,
@@ -2598,7 +2611,19 @@ export async function startReviewServer(
                 ...(commitInfo && { commitInfo }),
                 ...(generatedFiles && { generatedFiles }),
                 ...(baseBehindRemote && { baseBehindRemote: true }),
-                ...(clientGitContext && { gitContext: clientGitContext }),
+                // The response still carries a transiently recomputed context
+                // (worktree switches on plain git) even when the session did
+                // not adopt it — matching the pre-jj-line behavior.
+                ...(updatedContext || clientGitContext
+                  ? {
+                      gitContext: updatedContext
+                        ? {
+                            ...updatedContext,
+                            diffFallback: clientGitContext?.diffFallback,
+                          }
+                        : clientGitContext,
+                    }
+                  : {}),
                 ...(currentError && { error: currentError }),
                 semanticDiff: switchSemanticDiff,
                 callFlow: switchCallFlow,

--- a/packages/server/vcs.ts
+++ b/packages/server/vcs.ts
@@ -6,6 +6,7 @@ import {
   createGitProvider,
   createJjProvider,
   createVcsApi,
+  resolveAvailableDiffType,
   resolveInitialDiffType,
 } from "@plannotator/shared/vcs-core";
 import {
@@ -65,7 +66,7 @@ export const {
   materializeVcsSnapshot,
 } = api;
 
-export { resolveInitialDiffType, gitRuntime };
+export { resolveAvailableDiffType, resolveInitialDiffType, gitRuntime };
 
 export type {
   DiffOption,

--- a/packages/shared/jj-core.test.ts
+++ b/packages/shared/jj-core.test.ts
@@ -10,6 +10,7 @@ import {
   jjLineBaseRevset,
   parseJjBookmarkList,
   parseJjRemoteBookmarkList,
+  resolveJjLineBase,
   type ReviewJjRuntime,
   runJjDiff,
   selectDefaultJjCompareTarget,
@@ -243,8 +244,37 @@ describe("jj compare targets", () => {
       // Verify the fixture's configured boundary independently of the code under test.
       expect(jj(["log", "--no-graph", "-r", "roots(reachable(@, mutable()))-", "-T", "bookmarks"], immutable).trim())
         .toBe("development");
+      const developmentCommitId = jj(["log", "--no-graph", "-r", "development", "-T", "commit_id"], immutable).trim();
       await expect(selectDefaultJjCompareTarget(sandbox.runtime(immutable), workspace))
-        .resolves.toBe("development");
+        .resolves.toBe(developmentCommitId);
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  testIfJj("keeps the resolved base when its bookmark moves", async () => {
+    const sandbox = createJjSandbox();
+    const workspace = join(sandbox.root, "repo");
+    const immutable = immutableHeadsAlias('bookmarks(exact:"development")');
+    const jj = (args: string[], config?: string[]) => sandbox.jj(args, { cwd: workspace, config });
+
+    try {
+      mkdirSync(workspace);
+      jj(["git", "init", "."]);
+      writeFileSync(join(workspace, "history.txt"), "development\n");
+      jj(["commit", "-m", "development"]);
+      jj(["bookmark", "create", "development", "-r", "@-"]);
+      jj(["new", "development"]);
+      appendFileSync(join(workspace, "history.txt"), "feature\n");
+      jj(["commit", "-m", "feature"]);
+
+      const resolvedBase = await selectDefaultJjCompareTarget(sandbox.runtime(immutable), workspace);
+      jj(["bookmark", "set", "development", "-r", "@-"], immutable);
+
+      const stable = await runJjDiff(sandbox.runtime(immutable), "jj-line", resolvedBase, workspace);
+      const moving = await runJjDiff(sandbox.runtime(immutable), "jj-line", "development", workspace);
+      expect(stable.patch).toContain("+feature");
+      expect(moving.patch).not.toContain("+feature");
     } finally {
       sandbox.cleanup();
     }
@@ -273,8 +303,9 @@ describe("jj compare targets", () => {
         jj(["bookmark", "create", change, "-r", "@-"]);
       }
 
+      const mainCommitId = jj(["log", "--no-graph", "-r", "main", "-T", "commit_id"], immutable).trim();
       await expect(selectDefaultJjCompareTarget(sandbox.runtime(immutable), workspace))
-        .resolves.toBe("main");
+        .resolves.toBe(mainCommitId);
     } finally {
       sandbox.cleanup();
     }
@@ -300,10 +331,10 @@ describe("jj compare targets", () => {
       writeFileSync(join(colleague, "history.txt"), "main\n");
       asColleague(["commit", "-m", "main"]);
       asColleague(["bookmark", "create", "main", "-r", "@-"]);
-      asColleague(["git", "push", "-b", "main", "--allow-new"]);
+      asColleague(["git", "push", "-b", "main"]);
       appendFileSync(join(colleague, "history.txt"), "colleague work\n");
       asColleague(["commit", "-m", "colleague work"]);
-      asColleague(["git", "push", "--change", "@-", "--allow-new"]);
+      asColleague(["git", "push", "--change", "@-"]);
 
       sandbox.jj(["git", "clone", remote, workspace, "--colocate"]);
       const jj = (args: string[]) => sandbox.jj(args, { cwd: workspace });
@@ -359,53 +390,67 @@ describe("jj compare targets", () => {
         jj(["bookmark", "create", feature, "-r", "@-"]);
       }
 
+      const mainCommitId = jj(["log", "--no-graph", "-r", "main", "-T", "commit_id"], immutable).trim();
       await expect(selectDefaultJjCompareTarget(sandbox.runtime(immutable), workspace))
-        .resolves.toBe("main");
+        .resolves.toBe(mainCommitId);
     } finally {
       sandbox.cleanup();
     }
   });
 
-  test("resolves the line base in one JJ query and prefers its remote bookmark", async () => {
+  test("resolves the line base in one JJ query and keeps bookmark metadata separate", async () => {
     const calls: string[][] = [];
     const runtime: ReviewJjRuntime = {
       async runJj(args) {
         calls.push(args);
         return {
-          stdout: '[{"name":"development"},{"name":"development","remote":"origin"}]\\t0123456789abcdef\\n',
+          stdout: '[{"name":"development"},{"name":"development","remote":"origin"}]\\t0123456789abcdef\\t"Develop the feature"\\n',
           stderr: "",
           exitCode: 0,
         };
       },
     };
 
-    await expect(selectDefaultJjCompareTarget(runtime, "/repo")).resolves.toBe("development@origin");
+    await expect(resolveJjLineBase(runtime, "/repo")).resolves.toEqual({
+      kind: "resolved",
+      revision: {
+        commitId: "0123456789abcdef",
+        bookmarks: ["development@origin", "development"],
+        subject: "Develop the feature",
+      },
+    });
     expect(calls).toEqual([[
       "log",
       "--no-graph",
       "-r",
-      "latest(fork_point(roots(reachable(@, mutable()))-), 1)",
+      "exactly(fork_point(roots(reachable(@, mutable()))-), 1)",
       "-T",
-      'json(bookmarks) ++ "\\t" ++ commit_id ++ "\\n"',
+      'json(bookmarks) ++ "\\t" ++ commit_id ++ "\\t" ++ json(description.first_line()) ++ "\\n"',
     ]]);
   });
 
-  // The remote-before-local preference is only meaningful within one commit.
-  // `latest(..., 1)` is what keeps the answer to one record; if a second one
-  // ever arrives, the nearer commit's local bookmark must still win over a
-  // remote bookmark further away.
-  test("reads only the first record, so bookmark preference cannot cross commits", async () => {
+  test("reports every fork point instead of choosing one by timestamp", async () => {
+    let calls = 0;
     const runtime: ReviewJjRuntime = {
       async runJj() {
+        calls += 1;
+        if (calls === 1) return { stdout: "", stderr: "Revset `exactly()` expected 1 revision", exitCode: 1 };
         return {
-          stdout: '[{"name":"nearest"}]\\tabc\\n[{"name":"further","remote":"origin"}]\\tdef\\n',
+          stdout: '[{"name":"left"}]\\t' + "a".repeat(40) + '\\t"Merge left"\\n'
+            + '[{"name":"right","remote":"origin"}]\\t' + "b".repeat(40) + '\\t"Merge right"\\n',
           stderr: "",
           exitCode: 0,
         };
       },
     };
 
-    await expect(selectDefaultJjCompareTarget(runtime)).resolves.toBe("nearest");
+    await expect(resolveJjLineBase(runtime)).resolves.toEqual({
+      kind: "ambiguous",
+      candidates: [
+        { commitId: "a".repeat(40), bookmarks: ["left"], subject: "Merge left" },
+        { commitId: "b".repeat(40), bookmarks: ["right@origin"], subject: "Merge right" },
+      ],
+    });
   });
 
   test("uses the base commit id when it has no usable bookmark", async () => {
@@ -415,10 +460,10 @@ describe("jj compare targets", () => {
       },
     });
 
-    await expect(selectDefaultJjCompareTarget(runtimeFor("[]\\t0123456789abcdef\\n")))
+    await expect(selectDefaultJjCompareTarget(runtimeFor('[]\\t0123456789abcdef\\t"Base"\\n')))
       .resolves.toBe("0123456789abcdef");
     // A generated push bookmark is not a usable name, so the id is used instead.
-    await expect(selectDefaultJjCompareTarget(runtimeFor('[{"name":"push-vmopwunwxopv","remote":"origin"}]\\t0123456789abcdef\\n')))
+    await expect(selectDefaultJjCompareTarget(runtimeFor('[{"name":"push-vmopwunwxopv","remote":"origin"}]\\t0123456789abcdef\\t"Base"\\n')))
       .resolves.toBe("0123456789abcdef");
   });
 
@@ -436,7 +481,7 @@ describe("jj compare targets", () => {
     // e.g. a jj too old for `fork_point`/`reachable`.
     await expect(selectDefaultJjCompareTarget(runtimeFor("", "unknown function", 1))).resolves.toBe("trunk()");
     // A repo with no immutable history forks at the all-zero root commit.
-    await expect(selectDefaultJjCompareTarget(runtimeFor(`[]\\t${"0".repeat(40)}\\n`))).resolves.toBe("trunk()");
+    await expect(selectDefaultJjCompareTarget(runtimeFor(`[]\\t${"0".repeat(40)}\\t""\\n`))).resolves.toBe("trunk()");
   });
 
   test("treats bookmarks and revsets correctly in line-of-work revsets", () => {

--- a/packages/shared/jj-core.test.ts
+++ b/packages/shared/jj-core.test.ts
@@ -419,6 +419,8 @@ describe("jj compare targets", () => {
         subject: "Develop the feature",
       },
     });
+    // Deliberate pin: the revset IS the behavior under test — `exactly(...)`
+    // vs the old `latest(...)` is the whole fix, so drift here must fail.
     expect(calls).toEqual([[
       "log",
       "--no-graph",

--- a/packages/shared/jj-core.ts
+++ b/packages/shared/jj-core.ts
@@ -392,7 +392,9 @@ export function getJjDiffArgs(
     case "jj-line":
       return {
         args: ["diff", "--git", ...whitespaceArgs, "--from", jjLineBaseRevset(compareTarget), "--to", "@"],
-        label: `Line of work vs ${compareTarget}`,
+        // A frozen full commit id would render as 40+ hex chars in the
+        // header label; show the short form like jj itself does.
+        label: `Line of work vs ${/^[0-9a-f]{40,64}$/.test(compareTarget) ? compareTarget.slice(0, 12) : compareTarget}`,
       };
     case "jj-evolog":
       // compareTarget is the short commit ID of an older evolog entry.

--- a/packages/shared/jj-core.ts
+++ b/packages/shared/jj-core.ts
@@ -6,6 +6,8 @@ import {
   type GitContext,
   type GitDiffOptions,
   type JjEvoLogEntry,
+  type JjLineBaseResolution,
+  type JjRevisionInfo,
   JJ_TRUNK_REVSET,
   jjLineBaseRevset,
   parseRemoteBookmark,
@@ -18,6 +20,8 @@ export {
   jjLineBaseRevset,
   parseRemoteBookmark,
   type JjEvoLogEntry,
+  type JjLineBaseResolution,
+  type JjRevisionInfo,
 } from "./review-core";
 
 export interface ReviewJjRuntime {
@@ -28,16 +32,12 @@ export interface ReviewJjRuntime {
 }
 
 // `reachable(@, mutable())` is JJ's definition of the stack being worked on.
-// Its root parents are where that line diverged from immutable history.
-//
-// `latest(..., 1)` is what keeps the query single-record. A criss-cross history
-// can leave several fork points, and the parser below reads one record only, so
-// the tie-break belongs in the revset where it is deliberate and testable
-// rather than in a silent "first row wins" slice. It also matters for
-// correctness: bookmark preference (remote before local) is only meaningful
-// within one commit, so a multi-row answer could otherwise pick a remote
-// bookmark from one commit over a local bookmark on a nearer one.
-const JJ_LINE_BASE_REVSET = "latest(fork_point(roots(reachable(@, mutable()))-), 1)";
+// Its root parents are where that line diverged from immutable history. A
+// criss-cross history can have several equally valid fork points; requiring
+// exactly one prevents timestamp order from silently choosing review content.
+const JJ_LINE_BASE_CANDIDATES_REVSET = "fork_point(roots(reachable(@, mutable()))-)";
+const JJ_LINE_BASE_REVSET = `exactly(${JJ_LINE_BASE_CANDIDATES_REVSET}, 1)`;
+const JJ_LINE_BASE_TEMPLATE = 'json(bookmarks) ++ "\\t" ++ commit_id ++ "\\t" ++ json(description.first_line()) ++ "\\n"';
 
 // `jj git push --change` mints bookmarks under `git.push-bookmark-prefix`
 // (default `push-`). They name one change, not a line of work, so they are
@@ -66,8 +66,28 @@ export async function getJjContext(
 ): Promise<GitContext> {
   const root = await detectJjWorkspace(runtime, cwd);
   const targets = await listJjCompareTargets(runtime, root ?? cwd);
-  const defaultTarget = await selectDefaultJjCompareTarget(runtime, root ?? cwd);
+  const jjLineBase = await resolveJjLineBase(runtime, root ?? cwd);
+  const defaultTarget = jjLineBase.kind === "resolved"
+    ? jjLineBase.revision.commitId
+    : JJ_TRUNK_REVSET;
   const contextCwd = root ?? cwd;
+  const diffAvailability = jjLineBase.kind === "resolved"
+    ? undefined
+    : {
+        "jj-line": {
+          fallbackDiffType: "jj-current",
+          message: jjLineBase.kind === "ambiguous"
+            ? "Jujutsu found multiple possible line-of-work bases. Showing Current change instead."
+            : `${jjLineBase.reason} Showing Current change instead.`,
+          ...(jjLineBase.kind === "ambiguous" && {
+            candidates: jjLineBase.candidates.map((candidate) => ({
+              revision: candidate.commitId,
+              labels: candidate.bookmarks,
+              subject: candidate.subject,
+            })),
+          }),
+        },
+      };
 
   const evologs = await getJjEvoLogEntries(runtime, root ?? cwd);
 
@@ -97,8 +117,10 @@ export async function getJjContext(
       },
     },
     repository: contextCwd ? { displayFallback: basename(contextCwd) } : undefined,
+    diffAvailability,
     cwd: contextCwd,
     vcsType: "jj",
+    jjLineBase,
     jjEvologs: evologs.length >= 2 ? evologs : undefined,
   };
 }
@@ -386,38 +408,73 @@ export function getJjDiffArgs(
   }
 }
 
+export async function resolveJjLineBase(
+  runtime: ReviewJjRuntime,
+  cwd?: string,
+): Promise<JjLineBaseResolution> {
+  const result = await queryJjLineBases(runtime, JJ_LINE_BASE_REVSET, cwd);
+  if (result.exitCode === 0) {
+    const [revision] = parseJjLineBaseRecords(result.stdout);
+    if (!revision || JJ_ROOT_COMMIT_ID.test(revision.commitId)) {
+      return { kind: "unavailable", reason: "The line of work starts at the repository root." };
+    }
+    return { kind: "resolved", revision };
+  }
+
+  // `exactly(..., 1)` deliberately rejects both an empty set and a set with
+  // several fork points. Query the candidates only after that rejection so
+  // the normal path remains one repository lookup.
+  const candidatesResult = await queryJjLineBases(runtime, JJ_LINE_BASE_CANDIDATES_REVSET, cwd);
+  if (candidatesResult.exitCode !== 0) {
+    return {
+      kind: "unavailable",
+      reason: firstErrorLine(result.stderr) ?? "Jujutsu could not resolve a line-of-work base.",
+    };
+  }
+
+  const candidates = parseJjLineBaseRecords(candidatesResult.stdout)
+    .filter((revision) => !JJ_ROOT_COMMIT_ID.test(revision.commitId));
+  if (candidates.length > 1) return { kind: "ambiguous", candidates };
+  if (candidates.length === 1) return { kind: "resolved", revision: candidates[0] };
+  return { kind: "unavailable", reason: "Jujutsu could not find a line-of-work base." };
+}
+
 export async function selectDefaultJjCompareTarget(
   runtime: ReviewJjRuntime,
   cwd?: string,
 ): Promise<string> {
-  const result = await runtime.runJj([
+  const resolution = await resolveJjLineBase(runtime, cwd);
+  return resolution.kind === "resolved" ? resolution.revision.commitId : JJ_TRUNK_REVSET;
+}
+
+function queryJjLineBases(runtime: ReviewJjRuntime, revset: string, cwd?: string) {
+  return runtime.runJj([
     "log",
     "--no-graph",
     "-r",
-    JJ_LINE_BASE_REVSET,
+    revset,
     "-T",
-    'json(bookmarks) ++ "\\t" ++ commit_id ++ "\\n"',
+    JJ_LINE_BASE_TEMPLATE,
   ], { cwd });
-  // Every unresolvable case falls back to `trunk()`, which is what this
-  // returned before the line-of-work base was inferred at all. The only live
-  // caller is `getJjContext`, which runs on the review startup path with no
-  // handler above it, so throwing here does not report a problem: it aborts
-  // `plannotator review` with a stack trace before the server is built. That
-  // also covers a `jj` too old for `fork_point`/`reachable`, where the revset
-  // itself fails and the previous default is still perfectly serviceable.
-  if (result.exitCode !== 0) return JJ_TRUNK_REVSET;
+}
 
-  const [record] = splitJjTemplateRecords(result.stdout);
-  if (!record) return JJ_TRUNK_REVSET;
-
-  const fields = splitJjTemplateFields(record);
-  const bookmark = parseJjResolvedBookmarks(fields?.[0] ?? record)
-    .find((name) => !isGeneratedPushBookmark(name));
-  if (bookmark) return bookmark;
-
-  const commitId = fields?.[1]?.trim();
-  if (commitId && !JJ_ROOT_COMMIT_ID.test(commitId)) return commitId;
-  return JJ_TRUNK_REVSET;
+function parseJjLineBaseRecords(stdout: string): JjRevisionInfo[] {
+  const revisions: JjRevisionInfo[] = [];
+  for (const record of splitJjTemplateRecords(stdout)) {
+    if (!record) continue;
+    const fields = splitJjTemplateFields(record, 3);
+    if (!fields) continue;
+    const commitId = fields[1]?.trim();
+    if (!commitId) continue;
+    const bookmarks = parseJjResolvedBookmarks(fields[0])
+      .filter((name) => !isGeneratedPushBookmark(name));
+    revisions.push({
+      commitId,
+      bookmarks,
+      subject: parseSerializedJjString(fields[2]) ?? "",
+    });
+  }
+  return revisions;
 }
 
 function isGeneratedPushBookmark(target: string): boolean {
@@ -544,14 +601,9 @@ function splitJjTemplateRecords(stdout: string): string[] {
   return stdout.split(/\n|\\n/g);
 }
 
-function splitJjTemplateFields(line: string): [string, string] | null {
-  const literalTab = line.indexOf("\t");
-  if (literalTab !== -1) return [line.slice(0, literalTab), line.slice(literalTab + 1)];
-
-  const escapedTab = line.indexOf("\\t");
-  if (escapedTab !== -1) return [line.slice(0, escapedTab), line.slice(escapedTab + 2)];
-
-  return null;
+function splitJjTemplateFields(line: string, expected = 2): string[] | null {
+  const fields = line.includes("\t") ? line.split("\t") : line.split("\\t");
+  return fields.length >= expected ? fields : null;
 }
 
 function parseSerializedJjString(value: string): string | null {

--- a/packages/shared/review-core.ts
+++ b/packages/shared/review-core.ts
@@ -82,6 +82,39 @@ export interface RepositoryContext {
   displayFallback?: string;
 }
 
+export interface ReviewBaseCandidate {
+  revision: string;
+  labels: string[];
+  subject: string;
+}
+
+export interface ReviewDiffFallback {
+  requestedDiffType: string;
+  effectiveDiffType: string;
+  message: string;
+  candidates?: ReviewBaseCandidate[];
+}
+
+export interface DiffAvailability {
+  fallbackDiffType: string;
+  message: string;
+  candidates?: ReviewBaseCandidate[];
+}
+
+export interface JjRevisionInfo {
+  /** Full immutable commit ID used for every review computation. */
+  commitId: string;
+  /** Names that pointed at this revision when it was resolved. */
+  bookmarks: string[];
+  /** First line of the revision description, for disambiguation in pickers. */
+  subject: string;
+}
+
+export type JjLineBaseResolution =
+  | { kind: "resolved"; revision: JjRevisionInfo }
+  | { kind: "ambiguous"; candidates: JjRevisionInfo[] }
+  | { kind: "unavailable"; reason: string };
+
 export interface JjEvoLogEntry {
   /** Short commit ID (12 hex chars) */
   commitId: string;
@@ -112,10 +145,16 @@ export interface GitContext {
   availableBranches: AvailableBranches;
   compareTarget?: CompareTargetConfig;
   repository?: RepositoryContext;
+  /** Provider-authored fallback for modes that cannot resolve in this repository. */
+  diffAvailability?: Record<string, DiffAvailability>;
+  /** Requested and effective modes when startup used one of those fallbacks. */
+  diffFallback?: ReviewDiffFallback;
   cwd?: string;
   vcsType?: "git" | "gitbutler" | "jj" | "p4";
   /** Hash of the exact GitButler branch/commit topology used for this context. */
   gitButlerRevision?: string;
+  /** Automatic line-of-work base resolution (jj only). */
+  jjLineBase?: JjLineBaseResolution;
   /** Evolution log entries for the current jj change (jj only). */
   jjEvologs?: JjEvoLogEntry[];
   /** HEAD ancestry, newest first. Powers the commit-based baseline picker (#709). */

--- a/packages/shared/vcs-core.test.ts
+++ b/packages/shared/vcs-core.test.ts
@@ -288,6 +288,41 @@ describe("createVcsApi", () => {
     });
   });
 
+  test("falls back from an unavailable provider mode without changing the requested preference", async () => {
+    const jj = provider("jj", true, ["jj-current", "jj-line"], {
+      defaultBranch: "trunk()",
+      diffOptions: [
+        { id: "jj-current", label: "Current change" },
+        { id: "jj-line", label: "Line of work" },
+      ],
+      diffAvailability: {
+        "jj-line": {
+          fallbackDiffType: "jj-current",
+          message: "Choose a line-of-work base.",
+          candidates: [{ revision: "abc", labels: ["left"], subject: "Left base" }],
+        },
+      },
+      vcsType: "jj",
+    });
+    const api = createVcsApi([jj]);
+
+    await expect(api.prepareLocalReviewDiff({
+      cwd: "/repo",
+      requestedDiffType: "jj-line",
+      configuredDiffType: "jj-current",
+    })).resolves.toMatchObject({
+      diffType: "jj-current",
+      rawPatch: "jj:jj-current:trunk()",
+      gitContext: {
+        diffFallback: {
+          requestedDiffType: "jj-line",
+          effectiveDiffType: "jj-current",
+          message: "Choose a line-of-work base.",
+        },
+      },
+    });
+  });
+
   test("uses provider context captured atomically with the prepared patch", async () => {
     const initialContext = context({
       vcsType: "gitbutler",

--- a/packages/shared/vcs-core.ts
+++ b/packages/shared/vcs-core.ts
@@ -517,17 +517,31 @@ export function createVcsApi(providers: readonly VcsProvider[]): VcsApi {
       const { provider, gitContext } = await getContextWithProvider(options.cwd, options.vcsType);
       const ownsRequestedDiffType = options.requestedDiffType !== undefined
         && provider.ownsDiffType(options.requestedDiffType);
-      const diffType = resolveRequestedDiffType(
+      const requestedDiffType = resolveRequestedDiffType(
         provider,
         gitContext,
         options.requestedDiffType,
         options.configuredDiffType,
       );
+      const resolution = resolveAvailableDiffType(gitContext, requestedDiffType, options.requestedBase !== undefined);
+      const fallback = resolution.fallback;
+      const diffType = resolution.diffType;
       const base = resolveInitialBase(gitContext, diffType, options.requestedBase, ownsRequestedDiffType);
       const result = await provider.runDiff(diffType, base, gitContext.cwd ?? options.cwd, {
         hideWhitespace: options.hideWhitespace,
       });
-      const effectiveContext = result.gitContext ?? gitContext;
+      const resultContext = result.gitContext ?? gitContext;
+      const effectiveContext = fallback
+        ? {
+            ...resultContext,
+            diffFallback: {
+              requestedDiffType,
+              effectiveDiffType: diffType,
+              message: fallback.message,
+              candidates: fallback.candidates,
+            },
+          }
+        : resultContext;
 
       return {
         gitContext: effectiveContext,
@@ -618,6 +632,18 @@ export function createVcsApi(providers: readonly VcsProvider[]): VcsApi {
       }
       return provider.materializeSnapshot(options);
     },
+  };
+}
+
+export function resolveAvailableDiffType(
+  gitContext: GitContext,
+  requestedDiffType: DiffType,
+  hasExplicitBase = false,
+): { diffType: DiffType; fallback?: NonNullable<GitContext["diffAvailability"]>[string] } {
+  const fallback = hasExplicitBase ? undefined : gitContext.diffAvailability?.[requestedDiffType];
+  return {
+    diffType: (fallback?.fallbackDiffType ?? requestedDiffType) as DiffType,
+    ...(fallback && { fallback }),
   };
 }
 


### PR DESCRIPTION
## Summary

- resolve automatic JJ line-of-work bases to immutable full commit IDs
- report ambiguous or unavailable fork points instead of choosing by timestamp or silently using trunk
- fall back honestly to Current change while preserving the requested Line of work preference
- expose detected fork points for explicit selection and keep Bun/Pi behavior aligned

## Why

A moving remote bookmark or ambiguous fork-point revset could make a JJ review include unrelated changes or label a Current-change diff as Line of work. Freezing the automatic base and representing resolution failure explicitly keeps every diff, snapshot, fingerprint, and file lookup on the same revision.

## Validation

- `bun test packages/shared/jj-core.test.ts packages/shared/vcs-core.test.ts packages/server/jj.test.ts packages/server/vcs.test.ts`
- `bun test apps/pi-extension/server.test.ts`
- `bunx tsc --noEmit -p packages/server/tsconfig.json`
