### PR TITLE
fix(ui): drop the annotation count pill from the header decision primary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,7 +229,7 @@ Approve → approved prompt sent to agent session (with the note/annotations whe
 The agent-destination review header uses the same adaptive split control the annotate surfaces
 adopted: a ghost-X Close plus `DecisionControl` (`packages/ui/components/DecisionControl.tsx`)
 rendered from the pure `buildDecisionSpec` mapping — `Approve` with no annotations,
-`Send Feedback · n` otherwise, with `Request changes…` / `Send with a note…` and the explicit
+`Send Feedback` otherwise, with `Request changes…` / `Send with a note…` and the explicit
 `Approve, discard n annotations…` confirm behind the caret. One `submitPrimaryDecision()`
 callback serves the header primary, the global `Mod+Enter` handler, and the compact primary row.
 Transport routing is pure in `packages/review-editor/reviewDecision.ts` and single-endpoint:
@@ -294,7 +294,7 @@ deletable — and both producers share one shape factory, `createGeneralReviewCo
 `reviewDecision.ts`: `scope:'general'`, sentinel `filePath ''`/0/0, `review-note-` UUID id, and
 deliberately **no PR context**, so the comment passes every PR scope predicate and survives an
 in-place PR switch. Creating one raises `totalAnnotationCount`, which is what flips the header
-control to `Send Feedback · n` — the control is state-driven, not wired to the button. The
+control to `Send Feedback` — the control is state-driven, not wired to the button. The
 feedback archive records each annotation's `scope` (additive `scope?: string` in
 `packages/shared/feedback-archive.ts`'s normalizer, vendored to Pi), so a review-level general
 comment stays distinguishable from a line comment in `index.jsonl`.
@@ -382,7 +382,7 @@ Done / Approve (gate) → positive decision recorded (see the decision control b
 Every annotate surface's header decision is one adaptive split control, `DecisionControl`
 (`packages/ui/components/DecisionControl.tsx`), rendered from the pure `buildDecisionSpec`
 state→spec mapping (`packages/ui/utils/decisionSpec.ts`) beside a ghost-X Close: `Done` (or
-`Approve` in gate mode) with nothing to send, `Send Feedback · n` otherwise, with the alternate
+`Approve` in gate mode) with nothing to send, `Send Feedback` otherwise, with the alternate
 decisions and the in-place note composer behind the caret. One `submitPrimaryDecision()` callback
 serves the header primary, the global `Mod+Enter` handler, and the compact primary row, so
 keyboard and header can never disagree. Transport routing is pure in

--- a/packages/core/guide-viewer-manifest.ts
+++ b/packages/core/guide-viewer-manifest.ts
@@ -6,9 +6,9 @@ import type { GuideViewerAssets } from "./guide-format";
 
 export const GUIDE_VIEWER_MANIFEST: Omit<GuideViewerAssets, "baseUrl"> = {
   js: "viewer.KTNT-M2b.js",
-  css: "viewer.RraIV59Z.css",
+  css: "viewer.B0Ro0qg9.css",
   jsIntegrity: "sha384-UGxkmDjeL0LMAKSAnleY0ewq4d4vtotFlHvHYWaK6UGIWmV30DyT5wSKQEz2NHdV",
-  cssIntegrity: "sha384-WoVNNlixesWzvZmhMUBvp8IHXZ5zjhatX42B7BnrTSUzcSFWD6fJq0nYDK+17msw",
+  cssIntegrity: "sha384-nCJAkARK5upOwP8psUDiybAkhN5JKQRTHVPPtwu39SqMNUrg055NzFlTfiTlaWtC",
   langs: {
     "astro": "chunks/astro.Ts5EKq2l.js",
     "c": "chunks/c.BIGW1oBm.js",

--- a/packages/review-editor/App.decisionControl.test.tsx
+++ b/packages/review-editor/App.decisionControl.test.tsx
@@ -599,8 +599,9 @@ describe.if(hasDom)("review decision control (agent mode)", () => {
     await settle();
 
     // The control is state-driven: one durable comment flips the primary.
+    // The label carries no count (maintainer ruling); the count lives in the menu copy only.
     expect(primaryButton()!.textContent).toContain("Send Feedback");
-    expect(primaryButton()!.textContent).toContain("1");
+    expect(primaryButton()!.textContent).not.toMatch(/\d/);
 
     await act(async () => primaryButton()!.click());
     await settle();
@@ -805,7 +806,6 @@ describe.if(hasDom)("review decision control (platform mode)", () => {
     await settle();
 
     expect(primaryButton()!.textContent).toContain("Post Comments");
-    expect(primaryButton()!.textContent).toContain("1");
 
     const doubleTapAlt = async () => {
       await act(async () => {
@@ -818,11 +818,9 @@ describe.if(hasDom)("review decision control (platform mode)", () => {
     await doubleTapAlt();
     // Agent spec, same annotation count — the flip swaps the spec, never the state.
     expect(primaryButton()!.textContent).toContain("Send Feedback");
-    expect(primaryButton()!.textContent).toContain("1");
 
     await doubleTapAlt();
     expect(primaryButton()!.textContent).toContain("Post Comments");
-    expect(primaryButton()!.textContent).toContain("1");
     expect(submissions).toHaveLength(0);
   });
 });

--- a/packages/ui/components/DecisionControl.tsx
+++ b/packages/ui/components/DecisionControl.tsx
@@ -475,16 +475,6 @@ export const DecisionControl: React.FC<DecisionControlProps> = ({
             {spec.primary.label}
           </span>
         )}
-        {typeof spec.primary.count === 'number' && (
-          // The count is the state indicator, not decoration: present at every
-          // breakpoint, unlike the labels.
-          <span
-            data-decision-count="true"
-            className="rounded-full bg-white/25 px-1.5 text-[10px] font-bold leading-4"
-          >
-            {spec.primary.count}
-          </span>
-        )}
       </Button>
   );
 

--- a/packages/ui/utils/decisionSpec.test.ts
+++ b/packages/ui/utils/decisionSpec.test.ts
@@ -221,12 +221,13 @@ describe('buildDecisionSpec invariants', () => {
     }
   });
 
-  // Guards a stale count in the label after an annotation is deleted.
-  it('interpolates the live count into the pill and the discard copy', () => {
+  // Guards a stale count in the discard copy after an annotation is deleted,
+  // and pins that the primary label itself never carries a count.
+  it('interpolates the live count into the discard copy, never the primary', () => {
     const zero = buildDecisionSpec({
       app: 'annotate', gate: false, count: 0, hasFeedback: true, approvalNotesSupported: false,
     });
-    expect(zero.primary.count).toBeUndefined();
+    expect('count' in zero.primary).toBe(false);
     // Nothing to discard at zero — no discard item with a lying "0 annotations".
     expect(itemIds(zero)).not.toContain('discard-and-finish');
 
@@ -249,7 +250,8 @@ describe('buildDecisionSpec invariants', () => {
     const three = buildDecisionSpec({
       app: 'review', gate: true, count: 3, hasFeedback: true, approvalNotesSupported: true,
     });
-    expect(three.primary.count).toBe(3);
+    expect('count' in three.primary).toBe(false);
+    expect(three.primary.label).toBe('Send Feedback');
     const discard = three.items.find((item) => item.id === 'discard-and-finish')!;
     expect(discard.label).toContain('3');
     expect(discard.confirm!.title).toContain('3');

--- a/packages/ui/utils/decisionSpec.ts
+++ b/packages/ui/utils/decisionSpec.ts
@@ -35,7 +35,6 @@ export interface DecisionPrimary {
   title: string;            // tooltip / aria description
   tone: Exclude<DecisionTone, 'destructive'>;
   icon?: 'check' | 'send';
-  count?: number;           // rendered as the inline pill; omitted when 0
   /**
    * Platform self-approval (PR6, §3.4): rendered dimmed but NOT disabled.
    * The reason surfaces through the shared Tooltip + aria-describedby (the
@@ -87,7 +86,7 @@ export interface DecisionSpecInput {
   app: 'annotate' | 'review';
   /** Annotate: `gate`. Review: always true — review's primary decision IS approval. */
   gate: boolean;
-  /** The count rendered in the pill and interpolated into labels. */
+  /** The annotation count interpolated into the menu's discard and note copy (never the primary label). */
   count: number;
   /**
    * Whether there is anything to send. Deliberately separate from `count`:
@@ -327,7 +326,6 @@ function buildFeedbackSpec(input: DecisionSpecInput, approvalFlow: boolean): Dec
       title: 'Send your feedback to the agent',
       tone: 'primary',
       icon: 'send',
-      count: count > 0 ? count : undefined,
     },
     items,
   };
@@ -395,7 +393,6 @@ function buildPlatformSpec(input: DecisionSpecInput, platform: DecisionPlatformI
       title: `Post review to ${platform.label}`,
       tone: 'primary',
       icon: 'send',
-      count: count > 0 ? count : undefined,
     },
     items: [
       {

--- a/tests/UI-TESTING.md
+++ b/tests/UI-TESTING.md
@@ -187,7 +187,7 @@ UI test scripts simulate plugin behavior locally:
 1. Builds review app (`bun run build:review`)
 2. Starts review server with sample git diff
 3. Opens browser with code review UI
-4. Verifies "OpenCode" badge + the header decision control (`Approve` at zero annotations, `Send Feedback · n` once you annotate — not "Copy Feedback")
+4. Verifies "OpenCode" badge + the header decision control (`Approve` at zero annotations, `Send Feedback` once you annotate — not "Copy Feedback")
 5. Tests feedback submission flow
 
 **`test-codex-plan-review-e2e.sh`**
@@ -381,7 +381,7 @@ Build failed with X errors
 ## Decision Control Manual Checklist
 
 Not CI. Every annotate surface and the review header share one adaptive split control
-(`DecisionControl`): a positive primary (`Done` / `Approve` / `Send Feedback · n`) plus a caret
+(`DecisionControl`): a positive primary (`Done` / `Approve` / `Send Feedback`) plus a caret
 menu with the alternate decisions and the in-place note composer. Run each flow in both states —
 zero annotations and n annotations — on desktop AND on a real phone (touch has no `Mod+Enter`,
 which is the regression class this control exists to fix).
@@ -390,7 +390,7 @@ which is the regression class this control exists to fix).
    clicking it submits the "no feedback" record and the terminal prints it. Caret →
    `Done with a note…` opens the composer in place: `Enter` inserts a newline, `Mod+Enter`
    submits, `Escape` steps back to the menu keeping the draft. Add an annotation: the primary
-   flips to `Send Feedback · 1`, and `Done, discard 1 annotation…` raises the one confirm.
+   flips to `Send Feedback`, and `Done, discard 1 annotation…` raises the one confirm.
 2. **Annotate, gate mode** (`plannotator annotate notes.md --gate --json`). The zero-state
    primary is `Approve` and posts `/api/approve` (stdout records `"approved"`; with
    `--require-approval` only approval exits `0`); `Request changes…` records an annotated
@@ -402,7 +402,7 @@ which is the regression class this control exists to fix).
 4. **HTML / live-app annotate** (`plannotator annotate page.html`, `plannotator annotate
    http://localhost:<port>`). Open the caret menu, then click the framed page: the popover
    dismisses (iframe focus is the dismissal signal — there is no parent pointerdown).
-5. **Review, agent mode** (`plannotator review`). `Approve` at zero, `Send Feedback · n` after
+5. **Review, agent mode** (`plannotator review`). `Approve` at zero, `Send Feedback` after
    annotating; approving despite annotations is two clicks (caret → `Approve, discard n
    annotations…` → `Discard & approve`). With the composer open, `Escape` returns to the menu
    and does NOT collapse the file tree or close the sidebar; a second `Escape` closes the menu;
@@ -417,7 +417,7 @@ which is the regression class this control exists to fix).
    (`DecisionNoteDialog`), not an inline textarea.
 8. **Sidebar general comment** (review). "+ General comment" is reachable at zero annotations
    (empty state) and from the General section header; creating one flips the header control to
-   `Send Feedback · 1`.
+   `Send Feedback`.
 
 ## WebMCP Manual Checklist
 


### PR DESCRIPTION
## Summary

- The header decision primary no longer renders the inline count pill: it reads **Send Feedback** / **Post Comments**, not `Send Feedback · n` (maintainer ruling).
- `DecisionPrimary.count` is removed from the pure spec; the annotation count still drives the caret menu's discard and approve-with-notes copy, which is where it is needed.
- `decisionSpec.test.ts` and the review `App.decisionControl` suite now pin that the primary label carries no digits; AGENTS.md and `tests/UI-TESTING.md` stop spelling the control with a count.

Below the label breakpoint the primary is icon-only, the same as Approve/Done already were. `DecisionControl` is off the `@plannotator/ui` host-supported surface, so no package bump.

## Test plan

- [x] `bun x tsc --noEmit -p packages/ui/tsconfig.json`
- [x] `DOM_TESTS=1 bun test packages/ui packages/editor packages/review-editor`