### PR TITLE
fix(review): prevent submission footer overlap

### DIFF
--- a/packages/review-editor/components/ReviewSubmissionDialog.tsx
+++ b/packages/review-editor/components/ReviewSubmissionDialog.tsx
@@ -551,8 +551,10 @@ export function ReviewSubmissionDialog({
           View on {platformLabel} after submitting
         </label>
 
+        </div>
+
         {/* Actions */}
-        <div className="sticky bottom-0 -mx-4 -mb-4 flex justify-end gap-2 border-t border-border/50 bg-card px-4 pb-4 pt-3 sm:-mx-6 sm:-mb-6 sm:px-6 sm:pb-6">
+        <div className="shrink-0 flex justify-end gap-2 border-t border-border/50 bg-card px-4 pb-4 pt-3 sm:px-6 sm:pb-6">
           <button
             data-pn-touch-target
             onClick={onCancel}
@@ -585,7 +587,6 @@ export function ReviewSubmissionDialog({
                     ? 'Approve'
                     : 'Post Comments'}
           </button>
-        </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/packages/review-editor/components/ReviewSubmissionDialog.ui.test.tsx
+++ b/packages/review-editor/components/ReviewSubmissionDialog.ui.test.tsx
@@ -90,6 +90,15 @@ describe('ReviewSubmissionDialog submission outcomes', () => {
     expect(actionButton()?.hasAttribute('data-pn-touch-target')).toBe(true);
   });
 
+  test.skipIf(!hasDom)('keeps the action footer outside the scrollable form body', async () => {
+    await renderSubmission({ targets: [baseTarget], orphans: [] });
+
+    const scrollableBody = document.querySelector('textarea')?.closest('.overflow-y-auto');
+
+    expect(scrollableBody).not.toBeNull();
+    expect(scrollableBody?.contains(actionButton())).toBe(false);
+  });
+
   test.skipIf(!hasDom)('ignores Escape while a platform submission is in flight', async () => {
     let cancelCount = 0;
     await renderSubmission(


### PR DESCRIPTION
## Problem

The GitHub/GitLab review submission dialog kept its sticky action footer inside the scrollable form body. At constrained heights, the footer overlaid the final form control and visibly clipped the "View on GitHub after submitting" checkbox.

## Fix

Move the action footer outside the scrollable body and make it a non-shrinking sibling. The form content can now scroll independently while the actions remain available without covering any fields.

Add a regression test that verifies the action footer is not contained by the dialog's scrollable form region.

## Review Focus

The meaningful layout change is limited to the boundary between the scrollable form body and the persistent action footer. Submission behavior, button states, and platform actions are unchanged.


Before:
<img width="572" height="432" alt="file-c63dbd71d55ca53c3f9a43ceb8171eb8" src="https://github.com/user-attachments/assets/07a49a7a-d864-442c-8293-5a4fa30b1785" />


After:
<img width="562" height="470" alt="image" src="https://github.com/user-attachments/assets/dabe21a3-1cbd-4c58-84d4-e209b268a1be" />


## Test Plan

- [x] `DOM_TESTS=1 bun test packages/review-editor/components/ReviewSubmissionDialog.ui.test.tsx` (6 pass)
- [x] `bun run --cwd apps/review build`
- [x] Rebuilt the local hook bundle and verified the GitHub approval dialog against a live PR: the checkbox is fully visible above the footer and the two regions do not overlap
- [x] Impeccable layout detector reports no findings for the changed files
- [ ] Full repository typecheck is currently unavailable from the root script because `tsc` is not on the root PATH after the latest upstream dependency layout; a direct app typecheck also reports unrelated baseline errors across existing files
