### PR TITLE
feat(review): add provider-aware review defaults

### DIFF
--- a/apps/hook/server/index.ts
+++ b/apps/hook/server/index.ts
@@ -1096,13 +1096,13 @@ if (args[0] === "sessions") {
         isPRMode: false,
         isWorkspace: false,
         providerId,
-        resolvedDefaultDiffType: resolveDefaultDiffType(config),
+        resolvedDefaultDiffType: resolveDefaultDiffType(config, providerId),
       });
       const diffResult = await prepareLocalReviewDiff({
         vcsType: reviewArgs.vcsType,
         requestedDiffType: openState.requestedDiffType,
         requestedBase: openState.requestedBase,
-        configuredDiffType: resolveDefaultDiffType(config),
+        configuredDiffType: resolveDefaultDiffType(config, providerId),
         hideWhitespace: config.diffOptions?.hideWhitespace ?? false,
       });
       gitContext = diffResult.gitContext;
@@ -1903,7 +1903,7 @@ if (args[0] === "sessions") {
         isPRMode: false,
         isWorkspace: false,
         providerId,
-        resolvedDefaultDiffType: resolveDefaultDiffType(config),
+        resolvedDefaultDiffType: resolveDefaultDiffType(config, providerId),
         cwd,
       });
       const diffResult = await prepareLocalReviewDiff({
@@ -1911,7 +1911,7 @@ if (args[0] === "sessions") {
         vcsType: reviewArgs.vcsType,
         requestedDiffType: openState.requestedDiffType,
         requestedBase: openState.requestedBase,
-        configuredDiffType: resolveDefaultDiffType(config),
+        configuredDiffType: resolveDefaultDiffType(config, providerId),
         hideWhitespace: config.diffOptions?.hideWhitespace ?? false,
       });
       gitContext = diffResult.gitContext;

--- a/apps/opencode-plugin/commands.ts
+++ b/apps/opencode-plugin/commands.ts
@@ -163,7 +163,7 @@ export async function handleReviewCommand(
         isPRMode: false,
         isWorkspace: false,
         providerId,
-        resolvedDefaultDiffType: resolveDefaultDiffType(config),
+        resolvedDefaultDiffType: resolveDefaultDiffType(config, providerId),
         baseResolves,
       });
       if (openState.error) {
@@ -179,7 +179,7 @@ export async function handleReviewCommand(
           vcsType: reviewArgs.vcsType,
           requestedDiffType: openState.requestedDiffType,
           requestedBase: openState.requestedBase,
-          configuredDiffType: resolveDefaultDiffType(config),
+          configuredDiffType: resolveDefaultDiffType(config, providerId),
           hideWhitespace: config.diffOptions?.hideWhitespace ?? false,
         });
         gitContext = diffResult.gitContext;

--- a/apps/pi-extension/plannotator-browser.ts
+++ b/apps/pi-extension/plannotator-browser.ts
@@ -619,7 +619,7 @@ async function createCodeReviewBrowserSession(
 					isPRMode: false,
 					isWorkspace: false,
 					providerId,
-					resolvedDefaultDiffType: resolveDefaultDiffType(config),
+					resolvedDefaultDiffType: resolveDefaultDiffType(config, providerId),
 					baseResolves,
 				});
 				if (openState.error) throw new Error(openState.error);
@@ -642,7 +642,7 @@ async function createCodeReviewBrowserSession(
 				vcsType: options.vcsType,
 				requestedDiffType,
 				requestedBase,
-				configuredDiffType: resolveDefaultDiffType(config),
+				configuredDiffType: resolveDefaultDiffType(config, managedVcs?.id ?? options.vcsType),
 				hideWhitespace: config.diffOptions?.hideWhitespace ?? false,
 			});
 			gitCtx = result.gitContext;

--- a/apps/pi-extension/review-args-parity.test.ts
+++ b/apps/pi-extension/review-args-parity.test.ts
@@ -35,7 +35,11 @@ describe("vendored review-args parity", () => {
       providerId: "jj",
       resolvedDefaultDiffType: "since-base",
     });
-    expect(state.error).toContain("--base is not supported in jj sessions");
+    expect(state).toEqual({
+      requestedBase: "main",
+      requestedDiffType: "jj-line",
+      notices: [],
+    });
   });
 
   test("the review command handler forwards the parsed open state", async () => {

--- a/apps/pi-extension/server/serverReview.ts
+++ b/apps/pi-extension/server/serverReview.ts
@@ -188,6 +188,7 @@ import {
 	canStageFiles,
 	detectRemoteDefaultCompareTarget,
 	getVcsContext,
+	getVcsReviewSettings,
 	getVcsDiffFingerprint,
 	getVcsFileContentsForDiff,
 	resolveVcsCwd,
@@ -2092,6 +2093,7 @@ export async function startReviewServer(options: {
 				hideWhitespace: servedHideWhitespace,
 				...(workspace && { diffOptions: workspace.diffOptions }),
 				gitContext: hasLocalAccess ? servedGitContext : undefined,
+				reviewSettings: getVcsReviewSettings(),
 				sharingEnabled,
 				approvalNotesSupported,
 				// Mount is the only place the pin matters, so it rides /api/diff
@@ -3163,10 +3165,11 @@ export async function startReviewServer(options: {
 			}
 		} else if (url.pathname === "/api/config" && req.method === "POST") {
 			try {
-				const body = (await parseBody(req)) as { displayName?: string; diffOptions?: Record<string, unknown>; theme?: Record<string, unknown>; favicon?: FaviconStyle; reviewAnalysis?: Record<string, unknown>; conventionalComments?: boolean };
+				const body = (await parseBody(req)) as { displayName?: string; diffOptions?: Record<string, unknown>; reviewDefaults?: Record<string, { defaultDiffType?: string }>; theme?: Record<string, unknown>; favicon?: FaviconStyle; reviewAnalysis?: Record<string, unknown>; conventionalComments?: boolean };
 				const toSave: Record<string, unknown> = {};
 				if (body.displayName !== undefined) toSave.displayName = body.displayName;
 				if (body.diffOptions !== undefined) toSave.diffOptions = body.diffOptions;
+				if (body.reviewDefaults !== undefined) toSave.reviewDefaults = body.reviewDefaults;
 				if (body.theme !== undefined) toSave.theme = body.theme;
 				if (isFaviconStyle(body.favicon)) toSave.favicon = body.favicon;
 				if (body.reviewAnalysis !== undefined) {

--- a/apps/pi-extension/server/vcs.ts
+++ b/apps/pi-extension/server/vcs.ts
@@ -193,6 +193,7 @@ const api = createVcsApi([
 ]);
 
 export const {
+	getReviewSettings: getVcsReviewSettings,
 	detectVcs,
 	detectManagedVcs,
 	vcsOwnsDiffType,

--- a/packages/core/config-types.ts
+++ b/packages/core/config-types.ts
@@ -1,4 +1,40 @@
-export type DefaultDiffType = 'since-base' | 'local-vs-remote' | 'uncommitted' | 'unstaged' | 'staged' | 'merge-base' | 'all';
+export type DefaultDiffType =
+  | 'since-base'
+  | 'local-vs-remote'
+  | 'uncommitted'
+  | 'unstaged'
+  | 'staged'
+  | 'merge-base'
+  | 'all'
+  | 'jj-current'
+  | 'jj-last'
+  | 'jj-line'
+  | 'jj-evolog'
+  | 'jj-all';
+
+export interface ProviderReviewDefaults {
+  defaultDiffType?: string;
+}
+
+export type ReviewDefaults = Record<string, ProviderReviewDefaults>;
+
+export interface ReviewSettingsDiffOption {
+  id: string;
+  label: string;
+  description: string;
+}
+
+export interface VcsReviewSettingsDescriptor {
+  id: string;
+  label: string;
+  defaultDiffType: string;
+  diffOptions: ReviewSettingsDiffOption[];
+  capabilities: {
+    statusSections: boolean;
+    staging: boolean;
+    compareTarget: boolean;
+  };
+}
 export type DiffLineBgIntensity = 'subtle' | 'normal' | 'strong';
 
 /**

--- a/packages/core/guide-viewer-manifest.ts
+++ b/packages/core/guide-viewer-manifest.ts
@@ -5,9 +5,9 @@
 import type { GuideViewerAssets } from "./guide-format";
 
 export const GUIDE_VIEWER_MANIFEST: Omit<GuideViewerAssets, "baseUrl"> = {
-  js: "viewer.C8JgNbZu.js",
+  js: "viewer.BB4fQouN.js",
   css: "viewer.KIp-iPxY.css",
-  jsIntegrity: "sha384-dqRkZ2N5WNwLIuwa+1kdrvswkOVHpkBxrrJ5mTU4YrUWzO/8fRS5MRTlDGV9t7eB",
+  jsIntegrity: "sha384-VoXz96TINekI60NrEdNdMZAzJ3EuHBKxro8eENNlYvTdjxUS/mu4zOwgOdxAC4cT",
   cssIntegrity: "sha384-Ty9hGpag8KIAGMDPg7ImsB4L5RabqvonNVjrj/CnYqSJDqIgPRBwjEMoK9/EvgXm",
   langs: {
     "astro": "chunks/astro.BykyiR6i.js",

--- a/packages/review-editor/App.tsx
+++ b/packages/review-editor/App.tsx
@@ -7,6 +7,7 @@
 import '@plannotator/ui/utils/math-eager';
 import '@plannotator/ui/utils/identity-tater';
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import type { VcsReviewSettingsDescriptor } from '@plannotator/core/config-types';
 import { type Origin, getAgentName } from '@plannotator/shared/agents';
 import { ThemeProvider, useTheme } from '@plannotator/ui/components/ThemeProvider';
 import { TooltipProvider } from '@plannotator/ui/components/Tooltip';
@@ -560,6 +561,7 @@ const ReviewApp: React.FC = () => {
   const [reviewMode, setReviewMode] = useState<string | null>(null);
   const [diffType, setDiffType] = useState<string>('uncommitted');
   const [gitContext, setGitContext] = useState<GitContext | null>(null);
+  const [reviewSettings, setReviewSettings] = useState<VcsReviewSettingsDescriptor[]>([]);
   const [workspaceDiffOptions, setWorkspaceDiffOptions] = useState<DiffOption[] | null>(null);
   // Two bases:
   //   selectedBase  — what the picker is currently showing (UI intent).
@@ -1986,6 +1988,7 @@ const ReviewApp: React.FC = () => {
         diffType?: string;
         base?: string;
         gitContext?: GitContext;
+        reviewSettings?: VcsReviewSettingsDescriptor[];
         diffOptions?: DiffOption[];
         agentCwd?: string | null;
         sharingEnabled?: boolean;
@@ -2036,6 +2039,7 @@ const ReviewApp: React.FC = () => {
         setFiles(apiFiles);
         setReviewMode(data.mode ?? null);
         setWorkspaceDiffOptions(data.mode === 'workspace' ? (data.diffOptions ?? []) : null);
+        setReviewSettings(data.reviewSettings ?? data.gitContext?.reviewSettings ?? []);
         if (data.origin) setOrigin(data.origin);
         if (data.diffType) setDiffType(data.diffType);
         if (data.gitContext) {
@@ -5390,6 +5394,8 @@ const ReviewApp: React.FC = () => {
             mode="review"
             aiProviders={aiProviders}
             gitUser={gitUser}
+            reviewSettings={reviewSettings}
+            activeVcsId={gitContext?.vcsType}
             externalOpen={openSettingsMenu}
             onExternalClose={() => setOpenSettingsMenu(false)}
             // Local git session where since-base isn't offered (base ref

--- a/packages/server/review.ts
+++ b/packages/server/review.ts
@@ -11,7 +11,7 @@
 
 import { isRemoteSession, getServerHostname, startBunServerOnAvailablePort, buildAdvertisedUrl } from "./remote";
 import type { Origin } from "@plannotator/shared/agents";
-import { type DiffType, type GitContext, runVcsDiff, getVcsFileContentsForDiff, getVcsDiffFingerprint, canStageFiles, stageFile, unstageFile, resolveVcsCwd, validateFilePath, getVcsContext, detectRemoteDefaultCompareTarget, vcsOwnsDiffType, vcsSupportsSnapshot, materializeVcsSnapshot, gitRuntime } from "./vcs";
+import { type DiffType, type GitContext, runVcsDiff, getVcsFileContentsForDiff, getVcsDiffFingerprint, canStageFiles, stageFile, unstageFile, resolveVcsCwd, validateFilePath, getVcsContext, getVcsReviewSettings, detectRemoteDefaultCompareTarget, vcsOwnsDiffType, vcsSupportsSnapshot, materializeVcsSnapshot, gitRuntime } from "./vcs";
 import { basename } from "node:path";
 import { existsSync } from "node:fs";
 import { SingleFlight } from "@plannotator/shared/single-flight";
@@ -2078,6 +2078,7 @@ export async function startReviewServer(
               hideWhitespace: servedHideWhitespace,
               ...(workspace && { diffOptions: workspace.diffOptions }),
               gitContext: hasLocalAccess ? servedGitContext : undefined,
+              reviewSettings: getVcsReviewSettings(),
               sharingEnabled,
               approvalNotesSupported,
               // Mount is the only place the pin matters, so it rides /api/diff
@@ -3233,10 +3234,11 @@ export async function startReviewServer(
           // API: Update user config (write-back to ~/.plannotator/config.json)
           if (url.pathname === "/api/config" && req.method === "POST") {
             try {
-              const body = (await req.json()) as { displayName?: string; diffOptions?: Record<string, unknown>; theme?: Record<string, unknown>; favicon?: FaviconStyle; reviewAnalysis?: Record<string, unknown>; conventionalComments?: boolean; conventionalLabels?: unknown[] | null };
+              const body = (await req.json()) as { displayName?: string; diffOptions?: Record<string, unknown>; reviewDefaults?: Record<string, { defaultDiffType?: string }>; theme?: Record<string, unknown>; favicon?: FaviconStyle; reviewAnalysis?: Record<string, unknown>; conventionalComments?: boolean; conventionalLabels?: unknown[] | null };
               const toSave: Record<string, unknown> = {};
               if (body.displayName !== undefined) toSave.displayName = body.displayName;
               if (body.diffOptions !== undefined) toSave.diffOptions = body.diffOptions;
+              if (body.reviewDefaults !== undefined) toSave.reviewDefaults = body.reviewDefaults;
               if (body.theme !== undefined) toSave.theme = body.theme;
               if (isFaviconStyle(body.favicon)) toSave.favicon = body.favicon;
               if (body.reviewAnalysis !== undefined) {

--- a/packages/server/vcs.test.ts
+++ b/packages/server/vcs.test.ts
@@ -26,7 +26,7 @@ describe("resolveInitialDiffType", () => {
     expect(resolveInitialDiffType(context({ vcsType: "p4" }), "merge-base")).toBe("p4-default");
   });
 
-  test("ignores saved Git defaults for jj contexts", () => {
+  test("uses JJ defaults and ignores saved Git defaults for jj contexts", () => {
     const jjContext = context({
       defaultBranch: "trunk()",
       diffOptions: [
@@ -37,6 +37,7 @@ describe("resolveInitialDiffType", () => {
       vcsType: "jj",
     });
 
+    expect(resolveInitialDiffType(jjContext, "jj-line")).toBe("jj-line");
     expect(resolveInitialDiffType(jjContext, "all")).toBe("jj-current");
     expect(resolveInitialDiffType(jjContext, "merge-base")).toBe("jj-current");
     expect(resolveInitialDiffType(jjContext, "unstaged")).toBe("jj-current");

--- a/packages/server/vcs.ts
+++ b/packages/server/vcs.ts
@@ -48,6 +48,7 @@ const api = createVcsApi([
 ]);
 
 export const {
+  getReviewSettings: getVcsReviewSettings,
   detectVcs,
   detectManagedVcs,
   vcsOwnsDiffType,

--- a/packages/shared/config.test.ts
+++ b/packages/shared/config.test.ts
@@ -39,6 +39,20 @@ describe("resolveDefaultDiffType", () => {
       diffOptions: { defaultDiffType: "local-vs-remote" },
     })).toBe("local-vs-remote");
   });
+
+  test("resolves provider defaults without leaking Git preferences into JJ", () => {
+    const config = {
+      diffOptions: { defaultDiffType: "unstaged" as const },
+      reviewDefaults: {
+        git: { defaultDiffType: "merge-base" },
+        jj: { defaultDiffType: "jj-line" },
+      },
+    };
+
+    expect(resolveDefaultDiffType(config, "git")).toBe("merge-base");
+    expect(resolveDefaultDiffType(config, "jj")).toBe("jj-line");
+    expect(resolveDefaultDiffType({ diffOptions: config.diffOptions }, "jj")).toBe("jj-current");
+  });
 });
 
 describe("parseReviewAnalysisConfig", () => {
@@ -360,7 +374,7 @@ describe("config.json boolean coercion", () => {
   }
 });
 
-describe("favicon config persistence", () => {
+describe("config persistence", () => {
   const originalDataDir = process.env.PLANNOTATOR_DATA_DIR;
   let tempDir: string;
 
@@ -393,6 +407,16 @@ describe("favicon config persistence", () => {
     saveConfig({ favicon: unknownFavicon });
     expect(loadConfig().favicon).toBe(unknownFavicon);
     expect(getServerConfig(null).favicon).toBeUndefined();
+  });
+
+  test("merges provider review defaults without dropping another provider", () => {
+    saveConfig({ reviewDefaults: { git: { defaultDiffType: "merge-base" } } });
+    saveConfig({ reviewDefaults: { jj: { defaultDiffType: "jj-line" } } });
+
+    expect(getServerConfig(null).reviewDefaults).toEqual({
+      git: { defaultDiffType: "merge-base" },
+      jj: { defaultDiffType: "jj-line" },
+    });
   });
 });
 

--- a/packages/shared/config.ts
+++ b/packages/shared/config.ts
@@ -103,6 +103,8 @@ export function mergePromptConfig(
 export interface PlannotatorConfig {
   displayName?: string;
   diffOptions?: DiffOptions;
+  /** Provider-scoped review defaults. Unknown provider keys are preserved. */
+  reviewDefaults?: Record<string, { defaultDiffType?: string }>;
   /** Optional analysis layers used by code review. */
   reviewAnalysis?: {
     /** Named-entity semantic diff. Enabled by default for backwards compatibility. */
@@ -508,6 +510,9 @@ export function saveConfig(partial: Partial<PlannotatorConfig>): void {
     const mergedReviewAnalysis = (current.reviewAnalysis || partial.reviewAnalysis)
       ? { ...current.reviewAnalysis, ...partial.reviewAnalysis }
       : undefined;
+    const mergedReviewDefaults = (current.reviewDefaults || partial.reviewDefaults)
+      ? { ...current.reviewDefaults, ...partial.reviewDefaults }
+      : undefined;
     const mergedPrompts = mergePromptConfig(current.prompts, partial.prompts);
     const merged = {
       ...current,
@@ -515,6 +520,7 @@ export function saveConfig(partial: Partial<PlannotatorConfig>): void {
       diffOptions: mergedDiffOptions,
       theme: mergedTheme,
       reviewAnalysis: mergedReviewAnalysis,
+      reviewDefaults: mergedReviewDefaults,
       prompts: mergedPrompts,
     };
     writeConfigAtomic(getConfigPath(), JSON.stringify(merged, null, 2) + "\n");
@@ -545,6 +551,7 @@ export function detectGitUser(): string | null {
 export function getServerConfig(gitUser: string | null): {
   displayName?: string;
   diffOptions?: DiffOptions;
+  reviewDefaults?: PlannotatorConfig["reviewDefaults"];
   theme?: ThemeConfig;
   favicon?: FaviconStyle;
   reviewAnalysis: NonNullable<PlannotatorConfig["reviewAnalysis"]>;
@@ -558,6 +565,7 @@ export function getServerConfig(gitUser: string | null): {
   return {
     displayName: cfg.displayName,
     diffOptions: cfg.diffOptions,
+    ...(cfg.reviewDefaults !== undefined && { reviewDefaults: cfg.reviewDefaults }),
     ...(cfg.theme !== undefined && { theme: cfg.theme }),
     ...(isFaviconStyle(cfg.favicon) && { favicon: cfg.favicon }),
     // These values gate server-side work, so always make the resolved defaults
@@ -602,10 +610,26 @@ export function isAgentTerminalSide(
  * 'since-base' (the composite "what would GitHub show" view). Users with an
  * explicit defaultDiffType keep their choice.
  */
-export function resolveDefaultDiffType(cfg?: PlannotatorConfig): DefaultDiffType {
-  const v = cfg?.diffOptions?.defaultDiffType as string | undefined;
-  if (v === 'branch') return 'merge-base';
-  return v === 'since-base' || v === 'local-vs-remote' || v === 'uncommitted' || v === 'unstaged' || v === 'staged' || v === 'merge-base' || v === 'all' ? v : 'since-base';
+export function resolveDefaultDiffType(
+  cfg?: PlannotatorConfig,
+  providerId = "git",
+): DefaultDiffType {
+  const providerValue = cfg?.reviewDefaults?.[providerId]?.defaultDiffType;
+  const legacyGitValue = providerId === "git"
+    ? cfg?.diffOptions?.defaultDiffType as string | undefined
+    : undefined;
+  const value = providerValue ?? legacyGitValue;
+  if (value === "branch") return "merge-base";
+  if (providerId === "jj") {
+    return value === "jj-current" || value === "jj-last" || value === "jj-line"
+      || value === "jj-evolog" || value === "jj-all"
+      ? value
+      : "jj-current";
+  }
+  return value === "since-base" || value === "local-vs-remote" || value === "uncommitted"
+    || value === "unstaged" || value === "staged" || value === "merge-base" || value === "all"
+    ? value
+    : "since-base";
 }
 
 /**

--- a/packages/shared/review-args.test.ts
+++ b/packages/shared/review-args.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { REVIEW_OPEN_DIFF_TYPES, parseReviewArgs } from "./review-args";
-import { GIT_DIFF_TYPES } from "./vcs-core";
+import { GIT_DIFF_TYPES, JJ_DIFF_TYPES } from "./vcs-core";
 
 describe("parseReviewArgs", () => {
   test("defaults to auto VCS and local PR checkout", () => {
@@ -111,6 +111,15 @@ describe("parseReviewArgs", () => {
     expect(parsed.errors).toEqual([]);
   });
 
+  test("accepts stable JJ diff modes as explicit session overrides", () => {
+    expect(parseReviewArgs(["--diff-type", "jj-line", "--base", "develop@origin"])).toMatchObject({
+      vcsType: undefined,
+      diffType: "jj-line",
+      base: "develop@origin",
+      errors: [],
+    });
+  });
+
   test("--base's value cannot shadow a following PR URL", () => {
     // Failure caught: the value token landing in positional[0] and shadowing
     // the URL — a real regression path since only positional[0] is a URL
@@ -156,10 +165,10 @@ describe("parseReviewArgs", () => {
     ]);
   });
 
-  test("REVIEW_OPEN_DIFF_TYPES is exactly GIT_DIFF_TYPES", () => {
-    // Failure caught: a git diff type added to one set and not the other,
-    // making a valid mode unreachable from (or falsely advertised by) the CLI.
-    expect(new Set(REVIEW_OPEN_DIFF_TYPES)).toEqual(GIT_DIFF_TYPES);
+  test("REVIEW_OPEN_DIFF_TYPES is exactly the stable Git and JJ modes", () => {
+    // Failure caught: a stable provider diff type added to one set and not the
+    // other, making a valid mode unreachable from the CLI.
+    expect(new Set(REVIEW_OPEN_DIFF_TYPES)).toEqual(new Set([...GIT_DIFF_TYPES, ...JJ_DIFF_TYPES]));
   });
 
   test("an unknown dashed token cannot shadow a PR URL", () => {

--- a/packages/shared/review-args.ts
+++ b/packages/shared/review-args.ts
@@ -8,7 +8,8 @@ import { stripWrappingQuotes } from "./resolve-file";
  * other would make a valid mode unreachable from the CLI). Kept as a literal
  * list here (type-only imports elsewhere) so review-args stays light for
  * plugin hosts. Session-navigation states (`commit:<sha>`, `worktree:*`,
- * `gitbutler:*`, jj/p4 modes) are deliberately not open states.
+ * `gitbutler:*` and p4 modes) are deliberately not open states. JJ's stable
+ * built-in modes are valid open defaults and explicit per-invocation seeds.
  */
 export const REVIEW_OPEN_DIFF_TYPES = [
   "since-base",
@@ -20,6 +21,11 @@ export const REVIEW_OPEN_DIFF_TYPES = [
   "branch",
   "merge-base",
   "all",
+  "jj-current",
+  "jj-last",
+  "jj-line",
+  "jj-evolog",
+  "jj-all",
 ] as const;
 
 export type ReviewOpenDiffType = (typeof REVIEW_OPEN_DIFF_TYPES)[number];

--- a/packages/shared/review-core.ts
+++ b/packages/shared/review-core.ts
@@ -5,6 +5,7 @@
  * self-contained while review diff logic remains sourced from one module.
  */
 
+import type { VcsReviewSettingsDescriptor } from "@plannotator/core/config-types";
 import {
   formatDiffMetadataPathToken,
   formatPatchPathToken,
@@ -116,6 +117,8 @@ export interface GitContext {
   vcsType?: "git" | "gitbutler" | "jj" | "p4";
   /** Hash of the exact GitButler branch/commit topology used for this context. */
   gitButlerRevision?: string;
+  /** Review settings contributed by the providers registered in this runtime. */
+  reviewSettings?: VcsReviewSettingsDescriptor[];
   /** Evolution log entries for the current jj change (jj only). */
   jjEvologs?: JjEvoLogEntry[];
   /** HEAD ancestry, newest first. Powers the commit-based baseline picker (#709). */

--- a/packages/shared/review-open-state.test.ts
+++ b/packages/shared/review-open-state.test.ts
@@ -38,11 +38,11 @@ describe("resolveReviewOpenState", () => {
     expect(state.notices).toEqual([]);
   });
 
-  test.each(["gitbutler", "jj", "p4"] as const)(
+  test.each(["gitbutler", "p4"] as const)(
     "%s + --base errors instead of accept-and-ignore",
     (providerId) => {
-      // resolveInitialBase hard-returns the detected default on jj/gitbutler
-      // (and p4 has no base at all): accepting the flag would quietly review
+      // These providers derive their own base (or have none): accepting the
+      // flag would quietly review
       // against the wrong base — the silent lie this matrix exists to prevent.
       const state = resolveReviewOpenState(
         input({ providerId, parsed: { base: "feature/part-1" }, baseResolves: true }),
@@ -52,7 +52,7 @@ describe("resolveReviewOpenState", () => {
     },
   );
 
-  test.each(["gitbutler", "jj", "p4"] as const)(
+  test.each(["gitbutler", "p4"] as const)(
     "%s + --diff-type since-base errors instead of accept-and-ignore",
     (providerId) => {
       // ownsDiffType rejects git diff ids on these providers, so the request
@@ -63,6 +63,25 @@ describe("resolveReviewOpenState", () => {
       expect(state.error).toContain("--diff-type is not supported");
     },
   );
+
+  test("JJ flags seed native modes and only allow a base for line-of-work", () => {
+    expect(resolveReviewOpenState(input({
+      providerId: "jj",
+      parsed: { diffType: "jj-last" },
+      resolvedDefaultDiffType: "jj-current",
+    }))).toEqual({ requestedDiffType: "jj-last", notices: [] });
+
+    expect(resolveReviewOpenState(input({
+      providerId: "jj",
+      parsed: { base: "develop@origin" },
+      resolvedDefaultDiffType: "jj-current",
+    }))).toEqual({ requestedBase: "develop@origin", requestedDiffType: "jj-line", notices: [] });
+
+    expect(resolveReviewOpenState(input({
+      providerId: "jj",
+      parsed: { base: "develop@origin", diffType: "jj-current" },
+    })).error).toContain("--base has no effect");
+  });
 
   test("workspace + either flag errors (a base parameter with nowhere to go)", () => {
     const base = resolveReviewOpenState(

--- a/packages/shared/review-open-state.ts
+++ b/packages/shared/review-open-state.ts
@@ -13,7 +13,7 @@ import type { ParsedReviewArgs } from "./review-args";
 import type { AvailableBranches, DiffType } from "./review-core";
 
 /** The diff types for which a base ref is meaningful (compareTarget.diffTypes). */
-export const BASE_RELATIVE_DIFF_TYPES = ["since-base", "branch", "merge-base"] as const;
+export const BASE_RELATIVE_DIFF_TYPES = ["since-base", "branch", "merge-base", "jj-line"] as const;
 
 const BASE_RELATIVE = new Set<string>(BASE_RELATIVE_DIFF_TYPES);
 
@@ -77,11 +77,21 @@ export function resolveReviewOpenState(input: ReviewOpenStateInput): ReviewOpenS
     );
   }
   if (input.providerId === "jj") {
-    return fail(
-      base !== undefined
-        ? "--base is not supported in jj sessions yet (only the jj-line mode has a base)."
-        : "--diff-type is not supported in jj sessions; jj modes are selected in the UI.",
-    );
+    if (diffType !== undefined && !diffType.startsWith("jj-")) {
+      return fail(`--diff-type ${diffType} is not available in Jujutsu sessions.`);
+    }
+    if (base !== undefined && diffType !== undefined && diffType !== "jj-line") {
+      return fail(`--base has no effect with --diff-type ${diffType}.\nBase-relative Jujutsu diff type: jj-line.`);
+    }
+    return {
+      ...(base !== undefined && { requestedBase: base }),
+      ...(diffType !== undefined
+        ? { requestedDiffType: diffType }
+        : base !== undefined
+          ? { requestedDiffType: "jj-line" as const }
+          : {}),
+      notices: [],
+    };
   }
   if (input.providerId === "p4") {
     return fail(

--- a/packages/shared/vcs-core.test.ts
+++ b/packages/shared/vcs-core.test.ts
@@ -83,6 +83,33 @@ describe("createVcsApi", () => {
     await expect(api.getVcsContext("/repo")).resolves.toMatchObject({ vcsType: "jj" });
   });
 
+  test("exposes settings descriptors from registered providers without requiring every provider to implement one", async () => {
+    const git = {
+      ...provider("git", true, ["uncommitted"]),
+      reviewSettings: {
+        id: "git",
+        label: "Git",
+        defaultDiffType: "uncommitted",
+        diffOptions: [{ id: "uncommitted", label: "Uncommitted", description: "Working tree changes" }],
+        capabilities: { statusSections: true, staging: true, compareTarget: true },
+      },
+    } satisfies VcsProvider;
+    const plugin = {
+      ...provider("plugin-vcs", false, ["plugin-diff"]),
+      reviewSettings: {
+        id: "plugin-vcs",
+        label: "Plugin VCS",
+        defaultDiffType: "plugin-diff",
+        diffOptions: [{ id: "plugin-diff", label: "Plugin diff", description: "Plugin changes" }],
+        capabilities: { statusSections: false, staging: false, compareTarget: false },
+      },
+    } satisfies VcsProvider;
+    const p4 = provider("p4", false, ["p4-default"]);
+
+    const context = await createVcsApi([plugin, git, p4]).getVcsContext("/repo");
+    expect(context.reviewSettings?.map((descriptor) => descriptor.id)).toEqual(["plugin-vcs", "git"]);
+  });
+
   test("selects GitButler ahead of Git without changing JJ precedence", async () => {
     const jj = provider("jj", false, ["jj-current"], {}, "/repo");
     const gitButler = provider("gitbutler", true, ["gitbutler:workspace"], {}, "/repo");
@@ -431,7 +458,7 @@ describe("resolveInitialDiffType", () => {
     expect(resolveInitialDiffType(context({ vcsType: "p4" }), "merge-base")).toBe("p4-default");
   });
 
-  test("ignores saved Git defaults for jj contexts", () => {
+  test("uses JJ defaults and ignores saved Git defaults for jj contexts", () => {
     const jjContext = context({
       defaultBranch: "trunk()",
       diffOptions: [
@@ -442,6 +469,7 @@ describe("resolveInitialDiffType", () => {
       vcsType: "jj",
     });
 
+    expect(resolveInitialDiffType(jjContext, "jj-line")).toBe("jj-line");
     expect(resolveInitialDiffType(jjContext, "all")).toBe("jj-current");
     expect(resolveInitialDiffType(jjContext, "merge-base")).toBe("jj-current");
     expect(resolveInitialDiffType(jjContext, "unstaged")).toBe("jj-current");

--- a/packages/shared/vcs-core.ts
+++ b/packages/shared/vcs-core.ts
@@ -1,3 +1,4 @@
+import type { VcsReviewSettingsDescriptor } from "@plannotator/core/config-types";
 import {
   type DiffResult,
   type DiffType,
@@ -61,6 +62,7 @@ export {
 
 export interface VcsProvider {
   readonly id: string;
+  readonly reviewSettings?: VcsReviewSettingsDescriptor;
   detect(cwd?: string): Promise<boolean>;
   getRoot?(cwd?: string): Promise<string | null>;
   ownsDiffType(diffType: string): boolean;
@@ -110,6 +112,7 @@ export interface VcsSnapshot {
 export type VcsSelection = "auto" | "git" | "gitbutler" | "jj" | "p4";
 
 export interface VcsApi {
+  getReviewSettings(): VcsReviewSettingsDescriptor[];
   detectVcs(cwd?: string): Promise<VcsProvider>;
   detectManagedVcs(cwd?: string, vcsType?: VcsSelection): Promise<VcsProvider | null>;
   vcsOwnsDiffType(vcsType: Exclude<VcsSelection, "auto">, diffType: string): boolean;
@@ -172,7 +175,37 @@ export interface PreparedLocalReviewDiff {
 // `review --diff-type` accepts) against it — a git diff type added to one set
 // and not the other would make a valid mode unreachable from the CLI.
 export const GIT_DIFF_TYPES = new Set(["since-base", "local-vs-remote", "uncommitted", "staged", "unstaged", "last-commit", "branch", "merge-base", "all"]);
-const JJ_DIFF_TYPES = new Set(["jj-current", "jj-last", "jj-line", "jj-evolog", "jj-all"]);
+export const JJ_DIFF_TYPES = new Set(["jj-current", "jj-last", "jj-line", "jj-evolog", "jj-all"]);
+
+const GIT_REVIEW_SETTINGS: VcsReviewSettingsDescriptor = {
+  id: "git",
+  label: "Git",
+  defaultDiffType: "since-base",
+  diffOptions: [
+    { id: "since-base", label: "All Changes (Recommended)", description: "Everything since your branch split from main — committed, uncommitted, and untracked" },
+    { id: "local-vs-remote", label: "Local vs Remote Branch", description: "Your local branch and working tree compared with its last-fetched remote-tracking branch" },
+    { id: "uncommitted", label: "Uncommitted", description: "Everything you've changed since your last commit" },
+    { id: "unstaged", label: "Unstaged", description: "Only changes you haven't staged yet" },
+    { id: "staged", label: "Staged", description: "Only changes you've staged for commit" },
+    { id: "merge-base", label: "Committed changes (PR view)", description: "Everything you've committed on this branch" },
+    { id: "all", label: "All Files (HEAD)", description: "Every tracked file at HEAD, shown as additions" },
+  ],
+  capabilities: { statusSections: true, staging: true, compareTarget: true },
+};
+
+const JJ_REVIEW_SETTINGS: VcsReviewSettingsDescriptor = {
+  id: "jj",
+  label: "Jujutsu",
+  defaultDiffType: "jj-current",
+  diffOptions: [
+    { id: "jj-current", label: "Current change", description: "Only the changes in the working-copy change" },
+    { id: "jj-line", label: "Line of work", description: "The complete mutable line of work leading to the working copy" },
+    { id: "jj-last", label: "Last change", description: "The change immediately before the working copy" },
+    { id: "jj-evolog", label: "Evolution diff", description: "How the current change differs from its previous state" },
+    { id: "jj-all", label: "All files", description: "Every file at the working-copy revision, shown as additions" },
+  ],
+  capabilities: { statusSections: false, staging: false, compareTarget: true },
+};
 
 function selectNearestProvider(
   candidates: Array<{ provider: VcsProvider; root: string | null; order: number }>,
@@ -208,6 +241,7 @@ function vcsRootDepth(root: string): number {
 export function createGitProvider(runtime: ReviewGitRuntime): VcsProvider {
   return {
     id: "git",
+    reviewSettings: GIT_REVIEW_SETTINGS,
 
     async detect(cwd?: string): Promise<boolean> {
       try {
@@ -285,6 +319,7 @@ export function createGitProvider(runtime: ReviewGitRuntime): VcsProvider {
 export function createJjProvider(runtime: ReviewJjRuntime, gitRuntime: ReviewGitRuntime): VcsProvider {
   return {
     id: "jj",
+    reviewSettings: JJ_REVIEW_SETTINGS,
 
     async detect(cwd?: string): Promise<boolean> {
       return (await detectJjWorkspace(runtime, cwd)) !== null;
@@ -466,7 +501,16 @@ export function createVcsApi(providers: readonly VcsProvider[]): VcsApi {
     vcsType?: VcsSelection,
   ): Promise<{ provider: VcsProvider; gitContext: GitContext }> {
     const provider = await getProviderForSelection(vcsType, cwd);
-    return { provider, gitContext: await provider.getContext(cwd) };
+    const gitContext = await provider.getContext(cwd);
+    return {
+      provider,
+      gitContext: {
+        ...gitContext,
+        reviewSettings: providerList.flatMap((candidate) =>
+          candidate.reviewSettings ? [candidate.reviewSettings] : []
+        ),
+      },
+    };
   }
 
   function resolveRequestedDiffType(
@@ -497,6 +541,10 @@ export function createVcsApi(providers: readonly VcsProvider[]): VcsApi {
   }
 
   return {
+    getReviewSettings(): VcsReviewSettingsDescriptor[] {
+      return providerList.flatMap((provider) => provider.reviewSettings ? [provider.reviewSettings] : []);
+    },
+
     detectVcs,
     detectManagedVcs,
 
@@ -627,9 +675,6 @@ export function resolveInitialDiffType(
 ): DiffType {
   if (gitContext.vcsType === "p4") {
     return "p4-default";
-  }
-  if (gitContext.vcsType === "jj") {
-    return "jj-current";
   }
   if (gitContext.diffOptions.some((option) => option.id === configuredDiffType)) {
     return configuredDiffType;

--- a/packages/ui/components/Settings.tsx
+++ b/packages/ui/components/Settings.tsx
@@ -2,9 +2,17 @@ import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import type { AnnotateAgentTerminalSide } from '@plannotator/core/agent-terminal';
 import type { Origin } from '@plannotator/core/agents';
-import type { DiffLineBgIntensity } from '@plannotator/core/config-types';
+import type { DiffLineBgIntensity, VcsReviewSettingsDescriptor } from '@plannotator/core/config-types';
 import type { TokenHoverDelay } from '@plannotator/core/token-hover';
-import { configStore, useConfigValue, setReviewPanelView, setReviewDefaultDiffType, setReviewAutoViewed } from '../config';
+import {
+  configStore,
+  useConfigValue,
+  setReviewPanelView,
+  setReviewDefaultDiffType,
+  getProviderReviewDefaultDiffType,
+  setProviderReviewDefaultDiffType,
+  setReviewAutoViewed,
+} from '../config';
 import { setWebMcpToolsEnabled, useWebMcpToolsEnabled } from '../webmcp/preference';
 import { loadDiffFont } from '../utils/diffFonts';
 import { TaterSpritePullup } from './TaterSpritePullup';
@@ -78,7 +86,7 @@ import {
 import { requestVimDocumentFocus } from '../hooks/useVimDocumentFocus';
 import { AnalysisLayerToggle } from './AnalysisLayerToggle';
 
-type SettingsTab = 'general' | 'theme' | 'git' | 'display' | 'analysis' | 'saving' | 'labels' | 'vim' | 'shortcuts' | 'ai' | 'files' | 'obsidian' | 'bear' | 'octarine' | 'comments' | 'hooks';
+type SettingsTab = 'general' | 'theme' | 'review' | 'display' | 'analysis' | 'saving' | 'labels' | 'vim' | 'shortcuts' | 'ai' | 'files' | 'obsidian' | 'bear' | 'octarine' | 'comments' | 'hooks';
 
 interface SettingsProps {
   taterMode: boolean;
@@ -98,6 +106,10 @@ interface SettingsProps {
    *  (base ref unresolvable) — the Git tab shows a note that the Git-status
    *  preference can't take effect in THIS repo. */
   sinceBaseUnavailable?: boolean;
+  /** Provider-owned defaults available in this review runtime. */
+  reviewSettings?: VcsReviewSettingsDescriptor[];
+  /** Provider active in the current review. */
+  activeVcsId?: string;
   /** The host is rendering its compact touch shell (review only). Display
    *  settings that the compact shell overrides for the session are hidden
    *  there instead of silently editing the desktop preference. */
@@ -171,18 +183,6 @@ export const LINE_BG_INTENSITY_OPTIONS: { value: DiffLineBgIntensity; label: str
   { value: 'normal', label: 'Normal' },
   { value: 'strong', label: 'Strong' },
 ];
-const DEFAULT_DIFF_TYPE_OPTIONS = [
-  // "All Changes" belongs to since-base (the flagship composite); uncommitted
-  // reverts to its plain name so the two stay distinguishable side by side.
-  { value: 'since-base' as const, label: 'All Changes (Recommended)', description: "Everything since your branch split from main — committed, uncommitted, and untracked" },
-  { value: 'local-vs-remote' as const, label: 'Local vs Remote Branch', description: "Your local branch and working tree compared with its last-fetched remote-tracking branch" },
-  { value: 'uncommitted' as const, label: 'Uncommitted', description: "Everything you've changed since your last commit" },
-  { value: 'unstaged' as const, label: 'Unstaged', description: "Only changes you haven't staged yet" },
-  { value: 'staged' as const, label: 'Staged', description: "Only changes you've staged for commit" },
-  { value: 'merge-base' as const, label: 'Committed changes (PR view)', description: "Everything you've committed on this branch" },
-  { value: 'all' as const, label: 'All Files (HEAD)', description: "Every tracked file at HEAD, shown as additions" },
-];
-
 const AGENT_TERMINAL_SIDE_OPTIONS: { value: AnnotateAgentTerminalSide; label: string }[] = [
   { value: 'left', label: 'Left' },
   { value: 'right', label: 'Right' },
@@ -396,87 +396,116 @@ function ReviewAnalysisTab() {
   );
 }
 
-const GitTab: React.FC<{ sinceBaseUnavailable?: boolean }> = ({ sinceBaseUnavailable }) => {
-  const defaultDiffType = useConfigValue('defaultDiffType');
+const ReviewSettingsTab: React.FC<{
+  providers: VcsReviewSettingsDescriptor[];
+  activeVcsId?: string;
+  sinceBaseUnavailable?: boolean;
+}> = ({ providers, activeVcsId, sinceBaseUnavailable }) => {
+  useConfigValue('reviewDefaults');
+  useConfigValue('defaultDiffType');
   const reviewPanelView = useConfigValue('reviewPanelView');
   const reviewAutoViewed = useConfigValue('reviewAutoViewed');
+  const [selectedProviderId, setSelectedProviderId] = useState(() =>
+    providers.some((provider) => provider.id === activeVcsId)
+      ? activeVcsId!
+      : providers[0]?.id ?? ''
+  );
+  const provider = providers.find((candidate) => candidate.id === selectedProviderId) ?? providers[0];
+  const defaultDiffType = provider ? getProviderReviewDefaultDiffType(provider) : '';
+
+  useEffect(() => {
+    if (activeVcsId && providers.some((candidate) => candidate.id === activeVcsId)) {
+      setSelectedProviderId(activeVcsId);
+    }
+  }, [activeVcsId, providers]);
+
   return (
     <div className="space-y-5">
       <div className="space-y-2">
         <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
           Viewed files
         </div>
-        {/* Never write `reviewAutoViewed` directly — setReviewAutoViewed also
-            consumes the first-time notice, since an explicit toggle is proof
-            the reviewer already found the switch. */}
         <ToggleSwitch
           checked={reviewAutoViewed}
-          onChange={(v) => setReviewAutoViewed(v)}
+          onChange={setReviewAutoViewed}
           label="Auto-mark viewed"
           description="Mark a file viewed when you scroll past it or move on to another file. Files you un-view stay un-viewed, and files that change on refresh become un-viewed."
         />
       </div>
-      <div className="space-y-2">
-        <div>
-          <div className="text-sm font-medium">Default review view</div>
-          <div className="text-xs text-muted-foreground">Which panel a code review opens in</div>
-          {/* This is a GLOBAL preference — never hide the options because the
-              CURRENT repo can't serve them; just say so. Without this note,
-              picking Git status on a repo whose base ref doesn't resolve
-              silently falls back to Tree and the setting looks broken. */}
-          {sinceBaseUnavailable && (
-            <div className="text-xs text-warning mt-1">
-              Git status view isn't available in this repository (its base branch
-              couldn't be resolved) — reviews here open in Tree. The preference
-              still applies in repositories where it works.
-            </div>
-          )}
+
+      {providers.length > 1 && provider && (
+        <div className="space-y-2">
+          <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            Defaults for
+          </div>
+          <SegmentedControl
+            options={providers.map((candidate) => ({ value: candidate.id, label: candidate.label }))}
+            value={provider.id}
+            onChange={setSelectedProviderId}
+          />
         </div>
-        {/* No Commits option here: the Commits view is session-only (entered
-            via the panel toggle) and is never the opening view. */}
-        <SegmentedControl
-          options={[
-            { value: 'sections' as const, label: 'Git status' },
-            { value: 'tree' as const, label: 'Tree' },
-          ]}
-          value={reviewPanelView}
-          onChange={setReviewPanelView}
-        />
-      </div>
-      <div className="space-y-2">
-      <div>
-        <div className="text-sm font-medium">Default Diff View</div>
-        <div className="text-xs text-muted-foreground">Which changes to show when you open a code review</div>
-      </div>
-      <div className="space-y-2">
-        {DEFAULT_DIFF_TYPE_OPTIONS.map((opt) => (
-          <button
-            key={opt.value}
-            type="button"
-            // Coupling (sections ⟺ since-base) lives in the shared setter —
-            // never write the pair by hand (see config/reviewView).
-            onClick={() => setReviewDefaultDiffType(opt.value)}
-            className={`w-full flex items-start gap-3 p-3 rounded-lg border transition-colors text-left ${
-              defaultDiffType === opt.value
-                ? 'border-primary bg-primary/5'
-                : 'border-border hover:border-muted-foreground/30 hover:bg-muted/50'
-            }`}
-          >
-            <div className={`mt-0.5 w-4 h-4 rounded-full border-2 flex-shrink-0 flex items-center justify-center ${
-              defaultDiffType === opt.value ? 'border-primary' : 'border-muted-foreground/40'
-            }`}>
-              {defaultDiffType === opt.value && (
-                <div className="w-2 h-2 rounded-full bg-primary" />
-              )}
-            </div>
-            <div>
-              <div className="text-sm font-medium">{opt.label}</div>
-              <div className="text-xs text-muted-foreground">{opt.description}</div>
-            </div>
-          </button>
-        ))}
-      </div>
-      </div>
+      )}
+
+      {provider?.capabilities.statusSections && (
+        <div className="space-y-2">
+          <div>
+            <div className="text-sm font-medium">Default review view</div>
+            <div className="text-xs text-muted-foreground">Which panel a code review opens in</div>
+            {sinceBaseUnavailable && provider.id === activeVcsId && (
+              <div className="text-xs text-warning mt-1">
+                Git status view isn't available in this repository (its base branch
+                couldn't be resolved) — reviews here open in Tree. The preference
+                still applies in repositories where it works.
+              </div>
+            )}
+          </div>
+          <SegmentedControl
+            options={[
+              { value: 'sections' as const, label: 'Git status' },
+              { value: 'tree' as const, label: 'Tree' },
+            ]}
+            value={reviewPanelView}
+            onChange={setReviewPanelView}
+          />
+        </div>
+      )}
+
+      {provider && (
+        <div className="space-y-2">
+          <div>
+            <div className="text-sm font-medium">Default diff view</div>
+            <div className="text-xs text-muted-foreground">Which changes to show when you open a code review</div>
+          </div>
+          <div className="space-y-2">
+            {provider.diffOptions.map((option) => (
+              <button
+                key={option.id}
+                type="button"
+                onClick={() => provider.id === 'git'
+                  ? setReviewDefaultDiffType(option.id as Parameters<typeof setReviewDefaultDiffType>[0])
+                  : setProviderReviewDefaultDiffType(provider.id, option.id)}
+                className={`w-full flex items-start gap-3 p-3 rounded-lg border transition-colors text-left ${
+                  defaultDiffType === option.id
+                    ? 'border-primary bg-primary/5'
+                    : 'border-border hover:border-muted-foreground/30 hover:bg-muted/50'
+                }`}
+              >
+                <div className={`mt-0.5 w-4 h-4 rounded-full border-2 flex-shrink-0 flex items-center justify-center ${
+                  defaultDiffType === option.id ? 'border-primary' : 'border-muted-foreground/40'
+                }`}>
+                  {defaultDiffType === option.id && (
+                    <div className="w-2 h-2 rounded-full bg-primary" />
+                  )}
+                </div>
+                <div>
+                  <div className="text-sm font-medium">{option.label}</div>
+                  <div className="text-xs text-muted-foreground">{option.description}</div>
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 };
@@ -929,7 +958,7 @@ const CommentsTab: React.FC = () => {
   );
 };
 
-export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange, onIdentityChange, origin, mode = 'plan', onUIPreferencesChange, externalOpen, onExternalClose, aiProviders = [], gitUser, sinceBaseUnavailable, isCompactTouchLayout = false, onDetectObsidianVaults, agentTerminalAvailable = false, webmcpAvailable = false }) => {
+export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange, onIdentityChange, origin, mode = 'plan', onUIPreferencesChange, externalOpen, onExternalClose, aiProviders = [], gitUser, sinceBaseUnavailable, reviewSettings = [], activeVcsId, isCompactTouchLayout = false, onDetectObsidianVaults, agentTerminalAvailable = false, webmcpAvailable = false }) => {
   const webmcpTools = useWebMcpToolsEnabled();
   const [showDialog, setShowDialog] = useState(false);
   const settingsWasOpenRef = useRef(false);
@@ -1005,7 +1034,7 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
       t.push({ id: 'labels', label: 'Labels' });
     }
     if (mode === 'review') {
-      t.push({ id: 'git', label: 'Git' });
+      t.push({ id: 'review', label: 'Review' });
       t.push({ id: 'display', label: 'Editor' });
       t.push({ id: 'analysis', label: 'Analysis' });
       t.push({ id: 'comments', label: 'Comments' });
@@ -1573,9 +1602,13 @@ export const Settings: React.FC<SettingsProps> = ({ taterMode, onTaterModeChange
                 {/* === THEME TAB === */}
                 {activeTab === 'theme' && <ThemeTab onPreview={() => { setShowDialog(false); setThemePreview(true); }} />}
 
-                {/* === GIT TAB === */}
-                {activeTab === 'git' && mode === 'review' && (
-                  <GitTab sinceBaseUnavailable={sinceBaseUnavailable} />
+                {/* === REVIEW TAB === */}
+                {activeTab === 'review' && mode === 'review' && (
+                  <ReviewSettingsTab
+                    providers={reviewSettings}
+                    activeVcsId={activeVcsId}
+                    sinceBaseUnavailable={sinceBaseUnavailable}
+                  />
                 )}
 
                 {/* === DISPLAY TAB === */}

--- a/packages/ui/config/index.ts
+++ b/packages/ui/config/index.ts
@@ -4,6 +4,8 @@ export { useConfigValue } from './useConfig';
 export {
   setReviewPanelView,
   setReviewDefaultDiffType,
+  getProviderReviewDefaultDiffType,
+  setProviderReviewDefaultDiffType,
   getPersistedReviewPanelView,
   setReviewAutoViewed,
   needsAutoViewedNotice,

--- a/packages/ui/config/reviewPanelViewLastUsed.test.ts
+++ b/packages/ui/config/reviewPanelViewLastUsed.test.ts
@@ -2,7 +2,12 @@ import { afterEach, describe, expect, test } from 'bun:test';
 import { resetStorageBackend, setStorageBackend } from '../utils/storage';
 import { SETTINGS } from './settings';
 import { ConfigStoreForTest } from './configStore';
-import { setReviewDefaultDiffType, setReviewPanelView } from './reviewView';
+import {
+  getProviderReviewDefaultDiffType,
+  setProviderReviewDefaultDiffType,
+  setReviewDefaultDiffType,
+  setReviewPanelView,
+} from './reviewView';
 
 function installMemoryBackend(): Map<string, string> {
   const values = new Map<string, string>();
@@ -73,6 +78,26 @@ describe('reviewPanelViewLastUsed setting', () => {
     expect(store.get('defaultDiffType')).toBe('since-base');
     // ...but the user's last-used view survived.
     expect(store.get('reviewPanelViewLastUsed')).toBe('tree');
+  });
+
+  test('keeps provider defaults independent and falls back to provider metadata', () => {
+    installMemoryBackend();
+    const store = makeStore();
+    const jj = {
+      id: 'jj',
+      label: 'Jujutsu',
+      defaultDiffType: 'jj-current',
+      diffOptions: [
+        { id: 'jj-current', label: 'Current', description: 'Current change' },
+        { id: 'jj-line', label: 'Line', description: 'Line of work' },
+      ],
+      capabilities: { statusSections: false, staging: false, compareTarget: true },
+    };
+
+    expect(getProviderReviewDefaultDiffType(jj, store)).toBe('jj-current');
+    setProviderReviewDefaultDiffType('jj', 'jj-line', store);
+    expect(getProviderReviewDefaultDiffType(jj, store)).toBe('jj-line');
+    expect(store.get('defaultDiffType')).toBe('since-base');
   });
 
   test('local-vs-remote persists as a Tree-compatible default', () => {

--- a/packages/ui/config/reviewView.ts
+++ b/packages/ui/config/reviewView.ts
@@ -1,6 +1,7 @@
 import { configStore } from './configStore';
 import { SETTINGS } from './settings';
 import { storage } from '../utils/storage';
+import type { VcsReviewSettingsDescriptor } from '@plannotator/core/config-types';
 
 /**
  * The ONLY writers for the coupled setting pair (reviewPanelView,
@@ -68,12 +69,39 @@ export function setReviewDefaultDiffType(
   store: PanelViewConfigStore = configStore,
 ): void {
   store.set('defaultDiffType', value);
+  setProviderReviewDefaultDiffType('git', value, store);
   if (value !== 'since-base' && store.get('reviewPanelView') !== 'tree') {
     store.set('reviewPanelView', 'tree');
     // The snap is an explicit-choice consequence (the user picked a classic
     // diff default), so it syncs the memo like any explicit view write.
     store.set('reviewPanelViewLastUsed', 'tree');
   }
+}
+
+export function getProviderReviewDefaultDiffType(
+  descriptor: VcsReviewSettingsDescriptor,
+  store: PanelViewConfigStore = configStore,
+): string {
+  const configured = store.get('reviewDefaults')[descriptor.id]?.defaultDiffType;
+  if (configured && descriptor.diffOptions.some((option) => option.id === configured)) {
+    return configured;
+  }
+  if (descriptor.id === 'git') {
+    const legacy = store.get('defaultDiffType');
+    if (descriptor.diffOptions.some((option) => option.id === legacy)) return legacy;
+  }
+  return descriptor.defaultDiffType;
+}
+
+export function setProviderReviewDefaultDiffType(
+  providerId: string,
+  value: string,
+  store: PanelViewConfigStore = configStore,
+): void {
+  store.set('reviewDefaults', {
+    ...store.get('reviewDefaults'),
+    [providerId]: { defaultDiffType: value },
+  });
 }
 
 

--- a/packages/ui/config/settings.ts
+++ b/packages/ui/config/settings.ts
@@ -13,7 +13,7 @@ import {
   isAnnotateAgentTerminalSide,
   type AnnotateAgentTerminalSide,
 } from '@plannotator/core/agent-terminal';
-import type { DiffLineBgIntensity } from '@plannotator/core/config-types';
+import type { DiffLineBgIntensity, ReviewDefaults } from '@plannotator/core/config-types';
 import { isFaviconStyle, type FaviconStyle } from '@plannotator/core/favicon';
 import {
   DEFAULT_TOKEN_HOVER_DELAY_MS,
@@ -91,6 +91,19 @@ export function readThemePairCookies(keys?: ThemePairLegacyKeys): ThemePair | un
 const DIFF_LINE_BG_INTENSITY_VALUES = ['subtle', 'normal', 'strong'] as const;
 function isDiffLineBgIntensity(v: unknown): v is DiffLineBgIntensity {
   return typeof v === 'string' && (DIFF_LINE_BG_INTENSITY_VALUES as readonly string[]).includes(v);
+}
+
+function parseReviewDefaults(value: unknown): ReviewDefaults | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const defaults: ReviewDefaults = {};
+  for (const [providerId, providerValue] of Object.entries(value)) {
+    if (!providerId || !providerValue || typeof providerValue !== 'object' || Array.isArray(providerValue)) continue;
+    const defaultDiffType = (providerValue as Record<string, unknown>).defaultDiffType;
+    if (typeof defaultDiffType === 'string' && defaultDiffType) {
+      defaults[providerId] = { defaultDiffType };
+    }
+  }
+  return defaults;
 }
 
 export interface SettingDef<T> {
@@ -330,6 +343,25 @@ export const SETTINGS = {
     toCookie: (value: boolean) =>
       storage.setItem('plannotator-review-show-stage-controls', String(value)),
     serverKey: undefined, fromServer: undefined, toServer: undefined,
+  },
+
+  reviewDefaults: {
+    defaultValue: {} as ReviewDefaults,
+    fromCookie: () => {
+      const value = storage.getItem('plannotator-review-defaults');
+      if (!value) return undefined;
+      try {
+        return parseReviewDefaults(JSON.parse(value));
+      } catch {
+        return undefined;
+      }
+    },
+    toCookie: (value: ReviewDefaults) =>
+      storage.setItem('plannotator-review-defaults', JSON.stringify(value)),
+    serverKey: 'reviewDefaults',
+    fromServer: (serverConfig: Record<string, unknown>) =>
+      parseReviewDefaults(serverConfig.reviewDefaults),
+    toServer: (value: ReviewDefaults) => ({ reviewDefaults: value }),
   },
 
   defaultDiffType: {


### PR DESCRIPTION
## Summary

- replace the Git-named settings tab with a provider-aware Review tab
- let registered VCS providers describe their own default review modes
- persist defaults under provider namespaces while retaining legacy Git behavior
- add JJ defaults without inventing Git-only staging, status, or remote-branch semantics
- keep explicit `--base` and `--diff-type` session overrides authoritative across Bun, OpenCode, and Pi

## Why

Review-wide settings and Git-only behavior were coupled in one global configuration. Provider-owned descriptors keep the UI small and generic while allowing Git and JJ to expose only the modes they actually support.

## Validation

- `bun test packages/shared/config.test.ts packages/shared/vcs-core.test.ts packages/shared/review-open-state.test.ts packages/shared/review-args.test.ts packages/server/vcs.test.ts packages/ui/config/reviewPanelViewLastUsed.test.ts`
- `bun test apps/pi-extension/review-args-parity.test.ts apps/pi-extension/server.test.ts`
- `bun run --cwd apps/review build`
- `bun run build:hook`
