### PR TITLE
fix(opencode): co-promote the session-URL notice with the feedback on OpenCode 2

### DIFF
--- a/apps/opencode-plugin/native-commands.test.ts
+++ b/apps/opencode-plugin/native-commands.test.ts
@@ -421,12 +421,65 @@ describe("V2 feedback delivery", () => {
 
   test("feedback is queued, never steered into a running turn", async () => {
     // The invocation's own delivery was chosen at admission; a review comes
-    // back minutes later, when a steer would land mid-turn.
+    // back minutes later, when a steer would land mid-turn. This client posted
+    // no session-URL notice, so nothing of ours is pending ahead of it.
     const { client, prompt } = makeBridge(async () => {});
 
     await client.session.prompt({
       path: { id: "session-1" },
       body: { parts: [{ type: "text", text: "LGTM" }] },
+    });
+
+    expect(prompt.mock.calls[0]![0]).toMatchObject({ delivery: "queue" });
+  });
+
+  // Regression (#1515): a session-URL notice is a pending inbox row that the
+  // feedback's own wake promotes. Queued rows promote one at a time
+  // (`SessionInbox.promote`, packages/core/src/session/inbox.ts), so queued
+  // feedback behind a pending notice runs the notice as its own model turn
+  // first. The two must share one promotion, and steers promote as a batch.
+  test("feedback follows a pending session-URL notice into the same promotion", async () => {
+    const synthetic = mock(async (_input: unknown) => ({}));
+    const prompt = mock(async (_input: unknown) => ({}));
+    const client = createV2BridgeClient({
+      ctx: { session: { synthetic, prompt } } as never,
+      getAgents: async () => [],
+      sessionID: "session-1",
+    });
+
+    await client.notifyUrl!({ url: "http://127.0.0.1:19432", message: "ready" });
+    await client.session.prompt({
+      path: { id: "session-1" },
+      body: { parts: [{ type: "text", text: "fix the null check" }] },
+    });
+
+    expect(synthetic.mock.calls[0]![0]).toMatchObject({ delivery: "steer" });
+    expect(prompt.mock.calls[0]![0]).toMatchObject({ delivery: "steer" });
+  });
+
+  // Regression: a notice the host REFUSED is not pending, so nothing has to be
+  // co-promoted and the feedback keeps its late-arrival queue delivery. Marking
+  // the notice pending before the host accepted it would steer every review on
+  // a host whose `session.synthetic` never works.
+  test("a rejected notice leaves the feedback queued", async () => {
+    const prompt = mock(async (_input: unknown) => ({}));
+    const client = createV2BridgeClient({
+      ctx: {
+        session: {
+          synthetic: async () => {
+            throw new Error("session gone");
+          },
+          prompt,
+        },
+      } as never,
+      getAgents: async () => [],
+      sessionID: "session-1",
+    });
+
+    await client.notifyUrl!({ url: "http://127.0.0.1:19432", message: "ready" }).catch(() => {});
+    await client.session.prompt({
+      path: { id: "session-1" },
+      body: { parts: [{ type: "text", text: "fix the null check" }] },
     });
 
     expect(prompt.mock.calls[0]![0]).toMatchObject({ delivery: "queue" });
@@ -545,10 +598,6 @@ describe("V2 session URL delivery", () => {
   // Regression: without `resume: false` upstream calls `execution.wake`
   // (packages/core/src/session/session.ts), so merely showing a URL would start
   // a model turn the reviewer never asked for and burn tokens on every command.
-  // #1459 extension: resume: false only defers the immediate wake; the host
-  // default delivery is "steer", which any later wake (including spurious
-  // idle wakes on OpenCode 2 betas) promotes into its own model turn. The
-  // notice must therefore also pin queue delivery.
   test("the notice never wakes a model turn", async () => {
     const { synthetic, ctx } = makeSyntheticCtx();
     const client = createV2BridgeClient({ ctx, getAgents: async () => [], sessionID: "session-1" });
@@ -556,7 +605,24 @@ describe("V2 session URL delivery", () => {
     pushUrlLine(client);
     await Promise.resolve();
 
-    expect(synthetic.mock.calls[0]![0]).toMatchObject({ resume: false, delivery: "queue" });
+    expect(synthetic.mock.calls[0]![0]).toMatchObject({ resume: false });
+  });
+
+  // Regression (#1515): `resume: false` only declines the immediate wake — the
+  // row still waits in the inbox and is promoted by the next wake, which is the
+  // feedback's. `SessionInbox.promote` (packages/core/src/session/inbox.ts)
+  // promotes pending steers as a batch but queued rows one at a time, so a
+  // QUEUED notice ahead of queued feedback becomes its own model turn and the
+  // reviewer's annotations land behind it. #1459 set this to "queue"; that is
+  // what produced #1515.
+  test("the notice rides the delivery that batches, not the one that isolates", async () => {
+    const { synthetic, ctx } = makeSyntheticCtx();
+    const client = createV2BridgeClient({ ctx, getAgents: async () => [], sessionID: "session-1" });
+
+    pushUrlLine(client);
+    await Promise.resolve();
+
+    expect(synthetic.mock.calls[0]![0]).toMatchObject({ delivery: "steer" });
   });
 
   // Regression: `session.synthetic` is absent on older V2 hosts, and a session

--- a/apps/opencode-plugin/server.test.ts
+++ b/apps/opencode-plugin/server.test.ts
@@ -401,8 +401,12 @@ describe("V2 plan review URL delivery", () => {
       sessionID: "session-1",
       description: formatSessionUrlNotice(SESSION_URL),
       resume: false,
-      // #1459: queue delivery keeps the notice out of steer-scoped promotion.
-      delivery: "queue",
+      // #1515: `resume: false` only declines the immediate wake. The row still
+      // waits in the inbox, and a queued row promotes alone while steers
+      // promote as a batch (`SessionInbox.promote`), so queue delivery is what
+      // turns a notice into its own model turn. Mid-tool-call here, a steer
+      // lands at the running turn's next step boundary instead.
+      delivery: "steer",
     });
   });
 

--- a/apps/opencode-plugin/v2-client.ts
+++ b/apps/opencode-plugin/v2-client.ts
@@ -17,7 +17,11 @@ export interface V2SessionDomain {
   switchAgent?: (input: { sessionID: string; agent: string }) => Promise<unknown>;
   context?: (input: { sessionID: string }) => Promise<unknown>;
   /**
-   * Put a message in the session WITHOUT starting a model turn.
+   * Put a message in the session without starting a model turn NOW.
+   *
+   * `resume: false` declines the immediate wake; it does not exempt the message
+   * from the next promotion, which is what `delivery` governs. Widened to
+   * `unknown` like `prompt`'s, because the delivery literals are the host's.
    *
    * Optional because it only exists on hosts whose plugin API carries it
    * (`SessionDomain` in `packages/plugin/src/promise/session.ts`); every call
@@ -28,6 +32,7 @@ export interface V2SessionDomain {
     text: string;
     description?: string;
     resume?: boolean;
+    delivery?: unknown;
   }) => Promise<unknown>;
 }
 
@@ -195,7 +200,8 @@ function readSessionId(request: unknown): string | undefined {
 }
 
 /**
- * How Plannotator feedback is admitted to the session.
+ * How Plannotator feedback is admitted to the session when nothing of ours is
+ * already pending ahead of it.
  *
  * A command invocation carries its own delivery, but that value was chosen when
  * the user pressed enter, and a review comes back minutes later: replaying a
@@ -205,6 +211,36 @@ function readSessionId(request: unknown): string | undefined {
  * explicitly rather than omitted.
  */
 const FEEDBACK_DELIVERY = "queue";
+
+/**
+ * How BOTH the session-URL notice and the feedback that follows it are admitted,
+ * so OpenCode promotes them into ONE model turn (#1515).
+ *
+ * OpenCode 2 admits every plugin message — `session.prompt` and
+ * `session.synthetic` alike — as a pending inbox row, and `resume: false` only
+ * declines to wake the session NOW; it never exempts the row from a later
+ * promotion. Promotion is not symmetric between the two delivery kinds
+ * (`SessionInbox.promote`, `packages/core/src/session/inbox.ts` @ v2.0.2):
+ *
+ *  - pending steers are promoted as a BATCH ("publish(db, bus, sessionID,
+ *    control === -1 ? steers : steers.slice(0, control))"), so several steer
+ *    rows enter the same turn;
+ *  - a queued row is promoted ONE AT A TIME (the `limit(1)` select), and only
+ *    after the steers.
+ *
+ * A promoted synthetic becomes a user-role message (`to-llm-message.ts`) and
+ * the runner then runs a full model step for it, with no "was this real user
+ * input?" guard. So a queued notice sitting ahead of queued feedback is
+ * promoted alone and becomes its own model turn, with the reviewer's feedback
+ * stuck behind it — exactly what #1515 reports. Riding "steer" for both is what
+ * makes the notice and the feedback one batch, which is the same reason
+ * upstream's own transcript notices (shell results, `Session.shell`) leave the
+ * host default of "steer" in place instead of queueing.
+ *
+ * Only used when this client actually posted a notice; a review that posted
+ * none keeps `FEEDBACK_DELIVERY` and its late-arrival guarantee.
+ */
+const CO_PROMOTED_DELIVERY = "steer";
 
 /**
  * The one line a user is shown when a Plannotator session opens on OpenCode 2.
@@ -247,12 +283,12 @@ export function formatSessionUrlNotice(url: string): string {
  *  - Setting no `metadata.source` keeps it on the plain "Notice" row rather
  *    than the subagent/shell completion row.
  *
- * `delivery` is an explicit "queue", mirroring `FEEDBACK_DELIVERY` (#1459).
- * The host default resolves to "steer", and a pending steer row is promoted
- * FIRST by any wake, including spurious idle wakes observed on OpenCode 2
- * betas where `resume: false` defers the immediate wake but a later wake
- * turns the notice into its own model turn. Queue delivery keeps the notice
- * out of every steer-scoped promotion and is a no-op on well-behaved hosts.
+ * `delivery` is an explicit `CO_PROMOTED_DELIVERY` ("steer"), which is also the
+ * host default. #1459 tried "queue" here; #1515 is what that produced, because
+ * a queued row is promoted alone while steers are promoted as a batch. See
+ * `CO_PROMOTED_DELIVERY` above for the promotion rules and the citations. The
+ * feedback that follows rides the same delivery, so the notice enters the model
+ * turn the reviewer actually asked for instead of starting one of its own.
  *
  * This does not contradict the reason feedback avoids synthetic injection.
  * Upstream #44788 is about a synthetic message not reliably reaching the MODEL
@@ -266,19 +302,28 @@ export function formatSessionUrlNotice(url: string): string {
 export function createSessionUrlNotifier(
   ctx: V2ContextLike,
   sessionID: string | undefined,
+  /**
+   * Called once the host has ACCEPTED a notice, so the feedback that follows can
+   * be admitted with the delivery that co-promotes with it. Never called for a
+   * rejected notice: nothing is then pending and the plain queue delivery is
+   * still the right one.
+   */
+  onAdmitted?: () => void,
 ): ((input: { url: string; message: string }) => Promise<unknown>) | undefined {
   const synthetic = ctx.session?.synthetic;
   if (typeof synthetic !== "function" || !sessionID) return undefined;
   return async ({ url }) => {
     const notice = formatSessionUrlNotice(url);
-    return await synthetic({
+    const admitted = await synthetic({
       sessionID,
       text: notice,
       description: notice,
       resume: false,
-      // #1459: never ride the "steer" default; see the delivery note above.
-      delivery: FEEDBACK_DELIVERY,
+      // #1515: the notice and the feedback must share one promotion.
+      delivery: CO_PROMOTED_DELIVERY,
     });
+    onAdmitted?.();
+    return admitted;
   };
 }
 
@@ -305,7 +350,16 @@ export function createV2BridgeClient(input: {
 }): V2BridgeClient {
   const warn = input.warn ?? ((message: string) => console.error(message));
   const loggedUrls = new Set<string>();
-  const notifyUrl = createSessionUrlNotifier(input.ctx, input.sessionID);
+  // Whether a session-URL notice of ours is still waiting in this session's
+  // inbox. It is the only thing that can sit AHEAD of the reviewer's feedback,
+  // and the plugin session domain exposes no way to withdraw a pending row
+  // (`SessionDomain` is a fixed Pick in `packages/plugin/src/promise/session.ts`
+  // with no inbox member, even though the server itself routes
+  // `session.inbox.cancel`), so the feedback joins its promotion instead.
+  let noticePending = false;
+  const notifyUrl = createSessionUrlNotifier(input.ctx, input.sessionID, () => {
+    noticePending = true;
+  });
   return {
     ...(notifyUrl && { notifyUrl }),
     app: {
@@ -342,11 +396,15 @@ export function createV2BridgeClient(input: {
         if (typeof prompt !== "function") {
           throw new Error("OpenCode 2 host exposes no session.prompt; cannot deliver Plannotator feedback.");
         }
-        return await prompt({
+        const delivered = await prompt({
           sessionID,
           text: joinTextParts(Array.isArray(body.parts) ? body.parts : []),
-          delivery: FEEDBACK_DELIVERY,
+          delivery: noticePending ? CO_PROMOTED_DELIVERY : FEEDBACK_DELIVERY,
         });
+        // Admitted: the notice is no longer the row ahead of us, so any later
+        // delivery on this client is a plain late arrival again.
+        noticePending = false;
+        return delivered;
       },
     },
   };


### PR DESCRIPTION
Closes #1515. Follow-up to #1460 / #1459.

## What the reporter sees

On OpenCode v2.0.2, `/plannotator-last` prints "◈ Plannotator session ready: <url>" and the agent stays idle (correct). When Send Feedback arrives, the agent wakes but first runs a whole model turn on the URL notice, and the annotations land in the turn after it.

## Why, verified against the OpenCode v2.0.2 source (`ea5ae23295`)

- A plugin's `session.synthetic` is not a notification. It admits a pending inbox row; `resume: false` only declines the wake right then (`packages/core/src/session/session.ts:168,304`). It never exempts the row from the next promotion.
- Delivery kinds are exactly `steer | queue` (`packages/schema/src/session-inbox.ts:11`). There is no non-promotable kind, and the plugin `SessionDomain` Pick has no inbox cancel (`packages/plugin/src/promise/session.ts:112-129`), even though the server routes one.
- Promotion is asymmetric (`packages/core/src/session/inbox.ts:496-535`): pending **steers publish as a batch**; **queued rows publish one at a time**, oldest first (`limit(1)`), and only after the steers.
- The feedback's own `session.prompt` wakes the session at an idle boundary with `input` scope. `promote(…, "input")` then takes the single oldest queued row, which is the notice #1460 pinned to `queue`. A promoted synthetic is a plain user-role message (`runner/to-llm-message.ts:257`), so it gets a full model step.

#1460's own caveat named this hole. It is not a spurious wake; it is the reviewer's feedback waking the session.

## The fix

The notice rides `steer` delivery (the host default), and feedback that follows an **admitted** notice rides `steer` too, so the two share one promotion and enter one turn. A rejected notice, OpenCode 1 (which uses a real toast and has no inbox), and hosts without `session.synthetic` keep `FEEDBACK_DELIVERY = "queue"` and its late-arrival behavior unchanged. `apps/opencode-plugin/index.ts` (v1) is untouched.

Side effect, stated: while a notice of ours is pending, feedback submitted during a running turn lands at that turn's next step boundary instead of after it. That is bounded to sessions that posted a notice, where the queued ordering was already broken.

Also declares `delivery` on the duck-typed `synthetic` signature, which the code has passed since #1460 without a type.

## Not in this PR

- Removing the transcript line entirely on OpenCode 2 needs a TUI plugin entrypoint (`<pkg>/tui`, `ctx.ui.toast.show`) on hosts that expose `features.tui`. Worth a follow-up; it would restore v1's toast semantics.
- Upstream ask: a render-only delivery kind, or `session.inbox.cancel` in the plugin `SessionDomain`.

## Test plan

- [x] `bun test apps/opencode-plugin`: 175 pass. Flipping `CO_PROMOTED_DELIVERY` back to `"queue"` fails exactly the three new/changed assertions (notice delivery, feedback-after-notice delivery, plan-review URL delivery) and nothing else.
- [x] `bun build apps/opencode-plugin/server.ts --target node` succeeds.
- Not reproduced at runtime: the only local OpenCode is 1.18.x and the plugin pins types only; the finding is a code trace against the v2.0.2 tag.